### PR TITLE
fix(wasm-demo): fix Pages build (threaded wasm __heap_base)

### DIFF
--- a/crates/primitives/examples/wasm-demo/.cargo/config.toml
+++ b/crates/primitives/examples/wasm-demo/.cargo/config.toml
@@ -11,4 +11,10 @@ rustflags = [
   "-C", "link-arg=--export=__tls_size",
   "-C", "link-arg=--export=__tls_align",
   "-C", "link-arg=--export=__tls_base",
+  # Newer LLD no longer keeps __heap_base as an exported symbol by default, so
+  # wasm-bindgen's threading transform fails with "failed to find __heap_base
+  # for injecting thread id". Export it (and __data_end) explicitly so the
+  # threaded build keeps working across nightly toolchain bumps.
+  "-C", "link-arg=--export=__heap_base",
+  "-C", "link-arg=--export=__data_end",
 ]

--- a/crates/primitives/examples/wasm-demo/Cargo.toml
+++ b/crates/primitives/examples/wasm-demo/Cargo.toml
@@ -24,7 +24,6 @@ alloy-primitives.workspace = true
 alloy-signer-local.workspace = true
 getrandom = { version = "0.2.12", features = ["js"] }
 
-# Configure WASM output optimization
-[profile.release]
-opt-level = "s"
-lto = true
+# WASM output size is optimized by the workspace-root [profile.release]; cargo
+# ignores [profile.*] defined in non-root workspace members and warns about it,
+# so there is intentionally no per-package release profile here.

--- a/crates/primitives/examples/wasm-demo/README.md
+++ b/crates/primitives/examples/wasm-demo/README.md
@@ -12,9 +12,9 @@ This example demonstrates the BMT (Binary Merkle Tree) hasher and SVG icon gener
 
 ### Prerequisites
 
-- [Rust](https://www.rust-lang.org/tools/install) (1.85.0 or later recommended)
+- [Rust](https://www.rust-lang.org/tools/install) nightly with the `rust-src` component. Threaded wasm needs `-Z build-std`, which is nightly-only. `rust-toolchain.toml` pins this for you.
 - [Trunk](https://trunkrs.dev/) - A WASM application bundler for Rust
-- WebAssembly target: `rustup target add wasm32-unknown-unknown`
+- WebAssembly target: `rustup target add wasm32-unknown-unknown` (or `rustup component add rust-src --toolchain nightly` plus the target)
 
 ### Quick Start
 
@@ -40,6 +40,12 @@ trunk build --release
 ```
 
 The compiled files will be in the `dist` directory, ready for deployment to any static hosting service.
+
+### Threaded wasm build configuration
+
+The demo links nectar-primitives with `wasm-bindgen-rayon` for parallel BMT hashing, so it is built as a threaded wasm module. `.cargo/config.toml` enables the required `atomics`, `bulk-memory` and `mutable-globals` target features, builds `std` from source via `-Z build-std`, and exports the symbols wasm-bindgen's threading transform needs.
+
+One of those exports is `__heap_base`. Recent LLD releases stopped keeping `__heap_base` as an exported symbol by default, which made wasm-bindgen fail with `failed to prepare module for threading: failed to find __heap_base for injecting thread id` on newer nightly toolchains while older nightlies still worked. The config exports `__heap_base` (and `__data_end`) explicitly so the threaded build stays green across toolchain bumps. Keep these exports if you upgrade the toolchain.
 
 ### Cross-origin isolation (SharedArrayBuffer)
 

--- a/crates/primitives/examples/wasm-demo/Trunk.toml
+++ b/crates/primitives/examples/wasm-demo/Trunk.toml
@@ -6,6 +6,10 @@ release = true
 target = "index.html"
 # Output directory (created automatically)
 dist = "dist"
+# Leave wasm-opt disabled: binaryen must run with --enable-threads to accept the
+# shared-memory threaded module, and that is not wired into the Pages workflow.
+# Size optimization comes from the workspace-root release profile instead.
+wasm_opt = false
 
 public_url = "/"
 filehash = false


### PR DESCRIPTION
The "Deploy WASM Demo to GitHub Pages" workflow (`.github/workflows/example.yml`) was failing on `main` at the "Build WASM Demo" step.

## Exact-CI reproduction

CI runs `cd crates/primitives/examples/wasm-demo && RUSTUP_TOOLCHAIN=nightly trunk build --release --public-url /nectar/` with nightly rustc 1.98.0 (`dtolnay/rust-toolchain@nightly`), trunk 0.21.14 (`jetli/trunk-action`), and trunk auto-downloads wasm-bindgen 0.2.122 to match `Cargo.lock`. I reproduced this locally with the same nightly 1.98.0, trunk 0.21.14, and wasm-bindgen 0.2.122, and got the identical failure:

```
error: failed to prepare module for threading
    failed to find `__heap_base` for injecting thread id
```

A prior fix passed locally but CI stayed red because of toolchain skew: an older nightly (1.95.0) still exported `__heap_base` and the build went green, while CI 1.98.0 does not. Confirmed by inspecting the linked wasm: under 1.95 `__heap_base` is present, under 1.98 it is absent (string count 0, no export entry).

## Root cause

The demo links `nectar-primitives` with `wasm-bindgen-rayon`, so it is built as a threaded wasm module and wasm-bindgen runs its threading transform. That transform needs the `__heap_base` symbol. Recent LLD releases stopped keeping `__heap_base` exported by default, so on nightly 1.98 the symbol is missing from the linked wasm and the transform aborts. The demo `.cargo/config.toml` exported the TLS symbols but not `__heap_base`.

## Fix (threaded, kept)

This is the clean threaded fix; the parallel BMT benchmark is preserved, no fallback to single-threaded was needed.

- `.cargo/config.toml`: export `__heap_base` (and `__data_end`) explicitly via `link-arg=--export=...`, the standard wasm-bindgen-rayon recipe, so the threaded build stays green across nightly bumps.
- `Cargo.toml`: drop the per-package `[profile.release]`. Cargo ignores profiles in non-root workspace members and emits "profiles for the non-root package will be ignored"; the workspace-root `[profile.release]` governs size.
- `Trunk.toml`: set `wasm_opt = false` explicitly. binaryen would need `--enable-threads` to accept the shared-memory module, and that is not wired into the Pages workflow.
- `README.md`: document the threading config, the nightly + `rust-src` prerequisite, and the `__heap_base` toolchain gotcha.

## Verification

With the exact CI toolchain (nightly 1.98.0, trunk 0.21.14, wasm-bindgen 0.2.122), `trunk build --release --public-url /nectar/` now exits 0, produces `dist/` with the `wasm-bindgen-rayon` threading glue under `snippets/`, the "non-root package profile ignored" warning is gone, and `__heap_base` is present in the linked wasm. `cargo build` for the full workspace is also green.

## Maintainer note

No `.github/workflows/` changes were made (no workflow scope). The Pages deploy job only runs on push to `main` (or `workflow_dispatch`), so it does not execute on this PR. It was validated by running the exact CI build command with the exact CI toolchain versions locally, as described above. Once merged it will run on `main` and deploy.

Closes the failing run 27187887516.