### PR TITLE
chore(deps): ignore RUSTSEC-2026-0173 (proc-macro-error2 unmaintained)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,13 @@
+# cargo-audit configuration
+# https://rustsec.org/
+
+[advisories]
+# Ignored advisories - build-time only dependencies that don't affect runtime
+ignore = [
+    # proc-macro-error2 is unmaintained but pulled in by alloy-sol-macro &
+    # alloy-sol-macro-expander as a compile-time proc-macro dependency. The latest
+    # alloy-core (1.6.0) and its main branch still depend on it, so there is no
+    # upstream version to bump to. Build-time only, never shipped in the binary or
+    # wasm artifact, no runtime reachability.
+    "RUSTSEC-2026-0173", # proc-macro-error2 unmaintained - via alloy-sol-macro-expander
+]


### PR DESCRIPTION
RUSTSEC-2026-0173 flags `proc-macro-error2` as unmaintained (informational, not a vulnerability).

It enters the tree only through `alloy-sol-macro` and `alloy-sol-macro-expander` as a compile-time proc-macro dependency. The latest alloy-core (1.6.0) and its main branch still depend on it, so there is no upstream version to bump to. It is build-time only, never shipped in the binary or wasm artifact, and has no runtime reachability.

Adds the first `.cargo/audit.toml` for the repo, scoped to this advisory.

Closes #44