### PR TITLE
feat(postage-issuer)!: make MemoryIssuer fill-only and refuse mutable batches

### DIFF
--- a/crates/postage-issuer/src/error.rs
+++ b/crates/postage-issuer/src/error.rs
@@ -10,6 +10,26 @@ pub enum IssuerError {
         "mutable batch issuance requires reserved-slot awareness; build a nectar_postage_usage::Snapshot for the batch and stamp through Snapshot::issuer(owner) / SnapshotIssuer"
     )]
     MutableNotSupported,
+
+    /// An immutable batch was given to a ring issuer.
+    ///
+    /// Ring issuance is overwrite-aware and only valid for a mutable batch. An
+    /// immutable batch is fill-only and must use `MemoryIssuer`.
+    #[error(
+        "immutable batch cannot be stamped with a ring issuer; immutable batches are fill-only, use MemoryIssuer::from_batch"
+    )]
+    ImmutableNotSupported,
+
+    /// A ring bucket had no unprotected slot to issue.
+    ///
+    /// Every slot in the bucket is reserved, so the ring cannot advance without
+    /// re-emitting a protected slot. This is geometrically impossible at real
+    /// batch depths and signals a malformed reservation.
+    #[error("ring bucket {bucket} has no unprotected slot to issue")]
+    RingExhausted {
+        /// The bucket that had no unprotected slot.
+        bucket: u32,
+    },
 }
 
 /// Errors that can occur when signing stamps.

--- a/crates/postage-issuer/src/error.rs
+++ b/crates/postage-issuer/src/error.rs
@@ -2,6 +2,16 @@
 
 use thiserror::Error;
 
