### PR TITLE
fix(time): unify wall-clock on web-time so primitives run on wasm32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2051,7 +2051,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "nectar-contracts"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -2061,7 +2061,7 @@ dependencies = [
 
 [[package]]
 name = "nectar-mantaray"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "alloy-primitives",
  "bitflags",
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "nectar-postage"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -2093,11 +2093,12 @@ dependencies = [
  "serde",
  "thiserror",
  "tokio",
+ "web-time",
 ]
 
 [[package]]
 name = "nectar-postage-issuer"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -2116,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "nectar-primitives"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -2144,12 +2145,13 @@ dependencies = [
  "tokio",
  "wasm-bindgen",
  "wasm-bindgen-rayon",
+ "web-time",
  "zeroize",
 ]
 
 [[package]]
 name = "nectar-swarms"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "alloy-chains",
  "num_enum",
@@ -3592,6 +3594,16 @@ name = "web-sys"
 version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*", "crates/**/examples/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.92"
 authors = ["Nexum Contributors"]
@@ -35,12 +35,12 @@ check.all_targets = true
 
 [workspace.dependencies]
 # nectar crates
-nectar-contracts = { version = "0.1.1", path = "crates/contracts" }
-nectar-mantaray = { version = "0.1.1", path = "crates/mantaray" }
-nectar-primitives = { version = "0.1.1", path = "crates/primitives" }
-nectar-swarms = { version = "0.1.1", path = "crates/swarms" }
-nectar-postage = { version = "0.1.1", path = "crates/postage" }
-nectar-postage-issuer = { version = "0.1.1", path = "crates/postage-issuer" }
+nectar-contracts = { version = "0.2.0", path = "crates/contracts" }
+nectar-mantaray = { version = "0.2.0", path = "crates/mantaray" }
+nectar-primitives = { version = "0.2.0", path = "crates/primitives" }
+nectar-swarms = { version = "0.2.0", path = "crates/swarms" }
+nectar-postage = { version = "0.2.0", path = "crates/postage" }
+nectar-postage-issuer = { version = "0.2.0", path = "crates/postage-issuer" }
 
 # alloy
 alloy-primitives = { version = "1.6", default-features = false }
@@ -66,6 +66,12 @@ num_enum = { version = "0.7", default-features = false }
 
 # sync
 parking_lot = "0.12"
+
+# time: drop-in std::time on native, browser clock on wasm32. Unifies the
+# wall-clock surface so primitives that capture the current time (timestamps,
+# stamp issuance) link and run on wasm32-unknown-unknown instead of panicking
+# through the std unsupported-platform stub.
+web-time = "1.1"
 
 # concurrency and parallelism
 rayon = "1.10"

--- a/crates/postage/Cargo.toml
+++ b/crates/postage/Cargo.toml
@@ -31,6 +31,9 @@ k256 = { workspace = true }
 serde = { workspace = true, optional = true }
 rayon = { workspace = true, optional = true }
 arbitrary = { workspace = true, features = ["derive"], optional = true }
+# wall clock for stamp issuance timestamps; std::time on native, browser clock
+# on wasm32. Only needed with the `std` feature (the no_std path returns 0).
+web-time = { workspace = true, optional = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
@@ -51,7 +54,7 @@ required-features = ["parallel"]
 default = ["std"]
 
 # Standard library support. Enables BatchStore, BatchFactory, and timestamp functions.
-std = ["nectar-primitives/std", "alloy-primitives/std", "thiserror/std", "serde?/std"]
+std = ["dep:web-time", "nectar-primitives/std", "alloy-primitives/std", "thiserror/std", "serde?/std"]
 
 # Serialization support with serde.
 serde = ["dep:serde", "nectar-primitives/serde", "alloy-primitives/serde"]

--- a/crates/postage/src/util.rs
+++ b/crates/postage/src/util.rs
@@ -10,7 +10,7 @@ use nectar_primitives::SwarmAddress;
 #[cfg(feature = "std")]
 #[inline]
 pub fn current_timestamp() -> u64 {
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use web_time::{SystemTime, UNIX_EPOCH};
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos() as u64)

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -43,6 +43,9 @@ zeroize = { workspace = true, features = ["derive"] }
 # synchronization
 parking_lot = "0.12"
 
+# wall clock: std::time on native, browser clock on wasm32 (see Timestamp::now)
+web-time.workspace = true
+
 # async support
 futures.workspace = true
 tokio = { workspace = true, features = ["io-util"], optional = true }

--- a/crates/primitives/src/timestamp.rs
+++ b/crates/primitives/src/timestamp.rs
@@ -55,11 +55,15 @@ impl Timestamp {
 
     /// Capture the current wall-clock time as a [`Timestamp`].
     ///
+    /// The clock comes from `web-time`, which is `std::time` on native targets
+    /// and the browser clock on `wasm32`, so this runs on every supported
+    /// target instead of panicking through the std unsupported-platform stub.
+    ///
     /// Panics only if the system clock is set before the unix epoch, which
     /// would already break far more than this primitive. Pre-1970 callers
     /// can construct via [`Self::from_seconds`] manually.
     pub fn now() -> Self {
-        use std::time::{SystemTime, UNIX_EPOCH};
+        use web_time::{SystemTime, UNIX_EPOCH};
         let secs = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("system clock set before unix epoch")


### PR DESCRIPTION
## Summary

`Timestamp::now` and the postage stamp-issuance timestamp both read the current time through `std::time::SystemTime::now`, which panics on `wasm32-unknown-unknown` via the std unsupported-platform stub (`time not implemented on this platform`).

Any consumer that mints a timestamp on wasm hits that panic the moment the clock is read. The concrete trigger downstream is a browser Swarm node signing its peer record at handshake (vertex `swarm-demo`): the demo reaches the dial step and then panics inside `Timestamp::now`. The BMT-hashing wasm example in this repo never reads the clock, so it never surfaced the issue here.

## Change

Route both call sites through `web-time`, a drop-in `std::time` re-export on native targets and a browser-clock shim on `wasm32`. The wall-clock surface is now unified on one crate, so capturing the current time links and runs on every supported target instead of panicking.

- `nectar-primitives`: `Timestamp::now` uses `web_time::{SystemTime, UNIX_EPOCH}`.
- `nectar-postage`: `current_timestamp` (behind the `std` feature) uses the same, with `web-time` added as an optional dep enabled by `std`.

Minor bump to `0.2.0`: no public API changes, but the wasm32 behaviour of `Timestamp::now` and `current_timestamp` changes from panic to working.

## Verification

`cargo build` and `cargo test -p nectar-primitives -p nectar-postage` pass on native; `cargo build -p nectar-primitives -p nectar-postage --target wasm32-unknown-unknown` builds clean.