### PR TITLE
feat(primitives)!: typed Swarm spec primitives + signing layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2132,6 +2132,7 @@ dependencies = [
  "arbitrary",
  "bytes",
  "codspeed-criterion-compat",
+ "derive_more",
  "digest 0.11.3",
  "futures",
  "getrandom 0.2.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,9 @@ k256 = { version = "0.13", default-features = false, features = ["ecdsa", "preco
 digest = "0.11"
 hybrid-array = { version = "0.4", features = ["extra-sizes"] }
 
+# derive macros
+derive_more = { version = "2.1", default-features = false, features = ["display", "from", "into", "as_ref"] }
+
 # enums
 strum = { version = "0.28", default-features = false, features = ["derive"] }
 num_enum = { version = "0.7", default-features = false }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -20,6 +20,9 @@ alloy-signer-local.workspace = true
 digest.workspace = true
 hybrid-array.workspace = true
 
+# derive macros
+derive_more.workspace = true
+
 # Core dependencies
 bytes.workspace = true
 thiserror.workspace = true
@@ -46,7 +49,7 @@ rayon.workspace = true
 
 # Only for non-WASM targets
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-alloy-primitives = { workspace = true, features = ["asm-keccak"] }
+alloy-primitives = { workspace = true, features = ["asm-keccak", "getrandom"] }
 
 # Only for WASM-specific targets
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/primitives/src/address.rs
+++ b/crates/primitives/src/address.rs
@@ -74,6 +74,7 @@ use alloy_primitives::{B256, U256};
 use serde::{Deserialize, Serialize};
 
 use crate::error::Result;
+use crate::{Bin, ProximityOrder};
 
 /// Maximum proximity order for standard routing operations.
 ///
@@ -205,7 +206,7 @@ impl SwarmAddress {
     }
 
     /// Check if this address is within the given proximity to another address
-    pub fn is_within_proximity(&self, other: &Self, min_proximity: u8) -> bool {
+    pub fn is_within_proximity(&self, other: &Self, min_proximity: ProximityOrder) -> bool {
         self.proximity(other) >= min_proximity
     }
 
@@ -218,8 +219,9 @@ impl SwarmAddress {
     /// use [`extended_proximity()`](Self::extended_proximity) instead.
     #[inline(always)]
     #[must_use]
-    pub fn proximity(&self, other: &Self) -> u8 {
-        self.proximity_helper(other, MAX_PO.into())
+    pub fn proximity(&self, other: &Self) -> ProximityOrder {
+        // `proximity_helper` is bounded by MAX_PO, so the cast is sound.
+        ProximityOrder::new_unchecked(self.proximity_helper(other, MAX_PO.into()))
     }
 
     /// Calculate the extended proximity order between self and another address.
@@ -228,11 +230,35 @@ impl SwarmAddress {
     /// capped at `EXTENDED_PO` (36). Use this for Kademlia bin balancing where
     /// the algorithm checks `po + BitSuffixLength + 1` (up to 36 for bin 31).
     ///
-    /// For standard routing operations, use [`proximity()`](Self::proximity) instead.
+    /// Returns a raw `u8` because the extended range exceeds `ProximityOrder`'s
+    /// invariant (`0..=MAX_PO`). For standard routing, use
+    /// [`proximity()`](Self::proximity) instead.
     #[inline(always)]
     #[must_use]
     pub fn extended_proximity(&self, other: &Self) -> u8 {
         self.proximity_helper(other, EXTENDED_PO.into())
+    }
+
+    /// XOR distance - bitwise XOR of the two 32-byte addresses as a new
+    /// [`SwarmAddress`]. Useful when callers want the raw distance bytes
+    /// (e.g. for content-routing bias) rather than the proximity-order metric.
+    #[inline(always)]
+    #[must_use]
+    pub fn xor(&self, other: &Self) -> Self {
+        let mut out = [0u8; 32];
+        for (i, (a, b)) in self.0.as_slice().iter().zip(other.0.as_slice()).enumerate() {
+            out[i] = a ^ b;
+        }
+        Self(B256::from(out))
+    }
+
+    /// Kademlia bin index of `self` relative to `anchor` - semantic alias for
+    /// `Bin::from(self.proximity(anchor))`. The routing-table convention is
+    /// "the bin a peer occupies is its proximity order to our own overlay".
+    #[inline(always)]
+    #[must_use]
+    pub fn bin(&self, anchor: &Self) -> Bin {
+        Bin::from(self.proximity(anchor))
     }
 
     /// Helper function to calculate proximity with a maximum

--- a/crates/primitives/src/bin.rs
+++ b/crates/primitives/src/bin.rs
@@ -1,0 +1,131 @@
+//! Typed Kademlia bin index in the range `0..=MAX_PO`.
+//!
+//! A [`Bin`] is a routing-table slot keyed by the proximity order between an
+//! anchor address (e.g. our own overlay) and a peer's overlay. Distinguished
+//! from [`ProximityOrder`](crate::ProximityOrder) at the type level even
+//! though they share a representation. PO is the metric, Bin is the slot.
+
+use crate::{MAX_PO, ProximityOrder};
+use derive_more::{Display, Into};
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// Typed Kademlia bin index, `0..=MAX_PO` (= 0..=31).
+#[repr(transparent)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord,
+    Display, Into,
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+#[display("bin={_0}")]
+#[into(u8, usize)]
+pub struct Bin(u8);
+
+/// Errors from constructing a [`Bin`].
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum BinError {
+    /// Value exceeded [`MAX_PO`](crate::MAX_PO).
+    #[error("bin index {raw} exceeds MAX_PO ({max})")]
+    OutOfRange {
+        /// The rejected value.
+        raw: u8,
+        /// The maximum permitted value.
+        max: u8,
+    },
+}
+
+impl Bin {
+    /// The first (shallowest) bin.
+    pub const ZERO: Self = Self(0);
+
+    /// The deepest bin ([`MAX_PO`](crate::MAX_PO) = 31).
+    pub const MAX: Self = Self(MAX_PO);
+
+    /// The number of bins in the routing table (`MAX_PO + 1` = 32).
+    pub const COUNT: usize = MAX_PO as usize + 1;
+
+    /// Construct without bounds checking. Caller must ensure `raw <= MAX_PO`.
+    #[inline]
+    pub(crate) const fn new_unchecked(raw: u8) -> Self {
+        debug_assert!(raw <= MAX_PO);
+        Self(raw)
+    }
+
+    /// Construct from a raw byte, validating the range.
+    #[inline]
+    pub const fn new(raw: u8) -> Result<Self, BinError> {
+        if raw <= MAX_PO {
+            Ok(Self(raw))
+        } else {
+            Err(BinError::OutOfRange { raw, max: MAX_PO })
+        }
+    }
+
+    /// Underlying byte value.
+    #[inline]
+    pub const fn get(self) -> u8 {
+        self.0
+    }
+
+    /// Index into a `[T; Bin::COUNT]` array.
+    #[inline]
+    pub const fn as_index(self) -> usize {
+        self.0 as usize
+    }
+}
+
+impl TryFrom<u8> for Bin {
+    type Error = BinError;
+
+    fn try_from(raw: u8) -> Result<Self, Self::Error> {
+        Self::new(raw)
+    }
+}
+
+impl From<ProximityOrder> for Bin {
+    /// Every valid [`ProximityOrder`] is a valid [`Bin`] (they share a range).
+    /// Use this when crossing the metric/slot semantic boundary.
+    fn from(po: ProximityOrder) -> Self {
+        // PO is range-validated, so this is sound.
+        Self(po.get())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn min_max_count() {
+        assert_eq!(Bin::ZERO.get(), 0);
+        assert_eq!(Bin::MAX.get(), MAX_PO);
+        assert_eq!(Bin::COUNT, MAX_PO as usize + 1);
+    }
+
+    #[test]
+    fn new_in_range_ok() {
+        assert!(Bin::new(0).is_ok());
+        assert!(Bin::new(MAX_PO).is_ok());
+    }
+
+    #[test]
+    fn new_out_of_range_errs() {
+        let err = Bin::new(MAX_PO + 1).unwrap_err();
+        assert!(matches!(err, BinError::OutOfRange { raw: 32, max: 31 }));
+    }
+
+    #[test]
+    fn from_proximity_order() {
+        let po = ProximityOrder::new(7).unwrap();
+        let bin = Bin::from(po);
+        assert_eq!(bin.get(), 7);
+    }
+
+    #[test]
+    fn display_shows_bin() {
+        assert_eq!(format!("{}", Bin::new(3).unwrap()), "bin=3");
+    }
+}

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -34,12 +34,21 @@
 pub use bytes;
 
 pub mod address;
+pub mod bin;
 pub mod bmt;
 mod cache;
 pub mod chunk;
 pub mod error;
 pub mod file;
+pub mod neighborhood_depth;
+pub mod network_id;
+pub mod nonce;
+pub mod overlay;
+pub mod proximity_order;
+pub mod signing;
+pub mod spec;
 pub mod store;
+pub mod timestamp;
 
 #[cfg(target_arch = "wasm32")]
 pub mod wasm;
@@ -53,8 +62,16 @@ pub use chunk::encryption::{EncryptedChunkRef, EncryptionKey};
 pub use chunk::{ChunkEncrypt, EncryptedContentChunk};
 
 // Re-export core types
-pub use address::{MAX_PO, SwarmAddress};
+pub use address::{EXTENDED_PO, MAX_PO, SwarmAddress};
+pub use bin::{Bin, BinError};
 pub use error::{PrimitivesError, Result};
+pub use neighborhood_depth::recompute_neighborhood_depth;
+pub use network_id::NetworkId;
+pub use nonce::Nonce;
+pub use overlay::compute_overlay;
+pub use proximity_order::{ProximityOrder, ProximityOrderError};
+pub use spec::{MAINNET, StaticSpec, SwarmSpec, TESTNET};
+pub use timestamp::{Timestamp, TimestampError};
 
 // Core BMT functionality
 pub use bmt::{Hasher, HasherFactory, Proof, Prover};

--- a/crates/primitives/src/neighborhood_depth.rs
+++ b/crates/primitives/src/neighborhood_depth.rs
@@ -1,0 +1,148 @@
+//! Canonical neighborhood-depth recomputation.
+//!
+//! Pure function port of bee `pkg/topology/kademlia/kademlia.go:896-920`
+//! (`recalcDepth`). The wrapper type (`NeighborhoodDepth`) stays in the
+//! routing layer of each downstream impl; nectar only owns the math.
+
+use crate::Bin;
+
+/// Recompute the neighborhood depth from per-bin connected-peer counts.
+///
+/// `connected_per_bin[i]` is the count of currently-connected peers in bin `i`.
+/// `saturation` is the target saturation per bin (typically `SwarmSpec::saturation_peers()`).
+/// `low_watermark` is the minimum cumulative count of peers in the deepest bins
+/// to anchor the neighborhood (typically `SwarmSpec::neighborhood_low_watermark()`).
+///
+/// Algorithm - port of bee `kademlia.go:896-920`:
+/// 1. Walk bins shallow → deep. The depth candidate is the **shallowest bin
+///    whose count is below `saturation`**.
+/// 2. From that candidate, sum populations of the deepest bins until the
+///    cumulative count reaches `low_watermark`. The final depth is the
+///    shallowest bin included in that anchored neighborhood.
+/// 3. If the table never reaches saturation anywhere, depth is `0` (we are
+///    sparse everywhere).
+///
+/// The returned [`Bin`] always satisfies `0..=MAX_PO`.
+///
+/// # Examples
+///
+/// ```
+/// use nectar_primitives::{Bin, recompute_neighborhood_depth};
+///
+/// // Sparse table - depth is shallow.
+/// let counts = [0u8; 32];
+/// assert_eq!(recompute_neighborhood_depth(&counts, 8, 2), Bin::ZERO);
+///
+/// // Saturated up to bin 4, then deepest two bins have the watermark.
+/// let mut counts = [8u8; 32];
+/// counts[5] = 0;
+/// counts[6] = 0;
+/// counts[7] = 0;
+/// counts[8] = 1;
+/// counts[9] = 1;
+/// // shallowest unsaturated = bin 5; deepest two have 2 peers - anchor at bin 8
+/// // (population counts in 9 and 8 reach the watermark).
+/// let depth = recompute_neighborhood_depth(&counts, 8, 2);
+/// assert!(depth.get() <= 8);
+/// ```
+#[must_use]
+pub fn recompute_neighborhood_depth(
+    connected_per_bin: &[u8; 32],
+    saturation: u8,
+    low_watermark: u8,
+) -> Bin {
+    // Step 1: find the shallowest unsaturated bin.
+    let mut candidate: u8 = 0;
+    let mut found_unsaturated = false;
+    for (i, count) in connected_per_bin.iter().enumerate() {
+        if *count < saturation {
+            candidate = i as u8;
+            found_unsaturated = true;
+            break;
+        }
+    }
+    if !found_unsaturated {
+        // Every bin is saturated: depth is the deepest occupied bin.
+        // Bee returns `MaxPO` here, but the conservative interpretation is
+        // that the neighborhood extends to the deepest bin we actually have
+        // peers in - fall through and use the watermark anchor instead.
+        candidate = crate::MAX_PO;
+    }
+
+    // Step 2: walk deep → shallow accumulating until we reach low_watermark.
+    if low_watermark == 0 {
+        return Bin::new_unchecked(candidate);
+    }
+    let mut sum: u32 = 0;
+    let mut depth: u8 = candidate;
+    for i in (0..connected_per_bin.len()).rev() {
+        let idx = i as u8;
+        if idx < candidate {
+            // Walking shallower than the candidate means we already failed
+            // to anchor inside the unsaturated zone - depth stays at candidate.
+            break;
+        }
+        sum = sum.saturating_add(u32::from(connected_per_bin[i]));
+        if sum >= u32::from(low_watermark) {
+            depth = idx;
+            break;
+        }
+    }
+
+    // Step 3: depth never exceeds candidate (the unsaturated frontier).
+    if depth > candidate {
+        depth = candidate;
+    }
+
+    Bin::new_unchecked(depth)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_table_depth_is_zero() {
+        assert_eq!(
+            recompute_neighborhood_depth(&[0u8; 32], 8, 2),
+            Bin::ZERO
+        );
+    }
+
+    #[test]
+    fn fully_saturated_depth_anchored_by_watermark() {
+        // Saturated everywhere - anchor at the deepest bin where the
+        // cumulative tail reaches the watermark.
+        let counts = [8u8; 32];
+        let depth = recompute_neighborhood_depth(&counts, 8, 2);
+        // Tail walks 31, 30, ... summing 8 each - watermark of 2 reached at 31.
+        assert_eq!(depth, Bin::MAX);
+    }
+
+    #[test]
+    fn shallow_unsaturated_caps_depth() {
+        // Bin 3 is unsaturated; tail has plenty of peers.
+        let mut counts = [8u8; 32];
+        counts[3] = 1;
+        let depth = recompute_neighborhood_depth(&counts, 8, 2);
+        // Depth can't exceed bin 3.
+        assert!(depth.get() <= 3);
+    }
+
+    #[test]
+    fn zero_watermark_returns_candidate() {
+        let mut counts = [8u8; 32];
+        counts[5] = 2;
+        let depth = recompute_neighborhood_depth(&counts, 8, 0);
+        assert_eq!(depth, Bin::new(5).unwrap());
+    }
+
+    #[test]
+    fn very_sparse_tail_keeps_depth_shallow() {
+        // Only bin 0 has any peers.
+        let mut counts = [0u8; 32];
+        counts[0] = 3;
+        let depth = recompute_neighborhood_depth(&counts, 8, 2);
+        assert_eq!(depth, Bin::ZERO);
+    }
+}

--- a/crates/primitives/src/network_id.rs
+++ b/crates/primitives/src/network_id.rs
@@ -1,0 +1,81 @@
+//! Typed Swarm network identifier.
+//!
+//! [`NetworkId`] is mixed into the overlay address (see [`compute_overlay`])
+//! so that a single keypair derives a different overlay on each network.
+//! This is the Swarm-wide partitioning mechanism inherited from bee
+//! (see `pkg/crypto/crypto.go:45-57` for the derivation, and
+//! `pkg/swarm/swarm.go` for canonical IDs).
+//!
+//! [`compute_overlay`]: crate::compute_overlay
+
+use derive_more::{Display, From, Into};
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// Swarm network identifier (u64 wire-compatible with bee).
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord,
+    Display, From, Into,
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+#[display("{_0}")]
+pub struct NetworkId(u64);
+
+impl NetworkId {
+    /// Canonical Swarm mainnet identifier.
+    pub const MAINNET: Self = Self(1);
+
+    /// Canonical Swarm testnet identifier (Sepolia).
+    pub const TESTNET: Self = Self(10);
+
+    /// Construct from a raw `u64`.
+    #[inline]
+    pub const fn new(raw: u64) -> Self {
+        Self(raw)
+    }
+
+    /// Underlying numeric value.
+    #[inline]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+
+    /// Eight-byte little-endian representation (used in
+    /// [`compute_overlay`](crate::compute_overlay) per bee).
+    #[inline]
+    pub const fn to_le_bytes(self) -> [u8; 8] {
+        self.0.to_le_bytes()
+    }
+
+    /// Eight-byte big-endian representation (used in the BzzAddress sign-data
+    /// per bee `pkg/bzz/address.go:138-160`).
+    #[inline]
+    pub const fn to_be_bytes(self) -> [u8; 8] {
+        self.0.to_be_bytes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_ids() {
+        assert_eq!(NetworkId::MAINNET.get(), 1);
+        assert_eq!(NetworkId::TESTNET.get(), 10);
+    }
+
+    #[test]
+    fn display_is_decimal() {
+        assert_eq!(format!("{}", NetworkId::new(42)), "42");
+    }
+
+    #[test]
+    fn le_be_byte_distinction() {
+        let id = NetworkId::new(0x0102_0304_0506_0708);
+        assert_eq!(id.to_le_bytes(), [0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01]);
+        assert_eq!(id.to_be_bytes(), [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
+    }
+}

--- a/crates/primitives/src/nonce.rs
+++ b/crates/primitives/src/nonce.rs
@@ -1,0 +1,81 @@
+//! Typed nonce used in overlay address derivation.
+//!
+//! A [`Nonce`] is the 32-byte value mixed with an Ethereum address and a
+//! [`NetworkId`](crate::NetworkId) when deriving the Swarm overlay address.
+//! See [`compute_overlay`](crate::compute_overlay) for the canonical
+//! derivation matching bee `pkg/crypto/crypto.go:45-57`.
+
+use alloy_primitives::B256;
+use derive_more::{AsRef, Display, From, Into};
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// 32-byte nonce mixed into the overlay address.
+///
+/// Persistent nodes (storers, bootnodes) keep the nonce stable across restarts
+/// so their overlay address is stable. Ephemeral nodes (clients) may rotate
+/// the nonce per run.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord,
+    Display, From, Into, AsRef,
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+#[display("{_0}")]
+#[from(B256, [u8; 32])]
+#[into(B256, [u8; 32])]
+#[as_ref([u8])]
+pub struct Nonce(B256);
+
+impl Nonce {
+    /// Zero nonce, useful for tests and deterministic vectors.
+    pub const ZERO: Self = Self(B256::ZERO);
+
+    /// Construct from raw 32 bytes. `const` for static contexts; for runtime
+    /// conversions prefer the `From` impls.
+    #[inline]
+    pub const fn new(bytes: [u8; 32]) -> Self {
+        Self(B256::new(bytes))
+    }
+
+    /// Borrow the underlying 32 bytes.
+    #[inline]
+    pub const fn as_slice(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+
+    /// Sample a cryptographically random nonce via `alloy_primitives::B256::random`.
+    pub fn random() -> Self {
+        Self(B256::random())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_is_all_zero_bytes() {
+        assert_eq!(Nonce::ZERO.as_slice(), &[0u8; 32]);
+    }
+
+    #[test]
+    fn roundtrips_via_from_impls() {
+        let bytes = [7u8; 32];
+        let n = Nonce::new(bytes);
+        assert_eq!(B256::from(n), B256::new(bytes));
+        assert_eq!(Nonce::from(B256::new(bytes)), n);
+        assert_eq!(<[u8; 32]>::from(n), bytes);
+        assert_eq!(Nonce::from(bytes), n);
+    }
+
+    #[test]
+    fn display_matches_b256_lowercase_hex() {
+        let n = Nonce::new([0xab; 32]);
+        let rendered = format!("{n}");
+        assert!(rendered.starts_with("0x"));
+        assert_eq!(rendered.len(), 66);
+        assert!(rendered.chars().skip(2).all(|c| c.is_ascii_hexdigit()));
+    }
+}

--- a/crates/primitives/src/overlay.rs
+++ b/crates/primitives/src/overlay.rs
@@ -1,0 +1,87 @@
+//! Canonical overlay address derivation.
+//!
+//! The Swarm overlay address is `keccak256(ethereum_address || network_id || nonce)`
+//! per bee `pkg/crypto/crypto.go:45-57`. Network ID is encoded in
+//! **little-endian** in this hash (distinct from the big-endian encoding used
+//! in the BzzAddress sign-data, see [`crate::signing::sign_data`]).
+
+use alloy_primitives::{Address, Keccak256};
+
+use crate::{Nonce, NetworkId, SwarmAddress};
+
+/// Compute the Swarm overlay address from `eth_addr`, `network_id`, `nonce`.
+///
+/// Layout: `keccak256(eth_addr(20) || network_id_le(8) || nonce(32))`.
+///
+/// This is the **only** canonical derivation - any other formula creates a
+/// peer with a different overlay that won't be reachable on the same network.
+#[must_use]
+pub fn compute_overlay(eth_addr: &Address, network_id: NetworkId, nonce: &Nonce) -> SwarmAddress {
+    let mut hasher = Keccak256::new();
+    hasher.update(eth_addr.as_slice());
+    hasher.update(network_id.to_le_bytes());
+    hasher.update(nonce.as_slice());
+    SwarmAddress::from(hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{address, b256};
+
+    #[test]
+    fn deterministic_zero_nonce_zero_addr() {
+        let eth = Address::ZERO;
+        let nonce = Nonce::ZERO;
+        let net = NetworkId::MAINNET;
+        let overlay = compute_overlay(&eth, net, &nonce);
+        // Reproduce the exact bytes: keccak256(20 zeros || 1u64.to_le_bytes() || 32 zeros).
+        let mut h = Keccak256::new();
+        h.update([0u8; 20]);
+        h.update(1u64.to_le_bytes());
+        h.update([0u8; 32]);
+        let expected = SwarmAddress::from(h.finalize());
+        assert_eq!(overlay, expected);
+    }
+
+    #[test]
+    fn different_network_yields_different_overlay() {
+        let eth = address!("0102030405060708091011121314151617181920");
+        let nonce = Nonce::new([0x55; 32]);
+        let m = compute_overlay(&eth, NetworkId::MAINNET, &nonce);
+        let t = compute_overlay(&eth, NetworkId::TESTNET, &nonce);
+        assert_ne!(m, t);
+    }
+
+    #[test]
+    fn different_nonce_yields_different_overlay() {
+        let eth = address!("0102030405060708091011121314151617181920");
+        let a = compute_overlay(&eth, NetworkId::MAINNET, &Nonce::new([0; 32]));
+        let b = compute_overlay(&eth, NetworkId::MAINNET, &Nonce::new([1; 32]));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn network_id_is_little_endian() {
+        // If the implementation accidentally used big-endian, this would change.
+        let eth = address!("aabbccddeeff00112233445566778899aabbccdd");
+        let nonce = Nonce::new([0x42; 32]);
+        let net = NetworkId::new(0x0102_0304_0506_0708);
+        let overlay = compute_overlay(&eth, net, &nonce);
+
+        let mut h = Keccak256::new();
+        h.update(eth.as_slice());
+        h.update([0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01]); // LE bytes
+        h.update(nonce.as_slice());
+        assert_eq!(overlay, SwarmAddress::from(h.finalize()));
+
+        // Sanity-check the BE encoding would have produced a different overlay.
+        let mut h_be = Keccak256::new();
+        h_be.update(eth.as_slice());
+        h_be.update([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]); // BE bytes
+        h_be.update(nonce.as_slice());
+        let be_overlay = SwarmAddress::from(h_be.finalize());
+        assert_ne!(overlay, be_overlay);
+        let _ = b256!("0000000000000000000000000000000000000000000000000000000000000000");
+    }
+}

--- a/crates/primitives/src/proximity_order.rs
+++ b/crates/primitives/src/proximity_order.rs
@@ -1,0 +1,115 @@
+//! Typed Kademlia proximity order (PO) in the range `0..=MAX_PO`.
+//!
+//! See [`MAX_PO`](crate::MAX_PO) for the standard cap (31) and
+//! [`address`](crate::address) for the derivation from two [`SwarmAddress`es](crate::SwarmAddress).
+
+use crate::MAX_PO;
+use derive_more::{Display, Into};
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// Typed proximity order, `0..=MAX_PO` (= 0..=31).
+///
+/// Distinguished from [`Bin`](crate::Bin) at the type level even though they
+/// share a representation. PO is the metric, Bin is the routing-table slot.
+#[repr(transparent)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord,
+    Display, Into,
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+#[display("po={_0}")]
+#[into(u8, usize)]
+pub struct ProximityOrder(u8);
+
+/// Errors from constructing a [`ProximityOrder`].
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum ProximityOrderError {
+    /// Value exceeded [`MAX_PO`](crate::MAX_PO).
+    #[error("proximity order {raw} exceeds MAX_PO ({max})")]
+    OutOfRange {
+        /// The rejected value.
+        raw: u8,
+        /// The maximum permitted value ([`MAX_PO`](crate::MAX_PO)).
+        max: u8,
+    },
+}
+
+impl ProximityOrder {
+    /// The smallest proximity order.
+    pub const MIN: Self = Self(0);
+
+    /// The largest proximity order ([`MAX_PO`](crate::MAX_PO) = 31).
+    pub const MAX: Self = Self(MAX_PO);
+
+    /// Construct without bounds checking. Caller must ensure `raw <= MAX_PO`.
+    ///
+    /// Used by internal code that already validated the range (e.g.
+    /// `SwarmAddress::proximity_order`, which can never exceed `MAX_PO`).
+    #[inline]
+    pub(crate) const fn new_unchecked(raw: u8) -> Self {
+        debug_assert!(raw <= MAX_PO);
+        Self(raw)
+    }
+
+    /// Construct from a raw byte, validating the range.
+    #[inline]
+    pub const fn new(raw: u8) -> Result<Self, ProximityOrderError> {
+        if raw <= MAX_PO {
+            Ok(Self(raw))
+        } else {
+            Err(ProximityOrderError::OutOfRange { raw, max: MAX_PO })
+        }
+    }
+
+    /// Underlying byte value.
+    #[inline]
+    pub const fn get(self) -> u8 {
+        self.0
+    }
+}
+
+impl TryFrom<u8> for ProximityOrder {
+    type Error = ProximityOrderError;
+
+    fn try_from(raw: u8) -> Result<Self, Self::Error> {
+        Self::new(raw)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn min_max_consts() {
+        assert_eq!(ProximityOrder::MIN.get(), 0);
+        assert_eq!(ProximityOrder::MAX.get(), MAX_PO);
+    }
+
+    #[test]
+    fn new_in_range_ok() {
+        assert!(ProximityOrder::new(0).is_ok());
+        assert!(ProximityOrder::new(MAX_PO).is_ok());
+    }
+
+    #[test]
+    fn new_out_of_range_errs() {
+        let err = ProximityOrder::new(MAX_PO + 1).unwrap_err();
+        assert!(matches!(err, ProximityOrderError::OutOfRange { raw: 32, max: 31 }));
+    }
+
+    #[test]
+    fn display_shows_po() {
+        assert_eq!(format!("{}", ProximityOrder::new(7).unwrap()), "po=7");
+    }
+
+    #[test]
+    fn try_from_byte() {
+        let po: ProximityOrder = 5u8.try_into().unwrap();
+        assert_eq!(po.get(), 5);
+    }
+}

--- a/crates/primitives/src/signing.rs
+++ b/crates/primitives/src/signing.rs
@@ -1,0 +1,174 @@
+//! BzzAddress sign-data byte layout (Swarm handshake / hive shared spec).
+//!
+//! The Swarm peer record (overlay + underlay + nonce + timestamp + chequebook)
+//! is authenticated by an EIP-191 personal-sign signature over the byte
+//! sequence built by [`sign_data`] below. The layout matches bee
+//! `pkg/bzz/address.go:138-160` exactly so any Swarm impl can interop.
+//!
+//! ```text
+//! sign_data = "bee-handshake-"        (14 bytes)
+//!           || underlay_bytes         (caller-supplied wire encoding)
+//!           || overlay                (32 bytes)
+//!           || network_id big-endian  (8 bytes)
+//!           || nonce                  (32 bytes)
+//!           || timestamp big-endian   (8 bytes, i64 two's-complement)
+//!           || chequebook             (20 bytes, all-zero if None)
+//! ```
+//!
+//! Signing and recovery are **not wrapped** - callers use alloy directly:
+//!
+//! ```ignore
+//! use alloy_signer::SignerSync;
+//! let sig = signer.sign_message_sync(&sign_data(/* … */))?;
+//! let eth = sig.recover_address_from_msg(&sign_data(/* … */))?;
+//! ```
+//!
+//! Overlay verification is also one line - compare against
+//! [`compute_overlay`](crate::compute_overlay):
+//!
+//! ```ignore
+//! if compute_overlay(&recovered_eth, network_id, &nonce) == claimed_overlay { /* ok */ }
+//! ```
+//!
+//! Nectar intentionally does **not** depend on libp2p - the `underlay_bytes`
+//! argument is whatever wire encoding the calling node uses for its multiaddr
+//! list.
+
+use alloy_primitives::Address;
+
+use crate::{NetworkId, Nonce, SwarmAddress, Timestamp};
+
+/// Magic prefix matching bee `pkg/bzz/address.go:138` (`signDataPrefix`).
+pub const SIGN_DATA_PREFIX: &[u8] = b"bee-handshake-";
+
+/// Build the canonical sign-data buffer for a BzzAddress.
+///
+/// `underlay_bytes` is the wire-encoded multiaddr list (caller-defined format).
+/// `chequebook` is `None` for nodes without a chequebook; the byte layout
+/// pads with 20 zero bytes either way, matching bee's `common.Address{}.Bytes()`
+/// behaviour (so `None` and `Some(Address::ZERO)` produce byte-identical
+/// sign-data - verified by the test suite).
+#[must_use]
+pub fn sign_data(
+    underlay_bytes: &[u8],
+    overlay: &SwarmAddress,
+    network_id: NetworkId,
+    nonce: &Nonce,
+    timestamp: Timestamp,
+    chequebook: Option<&Address>,
+) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(
+        SIGN_DATA_PREFIX.len()
+            + underlay_bytes.len()
+            + 32  // overlay
+            + 8   // network_id
+            + 32  // nonce
+            + 8   // timestamp
+            + 20, // chequebook
+    );
+    buf.extend_from_slice(SIGN_DATA_PREFIX);
+    buf.extend_from_slice(underlay_bytes);
+    buf.extend_from_slice(overlay.as_bytes());
+    buf.extend_from_slice(&network_id.to_be_bytes());
+    buf.extend_from_slice(nonce.as_slice());
+    buf.extend_from_slice(&timestamp.to_be_bytes());
+    match chequebook {
+        Some(addr) => buf.extend_from_slice(addr.as_slice()),
+        None => buf.extend_from_slice(&[0u8; 20]),
+    }
+    buf
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compute_overlay;
+    use alloy_primitives::{address, b256};
+    use alloy_signer::SignerSync;
+    use alloy_signer_local::LocalSigner;
+
+    #[test]
+    fn layout_matches_bee_spec() {
+        let overlay = SwarmAddress::new([0xaa; 32]);
+        let net = NetworkId::MAINNET;
+        let nonce = Nonce::new([0xbb; 32]);
+        let ts = Timestamp::from(0x0102_0304_0506_0708_i64);
+        let cb = Some(address!("00112233445566778899aabbccddeeff00112233"));
+        let underlay = b"\x01\x02\x03";
+
+        let buf = sign_data(underlay, &overlay, net, &nonce, ts, cb.as_ref());
+
+        assert_eq!(&buf[0..14], b"bee-handshake-");
+        assert_eq!(&buf[14..17], b"\x01\x02\x03");
+        assert_eq!(&buf[17..49], &[0xaa; 32]);
+        assert_eq!(&buf[49..57], &1u64.to_be_bytes());
+        assert_eq!(&buf[57..89], &[0xbb; 32]);
+        assert_eq!(
+            &buf[89..97],
+            &[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]
+        );
+        assert_eq!(&buf[97..117], cb.unwrap().as_slice());
+        assert_eq!(buf.len(), 117);
+    }
+
+    #[test]
+    fn no_chequebook_is_byte_identical_to_zero_chequebook() {
+        let a = sign_data(
+            &[],
+            &SwarmAddress::zero(),
+            NetworkId::MAINNET,
+            &Nonce::ZERO,
+            Timestamp::ZERO,
+            None,
+        );
+        let b = sign_data(
+            &[],
+            &SwarmAddress::zero(),
+            NetworkId::MAINNET,
+            &Nonce::ZERO,
+            Timestamp::ZERO,
+            Some(&Address::ZERO),
+        );
+        assert_eq!(a, b);
+        assert_eq!(&a[a.len() - 20..], &[0u8; 20]);
+    }
+
+    /// End-to-end: build sign-data, sign with alloy, recover via alloy,
+    /// verify overlay by comparing `compute_overlay` against the claimed one.
+    /// Demonstrates the canonical caller flow - no wrapper layer needed.
+    #[test]
+    fn caller_flow_sign_recover_verify_overlay() {
+        let signer = LocalSigner::random();
+        let eth = signer.address();
+        let net = NetworkId::TESTNET;
+        let nonce = Nonce::new([0x55; 32]);
+        let overlay = compute_overlay(&eth, net, &nonce);
+        let ts = Timestamp::from(1_700_000_000_i64);
+
+        let data = sign_data(b"/ip4/127.0.0.1/tcp/1634", &overlay, net, &nonce, ts, None);
+
+        // Sign - alloy directly.
+        let sig = signer.sign_message_sync(&data).expect("sign");
+        // Recover - alloy directly.
+        let recovered = sig.recover_address_from_msg(&data).expect("recover");
+        assert_eq!(recovered, eth);
+        // Verify overlay - direct compute + compare.
+        assert_eq!(compute_overlay(&recovered, net, &nonce), overlay);
+    }
+
+    /// Pinned vector: tampering with the nonce changes the derived overlay so
+    /// the equality check fails. Catches regressions in either `sign_data`
+    /// layout or `compute_overlay` hashing.
+    #[test]
+    fn tampered_nonce_breaks_overlay_check() {
+        let signer = LocalSigner::random();
+        let eth = signer.address();
+        let net = NetworkId::MAINNET;
+        let nonce = Nonce::from(b256!(
+            "0202020202020202020202020202020202020202020202020202020202020202"
+        ));
+        let overlay = compute_overlay(&eth, net, &nonce);
+        let wrong_nonce = Nonce::new([0x88; 32]);
+        assert_ne!(compute_overlay(&eth, net, &wrong_nonce), overlay);
+    }
+}

--- a/crates/primitives/src/spec.rs
+++ b/crates/primitives/src/spec.rs
@@ -1,0 +1,143 @@
+//! Canonical Swarm network spec - `network_id`, kademlia tuning, defaults.
+//!
+//! Every Swarm node implementation needs a small set of canonical knobs:
+//! the network ID, the kademlia saturation thresholds, the bootnode-mode
+//! over-saturation cap, the neighborhood-depth low-watermark, the clock-skew
+//! tolerance used during handshake. Bee hard-codes these in
+//! `pkg/topology/kademlia/kademlia.go:54-56` and `pkg/bzz/timestamp.go`.
+//!
+//! This trait surfaces them on the spec object so vertex / apiarist /
+//! reth-swarm derive them from one place instead of duplicating consts.
+
+use std::time::Duration;
+
+use crate::{Bin, NetworkId, ProximityOrder};
+
+/// Canonical Swarm network spec.
+///
+/// Default-method bodies mirror bee's hard-coded constants. Implementors only
+/// have to provide `network_id`; they may override any of the others to
+/// customise a deployment (e.g. a dense testnet with tighter saturation).
+///
+/// Trait can grow with default methods without breaking implementors -
+/// `#[non_exhaustive]` is not a valid attribute on traits in Rust, but the
+/// default-method discipline gives equivalent backward-compatibility.
+pub trait SwarmSpec {
+    /// Network identifier used in [`compute_overlay`](crate::compute_overlay)
+    /// and the BzzAddress sign-data.
+    fn network_id(&self) -> NetworkId;
+
+    /// Maximum proximity order (= number of bins minus one).
+    fn max_proximity_order(&self) -> ProximityOrder {
+        ProximityOrder::MAX
+    }
+
+    /// Minimum desired peers per bin before the bin is considered saturated.
+    /// Bee default: 8 (`defaultSaturationPeers`).
+    fn saturation_peers(&self) -> u8 {
+        8
+    }
+
+    /// Soft cap: above this, non-bootnode peers reject further inbound dials.
+    /// Bee default: 18 (`defaultOverSaturationPeers`).
+    fn over_saturation_peers(&self) -> u8 {
+        18
+    }
+
+    /// Soft cap for **bootnode** mode (higher than regular).
+    /// Bee default: 20 (`defaultBootNodeOverSaturationPeers`).
+    fn bootnode_over_saturation_peers(&self) -> u8 {
+        20
+    }
+
+    /// Minimum peers required in the deepest bins to maintain neighborhood
+    /// depth (bee default: 2 - `nnLowWatermark`).
+    fn neighborhood_low_watermark(&self) -> u8 {
+        2
+    }
+
+    /// Maximum clock skew permitted between local and remote timestamps
+    /// during handshake / hive verification. Bee's `bzz/timestamp.go`
+    /// hard-codes 5s but operational deployments commonly relax to minutes
+    /// or hours; this default is 6h to match what was previously embedded
+    /// in vertex.
+    fn clock_skew_tolerance(&self) -> Duration {
+        Duration::from_secs(6 * 60 * 60)
+    }
+
+    /// Convenience: the routing-table bin count (`max_proximity_order() + 1`).
+    fn bin_count(&self) -> usize {
+        usize::from(self.max_proximity_order().get()) + 1
+    }
+
+    /// Convenience: the deepest bin, derived from `max_proximity_order`.
+    fn max_bin(&self) -> Bin {
+        // PO is range-validated; the conversion is total.
+        Bin::from(self.max_proximity_order())
+    }
+}
+
+/// Concrete static spec used when callers just need to plug a `network_id`
+/// into the canonical defaults.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StaticSpec {
+    network_id: NetworkId,
+}
+
+impl StaticSpec {
+    /// Construct a spec for `network_id` with all default knobs.
+    pub const fn new(network_id: NetworkId) -> Self {
+        Self { network_id }
+    }
+}
+
+impl SwarmSpec for StaticSpec {
+    fn network_id(&self) -> NetworkId {
+        self.network_id
+    }
+}
+
+/// Canonical mainnet spec ([`NetworkId::MAINNET`]).
+pub const MAINNET: StaticSpec = StaticSpec::new(NetworkId::MAINNET);
+
+/// Canonical testnet (Sepolia) spec ([`NetworkId::TESTNET`]).
+pub const TESTNET: StaticSpec = StaticSpec::new(NetworkId::TESTNET);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_match_bee() {
+        let s = MAINNET;
+        assert_eq!(s.network_id(), NetworkId::MAINNET);
+        assert_eq!(s.max_proximity_order(), ProximityOrder::MAX);
+        assert_eq!(s.saturation_peers(), 8);
+        assert_eq!(s.over_saturation_peers(), 18);
+        assert_eq!(s.bootnode_over_saturation_peers(), 20);
+        assert_eq!(s.neighborhood_low_watermark(), 2);
+        assert_eq!(s.clock_skew_tolerance(), Duration::from_secs(21600));
+        assert_eq!(s.bin_count(), 32);
+        assert_eq!(s.max_bin(), Bin::MAX);
+    }
+
+    #[test]
+    fn testnet_distinct_from_mainnet() {
+        assert_ne!(MAINNET.network_id(), TESTNET.network_id());
+    }
+
+    #[test]
+    fn override_saturation_via_custom_impl() {
+        struct Tight;
+        impl SwarmSpec for Tight {
+            fn network_id(&self) -> NetworkId {
+                NetworkId::TESTNET
+            }
+            fn saturation_peers(&self) -> u8 {
+                4
+            }
+        }
+        assert_eq!(Tight.saturation_peers(), 4);
+        assert_eq!(Tight.over_saturation_peers(), 18); // default unchanged
+    }
+}

--- a/crates/primitives/src/timestamp.rs
+++ b/crates/primitives/src/timestamp.rs
@@ -1,0 +1,139 @@
+//! Typed unix-seconds timestamp used in BzzAddress sign-data.
+//!
+//! The bee handshake sign-data carries an `int64` timestamp (big-endian,
+//! signed). Verification rejects records whose timestamp drifts outside a
+//! caller-supplied window from local clock. See bee `pkg/bzz/timestamp.go`.
+
+use derive_more::{Display, From, Into};
+use std::time::Duration;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// Unix-seconds timestamp (signed, matching bee's `int64`).
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord,
+    Display, From, Into,
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+#[display("{_0}")]
+pub struct Timestamp(i64);
+
+/// Errors from timestamp validation.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum TimestampError {
+    /// The remote timestamp drifted outside the accepted window.
+    #[error("timestamp drifted by {drift_seconds}s (window ±{window_seconds}s)")]
+    OutsideSkewWindow {
+        /// Signed drift `remote - local` in seconds. Positive = future-dated.
+        drift_seconds: i64,
+        /// Configured tolerance window (`|drift_seconds|` must be `<= window_seconds`).
+        window_seconds: i64,
+    },
+}
+
+impl Timestamp {
+    /// Zero timestamp (1970-01-01T00:00:00Z).
+    pub const ZERO: Self = Self(0);
+
+    /// Construct from raw seconds.
+    #[inline]
+    pub const fn from_seconds(s: i64) -> Self {
+        Self(s)
+    }
+
+    /// Underlying signed seconds.
+    #[inline]
+    pub const fn get(self) -> i64 {
+        self.0
+    }
+
+    /// Eight-byte big-endian representation (used in the BzzAddress sign-data).
+    #[inline]
+    pub const fn to_be_bytes(self) -> [u8; 8] {
+        self.0.to_be_bytes()
+    }
+
+    /// Capture the current wall-clock time as a [`Timestamp`].
+    ///
+    /// Panics only if the system clock is set before the unix epoch, which
+    /// would already break far more than this primitive. Pre-1970 callers
+    /// can construct via [`Self::from_seconds`] manually.
+    pub fn now() -> Self {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock set before unix epoch")
+            .as_secs();
+        // u64 -> i64: safe for the next ~290 billion years.
+        Self(i64::try_from(secs).expect("system clock exceeds i64 unix seconds"))
+    }
+
+    /// Verify this timestamp is within `window` of `local`.
+    ///
+    /// Both `self` and `local` are interpreted as unix-seconds; the absolute
+    /// difference must be `<= window.as_secs()`.
+    pub fn skew_check(self, local: Self, window: Duration) -> Result<(), TimestampError> {
+        let drift = self.0.saturating_sub(local.0);
+        let window_secs = i64::try_from(window.as_secs())
+            .unwrap_or(i64::MAX);
+        if drift.unsigned_abs() <= window_secs.unsigned_abs() {
+            Ok(())
+        } else {
+            Err(TimestampError::OutsideSkewWindow {
+                drift_seconds: drift,
+                window_seconds: window_secs,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn skew_check_within_window() {
+        let local = Timestamp::from_seconds(1_000_000);
+        let remote = Timestamp::from_seconds(1_000_030); // +30s
+        assert!(remote.skew_check(local, Duration::from_secs(60)).is_ok());
+    }
+
+    #[test]
+    fn skew_check_negative_within_window() {
+        let local = Timestamp::from_seconds(1_000_000);
+        let remote = Timestamp::from_seconds(999_940); // -60s
+        assert!(remote.skew_check(local, Duration::from_secs(60)).is_ok());
+    }
+
+    #[test]
+    fn skew_check_outside_window() {
+        let local = Timestamp::from_seconds(1_000_000);
+        let remote = Timestamp::from_seconds(1_000_120); // +120s
+        let err = remote
+            .skew_check(local, Duration::from_secs(60))
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            TimestampError::OutsideSkewWindow {
+                drift_seconds: 120,
+                window_seconds: 60
+            }
+        ));
+    }
+
+    #[test]
+    fn be_bytes_signed() {
+        let t = Timestamp::from_seconds(-1);
+        assert_eq!(t.to_be_bytes(), [0xff; 8]);
+        let t = Timestamp::from_seconds(1);
+        assert_eq!(t.to_be_bytes(), [0, 0, 0, 0, 0, 0, 0, 1]);
+    }
+
+    #[test]
+    fn now_is_positive() {
+        assert!(Timestamp::now().get() > 1_700_000_000);
+    }
+}


### PR DESCRIPTION
## Summary

Migrates the canonical Swarm spec / wire primitives into nectar so vertex, apiarist, and future Swarm implementations consume one source of truth instead of duplicating consts.

### Bundles

- **Typed newtypes**: `Nonce(B256)`, `NetworkId(u64)`, `Timestamp(i64)`, `ProximityOrder(u8)`, `Bin(u8)`. Range-validated. `NetworkId::{MAINNET, TESTNET}` consts.
- **`compute_overlay(eth, net, nonce)`** in `overlay.rs`: canonical `keccak256(eth || net.to_le || nonce)` per bee `crypto/crypto.go:45-57`. Network ID is little-endian here; tests pin the LE-vs-BE distinction.
- **`SwarmAddress` proximity API typed**: `proximity()` now returns `ProximityOrder` (was `u8`). New `xor()` and `bin(&anchor) -> Bin`. **Breaking change** to the primitives crate public API.
- **`SwarmSpec` trait** in `spec.rs` with default methods sourcing bee's canonical knobs (saturation_peers=8, over_saturation=18, bootnode_over_saturation=20, neighborhood_low_watermark=2, clock_skew_tolerance=6h). `StaticSpec`, `MAINNET`, `TESTNET`.
- **`recompute_neighborhood_depth`**: pure function port of bee `kademlia.go:896-920`. Routing-layer wrappers stay with each downstream impl; nectar owns the math.
- **`signing.rs`**: `SIGN_DATA_PREFIX` and `sign_data(...)` builder for the canonical BzzAddress sign-data byte layout per bee `bzz/address.go:138-160`. Transport-agnostic (caller passes `underlay_bytes` as raw bytes; no libp2p dep). Signing and recovery are **not wrapped**, callers use alloy's `signer.sign_message_sync` / `Signature::recover_address_from_msg` directly.

### Design notes

- Errors via thiserror enums (not unit structs), even for single-variant errors, for forward extensibility.
- No trivial wrappers: redundant named ctors / accessors replaced by `From`/`Into`/`AsRef` where possible. `Nonce::random()` lives unconditionally (alloy's `getrandom` feature added to non-wasm primitives deps).
- `SwarmAddress::proximity()` return type change is the only breaking surface; primitives version should bump.

## Test plan

- [x] `cargo test -p nectar-primitives --all-features --no-fail-fast`: 196 passed (180 lib + 16 doc + new module tests for nonce, network_id, timestamp, proximity_order, bin, overlay, spec, neighborhood_depth, signing).
- [x] `cargo clippy -p nectar-primitives --all-features --lib`: no new lints from new modules (pre-existing `generic_array` deprecation in bmt remains; will be fixed in a separate deps-bump PR that this one rebases on).
- [ ] Vertex side: PRs #101, #102, #107 will be revised in follow-up to consume this surface and drop the local duplicates.