### PR TITLE
feat(postage-usage): add from_batch constructors and Mutability enum

### DIFF
--- a/crates/postage-usage/src/codec.rs
+++ b/crates/postage-usage/src/codec.rs
@@ -10,7 +10,7 @@ use bytes::Bytes;
 use nectar_postage::BatchId;
 
 use crate::snapshot::Snapshot;
-use crate::table::{UsageTable, validate_geometry};
+use crate::table::{Mutability, UsageTable, validate_geometry};
 use crate::{
     MAGIC, MAX_EXCEPTIONS, MAX_PAYLOAD_SIZE, MAX_WIDTH, ROOT_HEADER_SIZE, Result, UsageError,
 };
@@ -576,11 +576,18 @@ impl RootInfo {
         // [`Issuer`](crate::Issuer) through [`Snapshot::issuer`](crate::Snapshot::issuer),
         // which is the only counter-advance path, so issuance on a recovered
         // mutable snapshot is reserved-aware by construction.
-        let table = if self.mutable {
-            UsageTable::from_counts_mutable(self.batch_id, self.depth, self.bucket_depth, counts)?
+        let mutability = if self.mutable {
+            Mutability::Mutable
         } else {
-            UsageTable::from_counts(self.batch_id, self.depth, self.bucket_depth, counts)?
+            Mutability::Immutable
         };
+        let table = UsageTable::from_counts(
+            self.batch_id,
+            self.depth,
+            self.bucket_depth,
+            counts,
+            mutability,
+        )?;
         Snapshot::from_parts(Snapshot::recovered_parts(table, self.sequence, self.slots)?)
     }
 }
@@ -631,7 +638,7 @@ mod tests {
         use alloy_primitives::B256;
 
         // Build a minimal valid mutable root: width 0, one slot, no exceptions.
-        let table = UsageTable::new_mutable(B256::repeat_byte(0x42), 20, 16).unwrap();
+        let table = UsageTable::new(B256::repeat_byte(0x42), 20, 16, Mutability::Mutable).unwrap();
         let encoded = encode(&table, 1, &[0]).unwrap();
         let mut root = encoded.root.to_vec();
         assert_eq!(root[38], 0x01, "mutable flag must be set");

--- a/crates/postage-usage/src/lib.rs
+++ b/crates/postage-usage/src/lib.rs
@@ -26,14 +26,15 @@
 //!
 //! ```
 //! use alloy_primitives::{Address, B256};
-//! use nectar_postage_usage::{RootInfo, Snapshot, SwarmAddress, UsageTable};
+//! use nectar_postage_usage::{Mutability, RootInfo, Snapshot, SwarmAddress, UsageTable};
 //!
 //! let batch_id = B256::repeat_byte(0x42);
 //! let owner = Address::repeat_byte(0x11);
 //!
 //! // Issue a stamp for an uploaded chunk through the snapshot's issuing handle,
 //! // then plan a persist.
-//! let mut snapshot = Snapshot::new(UsageTable::new(batch_id, 20, 16).unwrap());
+//! let table = UsageTable::new(batch_id, 20, 16, Mutability::Immutable).unwrap();
+//! let mut snapshot = Snapshot::new(table);
 //! let address = SwarmAddress::from(B256::repeat_byte(0x99));
 //! snapshot.issuer(owner).record_address(&address).unwrap();
 //! let plan = snapshot.plan_persist(&owner).unwrap();
@@ -99,7 +100,7 @@ mod seal;
 pub use codec::{Encoded, RootInfo};
 pub use error::UsageError;
 pub use snapshot::{Issuer, PersistPlan, PlannedChunk, Snapshot, SnapshotParts};
-pub use table::{TableView, UsageTable};
+pub use table::{Mutability, TableView, UsageTable};
 
 #[cfg(feature = "issuer")]
 pub use issuer::SnapshotIssuer;
@@ -109,8 +110,12 @@ pub use seal::{SealError, SealedChunk, seal_plan};
 
 pub use nectar_primitives::SwarmAddress;
 
+/// Postage types re-exported so a downstream caller naming
+/// [`PlannedChunk::stamp_index`] or calling [`UsageTable::from_batch`] does not
+/// need a direct `nectar-postage` dependency.
+pub use nectar_postage::{Batch, BatchId, StampIndex};
+
 use alloy_primitives::{Address, B256, Keccak256};
-use nectar_postage::BatchId;
 
 /// Result alias for this crate.
 pub type Result<T> = core::result::Result<T, UsageError>;

--- a/crates/postage-usage/src/snapshot.rs
+++ b/crates/postage-usage/src/snapshot.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 
 use alloy_primitives::{Address, B256};
 use bytes::Bytes;
-use nectar_postage::{BatchId, StampIndex, calculate_bucket};
+use nectar_postage::{Batch, BatchId, StampIndex, calculate_bucket};
 use nectar_primitives::SwarmAddress;
 
 use crate::codec::{self, Encoded};
@@ -140,6 +140,18 @@ impl Snapshot {
         }
     }
 
+    /// Wraps a fresh, never-persisted table built from a [`Batch`].
+    ///
+    /// The table's geometry and mutability are read from the batch: an immutable
+    /// batch yields a fill-watermark table, a mutable batch
+    /// (`batch.immutable() == false`) a wrapping ring. As with [`new`](Self::new),
+    /// this is correct *only* for a genuinely new batch and starts the persist
+    /// history at sequence 0 with no allocated slots; recovered or extracted state
+    /// round-trips through [`from_parts`](Self::from_parts) instead.
+    pub fn from_batch(batch: &Batch) -> Result<Self> {
+        Ok(Self::new(UsageTable::from_batch(batch)?))
+    }
+
     /// Validates the slots of a table/sequence/slots triple against the table
     /// geometry, the shared check behind [`from_parts`](Self::from_parts) and
     /// the codec's recovery path.