+/// Errors that can occur when constructing a stamp issuer.
+#[derive(Debug, Error)]
+pub enum IssuerError {
+    /// Mutable batches require reserved-slot awareness that this primitive issuer cannot provide.
+    #[error(
+        "mutable batch issuance requires reserved-slot awareness; build a nectar_postage_usage::Snapshot for the batch and stamp through Snapshot::issuer(owner) / SnapshotIssuer"
+    )]
+    MutableNotSupported,
+}
+
 /// Errors that can occur when signing stamps.
 #[derive(Debug, Error)]
 pub enum SigningError {

--- a/crates/postage-issuer/src/issuer.rs
+++ b/crates/postage-issuer/src/issuer.rs
@@ -170,10 +170,11 @@ impl MemoryIssuer {
     ///
     /// Immutable batches yield a fill-only issuer identical to
     /// [`MemoryIssuer::new`] for the same geometry. Mutable batches are refused
-    /// with [`IssuerError::MutableNotSupported`]: overwrite-aware issuance needs
-    /// reserved-slot awareness that this primitive issuer cannot provide, so a
-    /// mutable batch must be stamped through the owner-aware
-    /// `nectar_postage_usage::Snapshot::issuer` / `SnapshotIssuer` instead.
+    /// with [`IssuerError::MutableNotSupported`] so a ring is never produced by
+    /// accident: overwrite-aware issuance must be requested by name through
+    /// [`RingIssuer::external`](crate::RingIssuer::external) for external
+    /// tracking, or [`RingIssuer::reserved`](crate::RingIssuer::reserved) for
+    /// self-hosting, where the protected slots come from `nectar-postage-usage`.
     pub fn from_batch(batch: &Batch) -> Result<Self, IssuerError> {
         if batch.immutable() {
             Ok(Self::new(batch.id(), batch.depth(), batch.bucket_depth()))

--- a/crates/postage-issuer/src/issuer.rs
+++ b/crates/postage-issuer/src/issuer.rs
@@ -120,11 +120,43 @@ pub trait StampIssuer {
     }
 }
 
+/// Selects how a [`MemoryIssuer`] allocates indices within a bucket.
+///
+/// The mode mirrors the on-chain mutability of the batch the issuer serves.
+/// An immutable batch may never reuse a slot, so issuance fills each bucket
+/// once and then refuses further stamps. A mutable batch may overwrite an
+/// existing slot with a fresher chunk, so issuance walks the bucket as a ring
+/// and wraps back to the first slot once every slot has been written.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IssuanceMode {
+    /// Fill each bucket once, refusing issuance with
+    /// [`StampError::BucketFull`] when the bucket reaches capacity.
+    ///
+    /// This is the semantics of an immutable batch.
+    Fill,
+    /// Walk each bucket as a ring cursor, wrapping back to slot zero once
+    /// every slot has been written so a later chunk overwrites an earlier one.
+    ///
+    /// This is the semantics of a mutable batch. Issuance never reports
+    /// [`StampError::BucketFull`], but utilisation is still reported honestly:
+    /// it counts the distinct slots that have been written and saturates at
+    /// the bucket capacity rather than growing without bound.
+    Ring,
+}
+
 /// An in-memory stamp issuer that tracks bucket utilization.
 ///
 /// This implementation stores bucket indices in a vector and is suitable
 /// for most use cases where the issuer state doesn't need to persist
 /// across restarts.
+///
+/// The issuer operates in one of two [`IssuanceMode`]s. In [`IssuanceMode::Fill`]
+/// every slot is written at most once and the bucket is refused once full. In
+/// [`IssuanceMode::Ring`] the cursor wraps so a later chunk overwrites the
+/// slot held by an earlier one, matching the overwrite semantics of a mutable
+/// batch. Utilisation is reported honestly in both modes: it never exceeds the
+/// bucket capacity, and a ring that has wrapped reports its bucket as full even
+/// though issuance into it continues to succeed.
 #[derive(Debug, Clone)]
 pub struct MemoryIssuer {
     /// The batch ID.
@@ -133,8 +165,20 @@ pub struct MemoryIssuer {
     depth: u8,
     /// The bucket depth.
     bucket_depth: u8,
-    /// Current index for each bucket.
+    /// How indices are allocated within a bucket.
+    mode: IssuanceMode,
+    /// Next slot to write for each bucket.
+    ///
+    /// In [`IssuanceMode::Ring`] this is the ring cursor and wraps modulo the
+    /// bucket capacity. In [`IssuanceMode::Fill`] it is monotonic and never
+    /// reaches the capacity.
     bucket_indices: alloc::vec::Vec<u32>,
+    /// Whether each bucket has been written to capacity at least once.
+    ///
+    /// Only set in [`IssuanceMode::Ring`], where the cursor wraps and so can no
+    /// longer be used to tell a saturated bucket apart from an empty one. Used
+    /// to report utilisation honestly once a ring has wrapped.
+    bucket_saturated: alloc::vec::Vec<bool>,
     /// Maximum utilization across all buckets.
     max_utilization: u32,
     /// Total stamps issued.
@@ -144,22 +188,55 @@ pub struct MemoryIssuer {
 extern crate alloc;
 
 impl MemoryIssuer {
-    /// Creates a new memory issuer for the given batch.
+    /// Creates a new memory issuer for the given batch in [`IssuanceMode::Fill`].
     pub fn new(batch_id: BatchId, depth: u8, bucket_depth: u8) -> Self {
+        Self::with_mode(batch_id, depth, bucket_depth, IssuanceMode::Fill)
+    }
+
+    /// Creates a new memory issuer for the given batch in the requested mode.
+    pub fn with_mode(batch_id: BatchId, depth: u8, bucket_depth: u8, mode: IssuanceMode) -> Self {
         let bucket_count = 1usize << bucket_depth;
         Self {
             batch_id,
             depth,
             bucket_depth,
+            mode,
             bucket_indices: alloc::vec![0u32; bucket_count],
+            bucket_saturated: alloc::vec![false; bucket_count],
             max_utilization: 0,
             stamps_issued: 0,
         }
     }
 
     /// Creates a memory issuer from a batch.
+    ///
+    /// The issuance mode is selected from the batch mutability: an immutable
+    /// batch issues in [`IssuanceMode::Fill`] and a mutable batch issues in
+    /// [`IssuanceMode::Ring`].
     pub fn from_batch(batch: &Batch) -> Self {
-        Self::new(batch.id(), batch.depth(), batch.bucket_depth())
+        let mode = if batch.immutable() {
+            IssuanceMode::Fill
+        } else {
+            IssuanceMode::Ring
+        };
+        Self::with_mode(batch.id(), batch.depth(), batch.bucket_depth(), mode)
+    }
+
+    /// Returns the issuance mode.
+    pub const fn mode(&self) -> IssuanceMode {
+        self.mode
+    }
+
+    /// Returns the number of distinct slots written in a bucket.
+    ///
+    /// This saturates at the bucket capacity, so a wrapped ring reports the
+    /// bucket as full rather than counting overwrites as fresh utilisation.
+    fn bucket_fill(&self, bucket_idx: usize) -> u32 {
+        if self.bucket_saturated[bucket_idx] {
+            1u32 << (self.depth - self.bucket_depth)
+        } else {
+            self.bucket_indices[bucket_idx]
+        }
     }
 }
 
@@ -172,28 +249,47 @@ impl StampIssuer for MemoryIssuer {
         let bucket = calculate_bucket(address, self.bucket_depth);
         let bucket_idx = bucket as usize;
 
-        // Get current index for this bucket
-        let current_index = self.bucket_indices[bucket_idx];
-
-        // Check if bucket is full
         let bucket_capacity = 1u32 << (self.depth - self.bucket_depth);
-        if current_index >= bucket_capacity {
-            return Err(StampError::BucketFull {
-                bucket,
-                capacity: bucket_capacity,
-            });
+
+        // The slot this stamp is written into. In Fill mode this is the next
+        // unused slot; in Ring mode it is the ring cursor, which may point at a
+        // slot a previous chunk already wrote.
+        let position = self.bucket_indices[bucket_idx];
+
+        match self.mode {
+            IssuanceMode::Fill => {
+                if position >= bucket_capacity {
+                    return Err(StampError::BucketFull {
+                        bucket,
+                        capacity: bucket_capacity,
+                    });
+                }
+                self.bucket_indices[bucket_idx] = position + 1;
+            }
+            IssuanceMode::Ring => {
+                // Advance the cursor and wrap at the bucket capacity. Once the
+                // cursor wraps the bucket is saturated: every slot has been
+                // written and further issuance overwrites the oldest chunk.
+                let next = position + 1;
+                if next >= bucket_capacity {
+                    self.bucket_saturated[bucket_idx] = true;
+                    self.bucket_indices[bucket_idx] = 0;
+                } else {
+                    self.bucket_indices[bucket_idx] = next;
+                }
+            }
         }
 
-        // Increment the bucket index
-        self.bucket_indices[bucket_idx] = current_index + 1;
         self.stamps_issued += 1;
 
-        // Update max utilization
-        if current_index + 1 > self.max_utilization {
-            self.max_utilization = current_index + 1;
+        // Update max utilization from the honest fill of this bucket, which
+        // never exceeds the bucket capacity even when a ring has wrapped.
+        let fill = self.bucket_fill(bucket_idx);
+        if fill > self.max_utilization {
+            self.max_utilization = fill;
         }
 
-        let index = StampIndex::new(bucket, current_index);
+        let index = StampIndex::new(bucket, position);
 
         Ok(StampDigest::new(*address, self.batch_id, index, timestamp))
     }
@@ -215,10 +311,11 @@ impl StampIssuer for MemoryIssuer {
     }
 
     fn bucket_utilization(&self, bucket: u32) -> u32 {
-        self.bucket_indices
-            .get(bucket as usize)
-            .copied()
-            .unwrap_or(0)
+        let bucket_idx = bucket as usize;
+        if bucket_idx >= self.bucket_indices.len() {
+            return 0;
+        }
+        self.bucket_fill(bucket_idx)
     }
 
     fn bucket_has_capacity(&self, bucket: u32) -> bool {
@@ -226,8 +323,11 @@ impl StampIssuer for MemoryIssuer {
         if bucket_idx >= self.bucket_indices.len() {
             return false;
         }
+        // Report honestly whether a fresh, never-written slot remains. A ring
+        // that has wrapped reports no spare capacity even though further
+        // issuance still succeeds by overwriting an earlier chunk.
         let bucket_capacity = 1u32 << (self.depth - self.bucket_depth);
-        self.bucket_indices[bucket_idx] < bucket_capacity
+        self.bucket_fill(bucket_idx) < bucket_capacity
     }
 
     fn stamps_issued(&self) -> u64 {
@@ -366,5 +466,130 @@ mod tests {
 
         // 3/4 = 0.75
         assert!(issuer.is_near_capacity(0.75));
+    }
+
+    #[test]
+    fn test_memory_issuer_ring_wraps_instead_of_full() {
+        // depth=17, bucket_depth=16 gives 2 slots per bucket.
+        let mut issuer = MemoryIssuer::with_mode(B256::ZERO, 17, 16, IssuanceMode::Ring);
+
+        let address = test_address(0xABCD);
+
+        // Fill both slots in order.
+        let d0 = issuer.prepare_stamp(&address, 1).unwrap();
+        let d1 = issuer.prepare_stamp(&address, 2).unwrap();
+        assert_eq!(d0.index.index(), 0);
+        assert_eq!(d1.index.index(), 1);
+
+        // A third issuance wraps back to slot zero rather than failing.
+        let d2 = issuer.prepare_stamp(&address, 3).unwrap();
+        assert_eq!(d2.index.index(), 0);
+
+        // And it keeps walking the ring.
+        let d3 = issuer.prepare_stamp(&address, 4).unwrap();
+        assert_eq!(d3.index.index(), 1);
+
+        assert_eq!(issuer.stamps_issued(), 4);
+    }
+
+    #[test]
+    fn test_memory_issuer_ring_index_stays_within_capacity() {
+        // depth=18, bucket_depth=16 gives 4 slots per bucket.
+        let mut issuer = MemoryIssuer::with_mode(B256::ZERO, 18, 16, IssuanceMode::Ring);
+
+        let address = test_address(0x0042);
+
+        // Issue many more chunks than the bucket can hold; every wire index
+        // must remain a valid slot in [0, capacity).
+        for ts in 0..100u64 {
+            let digest = issuer.prepare_stamp(&address, ts).unwrap();
+            assert!(digest.index.index() < 4, "index escaped bucket capacity");
+        }
+        assert_eq!(issuer.stamps_issued(), 100);
+    }
+
+    #[test]
+    fn test_memory_issuer_ring_utilization_is_honest() {
+        // depth=18, bucket_depth=16 gives 4 slots per bucket.
+        let mut issuer = MemoryIssuer::with_mode(B256::ZERO, 18, 16, IssuanceMode::Ring);
+
+        let address = test_address(0x0001);
+
+        // Utilisation climbs slot by slot as fresh slots are written.
+        for (n, ts) in (1..=4u64).enumerate() {
+            issuer.prepare_stamp(&address, ts).unwrap();
+            assert_eq!(issuer.bucket_utilization(0x0001), (n as u32) + 1);
+        }
+
+        // Capacity is reached; a wrapped ring saturates at capacity and does
+        // not count overwrites as fresh utilisation.
+        assert_eq!(issuer.bucket_utilization(0x0001), 4);
+        assert_eq!(issuer.max_bucket_utilization(), 4);
+
+        for ts in 5..20u64 {
+            issuer.prepare_stamp(&address, ts).unwrap();
+            assert_eq!(issuer.bucket_utilization(0x0001), 4);
+            assert_eq!(issuer.max_bucket_utilization(), 4);
+        }
+    }
+
+    #[test]
+    fn test_memory_issuer_ring_capacity_reported_honestly() {
+        // depth=17, bucket_depth=16 gives 2 slots per bucket.
+        let mut issuer = MemoryIssuer::with_mode(B256::ZERO, 17, 16, IssuanceMode::Ring);
+
+        let address = test_address(0x0001);
+
+        // Spare capacity while fresh slots remain.
+        assert!(issuer.bucket_has_capacity(0x0001));
+        issuer.prepare_stamp(&address, 1).unwrap();
+        assert!(issuer.bucket_has_capacity(0x0001));
+
+        // Once every slot has been written the ring reports no spare capacity,
+        // even though issuance into it still succeeds by overwriting.
+        issuer.prepare_stamp(&address, 2).unwrap();
+        assert!(!issuer.bucket_has_capacity(0x0001));
+
+        // Issuance still succeeds despite the bucket reporting no capacity.
+        assert!(issuer.prepare_stamp(&address, 3).is_ok());
+        assert!(!issuer.bucket_has_capacity(0x0001));
+    }
+
+    #[test]
+    fn test_memory_issuer_from_batch_selects_mode() {
+        use nectar_postage::Batch;
+
+        let mutable = Batch::new(B256::ZERO, 0, 0, Default::default(), 20, 16, false);
+        let immutable = Batch::new(B256::ZERO, 0, 0, Default::default(), 20, 16, true);
+
+        assert_eq!(
+            MemoryIssuer::from_batch(&mutable).mode(),
+            IssuanceMode::Ring
+        );
+        assert_eq!(
+            MemoryIssuer::from_batch(&immutable).mode(),
+            IssuanceMode::Fill
+        );
+    }
+
+    #[test]
+    fn test_memory_issuer_fill_mode_unchanged() {
+        // depth=17, bucket_depth=16 gives 2 slots per bucket. Fill mode is the
+        // default and must still refuse a full bucket.
+        let mut issuer = MemoryIssuer::new(B256::ZERO, 17, 16);
+        assert_eq!(issuer.mode(), IssuanceMode::Fill);
+
+        let address = test_address(0xABCD);
+        assert!(issuer.prepare_stamp(&address, 1).is_ok());
+        assert!(issuer.prepare_stamp(&address, 2).is_ok());
+
+        let result = issuer.prepare_stamp(&address, 3);
+        assert!(matches!(
+            result,
+            Err(StampError::BucketFull {
+                bucket: 0xABCD,
+                capacity: 2
+            })
+        ));
     }
 }

--- a/crates/postage-issuer/src/issuer.rs
+++ b/crates/postage-issuer/src/issuer.rs
@@ -172,8 +172,8 @@ impl MemoryIssuer {
     /// [`MemoryIssuer::new`] for the same geometry. Mutable batches are refused
     /// with [`IssuerError::MutableNotSupported`]: overwrite-aware issuance needs
     /// reserved-slot awareness that this primitive issuer cannot provide, so a
-    /// mutable batch must be stamped through
-    /// [`nectar_postage_usage::Snapshot::issuer`] / `SnapshotIssuer` instead.
+    /// mutable batch must be stamped through the owner-aware
+    /// `nectar_postage_usage::Snapshot::issuer` / `SnapshotIssuer` instead.
     pub fn from_batch(batch: &Batch) -> Result<Self, IssuerError> {
         if batch.immutable() {
             Ok(Self::new(batch.id(), batch.depth(), batch.bucket_depth()))

--- a/crates/postage-issuer/src/issuer.rs
+++ b/crates/postage-issuer/src/issuer.rs
@@ -1,5 +1,6 @@
 //! Stamp issuer trait for tracking bucket utilization.
 
+use crate::error::IssuerError;
 use nectar_postage::{Batch, BatchId, StampDigest, StampError, StampIndex, calculate_bucket};
 use nectar_primitives::SwarmAddress;
 
@@ -120,43 +121,17 @@ pub trait StampIssuer {
     }
 }
 
-/// Selects how a [`MemoryIssuer`] allocates indices within a bucket.
-///
-/// The mode mirrors the on-chain mutability of the batch the issuer serves.
-/// An immutable batch may never reuse a slot, so issuance fills each bucket
-/// once and then refuses further stamps. A mutable batch may overwrite an
-/// existing slot with a fresher chunk, so issuance walks the bucket as a ring
-/// and wraps back to the first slot once every slot has been written.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum IssuanceMode {
-    /// Fill each bucket once, refusing issuance with
-    /// [`StampError::BucketFull`] when the bucket reaches capacity.
-    ///
-    /// This is the semantics of an immutable batch.
-    Fill,
-    /// Walk each bucket as a ring cursor, wrapping back to slot zero once
-    /// every slot has been written so a later chunk overwrites an earlier one.
-    ///
-    /// This is the semantics of a mutable batch. Issuance never reports
-    /// [`StampError::BucketFull`], but utilisation is still reported honestly:
-    /// it counts the distinct slots that have been written and saturates at
-    /// the bucket capacity rather than growing without bound.
-    Ring,
-}
-
 /// An in-memory stamp issuer that tracks bucket utilization.
 ///
 /// This implementation stores bucket indices in a vector and is suitable
 /// for most use cases where the issuer state doesn't need to persist
 /// across restarts.
 ///
-/// The issuer operates in one of two [`IssuanceMode`]s. In [`IssuanceMode::Fill`]
-/// every slot is written at most once and the bucket is refused once full. In
-/// [`IssuanceMode::Ring`] the cursor wraps so a later chunk overwrites the
-/// slot held by an earlier one, matching the overwrite semantics of a mutable
-/// batch. Utilisation is reported honestly in both modes: it never exceeds the
-/// bucket capacity, and a ring that has wrapped reports its bucket as full even
-/// though issuance into it continues to succeed.
+/// Issuance is fill-only: every slot is written at most once and the bucket is
+/// refused with [`StampError::BucketFull`] once full. Mutable, overwrite-aware
+/// issuance is intentionally absent from this crate; it requires reserved-slot
+/// awareness that lives in `nectar-postage-usage`. See the crate-root
+/// documentation for the steer toward `Snapshot::issuer` / `SnapshotIssuer`.
 #[derive(Debug, Clone)]
 pub struct MemoryIssuer {
     /// The batch ID.
@@ -165,20 +140,10 @@ pub struct MemoryIssuer {
     depth: u8,
     /// The bucket depth.
     bucket_depth: u8,
-    /// How indices are allocated within a bucket.
-    mode: IssuanceMode,
     /// Next slot to write for each bucket.
     ///
-    /// In [`IssuanceMode::Ring`] this is the ring cursor and wraps modulo the
-    /// bucket capacity. In [`IssuanceMode::Fill`] it is monotonic and never
-    /// reaches the capacity.
+    /// This watermark is monotonic and never reaches the capacity.
     bucket_indices: alloc::vec::Vec<u32>,
-    /// Whether each bucket has been written to capacity at least once.
-    ///
-    /// Only set in [`IssuanceMode::Ring`], where the cursor wraps and so can no
-    /// longer be used to tell a saturated bucket apart from an empty one. Used
-    /// to report utilisation honestly once a ring has wrapped.
-    bucket_saturated: alloc::vec::Vec<bool>,
     /// Maximum utilization across all buckets.
     max_utilization: u32,
     /// Total stamps issued.
@@ -188,21 +153,14 @@ pub struct MemoryIssuer {
 extern crate alloc;
 
 impl MemoryIssuer {
-    /// Creates a new memory issuer for the given batch in [`IssuanceMode::Fill`].
+    /// Creates a new fill-only memory issuer for the given batch geometry.
     pub fn new(batch_id: BatchId, depth: u8, bucket_depth: u8) -> Self {
-        Self::with_mode(batch_id, depth, bucket_depth, IssuanceMode::Fill)
-    }
-
-    /// Creates a new memory issuer for the given batch in the requested mode.
-    pub fn with_mode(batch_id: BatchId, depth: u8, bucket_depth: u8, mode: IssuanceMode) -> Self {
         let bucket_count = 1usize << bucket_depth;
         Self {
             batch_id,
             depth,
             bucket_depth,
-            mode,
             bucket_indices: alloc::vec![0u32; bucket_count],
-            bucket_saturated: alloc::vec![false; bucket_count],
             max_utilization: 0,
             stamps_issued: 0,
         }
@@ -210,32 +168,17 @@ impl MemoryIssuer {
 
     /// Creates a memory issuer from a batch.
     ///
-    /// The issuance mode is selected from the batch mutability: an immutable
-    /// batch issues in [`IssuanceMode::Fill`] and a mutable batch issues in
-    /// [`IssuanceMode::Ring`].
-    pub fn from_batch(batch: &Batch) -> Self {
-        let mode = if batch.immutable() {
-            IssuanceMode::Fill
+    /// Immutable batches yield a fill-only issuer identical to
+    /// [`MemoryIssuer::new`] for the same geometry. Mutable batches are refused
+    /// with [`IssuerError::MutableNotSupported`]: overwrite-aware issuance needs
+    /// reserved-slot awareness that this primitive issuer cannot provide, so a
+    /// mutable batch must be stamped through
+    /// [`nectar_postage_usage::Snapshot::issuer`] / `SnapshotIssuer` instead.
+    pub fn from_batch(batch: &Batch) -> Result<Self, IssuerError> {
+        if batch.immutable() {
+            Ok(Self::new(batch.id(), batch.depth(), batch.bucket_depth()))
         } else {
-            IssuanceMode::Ring
-        };
-        Self::with_mode(batch.id(), batch.depth(), batch.bucket_depth(), mode)
-    }
-
-    /// Returns the issuance mode.
-    pub const fn mode(&self) -> IssuanceMode {
-        self.mode
-    }
-
-    /// Returns the number of distinct slots written in a bucket.
-    ///
-    /// This saturates at the bucket capacity, so a wrapped ring reports the
-    /// bucket as full rather than counting overwrites as fresh utilisation.
-    fn bucket_fill(&self, bucket_idx: usize) -> u32 {
-        if self.bucket_saturated[bucket_idx] {
-            1u32 << (self.depth - self.bucket_depth)
-        } else {
-            self.bucket_indices[bucket_idx]
+            Err(IssuerError::MutableNotSupported)
         }
     }
 }
@@ -251,42 +194,22 @@ impl StampIssuer for MemoryIssuer {
 
         let bucket_capacity = 1u32 << (self.depth - self.bucket_depth);
 
-        // The slot this stamp is written into. In Fill mode this is the next
-        // unused slot; in Ring mode it is the ring cursor, which may point at a
-        // slot a previous chunk already wrote.
+        // The next unused slot in this bucket.
         let position = self.bucket_indices[bucket_idx];
 
-        match self.mode {
-            IssuanceMode::Fill => {
-                if position >= bucket_capacity {
-                    return Err(StampError::BucketFull {
-                        bucket,
-                        capacity: bucket_capacity,
-                    });
-                }
-                self.bucket_indices[bucket_idx] = position + 1;
-            }
-            IssuanceMode::Ring => {
-                // Advance the cursor and wrap at the bucket capacity. Once the
-                // cursor wraps the bucket is saturated: every slot has been
-                // written and further issuance overwrites the oldest chunk.
-                let next = position + 1;
-                if next >= bucket_capacity {
-                    self.bucket_saturated[bucket_idx] = true;
-                    self.bucket_indices[bucket_idx] = 0;
-                } else {
-                    self.bucket_indices[bucket_idx] = next;
-                }
-            }
+        if position >= bucket_capacity {
+            return Err(StampError::BucketFull {
+                bucket,
+                capacity: bucket_capacity,
+            });
         }
+        self.bucket_indices[bucket_idx] = position + 1;
 
         self.stamps_issued += 1;
 
-        // Update max utilization from the honest fill of this bucket, which
-        // never exceeds the bucket capacity even when a ring has wrapped.
-        let fill = self.bucket_fill(bucket_idx);
-        if fill > self.max_utilization {
-            self.max_utilization = fill;
+        // Update max utilization from the monotone fill of this bucket.
+        if self.bucket_indices[bucket_idx] > self.max_utilization {
+            self.max_utilization = self.bucket_indices[bucket_idx];
         }
 
         let index = StampIndex::new(bucket, position);
@@ -315,7 +238,7 @@ impl StampIssuer for MemoryIssuer {
         if bucket_idx >= self.bucket_indices.len() {
             return 0;
         }
-        self.bucket_fill(bucket_idx)
+        self.bucket_indices[bucket_idx]
     }
 
     fn bucket_has_capacity(&self, bucket: u32) -> bool {
@@ -323,11 +246,8 @@ impl StampIssuer for MemoryIssuer {
         if bucket_idx >= self.bucket_indices.len() {
             return false;
         }
-        // Report honestly whether a fresh, never-written slot remains. A ring
-        // that has wrapped reports no spare capacity even though further
-        // issuance still succeeds by overwriting an earlier chunk.
         let bucket_capacity = 1u32 << (self.depth - self.bucket_depth);
-        self.bucket_fill(bucket_idx) < bucket_capacity
+        self.bucket_indices[bucket_idx] < bucket_capacity
     }
 
     fn stamps_issued(&self) -> u64 {
@@ -469,127 +389,47 @@ mod tests {
     }
 
     #[test]
-    fn test_memory_issuer_ring_wraps_instead_of_full() {
-        // depth=17, bucket_depth=16 gives 2 slots per bucket.
-        let mut issuer = MemoryIssuer::with_mode(B256::ZERO, 17, 16, IssuanceMode::Ring);
-
-        let address = test_address(0xABCD);
-
-        // Fill both slots in order.
-        let d0 = issuer.prepare_stamp(&address, 1).unwrap();
-        let d1 = issuer.prepare_stamp(&address, 2).unwrap();
-        assert_eq!(d0.index.index(), 0);
-        assert_eq!(d1.index.index(), 1);
-
-        // A third issuance wraps back to slot zero rather than failing.
-        let d2 = issuer.prepare_stamp(&address, 3).unwrap();
-        assert_eq!(d2.index.index(), 0);
-
-        // And it keeps walking the ring.
-        let d3 = issuer.prepare_stamp(&address, 4).unwrap();
-        assert_eq!(d3.index.index(), 1);
-
-        assert_eq!(issuer.stamps_issued(), 4);
-    }
-
-    #[test]
-    fn test_memory_issuer_ring_index_stays_within_capacity() {
-        // depth=18, bucket_depth=16 gives 4 slots per bucket.
-        let mut issuer = MemoryIssuer::with_mode(B256::ZERO, 18, 16, IssuanceMode::Ring);
-
-        let address = test_address(0x0042);
-
-        // Issue many more chunks than the bucket can hold; every wire index
-        // must remain a valid slot in [0, capacity).
-        for ts in 0..100u64 {
-            let digest = issuer.prepare_stamp(&address, ts).unwrap();
-            assert!(digest.index.index() < 4, "index escaped bucket capacity");
-        }
-        assert_eq!(issuer.stamps_issued(), 100);
-    }
-
-    #[test]
-    fn test_memory_issuer_ring_utilization_is_honest() {
-        // depth=18, bucket_depth=16 gives 4 slots per bucket.
-        let mut issuer = MemoryIssuer::with_mode(B256::ZERO, 18, 16, IssuanceMode::Ring);
-
-        let address = test_address(0x0001);
-
-        // Utilisation climbs slot by slot as fresh slots are written.
-        for (n, ts) in (1..=4u64).enumerate() {
-            issuer.prepare_stamp(&address, ts).unwrap();
-            assert_eq!(issuer.bucket_utilization(0x0001), (n as u32) + 1);
-        }
-
-        // Capacity is reached; a wrapped ring saturates at capacity and does
-        // not count overwrites as fresh utilisation.
-        assert_eq!(issuer.bucket_utilization(0x0001), 4);
-        assert_eq!(issuer.max_bucket_utilization(), 4);
-
-        for ts in 5..20u64 {
-            issuer.prepare_stamp(&address, ts).unwrap();
-            assert_eq!(issuer.bucket_utilization(0x0001), 4);
-            assert_eq!(issuer.max_bucket_utilization(), 4);
-        }
-    }
-
-    #[test]
-    fn test_memory_issuer_ring_capacity_reported_honestly() {
-        // depth=17, bucket_depth=16 gives 2 slots per bucket.
-        let mut issuer = MemoryIssuer::with_mode(B256::ZERO, 17, 16, IssuanceMode::Ring);
-
-        let address = test_address(0x0001);
-
-        // Spare capacity while fresh slots remain.
-        assert!(issuer.bucket_has_capacity(0x0001));
-        issuer.prepare_stamp(&address, 1).unwrap();
-        assert!(issuer.bucket_has_capacity(0x0001));
-
-        // Once every slot has been written the ring reports no spare capacity,
-        // even though issuance into it still succeeds by overwriting.
-        issuer.prepare_stamp(&address, 2).unwrap();
-        assert!(!issuer.bucket_has_capacity(0x0001));
-
-        // Issuance still succeeds despite the bucket reporting no capacity.
-        assert!(issuer.prepare_stamp(&address, 3).is_ok());
-        assert!(!issuer.bucket_has_capacity(0x0001));
-    }
-
-    #[test]
-    fn test_memory_issuer_from_batch_selects_mode() {
+    fn test_memory_issuer_from_batch_mutable_refused() {
         use nectar_postage::Batch;
 
+        // A mutable batch must never yield an issuer: the obvious constructor
+        // refuses it instead of handing back a reserved-blind ring that would
+        // silently overwrite a self-hosted snapshot's own chunks.
         let mutable = Batch::new(B256::ZERO, 0, 0, Default::default(), 20, 16, false);
-        let immutable = Batch::new(B256::ZERO, 0, 0, Default::default(), 20, 16, true);
 
-        assert_eq!(
-            MemoryIssuer::from_batch(&mutable).mode(),
-            IssuanceMode::Ring
-        );
-        assert_eq!(
-            MemoryIssuer::from_batch(&immutable).mode(),
-            IssuanceMode::Fill
-        );
+        assert!(matches!(
+            MemoryIssuer::from_batch(&mutable),
+            Err(IssuerError::MutableNotSupported)
+        ));
     }
 
     #[test]
-    fn test_memory_issuer_fill_mode_unchanged() {
-        // depth=17, bucket_depth=16 gives 2 slots per bucket. Fill mode is the
-        // default and must still refuse a full bucket.
-        let mut issuer = MemoryIssuer::new(B256::ZERO, 17, 16);
-        assert_eq!(issuer.mode(), IssuanceMode::Fill);
+    fn test_memory_issuer_from_batch_immutable_parity_with_new() {
+        use nectar_postage::Batch;
 
-        let address = test_address(0xABCD);
-        assert!(issuer.prepare_stamp(&address, 1).is_ok());
-        assert!(issuer.prepare_stamp(&address, 2).is_ok());
+        // An immutable batch yields a fill-only issuer byte-for-byte identical
+        // to `new` for the same geometry: same indices and the same digest.
+        let batch_id = B256::from([0x11u8; 32]);
+        let immutable = Batch::new(batch_id, 0, 0, Default::default(), 17, 16, true);
 
-        let result = issuer.prepare_stamp(&address, 3);
-        assert!(matches!(
-            result,
-            Err(StampError::BucketFull {
-                bucket: 0xABCD,
-                capacity: 2
-            })
-        ));
+        let mut from_batch = MemoryIssuer::from_batch(&immutable).unwrap();
+        let mut from_new = MemoryIssuer::new(batch_id, 17, 16);
+
+        for ts in 0..2u64 {
+            for leading in [0xCBE5u16, 0x0001, 0xABCD] {
+                let address = test_address(leading);
+                let a = from_batch.prepare_stamp(&address, ts).unwrap();
+                let b = from_new.prepare_stamp(&address, ts).unwrap();
+                assert_eq!(a.index.bucket(), b.index.bucket());
+                assert_eq!(a.index.index(), b.index.index());
+                assert_eq!(a.to_prehash(), b.to_prehash());
+            }
+        }
+
+        assert_eq!(
+            from_batch.max_bucket_utilization(),
+            from_new.max_bucket_utilization()
+        );
+        assert_eq!(from_batch.stamps_issued(), from_new.stamps_issued());
     }
 }

--- a/crates/postage-issuer/src/lib.rs
+++ b/crates/postage-issuer/src/lib.rs
@@ -47,7 +47,7 @@ pub use nectar_postage::*;
 pub use error::SigningError;
 
 // Issuing
-pub use issuer::{MemoryIssuer, StampIssuer};
+pub use issuer::{IssuanceMode, MemoryIssuer, StampIssuer};
 pub use sharded::ShardedIssuer;
 pub use stamper::{BatchStamper, Stamper};
 

--- a/crates/postage-issuer/src/lib.rs
+++ b/crates/postage-issuer/src/lib.rs
@@ -10,8 +10,9 @@
 //! crate. Reserved-aware mutable issuance lives in `nectar-postage-usage` via
 //! `Snapshot::issuer` / `SnapshotIssuer`, which knows the owner's reserved
 //! slots and skips them; a ring here would be reserved-blind and silently evict
-//! a self-hosted snapshot's own chunks. [`MemoryIssuer::from_batch`] therefore
-//! refuses a mutable batch with [`IssuerError::MutableNotSupported`].
+//! a self-hosted snapshot's own chunks. Both [`MemoryIssuer::from_batch`] and
+//! [`ShardedIssuer::from_batch`] therefore refuse a mutable batch with
+//! [`IssuerError::MutableNotSupported`].
 //!
 //! # Features
 //!

--- a/crates/postage-issuer/src/lib.rs
+++ b/crates/postage-issuer/src/lib.rs
@@ -6,6 +6,13 @@
 //! For verification-only use cases (like `vertex` nodes), use
 //! [`nectar-postage`](nectar_postage) directly.
 //!
+//! Mutable, overwrite-aware (ring) issuance is intentionally absent from this
+//! crate. Reserved-aware mutable issuance lives in `nectar-postage-usage` via
+//! `Snapshot::issuer` / `SnapshotIssuer`, which knows the owner's reserved
+//! slots and skips them; a ring here would be reserved-blind and silently evict
+//! a self-hosted snapshot's own chunks. [`MemoryIssuer::from_batch`] therefore
+//! refuses a mutable batch with [`IssuerError::MutableNotSupported`].
+//!
 //! # Features
 //!
 //! - `std` (default) - Enables standard library support
@@ -44,10 +51,10 @@ mod stamper;
 pub use nectar_postage::*;
 
 // Errors (override nectar_postage::StampError with our own that includes signing)
-pub use error::SigningError;
+pub use error::{IssuerError, SigningError};
 
 // Issuing
-pub use issuer::{IssuanceMode, MemoryIssuer, StampIssuer};
+pub use issuer::{MemoryIssuer, StampIssuer};
 pub use sharded::ShardedIssuer;
 pub use stamper::{BatchStamper, Stamper};
 

--- a/crates/postage-issuer/src/lib.rs
+++ b/crates/postage-issuer/src/lib.rs
@@ -6,13 +6,43 @@
 //! For verification-only use cases (like `vertex` nodes), use
 //! [`nectar-postage`](nectar_postage) directly.
 //!
-//! Mutable, overwrite-aware (ring) issuance is intentionally absent from this
-//! crate. Reserved-aware mutable issuance lives in `nectar-postage-usage` via
-//! `Snapshot::issuer` / `SnapshotIssuer`, which knows the owner's reserved
-//! slots and skips them; a ring here would be reserved-blind and silently evict
-//! a self-hosted snapshot's own chunks. Both [`MemoryIssuer::from_batch`] and
-//! [`ShardedIssuer::from_batch`] therefore refuse a mutable batch with
-//! [`IssuerError::MutableNotSupported`].
+//! # Immutable and mutable issuance
+//!
+//! Immutable batches are fill-only: every slot is written at most once and a
+//! full bucket is refused. Use [`MemoryIssuer`] (or [`ShardedIssuer`] for
+//! parallel stamping). Their `from_batch` constructors deliberately refuse a
+//! mutable batch with [`IssuerError::MutableNotSupported`], so a ring is never
+//! produced by accident from the generic constructor.
+//!
+//! Mutable batches are overwrite-aware: a later chunk may reuse the slot held
+//! by an older one. This is the ring issuance in [`RingIssuer`] (and
+//! [`ShardedRingIssuer`] for parallel stamping), and it must be requested by
+//! name. A ring carries its reservation policy in a type parameter so a
+//! reserved-blind ring can never be used in a self-hosting context:
+//!
+//! - [`RingIssuer::external`] builds a [`RingIssuer<Unreserved>`] for external
+//!   tracking: the caller keeps usage state outside the batch and nothing in
+//!   the batch is protected.
+//! - [`RingIssuer::reserved`] builds a [`RingIssuer<Reserved>`] for
+//!   self-hosting: the protected slots come from `nectar-postage-usage`, and
+//!   the ring never re-emits one even after it wraps.
+//!
+//! There is no public conversion from [`Unreserved`] to [`Reserved`], so a
+//! self-hosting context that demands a [`RingIssuer<Reserved>`] cannot be handed
+//! a reserved-blind ring. The following does not compile:
+//!
+//! ```compile_fail
+//! use nectar_postage_issuer::{RingIssuer, Reserved, Unreserved};
+//! use nectar_postage::Batch;
+//! use alloy_primitives::B256;
+//!
+//! fn self_hosting_sink(_ring: RingIssuer<Reserved>) {}
+//!
+//! let batch = Batch::new(B256::ZERO, 0, 0, Default::default(), 20, 16, false);
+//! let unreserved: RingIssuer<Unreserved> = RingIssuer::external(&batch).unwrap();
+//! // A reserved-blind ring is not a Reserved ring, and there is no conversion.
+//! self_hosting_sink(unreserved);
+//! ```
 //!
 //! # Features
 //!
@@ -45,7 +75,9 @@
 mod error;
 mod factory;
 mod issuer;
+mod ring;
 mod sharded;
+mod sharded_ring;
 mod stamper;
 
 // Re-export core types from nectar-postage (includes BatchEvent, BatchEventHandler)
@@ -58,6 +90,10 @@ pub use error::{IssuerError, SigningError};
 pub use issuer::{MemoryIssuer, StampIssuer};
 pub use sharded::ShardedIssuer;
 pub use stamper::{BatchStamper, Stamper};
+
+// Mutable (ring) issuing with a type-state reservation guard
+pub use ring::{Reservation, Reserved, RingIssuer, Unreserved};
+pub use sharded_ring::ShardedRingIssuer;
 
 // Factory (std only)
 #[cfg(feature = "std")]

--- a/crates/postage-issuer/src/ring.rs
+++ b/crates/postage-issuer/src/ring.rs
@@ -1,0 +1,565 @@
+//! Type-state mutable (ring) stamp issuance.
+//!
+//! A mutable batch lets a fresh chunk overwrite the slot held by an older one,
+//! so issuance walks each bucket as a ring cursor and wraps back to the first
+//! slot once every slot has been written. This is the overwrite behaviour an
+//! immutable batch must never have, which is why the fill-only [`MemoryIssuer`]
+//! and [`ShardedIssuer`] refuse a mutable batch outright.
+//!
+//! A reserved-blind ring is dangerous in a self-hosting context: when the owner
+//! keeps its own chunks in the same batch, an unconstrained ring would wrap
+//! around and silently evict them. To make that impossible at compile time the
+//! ring carries its reservation policy in a type parameter:
+//!
+//! - [`RingIssuer<Unreserved>`] protects nothing. It suits external tracking,
+//!   where the caller keeps usage state elsewhere and nothing in the batch is
+//!   protected.
+//! - [`RingIssuer<Reserved>`] protects a supplied set of `(bucket, index)`
+//!   slots and never re-emits one, even after the ring wraps. The protected
+//!   slots come from `nectar-postage-usage` when the batch self-hosts.
+//!
+//! There is no public conversion from [`Unreserved`] to [`Reserved`], so a
+//! function that demands a [`RingIssuer<Reserved>`] cannot be handed a
+//! reserved-blind ring by mistake.
+//!
+//! [`MemoryIssuer`]: crate::MemoryIssuer
+//! [`ShardedIssuer`]: crate::ShardedIssuer
+
+extern crate alloc;
+
+use alloc::collections::BTreeSet;
+use alloc::vec::Vec;
+
+use nectar_postage::{Batch, BatchId, StampDigest, StampError, StampIndex, calculate_bucket};
+use nectar_primitives::SwarmAddress;
+
+use crate::StampIssuer;
+use crate::error::IssuerError;
+
+mod sealed {
+    /// Seals [`Reservation`](super::Reservation) so external crates cannot add
+    /// reservation policies and break the self-hosting invariant.
+    pub trait Sealed {}
+}
+
+/// A reservation policy: answers whether a given `(bucket, index)` slot is
+/// protected and must never be emitted by a ring.
+///
+/// The trait is sealed. Only [`Unreserved`] and [`Reserved`] implement it, so
+/// the set of policies a ring can carry is fixed by this crate and an external
+/// crate cannot weaken the self-hosting guarantee.
+pub trait Reservation: sealed::Sealed {
+    /// Returns `true` if the slot at `index` in `bucket` is protected and must
+    /// not be issued.
+    fn is_protected(&self, bucket: u32, index: u32) -> bool;
+}
+
+/// A reservation policy that protects nothing.
+///
+/// A [`RingIssuer<Unreserved>`] wraps freely and may re-emit any slot. It suits
+/// external tracking, where the caller holds usage state outside the batch.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Unreserved;
+
+impl sealed::Sealed for Unreserved {}
+
+impl Reservation for Unreserved {
+    #[inline]
+    fn is_protected(&self, _bucket: u32, _index: u32) -> bool {
+        false
+    }
+}
+
+/// A reservation policy that protects a fixed set of `(bucket, index)` slots.
+///
+/// A [`RingIssuer<Reserved>`] never emits a protected slot, even after the ring
+/// wraps. The protected slots are the chunks a self-hosting owner keeps in the
+/// batch, supplied by `nectar-postage-usage`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Reserved {
+    /// The protected slots the ring must never re-emit, keyed by bucket.
+    slots: BTreeSet<(u32, u32)>,
+}
+
+impl Reserved {
+    /// Builds a reservation from an iterator of protected `(bucket, index)`
+    /// slots.
+    pub fn new(slots: impl IntoIterator<Item = (u32, u32)>) -> Self {
+        Self {
+            slots: slots.into_iter().collect(),
+        }
+    }
+
+    /// Returns the number of protected slots.
+    pub fn len(&self) -> usize {
+        self.slots.len()
+    }
+
+    /// Returns `true` if no slot is protected.
+    pub fn is_empty(&self) -> bool {
+        self.slots.is_empty()
+    }
+}
+
+impl FromIterator<(u32, u32)> for Reserved {
+    fn from_iter<T: IntoIterator<Item = (u32, u32)>>(iter: T) -> Self {
+        Self::new(iter)
+    }
+}
+
+impl sealed::Sealed for Reserved {}
+
+impl Reservation for Reserved {
+    #[inline]
+    fn is_protected(&self, bucket: u32, index: u32) -> bool {
+        self.slots.contains(&(bucket, index))
+    }
+}
+
+/// A mutable (ring) stamp issuer.
+///
+/// Issuance advances a per-bucket cursor and wraps at the bucket capacity
+/// `2^(depth - bucket_depth)`, so a later chunk overwrites the slot held by an
+/// earlier one. The reservation policy `R` decides which slots, if any, the
+/// ring must skip:
+///
+/// - [`RingIssuer::external`] builds a [`RingIssuer<Unreserved>`] that protects
+///   nothing.
+/// - [`RingIssuer::reserved`] builds a [`RingIssuer<Reserved>`] that never
+///   emits a protected slot.
+///
+/// Both constructors require a mutable batch. An immutable batch is refused
+/// with [`IssuerError::ImmutableNotSupported`]: immutable batches are fill-only
+/// and use [`MemoryIssuer`](crate::MemoryIssuer).
+#[derive(Debug, Clone)]
+pub struct RingIssuer<R = Unreserved> {
+    /// The batch ID.
+    batch_id: BatchId,
+    /// The batch depth.
+    depth: u8,
+    /// The bucket depth.
+    bucket_depth: u8,
+    /// The bucket capacity, `2^(depth - bucket_depth)`.
+    bucket_capacity: u32,
+    /// Ring cursor for each bucket. Wraps modulo the bucket capacity.
+    cursors: Vec<u32>,
+    /// Whether each bucket has been written to capacity at least once.
+    ///
+    /// Once the cursor wraps it can no longer tell a saturated bucket apart
+    /// from an empty one, so this tracks saturation to report utilisation
+    /// honestly.
+    saturated: Vec<bool>,
+    /// Maximum utilisation observed across all buckets.
+    max_utilization: u32,
+    /// Total stamps issued.
+    stamps_issued: u64,
+    /// The reservation policy.
+    reservation: R,
+}
+
+impl RingIssuer<Unreserved> {
+    /// Builds an externally tracked ring for a mutable batch.
+    ///
+    /// The ring protects nothing: it wraps freely and may re-emit any slot. The
+    /// caller is responsible for tracking usage outside the batch, which is the
+    /// external-tracking model.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IssuerError::ImmutableNotSupported`] if the batch is immutable;
+    /// immutable batches are fill-only and use
+    /// [`MemoryIssuer`](crate::MemoryIssuer).
+    pub fn external(batch: &Batch) -> Result<Self, IssuerError> {
+        Self::for_mutable_batch(batch, Unreserved)
+    }
+}
+
+impl RingIssuer<Reserved> {
+    /// Builds a self-hosting ring for a mutable batch with a set of protected
+    /// slots.
+    ///
+    /// The ring never emits a protected slot, even after it wraps. The
+    /// protected slots are the chunks the owner keeps in the batch, supplied by
+    /// `nectar-postage-usage`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IssuerError::ImmutableNotSupported`] if the batch is immutable;
+    /// immutable batches are fill-only and use
+    /// [`MemoryIssuer`](crate::MemoryIssuer).
+    pub fn reserved(
+        batch: &Batch,
+        slots: impl IntoIterator<Item = (u32, u32)>,
+    ) -> Result<Self, IssuerError> {
+        Self::for_mutable_batch(batch, Reserved::new(slots))
+    }
+}
+
+impl<R: Reservation> RingIssuer<R> {
+    /// Builds a ring for a mutable batch with the given reservation policy.
+    fn for_mutable_batch(batch: &Batch, reservation: R) -> Result<Self, IssuerError> {
+        if batch.immutable() {
+            return Err(IssuerError::ImmutableNotSupported);
+        }
+        Ok(Self::with_reservation(
+            batch.id(),
+            batch.depth(),
+            batch.bucket_depth(),
+            reservation,
+        ))
+    }
+
+    /// Builds a ring directly from geometry and a reservation policy.
+    fn with_reservation(batch_id: BatchId, depth: u8, bucket_depth: u8, reservation: R) -> Self {
+        let bucket_count = 1usize << bucket_depth;
+        Self {
+            batch_id,
+            depth,
+            bucket_depth,
+            bucket_capacity: 1u32 << (depth - bucket_depth),
+            cursors: alloc::vec![0u32; bucket_count],
+            saturated: alloc::vec![false; bucket_count],
+            max_utilization: 0,
+            stamps_issued: 0,
+            reservation,
+        }
+    }
+
+    /// Returns the number of distinct slots written in a bucket.
+    ///
+    /// This saturates at the bucket capacity, so a wrapped ring reports the
+    /// bucket as full rather than counting overwrites as fresh utilisation.
+    fn bucket_fill(&self, bucket_idx: usize) -> u32 {
+        if self.saturated[bucket_idx] {
+            self.bucket_capacity
+        } else {
+            self.cursors[bucket_idx]
+        }
+    }
+
+    /// Advances the cursor for `bucket` to the next unprotected slot, returning
+    /// the slot to emit.
+    ///
+    /// The cursor starts at its current position and walks forward, wrapping at
+    /// the bucket capacity and marking the bucket saturated on each wrap. Up to
+    /// `bucket_capacity` slots are inspected; if every slot is protected the
+    /// bucket has no issuable slot and [`IssuerError::RingExhausted`] is
+    /// returned rather than emitting a protected slot.
+    fn next_slot(&mut self, bucket: u32) -> Result<u32, IssuerError> {
+        let bucket_idx = bucket as usize;
+        for _ in 0..self.bucket_capacity {
+            let position = self.cursors[bucket_idx];
+
+            // Advance the cursor, wrapping at the bucket capacity and marking
+            // saturation on each wrap.
+            let next = position + 1;
+            if next >= self.bucket_capacity {
+                self.saturated[bucket_idx] = true;
+                self.cursors[bucket_idx] = 0;
+            } else {
+                self.cursors[bucket_idx] = next;
+            }
+
+            if !self.reservation.is_protected(bucket, position) {
+                return Ok(position);
+            }
+        }
+        Err(IssuerError::RingExhausted { bucket })
+    }
+
+    /// Prepares a stamp digest for the given chunk address.
+    ///
+    /// Advances the bucket ring to the next unprotected slot and returns the
+    /// digest to sign.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StampError`] only via [`IssuerError::RingExhausted`] when every
+    /// slot in the target bucket is protected, which is geometrically
+    /// impossible at real batch depths.
+    fn prepare_ring_stamp(
+        &mut self,
+        address: &SwarmAddress,
+        timestamp: u64,
+    ) -> Result<StampDigest, IssuerError> {
+        let bucket = calculate_bucket(address, self.bucket_depth);
+        let position = self.next_slot(bucket)?;
+
+        self.stamps_issued += 1;
+
+        let fill = self.bucket_fill(bucket as usize);
+        if fill > self.max_utilization {
+            self.max_utilization = fill;
+        }
+
+        let index = StampIndex::new(bucket, position);
+        Ok(StampDigest::new(*address, self.batch_id, index, timestamp))
+    }
+
+    /// Returns the bucket capacity, `2^(depth - bucket_depth)`.
+    pub const fn bucket_capacity(&self) -> u32 {
+        self.bucket_capacity
+    }
+
+    /// Returns a reference to the reservation policy.
+    pub const fn reservation(&self) -> &R {
+        &self.reservation
+    }
+}
+
+impl<R: Reservation> StampIssuer for RingIssuer<R> {
+    fn prepare_stamp(
+        &mut self,
+        address: &SwarmAddress,
+        timestamp: u64,
+    ) -> Result<StampDigest, StampError> {
+        // A ring never reports BucketFull; the only failure is a fully reserved
+        // bucket, which is geometrically impossible at real depths. Surface it
+        // through StampError::BucketFull so it flows through the StampIssuer and
+        // Stamper contract without a new wire error.
+        self.prepare_ring_stamp(address, timestamp)
+            .map_err(|err| match err {
+                IssuerError::RingExhausted { bucket } => StampError::BucketFull {
+                    bucket,
+                    capacity: self.bucket_capacity,
+                },
+                // `prepare_ring_stamp` only ever yields RingExhausted.
+                _ => unreachable!("ring issuance only fails with RingExhausted"),
+            })
+    }
+
+    fn batch_id(&self) -> BatchId {
+        self.batch_id
+    }
+
+    fn batch_depth(&self) -> u8 {
+        self.depth
+    }
+
+    fn bucket_depth(&self) -> u8 {
+        self.bucket_depth
+    }
+
+    fn max_bucket_utilization(&self) -> u32 {
+        self.max_utilization
+    }
+
+    fn bucket_utilization(&self, bucket: u32) -> u32 {
+        let bucket_idx = bucket as usize;
+        if bucket_idx >= self.cursors.len() {
+            return 0;
+        }
+        self.bucket_fill(bucket_idx)
+    }
+
+    fn bucket_has_capacity(&self, bucket: u32) -> bool {
+        let bucket_idx = bucket as usize;
+        if bucket_idx >= self.cursors.len() {
+            return false;
+        }
+        // Report honestly whether a fresh, never-written slot remains. A ring
+        // that has wrapped reports no spare capacity even though issuance into
+        // it still succeeds by overwriting an earlier chunk.
+        self.bucket_fill(bucket_idx) < self.bucket_capacity
+    }
+
+    fn stamps_issued(&self) -> u64 {
+        self.stamps_issued
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::B256;
+
+    fn test_address(leading: u16) -> SwarmAddress {
+        let mut bytes = [0u8; 32];
+        bytes[0] = (leading >> 8) as u8;
+        bytes[1] = leading as u8;
+        SwarmAddress::new(bytes)
+    }
+
+    fn mutable_batch(depth: u8, bucket_depth: u8) -> Batch {
+        Batch::new(
+            B256::ZERO,
+            0,
+            0,
+            Default::default(),
+            depth,
+            bucket_depth,
+            false,
+        )
+    }
+
+    fn immutable_batch(depth: u8, bucket_depth: u8) -> Batch {
+        Batch::new(
+            B256::ZERO,
+            0,
+            0,
+            Default::default(),
+            depth,
+            bucket_depth,
+            true,
+        )
+    }
+
+    #[test]
+    fn external_ring_wraps_and_reuses_slots() {
+        // depth=17, bucket_depth=16 gives 2 slots per bucket.
+        let batch = mutable_batch(17, 16);
+        let mut issuer = RingIssuer::external(&batch).unwrap();
+
+        let address = test_address(0xABCD);
+
+        let d0 = issuer.prepare_ring_stamp(&address, 1).unwrap();
+        let d1 = issuer.prepare_ring_stamp(&address, 2).unwrap();
+        assert_eq!(d0.index.index(), 0);
+        assert_eq!(d1.index.index(), 1);
+
+        // A third issuance wraps back to slot zero rather than failing.
+        let d2 = issuer.prepare_ring_stamp(&address, 3).unwrap();
+        assert_eq!(d2.index.index(), 0);
+
+        let d3 = issuer.prepare_ring_stamp(&address, 4).unwrap();
+        assert_eq!(d3.index.index(), 1);
+
+        assert_eq!(issuer.stamps_issued(), 4);
+    }
+
+    #[test]
+    fn external_ring_index_stays_within_capacity() {
+        // depth=18, bucket_depth=16 gives 4 slots per bucket.
+        let batch = mutable_batch(18, 16);
+        let mut issuer = RingIssuer::external(&batch).unwrap();
+
+        let address = test_address(0x0042);
+
+        for ts in 0..100u64 {
+            let digest = issuer.prepare_ring_stamp(&address, ts).unwrap();
+            assert!(digest.index.index() < 4, "index escaped bucket capacity");
+        }
+        assert_eq!(issuer.stamps_issued(), 100);
+    }
+
+    #[test]
+    fn reserved_ring_never_emits_a_protected_slot() {
+        // depth=18, bucket_depth=16 gives 4 slots per bucket. Protect slots 1
+        // and 3 in the target bucket; the ring may only ever emit 0 and 2.
+        let batch = mutable_batch(18, 16);
+        let bucket = calculate_bucket(&test_address(0x00AA), 16);
+        let mut issuer = RingIssuer::reserved(&batch, [(bucket, 1), (bucket, 3)]).unwrap();
+
+        let address = test_address(0x00AA);
+
+        // Issue far past one wrap so every wrap is exercised.
+        for ts in 0..50u64 {
+            let digest = issuer.prepare_ring_stamp(&address, ts).unwrap();
+            let index = digest.index.index();
+            assert!(
+                index == 0 || index == 2,
+                "ring emitted protected or out-of-range slot {index}"
+            );
+            assert!(!issuer.reservation().is_protected(bucket, index));
+        }
+    }
+
+    #[test]
+    fn reserved_ring_exhausts_when_every_slot_is_protected() {
+        // depth=17, bucket_depth=16 gives 2 slots per bucket. Protect both, so
+        // the bucket has no issuable slot.
+        let batch = mutable_batch(17, 16);
+        let bucket = calculate_bucket(&test_address(0x0001), 16);
+        let mut issuer = RingIssuer::reserved(&batch, [(bucket, 0), (bucket, 1)]).unwrap();
+
+        let address = test_address(0x0001);
+        assert!(matches!(
+            issuer.prepare_ring_stamp(&address, 1),
+            Err(IssuerError::RingExhausted { bucket: b }) if b == bucket
+        ));
+    }
+
+    #[test]
+    fn external_refuses_immutable_batch() {
+        let batch = immutable_batch(20, 16);
+        assert!(matches!(
+            RingIssuer::external(&batch),
+            Err(IssuerError::ImmutableNotSupported)
+        ));
+    }
+
+    #[test]
+    fn reserved_refuses_immutable_batch() {
+        let batch = immutable_batch(20, 16);
+        assert!(matches!(
+            RingIssuer::reserved(&batch, [(0u32, 0u32)]),
+            Err(IssuerError::ImmutableNotSupported)
+        ));
+    }
+
+    #[test]
+    fn ring_reports_utilisation_and_capacity_honestly() {
+        // depth=17, bucket_depth=16 gives 2 slots per bucket.
+        let batch = mutable_batch(17, 16);
+        let mut issuer = RingIssuer::external(&batch).unwrap();
+
+        let address = test_address(0x0001);
+        let bucket = calculate_bucket(&address, 16);
+
+        assert!(issuer.bucket_has_capacity(bucket));
+        issuer.prepare_ring_stamp(&address, 1).unwrap();
+        assert!(issuer.bucket_has_capacity(bucket));
+        assert_eq!(issuer.bucket_utilization(bucket), 1);
+
+        issuer.prepare_ring_stamp(&address, 2).unwrap();
+        assert!(!issuer.bucket_has_capacity(bucket));
+        assert_eq!(issuer.bucket_utilization(bucket), 2);
+        assert_eq!(issuer.max_bucket_utilization(), 2);
+
+        // Issuance still succeeds despite the bucket reporting no capacity, and
+        // utilisation saturates rather than counting overwrites.
+        issuer.prepare_ring_stamp(&address, 3).unwrap();
+        assert_eq!(issuer.bucket_utilization(bucket), 2);
+        assert_eq!(issuer.max_bucket_utilization(), 2);
+    }
+
+    #[test]
+    fn ring_drops_into_batch_stamper() {
+        use crate::{BatchStamper, Stamper};
+        use alloy_signer_local::PrivateKeySigner;
+
+        // depth=17, bucket_depth=16 gives 2 slots per bucket. A ring stamps
+        // through BatchStamper exactly like a MemoryIssuer, wrapping past the
+        // bucket capacity instead of refusing.
+        let batch = mutable_batch(17, 16);
+        let issuer = RingIssuer::external(&batch).unwrap();
+        let signer = PrivateKeySigner::random();
+        let mut stamper = BatchStamper::new(issuer, signer);
+
+        let address = test_address(0xABCD);
+
+        let s0 = stamper.stamp(&address).unwrap();
+        let s1 = stamper.stamp(&address).unwrap();
+        let s2 = stamper.stamp(&address).unwrap();
+
+        assert_eq!(s0.index(), 0);
+        assert_eq!(s1.index(), 1);
+        // Wraps rather than failing, which a fill-only issuer would not.
+        assert_eq!(s2.index(), 0);
+        assert_eq!(s0.bucket(), s2.bucket());
+    }
+
+    #[test]
+    fn ring_stamp_issuer_surfaces_exhaustion_as_bucket_full() {
+        let batch = mutable_batch(17, 16);
+        let bucket = calculate_bucket(&test_address(0x0001), 16);
+        let mut issuer = RingIssuer::reserved(&batch, [(bucket, 0), (bucket, 1)]).unwrap();
+
+        let address = test_address(0x0001);
+        let result = StampIssuer::prepare_stamp(&mut issuer, &address, 1);
+        assert!(matches!(
+            result,
+            Err(StampError::BucketFull { bucket: b, capacity: 2 }) if b == bucket
+        ));
+    }
+}

--- a/crates/postage-issuer/src/ring.rs
+++ b/crates/postage-issuer/src/ring.rs
@@ -146,10 +146,10 @@ pub struct RingIssuer<R = Unreserved> {
     /// Whether each bucket has been written to capacity at least once.
     ///
     /// Once the cursor wraps it can no longer tell a saturated bucket apart
-    /// from an empty one, so this tracks saturation to report utilisation
+    /// from an empty one, so this tracks saturation to report utilization
     /// honestly.
     saturated: Vec<bool>,
-    /// Maximum utilisation observed across all buckets.
+    /// Maximum utilization observed across all buckets.
     max_utilization: u32,
     /// Total stamps issued.
     stamps_issued: u64,
@@ -228,7 +228,7 @@ impl<R: Reservation> RingIssuer<R> {
     /// Returns the number of distinct slots written in a bucket.
     ///
     /// This saturates at the bucket capacity, so a wrapped ring reports the
-    /// bucket as full rather than counting overwrites as fresh utilisation.
+    /// bucket as full rather than counting overwrites as fresh utilization.
     fn bucket_fill(&self, bucket_idx: usize) -> u32 {
         if self.saturated[bucket_idx] {
             self.bucket_capacity
@@ -498,7 +498,7 @@ mod tests {
     }
 
     #[test]
-    fn ring_reports_utilisation_and_capacity_honestly() {
+    fn ring_reports_utilization_and_capacity_honestly() {
         // depth=17, bucket_depth=16 gives 2 slots per bucket.
         let batch = mutable_batch(17, 16);
         let mut issuer = RingIssuer::external(&batch).unwrap();
@@ -517,7 +517,7 @@ mod tests {
         assert_eq!(issuer.max_bucket_utilization(), 2);
 
         // Issuance still succeeds despite the bucket reporting no capacity, and
-        // utilisation saturates rather than counting overwrites.
+        // utilization saturates rather than counting overwrites.
         issuer.prepare_ring_stamp(&address, 3).unwrap();
         assert_eq!(issuer.bucket_utilization(bucket), 2);
         assert_eq!(issuer.max_bucket_utilization(), 2);

--- a/crates/postage-issuer/src/sharded.rs
+++ b/crates/postage-issuer/src/sharded.rs
@@ -169,10 +169,13 @@ impl ShardedIssuer {
     ///
     /// Immutable batches yield a fill-only issuer. Mutable batches are refused
     /// with [`IssuerError::MutableNotSupported`], matching
-    /// [`MemoryIssuer::from_batch`](crate::MemoryIssuer::from_batch): overwrite-aware
-    /// issuance needs reserved-slot awareness this primitive issuer cannot
-    /// provide, so a mutable batch must be stamped through the owner-aware
-    /// `nectar_postage_usage::Snapshot::issuer` / `SnapshotIssuer` instead.
+    /// [`MemoryIssuer::from_batch`](crate::MemoryIssuer::from_batch), so a ring
+    /// is never produced by accident. Overwrite-aware parallel issuance must be
+    /// requested by name through
+    /// [`ShardedRingIssuer::external`](crate::ShardedRingIssuer::external) for
+    /// external tracking, or
+    /// [`ShardedRingIssuer::reserved`](crate::ShardedRingIssuer::reserved) for
+    /// self-hosting, where the protected slots come from `nectar-postage-usage`.
     pub fn from_batch(batch: &Batch) -> Result<Self, IssuerError> {
         if batch.immutable() {
             Ok(Self::new(batch.id(), batch.depth(), batch.bucket_depth()))

--- a/crates/postage-issuer/src/sharded.rs
+++ b/crates/postage-issuer/src/sharded.rs
@@ -15,6 +15,7 @@
 
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 
+use crate::error::IssuerError;
 use nectar_postage::{Batch, BatchId, StampDigest, StampError, StampIndex, calculate_bucket};
 use nectar_primitives::SwarmAddress;
 
@@ -165,8 +166,19 @@ impl ShardedIssuer {
     }
 
     /// Creates a sharded issuer from a batch.
-    pub fn from_batch(batch: &Batch) -> Self {
-        Self::new(batch.id(), batch.depth(), batch.bucket_depth())
+    ///
+    /// Immutable batches yield a fill-only issuer. Mutable batches are refused
+    /// with [`IssuerError::MutableNotSupported`], matching
+    /// [`MemoryIssuer::from_batch`](crate::MemoryIssuer::from_batch): overwrite-aware
+    /// issuance needs reserved-slot awareness this primitive issuer cannot
+    /// provide, so a mutable batch must be stamped through the owner-aware
+    /// `nectar_postage_usage::Snapshot::issuer` / `SnapshotIssuer` instead.
+    pub fn from_batch(batch: &Batch) -> Result<Self, IssuerError> {
+        if batch.immutable() {
+            Ok(Self::new(batch.id(), batch.depth(), batch.bucket_depth()))
+        } else {
+            Err(IssuerError::MutableNotSupported)
+        }
     }
 
     /// Maps a bucket to its shard index.
@@ -356,6 +368,28 @@ const fn stamp_from_signature(digest: &StampDigest, sig: Signature) -> Stamp {
 mod tests {
     use super::*;
     use alloy_primitives::B256;
+
+    #[test]
+    fn test_sharded_issuer_from_batch_mutable_refused() {
+        use nectar_postage::Batch;
+
+        // The parallel constructor refuses a mutable batch for the same reason
+        // as MemoryIssuer: a reserved-blind ring would silently overwrite a
+        // self-hosted snapshot's own chunks.
+        let mutable = Batch::new(B256::ZERO, 0, 0, Default::default(), 20, 16, false);
+        assert!(matches!(
+            ShardedIssuer::from_batch(&mutable),
+            Err(IssuerError::MutableNotSupported)
+        ));
+    }
+
+    #[test]
+    fn test_sharded_issuer_from_batch_immutable_ok() {
+        use nectar_postage::Batch;
+
+        let immutable = Batch::new(B256::ZERO, 0, 0, Default::default(), 20, 16, true);
+        assert!(ShardedIssuer::from_batch(&immutable).is_ok());
+    }
 
     #[test]
     fn test_sharded_issuer_basic() {

--- a/crates/postage-issuer/src/sharded_ring.rs
+++ b/crates/postage-issuer/src/sharded_ring.rs
@@ -1,0 +1,470 @@
+//! Sharded type-state mutable (ring) stamp issuance.
+//!
+//! [`ShardedRingIssuer`] is the parallel counterpart of
+//! [`RingIssuer`](crate::RingIssuer): it partitions the bucket space across
+//! shards so multiple threads can stamp into distinct shards concurrently,
+//! while each bucket still advances as a ring cursor that wraps at the bucket
+//! capacity.
+//!
+//! The reservation policy is carried in the same type parameter `R` as the
+//! single-threaded ring, so the self-hosting guarantee is identical:
+//!
+//! - [`ShardedRingIssuer::external`] builds a [`ShardedRingIssuer<Unreserved>`]
+//!   that protects nothing.
+//! - [`ShardedRingIssuer::reserved`] builds a [`ShardedRingIssuer<Reserved>`]
+//!   that never emits a protected slot, distributing the supplied slots to the
+//!   shard that owns each bucket.
+
+use std::sync::Mutex;
+
+use nectar_postage::{Batch, BatchId, StampDigest, StampError, StampIndex, calculate_bucket};
+use nectar_primitives::SwarmAddress;
+
+use crate::error::IssuerError;
+use crate::ring::{Reservation, Reserved, Unreserved};
+
+/// Number of shards for bucket partitioning. Must be a power of two.
+const DEFAULT_SHARD_COUNT: usize = 16;
+
+/// A shard owning the ring cursors for a contiguous range of buckets.
+///
+/// Each shard carries the reservation entries for its own bucket range and is
+/// guarded by its own lock, so threads stamping into different shards do not
+/// contend.
+#[derive(Debug)]
+struct RingShard<R> {
+    /// Base global bucket index for this shard.
+    base_bucket: u32,
+    /// Ring cursor and saturation state for each bucket in this shard.
+    state: Mutex<RingShardState>,
+    /// The reservation entries that fall within this shard's bucket range.
+    reservation: R,
+}
+
+#[derive(Debug)]
+struct RingShardState {
+    /// Ring cursor per local bucket. Wraps modulo the bucket capacity.
+    cursors: Vec<u32>,
+    /// Whether each local bucket has been written to capacity at least once.
+    saturated: Vec<bool>,
+}
+
+impl<R: Reservation> RingShard<R> {
+    fn new(base_bucket: u32, buckets_per_shard: u32, reservation: R) -> Self {
+        let count = buckets_per_shard as usize;
+        Self {
+            base_bucket,
+            state: Mutex::new(RingShardState {
+                cursors: alloc_zeroed_u32(count),
+                saturated: vec![false; count],
+            }),
+            reservation,
+        }
+    }
+
+    #[inline]
+    const fn local_index(&self, bucket: u32) -> usize {
+        (bucket - self.base_bucket) as usize
+    }
+
+    /// Advances the ring for `bucket` to the next unprotected slot under the
+    /// shard lock, returning the slot to emit.
+    ///
+    /// Returns [`IssuerError::RingExhausted`] if every slot in the bucket is
+    /// protected.
+    fn next_slot(&self, bucket: u32, bucket_capacity: u32) -> Result<u32, IssuerError> {
+        let local = self.local_index(bucket);
+        let mut state = self.state.lock().expect("ring shard lock poisoned");
+        for _ in 0..bucket_capacity {
+            let position = state.cursors[local];
+
+            let next = position + 1;
+            if next >= bucket_capacity {
+                state.saturated[local] = true;
+                state.cursors[local] = 0;
+            } else {
+                state.cursors[local] = next;
+            }
+
+            if !self.reservation.is_protected(bucket, position) {
+                return Ok(position);
+            }
+        }
+        Err(IssuerError::RingExhausted { bucket })
+    }
+
+    /// Returns the number of distinct slots written in a bucket, saturating at
+    /// the bucket capacity.
+    fn utilization(&self, bucket: u32, bucket_capacity: u32) -> u32 {
+        let local = self.local_index(bucket);
+        let state = self.state.lock().expect("ring shard lock poisoned");
+        if state.saturated[local] {
+            bucket_capacity
+        } else {
+            state.cursors[local]
+        }
+    }
+}
+
+fn alloc_zeroed_u32(count: usize) -> Vec<u32> {
+    vec![0u32; count]
+}
+
+/// A sharded mutable (ring) stamp issuer for high-throughput parallel stamping.
+///
+/// The bucket space is partitioned across shards, each guarded by its own lock,
+/// so threads stamping into distinct shards proceed without contention. Within
+/// a bucket, issuance advances a ring cursor that wraps at the bucket capacity,
+/// so a later chunk overwrites the slot held by an earlier one.
+///
+/// The reservation policy `R` decides which slots, if any, the ring must skip:
+///
+/// - [`ShardedRingIssuer::external`] protects nothing.
+/// - [`ShardedRingIssuer::reserved`] never emits a protected slot, routing each
+///   protected slot to the shard that owns its bucket.
+///
+/// Both constructors require a mutable batch; an immutable batch is refused with
+/// [`IssuerError::ImmutableNotSupported`].
+#[derive(Debug)]
+pub struct ShardedRingIssuer<R = Unreserved> {
+    /// The batch ID.
+    batch_id: BatchId,
+    /// The batch depth.
+    depth: u8,
+    /// The bucket depth.
+    bucket_depth: u8,
+    /// The bucket capacity, `2^(depth - bucket_depth)`.
+    bucket_capacity: u32,
+    /// The shards, each owning a contiguous bucket range.
+    shards: Vec<RingShard<R>>,
+    /// Mask for mapping a bucket to its shard index.
+    shard_mask: u32,
+    /// Bits to shift a bucket by to obtain its shard index.
+    shard_shift: u32,
+    /// Maximum utilisation observed, guarded for cross-shard aggregation.
+    max_utilization: Mutex<u32>,
+    /// Total stamps issued, guarded for cross-shard aggregation.
+    stamps_issued: Mutex<u64>,
+}
+
+impl ShardedRingIssuer<Unreserved> {
+    /// Builds an externally tracked sharded ring for a mutable batch.
+    ///
+    /// The ring protects nothing. The caller tracks usage outside the batch.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IssuerError::ImmutableNotSupported`] if the batch is immutable.
+    pub fn external(batch: &Batch) -> Result<Self, IssuerError> {
+        Self::for_mutable_batch(batch, |_, _, _| Unreserved)
+    }
+}
+
+impl ShardedRingIssuer<Reserved> {
+    /// Builds a self-hosting sharded ring for a mutable batch with a set of
+    /// protected slots.
+    ///
+    /// Each protected slot is routed to the shard that owns its bucket, so the
+    /// ring never emits a protected slot regardless of which thread stamps into
+    /// that shard.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IssuerError::ImmutableNotSupported`] if the batch is immutable.
+    pub fn reserved(
+        batch: &Batch,
+        slots: impl IntoIterator<Item = (u32, u32)>,
+    ) -> Result<Self, IssuerError> {
+        let slots: Vec<(u32, u32)> = slots.into_iter().collect();
+        Self::for_mutable_batch(batch, |base, end, _idx| {
+            // Distribute the reserved slots to the shard that owns each bucket.
+            Reserved::new(
+                slots
+                    .iter()
+                    .copied()
+                    .filter(|&(bucket, _)| bucket >= base && bucket < end),
+            )
+        })
+    }
+}
+
+impl<R: Reservation> ShardedRingIssuer<R> {
+    fn for_mutable_batch(
+        batch: &Batch,
+        make_reservation: impl Fn(u32, u32, usize) -> R,
+    ) -> Result<Self, IssuerError> {
+        if batch.immutable() {
+            return Err(IssuerError::ImmutableNotSupported);
+        }
+        Ok(Self::with_shard_count(
+            batch.id(),
+            batch.depth(),
+            batch.bucket_depth(),
+            DEFAULT_SHARD_COUNT,
+            make_reservation,
+        ))
+    }
+
+    fn with_shard_count(
+        batch_id: BatchId,
+        depth: u8,
+        bucket_depth: u8,
+        shard_count: usize,
+        make_reservation: impl Fn(u32, u32, usize) -> R,
+    ) -> Self {
+        assert!(
+            shard_count.is_power_of_two(),
+            "shard_count must be a power of 2"
+        );
+
+        let total_buckets = 1u32 << bucket_depth;
+        let shard_count = shard_count.min(total_buckets as usize);
+        let buckets_per_shard = total_buckets / shard_count as u32;
+        let bucket_capacity = 1u32 << (depth - bucket_depth);
+
+        let shard_bits = (shard_count as u32).trailing_zeros();
+        let shard_shift = bucket_depth as u32 - shard_bits;
+        let shard_mask = (shard_count - 1) as u32;
+
+        let shards: Vec<_> = (0..shard_count)
+            .map(|i| {
+                let base = i as u32 * buckets_per_shard;
+                let end = base + buckets_per_shard;
+                RingShard::new(base, buckets_per_shard, make_reservation(base, end, i))
+            })
+            .collect();
+
+        Self {
+            batch_id,
+            depth,
+            bucket_depth,
+            bucket_capacity,
+            shards,
+            shard_mask,
+            shard_shift,
+            max_utilization: Mutex::new(0),
+            stamps_issued: Mutex::new(0),
+        }
+    }
+
+    #[inline]
+    const fn shard_index(&self, bucket: u32) -> usize {
+        ((bucket >> self.shard_shift) & self.shard_mask) as usize
+    }
+
+    /// Prepares a stamp digest for the given chunk address.
+    ///
+    /// Thread-safe: it may be called concurrently from multiple threads, with
+    /// contention limited to the shard owning the chunk's bucket.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StampError::BucketFull`] only when every slot in the target
+    /// bucket is protected, which is geometrically impossible at real batch
+    /// depths.
+    pub fn prepare_stamp(
+        &self,
+        address: &SwarmAddress,
+        timestamp: u64,
+    ) -> Result<StampDigest, StampError> {
+        let bucket = calculate_bucket(address, self.bucket_depth);
+        let shard = &self.shards[self.shard_index(bucket)];
+
+        let position =
+            shard
+                .next_slot(bucket, self.bucket_capacity)
+                .map_err(|_| StampError::BucketFull {
+                    bucket,
+                    capacity: self.bucket_capacity,
+                })?;
+
+        {
+            let mut issued = self.stamps_issued.lock().expect("stamps lock poisoned");
+            *issued += 1;
+        }
+        let fill = shard.utilization(bucket, self.bucket_capacity);
+        {
+            let mut max = self
+                .max_utilization
+                .lock()
+                .expect("max utilisation lock poisoned");
+            if fill > *max {
+                *max = fill;
+            }
+        }
+
+        let index = StampIndex::new(bucket, position);
+        Ok(StampDigest::new(*address, self.batch_id, index, timestamp))
+    }
+
+    /// Returns the batch ID.
+    pub const fn batch_id(&self) -> BatchId {
+        self.batch_id
+    }
+
+    /// Returns the batch depth.
+    pub const fn batch_depth(&self) -> u8 {
+        self.depth
+    }
+
+    /// Returns the bucket depth.
+    pub const fn bucket_depth(&self) -> u8 {
+        self.bucket_depth
+    }
+
+    /// Returns the bucket capacity, `2^(depth - bucket_depth)`.
+    pub const fn bucket_capacity(&self) -> u32 {
+        self.bucket_capacity
+    }
+
+    /// Returns the number of shards.
+    pub const fn shard_count(&self) -> usize {
+        self.shards.len()
+    }
+
+    /// Returns the current utilisation of a specific bucket, saturating at the
+    /// bucket capacity once the ring has wrapped.
+    pub fn bucket_utilization(&self, bucket: u32) -> u32 {
+        let shard = &self.shards[self.shard_index(bucket)];
+        shard.utilization(bucket, self.bucket_capacity)
+    }
+
+    /// Returns the maximum bucket utilisation observed across all buckets.
+    pub fn max_bucket_utilization(&self) -> u32 {
+        *self
+            .max_utilization
+            .lock()
+            .expect("max utilisation lock poisoned")
+    }
+
+    /// Returns the total number of stamps issued.
+    pub fn stamps_issued(&self) -> u64 {
+        *self.stamps_issued.lock().expect("stamps lock poisoned")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::B256;
+
+    fn test_address(leading: u16) -> SwarmAddress {
+        let mut bytes = [0u8; 32];
+        bytes[0] = (leading >> 8) as u8;
+        bytes[1] = leading as u8;
+        SwarmAddress::new(bytes)
+    }
+
+    fn mutable_batch(depth: u8, bucket_depth: u8) -> Batch {
+        Batch::new(
+            B256::ZERO,
+            0,
+            0,
+            Default::default(),
+            depth,
+            bucket_depth,
+            false,
+        )
+    }
+
+    fn immutable_batch(depth: u8, bucket_depth: u8) -> Batch {
+        Batch::new(
+            B256::ZERO,
+            0,
+            0,
+            Default::default(),
+            depth,
+            bucket_depth,
+            true,
+        )
+    }
+
+    #[test]
+    fn external_sharded_ring_wraps_and_reuses_slots() {
+        // depth=17, bucket_depth=16 gives 2 slots per bucket.
+        let batch = mutable_batch(17, 16);
+        let issuer = ShardedRingIssuer::external(&batch).unwrap();
+
+        let address = test_address(0xABCD);
+
+        let d0 = issuer.prepare_stamp(&address, 1).unwrap();
+        let d1 = issuer.prepare_stamp(&address, 2).unwrap();
+        let d2 = issuer.prepare_stamp(&address, 3).unwrap();
+        assert_eq!(d0.index.index(), 0);
+        assert_eq!(d1.index.index(), 1);
+        assert_eq!(d2.index.index(), 0);
+        assert_eq!(issuer.stamps_issued(), 3);
+    }
+
+    #[test]
+    fn reserved_sharded_ring_never_emits_a_protected_slot() {
+        // depth=18, bucket_depth=16 gives 4 slots per bucket. Protect slots 1
+        // and 3 in the target bucket; the ring may only ever emit 0 and 2.
+        let batch = mutable_batch(18, 16);
+        let bucket = calculate_bucket(&test_address(0x00AA), 16);
+        let issuer = ShardedRingIssuer::reserved(&batch, [(bucket, 1), (bucket, 3)]).unwrap();
+
+        let address = test_address(0x00AA);
+        for ts in 0..50u64 {
+            let digest = issuer.prepare_stamp(&address, ts).unwrap();
+            let index = digest.index.index();
+            assert!(
+                index == 0 || index == 2,
+                "sharded ring emitted protected or out-of-range slot {index}"
+            );
+        }
+    }
+
+    #[test]
+    fn reserved_sharded_ring_routes_slots_to_the_owning_shard() {
+        // Two buckets in distinct shards each protect a different slot. Each
+        // shard must apply only its own bucket's protection.
+        let batch = mutable_batch(17, 16);
+        let bucket_lo = 0x0001u32;
+        let bucket_hi = 0xF001u32;
+        let issuer = ShardedRingIssuer::reserved(&batch, [(bucket_lo, 0), (bucket_hi, 1)]).unwrap();
+
+        let addr_lo = test_address(bucket_lo as u16);
+        let addr_hi = test_address(bucket_hi as u16);
+
+        // bucket_lo protects slot 0, so it may only emit slot 1.
+        for ts in 0..10u64 {
+            assert_eq!(issuer.prepare_stamp(&addr_lo, ts).unwrap().index.index(), 1);
+        }
+        // bucket_hi protects slot 1, so it may only emit slot 0.
+        for ts in 0..10u64 {
+            assert_eq!(issuer.prepare_stamp(&addr_hi, ts).unwrap().index.index(), 0);
+        }
+    }
+
+    #[test]
+    fn external_refuses_immutable_batch() {
+        let batch = immutable_batch(20, 16);
+        assert!(matches!(
+            ShardedRingIssuer::external(&batch),
+            Err(IssuerError::ImmutableNotSupported)
+        ));
+    }
+
+    #[test]
+    fn reserved_refuses_immutable_batch() {
+        let batch = immutable_batch(20, 16);
+        assert!(matches!(
+            ShardedRingIssuer::reserved(&batch, [(0u32, 0u32)]),
+            Err(IssuerError::ImmutableNotSupported)
+        ));
+    }
+
+    #[test]
+    fn reserved_sharded_ring_exhausts_when_every_slot_is_protected() {
+        let batch = mutable_batch(17, 16);
+        let bucket = calculate_bucket(&test_address(0x0001), 16);
+        let issuer = ShardedRingIssuer::reserved(&batch, [(bucket, 0), (bucket, 1)]).unwrap();
+
+        let address = test_address(0x0001);
+        assert!(matches!(
+            issuer.prepare_stamp(&address, 1),
+            Err(StampError::BucketFull { bucket: b, capacity: 2 }) if b == bucket
+        ));
+    }
+}

--- a/crates/postage-issuer/src/sharded_ring.rs
+++ b/crates/postage-issuer/src/sharded_ring.rs
@@ -141,7 +141,7 @@ pub struct ShardedRingIssuer<R = Unreserved> {
     shard_mask: u32,
     /// Bits to shift a bucket by to obtain its shard index.
     shard_shift: u32,
-    /// Maximum utilisation observed, guarded for cross-shard aggregation.
+    /// Maximum utilization observed, guarded for cross-shard aggregation.
     max_utilization: Mutex<u32>,
     /// Total stamps issued, guarded for cross-shard aggregation.
     stamps_issued: Mutex<u64>,
@@ -287,7 +287,7 @@ impl<R: Reservation> ShardedRingIssuer<R> {
             let mut max = self
                 .max_utilization
                 .lock()
-                .expect("max utilisation lock poisoned");
+                .expect("max utilization lock poisoned");
             if fill > *max {
                 *max = fill;
             }
@@ -322,19 +322,19 @@ impl<R: Reservation> ShardedRingIssuer<R> {
         self.shards.len()
     }
 
-    /// Returns the current utilisation of a specific bucket, saturating at the
+    /// Returns the current utilization of a specific bucket, saturating at the
     /// bucket capacity once the ring has wrapped.
     pub fn bucket_utilization(&self, bucket: u32) -> u32 {
         let shard = &self.shards[self.shard_index(bucket)];
         shard.utilization(bucket, self.bucket_capacity)
     }
 
-    /// Returns the maximum bucket utilisation observed across all buckets.
+    /// Returns the maximum bucket utilization observed across all buckets.
     pub fn max_bucket_utilization(&self) -> u32 {
         *self
             .max_utilization
             .lock()
-            .expect("max utilisation lock poisoned")
+            .expect("max utilization lock poisoned")
     }
 
     /// Returns the total number of stamps issued.

--- a/crates/postage-issuer/src/stamper.rs
+++ b/crates/postage-issuer/src/stamper.rs
@@ -96,7 +96,7 @@ pub trait Stamper {
 /// ```ignore
 /// use nectar_postage_issuer::{BatchStamper, MemoryIssuer, Stamper};
 ///
-/// let issuer = MemoryIssuer::from_batch(&batch);
+/// let issuer = MemoryIssuer::from_batch(&batch)?;
 /// let mut stamper = BatchStamper::new(issuer, my_signer);
 /// let stamp = stamper.stamp(&chunk_address)?;
 /// ```


### PR DESCRIPTION
## What

`nectar-postage-issuer` now supports mutable ring issuance through a type-state guard, replacing the previous blanket refusal of mutable batches with a typed, deliberate surface.

The ring is expressed as two distinct concrete types rather than a runtime mode flag:

- `RingIssuer<Unreserved>` is built with `RingIssuer::external(&batch)`. It protects no slots and is meant for callers that track utilization outside the batch.
- `RingIssuer<Reserved>` is built with `RingIssuer::reserved(&batch, slots)`. It protects a `(bucket, index)` set and is meant for self-hosting, where the protected slots come from `nectar-postage-usage`.
- `ShardedRingIssuer<Unreserved>` and `ShardedRingIssuer<Reserved>` are the sharded equivalents, routing each reserved slot to the shard that owns its bucket.

Both ring constructors require a mutable batch and return `ImmutableNotSupported` on an immutable one. The generic `MemoryIssuer::from_batch` and `ShardedIssuer::from_batch` continue to refuse mutable batches with `MutableNotSupported`, so a ring is never produced by accident; it must be named through `external` or `reserved`. Immutable fill issuance and all prior behaviour are unchanged.

A fully reserved bucket returns `RingExhausted` (surfaced as `BucketFull` through `StampIssuer`) rather than emitting a protected slot. `RingIssuer<R>` implements `StampIssuer` and drops into `BatchStamper` unchanged.

## Why

Closes #62.

The original change made `MemoryIssuer` fill-only and refused all mutable batches. The maintainer asked instead for external-tracking mutable issuance, with a compile-time guard so that a self-hosting context can never be handed a ring that is blind to its reserved slots. This reframes the work from "refuse all mutable" to "mutable is supported, typed, and deliberate".

## Testing

- External ring wrap and reuse: the `Unreserved` ring wraps at `2^(depth - bucket_depth)`, reuses slots, and keeps the emitted index within capacity, including the `cap = 1` edge.
- Honest utilization: a wrapped bucket reports full via a saturating utilization read rather than counting overwrites as fresh fill.
- `Reserved` never emits a protected slot: both the ring and the sharded ring issue well past the wrap and assert that no protected or out-of-range slot is ever emitted; a fully protected bucket exhausts.
- Sharded routing: reserved slots are distributed to the shard that owns each bucket, verified across bucket depths.
- Immutable refusal: `external()` and `reserved()` both refuse immutable batches for ring and sharded.
- Type-state compile_fail proof: a crate-root doctest shows that a `RingIssuer<Unreserved>` produced by `external` cannot be passed where `RingIssuer<Reserved>` is demanded, and it genuinely fails to compile on that mismatch.
- `BatchStamper` integration: the ring stamps through `BatchStamper` and wraps where a fill-only issuer would refuse.
- `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, the unit and doctest suite, and `RUSTDOCFLAGS=-D warnings` doc all pass.

## Security

The guard makes a reserved-blind ring unrepresentable in a self-hosting context:

- `external` is method-bound to `RingIssuer<Unreserved>` and `reserved` to `RingIssuer<Reserved>`; neither can fabricate the other.
- The `Reservation` trait is sealed through a private module, so no external crate can add a weaker policy that types as a reservation while protecting nothing.
- There is no `From`, `Into`, `Deref`, `AsRef`, `transmute`, or serde path between `Unreserved` and `Reserved`; fields are private, `Clone` preserves the type parameter, and neither issuer derives `Default`, so there is no reserved-blind-but-typed shortcut.
- `next_slot` skips every protected slot and returns `RingExhausted` rather than emit one, for both the ring and the sharded ring.

No accidental ring can reach a self-hosting batch: the generic `from_batch` constructors still refuse mutable batches, so a ring only appears when explicitly named, and the named constructors refuse immutable batches. This partitions mutability cleanly.

Residual note: the new `mod sharded_ring` is declared unconditionally and uses `std` (`std::sync::Mutex`, bare `Vec`), which extends an existing `std` leak in the no_std build. It does not affect the shipped default-features (std) path, interop, or correctness, and is tracked as a follow-up for wasm cone hygiene.

## AI Assistance

This change was produced by an automated multi-agent workflow: implementation, adversarial security review, and QA were all AI-generated. The work is human-reviewed before merge.

