### PR TITLE
chore: remove codecov integration

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -59,27 +59,12 @@ jobs:
               uses: arduino/setup-protoc@v3
               with:
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
-            - name: Install cargo-llvm-cov
-              uses: taiki-e/install-action@cargo-llvm-cov
-            - name: Generate coverage
+            - name: Run tests
               run: |
-                  cargo llvm-cov nextest \
+                  cargo nextest run \
                     ${{ matrix.args }} --workspace \
                     --no-tests=warn \
-                    -E "!kind(test)" \
-                    --lcov --output-path lcov.info
-            - name: Upload coverage artifact
-              uses: actions/upload-artifact@v4
-              with:
-                  name: coverage-report
-                  path: lcov.info
-                  retention-days: 1
-              # run: |
-              #     cargo nextest run \
-              #       ${{ matrix.args }} --workspace \
-              #       --no-tests=warn \
-              #       --partition hash:${{ matrix.partition }}/2 \
-              #       -E "!kind(test)"
+                    -E "!kind(test)"
 
     doc:
         name: doc tests (${{ matrix.network }})
@@ -100,21 +85,6 @@ jobs:
             - name: Run doctests
               # run: cargo test --doc --workspace --features "${{ matrix.network }}"
               run: cargo test --doc --workspace
-
-    upload-coverage:
-        name: Upload Coverage to Codecov
-        runs-on: ubuntu-latest
-        needs: [test]
-        steps:
-            - uses: actions/download-artifact@v4
-              with:
-                  name: coverage-report
-            - name: Upload coverage to Codecov
-              uses: codecov/codecov-action@v5
-              with:
-                  files: lcov.info
-                  fail_ci_if_error: true
-                  token: ${{ secrets.CODECOV_TOKEN }}
 
     unit-success:
         name: unit success


### PR DESCRIPTION
## What
Remove codecov integration from CI workflow.

Changes:
- Remove `upload-coverage` job
- Remove coverage generation with `cargo-llvm-cov`
- Replace with direct `cargo nextest run`

## Why
Reduce dependency on external service providers for CI.

## Testing
Workflow syntax validated. Tests will run on PR.

## AI Assistance
Claude Code used for workflow modification and PR creation.