### PR TITLE
refactor(postage-issuer): unify per-bucket counter logic behind a shared CounterTable

### DIFF
--- a/crates/postage-issuer/src/counter.rs
+++ b/crates/postage-issuer/src/counter.rs
@@ -10,7 +10,7 @@
 //! # Representation
 //!
 //! `counts[b]` lives in `[0, capacity]` in both modes and is the value the
-//! `nectar-postage-usage` wire format serialises verbatim:
+//! `nectar-postage-usage` wire format serializes verbatim:
 //!
 //! - [`CounterMode::Fill`]: `counts[b]` is a monotone fill watermark, the next
 //!   unused slot. Issuance returns the watermark and advances it; a full bucket

--- a/crates/postage-issuer/src/counter.rs
+++ b/crates/postage-issuer/src/counter.rs
@@ -1,0 +1,414 @@
+//! The shared per-bucket slot counter table.
+//!
+//! Every issuer in this crate, and the self-hosted snapshot in
+//! `nectar-postage-usage`, tracks the same per-bucket state: for each of the
+//! `2^bucket_depth` collision buckets, how far issuance has advanced into the
+//! bucket's `2^(depth - bucket_depth)` slots. [`CounterTable`] is that state and
+//! the single counter-advance primitive behind all of them, so the advance logic
+//! lives in exactly one place.
+//!
+//! # Representation
+//!
+//! `counts[b]` lives in `[0, capacity]` in both modes and is the value the
+//! `nectar-postage-usage` wire format serialises verbatim:
+//!
+//! - [`CounterMode::Fill`]: `counts[b]` is a monotone fill watermark, the next
+//!   unused slot. Issuance returns the watermark and advances it; a full bucket
+//!   fails with [`CounterError::BucketFull`] rather than overwriting.
+//! - [`CounterMode::Ring`]: `counts[b]` is a ring cursor. A cursor equal to
+//!   `capacity` means "wrap on the next write": the wrap is deferred so the
+//!   cursor stays in `[0, capacity]` exactly as it appears on the wire. Issuance
+//!   wraps at the capacity, so a full bucket churns instead of failing.
+//!
+//! In both modes `total_issued()` is the running sum of the counters. For a fill
+//! table that is the lifetime stamp count. For a ring table it is a deterministic
+//! checksum, not a lifetime count: a wrapped bucket is full yet its cursor may be
+//! small, so the sum does not count overwrites. The snapshot codec writes and
+//! re-checks this sum in both modes.
+
+extern crate alloc;
+
+use alloc::vec;
+use alloc::vec::Vec;
+
+use thiserror::Error;
+
+/// Whether a [`CounterTable`] fills each bucket once or wraps it as a ring.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CounterMode {
+    /// Fill-only: a monotone watermark per bucket; a full bucket is refused.
+    Fill,
+    /// Ring: a wrapping cursor per bucket; a full bucket overwrites the oldest
+    /// slot.
+    Ring,
+}
+
+/// An error advancing or constructing a [`CounterTable`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum CounterError {
+    /// A bucket index is outside the table's bucket range.
+    #[error("bucket {bucket} out of range")]
+    InvalidBucket {
+        /// The offending bucket index.
+        bucket: u32,
+    },
+
+    /// A fill bucket has no remaining slot. Never produced in ring mode.
+    #[error("bucket {bucket} has reached capacity {capacity}")]
+    BucketFull {
+        /// The full bucket.
+        bucket: u32,
+        /// The bucket capacity.
+        capacity: u32,
+    },
+
+    /// Every slot in a ring bucket is protected, so the ring cannot advance
+    /// without re-emitting a protected slot. The batch geometry forbids this at
+    /// real depths, so it signals a malformed reservation.
+    #[error("ring bucket {bucket} has no unprotected slot to issue")]
+    RingExhausted {
+        /// The exhausted bucket.
+        bucket: u32,
+    },
+
+    /// A counter vector does not match the bucket count.
+    #[error("expected {expected} counters, got {got}")]
+    CounterLength {
+        /// The expected number of counters.
+        expected: usize,
+        /// The number of counters provided.
+        got: usize,
+    },
+
+    /// A counter exceeds the per-bucket slot capacity.
+    #[error("counter {count} for bucket {bucket} exceeds capacity {capacity}")]
+    CounterOverflow {
+        /// The offending bucket.
+        bucket: u32,
+        /// The counter value.
+        count: u32,
+        /// The bucket capacity.
+        capacity: u32,
+    },
+}
+
+/// Per-bucket slot counters in the `[0, capacity]` deferred-wrap representation.
+///
+/// This is the shared engine behind every issuer in this crate and behind the
+/// self-hosted snapshot in `nectar-postage-usage`. It holds only the counters
+/// and the geometry needed to advance them; it is address-agnostic, so callers
+/// map a chunk address to a bucket and hand the bucket here.
+///
+/// The advance primitive is [`record`](Self::record). It takes a predicate that
+/// answers whether a `(bucket, slot)` is protected, so a ring never re-emits a
+/// reserved slot. Fill mode ignores the predicate; nothing protects a fill
+/// watermark because it only ever moves forward.
+#[derive(Debug, Clone)]
+pub struct CounterTable {
+    depth: u8,
+    bucket_depth: u8,
+    mode: CounterMode,
+    counts: Vec<u32>,
+    issued: u64,
+}
+
+impl PartialEq for CounterTable {
+    fn eq(&self, other: &Self) -> bool {
+        self.depth == other.depth
+            && self.bucket_depth == other.bucket_depth
+            && self.mode == other.mode
+            && self.counts == other.counts
+            && self.issued == other.issued
+    }
+}
+
+impl Eq for CounterTable {}
+
+impl CounterTable {
+    /// Creates an empty table for the given geometry and mode.
+    pub fn new(depth: u8, bucket_depth: u8, mode: CounterMode) -> Self {
+        Self {
+            depth,
+            bucket_depth,
+            mode,
+            counts: vec![0u32; 1usize << bucket_depth],
+            issued: 0,
+        }
+    }
+
+    /// Creates a table from existing counters, each in `[0, capacity]`.
+    ///
+    /// `counts` must hold exactly `2^bucket_depth` entries. The issued total is
+    /// recomputed as their sum.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CounterError::CounterLength`] if the vector length does not match
+    /// the bucket count, or [`CounterError::CounterOverflow`] if any counter
+    /// exceeds the bucket capacity.
+    pub fn from_counts(
+        depth: u8,
+        bucket_depth: u8,
+        mode: CounterMode,
+        counts: Vec<u32>,
+    ) -> Result<Self, CounterError> {
+        let expected = 1usize << bucket_depth;
+        if counts.len() != expected {
+            return Err(CounterError::CounterLength {
+                expected,
+                got: counts.len(),
+            });
+        }
+        let capacity = 1u32 << (depth - bucket_depth);
+        let mut issued = 0u64;
+        for (bucket, &count) in counts.iter().enumerate() {
+            if count > capacity {
+                return Err(CounterError::CounterOverflow {
+                    bucket: bucket as u32,
+                    count,
+                    capacity,
+                });
+            }
+            issued += u64::from(count);
+        }
+        Ok(Self {
+            depth,
+            bucket_depth,
+            mode,
+            counts,
+            issued,
+        })
+    }
+
+    /// Returns the batch depth.
+    pub const fn depth(&self) -> u8 {
+        self.depth
+    }
+
+    /// Returns the bucket (uniformity) depth.
+    pub const fn bucket_depth(&self) -> u8 {
+        self.bucket_depth
+    }
+
+    /// Returns whether this is a ring (`true`) or a fill watermark (`false`).
+    pub const fn is_ring(&self) -> bool {
+        matches!(self.mode, CounterMode::Ring)
+    }
+
+    /// Returns the number of collision buckets (`2^bucket_depth`).
+    pub const fn bucket_count(&self) -> u32 {
+        1u32 << self.bucket_depth
+    }
+
+    /// Returns the number of slots per bucket (`2^(depth - bucket_depth)`).
+    pub const fn bucket_capacity(&self) -> u32 {
+        1u32 << (self.depth - self.bucket_depth)
+    }
+
+    /// Returns the total batch capacity in slots (`2^depth`).
+    pub const fn total_capacity(&self) -> u64 {
+        1u64 << self.depth
+    }
+
+    /// Returns the per-bucket counters.
+    pub fn counts(&self) -> &[u32] {
+        &self.counts
+    }
+
+    /// Returns the counter of a bucket.
+    pub fn count(&self, bucket: u32) -> Result<u32, CounterError> {
+        self.counts
+            .get(bucket as usize)
+            .copied()
+            .ok_or(CounterError::InvalidBucket { bucket })
+    }
+
+    /// Returns the highest counter across all buckets.
+    pub fn max_count(&self) -> u32 {
+        self.counts.iter().copied().max().unwrap_or(0)
+    }
+
+    /// Returns the lowest counter across all buckets.
+    pub fn min_count(&self) -> u32 {
+        self.counts.iter().copied().min().unwrap_or(0)
+    }
+
+    /// Returns the sum of the per-bucket counters: the lifetime stamp count in
+    /// fill mode, a deterministic checksum in ring mode.
+    pub const fn total_issued(&self) -> u64 {
+        self.issued
+    }
+
+    /// Returns whether a fresh, never-written slot remains in `bucket`.
+    ///
+    /// A wrapped ring reports no spare capacity even though issuance into it
+    /// still succeeds by overwriting an earlier slot.
+    pub fn has_capacity(&self, bucket: u32) -> Result<bool, CounterError> {
+        Ok(self.count(bucket)? < self.bucket_capacity())
+    }
+
+    /// Advances the counter of `bucket`, skipping any slot for which
+    /// `is_protected` returns `true`, and returns the assigned slot.
+    ///
+    /// Fill mode returns the watermark and bumps it, failing with
+    /// [`CounterError::BucketFull`] at capacity; the predicate is unused because a
+    /// monotone watermark never lands on a reserved slot. Ring mode starts at the
+    /// cursor (wrapping a cursor that equals the capacity), skips protected slots,
+    /// returns the slot, and stores the cursor just past it in `[0, capacity]`. A
+    /// ring whose every slot is protected fails with
+    /// [`CounterError::RingExhausted`]; the geometry forbids this at real depths.
+    pub fn record(
+        &mut self,
+        bucket: u32,
+        is_protected: impl Fn(u32) -> bool,
+    ) -> Result<u32, CounterError> {
+        if bucket as usize >= self.counts.len() {
+            return Err(CounterError::InvalidBucket { bucket });
+        }
+        let capacity = self.bucket_capacity();
+
+        if matches!(self.mode, CounterMode::Fill) {
+            let count = &mut self.counts[bucket as usize];
+            if *count >= capacity {
+                return Err(CounterError::BucketFull { bucket, capacity });
+            }
+            let index = *count;
+            *count += 1;
+            self.issued += 1;
+            return Ok(index);
+        }
+
+        let old_cursor = self.counts[bucket as usize];
+        // Start at the cursor; a cursor equal to capacity means "wrap on the next
+        // write", resetting to 0 when the bucket bound is reached.
+        let mut candidate = if old_cursor >= capacity {
+            0
+        } else {
+            old_cursor
+        };
+        // Skip protected slots, wrapping. Bounded by `capacity` steps: if every
+        // slot is protected we fail rather than loop.
+        let mut steps = 0u32;
+        while is_protected(candidate) {
+            candidate = (candidate + 1) % capacity;
+            steps += 1;
+            if steps >= capacity {
+                return Err(CounterError::RingExhausted { bucket });
+            }
+        }
+        let index = candidate;
+        // The new cursor points just past the slot we returned. Storing
+        // `capacity` (rather than wrapping to 0 here) defers the wrap to the next
+        // write, keeping the cursor in [0, capacity] as on the wire.
+        let new_cursor = index + 1;
+        self.counts[bucket as usize] = new_cursor;
+        // Keep issued == sum(counts): fold in the signed delta (it decreases on
+        // wrap, when new_cursor < old_cursor).
+        self.issued = self.issued - u64::from(old_cursor) + u64::from(new_cursor);
+        Ok(index)
+    }
+
+    /// Increases the batch depth after an on-chain dilution, growing the
+    /// per-bucket capacity without moving any counter.
+    ///
+    /// The caller must reject a depth decrease before calling: the table adopts
+    /// whatever depth it is handed. Issuers check the non-decrease against their
+    /// own error type, and `nectar-postage-usage` validates the new geometry
+    /// against the snapshot format first.
+    pub const fn set_depth(&mut self, new_depth: u8) {
+        self.depth = new_depth;
+    }
+
+    /// Takes the elementwise maximum of this table's counters and `other`'s,
+    /// adopting `new_depth`, and recomputes the issued sum.
+    ///
+    /// The caller must ensure both tables share a bucket geometry and are fill
+    /// tables; the elementwise maximum is only a valid join for monotone fill
+    /// counters. `nectar-postage-usage` enforces that before calling.
+    pub fn merge_counts_max(&mut self, other: &Self, new_depth: u8) {
+        self.depth = new_depth;
+        let mut issued = 0u64;
+        for (mine, theirs) in self.counts.iter_mut().zip(other.counts.iter()) {
+            *mine = (*mine).max(*theirs);
+            issued += u64::from(*mine);
+        }
+        self.issued = issued;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn never(_slot: u32) -> bool {
+        false
+    }
+
+    #[test]
+    fn fill_is_a_monotone_watermark_that_refuses_a_full_bucket() {
+        // depth 17, bucket depth 16 gives 2 slots per bucket.
+        let mut table = CounterTable::new(17, 16, CounterMode::Fill);
+        assert_eq!(table.record(5, never).unwrap(), 0);
+        assert_eq!(table.record(5, never).unwrap(), 1);
+        assert_eq!(
+            table.record(5, never),
+            Err(CounterError::BucketFull {
+                bucket: 5,
+                capacity: 2
+            })
+        );
+        assert_eq!(table.count(5).unwrap(), 2);
+        assert_eq!(table.total_issued(), 2);
+    }
+
+    #[test]
+    fn ring_wraps_and_keeps_the_cursor_in_range() {
+        let mut table = CounterTable::new(17, 16, CounterMode::Ring);
+        assert_eq!(table.record(5, never).unwrap(), 0);
+        assert_eq!(table.record(5, never).unwrap(), 1);
+        // The cursor sits at capacity, the deferred-wrap state.
+        assert_eq!(table.count(5).unwrap(), 2);
+        // The next write wraps back to slot 0.
+        assert_eq!(table.record(5, never).unwrap(), 0);
+        assert_eq!(table.count(5).unwrap(), 1);
+    }
+
+    #[test]
+    fn ring_skips_protected_slots() {
+        // depth 18, bucket depth 16 gives 4 slots per bucket. Protect 1 and 3.
+        let mut table = CounterTable::new(18, 16, CounterMode::Ring);
+        let protected = |slot: u32| slot == 1 || slot == 3;
+        for _ in 0..20 {
+            let slot = table.record(0, protected).unwrap();
+            assert!(slot == 0 || slot == 2, "ring emitted protected slot {slot}");
+        }
+    }
+
+    #[test]
+    fn ring_exhausts_when_every_slot_is_protected() {
+        let mut table = CounterTable::new(17, 16, CounterMode::Ring);
+        assert_eq!(
+            table.record(0, |_| true),
+            Err(CounterError::RingExhausted { bucket: 0 })
+        );
+    }
+
+    #[test]
+    fn from_counts_sums_and_rejects_overflow() {
+        let mut counts = vec![0u32; 1usize << 16];
+        counts[7] = 2;
+        let table = CounterTable::from_counts(17, 16, CounterMode::Fill, counts).unwrap();
+        assert_eq!(table.total_issued(), 2);
+
+        let mut over = vec![0u32; 1usize << 16];
+        over[7] = 3;
+        assert_eq!(
+            CounterTable::from_counts(17, 16, CounterMode::Fill, over),
+            Err(CounterError::CounterOverflow {
+                bucket: 7,
+                count: 3,
+                capacity: 2
+            })
+        );
+    }
+}

--- a/crates/postage-issuer/src/error.rs
+++ b/crates/postage-issuer/src/error.rs
@@ -20,6 +20,15 @@ pub enum IssuerError {
     )]
     ImmutableNotSupported,
 
