### PR TITLE
chore(release): make workspace crates publishable on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.87"
 authors = ["Nexum Contributors"]
 license = "AGPL-3.0-or-later"
 homepage = "https://nxm-rs.github.io/nectar"
-repository = "https://nxm-rs.github.io/nectar"
+repository = "https://github.com/nxm-rs/nectar"
 exclude = ["benches/", "tests/"]
 
 [workspace.lints.rust]
@@ -35,12 +35,12 @@ check.all_targets = true
 
 [workspace.dependencies]
 # nectar crates
-nectar-contracts = { path = "crates/contracts" }
-nectar-mantaray = { path = "crates/mantaray" }
-nectar-primitives = { path = "crates/primitives" }
-nectar-swarms = { path = "crates/swarms" }
-nectar-postage = { path = "crates/postage" }
-nectar-postage-issuer = { path = "crates/postage-issuer" }
+nectar-contracts = { version = "0.1.0", path = "crates/contracts" }
+nectar-mantaray = { version = "0.1.0", path = "crates/mantaray" }
+nectar-primitives = { version = "0.1.0", path = "crates/primitives" }
+nectar-swarms = { version = "0.1.0", path = "crates/swarms" }
+nectar-postage = { version = "0.1.0", path = "crates/postage" }
+nectar-postage-issuer = { version = "0.1.0", path = "crates/postage-issuer" }
 
 # alloy
 alloy-primitives = { version = "1.6", default-features = false }

--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -9,6 +9,8 @@ homepage.workspace = true
 repository.workspace = true
 exclude.workspace = true
 description = "Swarm storage incentive contract bindings and addresses"
+documentation = "https://docs.rs/nectar-contracts"
+readme = "README.md"
 keywords = ["swarm", "ethereum", "contracts", "no_std"]
 categories = ["no-std", "data-structures"]
 
