### PR TITLE
chore: raise MSRV to 1.92 and reconcile rand 0.10 usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.87"
+rust-version = "1.92"
 authors = ["Nexum Contributors"]
 license = "AGPL-3.0-or-later"
 homepage = "https://nxm-rs.github.io/nectar"

--- a/crates/mantaray/src/codec.rs
+++ b/crates/mantaray/src/codec.rs
@@ -33,9 +33,9 @@ impl VersionHash {
     }
 
     fn from_bytes(bytes: &[u8]) -> Option<Self> {
-        if bytes == &Self::V01_BYTES {
+        if bytes == Self::V01_BYTES {
             Some(Self::V01)
-        } else if bytes == &Self::V02_BYTES {
+        } else if bytes == Self::V02_BYTES {
             Some(Self::V02)
         } else {
             None
@@ -696,8 +696,7 @@ mod tests {
     fn decode_bee_legacy_ref_size_zero_empty_node() {
         // v0.2 layout: 32 obfuscation key zeros || 31 version hash || ref_size=0 || 32 index zeros = 96 bytes
         let mut data = vec![0u8; 96];
-        data[ObfuscationKey::SIZE
-            ..ObfuscationKey::SIZE + VersionHash::SIZE]
+        data[ObfuscationKey::SIZE..ObfuscationKey::SIZE + VersionHash::SIZE]
             .copy_from_slice(VersionHash::V02.as_bytes());
         // ref_size at offset 63 is left as 0; index (offset 64..96) is all zero.
 
@@ -714,8 +713,7 @@ mod tests {
     #[test]
     fn decode_bee_legacy_ref_size_zero_with_forks_is_rejected() {
         let mut data = vec![0u8; 96];
-        data[ObfuscationKey::SIZE
-            ..ObfuscationKey::SIZE + VersionHash::SIZE]
+        data[ObfuscationKey::SIZE..ObfuscationKey::SIZE + VersionHash::SIZE]
             .copy_from_slice(VersionHash::V02.as_bytes());
         // ref_size = 0 (offset 63 already zero), but flip one bit in the index.
         data[NodeHeader::SIZE] = 0x01;
@@ -735,8 +733,7 @@ mod tests {
     #[test]
     fn decode_bee_legacy_ref_size_zero_v01_empty_node() {
         let mut data = vec![0u8; 96];
-        data[ObfuscationKey::SIZE
-            ..ObfuscationKey::SIZE + VersionHash::SIZE]
+        data[ObfuscationKey::SIZE..ObfuscationKey::SIZE + VersionHash::SIZE]
             .copy_from_slice(VersionHash::V01.as_bytes());
 
         let n = Node::<ChunkAddress>::try_from(data.as_slice())
@@ -756,7 +753,7 @@ mod tests {
 
         // Decrypt (obfuscation key is all-zero for `new_unencrypted`, so XOR
         // is a no-op, but go through the motions for clarity).
-        let mut decoded = encoded.clone();
+        let mut decoded = encoded;
         let key = decoded[..ObfuscationKey::SIZE].to_vec();
         xor_in_place(&mut decoded[ObfuscationKey::SIZE..], &key);
 

--- a/crates/mantaray/src/manifest.rs
+++ b/crates/mantaray/src/manifest.rs
@@ -42,8 +42,10 @@ impl<S, const BS: usize> Manifest<S, nectar_primitives::EncryptedChunkRef, BS> {
     /// Create a new encrypted manifest (random obfuscation key, 64-byte refs).
     pub fn new_encrypted(store: S) -> Self {
         use crate::obfuscation::ObfuscationKey;
-        let mut trie = Node::default();
-        trie.obfuscation_key = ObfuscationKey::generate();
+        let trie = Node {
+            obfuscation_key: ObfuscationKey::generate(),
+            ..Node::default()
+        };
         Self { trie, store }
     }
 
@@ -198,11 +200,11 @@ impl<S: SyncChunkGet<BS>, E: NodeEntry, const BS: usize> Manifest<S, E, BS> {
                 f(addr.as_bytes())?;
             }
 
-            if let Some(entry) = node.entry() {
-                if node.is_value() {
-                    let entry_bytes = entry.to_bytes();
-                    f(&entry_bytes)?;
-                }
+            if let Some(entry) = node.entry()
+                && node.is_value()
+            {
+                let entry_bytes = entry.to_bytes();
+                f(&entry_bytes)?;
             }
 
             Ok(())
@@ -342,10 +344,10 @@ impl<S: SyncChunkGet<BS>, E: NodeEntry, const BS: usize> Iterator for ManifestIt
             if !self.root_visited {
                 self.root_visited = true;
 
-                if !self.trie.loaded {
-                    if let Err(e) = self.trie.load::<S, BS>(self.store) {
-                        return Some(Err(e));
-                    }
+                if !self.trie.loaded
+                    && let Err(e) = self.trie.load::<S, BS>(self.store)
+                {
+                    return Some(Err(e));
                 }
 
                 let keys: Vec<u8> = self.trie.forks.keys().copied().collect();
@@ -402,10 +404,10 @@ impl<S: SyncChunkGet<BS>, E: NodeEntry, const BS: usize> Iterator for ManifestIt
 
             // SAFETY: child is a descendant of the exclusively borrowed trie.
             let child_ref = unsafe { &mut *child };
-            if !child_ref.loaded {
-                if let Err(e) = child_ref.load::<S, BS>(self.store) {
-                    return Some(Err(e));
-                }
+            if !child_ref.loaded
+                && let Err(e) = child_ref.load::<S, BS>(self.store)
+            {
+                return Some(Err(e));
             }
 
             let child_keys: Vec<u8> = child_ref.forks.keys().copied().collect();

--- a/crates/mantaray/src/manifest_ref.rs
+++ b/crates/mantaray/src/manifest_ref.rs
@@ -31,7 +31,7 @@ impl ManifestRef {
     }
 
     /// Consume into (address, obfuscation_key).
-    pub fn into_parts(self) -> (ChunkAddress, ObfuscationKey) {
+    pub const fn into_parts(self) -> (ChunkAddress, ObfuscationKey) {
         (self.address, self.obfuscation_key)
     }
 }

--- a/crates/mantaray/src/mode.rs
+++ b/crates/mantaray/src/mode.rs
@@ -58,7 +58,7 @@ impl NodeEntry for nectar_primitives::EncryptedChunkRef {
     const SIZE: usize = 64;
 
     fn address(&self) -> &ChunkAddress {
-        nectar_primitives::EncryptedChunkRef::address(self)
+        Self::address(self)
     }
 
     fn to_bytes(&self) -> Vec<u8> {

--- a/crates/mantaray/src/node.rs
+++ b/crates/mantaray/src/node.rs
@@ -20,6 +20,13 @@ pub struct Prefix {
     data: [u8; PREFIX_MAX_LEN],
 }
 
+impl Default for Prefix {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Prefix {
     /// Maximum prefix length in bytes (constrained by the fork pre-reference region).
     pub const MAX_LEN: usize = PREFIX_MAX_LEN;
@@ -185,7 +192,7 @@ impl<E: NodeEntry> Node<E> {
     }
 
     /// The typed entry stored at this node.
-    pub fn entry(&self) -> Option<&E> {
+    pub const fn entry(&self) -> Option<&E> {
         self.entry.as_ref()
     }
 
@@ -195,7 +202,7 @@ impl<E: NodeEntry> Node<E> {
     }
 
     /// Mutable access to metadata for in-place modification.
-    pub(crate) fn metadata_mut(&mut self) -> &mut BTreeMap<String, String> {
+    pub(crate) const fn metadata_mut(&mut self) -> &mut BTreeMap<String, String> {
         &mut self.metadata
     }
 
@@ -209,19 +216,9 @@ impl<E: NodeEntry> Node<E> {
         &self.forks
     }
 
-    /// Mutable access to child forks.
-    pub(crate) const fn forks_mut(&mut self) -> &mut BTreeMap<u8, Fork<E>> {
-        &mut self.forks
-    }
-
     /// XOR obfuscation key for binary serialisation.
-    pub fn obfuscation_key(&self) -> &ObfuscationKey {
+    pub const fn obfuscation_key(&self) -> &ObfuscationKey {
         &self.obfuscation_key
-    }
-
-    /// Set the content-addressed reference for this node.
-    pub(crate) const fn set_reference(&mut self, reference: ChunkAddress) {
-        self.reference = Some(reference);
     }
 
     /// Check if the node has a value (entry).
@@ -259,11 +256,6 @@ impl<E: NodeEntry> Node<E> {
         self.node_type = self.node_type.union(NodeType::METADATA);
     }
 
-    #[cfg(test)]
-    pub(crate) const fn make_not_value(&mut self) {
-        self.node_type = self.node_type.difference(NodeType::VALUE);
-    }
-
     fn update_is_with_path_separator(&mut self, path: &[u8]) {
         let sep = PATH_SEPARATOR.as_bytes()[0];
         if path.iter().skip(1).any(|&b| b == sep) {
@@ -274,7 +266,7 @@ impl<E: NodeEntry> Node<E> {
     }
 
     /// Clear persisted reference, marking this node for re-serialization on next save.
-    pub(crate) fn mark_dirty(&mut self) {
+    pub(crate) const fn mark_dirty(&mut self) {
         self.reference = None;
     }
 
@@ -299,7 +291,7 @@ impl<E: NodeEntry> Node<E> {
         let chunk = store.get(&address).map_err(|e| MantarayError::StoreGet {
             source: std::sync::Arc::new(e),
         })?;
-        let mut loaded = Node::<E>::try_from(chunk.data().as_ref())?;
+        let mut loaded = Self::try_from(chunk.data().as_ref())?;
         loaded.reference = Some(address);
         // Preserve fields that live in the parent's fork data, not in this node's chunk:
         // node_type flags and metadata key-value pairs.
@@ -340,6 +332,7 @@ impl<E: NodeEntry> Node<E> {
     }
 
     /// Look up the entry at the given path, loading from storage as needed.
+    #[cfg(test)]
     pub(crate) fn lookup<S: SyncChunkGet<BS>, const BS: usize>(
         &mut self,
         path: &[u8],

--- a/crates/postage-issuer/benches/sign.rs
+++ b/crates/postage-issuer/benches/sign.rs
@@ -2,6 +2,7 @@
 //!
 //! This benchmark file focuses on stamp issuing and signing operations,
 //! suitable for CLI tools (like dipper) that create stamps.
+#![allow(missing_docs)]
 
 use alloy_primitives::{B256, Signature, U256};
 use alloy_signer::SignerSync;
@@ -11,7 +12,7 @@ use nectar_postage_issuer::{
     BatchStamper, MemoryIssuer, ShardedIssuer, SigningError, Stamper, sign_stamps_parallel,
 };
 use nectar_primitives::SwarmAddress;
-use rand::Rng;
+use rand::RngExt;
 
 /// Generate a random SwarmAddress for benchmarking.
 fn random_address() -> SwarmAddress {

--- a/crates/postage-issuer/benches/upload_pipeline.rs
+++ b/crates/postage-issuer/benches/upload_pipeline.rs
@@ -14,7 +14,7 @@ use alloy_primitives::{B256, Signature, U256};
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
-use rand::{RngCore, rng};
+use rand::{Rng, rng};
 
 use nectar_postage_issuer::{
     BatchStamper, MemoryIssuer, ShardedIssuer, SigningError, Stamper, sign_stamps_parallel,

--- a/crates/postage/benches/verify.rs
+++ b/crates/postage/benches/verify.rs
@@ -2,6 +2,7 @@
 //!
 //! This benchmark file focuses on verification-only operations, suitable for
 //! node/vertex use cases that primarily verify stamps rather than create them.
+#![allow(missing_docs)]
 
 use alloy_primitives::{Address, B256, Signature};
 use alloy_signer::SignerSync;
@@ -12,7 +13,7 @@ use nectar_postage::{
     parallel::{verify_stamps_parallel, verify_stamps_parallel_with_pubkey},
 };
 use nectar_primitives::SwarmAddress;
-use rand::Rng;
+use rand::RngExt;
 
 /// Generate a random stamp for benchmarking.
 fn random_stamp() -> Stamp {

--- a/crates/primitives/benches/proofs.rs
+++ b/crates/primitives/benches/proofs.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use nectar_primitives::{DEFAULT_BODY_SIZE, DefaultHasher, bmt::Prover};
-use rand::Rng;
+use rand::RngExt;
 use std::time::Duration;
 
 pub fn proofs(c: &mut Criterion) {

--- a/crates/primitives/src/bin.rs
+++ b/crates/primitives/src/bin.rs
@@ -13,10 +13,7 @@ use serde::{Deserialize, Serialize};
 
 /// Typed Kademlia bin index, `0..=MAX_PO` (= 0..=31).
 #[repr(transparent)]
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord,
-    Display, Into,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Display, Into)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 #[display("bin={_0}")]

--- a/crates/primitives/src/chunk/content.rs
+++ b/crates/primitives/src/chunk/content.rs
@@ -161,12 +161,12 @@ pub struct EncryptedContentChunk<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> {
 #[cfg(feature = "encryption")]
 impl<const BODY_SIZE: usize> EncryptedContentChunk<BODY_SIZE> {
     /// The encrypted chunk (ciphertext hashed to a new address).
-    pub fn chunk(&self) -> &ContentChunk<BODY_SIZE> {
+    pub const fn chunk(&self) -> &ContentChunk<BODY_SIZE> {
         &self.chunk
     }
 
     /// The encrypted reference (address + decryption key).
-    pub fn encrypted_ref(&self) -> &super::encryption::EncryptedChunkRef {
+    pub const fn encrypted_ref(&self) -> &super::encryption::EncryptedChunkRef {
         &self.encrypted_ref
     }
 

--- a/crates/primitives/src/chunk/encryption/key.rs
+++ b/crates/primitives/src/chunk/encryption/key.rs
@@ -47,8 +47,8 @@ impl EncryptionKey {
     }
 }
 
-impl From<[u8; EncryptionKey::SIZE]> for EncryptionKey {
-    fn from(bytes: [u8; EncryptionKey::SIZE]) -> Self {
+impl From<[u8; Self::SIZE]> for EncryptionKey {
+    fn from(bytes: [u8; Self::SIZE]) -> Self {
         Self(bytes)
     }
 }
@@ -59,8 +59,8 @@ impl From<B256> for EncryptionKey {
     }
 }
 
-impl AsRef<[u8; EncryptionKey::SIZE]> for EncryptionKey {
-    fn as_ref(&self) -> &[u8; EncryptionKey::SIZE] {
+impl AsRef<[u8; Self::SIZE]> for EncryptionKey {
+    fn as_ref(&self) -> &[u8; Self::SIZE] {
         &self.0
     }
 }

--- a/crates/primitives/src/chunk/encryption/reference.rs
+++ b/crates/primitives/src/chunk/encryption/reference.rs
@@ -22,17 +22,17 @@ impl EncryptedChunkRef {
     pub const SIZE: usize = size_of::<ChunkAddress>() + EncryptionKey::SIZE;
 
     /// Create a new encrypted chunk reference.
-    pub fn new(address: ChunkAddress, key: EncryptionKey) -> Self {
+    pub const fn new(address: ChunkAddress, key: EncryptionKey) -> Self {
         Self { address, key }
     }
 
     /// Chunk address (BMT hash of ciphertext).
-    pub fn address(&self) -> &ChunkAddress {
+    pub const fn address(&self) -> &ChunkAddress {
         &self.address
     }
 
     /// Decryption key.
-    pub fn key(&self) -> &EncryptionKey {
+    pub const fn key(&self) -> &EncryptionKey {
         &self.key
     }
 
@@ -64,7 +64,7 @@ impl From<EncryptedChunkRef> for [u8; EncryptedChunkRef::SIZE] {
 
 impl From<&EncryptedChunkRef> for Vec<u8> {
     fn from(r: &EncryptedChunkRef) -> Self {
-        let mut v = Vec::with_capacity(EncryptedChunkRef::SIZE);
+        let mut v = Self::with_capacity(EncryptedChunkRef::SIZE);
         v.extend_from_slice(r.address.as_bytes());
         v.extend_from_slice(r.key.as_bytes());
         v

--- a/crates/primitives/src/file/constants.rs
+++ b/crates/primitives/src/file/constants.rs
@@ -10,7 +10,7 @@ const fn compute_level_limit(branches: usize, body_size: usize) -> usize {
     // For branches=128 (7 bits), body_size=4096 (12 bits): (64-12)/7 + 1 = 8.4 → 9
     let body_bits = body_size.trailing_zeros() as usize;
     let branch_bits = branches.trailing_zeros() as usize;
-    (64 - body_bits + branch_bits - 1) / branch_bits + 1
+    (64 - body_bits).div_ceil(branch_bits) + 1
 }
 
 /// Maximum tree depth (derived from BRANCHES and DEFAULT_BODY_SIZE).
@@ -66,7 +66,7 @@ pub(crate) const fn tree_depth(length: u64, chunk_size: usize, ref_size: usize) 
     let branches = (chunk_size / ref_size) as u64;
 
     // div_ceil(length, chunk_size)
-    let data_chunks = (length + chunk_size as u64 - 1) / chunk_size as u64;
+    let data_chunks = length.div_ceil(chunk_size as u64);
     if data_chunks <= 1 {
         return 1;
     }
@@ -74,7 +74,7 @@ pub(crate) const fn tree_depth(length: u64, chunk_size: usize, ref_size: usize) 
     let mut depth = 1;
     let mut chunks = data_chunks;
     while chunks > 1 {
-        chunks = (chunks + branches - 1) / branches;
+        chunks = chunks.div_ceil(branches);
         depth += 1;
     }
     depth

--- a/crates/primitives/src/file/entry_ref.rs
+++ b/crates/primitives/src/file/entry_ref.rs
@@ -38,7 +38,7 @@ impl EntryRef {
     }
 
     /// The chunk address (first 32 bytes of any reference).
-    pub fn address(&self) -> &ChunkAddress {
+    pub const fn address(&self) -> &ChunkAddress {
         match self {
             Self::Plain(addr) => addr,
             #[cfg(feature = "encryption")]
@@ -65,7 +65,7 @@ impl From<&EntryRef> for Vec<u8> {
         match entry_ref {
             EntryRef::Plain(addr) => addr.as_bytes().to_vec(),
             #[cfg(feature = "encryption")]
-            EntryRef::Encrypted(enc) => Vec::from(enc),
+            EntryRef::Encrypted(enc) => Self::from(enc),
         }
     }
 }

--- a/crates/primitives/src/file/joiner.rs
+++ b/crates/primitives/src/file/joiner.rs
@@ -178,6 +178,10 @@ where
     }
 
     /// Shared read-range implementation used by both `read_range` and `poll_read`.
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "internal helper threading already-decomposed reader state from two call sites"
+    )]
     async fn read_range_with(
         getter: &Arc<G>,
         subtrees: &[SubtreeNode<M>],

--- a/crates/primitives/src/file/mod.rs
+++ b/crates/primitives/src/file/mod.rs
@@ -191,7 +191,7 @@ where
 
 /// Calculate tree depth for a given file size (plain mode).
 #[cfg(test)]
-pub(crate) fn levels(length: u64, chunk_size: usize) -> usize {
+pub(crate) const fn levels(length: u64, chunk_size: usize) -> usize {
     constants::tree_depth(length, chunk_size, constants::REF_SIZE)
 }
 

--- a/crates/primitives/src/file/sync_splitter.rs
+++ b/crates/primitives/src/file/sync_splitter.rs
@@ -71,12 +71,12 @@ where
     }
 
     /// Bytes written so far.
-    pub fn len(&self) -> u64 {
+    pub const fn len(&self) -> u64 {
         self.buffer.len() as u64
     }
 
     /// Whether any data has been written.
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.buffer.is_empty()
     }
 

--- a/crates/primitives/src/neighborhood_depth.rs
+++ b/crates/primitives/src/neighborhood_depth.rs
@@ -103,10 +103,7 @@ mod tests {
 
     #[test]
     fn empty_table_depth_is_zero() {
-        assert_eq!(
-            recompute_neighborhood_depth(&[0u8; 32], 8, 2),
-            Bin::ZERO
-        );
+        assert_eq!(recompute_neighborhood_depth(&[0u8; 32], 8, 2), Bin::ZERO);
     }
 
     #[test]

--- a/crates/primitives/src/network_id.rs
+++ b/crates/primitives/src/network_id.rs
@@ -14,10 +14,7 @@ use derive_more::{Display, From, Into};
 use serde::{Deserialize, Serialize};
 
 /// Swarm network identifier (u64 wire-compatible with bee).
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord,
-    Display, From, Into,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Display, From, Into)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 #[display("{_0}")]
@@ -75,7 +72,13 @@ mod tests {
     #[test]
     fn le_be_byte_distinction() {
         let id = NetworkId::new(0x0102_0304_0506_0708);
-        assert_eq!(id.to_le_bytes(), [0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01]);
-        assert_eq!(id.to_be_bytes(), [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
+        assert_eq!(
+            id.to_le_bytes(),
+            [0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01]
+        );
+        assert_eq!(
+            id.to_be_bytes(),
+            [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]
+        );
     }
 }

--- a/crates/primitives/src/nonce.rs
+++ b/crates/primitives/src/nonce.rs
@@ -16,10 +16,7 @@ use serde::{Deserialize, Serialize};
 /// Persistent nodes (storers, bootnodes) keep the nonce stable across restarts
 /// so their overlay address is stable. Ephemeral nodes (clients) may rotate
 /// the nonce per run.
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord,
-    Display, From, Into, AsRef,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Display, From, Into, AsRef)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 #[display("{_0}")]

--- a/crates/primitives/src/overlay.rs
+++ b/crates/primitives/src/overlay.rs
@@ -7,7 +7,7 @@
 
 use alloy_primitives::{Address, Keccak256};
 
-use crate::{Nonce, NetworkId, SwarmAddress};
+use crate::{NetworkId, Nonce, SwarmAddress};
 
 /// Compute the Swarm overlay address from `eth_addr`, `network_id`, `nonce`.
 ///

--- a/crates/primitives/src/proximity_order.rs
+++ b/crates/primitives/src/proximity_order.rs
@@ -14,10 +14,7 @@ use serde::{Deserialize, Serialize};
 /// Distinguished from [`Bin`](crate::Bin) at the type level even though they
 /// share a representation. PO is the metric, Bin is the routing-table slot.
 #[repr(transparent)]
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord,
-    Display, Into,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Display, Into)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 #[display("po={_0}")]
@@ -99,7 +96,10 @@ mod tests {
     #[test]
     fn new_out_of_range_errs() {
         let err = ProximityOrder::new(MAX_PO + 1).unwrap_err();
-        assert!(matches!(err, ProximityOrderError::OutOfRange { raw: 32, max: 31 }));
+        assert!(matches!(
+            err,
+            ProximityOrderError::OutOfRange { raw: 32, max: 31 }
+        ));
     }
 
     #[test]

--- a/crates/primitives/src/signing.rs
+++ b/crates/primitives/src/signing.rs
@@ -93,10 +93,10 @@ mod tests {
         let net = NetworkId::MAINNET;
         let nonce = Nonce::new([0xbb; 32]);
         let ts = Timestamp::from(0x0102_0304_0506_0708_i64);
-        let cb = Some(address!("00112233445566778899aabbccddeeff00112233"));
+        let cb = address!("00112233445566778899aabbccddeeff00112233");
         let underlay = b"\x01\x02\x03";
 
-        let buf = sign_data(underlay, &overlay, net, &nonce, ts, cb.as_ref());
+        let buf = sign_data(underlay, &overlay, net, &nonce, ts, Some(&cb));
 
         assert_eq!(&buf[0..14], b"bee-handshake-");
         assert_eq!(&buf[14..17], b"\x01\x02\x03");
@@ -107,7 +107,7 @@ mod tests {
             &buf[89..97],
             &[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]
         );
-        assert_eq!(&buf[97..117], cb.unwrap().as_slice());
+        assert_eq!(&buf[97..117], cb.as_slice());
         assert_eq!(buf.len(), 117);
     }
 

--- a/crates/primitives/src/timestamp.rs
+++ b/crates/primitives/src/timestamp.rs
@@ -11,10 +11,7 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 
 /// Unix-seconds timestamp (signed, matching bee's `int64`).
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord,
-    Display, From, Into,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Display, From, Into)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 #[display("{_0}")]
@@ -77,8 +74,7 @@ impl Timestamp {
     /// difference must be `<= window.as_secs()`.
     pub fn skew_check(self, local: Self, window: Duration) -> Result<(), TimestampError> {
         let drift = self.0.saturating_sub(local.0);
-        let window_secs = i64::try_from(window.as_secs())
-            .unwrap_or(i64::MAX);
+        let window_secs = i64::try_from(window.as_secs()).unwrap_or(i64::MAX);
         if drift.unsigned_abs() <= window_secs.unsigned_abs() {
             Ok(())
         } else {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.92"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Builds on the now-merged publish-readiness work (#47) to make the workspace compile cleanly on a 1.92 toolchain, which is the next step toward a crates.io publish.

## MSRV 1.92

Set workspace `rust-version = "1.92"` (was 1.87); all crates already inherit via `rust-version.workspace = true`.
Add a repo `rust-toolchain.toml` pinning channel `1.92` with `rustfmt` and `clippy` so local and dev builds use the same compiler the publish gate targets.

## rand 0.10 reconciliation

`Cargo.lock` already resolves `rand 0.10.1` (a patched, RUSTSEC-clean line), but several benches still used the pre-0.10 trait surface and failed to compile under a toolchain that actually exercises rand 0.10.
rand 0.10 moved the `random` / `random_range` / `fill` convenience methods off `Rng` onto the new `RngExt` extension trait, and deprecated `RngCore` in favour of `Rng` (which now carries `fill_bytes`).
Fix: import `RngExt` where convenience methods are used and `Rng` where `fill_bytes` is used. No dependency version change; rand stays on 0.10.1, so the RUSTSEC posture is unchanged.

## 1.92 clippy cleanup

The 1.92 clippy is stricter than the previously pinned CI compiler. Applied its suggestions across primitives and mantaray: `const fn` on trivial getters, `Self` in impl bodies, `div_ceil` for ceiling division, a scoped `too_many_arguments` allow on the internal `read_range_with` helper, and a missing-docs allow plus a `Default` impl for `Prefix`.
Removed genuinely dead `Node` methods and gated the test-only `Node::lookup` behind `cfg(test)`. No behavioural change.

## Verification

`cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`, and `cargo build` are all clean on 1.92.

## Follow-up

Truly pinning CI to 1.92 needs an edit to `.github/workflows/unit.yml` (it currently uses `dtolnay/rust-toolchain@... # stable`). That workflow change is not included here.