+    /// Dilution may only increase the batch depth.
+    #[error("batch depth may not decrease ({current} -> {requested})")]
+    DepthDecrease {
+        /// The current depth.
+        current: u8,
+        /// The requested depth.
+        requested: u8,
+    },
+
     /// A ring bucket had no unprotected slot to issue.
     ///
     /// Every slot in the bucket is reserved, so the ring cannot advance without

--- a/crates/postage-issuer/src/issuer.rs
+++ b/crates/postage-issuer/src/issuer.rs
@@ -1,5 +1,6 @@
 //! Stamp issuer trait for tracking bucket utilization.
 
+use crate::counter::{CounterMode, CounterTable};
 use crate::error::IssuerError;
 use nectar_postage::{Batch, BatchId, StampDigest, StampError, StampIndex, calculate_bucket};
 use nectar_primitives::SwarmAddress;
@@ -92,8 +93,16 @@ pub trait StampIssuer {
     /// `false` if the bucket is full.
     fn bucket_has_capacity(&self, bucket: u32) -> bool;
 
-    /// Returns the total number of stamps issued.
-    fn stamps_issued(&self) -> u64;
+    /// Returns the lifetime number of stamps issued, if the issuer tracks one.
+    ///
+    /// A fill issuer tracks a true monotone count and returns `Some`. A mutable
+    /// ring issuer that keeps only a wrapping cursor has no lifetime count to
+    /// give and returns `None` rather than forwarding a checksum sum as if it
+    /// were a count: a wrapped bucket is full, yet the sum of its cursors does
+    /// not count the overwrites. Read saturation through
+    /// [`max_bucket_utilization`](Self::max_bucket_utilization) instead, which is
+    /// honest in both modes.
+    fn stamps_issued(&self) -> Option<u64>;
 
     /// Returns the total capacity of the batch (2^depth).
     fn total_capacity(&self) -> u64 {
@@ -136,34 +145,40 @@ pub trait StampIssuer {
 pub struct MemoryIssuer {
     /// The batch ID.
     batch_id: BatchId,
-    /// The batch depth.
-    depth: u8,
-    /// The bucket depth.
-    bucket_depth: u8,
-    /// Next slot to write for each bucket.
-    ///
-    /// This watermark is monotonic and never reaches the capacity.
-    bucket_indices: alloc::vec::Vec<u32>,
-    /// Maximum utilization across all buckets.
-    max_utilization: u32,
-    /// Total stamps issued.
-    stamps_issued: u64,
+    /// The shared per-bucket fill watermarks. `counts[b]` is the next unused
+    /// slot, monotone and never above the capacity.
+    counters: CounterTable,
 }
-
-extern crate alloc;
 
 impl MemoryIssuer {
     /// Creates a new fill-only memory issuer for the given batch geometry.
     pub fn new(batch_id: BatchId, depth: u8, bucket_depth: u8) -> Self {
-        let bucket_count = 1usize << bucket_depth;
         Self {
             batch_id,
-            depth,
-            bucket_depth,
-            bucket_indices: alloc::vec![0u32; bucket_count],
-            max_utilization: 0,
-            stamps_issued: 0,
+            counters: CounterTable::new(depth, bucket_depth, CounterMode::Fill),
         }
+    }
+
+    /// Applies an on-chain dilution, growing the per-bucket capacity without
+    /// moving any watermark.
+    ///
+    /// The new depth must not decrease. Diluting later is the prerequisite for
+    /// topping up a batch in place, so this mirrors the snapshot's dilution.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IssuerError::DepthDecrease`] if `new_depth` is below the current
+    /// depth.
+    pub const fn dilute(&mut self, new_depth: u8) -> Result<(), IssuerError> {
+        let current = self.counters.depth();
+        if new_depth < current {
+            return Err(IssuerError::DepthDecrease {
+                current,
+                requested: new_depth,
+            });
+        }
+        self.counters.set_depth(new_depth);
+        Ok(())
     }
 
     /// Creates a memory issuer from a batch.
@@ -190,28 +205,19 @@ impl StampIssuer for MemoryIssuer {
         address: &SwarmAddress,
         timestamp: u64,
     ) -> Result<StampDigest, StampError> {
-        let bucket = calculate_bucket(address, self.bucket_depth);
-        let bucket_idx = bucket as usize;
-
-        let bucket_capacity = 1u32 << (self.depth - self.bucket_depth);
-
-        // The next unused slot in this bucket.
-        let position = self.bucket_indices[bucket_idx];
-
-        if position >= bucket_capacity {
-            return Err(StampError::BucketFull {
-                bucket,
-                capacity: bucket_capacity,
-            });
-        }
-        self.bucket_indices[bucket_idx] = position + 1;
-
-        self.stamps_issued += 1;
-
-        // Update max utilization from the monotone fill of this bucket.
-        if self.bucket_indices[bucket_idx] > self.max_utilization {
-            self.max_utilization = self.bucket_indices[bucket_idx];
-        }
+        let bucket = calculate_bucket(address, self.counters.bucket_depth());
+        // Fill mode ignores the predicate; a monotone watermark never lands on a
+        // reserved slot.
+        let position =
+            self.counters
+                .record(bucket, |_| false)
+                .map_err(|err| StampError::BucketFull {
+                    bucket,
+                    capacity: match err {
+                        crate::counter::CounterError::BucketFull { capacity, .. } => capacity,
+                        _ => self.counters.bucket_capacity(),
+                    },
+                })?;
 
         let index = StampIndex::new(bucket, position);
 
@@ -223,36 +229,30 @@ impl StampIssuer for MemoryIssuer {
     }
 
     fn batch_depth(&self) -> u8 {
-        self.depth
+        self.counters.depth()
     }
 
     fn bucket_depth(&self) -> u8 {
-        self.bucket_depth
+        self.counters.bucket_depth()
     }
 
     fn max_bucket_utilization(&self) -> u32 {
-        self.max_utilization
+        // Fill watermarks are monotone, so the current maximum is the historical
+        // maximum.
+        self.counters.max_count()
     }
 
     fn bucket_utilization(&self, bucket: u32) -> u32 {
-        let bucket_idx = bucket as usize;
-        if bucket_idx >= self.bucket_indices.len() {
-            return 0;
-        }
-        self.bucket_indices[bucket_idx]
+        self.counters.count(bucket).unwrap_or(0)
     }
 
     fn bucket_has_capacity(&self, bucket: u32) -> bool {
-        let bucket_idx = bucket as usize;
-        if bucket_idx >= self.bucket_indices.len() {
-            return false;
-        }
-        let bucket_capacity = 1u32 << (self.depth - self.bucket_depth);
-        self.bucket_indices[bucket_idx] < bucket_capacity
+        self.counters.has_capacity(bucket).unwrap_or(false)
     }
 
-    fn stamps_issued(&self) -> u64 {
-        self.stamps_issued
+    fn stamps_issued(&self) -> Option<u64> {
+        // Fill issuance is monotone, so the counter sum is the lifetime count.
+        Some(self.counters.total_issued())
     }
 }
 
@@ -277,7 +277,7 @@ mod tests {
         assert_eq!(issuer.batch_depth(), 20);
         assert_eq!(issuer.bucket_depth(), 16);
         assert_eq!(issuer.max_bucket_utilization(), 0);
-        assert_eq!(issuer.stamps_issued(), 0);
+        assert_eq!(issuer.stamps_issued(), Some(0));
         assert_eq!(issuer.bucket_count(), 65536);
         assert_eq!(issuer.bucket_capacity(), 16);
     }
@@ -293,7 +293,7 @@ mod tests {
         assert_eq!(digest.index.bucket(), 0xCBE5);
         assert_eq!(digest.index.index(), 0);
         assert_eq!(digest.timestamp, 12345);
-        assert_eq!(issuer.stamps_issued(), 1);
+        assert_eq!(issuer.stamps_issued(), Some(1));
         assert_eq!(issuer.max_bucket_utilization(), 1);
     }
 
@@ -310,7 +310,7 @@ mod tests {
         assert_eq!(d1.index.index(), 0);
         assert_eq!(d2.index.index(), 1);
         assert_eq!(d3.index.index(), 2);
-        assert_eq!(issuer.stamps_issued(), 3);
+        assert_eq!(issuer.stamps_issued(), Some(3));
     }
 
     #[test]
@@ -432,5 +432,34 @@ mod tests {
             from_new.max_bucket_utilization()
         );
         assert_eq!(from_batch.stamps_issued(), from_new.stamps_issued());
+    }
+
+    #[test]
+    fn test_memory_issuer_dilute_grows_capacity_only() {
+        // depth=17, bucket_depth=16 gives 2 slots per bucket.
+        let mut issuer = MemoryIssuer::new(B256::ZERO, 17, 16);
+        let address = test_address(0xABCD);
+
+        // Fill the bucket, then a dilution to depth 18 (4 slots) reopens it
+        // without moving the existing watermark.
+        issuer.prepare_stamp(&address, 1).unwrap();
+        issuer.prepare_stamp(&address, 2).unwrap();
+        assert!(issuer.prepare_stamp(&address, 3).is_err());
+
+        issuer.dilute(18).unwrap();
+        assert_eq!(issuer.bucket_capacity(), 4);
+        // The watermark is unchanged, so the next slot is 2, not 0.
+        let d = issuer.prepare_stamp(&address, 4).unwrap();
+        assert_eq!(d.index.index(), 2);
+        assert_eq!(issuer.stamps_issued(), Some(3));
+
+        // Dilution may never decrease the depth.
+        assert!(matches!(
+            issuer.dilute(17),
+            Err(IssuerError::DepthDecrease {
+                current: 18,
+                requested: 17
+            })
+        ));
     }
 }

--- a/crates/postage-issuer/src/lib.rs
+++ b/crates/postage-issuer/src/lib.rs
@@ -72,6 +72,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+mod counter;
 mod error;
 mod factory;
 mod issuer;
@@ -85,6 +86,9 @@ pub use nectar_postage::*;
 
 // Errors (override nectar_postage::StampError with our own that includes signing)
 pub use error::{IssuerError, SigningError};
+
+// The shared per-bucket counter table behind every issuer and the snapshot.
+pub use counter::{CounterError, CounterMode, CounterTable};
 
 // Issuing
 pub use issuer::{MemoryIssuer, StampIssuer};

--- a/crates/postage-issuer/src/ring.rs
+++ b/crates/postage-issuer/src/ring.rs
@@ -34,6 +34,7 @@ use nectar_postage::{Batch, BatchId, StampDigest, StampError, StampIndex, calcul
 use nectar_primitives::SwarmAddress;
 
 use crate::StampIssuer;
+use crate::counter::{CounterError, CounterMode, CounterTable};
 use crate::error::IssuerError;
 
 mod sealed {
@@ -135,23 +136,21 @@ impl Reservation for Reserved {
 pub struct RingIssuer<R = Unreserved> {
     /// The batch ID.
     batch_id: BatchId,
-    /// The batch depth.
-    depth: u8,
-    /// The bucket depth.
-    bucket_depth: u8,
-    /// The bucket capacity, `2^(depth - bucket_depth)`.
-    bucket_capacity: u32,
-    /// Ring cursor for each bucket. Wraps modulo the bucket capacity.
-    cursors: Vec<u32>,
+    /// The shared per-bucket ring cursors, in the `[0, capacity]` deferred-wrap
+    /// representation. `counts[b] == capacity` means "wrap on the next write".
+    counters: CounterTable,
     /// Whether each bucket has been written to capacity at least once.
     ///
-    /// Once the cursor wraps it can no longer tell a saturated bucket apart
-    /// from an empty one, so this tracks saturation to report utilization
-    /// honestly.
+    /// The wire representation defers each wrap, so once a bucket has wrapped its
+    /// cursor falls back into `[0, capacity)` and no longer marks saturation on
+    /// its own. This in-memory latch records it so utilization is reported
+    /// honestly; it is never serialised.
     saturated: Vec<bool>,
-    /// Maximum utilization observed across all buckets.
+    /// Maximum utilization observed across all buckets, latched so a wrapped ring
+    /// reports its peak rather than the live cursor.
     max_utilization: u32,
-    /// Total stamps issued.
+    /// Lifetime stamps issued, a true monotone count of issuance calls (not the
+    /// counter sum, which a ring would undercount on wrap).
     stamps_issued: u64,
     /// The reservation policy.
     reservation: R,
@@ -214,10 +213,7 @@ impl<R: Reservation> RingIssuer<R> {
         let bucket_count = 1usize << bucket_depth;
         Self {
             batch_id,
-            depth,
-            bucket_depth,
-            bucket_capacity: 1u32 << (depth - bucket_depth),
-            cursors: alloc::vec![0u32; bucket_count],
+            counters: CounterTable::new(depth, bucket_depth, CounterMode::Ring),
             saturated: alloc::vec![false; bucket_count],
             max_utilization: 0,
             stamps_issued: 0,
@@ -231,40 +227,39 @@ impl<R: Reservation> RingIssuer<R> {
     /// bucket as full rather than counting overwrites as fresh utilization.
     fn bucket_fill(&self, bucket_idx: usize) -> u32 {
         if self.saturated[bucket_idx] {
-            self.bucket_capacity
+            self.counters.bucket_capacity()
         } else {
-            self.cursors[bucket_idx]
+            self.counters.counts()[bucket_idx]
         }
     }
 
-    /// Advances the cursor for `bucket` to the next unprotected slot, returning
-    /// the slot to emit.
+    /// Advances the cursor for `bucket` to the next unprotected slot through the
+    /// shared counter table, returning the slot to emit.
     ///
-    /// The cursor starts at its current position and walks forward, wrapping at
-    /// the bucket capacity and marking the bucket saturated on each wrap. Up to
-    /// `bucket_capacity` slots are inspected; if every slot is protected the
-    /// bucket has no issuable slot and [`IssuerError::RingExhausted`] is
-    /// returned rather than emitting a protected slot.
+    /// The shared table holds the cursor in the `[0, capacity]` deferred-wrap
+    /// representation and skips the reserved slots. Saturation is latched here
+    /// from the post-advance cursor: a cursor that reaches the capacity has just
+    /// written the bucket's last fresh slot. If every slot is protected the table
+    /// returns [`CounterError::RingExhausted`], mapped to
+    /// [`IssuerError::RingExhausted`].
     fn next_slot(&mut self, bucket: u32) -> Result<u32, IssuerError> {
-        let bucket_idx = bucket as usize;
-        for _ in 0..self.bucket_capacity {
-            let position = self.cursors[bucket_idx];
-
-            // Advance the cursor, wrapping at the bucket capacity and marking
-            // saturation on each wrap.
-            let next = position + 1;
-            if next >= self.bucket_capacity {
-                self.saturated[bucket_idx] = true;
-                self.cursors[bucket_idx] = 0;
-            } else {
-                self.cursors[bucket_idx] = next;
-            }
-
-            if !self.reservation.is_protected(bucket, position) {
-                return Ok(position);
-            }
+        let reservation = &self.reservation;
+        let position = self
+            .counters
+            .record(bucket, |slot| reservation.is_protected(bucket, slot))
+            .map_err(|err| match err {
+                CounterError::RingExhausted { bucket } => IssuerError::RingExhausted { bucket },
+                CounterError::InvalidBucket { bucket } => IssuerError::RingExhausted { bucket },
+                // Ring mode never reports BucketFull, and construction errors
+                // cannot arise from `record`.
+                _ => IssuerError::RingExhausted { bucket },
+            })?;
+        // A cursor sitting at the capacity has just filled the bucket's last
+        // fresh slot, so the bucket is saturated from here on.
+        if self.counters.count(bucket).unwrap_or(0) == self.counters.bucket_capacity() {
+            self.saturated[bucket as usize] = true;
         }
-        Err(IssuerError::RingExhausted { bucket })
+        Ok(position)
     }
 
     /// Prepares a stamp digest for the given chunk address.
@@ -282,7 +277,7 @@ impl<R: Reservation> RingIssuer<R> {
         address: &SwarmAddress,
         timestamp: u64,
     ) -> Result<StampDigest, IssuerError> {
-        let bucket = calculate_bucket(address, self.bucket_depth);
+        let bucket = calculate_bucket(address, self.counters.bucket_depth());
         let position = self.next_slot(bucket)?;
 
         self.stamps_issued += 1;
@@ -298,7 +293,7 @@ impl<R: Reservation> RingIssuer<R> {
 
     /// Returns the bucket capacity, `2^(depth - bucket_depth)`.
     pub const fn bucket_capacity(&self) -> u32 {
-        self.bucket_capacity
+        self.counters.bucket_capacity()
     }
 
     /// Returns a reference to the reservation policy.
@@ -321,7 +316,7 @@ impl<R: Reservation> StampIssuer for RingIssuer<R> {
             .map_err(|err| match err {
                 IssuerError::RingExhausted { bucket } => StampError::BucketFull {
                     bucket,
-                    capacity: self.bucket_capacity,
+                    capacity: self.counters.bucket_capacity(),
                 },
                 // `prepare_ring_stamp` only ever yields RingExhausted.
                 _ => unreachable!("ring issuance only fails with RingExhausted"),
@@ -333,11 +328,11 @@ impl<R: Reservation> StampIssuer for RingIssuer<R> {
     }
 
     fn batch_depth(&self) -> u8 {
-        self.depth
+        self.counters.depth()
     }
 
     fn bucket_depth(&self) -> u8 {
-        self.bucket_depth
+        self.counters.bucket_depth()
     }
 
     fn max_bucket_utilization(&self) -> u32 {
@@ -346,7 +341,7 @@ impl<R: Reservation> StampIssuer for RingIssuer<R> {
 
     fn bucket_utilization(&self, bucket: u32) -> u32 {
         let bucket_idx = bucket as usize;
-        if bucket_idx >= self.cursors.len() {
+        if bucket_idx >= self.counters.counts().len() {
             return 0;
         }
         self.bucket_fill(bucket_idx)
@@ -354,17 +349,19 @@ impl<R: Reservation> StampIssuer for RingIssuer<R> {
 
     fn bucket_has_capacity(&self, bucket: u32) -> bool {
         let bucket_idx = bucket as usize;
-        if bucket_idx >= self.cursors.len() {
+        if bucket_idx >= self.counters.counts().len() {
             return false;
         }
         // Report honestly whether a fresh, never-written slot remains. A ring
         // that has wrapped reports no spare capacity even though issuance into
         // it still succeeds by overwriting an earlier chunk.
-        self.bucket_fill(bucket_idx) < self.bucket_capacity
+        self.bucket_fill(bucket_idx) < self.counters.bucket_capacity()
     }
 
-    fn stamps_issued(&self) -> u64 {
-        self.stamps_issued
+    fn stamps_issued(&self) -> Option<u64> {
+        // A standalone ring keeps a true monotone issuance count, so it can be
+        // honest here even though its counter sum would undercount on wrap.
+        Some(self.stamps_issued)
     }
 }
 
@@ -424,7 +421,7 @@ mod tests {
         let d3 = issuer.prepare_ring_stamp(&address, 4).unwrap();
         assert_eq!(d3.index.index(), 1);
 
-        assert_eq!(issuer.stamps_issued(), 4);
+        assert_eq!(issuer.stamps_issued(), Some(4));
     }
 
     #[test]
@@ -439,7 +436,7 @@ mod tests {
             let digest = issuer.prepare_ring_stamp(&address, ts).unwrap();
             assert!(digest.index.index() < 4, "index escaped bucket capacity");
         }
-        assert_eq!(issuer.stamps_issued(), 100);
+        assert_eq!(issuer.stamps_issued(), Some(100));
     }
 
     #[test]

--- a/crates/postage-issuer/src/ring.rs
+++ b/crates/postage-issuer/src/ring.rs
@@ -144,7 +144,7 @@ pub struct RingIssuer<R = Unreserved> {
     /// The wire representation defers each wrap, so once a bucket has wrapped its
     /// cursor falls back into `[0, capacity)` and no longer marks saturation on
     /// its own. This in-memory latch records it so utilization is reported
-    /// honestly; it is never serialised.
+    /// honestly; it is never serialized.
     saturated: Vec<bool>,
     /// Maximum utilization observed across all buckets, latched so a wrapped ring
     /// reports its peak rather than the live cursor.

--- a/crates/postage-issuer/src/sharded.rs
+++ b/crates/postage-issuer/src/sharded.rs
@@ -184,6 +184,31 @@ impl ShardedIssuer {
         }
     }
 
+    /// Applies an on-chain dilution, growing the per-bucket capacity without
+    /// moving any watermark.
+    ///
+    /// The new depth must not decrease. Counters are untouched; only the
+    /// capacity that bounds them grows, so the next stamp in a previously full
+    /// bucket succeeds. This mirrors [`MemoryIssuer::dilute`](crate::MemoryIssuer::dilute)
+    /// for the parallel issuer and is the prerequisite for topping up a batch in
+    /// place.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IssuerError::DepthDecrease`] if `new_depth` is below the current
+    /// depth.
+    pub const fn dilute(&mut self, new_depth: u8) -> Result<(), IssuerError> {
+        if new_depth < self.depth {
+            return Err(IssuerError::DepthDecrease {
+                current: self.depth,
+                requested: new_depth,
+            });
+        }
+        self.depth = new_depth;
+        self.bucket_capacity = 1u32 << (new_depth - self.bucket_depth);
+        Ok(())
+    }
+
     /// Maps a bucket to its shard index.
     #[inline]
     const fn shard_index(&self, bucket: u32) -> usize {
@@ -415,6 +440,34 @@ mod tests {
         assert_eq!(digest.batch_id, B256::ZERO);
         assert_eq!(digest.timestamp, 12345);
         assert_eq!(issuer.stamps_issued(), 1);
+    }
+
+    #[test]
+    fn test_sharded_issuer_dilute_grows_capacity_only() {
+        // depth=17, bucket_depth=16 gives 2 slots per bucket.
+        let mut issuer = ShardedIssuer::new(B256::ZERO, 17, 16);
+        let address = SwarmAddress::from(B256::repeat_byte(0xAB));
+        let bucket = calculate_bucket(&address, 16);
+
+        issuer.prepare_stamp(&address, 1).unwrap();
+        issuer.prepare_stamp(&address, 2).unwrap();
+        assert!(issuer.prepare_stamp(&address, 3).is_err());
+
+        issuer.dilute(18).unwrap();
+        assert_eq!(issuer.bucket_capacity(), 4);
+        assert_eq!(issuer.batch_depth(), 18);
+        // The watermark is unchanged, so the next slot is 2.
+        let d = issuer.prepare_stamp(&address, 4).unwrap();
+        assert_eq!(d.index.index(), 2);
+        assert_eq!(issuer.bucket_utilization(bucket), 3);
+
+        assert!(matches!(
+            issuer.dilute(17),
+            Err(IssuerError::DepthDecrease {
+                current: 18,
+                requested: 17
+            })
+        ));
     }
 
     #[test]

--- a/crates/postage-usage/Cargo.toml
+++ b/crates/postage-usage/Cargo.toml
@@ -19,13 +19,13 @@ workspace = true
 
 [dependencies]
 nectar-postage = { workspace = true }
+nectar-postage-issuer = { workspace = true }
 nectar-primitives = { workspace = true }
 alloy-primitives = { workspace = true }
 bytes = { workspace = true }
 thiserror = { workspace = true }
 
 # optional
-nectar-postage-issuer = { workspace = true, optional = true }
 alloy-signer = { workspace = true, optional = true }
 
 [dev-dependencies]
@@ -36,12 +36,13 @@ alloy-signer-local = { workspace = true }
 default = ["std"]
 
 # Standard library support.
-std = ["nectar-postage/std", "alloy-primitives/std", "thiserror/std"]
+std = ["nectar-postage/std", "nectar-postage-issuer/std", "alloy-primitives/std", "thiserror/std"]
 
 # Implements `nectar_postage_issuer::StampIssuer` for `SnapshotIssuer` so a
-# snapshot can back a `BatchStamper` directly. Implies `std` via the issuer
-# crate.
-issuer = ["dep:nectar-postage-issuer", "std"]
+# snapshot can back a `BatchStamper` directly. The shared counter table that
+# backs every usage table already comes from the issuer crate; this feature adds
+# the `StampIssuer` adapter on top.
+issuer = ["std"]
 
 # Turns persist plans into signed single-owner chunks and stamps.
 seal = ["dep:alloy-signer", "std"]

--- a/crates/postage-usage/src/issuer.rs
+++ b/crates/postage-usage/src/issuer.rs
@@ -108,7 +108,15 @@ impl StampIssuer for SnapshotIssuer {
                 .unwrap_or(false)
     }
 
-    fn stamps_issued(&self) -> u64 {
-        self.snapshot.table_ref().total_issued()
+    fn stamps_issued(&self) -> Option<u64> {
+        // Immutable issuance is monotone, so the counter sum is the lifetime
+        // count. A mutable ring keeps only a wrapping cursor whose sum is a
+        // checksum, so there is no lifetime count to give: return `None` rather
+        // than forwarding the checksum as if it were a count.
+        if self.snapshot.table_ref().is_mutable() {
+            None
+        } else {
+            Some(self.snapshot.table_ref().total_issued())
+        }
     }
 }

--- a/crates/postage-usage/src/snapshot.rs
+++ b/crates/postage-usage/src/snapshot.rs
@@ -390,7 +390,7 @@ impl Snapshot {
     /// [`RootInfo::assemble`](crate::RootInfo::assemble). It borrows the snapshot
     /// mutably, so [`into_parts`](Self::into_parts) and
     /// [`plan_persist`](Self::plan_persist) cannot run while issuance is live,
-    /// which serialises persisting against issuing.
+    /// which serializes persisting against issuing.
     ///
     /// This single method is the issuance chokepoint. A future network-validation
     /// gate (nectar issue #65) lands here as one precondition, not a cross-cutting
@@ -580,7 +580,7 @@ impl Issuer<'_> {
         }
     }
 
-    /// Returns the counter sum the snapshot serialises and re-checks: the
+    /// Returns the counter sum the snapshot serializes and re-checks: the
     /// lifetime stamp count in immutable mode, a deterministic checksum in
     /// mutable mode.
     pub const fn checksum(&self) -> u64 {

--- a/crates/postage-usage/src/snapshot.rs
+++ b/crates/postage-usage/src/snapshot.rs
@@ -371,50 +371,14 @@ impl Snapshot {
         bucket: u32,
         reserved: &BTreeSet<(u32, u32)>,
     ) -> Result<u32> {
-        let table = &mut self.table;
-        let capacity = table.bucket_capacity();
-        if bucket as usize >= table.counts.len() {
-            return Err(UsageError::InvalidBucket { bucket });
-        }
-        if !table.mutable {
-            let count = &mut table.counts[bucket as usize];
-            if *count >= capacity {
-                return Err(UsageError::BucketFull { bucket, capacity });
-            }
-            let index = *count;
-            *count += 1;
-            table.issued += 1;
-            return Ok(index);
-        }
-
-        let old_cursor = table.counts[bucket as usize];
-        // Start at the cursor; a cursor equal to capacity means "wrap on the
-        // next write", resetting to 0 when the bucket bound is reached.
-        let mut candidate = if old_cursor >= capacity {
-            0
-        } else {
-            old_cursor
-        };
-        // Skip reserved slots, wrapping. Bounded by `capacity` steps: if every
-        // slot is reserved we fail rather than loop.
-        let mut steps = 0u32;
-        while reserved.contains(&(bucket, candidate)) {
-            candidate = (candidate + 1) % capacity;
-            steps += 1;
-            if steps >= capacity {
-                return Err(UsageError::RingExhausted { bucket });
-            }
-        }
-        let index = candidate;
-        // The new cursor points just past the slot we returned. Storing
-        // `capacity` (rather than wrapping to 0 here) defers the wrap to the
-        // next write, keeping the cursor in [0, capacity] as on the wire.
-        let new_cursor = index + 1;
-        table.counts[bucket as usize] = new_cursor;
-        // Keep issued == sum(counts): fold in the signed delta (it decreases
-        // on wrap, when new_cursor < old_cursor).
-        table.issued = table.issued - u64::from(old_cursor) + u64::from(new_cursor);
-        Ok(index)
+        // Both branches (fill watermark and reserved-aware ring) live in the
+        // shared counter table now. The reserved set is mapped into the table's
+        // per-slot protection predicate so a ring never re-emits a slot held by
+        // the snapshot's own chunks.
+        self.table
+            .counters_mut()
+            .record(bucket, |slot| reserved.contains(&(bucket, slot)))
+            .map_err(crate::table::map_counter_error)
     }
 
     /// Returns an issuing handle bound to `owner`, the only way to advance a
@@ -601,8 +565,25 @@ impl Issuer<'_> {
         self.snapshot.table_ref().has_capacity(bucket)
     }
 
-    /// Returns the running issued total (a checksum in mutable mode).
-    pub const fn stamps_issued(&self) -> u64 {
+    /// Returns the lifetime number of stamps issued, if one is well-defined.
+    ///
+    /// Immutable: the monotone counter sum is the lifetime count, returned as
+    /// `Some`. Mutable: the counters are ring cursors whose sum is a checksum,
+    /// not a lifetime count (a wrapped bucket is full yet its cursor may be
+    /// small), so this returns `None` rather than passing the checksum off as a
+    /// count. Read the checksum itself through [`checksum`](Self::checksum).
+    pub const fn stamps_issued(&self) -> Option<u64> {
+        if self.snapshot.table_ref().is_mutable() {
+            None
+        } else {
+            Some(self.snapshot.table_ref().total_issued())
+        }
+    }
+
+    /// Returns the counter sum the snapshot serialises and re-checks: the
+    /// lifetime stamp count in immutable mode, a deterministic checksum in
+    /// mutable mode.
+    pub const fn checksum(&self) -> u64 {
         self.snapshot.table_ref().total_issued()
     }
 }

--- a/crates/postage-usage/src/table.rs
+++ b/crates/postage-usage/src/table.rs
@@ -1,11 +1,37 @@
 //! In-memory per-bucket slot counters for a postage batch.
 
-use alloc::vec;
 use alloc::vec::Vec;
 
 use nectar_postage::BatchId;
+use nectar_postage_issuer::{CounterError, CounterMode, CounterTable};
 
 use crate::{MAX_BUCKET_DEPTH, MAX_COUNTER_BITS, Result, UsageError};
+
+/// Maps a shared-counter-table error onto a usage error. The usage table only
+/// ever feeds the shared table valid lengths and geometries, so the construction
+/// variants surface as their usage equivalents and the issuance variants cannot
+/// arise here.
+pub(crate) const fn map_counter_error(err: CounterError) -> UsageError {
+    match err {
+        CounterError::InvalidBucket { bucket } => UsageError::InvalidBucket { bucket },
+        CounterError::BucketFull { bucket, capacity } => {
+            UsageError::BucketFull { bucket, capacity }
+        }
+        CounterError::RingExhausted { bucket } => UsageError::RingExhausted { bucket },
+        CounterError::CounterLength { expected, got } => {
+            UsageError::CounterLength { expected, got }
+        }
+        CounterError::CounterOverflow {
+            bucket,
+            count,
+            capacity,
+        } => UsageError::CounterOverflow {
+            bucket,
+            count,
+            capacity,
+        },
+    }
+}
 
 /// Validates that a batch geometry is within the range supported by the
 /// snapshot format: `bucket_depth <= 16` and `depth - bucket_depth <= 31`.
@@ -63,32 +89,26 @@ pub(crate) const fn validate_geometry(depth: u8, bucket_depth: u8) -> Result<()>
 /// // `record_address` no longer exists on the inert table.
 /// table.record_address(&SwarmAddress::from(B256::repeat_byte(0x99))).unwrap();
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UsageTable {
     pub(crate) batch_id: BatchId,
-    pub(crate) depth: u8,
-    pub(crate) bucket_depth: u8,
-    pub(crate) counts: Vec<u32>,
-    pub(crate) issued: u64,
-    /// Whether this table is a mutable ring (true) or immutable fill watermark
-    /// (false).
-    pub(crate) mutable: bool,
+    /// The shared per-bucket counter table. It holds the counters, the issued
+    /// sum, the geometry, and the fill-or-ring mode, in the same `[0, capacity]`
+    /// representation the wire format serialises. The snapshot wraps this table
+    /// rather than carrying its own copy of the counter logic.
+    pub(crate) counters: CounterTable,
 }
-
-impl PartialEq for UsageTable {
-    fn eq(&self, other: &Self) -> bool {
-        self.batch_id == other.batch_id
-            && self.depth == other.depth
-            && self.bucket_depth == other.bucket_depth
-            && self.counts == other.counts
-            && self.issued == other.issued
-            && self.mutable == other.mutable
-    }
-}
-
-impl Eq for UsageTable {}
 
 impl UsageTable {
+    /// Returns the mode the geometry-checked constructors install for `mutable`.
+    const fn mode(mutable: bool) -> CounterMode {
+        if mutable {
+            CounterMode::Ring
+        } else {
+            CounterMode::Fill
+        }
+    }
+
     /// Creates an empty immutable table for a batch with the given geometry.
     pub fn new(batch_id: BatchId, depth: u8, bucket_depth: u8) -> Result<Self> {
         Self::new_with_mode(batch_id, depth, bucket_depth, false)
@@ -113,11 +133,7 @@ impl UsageTable {
         validate_geometry(depth, bucket_depth)?;
         Ok(Self {
             batch_id,
-            depth,
-            bucket_depth,
-            counts: vec![0; 1usize << bucket_depth],
-            issued: 0,
-            mutable,
+            counters: CounterTable::new(depth, bucket_depth, Self::mode(mutable)),
         })
     }
 
@@ -155,33 +171,9 @@ impl UsageTable {
         mutable: bool,
     ) -> Result<Self> {
         validate_geometry(depth, bucket_depth)?;
-        let expected = 1usize << bucket_depth;
-        if counts.len() != expected {
-            return Err(UsageError::CounterLength {
-                expected,
-                got: counts.len(),
-            });
-        }
-        let capacity = 1u32 << (depth - bucket_depth);
-        let mut issued = 0u64;
-        for (bucket, &count) in counts.iter().enumerate() {
-            if count > capacity {
-                return Err(UsageError::CounterOverflow {
-                    bucket: bucket as u32,
-                    count,
-                    capacity,
-                });
-            }
-            issued += u64::from(count);
-        }
-        Ok(Self {
-            batch_id,
-            depth,
-            bucket_depth,
-            counts,
-            issued,
-            mutable,
-        })
+        let counters = CounterTable::from_counts(depth, bucket_depth, Self::mode(mutable), counts)
+            .map_err(map_counter_error)?;
+        Ok(Self { batch_id, counters })
     }
 
     /// Returns the batch id this table describes.
@@ -192,32 +184,32 @@ impl UsageTable {
     /// Returns whether this table is a mutable ring (`true`) or an immutable
     /// fill watermark (`false`).
     pub const fn is_mutable(&self) -> bool {
-        self.mutable
+        self.counters.is_ring()
     }
 
     /// Returns the batch depth.
     pub const fn depth(&self) -> u8 {
-        self.depth
+        self.counters.depth()
     }
 
     /// Returns the bucket (uniformity) depth.
     pub const fn bucket_depth(&self) -> u8 {
-        self.bucket_depth
+        self.counters.bucket_depth()
     }
 
     /// Returns the number of collision buckets (`2^bucket_depth`).
     pub const fn bucket_count(&self) -> u32 {
-        1u32 << self.bucket_depth
+        self.counters.bucket_count()
     }
 
     /// Returns the number of slots per bucket (`2^(depth - bucket_depth)`).
     pub const fn bucket_capacity(&self) -> u32 {
-        1u32 << (self.depth - self.bucket_depth)
+        self.counters.bucket_capacity()
     }
 
     /// Returns the total batch capacity in slots (`2^depth`).
     pub const fn total_capacity(&self) -> u64 {
-        1u64 << self.depth
+        self.counters.total_capacity()
     }
 
     /// Returns the sum of the per-bucket counters.
@@ -227,35 +219,46 @@ impl UsageTable {
     /// (a wrapped bucket is full yet its cursor may be small). The codec writes
     /// and verifies it as a checksum in both modes.
     pub const fn total_issued(&self) -> u64 {
-        self.issued
+        self.counters.total_issued()
     }
 
     /// Returns the per-bucket counters.
     pub fn counts(&self) -> &[u32] {
-        &self.counts
+        self.counters.counts()
     }
 
     /// Returns the counter of a bucket.
     pub fn count(&self, bucket: u32) -> Result<u32> {
-        self.counts
-            .get(bucket as usize)
-            .copied()
-            .ok_or(UsageError::InvalidBucket { bucket })
+        self.counters.count(bucket).map_err(map_counter_error)
     }
 
     /// Returns the highest counter across all buckets.
     pub fn max_count(&self) -> u32 {
-        self.counts.iter().copied().max().unwrap_or(0)
+        self.counters.max_count()
     }
 
     /// Returns the lowest counter across all buckets.
     pub fn min_count(&self) -> u32 {
-        self.counts.iter().copied().min().unwrap_or(0)
+        self.counters.min_count()
     }
 
     /// Returns whether a bucket can accept another slot assignment.
     pub fn has_capacity(&self, bucket: u32) -> Result<bool> {
-        Ok(self.count(bucket)? < self.bucket_capacity())
+        self.counters
+            .has_capacity(bucket)
+            .map_err(map_counter_error)
+    }
+
+    /// Returns the shared counter table backing this usage table, for the
+    /// snapshot's counter-advance and merge paths.
+    pub(crate) const fn counters(&self) -> &CounterTable {
+        &self.counters
+    }
+
+    /// Returns a mutable reference to the shared counter table, the snapshot's
+    /// single counter-advance handle.
+    pub(crate) const fn counters_mut(&mut self) -> &mut CounterTable {
+        &mut self.counters
     }
 
     /// Increases the batch depth after an on-chain dilution.
@@ -264,14 +267,17 @@ impl UsageTable {
     /// depth must not decrease and must stay within the supported geometry.
     /// Exposed to callers through [`Snapshot::dilute`](crate::Snapshot::dilute).
     pub(crate) fn dilute(&mut self, new_depth: u8) -> Result<()> {
-        if new_depth < self.depth {
+        let current = self.counters.depth();
+        if new_depth < current {
             return Err(UsageError::DepthDecrease {
-                current: self.depth,
+                current,
                 requested: new_depth,
             });
         }
-        validate_geometry(new_depth, self.bucket_depth)?;
-        self.depth = new_depth;
+        validate_geometry(new_depth, self.counters.bucket_depth())?;
+        // The geometry is validated against the snapshot format above, so the
+        // shared table only needs to adopt the new depth.
+        self.counters.set_depth(new_depth);
         Ok(())
     }
 
@@ -287,21 +293,15 @@ impl UsageTable {
     /// Exposed to callers through
     /// [`Snapshot::merge_max`](crate::Snapshot::merge_max).
     pub(crate) fn merge_max(&mut self, other: &Self) -> Result<()> {
-        if self.mutable || other.mutable {
+        if self.is_mutable() || other.is_mutable() {
             return Err(UsageError::MutableMerge);
         }
-        if self.batch_id != other.batch_id || self.bucket_depth != other.bucket_depth {
+        if self.batch_id != other.batch_id || self.bucket_depth() != other.bucket_depth() {
             return Err(UsageError::BatchMismatch);
         }
-        let depth = self.depth.max(other.depth);
-        validate_geometry(depth, self.bucket_depth)?;
-        self.depth = depth;
-        let mut issued = 0u64;
-        for (mine, theirs) in self.counts.iter_mut().zip(other.counts.iter()) {
-            *mine = (*mine).max(*theirs);
-            issued += u64::from(*mine);
-        }
-        self.issued = issued;
+        let depth = self.depth().max(other.depth());
+        validate_geometry(depth, self.bucket_depth())?;
+        self.counters.merge_counts_max(other.counters(), depth);
         Ok(())
     }
 }
@@ -338,17 +338,17 @@ impl<'a> TableView<'a> {
     /// Returns whether the table is a mutable ring (`true`) or an immutable fill
     /// watermark (`false`).
     pub const fn is_mutable(&self) -> bool {
-        self.table.mutable
+        self.table.is_mutable()
     }
 
     /// Returns the batch depth.
     pub const fn depth(&self) -> u8 {
-        self.table.depth
+        self.table.depth()
     }
 
     /// Returns the bucket (uniformity) depth.
     pub const fn bucket_depth(&self) -> u8 {
-        self.table.bucket_depth
+        self.table.bucket_depth()
     }
 
     /// Returns the number of collision buckets (`2^bucket_depth`).
@@ -368,7 +368,7 @@ impl<'a> TableView<'a> {
 
     /// Returns the sum of the per-bucket counters (a checksum in mutable mode).
     pub const fn total_issued(&self) -> u64 {
-        self.table.issued
+        self.table.total_issued()
     }
 
     /// Returns the per-bucket counters.

--- a/crates/postage-usage/src/table.rs
+++ b/crates/postage-usage/src/table.rs
@@ -94,7 +94,7 @@ pub struct UsageTable {
     pub(crate) batch_id: BatchId,
     /// The shared per-bucket counter table. It holds the counters, the issued
     /// sum, the geometry, and the fill-or-ring mode, in the same `[0, capacity]`
-    /// representation the wire format serialises. The snapshot wraps this table
+    /// representation the wire format serializes. The snapshot wraps this table
     /// rather than carrying its own copy of the counter logic.
     pub(crate) counters: CounterTable,
 }
@@ -310,7 +310,7 @@ impl UsageTable {
 ///
 /// This is what [`Snapshot::table`](crate::Snapshot::table) and
 /// [`SnapshotParts::table`](crate::SnapshotParts::table) hand out. It exposes the
-/// counters and geometry a caller legitimately needs to inspect (utilisation,
+/// counters and geometry a caller legitimately needs to inspect (utilization,
 /// depth, mutability) but deliberately yields no owned [`UsageTable`]: it only
 /// borrows the table and does not [`Deref`](core::ops::Deref) to it, so cloning
 /// or copying the view produces another borrowed view, never an owned table that

--- a/crates/postage-usage/tests/issuer.rs
+++ b/crates/postage-usage/tests/issuer.rs
@@ -46,7 +46,8 @@ fn snapshot_issuer_issues_sequential_indices() {
     assert_eq!(StampIssuer::batch_id(&issuer), batch_id);
     assert_eq!(issuer.batch_depth(), 18);
     assert_eq!(StampIssuer::bucket_depth(&issuer), BUCKET_DEPTH);
-    assert_eq!(issuer.stamps_issued(), 2);
+    // An immutable snapshot tracks a true monotone count.
+    assert_eq!(issuer.stamps_issued(), Some(2));
     assert_eq!(issuer.max_bucket_utilization(), 2);
     assert_eq!(issuer.bucket_utilization(0xCBCB), 2);
     assert!(issuer.bucket_has_capacity(0xCBCB));
@@ -174,6 +175,41 @@ fn sole_issuance_path_cannot_evict_snapshot_slots() {
     for index in &reserved {
         assert!(snapshot.is_reserved(&owner(), *index));
     }
+}
+
+/// Both crates advance counters through the one shared table, so a snapshot's
+/// immutable issuance and a standalone `MemoryIssuer` over the same geometry
+/// assign byte-identical slots for the same addresses. If `record_bucket` still
+/// hand-rolled its own watermark this parity would be a coincidence; with the
+/// delegation it is structural.
+#[test]
+fn shared_counter_table_backs_both_crates_identically() {
+    use nectar_postage_issuer::MemoryIssuer;
+
+    let batch_id = B256::repeat_byte(0x42);
+    // A fresh, never-persisted snapshot reserves no slots, so its fill watermark
+    // advances exactly like a bare MemoryIssuer.
+    let table = UsageTable::new(batch_id, 20, BUCKET_DEPTH).unwrap();
+    let mut snapshot = Snapshot::new(table);
+    let mut memory = MemoryIssuer::new(batch_id, 20, BUCKET_DEPTH);
+
+    for bucket in [0x0001u32, 0x0001, 0xCBE5, 0x0001, 0xCBE5] {
+        for salt in 0..3u8 {
+            let addr = content_address(bucket, salt);
+            let from_snapshot = snapshot.issuer(owner()).record_address(&addr).unwrap();
+            let from_memory = memory.prepare_stamp(&addr, 0).unwrap().index;
+            assert_eq!(
+                from_snapshot, from_memory,
+                "snapshot and MemoryIssuer diverged; they no longer share one table"
+            );
+        }
+    }
+
+    // The shared counter sum is the lifetime count in immutable mode for both.
+    assert_eq!(
+        snapshot.table().total_issued(),
+        memory.stamps_issued().unwrap()
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What

This unifies the duplicated per-bucket counter logic behind a single serializable `CounterTable` in `nectar-postage-issuer`.

The shared table backs all three counter consumers: `MemoryIssuer` (fill mode), `RingIssuer` (ring mode), and `postage-usage`'s `UsageTable`. The snapshot's `record_bucket` previously carried two hand-written branches; it now delegates to the shared table's single `record(bucket, is_protected)` primitive. Callers supply a per-slot protection predicate: the ring's `Reservation` trait, the snapshot's reserved `BTreeSet`.

`StampIssuer::stamps_issued` now returns `Option<u64>` so mutable/ring issuers report `None` instead of forwarding the wire checksum sum as if it were a lifetime issuance count. Immutable fill issuers return `Some(count)` where the sum genuinely is the count. The checksum sum is exposed explicitly via a dedicated accessor.

`dilute()` was added to `MemoryIssuer` and `ShardedIssuer`: capacity grows while counters are left untouched, and a depth decrease returns a new `DepthDecrease` error variant.

## Why

Closes #63. The two open-coded counter-advance branches in `postage-usage` duplicated logic that already existed in the issuer crate. Collapsing them onto one primitive removes the divergence risk and gives every consumer the same well-tested advance, wrap, and reserved-skip behaviour.

## Testing

The SBU1 wire format is byte-for-byte unchanged. `crates/postage-usage/tests/vector.rs` is not touched (empty per-file diff); `CounterTable` adopts the existing `[0, capacity]` deferred-wrap representation and the codec was left untouched. All three golden vectors pass (`readme_worked_example_vector`, `readme_large_batch_multi_leaf_vector`, `mutable_vector_flags_byte_and_round_trip`), as do all 18 snapshot round-trips.

A new cross-crate parity test (`shared_counter_table_backs_both_crates_identically`) asserts that a `Snapshot` and a bare `MemoryIssuer` over the same geometry assign byte-identical slots.

Both crates are clean on `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`, and `cargo doc -D warnings`.

## Security

No reserved-blind path is reintroduced: the snapshot's only content-issuance entry forwards the reserved `(bucket, slot)` set into the shared `record_bucket` predicate, so a ring never re-emits a snapshot-owned slot. The #62 type-state guard is intact: the sealed `Reservation` trait keeps `Unreserved`/`Reserved` with no public conversion, both ring constructors refuse immutable batches, and both `compile_fail` doctests still fail to compile. `UsageTable` gained no public mutator (`counters_mut`/`dilute`/`merge_max` are `pub(crate)`). The wire representation did not diverge: the `total_issued == sum(counts)` invariant is preserved via a signed-delta fold and the `IssuedMismatch` decode check is unchanged.


## Scope

This PR is intentionally the whole of #63, whose scope is three things: unify the counter table, model mutable issuance honestly, and add `dilute` to the issuers. The `dilute()` methods on `MemoryIssuer` and `ShardedIssuer` are the explicit prerequisite #64 needs and are listed in the issue; the `stamps_issued -> Option<u64>` change plus the `checksum()` accessor are the "model honestly" half (a ring's counter sum is a checksum, not a lifetime count). They have no production callers yet because #64 and the consuming wave land next. The British -ise spellings the QA pass flagged are fixed.

## AI Assistance

This change was produced by an automated multi-agent workflow: implementation, adversarial security review, and QA were all AI-generated. The result is human-reviewed before merge.