@@ -30,3 +32,7 @@ proptest = { workspace = true }
 default = ["std"]
 std = ["alloy-primitives/std", "alloy-sol-types/std", "serde?/std"]
 serde = ["dep:serde", "alloy-primitives/serde"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/contracts/README.md
+++ b/crates/contracts/README.md
@@ -1,0 +1,18 @@
+# nectar-contracts
+
+Swarm storage incentive contract bindings and deployed contract addresses for Ethereum Swarm networks.
+
+Part of the [nectar](https://github.com/nxm-rs/nectar) workspace, a collection of low-level Ethereum Swarm primitives in Rust. See the [workspace README](https://github.com/nxm-rs/nectar) for the full crate list and project context.
+
+## Usage
+
+```toml
+[dependencies]
+nectar-contracts = "0.1"
+```
+
+This crate is `no_std` compatible (default features enable `std`).
+
+## License
+
+AGPL-3.0-or-later. See [LICENSE](https://github.com/nxm-rs/nectar/blob/main/LICENSE).

--- a/crates/mantaray/Cargo.toml
+++ b/crates/mantaray/Cargo.toml
@@ -3,10 +3,14 @@ name = "nectar-mantaray"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+exclude.workspace = true
 description = "Mantaray manifest trie for Ethereum Swarm"
+documentation = "https://docs.rs/nectar-mantaray"
+readme = "README.md"
 keywords = ["swarm", "ethereum", "manifest", "mantaray", "trie"]
 categories = ["data-structures"]
 
@@ -37,3 +41,7 @@ default = ["std"]
 std = ["alloy-primitives/std", "thiserror/std", "serde_json/std", "rand", "nectar-primitives/std"]
 serde = ["dep:serde", "alloy-primitives/serde"]
 encryption = ["nectar-primitives/encryption"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/mantaray/README.md
+++ b/crates/mantaray/README.md
@@ -1,0 +1,16 @@
+# nectar-mantaray
+
+Mantaray manifest trie for Ethereum Swarm. Maps human-readable paths (e.g. `index.html`, `img/logo.png`) to content-addressed chunk references, with XOR obfuscation, versioned binary serialisation, per-path metadata, and efficient partial updates via lazy loading and dirty-reference tracking.
+
+Part of the [nectar](https://github.com/nxm-rs/nectar) workspace, a collection of low-level Ethereum Swarm primitives in Rust. See the [workspace README](https://github.com/nxm-rs/nectar) for the full crate list and project context.
+
+## Usage
+
+```toml
+[dependencies]
+nectar-mantaray = "0.1"
+```
+
+## License
+
+AGPL-3.0-or-later. See [LICENSE](https://github.com/nxm-rs/nectar/blob/main/LICENSE).

--- a/crates/postage-issuer/Cargo.toml
+++ b/crates/postage-issuer/Cargo.toml
@@ -9,6 +9,8 @@ homepage.workspace = true
 repository.workspace = true
 exclude.workspace = true
 description = "Postage stamp issuing and signing for Ethereum Swarm"
+documentation = "https://docs.rs/nectar-postage-issuer"
+readme = "README.md"
 keywords = ["swarm", "ethereum", "postage", "signing"]
 categories = ["cryptography", "data-structures"]
 
@@ -16,7 +18,7 @@ categories = ["cryptography", "data-structures"]
 workspace = true
 
 [dependencies]
-nectar-postage = { path = "../postage" }
+nectar-postage = { workspace = true }
 nectar-primitives = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy-signer = { workspace = true }
@@ -63,3 +65,7 @@ parallel = ["dep:rayon", "std"]
 
 # Arbitrary trait implementations for property-based testing
 arbitrary = ["nectar-postage/arbitrary", "nectar-primitives/arbitrary"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/postage-issuer/README.md
+++ b/crates/postage-issuer/README.md
@@ -1,0 +1,16 @@
+# nectar-postage-issuer
+
+Postage stamp issuing and signing for Ethereum Swarm, including high-performance stamp issuance with optional parallel signing via rayon.
+
+Part of the [nectar](https://github.com/nxm-rs/nectar) workspace, a collection of low-level Ethereum Swarm primitives in Rust. See the [workspace README](https://github.com/nxm-rs/nectar) for the full crate list and project context.
+
+## Usage
+
+```toml
+[dependencies]
+nectar-postage-issuer = "0.1"
+```
+
+## License
+
+AGPL-3.0-or-later. See [LICENSE](https://github.com/nxm-rs/nectar/blob/main/LICENSE).

--- a/crates/postage/Cargo.toml
+++ b/crates/postage/Cargo.toml
@@ -9,6 +9,8 @@ homepage.workspace = true
 repository.workspace = true
 exclude.workspace = true
 description = "Postage stamp primitives for Ethereum Swarm"
+documentation = "https://docs.rs/nectar-postage"
+readme = "README.md"
 keywords = ["swarm", "ethereum", "postage", "no_std"]
 categories = ["no-std", "data-structures"]
 
@@ -59,3 +61,7 @@ parallel = ["dep:rayon", "std"]
 
 # Arbitrary trait implementations for property-based testing.
 arbitrary = ["dep:arbitrary", "nectar-primitives/arbitrary", "alloy-primitives/arbitrary"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/postage/README.md
+++ b/crates/postage/README.md
@@ -1,0 +1,18 @@
+# nectar-postage
+
+Postage stamp primitives for Ethereum Swarm: stamp and batch types, bucket math, and stamp verification (with optional parallel verification via rayon).
+
+Part of the [nectar](https://github.com/nxm-rs/nectar) workspace, a collection of low-level Ethereum Swarm primitives in Rust. See the [workspace README](https://github.com/nxm-rs/nectar) for the full crate list and project context.
+
+## Usage
+
+```toml
+[dependencies]
+nectar-postage = "0.1"
+```
+
+This crate is `no_std` compatible (default features enable `std`).
+
+## License
+
+AGPL-3.0-or-later. See [LICENSE](https://github.com/nxm-rs/nectar/blob/main/LICENSE).

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -3,9 +3,16 @@ name = "nectar-primitives"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+exclude.workspace = true
+description = "Core primitives for Ethereum Swarm: chunks, addresses, and binary merkle trees"
+documentation = "https://docs.rs/nectar-primitives"
+readme = "README.md"
+keywords = ["swarm", "ethereum", "chunk", "bmt", "storage"]
+categories = ["data-structures", "cryptography"]
 
 [lints]
 workspace = true
@@ -106,3 +113,7 @@ harness = false
 name = "encryption_bench"
 harness = false
 required-features = ["encryption"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/primitives/README.md
+++ b/crates/primitives/README.md
@@ -1,0 +1,25 @@
+# nectar-primitives
+
+Core primitives for Ethereum Swarm: content-addressed and single-owner chunks, Swarm addresses, and the Binary Merkle Tree (BMT) hasher with proof generation.
+
+Part of the [nectar](https://github.com/nxm-rs/nectar) workspace, a collection of low-level Ethereum Swarm primitives in Rust. See the [workspace README](https://github.com/nxm-rs/nectar) for the full crate list and project context.
+
+## Usage
+
+```toml
+[dependencies]
+nectar-primitives = "0.1"
+```
+
+```rust
+use nectar_primitives::DefaultContentChunk;
+
+let chunk = DefaultContentChunk::new(b"Hello, world!".as_slice()).unwrap();
+let address = chunk.address();
+```
+
+This crate is `no_std` compatible (default features enable `std`).
+
+## License
+
+AGPL-3.0-or-later. See [LICENSE](https://github.com/nxm-rs/nectar/blob/main/LICENSE).

--- a/crates/primitives/examples/wasm-demo/Cargo.toml
+++ b/crates/primitives/examples/wasm-demo/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 edition = "2021"
 description = "WASM demo for BMT hasher"
 license = "AGPL-3.0-or-later"
+publish = false
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/crates/swarms/Cargo.toml
+++ b/crates/swarms/Cargo.toml
@@ -9,6 +9,8 @@ homepage.workspace = true
 repository.workspace = true
 exclude.workspace = true
 description = "Canonical type definitions for Ethereum Swarm networks"
+documentation = "https://docs.rs/nectar-swarms"
+readme = "README.md"
 keywords = ["swarm", "ethereum", "network", "no_std"]
 categories = ["no-std", "data-structures"]
 
@@ -32,3 +34,7 @@ default = ["std"]
 std = ["strum/std", "alloy-chains/std", "serde?/std"]
 serde = ["dep:serde", "alloy-chains/serde"]
 arbitrary = ["alloy-chains/arbitrary"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/swarms/README.md
+++ b/crates/swarms/README.md
@@ -1,0 +1,18 @@
+# nectar-swarms
+
+Canonical type definitions for Ethereum Swarm networks: network identifiers (mainnet, testnet, and others) and their associated parameters.
+
+Part of the [nectar](https://github.com/nxm-rs/nectar) workspace, a collection of low-level Ethereum Swarm primitives in Rust. See the [workspace README](https://github.com/nxm-rs/nectar) for the full crate list and project context.
+
+## Usage
+
+```toml
+[dependencies]
+nectar-swarms = "0.1"
+```
+
+This crate is `no_std` compatible (default features enable `std`).
+
+## License
+
+AGPL-3.0-or-later. See [LICENSE](https://github.com/nxm-rs/nectar/blob/main/LICENSE).


### PR DESCRIPTION
## Publish-readiness report

This PR adds the crates.io metadata and fixes the mechanical publishability blockers across the workspace. Scope is metadata, READMEs, and publishability only. No dependency version bumps and no source logic changes.

### Crates inventory

Publishable (6):

| Crate | Role |
|---|---|
| `nectar-primitives` | chunks, addresses, BMT hasher and proofs (leaf) |
| `nectar-contracts` | storage-incentive contract bindings and addresses (leaf) |
| `nectar-swarms` | canonical network type definitions (leaf) |
| `nectar-postage` | postage stamp primitives, depends on primitives |
| `nectar-mantaray` | mantaray manifest trie, depends on primitives |
| `nectar-postage-issuer` | stamp issuing and signing, depends on postage and primitives |

Internal, not published:

| Crate | Status |
|---|---|
| `nectar-wasm-demo` (`crates/wasm-demo`) | already `publish = false` |
| `bmt-wasm-demo` (`crates/primitives/examples/wasm-demo`) | set `publish = false` in this PR |

### Dependency graph and recommended publish order

```
primitives, contracts, swarms   (leaves, any order)
        -> postage, mantaray    (depend on primitives)
        -> postage-issuer       (depends on postage + primitives)
```

Publish order: `nectar-primitives`, `nectar-contracts`, `nectar-swarms`, then `nectar-postage` and `nectar-mantaray`, then `nectar-postage-issuer`.

### What was fixed

- Workspace `repository` pointed at the GitHub Pages site (`nxm-rs.github.io/nectar`); changed to the source repo `https://github.com/nxm-rs/nectar`. `homepage` keeps the Pages site.
- Internal `nectar-*` workspace dependencies were bare `path` deps with no `version`, which crates.io rejects. Added `version = "0.1.0"` alongside each `path` so the published crates carry a registry version and cargo still uses the local path during development.
- `nectar-postage-issuer` depended on `nectar-postage` via a direct `path = "../postage"`. Switched to `nectar-postage = { workspace = true }` so it inherits the path-and-version pair.
- `nectar-primitives` was missing `authors`, `exclude`, `description`, `keywords`, and `categories`. Added all of them.
- `nectar-mantaray` was missing `authors` and `exclude`. Added both.
- Added `documentation` (docs.rs URL), `readme`, and a `[package.metadata.docs.rs]` block (`all-features` + `--cfg docsrs`) to every publishable crate. The workspace-level `[workspace.metadata.docs.rs]` is not inherited by member crates, and `contracts`, `postage`, and `swarms` gate nightly `doc_cfg` behind `cfg(docsrs)`, so the per-crate block is required for correct docs.rs builds.
- Added a short per-crate `README.md` to each publishable crate, each referencing the workspace.

### Dependency publishability

- No `git` dependencies anywhere in the workspace. No git-dep blocker.
- After this PR every internal cross-crate dependency carries both a `path` and a `version`.

### Verification

- `cargo build --workspace`: passes.
- `cargo doc --no-deps --workspace`: builds (only pre-existing rustdoc intra-doc link warnings, unchanged by this PR).
- `cargo publish --dry-run` for the three leaf crates passes cleanly:
  - `nectar-swarms`: Packaged 8 files, verified, dry-run upload aborted as expected.
  - `nectar-contracts`: verified, dry-run upload aborted as expected.
  - `nectar-primitives`: verified, dry-run upload aborted as expected.
- `cargo package` for `nectar-postage` succeeds; the registry verify step fails only because `nectar-primitives` is not on crates.io yet. Same applies to `nectar-mantaray` and `nectar-postage-issuer`. This is expected: dependent crates can only be dry-run verified after their deps are actually published, so the order above is the real gate.
- Benches and tests are correctly excluded from packages (the workspace `exclude = ["benches/", "tests/"]` now applies to `nectar-primitives` too, which was previously missing `exclude`). The encryption test vector `go_vector_4096.hex` (8 KiB) is retained; it is small and used by tests.

### Remaining blockers and owner decisions

1. crates.io clippy/compile state, not a metadata issue and out of scope here: `cargo clippy --all-targets --all-features -- -D warnings` fails with compile errors in test and bench code. The `Cargo.lock` resolves `rand` to 0.10.1 while the code uses the pre-0.10 API (`ThreadRng::fill`, `random`, `random_range`). This is a dependency-version problem owned by the RUSTSEC/version work, not this metadata PR. The library targets themselves build, so publish dry-runs pass, but this should be resolved before tagging a release.
2. Initial version numbers: all crates are pinned to `0.1.0`. Owner decision on whether `0.1.0` is the intended first published version for each crate.
3. License: all crates use `AGPL-3.0-or-later`. Confirm AGPL is the intended public license for primitives that other Swarm consumers are meant to import. This is a deliberate strong-copyleft choice and worth an explicit sign-off before first publish.
4. Public visibility: confirm all six crates above should be public on crates.io. The two demo crates are `publish = false`.
5. Pre-release wording: the workspace `README.md` still says "Not yet on crates.io" and the quick-start shows a `git` dependency. Update once the first release lands (left unchanged here to avoid pre-announcing).