### PR TITLE
feat(primitives): gate wasm-bindgen-rayon behind default-off `wasm-threads` feature

### DIFF
--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -65,7 +65,12 @@ alloy-primitives = { workspace = true, features = ["asm-keccak", "getrandom"] }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 alloy-primitives = { workspace = true, features = ["getrandom"] }
 wasm-bindgen.workspace = true
-wasm-bindgen-rayon = "1.3"
+# Gated behind the `wasm-threads` feature (default-off). Its presence forces
+# wasm-bindgen's threads transform, which requires a SharedArrayBuffer memory
+# (and thus COOP/COEP cross-origin isolation on the hosting page). Omitting it
+# yields a wasm that needs no shared memory; the plain `rayon` usage elsewhere
+# then runs inline (no thread pool) on wasm.
+wasm-bindgen-rayon = { version = "1.3", optional = true }
 js-sys.workspace = true
 getrandom.workspace = true
 getrandom_02.workspace = true
@@ -85,6 +90,14 @@ rand.workspace = true
 [features]
 default = ["std"]
 std = []
+# WASM thread pool via wasm-bindgen-rayon. OFF by default so the default wasm
+# build needs no SharedArrayBuffer / cross-origin isolation — letting it run on
+# hosts that can't set COOP/COEP (e.g. the eth.limo ENS gateway). Enable it
+# (`--features wasm-threads`) for the threaded build (faster BMT hashing, but
+# requires shared memory). Must stay out of `default`: dependents pull this
+# crate with default features, so a default-on threads feature would be forced
+# on transitively and couldn't be opted out.
+wasm-threads = ["dep:wasm-bindgen-rayon"]
 serde = ["dep:serde"]
 arbitrary = [
 	"std",

--- a/crates/primitives/src/wasm.rs
+++ b/crates/primitives/src/wasm.rs
@@ -19,7 +19,14 @@
 //! This uses [wasm-bindgen-rayon](https://github.com/RReverser/wasm-bindgen-rayon)
 //! for rayon-based parallelism via SharedArrayBuffer and Web Workers.
 
-// Re-export thread pool initialization from wasm-bindgen-rayon
+// Re-export thread pool initialization from wasm-bindgen-rayon.
+//
+// Gated behind the `wasm-threads` feature (default-off). The mere PRESENCE of
+// this re-export in the linked artifact makes wasm-bindgen run its threads
+// transform and require a SharedArrayBuffer memory (hence COOP/COEP on the
+// host) — independent of whether JS ever calls it. Without `wasm-threads`, the
+// wasm needs no shared memory; the plain `rayon` code paths run inline.
+#[cfg(feature = "wasm-threads")]
 pub use wasm_bindgen_rayon::init_thread_pool;
 
 // Re-export WASM bindings from each submodule


### PR DESCRIPTION
Currently `nectar-primitives` pulls `wasm-bindgen-rayon` unconditionally on `wasm32` and re-exports `init_thread_pool` from `src/wasm.rs`. The **mere presence** of that re-export forces wasm-bindgen's threads transform, which requires the module to use a **shared** (`SharedArrayBuffer`) memory. In a browser that means the hosting page must be **cross-origin isolated** (`COOP: same-origin` + `COEP: require-corp`).

That isolation requirement is a hard blocker for hosts that cannot set those response headers — notably **ENS gateways like eth.limo / bzz.limo** (they only send `Cross-Origin-Resource-Policy`, never COOP/COEP), and many static hosts. There is currently no way to build a `nectar-primitives` wasm that runs without shared memory.

### Change

Gate the thread pool behind a new **default-off** `wasm-threads` feature:

- `wasm-bindgen-rayon` becomes `optional = true`.
- `wasm-threads = ["dep:wasm-bindgen-rayon"]`.
- The `init_thread_pool` re-export in `src/wasm.rs` is `#[cfg(feature = "wasm-threads")]`.

Default builds are unchanged in API; they simply no longer pull `wasm-bindgen-rayon`, so the resulting wasm uses a plain (non-shared) linear memory and needs no cross-origin isolation. Consumers that want threaded BMT hashing opt in with `--features wasm-threads` (plus the usual `+atomics`/`--shared-memory` rustflags).

It is **default-off on purpose**: dependent crates (`nectar-postage`, `nectar-mantaray`, `nectar-postage-issuer`) depend on `nectar-primitives` with default features, so a default-on threads feature would be forced on transitively and could not be opted out by a downstream binary.

The plain `rayon` usage elsewhere (`bmt`, `file/sync_splitter_parallel`, `file/sync_joiner`) is untouched — on wasm without a thread pool it runs inline, which is correct (just single-threaded).

### Verification

- `cargo check -p nectar-primitives --target wasm32-unknown-unknown` (default): compiles, no `wasm-bindgen-rayon` in the graph, produces a non-shared memory.
- `--features wasm-threads`: pulls `wasm-bindgen-rayon` as before (threaded/shared-memory build).
- Verified end-to-end in a downstream wasm consumer: default build links without `--shared-memory`/`+atomics` and runs single-threaded; `--features wasm-threads` build imports a shared memory as before.