@@ -253,9 +265,9 @@ impl Snapshot {
     ///
     /// ```compile_fail
     /// use alloy_primitives::B256;
-    /// use nectar_postage_usage::{Snapshot, UsageTable};
+    /// use nectar_postage_usage::{Mutability, Snapshot, UsageTable};
     ///
-    /// let snapshot = Snapshot::new(UsageTable::new(B256::repeat_byte(0x42), 20, 16).unwrap());
+    /// let snapshot = Snapshot::new(UsageTable::new(B256::repeat_byte(0x42), 20, 16, Mutability::Immutable).unwrap());
     /// // `into_table` no longer exists; only `into_parts` can consume a snapshot.
     /// let table = snapshot.into_table();
     /// ```
@@ -266,10 +278,10 @@ impl Snapshot {
     ///
     /// ```compile_fail
     /// use alloy_primitives::{Address, B256};
-    /// use nectar_postage_usage::{Snapshot, UsageTable};
+    /// use nectar_postage_usage::{Mutability, Snapshot, UsageTable};
     ///
     /// let owner = Address::repeat_byte(0x11);
-    /// let snapshot = Snapshot::new(UsageTable::new(B256::repeat_byte(0x42), 20, 16).unwrap());
+    /// let snapshot = Snapshot::new(UsageTable::new(B256::repeat_byte(0x42), 20, 16, Mutability::Immutable).unwrap());
     /// let parts = snapshot.into_parts();
     /// // `parts.table` is private and only a `TableView` is exposed, so a fresh
     /// // sequence-0 snapshot cannot be rebuilt from extracted state.
@@ -284,9 +296,9 @@ impl Snapshot {
     ///
     /// ```compile_fail
     /// use alloy_primitives::B256;
-    /// use nectar_postage_usage::{Snapshot, UsageTable};
+    /// use nectar_postage_usage::{Mutability, Snapshot, UsageTable};
     ///
-    /// let snapshot = Snapshot::new(UsageTable::new(B256::repeat_byte(0x42), 20, 16).unwrap());
+    /// let snapshot = Snapshot::new(UsageTable::new(B256::repeat_byte(0x42), 20, 16, Mutability::Immutable).unwrap());
     /// // `table()` returns a `TableView`; cloning it yields another view, not a
     /// // `UsageTable`, so this does not type-check.
     /// let reset = Snapshot::new(snapshot.table().clone());

--- a/crates/postage-usage/src/table.rs
+++ b/crates/postage-usage/src/table.rs
@@ -2,7 +2,7 @@
 
 use alloc::vec::Vec;
 
-use nectar_postage::BatchId;
+use nectar_postage::{Batch, BatchId};
 use nectar_postage_issuer::{CounterError, CounterMode, CounterTable};
 
 use crate::{MAX_BUCKET_DEPTH, MAX_COUNTER_BITS, Result, UsageError};
@@ -48,6 +48,50 @@ pub(crate) const fn validate_geometry(depth: u8, bucket_depth: u8) -> Result<()>
     Ok(())
 }
 
+/// Whether a usage table is an immutable fill watermark or a mutable ring.
+///
+/// The fill-or-ring choice is a runtime flag, not a type parameter: the SBU1
+/// codec decodes it from the wire at runtime (see
+/// [`RootInfo::assemble`](crate::RootInfo::assemble)), so a type-state parameter
+/// would fight the wire decode. This enum makes the choice an explicit, named
+/// argument to the table constructors instead of a bare bool.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Mutability {
+    /// `counts[b]` is a monotone fill watermark, the next unused index; issuance
+    /// advances it and a full bucket fails rather than overwriting.
+    #[default]
+    Immutable,
+    /// `counts[b]` is a ring cursor in `[0, capacity]` that wraps at capacity, so
+    /// a full bucket churns instead of failing.
+    Mutable,
+}
+
+impl Mutability {
+    /// Picks the mutability from a batch: an immutable batch yields the fill
+    /// watermark table, a mutable batch (`batch.immutable() == false`) yields the
+    /// wrapping ring.
+    pub const fn from_batch(batch: &Batch) -> Self {
+        if batch.immutable() {
+            Self::Immutable
+        } else {
+            Self::Mutable
+        }
+    }
+
+    /// Returns whether this is the mutable (ring) variant.
+    pub const fn is_mutable(self) -> bool {
+        matches!(self, Self::Mutable)
+    }
+
+    /// Maps the mutability onto the shared counter table's mode.
+    const fn mode(self) -> CounterMode {
+        match self {
+            Self::Immutable => CounterMode::Fill,
+            Self::Mutable => CounterMode::Ring,
+        }
+    }
+}
+
 /// Per-bucket slot counters for a postage batch.
 ///
 /// For each of the `2^bucket_depth` collision buckets, this records the state
@@ -58,15 +102,17 @@ pub(crate) const fn validate_geometry(depth: u8, bucket_depth: u8) -> Result<()>
 /// slots first, so a bare table can never evict the chunks that record the
 /// batch state.
 ///
-/// - **Immutable** ([`new`](Self::new) / [`from_counts`](Self::from_counts)):
-///   `counts[b]` is a monotone fill watermark, the next unused index; issuance
-///   advances it and a full bucket fails rather than overwriting.
-/// - **Mutable** ([`new_mutable`](Self::new_mutable) /
-///   [`from_counts_mutable`](Self::from_counts_mutable)): `counts[b]` is a ring
-///   cursor in `[0, capacity]` that wraps at capacity, so a full bucket churns
-///   instead of failing. The reserved slots that the ring skips live on the
-///   issuing handle, not the table, so they cannot be lost when the table is
-///   moved.
+/// The fill-or-ring choice is a runtime [`Mutability`] flag passed to
+/// [`new`](Self::new) and [`from_counts`](Self::from_counts), or derived from a
+/// batch by [`from_batch`](Self::from_batch):
+///
+/// - **Immutable** ([`Mutability::Immutable`]): `counts[b]` is a monotone fill
+///   watermark, the next unused index; issuance advances it and a full bucket
+///   fails rather than overwriting.
+/// - **Mutable** ([`Mutability::Mutable`]): `counts[b]` is a ring cursor in
+///   `[0, capacity]` that wraps at capacity, so a full bucket churns instead of
+///   failing. The reserved slots that the ring skips live on the issuing handle,
+///   not the table, so they cannot be lost when the table is moved.
 ///
 /// A bare table cannot issue: it has no reserved-blind `record` mutator, so
 /// counter advances that skip reserved installation are a compile error, not a
@@ -74,18 +120,18 @@ pub(crate) const fn validate_geometry(depth: u8, bucket_depth: u8) -> Result<()>
 ///
 /// ```compile_fail
 /// use alloy_primitives::B256;
-/// use nectar_postage_usage::UsageTable;
+/// use nectar_postage_usage::{Mutability, UsageTable};
 ///
-/// let mut table = UsageTable::new_mutable(B256::repeat_byte(0x42), 18, 16).unwrap();
+/// let mut table = UsageTable::new(B256::repeat_byte(0x42), 18, 16, Mutability::Mutable).unwrap();
 /// // `record` no longer exists on the inert table.
 /// table.record(7).unwrap();
 /// ```
 ///
 /// ```compile_fail
 /// use alloy_primitives::B256;
-/// use nectar_postage_usage::{SwarmAddress, UsageTable};
+/// use nectar_postage_usage::{Mutability, SwarmAddress, UsageTable};
 ///
-/// let mut table = UsageTable::new_mutable(B256::repeat_byte(0x42), 18, 16).unwrap();
+/// let mut table = UsageTable::new(B256::repeat_byte(0x42), 18, 16, Mutability::Mutable).unwrap();
 /// // `record_address` no longer exists on the inert table.
 /// table.record_address(&SwarmAddress::from(B256::repeat_byte(0x99))).unwrap();
 /// ```
@@ -100,78 +146,57 @@ pub struct UsageTable {
 }
 
 impl UsageTable {
-    /// Returns the mode the geometry-checked constructors install for `mutable`.
-    const fn mode(mutable: bool) -> CounterMode {
-        if mutable {
-            CounterMode::Ring
-        } else {
-            CounterMode::Fill
-        }
-    }
-
-    /// Creates an empty immutable table for a batch with the given geometry.
-    pub fn new(batch_id: BatchId, depth: u8, bucket_depth: u8) -> Result<Self> {
-        Self::new_with_mode(batch_id, depth, bucket_depth, false)
-    }
-
-    /// Creates an empty mutable (ring-cursor) table.
+    /// Creates an empty table for a batch with the given geometry and
+    /// [`Mutability`].
     ///
-    /// Issuance is a per-bucket ring: once a bucket fills it wraps to index `0`.
-    /// The ring skips the snapshot's reserved slots, which are installed onto the
-    /// issuing handle by [`Snapshot::issuer`](crate::Snapshot::issuer), so the
-    /// ring never evicts the snapshot's own chunks.
-    pub fn new_mutable(batch_id: BatchId, depth: u8, bucket_depth: u8) -> Result<Self> {
-        Self::new_with_mode(batch_id, depth, bucket_depth, true)
-    }
-
-    fn new_with_mode(
+    /// An immutable table is a monotone fill watermark; a mutable table is a
+    /// per-bucket ring that wraps once a bucket fills. The ring skips the
+    /// snapshot's reserved slots, which are installed onto the issuing handle by
+    /// [`Snapshot::issuer`](crate::Snapshot::issuer), so it never evicts the
+    /// snapshot's own chunks.
+    pub fn new(
         batch_id: BatchId,
         depth: u8,
         bucket_depth: u8,
-        mutable: bool,
+        mutability: Mutability,
     ) -> Result<Self> {
         validate_geometry(depth, bucket_depth)?;
         Ok(Self {
             batch_id,
-            counters: CounterTable::new(depth, bucket_depth, Self::mode(mutable)),
+            counters: CounterTable::new(depth, bucket_depth, mutability.mode()),
         })
     }
 
-    /// Creates an immutable table from existing counters.
+    /// Creates an empty table whose geometry and [`Mutability`] are read from a
+    /// [`Batch`].
     ///
-    /// `counts` must hold exactly `2^bucket_depth` entries, each at most the
-    /// bucket capacity.
+    /// An immutable batch yields a fill-watermark table; a mutable batch
+    /// (`batch.immutable() == false`) yields a wrapping ring. This lets a caller
+    /// holding a `Batch` build the matching table without restating the geometry
+    /// or polarity by hand.
+    pub fn from_batch(batch: &Batch) -> Result<Self> {
+        Self::new(
+            batch.id(),
+            batch.depth(),
+            batch.bucket_depth(),
+            Mutability::from_batch(batch),
+        )
+    }
+
+    /// Creates a table from existing counters with the given [`Mutability`].
+    ///
+    /// `counts` must hold exactly `2^bucket_depth` entries, each in
+    /// `[0, capacity]`. For a mutable table the reserved slots are installed by
+    /// [`Snapshot::issuer`](crate::Snapshot::issuer) before issuing.
     pub fn from_counts(
         batch_id: BatchId,
         depth: u8,
         bucket_depth: u8,
         counts: Vec<u32>,
-    ) -> Result<Self> {
-        Self::from_counts_with_mode(batch_id, depth, bucket_depth, counts, false)
-    }
-
-    /// Creates a mutable (ring-cursor) table from existing cursors, each in
-    /// `[0, capacity]`. As with [`new_mutable`](Self::new_mutable), the reserved
-    /// slots are installed by [`Snapshot::issuer`](crate::Snapshot::issuer)
-    /// before issuing.
-    pub fn from_counts_mutable(
-        batch_id: BatchId,
-        depth: u8,
-        bucket_depth: u8,
-        counts: Vec<u32>,
-    ) -> Result<Self> {
-        Self::from_counts_with_mode(batch_id, depth, bucket_depth, counts, true)
-    }
-
-    fn from_counts_with_mode(
-        batch_id: BatchId,
-        depth: u8,
-        bucket_depth: u8,
-        counts: Vec<u32>,
-        mutable: bool,
+        mutability: Mutability,
     ) -> Result<Self> {
         validate_geometry(depth, bucket_depth)?;
-        let counters = CounterTable::from_counts(depth, bucket_depth, Self::mode(mutable), counts)
+        let counters = CounterTable::from_counts(depth, bucket_depth, mutability.mode(), counts)
             .map_err(map_counter_error)?;
         Ok(Self { batch_id, counters })
     }
@@ -399,7 +424,8 @@ impl<'a> TableView<'a> {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::b256;
+    use alloy_primitives::{Address, b256};
+    use nectar_postage::Batch;
 
     use super::*;
 
@@ -407,21 +433,81 @@ mod tests {
         b256!("0x1122334455667788112233445566778811223344556677881122334455667788")
     }
 
+    fn immutable_counts() -> Vec<u32> {
+        vec![0u32; 1usize << 16]
+    }
+
+    fn batch_with(depth: u8, bucket_depth: u8, immutable: bool) -> Batch {
+        Batch::new(
+            batch_id(),
+            1_000,
+            0,
+            Address::repeat_byte(0x11),
+            depth,
+            bucket_depth,
+            immutable,
+        )
+    }
+
     #[test]
     fn geometry_bounds() {
-        assert!(UsageTable::new(batch_id(), 20, 16).is_ok());
-        assert!(UsageTable::new(batch_id(), 16, 16).is_ok());
-        assert!(UsageTable::new(batch_id(), 47, 16).is_ok());
-        assert!(UsageTable::new(batch_id(), 48, 16).is_err());
-        assert!(UsageTable::new(batch_id(), 15, 16).is_err());
-        assert!(UsageTable::new(batch_id(), 20, 17).is_err());
+        let imm = Mutability::Immutable;
+        assert!(UsageTable::new(batch_id(), 20, 16, imm).is_ok());
+        assert!(UsageTable::new(batch_id(), 16, 16, imm).is_ok());
+        assert!(UsageTable::new(batch_id(), 47, 16, imm).is_ok());
+        assert!(UsageTable::new(batch_id(), 48, 16, imm).is_err());
+        assert!(UsageTable::new(batch_id(), 15, 16, imm).is_err());
+        assert!(UsageTable::new(batch_id(), 20, 17, imm).is_err());
+    }
+
+    #[test]
+    fn mutability_enum_matches_old_constructors() {
+        // The enum constructors produce the same tables the old `new`/`new_mutable`
+        // pair did: an immutable table is a fill watermark, a mutable table a ring.
+        let immutable = UsageTable::new(batch_id(), 20, 16, Mutability::Immutable).unwrap();
+        assert!(!immutable.is_mutable());
+
+        let mutable = UsageTable::new(batch_id(), 20, 16, Mutability::Mutable).unwrap();
+        assert!(mutable.is_mutable());
+
+        let from_counts_imm = UsageTable::from_counts(
+            batch_id(),
+            17,
+            16,
+            immutable_counts(),
+            Mutability::Immutable,
+        )
+        .unwrap();
+        assert!(!from_counts_imm.is_mutable());
+
+        let from_counts_mut =
+            UsageTable::from_counts(batch_id(), 17, 16, immutable_counts(), Mutability::Mutable)
+                .unwrap();
+        assert!(from_counts_mut.is_mutable());
+    }
+
+    #[test]
+    fn from_batch_picks_table_from_polarity() {
+        // An immutable batch yields a fill table; a mutable batch yields a ring.
+        let immutable_batch = batch_with(20, 16, true);
+        let immutable_table = UsageTable::from_batch(&immutable_batch).unwrap();
+        assert!(!immutable_table.is_mutable());
+        assert_eq!(immutable_table.batch_id(), batch_id());
+        assert_eq!(immutable_table.depth(), 20);
+        assert_eq!(immutable_table.bucket_depth(), 16);
+
+        let mutable_batch = batch_with(20, 16, false);
+        let mutable_table = UsageTable::from_batch(&mutable_batch).unwrap();
+        assert!(mutable_table.is_mutable());
+        assert_eq!(mutable_table.depth(), 20);
     }
 
     #[test]
     fn from_counts_sums_issued_and_rejects_overflow() {
         let mut counts = vec![0u32; 1usize << 16];
         counts[7] = 2;
-        let table = UsageTable::from_counts(batch_id(), 17, 16, counts).unwrap();
+        let table =
+            UsageTable::from_counts(batch_id(), 17, 16, counts, Mutability::Immutable).unwrap();
         assert_eq!(table.bucket_capacity(), 2);
         assert_eq!(table.total_issued(), 2);
         assert_eq!(table.max_count(), 2);
@@ -430,7 +516,7 @@ mod tests {
         let mut over = vec![0u32; 1usize << 16];
         over[7] = 3; // capacity is 2
         assert_eq!(
-            UsageTable::from_counts(batch_id(), 17, 16, over),
+            UsageTable::from_counts(batch_id(), 17, 16, over, Mutability::Immutable),
             Err(UsageError::CounterOverflow {
                 bucket: 7,
                 count: 3,
@@ -443,7 +529,8 @@ mod tests {
     fn dilute_grows_capacity_only() {
         let mut counts = vec![0u32; 1usize << 16];
         counts[0] = 1;
-        let mut table = UsageTable::from_counts(batch_id(), 17, 16, counts).unwrap();
+        let mut table =
+            UsageTable::from_counts(batch_id(), 17, 16, counts, Mutability::Immutable).unwrap();
         table.dilute(18).unwrap();
         assert_eq!(table.bucket_capacity(), 4);
         assert_eq!(table.count(0).unwrap(), 1);
@@ -463,8 +550,10 @@ mod tests {
         let mut counts_b = vec![0u32; 1usize << 16];
         counts_b[0] = 1;
         counts_b[1] = 1;
-        let mut a = UsageTable::from_counts(batch_id(), 18, 16, counts_a).unwrap();
-        let b = UsageTable::from_counts(batch_id(), 19, 16, counts_b).unwrap();
+        let mut a =
+            UsageTable::from_counts(batch_id(), 18, 16, counts_a, Mutability::Immutable).unwrap();
+        let b =
+            UsageTable::from_counts(batch_id(), 19, 16, counts_b, Mutability::Immutable).unwrap();
         a.merge_max(&b).unwrap();
         assert_eq!(a.depth(), 19);
         assert_eq!(a.count(0).unwrap(), 2);
@@ -475,11 +564,13 @@ mod tests {
     #[test]
     fn merge_max_rejects_mutable() {
         let zero = || vec![0u32; 1usize << 16];
-        let mut a = UsageTable::from_counts_mutable(batch_id(), 18, 16, zero()).unwrap();
-        let b = UsageTable::from_counts(batch_id(), 18, 16, zero()).unwrap();
+        let mut a =
+            UsageTable::from_counts(batch_id(), 18, 16, zero(), Mutability::Mutable).unwrap();
+        let b = UsageTable::from_counts(batch_id(), 18, 16, zero(), Mutability::Immutable).unwrap();
         assert_eq!(a.merge_max(&b), Err(UsageError::MutableMerge));
-        let mut c = UsageTable::from_counts(batch_id(), 18, 16, zero()).unwrap();
-        let d = UsageTable::from_counts_mutable(batch_id(), 18, 16, zero()).unwrap();
+        let mut c =
+            UsageTable::from_counts(batch_id(), 18, 16, zero(), Mutability::Immutable).unwrap();
+        let d = UsageTable::from_counts(batch_id(), 18, 16, zero(), Mutability::Mutable).unwrap();
         assert_eq!(c.merge_max(&d), Err(UsageError::MutableMerge));
     }
 }

--- a/crates/postage-usage/tests/issuer.rs
+++ b/crates/postage-usage/tests/issuer.rs
@@ -6,7 +6,7 @@
 use alloy_primitives::{Address, B256};
 use nectar_postage::{StampIndex, calculate_bucket};
 use nectar_postage_issuer::StampIssuer;
-use nectar_postage_usage::{Snapshot, SnapshotIssuer, UsageTable};
+use nectar_postage_usage::{Mutability, Snapshot, SnapshotIssuer, UsageTable};
 use nectar_primitives::SwarmAddress;
 
 const BUCKET_DEPTH: u8 = 16;
@@ -28,7 +28,7 @@ fn content_address(bucket: u32, salt: u8) -> SwarmAddress {
 #[test]
 fn snapshot_issuer_issues_sequential_indices() {
     let batch_id = B256::repeat_byte(0x42);
-    let table = UsageTable::new(batch_id, 18, BUCKET_DEPTH).unwrap();
+    let table = UsageTable::new(batch_id, 18, BUCKET_DEPTH, Mutability::Immutable).unwrap();
     // A fresh, never-persisted snapshot reserves no slots, so issuance fills the
     // bucket from index zero just as a bare table once did.
     let snapshot = Snapshot::new(table);
@@ -63,7 +63,8 @@ fn snapshot_issuer_issues_sequential_indices() {
 fn shared_table_immutable_never_collides_with_reserved_slots() {
     let batch_id = B256::repeat_byte(0x42);
     let counts = vec![5u32; 1usize << BUCKET_DEPTH];
-    let table = UsageTable::from_counts(batch_id, 24, BUCKET_DEPTH, counts).unwrap();
+    let table =
+        UsageTable::from_counts(batch_id, 24, BUCKET_DEPTH, counts, Mutability::Immutable).unwrap();
     let mut snapshot = Snapshot::new(table);
 
     // Persist once, recording the snapshot's own reserved slots.
@@ -89,7 +90,8 @@ fn shared_table_mutable_skips_reserved_across_wraps() {
     let batch_id = B256::repeat_byte(0x42);
     // Capacity 4 per bucket; fill near-full so the ring wraps almost at once.
     let counts = vec![2u32; 1usize << BUCKET_DEPTH];
-    let table = UsageTable::from_counts_mutable(batch_id, 18, BUCKET_DEPTH, counts).unwrap();
+    let table =
+        UsageTable::from_counts(batch_id, 18, BUCKET_DEPTH, counts, Mutability::Mutable).unwrap();
     assert!(table.is_mutable());
     let mut snapshot = Snapshot::new(table);
 
@@ -136,7 +138,8 @@ fn sole_issuance_path_cannot_evict_snapshot_slots() {
     // A mutable bucket at capacity 4, pre-filled to 3 so the very next stamp
     // wraps the ring and would land on the reserved slot under a naive issuer.
     let counts = vec![3u32; 1usize << BUCKET_DEPTH];
-    let table = UsageTable::from_counts_mutable(batch_id, 18, BUCKET_DEPTH, counts).unwrap();
+    let table =
+        UsageTable::from_counts(batch_id, 18, BUCKET_DEPTH, counts, Mutability::Mutable).unwrap();
     assert!(table.is_mutable());
 
     // `SnapshotIssuer` is the only `StampIssuer` this crate exposes. Persist
@@ -189,7 +192,7 @@ fn shared_counter_table_backs_both_crates_identically() {
     let batch_id = B256::repeat_byte(0x42);
     // A fresh, never-persisted snapshot reserves no slots, so its fill watermark
     // advances exactly like a bare MemoryIssuer.
-    let table = UsageTable::new(batch_id, 20, BUCKET_DEPTH).unwrap();
+    let table = UsageTable::new(batch_id, 20, BUCKET_DEPTH, Mutability::Immutable).unwrap();
     let mut snapshot = Snapshot::new(table);
     let mut memory = MemoryIssuer::new(batch_id, 20, BUCKET_DEPTH);
 
@@ -221,7 +224,7 @@ fn snapshot_issuer_adapter_drives_a_batch_stamper_path() {
     let owner = signer.address();
     let batch_id = B256::repeat_byte(0x77);
 
-    let table = UsageTable::new_mutable(batch_id, 20, BUCKET_DEPTH).unwrap();
+    let table = UsageTable::new(batch_id, 20, BUCKET_DEPTH, Mutability::Mutable).unwrap();
     let mut snapshot = Snapshot::new(table);
     snapshot.plan_persist(&owner).unwrap();
     let reserved = snapshot.reserved_stamp_indices(&owner);

--- a/crates/postage-usage/tests/seal.rs
+++ b/crates/postage-usage/tests/seal.rs
@@ -4,7 +4,7 @@
 
 use alloy_primitives::B256;
 use alloy_signer_local::PrivateKeySigner;
-use nectar_postage_usage::{Snapshot, UsageTable, seal_plan, usage_chunk_address};
+use nectar_postage_usage::{Mutability, Snapshot, UsageTable, seal_plan, usage_chunk_address};
 use nectar_primitives::Chunk;
 
 #[test]
@@ -17,7 +17,7 @@ fn sealed_chunks_and_stamps_verify() {
     // has no record path.
     let mut counts = vec![0u32; 1usize << 16];
     counts[123] = 1;
-    let table = UsageTable::from_counts(batch_id, 20, 16, counts).unwrap();
+    let table = UsageTable::from_counts(batch_id, 20, 16, counts, Mutability::Immutable).unwrap();
     let mut snapshot = Snapshot::new(table);
     let plan = snapshot.plan_persist(&owner).unwrap();
 

--- a/crates/postage-usage/tests/snapshot.rs
+++ b/crates/postage-usage/tests/snapshot.rs
@@ -4,8 +4,8 @@
 use alloy_primitives::{Address, B256};
 use nectar_postage::calculate_bucket;
 use nectar_postage_usage::{
-    MAGIC, PersistPlan, RootInfo, Snapshot, UsageError, UsageTable, usage_chunk_address,
-    usage_chunk_id,
+    Batch, MAGIC, Mutability, PersistPlan, RootInfo, Snapshot, UsageError, UsageTable,
+    usage_chunk_address, usage_chunk_id,
 };
 
 const BUCKET_DEPTH: u8 = 16;
@@ -38,9 +38,39 @@ fn roundtrip(plan: &PersistPlan) -> Snapshot {
     root.assemble(&leaves).unwrap()
 }
 
+const fn batch(depth: u8, immutable: bool) -> Batch {
+    Batch::new(
+        batch_id(),
+        1_000,
+        0,
+        owner(),
+        depth,
+        BUCKET_DEPTH,
+        immutable,
+    )
+}
+
+#[test]
+fn snapshot_from_batch_matches_batch_polarity() {
+    // An immutable batch yields a fill-watermark snapshot; a mutable batch
+    // (immutable() == false) yields a wrapping ring. The geometry is read
+    // straight from the batch.
+    let immutable = Snapshot::from_batch(&batch(20, true)).unwrap();
+    assert!(!immutable.table().is_mutable());
+    assert_eq!(immutable.table().batch_id(), batch_id());
+    assert_eq!(immutable.table().depth(), 20);
+    assert_eq!(immutable.table().bucket_depth(), BUCKET_DEPTH);
+    assert_eq!(immutable.sequence(), 0);
+
+    let mutable = Snapshot::from_batch(&batch(22, false)).unwrap();
+    assert!(mutable.table().is_mutable());
+    assert_eq!(mutable.table().depth(), 22);
+    assert_eq!(mutable.sequence(), 0);
+}
+
 #[test]
 fn empty_table_persists_as_a_single_small_root() {
-    let table = UsageTable::new(batch_id(), 20, BUCKET_DEPTH).unwrap();
+    let table = UsageTable::new(batch_id(), 20, BUCKET_DEPTH, Mutability::Immutable).unwrap();
     let mut snapshot = Snapshot::new(table);
     let plan = snapshot.plan_persist(&owner()).unwrap();
 
@@ -64,7 +94,9 @@ fn uniform_spread_uses_leaves_and_round_trips() {
     // Counts in 64..=127: base 64, deltas need 6 bits. A leaf holds
     // floor(32768 / 6) = 5461 buckets, so 65536 buckets need 13 leaves.
     let counts = synthetic_counts(buckets, 64, 63);
-    let table = UsageTable::from_counts(batch_id(), 24, BUCKET_DEPTH, counts).unwrap();
+    let table =
+        UsageTable::from_counts(batch_id(), 24, BUCKET_DEPTH, counts, Mutability::Immutable)
+            .unwrap();
     let mut snapshot = Snapshot::new(table);
     let plan = snapshot.plan_persist(&owner()).unwrap();
 
@@ -79,7 +111,9 @@ fn hot_bucket_becomes_an_exception_not_a_wider_table() {
     let buckets = 1usize << BUCKET_DEPTH;
     let mut counts = vec![0u32; buckets];
     counts[12345] = 200_000; // one hot bucket, everything else empty
-    let table = UsageTable::from_counts(batch_id(), 34, BUCKET_DEPTH, counts).unwrap();
+    let table =
+        UsageTable::from_counts(batch_id(), 34, BUCKET_DEPTH, counts, Mutability::Immutable)
+            .unwrap();
     let mut snapshot = Snapshot::new(table);
     let plan = snapshot.plan_persist(&owner()).unwrap();
 
@@ -94,7 +128,9 @@ fn hot_bucket_becomes_an_exception_not_a_wider_table() {
 fn steady_state_persists_allocate_nothing_and_keep_slots() {
     let buckets = 1usize << BUCKET_DEPTH;
     let counts = synthetic_counts(buckets, 10, 15);
-    let table = UsageTable::from_counts(batch_id(), 22, BUCKET_DEPTH, counts).unwrap();
+    let table =
+        UsageTable::from_counts(batch_id(), 22, BUCKET_DEPTH, counts, Mutability::Immutable)
+            .unwrap();
     let mut snapshot = Snapshot::new(table);
 
     let first = snapshot.plan_persist(&owner()).unwrap();
@@ -120,7 +156,9 @@ fn steady_state_persists_allocate_nothing_and_keep_slots() {
 fn snapshot_accounts_for_its_own_chunks() {
     let buckets = 1usize << BUCKET_DEPTH;
     let counts = synthetic_counts(buckets, 100, 90);
-    let table = UsageTable::from_counts(batch_id(), 24, BUCKET_DEPTH, counts).unwrap();
+    let table =
+        UsageTable::from_counts(batch_id(), 24, BUCKET_DEPTH, counts, Mutability::Immutable)
+            .unwrap();
     let issued_before = table.total_issued();
     let mut snapshot = Snapshot::new(table);
     let plan = snapshot.plan_persist(&owner()).unwrap();
@@ -140,7 +178,9 @@ fn snapshot_accounts_for_its_own_chunks() {
 fn dilution_changes_no_leaf_bytes() {
     let buckets = 1usize << BUCKET_DEPTH;
     let counts = synthetic_counts(buckets, 5, 7);
-    let table = UsageTable::from_counts(batch_id(), 20, BUCKET_DEPTH, counts).unwrap();
+    let table =
+        UsageTable::from_counts(batch_id(), 20, BUCKET_DEPTH, counts, Mutability::Immutable)
+            .unwrap();
     let mut snapshot = Snapshot::new(table);
     let before = snapshot.plan_persist(&owner()).unwrap();
 
@@ -160,7 +200,7 @@ fn dilution_changes_no_leaf_bytes() {
 fn small_bucket_depth_inlines_in_the_root() {
     // 256 buckets at any width fit inline in the root.
     let counts = synthetic_counts(256, 1000, 4000);
-    let table = UsageTable::from_counts(batch_id(), 21, 8, counts).unwrap();
+    let table = UsageTable::from_counts(batch_id(), 21, 8, counts, Mutability::Immutable).unwrap();
     let mut snapshot = Snapshot::new(table);
     let plan = snapshot.plan_persist(&owner()).unwrap();
     assert_eq!(plan.chunks.len(), 1);
@@ -176,7 +216,9 @@ fn full_capacity_counters_round_trip() {
     for c in counts.iter_mut().take(64) {
         *c = 0;
     }
-    let table = UsageTable::from_counts(batch_id(), 17, BUCKET_DEPTH, counts).unwrap();
+    let table =
+        UsageTable::from_counts(batch_id(), 17, BUCKET_DEPTH, counts, Mutability::Immutable)
+            .unwrap();
     let mut snapshot = Snapshot::new(table);
     match snapshot.plan_persist(&owner()) {
         Ok(plan) => {
@@ -194,7 +236,9 @@ fn full_capacity_counters_round_trip() {
 fn corruption_is_rejected() {
     let buckets = 1usize << BUCKET_DEPTH;
     let counts = synthetic_counts(buckets, 50, 40);
-    let table = UsageTable::from_counts(batch_id(), 23, BUCKET_DEPTH, counts).unwrap();
+    let table =
+        UsageTable::from_counts(batch_id(), 23, BUCKET_DEPTH, counts, Mutability::Immutable)
+            .unwrap();
     let mut snapshot = Snapshot::new(table);
     let plan = snapshot.plan_persist(&owner()).unwrap();
     let root_payload = plan.chunks[0].payload.to_vec();
@@ -245,7 +289,9 @@ fn corruption_is_rejected() {
 fn reserved_indices_match_planned_stamps_and_guard_reuse() {
     let buckets = 1usize << BUCKET_DEPTH;
     let counts = synthetic_counts(buckets, 10, 15);
-    let table = UsageTable::from_counts(batch_id(), 22, BUCKET_DEPTH, counts).unwrap();
+    let table =
+        UsageTable::from_counts(batch_id(), 22, BUCKET_DEPTH, counts, Mutability::Immutable)
+            .unwrap();
     let mut snapshot = Snapshot::new(table);
     let plan = snapshot.plan_persist(&owner()).unwrap();
 
@@ -270,7 +316,7 @@ fn reserved_indices_match_planned_stamps_and_guard_reuse() {
 
 #[test]
 fn encode_requires_an_allocated_root() {
-    let table = UsageTable::new(batch_id(), 20, BUCKET_DEPTH).unwrap();
+    let table = UsageTable::new(batch_id(), 20, BUCKET_DEPTH, Mutability::Immutable).unwrap();
     let snapshot = Snapshot::new(table);
     assert!(snapshot.encode().is_err());
 }
@@ -279,7 +325,8 @@ fn encode_requires_an_allocated_root() {
 fn mutable_round_trips_and_decodes_as_mutable() {
     let buckets = 1usize << BUCKET_DEPTH;
     let counts = synthetic_counts(buckets, 10, 15);
-    let table = UsageTable::from_counts_mutable(batch_id(), 22, BUCKET_DEPTH, counts).unwrap();
+    let table =
+        UsageTable::from_counts(batch_id(), 22, BUCKET_DEPTH, counts, Mutability::Mutable).unwrap();
     assert!(table.is_mutable());
     let mut snapshot = Snapshot::new(table);
     let plan = snapshot.plan_persist(&owner()).unwrap();
@@ -301,7 +348,8 @@ fn mutable_round_trips_and_decodes_as_mutable() {
 fn mutable_dilution_changes_no_cursor_or_leaf_bytes() {
     let buckets = 1usize << BUCKET_DEPTH;
     let counts = synthetic_counts(buckets, 5, 7);
-    let table = UsageTable::from_counts_mutable(batch_id(), 20, BUCKET_DEPTH, counts).unwrap();
+    let table =
+        UsageTable::from_counts(batch_id(), 20, BUCKET_DEPTH, counts, Mutability::Mutable).unwrap();
     let mut snapshot = Snapshot::new(table);
     let before = snapshot.plan_persist(&owner()).unwrap();
     let cursors_before = snapshot.table().counts().to_vec();
@@ -326,11 +374,12 @@ fn mutable_dilution_changes_no_cursor_or_leaf_bytes() {
 #[test]
 fn merge_max_rejects_mutable() {
     let buckets = 1usize << BUCKET_DEPTH;
-    let a = UsageTable::from_counts_mutable(
+    let a = UsageTable::from_counts(
         batch_id(),
         20,
         BUCKET_DEPTH,
         synthetic_counts(buckets, 1, 2),
+        Mutability::Mutable,
     )
     .unwrap();
     let b = UsageTable::from_counts(
@@ -338,6 +387,7 @@ fn merge_max_rejects_mutable() {
         20,
         BUCKET_DEPTH,
         synthetic_counts(buckets, 1, 2),
+        Mutability::Immutable,
     )
     .unwrap();
     // merge_max is exposed on the snapshot now; a mutable table is rejected.
@@ -353,7 +403,9 @@ fn recovered_mutable_issues_reserved_aware_through_the_handle() {
     let buckets = 1usize << BUCKET_DEPTH;
     // Fill the table close to full so cursors wrap fast.
     let counts = vec![3u32; buckets];
-    let table = UsageTable::from_counts_mutable(batch_id(), depth, BUCKET_DEPTH, counts).unwrap();
+    let table =
+        UsageTable::from_counts(batch_id(), depth, BUCKET_DEPTH, counts, Mutability::Mutable)
+            .unwrap();
     let mut snapshot = Snapshot::new(table);
     let plan = snapshot.plan_persist(&owner()).unwrap();
     let reserved = snapshot.reserved_stamp_indices(&owner());
@@ -383,7 +435,9 @@ fn recovered_mutable_issues_reserved_aware_through_the_handle() {
 fn extract_then_rebuild_preserves_sequence_and_slots() {
     let buckets = 1usize << BUCKET_DEPTH;
     let counts = synthetic_counts(buckets, 10, 15);
-    let table = UsageTable::from_counts(batch_id(), 22, BUCKET_DEPTH, counts).unwrap();
+    let table =
+        UsageTable::from_counts(batch_id(), 22, BUCKET_DEPTH, counts, Mutability::Immutable)
+            .unwrap();
     let mut snapshot = Snapshot::new(table);
 
     // Persist a few times so the sequence climbs above 0 and slots are allocated.
@@ -423,7 +477,9 @@ fn extract_then_rebuild_preserves_sequence_and_slots() {
 fn recovered_snapshot_rebuilds_through_from_parts_without_regressing() {
     let buckets = 1usize << BUCKET_DEPTH;
     let counts = synthetic_counts(buckets, 64, 63);
-    let table = UsageTable::from_counts(batch_id(), 24, BUCKET_DEPTH, counts).unwrap();
+    let table =
+        UsageTable::from_counts(batch_id(), 24, BUCKET_DEPTH, counts, Mutability::Immutable)
+            .unwrap();
     let mut snapshot = Snapshot::new(table);
     snapshot.plan_persist(&owner()).unwrap();
     let plan = snapshot.plan_persist(&owner()).unwrap();
@@ -442,7 +498,14 @@ fn table_view_exposes_counts_and_geometry_without_yielding_an_owned_table() {
     let buckets = 1usize << BUCKET_DEPTH;
     let mut counts = synthetic_counts(buckets, 64, 63);
     counts[7] = 200;
-    let table = UsageTable::from_counts(batch_id(), 24, BUCKET_DEPTH, counts.clone()).unwrap();
+    let table = UsageTable::from_counts(
+        batch_id(),
+        24,
+        BUCKET_DEPTH,
+        counts.clone(),
+        Mutability::Immutable,
+    )
+    .unwrap();
     let issued = table.total_issued();
     let mut snapshot = Snapshot::new(table);
     snapshot.plan_persist(&owner()).unwrap();

--- a/crates/postage-usage/tests/vector.rs
+++ b/crates/postage-usage/tests/vector.rs
@@ -10,7 +10,9 @@
 
 use alloy_primitives::{Address, B256, hex};
 use nectar_postage::calculate_bucket;
-use nectar_postage_usage::{RootInfo, Snapshot, UsageTable, usage_chunk_address, usage_chunk_id};
+use nectar_postage_usage::{
+    Mutability, RootInfo, Snapshot, UsageTable, usage_chunk_address, usage_chunk_id,
+};
 
 /// The full root payload from the README worked example: depth 12, bucket
 /// depth 8, counts `3 + (b mod 4)` with bucket 200 full at 16, after one
@@ -26,7 +28,7 @@ fn readme_worked_example_vector() {
     let owner = Address::repeat_byte(0x11);
     let mut counts: Vec<u32> = (0..256u32).map(|b| 3 + (b & 3)).collect();
     counts[200] = 16;
-    let table = UsageTable::from_counts(batch_id, 12, 8, counts).unwrap();
+    let table = UsageTable::from_counts(batch_id, 12, 8, counts, Mutability::Immutable).unwrap();
     let mut snapshot = Snapshot::new(table);
     let plan = snapshot.plan_persist(&owner).unwrap();
 
@@ -68,7 +70,7 @@ fn readme_large_batch_multi_leaf_vector() {
     let mut counts: Vec<u32> = (0..65536u32).map(|b| 100 + (b % 50)).collect();
     counts[0x1234] = 5000;
     counts[0xCBE5] = 8192;
-    let table = UsageTable::from_counts(batch_id, 29, 16, counts).unwrap();
+    let table = UsageTable::from_counts(batch_id, 29, 16, counts, Mutability::Immutable).unwrap();
     let mut snapshot = Snapshot::new(table);
     let plan = snapshot.plan_persist(&owner).unwrap();
 
@@ -118,7 +120,7 @@ fn mutable_vector_flags_byte_and_round_trip() {
     let owner = Address::repeat_byte(0x11);
     let mut counts: Vec<u32> = (0..256u32).map(|b| 3 + (b & 3)).collect();
     counts[200] = 16;
-    let table = UsageTable::from_counts_mutable(batch_id, 12, 8, counts).unwrap();
+    let table = UsageTable::from_counts(batch_id, 12, 8, counts, Mutability::Mutable).unwrap();
     let mut snapshot = Snapshot::new(table);
     let plan = snapshot.plan_persist(&owner).unwrap();
 


### PR DESCRIPTION
## What

Introduces a runtime `Mutability` enum (`Immutable`/`Mutable`, default `Immutable`) to `nectar-postage-usage` and collapses the four `UsageTable` constructors into two that take a `Mutability` parameter:

- `UsageTable::new(id, depth, bucket_depth, Mutability)`
- `UsageTable::from_counts(id, depth, bucket_depth, counts, Mutability)`

This replaces the previous `new`/`new_mutable` and `from_counts`/`from_counts_mutable` pairs.

Adds batch-driven constructors that read geometry and polarity directly from a `Batch`:

- `UsageTable::from_batch(&Batch)`
- `Snapshot::from_batch(&Batch)`
- `Mutability::from_batch(&Batch)`

Re-exports `Batch`, `BatchId`, and `StampIndex` from `nectar-postage` at the crate root so consumers see one canonical path.

## Why

Closes #57.

The previous constructor pairs encoded polarity as a bool baked into the function name, which forced every call site to choose the variant by hand and offered no single place to derive polarity from a batch. The `Mutability` enum makes the fill-versus-ring choice explicit and lets `from_batch` derive it from `batch.immutable()`: an immutable batch yields the fill watermark table, a mutable batch yields the ring table.

## Testing

- `cargo test -p nectar-postage-usage --all-features`: unit, integration, doctests, and compile-fail doctests all pass.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `RUSTDOCFLAGS=-D warnings cargo doc`: clean, all intra-doc links resolve.
- `cargo fmt --all`: clean.

New tests:

- `mutability_enum_matches_old_constructors` pins the enum constructors to the fill/ring tables the old `new`/`new_mutable` and `from_counts`/`from_counts_mutable` produced.
- `from_batch_picks_table_from_polarity` asserts an immutable batch yields the fill table and a mutable batch yields the ring table, with geometry read from the batch.
- `snapshot_from_batch_matches_batch_polarity` asserts `Snapshot::from_batch` selects fill for immutable and ring for mutable, geometry from the batch, sequence 0.

## Security and Correctness

Polarity is correct end to end and asserted, not assumed. `Mutability::from_batch` maps `batch.immutable() == true` to `Immutable` and `false` to `Mutable`; `Mutability::mode` maps `Immutable` to `CounterMode::Fill` and `Mutable` to `CounterMode::Ring`. `UsageTable::is_mutable()` reads the live counter mode (`counters.is_ring()`), so the tests verify the actual installed table rather than a stored flag. The codec recovery path preserves polarity: a recovered mutable table goes back through `Mutability::Mutable`, byte-identical to the prior branch. All SBU1 golden vectors are unchanged in the diff and pass. The re-exported postage types come from an already-present `nectar-postage` dependency, so no new dependency edge and no cycle.

This PR scope is #57 only. The companion #64 `DepthIncrease` work is not present on this branch. For reference, the #64 contract is that an unknown batch is a no-op; nothing in this diff alters that path.

## AI Assistance

This change was produced by an automated multi-agent workflow: implementation, adversarial review, and QA were all AI-generated. The result is human-reviewed before merge.
