### PR TITLE
feat(postage-issuer): map DepthIncrease events to issuer dilution

### DIFF
--- a/crates/postage-issuer/src/dilute_handler.rs
+++ b/crates/postage-issuer/src/dilute_handler.rs
@@ -1,0 +1,288 @@
+//! Wiring [`BatchEvent::DepthIncrease`] through to issuer dilution.
+//!
+//! A node that issues stamps holds a live issuer per batch. When the postage
+//! contract emits a depth increase for a batch, the matching issuer must grow
+//! its per-bucket capacity so that previously full buckets can accept more
+//! chunks. This module provides the small adapter that performs that wiring: a
+//! registry of dilutable issuers keyed by [`BatchId`] that implements
+//! [`BatchEventHandler`] and, on a [`BatchEvent::DepthIncrease`], calls
+//! [`Dilutable::dilute`] on the matching issuer.
+//!
+//! The adapter lives in the issuer crate rather than in `nectar-postage`
+//! because dilution is an issuer concern: `nectar-postage` is the lower crate
+//! and knows nothing about issuers, so the dependency points up from the event
+//! trait to the issuer.
+
+use std::collections::HashMap;
+
+use crate::error::IssuerError;
+use crate::issuer::MemoryIssuer;
+use crate::sharded::ShardedIssuer;
+use nectar_postage::{BatchEvent, BatchEventHandler, BatchId};
+
+/// An issuer whose per-bucket capacity can be grown by an on-chain dilution.
+///
+/// This is the minimal surface the [`IssuerRegistry`] needs to drive a
+/// [`BatchEvent::DepthIncrease`] through to the right issuer. It is implemented
+/// for the fill-only issuers in this crate ([`MemoryIssuer`] and
+/// [`ShardedIssuer`]); a self-hosting ring issuer dilutes through its snapshot
+/// in `nectar-postage-usage` and is not registered here.
+pub trait Dilutable {
+    /// Returns the batch ID this issuer issues stamps for.
+    fn batch_id(&self) -> BatchId;
+
+    /// Returns the current batch depth.
+    fn batch_depth(&self) -> u8;
+
+    /// Returns the current per-bucket capacity (`2^(depth - bucket_depth)`).
+    fn bucket_capacity(&self) -> u32;
+
+    /// Applies an on-chain dilution, growing the per-bucket capacity to the
+    /// geometry implied by `new_depth`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IssuerError::DepthDecrease`] if `new_depth` is below the
+    /// current depth.
+    fn dilute(&mut self, new_depth: u8) -> Result<(), IssuerError>;
+}
+
+impl Dilutable for MemoryIssuer {
+    // The geometry accessors come from the StampIssuer trait, so they are named
+    // explicitly to avoid resolving back into this Dilutable impl.
+    fn batch_id(&self) -> BatchId {
+        crate::StampIssuer::batch_id(self)
+    }
+
+    fn batch_depth(&self) -> u8 {
+        crate::StampIssuer::batch_depth(self)
+    }
+
+    fn bucket_capacity(&self) -> u32 {
+        crate::StampIssuer::bucket_capacity(self)
+    }
+
+    fn dilute(&mut self, new_depth: u8) -> Result<(), IssuerError> {
+        Self::dilute(self, new_depth)
+    }
+}
+
+impl Dilutable for ShardedIssuer {
+    fn batch_id(&self) -> BatchId {
+        Self::batch_id(self)
+    }
+
+    fn batch_depth(&self) -> u8 {
+        Self::batch_depth(self)
+    }
+
+    fn bucket_capacity(&self) -> u32 {
+        Self::bucket_capacity(self)
+    }
+
+    fn dilute(&mut self, new_depth: u8) -> Result<(), IssuerError> {
+        Self::dilute(self, new_depth)
+    }
+}
+
+/// A registry of dilutable issuers keyed by [`BatchId`].
+///
+/// Register a live issuer with [`register`](Self::register), then feed batch
+/// events through [`BatchEventHandler`]. A [`BatchEvent::DepthIncrease`] for a
+/// registered batch grows that issuer's capacity; an event for an unregistered
+/// batch is a no-op. All other event variants are ignored, since dilution is
+/// the only state this adapter owns.
+#[derive(Default)]
+pub struct IssuerRegistry {
+    issuers: HashMap<BatchId, Box<dyn Dilutable + Send>>,
+}
+
+impl IssuerRegistry {
+    /// Creates an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Registers an issuer under its own batch ID.
+    ///
+    /// A subsequent registration for the same batch ID replaces the previous
+    /// issuer and returns it.
+    pub fn register<I>(&mut self, issuer: I) -> Option<Box<dyn Dilutable + Send>>
+    where
+        I: Dilutable + Send + 'static,
+    {
+        self.issuers
+            .insert(Dilutable::batch_id(&issuer), Box::new(issuer))
+    }
+
+    /// Returns a shared reference to the issuer registered for `batch_id`.
+    pub fn get(&self, batch_id: &BatchId) -> Option<&(dyn Dilutable + Send)> {
+        self.issuers.get(batch_id).map(|boxed| &**boxed)
+    }
+
+    /// Removes the issuer registered for `batch_id`, if any.
+    pub fn remove(&mut self, batch_id: &BatchId) -> Option<Box<dyn Dilutable + Send>> {
+        self.issuers.remove(batch_id)
+    }
+
+    /// Returns the number of registered issuers.
+    pub fn len(&self) -> usize {
+        self.issuers.len()
+    }
+
+    /// Returns `true` if no issuers are registered.
+    pub fn is_empty(&self) -> bool {
+        self.issuers.is_empty()
+    }
+}
+
+impl std::fmt::Debug for IssuerRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IssuerRegistry")
+            .field("issuers", &self.issuers.keys().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+impl BatchEventHandler for IssuerRegistry {
+    type Error = IssuerError;
+
+    fn handle_event(&mut self, event: BatchEvent) -> Result<(), Self::Error> {
+        match event {
+            BatchEvent::DepthIncrease {
+                batch_id,
+                new_depth,
+            } => self
+                .issuers
+                .get_mut(&batch_id)
+                // A depth increase for a batch we do not track is a no-op, not
+                // an error: another handler owns that batch's issuer.
+                .map_or(Ok(()), |issuer| issuer.dilute(new_depth)),
+            // Created, TopUp, and Expired carry no capacity change this adapter
+            // is responsible for.
+            BatchEvent::Created { .. } | BatchEvent::TopUp { .. } | BatchEvent::Expired { .. } => {
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::B256;
+
+    fn batch_id(byte: u8) -> BatchId {
+        B256::repeat_byte(byte)
+    }
+
+    #[test]
+    fn depth_increase_grows_registered_issuer_capacity() {
+        // depth=17, bucket_depth=16 gives 2 slots per bucket.
+        let tracked = batch_id(0x11);
+        let mut registry = IssuerRegistry::new();
+        registry.register(MemoryIssuer::new(tracked, 17, 16));
+        assert_eq!(registry.get(&tracked).unwrap().bucket_capacity(), 2);
+
+        registry
+            .handle_event(BatchEvent::DepthIncrease {
+                batch_id: tracked,
+                new_depth: 18,
+            })
+            .unwrap();
+
+        // The diluted issuer reflects the new depth: depth 18 over bucket_depth
+        // 16 is 4 slots per bucket.
+        let issuer = registry.get(&tracked).unwrap();
+        assert_eq!(issuer.batch_depth(), 18);
+        assert_eq!(issuer.bucket_capacity(), 4);
+    }
+
+    #[test]
+    fn depth_increase_grows_sharded_issuer_capacity() {
+        let tracked = batch_id(0x22);
+        let mut registry = IssuerRegistry::new();
+        registry.register(ShardedIssuer::new(tracked, 17, 16));
+        assert_eq!(registry.get(&tracked).unwrap().bucket_capacity(), 2);
+
+        registry
+            .handle_event(BatchEvent::DepthIncrease {
+                batch_id: tracked,
+                new_depth: 20,
+            })
+            .unwrap();
+
+        let issuer = registry.get(&tracked).unwrap();
+        assert_eq!(issuer.batch_depth(), 20);
+        assert_eq!(issuer.bucket_capacity(), 16);
+    }
+
+    #[test]
+    fn depth_increase_for_unknown_batch_leaves_tracked_issuer_untouched() {
+        let tracked = batch_id(0x33);
+        let other = batch_id(0x44);
+
+        let mut registry = IssuerRegistry::new();
+        registry.register(MemoryIssuer::new(tracked, 17, 16));
+
+        // An event for a batch we do not track must not error and must leave
+        // the tracked issuer untouched.
+        registry
+            .handle_event(BatchEvent::DepthIncrease {
+                batch_id: other,
+                new_depth: 24,
+            })
+            .unwrap();
+
+        let issuer = registry.get(&tracked).unwrap();
+        assert_eq!(issuer.batch_depth(), 17);
+        assert_eq!(issuer.bucket_capacity(), 2);
+        // The unrelated batch was never registered, so nothing was created for
+        // it.
+        assert!(registry.get(&other).is_none());
+        assert_eq!(registry.len(), 1);
+    }
+
+    #[test]
+    fn non_depth_events_are_ignored() {
+        let tracked = batch_id(0x55);
+        let mut registry = IssuerRegistry::new();
+        registry.register(MemoryIssuer::new(tracked, 17, 16));
+
+        registry
+            .handle_event(BatchEvent::TopUp {
+                batch_id: tracked,
+                new_value: 1000,
+            })
+            .unwrap();
+        registry
+            .handle_event(BatchEvent::Expired { batch_id: tracked })
+            .unwrap();
+
+        let issuer = registry.get(&tracked).unwrap();
+        assert_eq!(issuer.batch_depth(), 17);
+        assert_eq!(issuer.bucket_capacity(), 2);
+    }
+
+    #[test]
+    fn depth_decrease_event_surfaces_error_defensively() {
+        // The contract never emits a decrease, but if a malformed event arrives
+        // the adapter must not silently corrupt state: the issuer's own guard
+        // refuses it and the error propagates.
+        let tracked = batch_id(0x66);
+        let mut registry = IssuerRegistry::new();
+        registry.register(MemoryIssuer::new(tracked, 18, 16));
+
+        let result = registry.handle_event(BatchEvent::DepthIncrease {
+            batch_id: tracked,
+            new_depth: 17,
+        });
+        assert!(matches!(
+            result,
+            Err(IssuerError::DepthDecrease {
+                current: 18,
+                requested: 17
+            })
+        ));
+    }
+}

--- a/crates/postage-issuer/src/lib.rs
+++ b/crates/postage-issuer/src/lib.rs
@@ -73,6 +73,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 mod counter;
+#[cfg(feature = "std")]
+mod dilute_handler;
 mod error;
 mod factory;
 mod issuer;
@@ -89,6 +91,10 @@ pub use error::{IssuerError, SigningError};
 
 // The shared per-bucket counter table behind every issuer and the snapshot.
 pub use counter::{CounterError, CounterMode, CounterTable};
+
+// Wiring on-chain depth-increase events through to issuer dilution (std only).
+#[cfg(feature = "std")]
+pub use dilute_handler::{Dilutable, IssuerRegistry};
 
 // Issuing
 pub use issuer::{MemoryIssuer, StampIssuer};

--- a/crates/postage/src/snapshot_store.rs
+++ b/crates/postage/src/snapshot_store.rs
@@ -27,8 +27,8 @@ use crate::BatchId;
 /// A cache for recovered issuer snapshot state, keyed by [`BatchId`].
 ///
 /// Implementations persist and load the snapshot state `S` for a batch. The
-/// network is the source of truth for this state (see the [module
-/// docs](self)); a store is only a warm-path cache, so a missing entry is
+/// network is the source of truth for this state (see the module-level
+/// docs); a store is only a warm-path cache, so a missing entry is
 /// reported as `Ok(None)` rather than an error and the caller recovers from the
 /// network instead.
 ///


### PR DESCRIPTION
## What

Adds a `BatchEventHandler` adapter that maps `BatchEvent::DepthIncrease` to issuer dilution.

The new `crates/postage-issuer/src/dilute_handler.rs` introduces a minimal `Dilutable` trait over the fill-only issuers (`MemoryIssuer`, `ShardedIssuer`) and an `IssuerRegistry` keyed by `BatchId` that implements `BatchEventHandler`. On a `DepthIncrease` event the registry calls `dilute(new_depth)` on the matching issuer; unknown batch ids are a documented no-op, and the remaining event variants (`Created`, `TopUp`, `Expired`) are explicitly ignored.

The adapter lives in `nectar-postage-issuer` (the upper crate) rather than `nectar-postage`, because it needs the issuer dilute methods. `nectar-postage-issuer` already depends on `nectar-postage` and re-exports `BatchEvent`/`BatchEventHandler`, so the dependency points up from the event trait to the issuer with no cycle; `nectar-postage` stays the lower crate and knows nothing about issuers. The module and its public exports (`Dilutable`, `IssuerRegistry`) are gated behind the `std` feature, matching the existing `std`-gated event trait, because `IssuerRegistry` uses `std::collections::HashMap`.

## Why

Closes #64.

The on-chain dilution event (a batch depth increase) needs to flow through to the in-memory issuer so its bucket capacity grows to match the new depth. This adapter is the wiring that turns a `BatchEvent::DepthIncrease` into the corresponding issuer state change without coupling the lower event crate to the issuer types.

## Testing

`cargo test -p nectar-postage-issuer` passes, including the five new behavioural tests:

- `depth_increase_grows_registered_issuer_capacity` (MemoryIssuer, depth 17 to 18 over bucket depth 16 gives capacity 2 to 4).
- `depth_increase_grows_sharded_issuer_capacity` (ShardedIssuer, depth 17 to 20 over bucket depth 16 gives capacity 2 to 16).
- `depth_increase_for_unknown_batch_leaves_tracked_issuer_untouched`.
- `non_depth_events_are_ignored`.
- `depth_decrease_event_surfaces_error_defensively`.

`cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo doc` are clean.

## Security and correctness

Two adversarial review angles (correctness, and API/composition) and a QA gate all returned pass.

For #64 the unknown-batch path is a no-op: `IssuerRegistry::handle_event` does `get_mut(&batch_id).map_or(Ok(()), |i| i.dilute(new_depth))`, so a `DepthIncrease` for an unregistered batch id returns `Ok(())` and mutates nothing. This is proven by `depth_increase_for_unknown_batch_leaves_tracked_issuer_untouched`, which asserts the tracked issuer keeps its depth and capacity and the registry length stays at one.

The polarity is asserted: only a `DepthIncrease` grows capacity, and a depth decrease cannot be expressed by the event. A malformed non-increase is refused by the issuer's own depth guard, so it surfaces `IssuerError::DepthDecrease` rather than corrupting state. This is covered by `depth_decrease_event_surfaces_error_defensively`.

No dependency cycle is introduced (`nectar-postage-issuer` depends on `nectar-postage`, not the reverse), the match over the four `BatchEvent` variants is exhaustive, and the capacity geometry is correct for both issuer kinds. The two `Dilutable` impls correctly disambiguate the `StampIssuer`-trait accessors (`crate::StampIssuer::` for `MemoryIssuer`) from the inherent ones (`Self::` for `ShardedIssuer`).

The task brief referenced #57 (`Mutability` enum, `from_batch`, SBU1 golden vectors); none of that is present in this branch's diff, so it does not apply to this PR.

## AI assistance

This change was produced by an automated multi-agent workflow: implementation, adversarial review, and QA were all AI-generated. The result is human-reviewed before merge.
