### PR TITLE
fix(primitives): fix proptest Arbitrary impl and WASM demo CI

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -5,6 +5,7 @@ on:
         branches: [main]
         paths:
             - "crates/primitives/examples/wasm-demo/**"
+            - "crates/primitives/src/**"
     workflow_dispatch: # Allow manual triggering
 
 env:
@@ -16,15 +17,13 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
-            - name: Install Rust
-              uses: actions-rs/toolchain@v1
+            - name: Install Rust nightly
+              uses: dtolnay/rust-toolchain@nightly
               with:
-                  profile: minimal
-                  toolchain: stable
-                  override: true
-                  target: wasm32-unknown-unknown
+                  targets: wasm32-unknown-unknown
+                  components: rust-src
 
             - name: Cache Rust dependencies
               uses: Swatinem/rust-cache@v2
@@ -39,7 +38,7 @@ jobs:
             - name: Build WASM Demo
               run: |
                   cd crates/primitives/examples/wasm-demo
-                  trunk build --release --public-url /nectar/
+                  RUSTUP_TOOLCHAIN=nightly trunk build --release --public-url /nectar/
 
             - name: Deploy to GitHub Pages
               uses: JamesIves/github-pages-deploy-action@v4

--- a/crates/primitives/examples/wasm-demo/.cargo/config.toml
+++ b/crates/primitives/examples/wasm-demo/.cargo/config.toml
@@ -1,0 +1,14 @@
+[unstable]
+build-std = ["panic_abort", "std"]
+
+[target.wasm32-unknown-unknown]
+rustflags = [
+  "-C", "target-feature=+atomics,+bulk-memory,+mutable-globals",
+  "-C", "link-arg=--shared-memory",
+  "-C", "link-arg=--import-memory",
+  "-C", "link-arg=--max-memory=1073741824",
+  "-C", "link-arg=--export=__wasm_init_tls",
+  "-C", "link-arg=--export=__tls_size",
+  "-C", "link-arg=--export=__tls_align",
+  "-C", "link-arg=--export=__tls_base",
+]

--- a/crates/primitives/examples/wasm-demo/rust-toolchain.toml
+++ b/crates/primitives/examples/wasm-demo/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly"
+components = ["rust-src"]
+targets = ["wasm32-unknown-unknown"]

--- a/crates/primitives/src/chunk/bmt_body.rs
+++ b/crates/primitives/src/chunk/bmt_body.rs
@@ -211,8 +211,19 @@ impl<const BODY_SIZE: usize> BmtBodyBuilder<BODY_SIZE, ReadyToBuild> {
 #[cfg(any(test, feature = "arbitrary"))]
 impl<'a, const BODY_SIZE: usize> arbitrary::Arbitrary<'a> for BmtBody<BODY_SIZE> {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let span = u64::arbitrary(u)?;
-        let data_len: usize = u.int_in_range(0..=BODY_SIZE)?;
+        // Decide whether to generate a leaf chunk (span == data_len) or an
+        // intermediate chunk (span > BODY_SIZE, full body).
+        let is_leaf: bool = u.arbitrary()?;
+
+        let (span, data_len) = if is_leaf {
+            let data_len: usize = u.int_in_range(0..=BODY_SIZE)?;
+            (data_len as u64, data_len)
+        } else {
+            // Intermediate node: span exceeds BODY_SIZE, body is always full.
+            let span = u.int_in_range(BODY_SIZE as u64 + 1..=u64::MAX)?;
+            (span, BODY_SIZE)
+        };
+
         let mut buf = vec![0; data_len];
         u.fill_buffer(&mut buf)?;
 


### PR DESCRIPTION
## What

Fixes two CI failures introduced on merge of #25 to `main`:

1. **Proptest panic in `BmtBody::arbitrary`**: the `Arbitrary` impl generated `span` and `data_len` independently, violating the builder invariant that `span == data_len` for leaf chunks. During proptest shrinking, invalid combinations caused a panic on `unwrap()`. Fixed by generating structurally valid leaf chunks (span = data_len) and intermediate chunks (span > BODY_SIZE, full body).

2. **WASM demo build failure**: `nectar-primitives` transitively pulls in `wasm-bindgen-rayon`, which requires nightly Rust with `build-std`, `atomics`, and `bulk-memory`. The workflow was using stable Rust. Fixed by switching to nightly toolchain and adding the required `.cargo/config.toml` and `rust-toolchain.toml` for the example crate.

## Why

Both CI workflows (`unit` and `Deploy WASM Demo`) are failing on `main` after #25 was merged. The PR branch CI passed because proptest shrinking is non-deterministic, and the WASM build was not triggered by the PR event paths.

## Testing

- `cargo test -p nectar-primitives` passes (all 145 tests including the previously failing `test_chunk_properties`)
- `cargo test --workspace` passes
- Ran the proptest multiple times to confirm shrinking no longer panics

AI Assistance: Claude Code used for investigation and implementation.