### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -24,8 +24,8 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
-      - uses: rustsec/audit-check@v2
+      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998  # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -24,7 +24,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998  # v2.0.0
         with:

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -17,7 +17,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
             - name: Install Rust nightly
               uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2  # nightly
@@ -26,12 +26,12 @@ jobs:
                   components: rust-src
 
             - name: Cache Rust dependencies
-              uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2.9.1
+              uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
               with:
                   shared-key: "wasm-demo"
 
             - name: Install Trunk
-              uses: jetli/trunk-action@68dbd78ba531c95d8ce3d262c9e63291926e9353  # v0.4.0
+              uses: jetli/trunk-action@1346cc09eace4beb84e403e199a471346d4684c9  # v0.5.1
               with:
                   version: "latest"
 

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -17,21 +17,21 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
             - name: Install Rust nightly
-              uses: dtolnay/rust-toolchain@nightly
+              uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2  # nightly
               with:
                   targets: wasm32-unknown-unknown
                   components: rust-src
 
             - name: Cache Rust dependencies
-              uses: Swatinem/rust-cache@v2
+              uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2.9.1
               with:
                   shared-key: "wasm-demo"
 
             - name: Install Trunk
-              uses: jetli/trunk-action@v0.4.0
+              uses: jetli/trunk-action@68dbd78ba531c95d8ce3d262c9e63291926e9353  # v0.4.0
               with:
                   version: "latest"
 
@@ -41,7 +41,7 @@ jobs:
                   RUSTUP_TOOLCHAIN=nightly trunk build --release --public-url /nectar/
 
             - name: Deploy to GitHub Pages
-              uses: JamesIves/github-pages-deploy-action@v4
+              uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f  # v4.8.0
               with:
                   folder: crates/primitives/examples/wasm-demo/dist
                   branch: gh-pages

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -48,10 +48,10 @@ jobs:
                     #   total_partitions: 1
         timeout-minutes: 30
         steps:
-            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
             - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444  # v1
             - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
-            - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2.9.1
+            - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
               with:
                   cache-on-failure: true
             - uses: taiki-e/install-action@1b57bc699ba2af96a06eb2a2a0d32b43a7d8e8b8  # nextest
@@ -76,10 +76,10 @@ jobs:
         #     matrix:
         #         network: ["ethereum", "optimism"]
         steps:
-            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
             - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444  # v1
             - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
-            - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2.9.1
+            - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
               with:
                   cache-on-failure: true
             - name: Run doctests

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -48,15 +48,15 @@ jobs:
                     #   total_partitions: 1
         timeout-minutes: 30
         steps:
-            - uses: actions/checkout@v4
-            - uses: rui314/setup-mold@v1
-            - uses: dtolnay/rust-toolchain@stable
-            - uses: Swatinem/rust-cache@v2
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+            - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444  # v1
+            - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+            - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2.9.1
               with:
                   cache-on-failure: true
-            - uses: taiki-e/install-action@nextest
+            - uses: taiki-e/install-action@1b57bc699ba2af96a06eb2a2a0d32b43a7d8e8b8  # nextest
             - if: "${{ matrix.type == 'book' }}"
-              uses: arduino/setup-protoc@v3
+              uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b  # v3.0.0
               with:
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
             - name: Run tests
@@ -76,10 +76,10 @@ jobs:
         #     matrix:
         #         network: ["ethereum", "optimism"]
         steps:
-            - uses: actions/checkout@v4
-            - uses: rui314/setup-mold@v1
-            - uses: dtolnay/rust-toolchain@stable
-            - uses: Swatinem/rust-cache@v2
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+            - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444  # v1
+            - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+            - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2.9.1
               with:
                   cache-on-failure: true
             - name: Run doctests
@@ -94,6 +94,6 @@ jobs:
         timeout-minutes: 30
         steps:
             - name: Decide whether the needed jobs succeeded or failed
-              uses: re-actors/alls-green@release/v1
+              uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # release/v1
               with:
                   jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Summary

Pin every third-party GitHub Actions reference in this repos workflows to a 40-character commit SHA, with the original ref preserved as a trailing comment. This defends CI against tag-supply-chain attacks where a compromised maintainer pushes a malicious commit and re-points an existing tag (as in the [tj-actions/changed-files March 2025 incident](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised)).

## Pinned actions

- actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
- arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b  # v3.0.0
- dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
- dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2  # nightly
- JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f  # v4.8.0
- jetli/trunk-action@68dbd78ba531c95d8ce3d262c9e63291926e9353  # v0.4.0
- re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # release/v1
- rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444  # v1
- rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998  # v2.0.0
- Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2.9.1
- taiki-e/install-action@1b57bc699ba2af96a06eb2a2a0d32b43a7d8e8b8  # nextest

## Out of scope

- `cla.yml` (`contributor-assistant/github-action`, `actions/create-github-app-token`) - handled in a separate PR.
- First-party `nxm-rs/*` actions / reusable workflows - none currently referenced.

## References

- https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised
- https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

## Test plan

- [ ] CI passes on this branch (all jobs still run as before, just from immutable SHAs).
- [ ] Spot-check one workflow file diff: ref hash matches `git ls-remote` for the listed tag.