### PR TITLE
feat(postage-usage): seal-timestamp monotonicity, dirty/evict signals, steady-state no-clone

### DIFF
--- a/crates/postage-usage/src/codec.rs
+++ b/crates/postage-usage/src/codec.rs
@@ -19,8 +19,15 @@ use crate::{
 /// payloads. Payload `n` of the snapshot (root is `n = 0`, leaf `i` is
 /// `n = i + 1`) belongs in the single-owner chunk with id
 /// [`usage_chunk_id`](crate::usage_chunk_id)`(batch_id, n)`.
+///
+/// Crate-internal: the only encoder is [`encode`], and [`Validated::plan_persist`]
+/// turns its output into the public [`PersistPlan`], so no external consumer ever
+/// holds an `Encoded`.
+///
+/// [`Validated::plan_persist`]: crate::Validated::plan_persist
+/// [`PersistPlan`]: crate::PersistPlan
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Encoded {
+pub(crate) struct Encoded {
     /// The root chunk payload.
     pub root: Bytes,
     /// The leaf chunk payloads, in chunk-index order.
@@ -183,6 +190,7 @@ fn select_width(counts: &[u32], base: u32, buckets: usize, allocated: usize) -> 
 }
 
 /// Encodes a snapshot into its root and leaf payloads.
+#[must_use = "the encoded payloads are the snapshot to publish; dropping them discards the encode"]
 pub(crate) fn encode(table: &UsageTable, sequence: u64, slots: &[u32]) -> Result<Encoded> {
     if slots.is_empty() {
         return Err(UsageError::Malformed("root slot not allocated"));
@@ -477,6 +485,7 @@ impl RootInfo {
     ///
     /// `leaves` must contain exactly [`leaf_count`](Self::leaf_count)
     /// payloads in chunk-index order.
+    #[must_use = "the reassembled snapshot is the recovered state; dropping it discards the assemble"]
     pub fn assemble<L: AsRef<[u8]>>(self, leaves: &[L]) -> Result<Snapshot> {
         let buckets = 1usize << self.bucket_depth;
         let capacity = 1u32 << (self.depth - self.bucket_depth);
@@ -631,6 +640,19 @@ mod tests {
         assert!(padding_is_zero(&[0b1010_0000], 3));
         assert!(!padding_is_zero(&[0b1011_0000], 3));
         assert!(padding_is_zero(&[0xff], 8));
+    }
+
+    #[test]
+    fn encode_requires_an_allocated_root() {
+        // Encoding with no allocated slot has no root slot to serialize, so the
+        // codec refuses it. The public path reaches encoding only through
+        // `plan_persist`, which always allocates the root first.
+        let table =
+            UsageTable::new(B256::repeat_byte(0x42), 20, 16, Mutability::Immutable).unwrap();
+        assert_eq!(
+            encode(&table, 0, &[]),
+            Err(UsageError::Malformed("root slot not allocated")),
+        );
     }
 
     #[test]

--- a/crates/postage-usage/src/lib.rs
+++ b/crates/postage-usage/src/lib.rs
@@ -108,7 +108,7 @@ mod issuer;
 #[cfg(feature = "seal")]
 mod seal;
 
-pub use codec::{Encoded, RootInfo};
+pub use codec::RootInfo;
 pub use error::UsageError;
 pub use snapshot::{
     Issuer, PersistPlan, PlannedChunk, PublishedSequence, Snapshot, SnapshotParts, Validated,

--- a/crates/postage-usage/src/seal.rs
+++ b/crates/postage-usage/src/seal.rs
@@ -7,7 +7,7 @@ use nectar_postage::{Stamp, StampDigest};
 use nectar_primitives::{Chunk, SingleOwnerChunk};
 use thiserror::Error;
 
-use crate::snapshot::PersistPlan;
+use crate::snapshot::{PersistPlan, Snapshot};
 
 /// Errors produced while sealing a persist plan.
 #[derive(Debug, Error)]
@@ -22,6 +22,17 @@ pub enum SealError {
     /// belong to the owner the plan was made for.
     #[error("sealed chunk address does not match plan")]
     AddressMismatch,
+    /// The seal timestamp does not strictly exceed the timestamp the previous
+    /// persist was sealed with in this process. Overwriting a metadata chunk in
+    /// place needs a strictly newer timestamp, so the reserve would refuse to
+    /// replace the previous version with this one.
+    #[error("seal timestamp {timestamp} does not exceed previous seal timestamp {previous}")]
+    NonIncreasingTimestamp {
+        /// The timestamp the seal was attempted with.
+        timestamp: u64,
+        /// The timestamp the previous persist was sealed with.
+        previous: u64,
+    },
 }
 
 /// A snapshot chunk ready for upload: the signed single-owner chunk and the
@@ -34,18 +45,43 @@ pub struct SealedChunk {
     pub stamp: Stamp,
 }
 
-/// Signs every chunk of a persist plan and stamps it with its planned slot.
+/// Signs every chunk of a persist plan and stamps it with its planned slot,
+/// enforcing in-process stamp-timestamp monotonicity.
 ///
-/// `signer` must be the batch owner key: it signs both the single-owner
-/// chunks and the stamps. `timestamp` must be strictly greater than the one
-/// used for the previous persist, so the new versions overwrite the old ones
-/// in place.
+/// `signer` must be the batch owner key: it signs both the single-owner chunks
+/// and the stamps. `timestamp` must strictly exceed the timestamp the previous
+/// persist of this `snapshot` was sealed with in this process
+/// ([`Snapshot::last_seal_timestamp`], also surfaced on
+/// [`PersistPlan::previous_timestamp`]); otherwise this returns
+/// [`SealError::NonIncreasingTimestamp`] and seals nothing. Because each
+/// metadata chunk keeps the same address and stamp index for the life of the
+/// batch, a newer version overwrites the previous one in place only with a
+/// strictly newer timestamp, so a non-increasing timestamp would leave the stale
+/// version standing. This is the single-owner clock-skew guard, complementary to
+/// the cross-process [`PublishedSequence`](crate::PublishedSequence) floor.
+///
+/// On success the snapshot records `timestamp` as its new floor, so the next
+/// persist's [`PersistPlan::previous_timestamp`] reflects it and monotonicity
+/// holds across the whole persist/seal cycle without caller bookkeeping. `plan`
+/// must have been planned from `snapshot`.
+#[must_use = "the sealed chunks are the snapshot to upload; dropping them discards the seal"]
 pub fn seal_plan(
+    snapshot: &mut Snapshot,
     plan: &PersistPlan,
     timestamp: u64,
     signer: &impl SignerSync,
 ) -> core::result::Result<Vec<SealedChunk>, SealError> {
-    plan.chunks
+    if let Some(previous) = snapshot.last_seal_timestamp()
+        && timestamp <= previous
+    {
+        return Err(SealError::NonIncreasingTimestamp {
+            timestamp,
+            previous,
+        });
+    }
+
+    let sealed = plan
+        .chunks
         .iter()
         .map(|planned| {
             let chunk = SingleOwnerChunk::new(planned.id, planned.payload.clone(), signer)?;
@@ -68,5 +104,10 @@ pub fn seal_plan(
             );
             Ok(SealedChunk { chunk, stamp })
         })
-        .collect()
+        .collect::<core::result::Result<Vec<_>, SealError>>()?;
+
+    // Only advance the floor once the whole plan sealed: a mid-plan failure
+    // leaves the snapshot's timestamp untouched so the seal can be retried.
+    snapshot.record_seal_timestamp(timestamp);
+    Ok(sealed)
 }

--- a/crates/postage-usage/src/snapshot.rs
+++ b/crates/postage-usage/src/snapshot.rs
@@ -59,6 +59,22 @@ pub struct Snapshot {
     table: UsageTable,
     sequence: u64,
     slots: Vec<u32>,
+    /// The counter sum ([`UsageTable::total_issued`]) captured at the last
+    /// planned persist, the baseline [`is_dirty`](Self::is_dirty) and
+    /// [`stamps_since_persist`](Self::stamps_since_persist) compare against.
+    /// `None` until the first persist, so a never-persisted snapshot that has
+    /// already issued reads as dirty.
+    issued_at_persist: Option<u64>,
+    /// The stamp timestamp the previous persist was sealed with in this process,
+    /// the in-process monotonicity floor [`seal_plan`](crate::seal_plan) checks a
+    /// new timestamp against. `None` until the first seal, and reset to `None` on
+    /// recovery (the published timestamp lives in the reserve, not the snapshot;
+    /// the cross-process floor is [`PublishedSequence`], nectar issue #70). This
+    /// is the single-owner clock-skew guard: it stops a later persist in the same
+    /// process from stamping a non-increasing timestamp, which the reserve would
+    /// refuse to overwrite the metadata chunk with.
+    #[cfg(feature = "seal")]
+    last_seal_timestamp: Option<u64>,
 }
 
 /// One chunk of a persist plan: the payload to publish and the slot to
@@ -144,6 +160,13 @@ pub struct PersistPlan {
     /// payload is unchanged from the previously persisted version, but must
     /// always publish the root.
     pub chunks: Vec<PlannedChunk>,
+    /// The stamp timestamp the previous persist was sealed with in this process,
+    /// or `None` if none has been sealed yet. [`seal_plan`](crate::seal_plan)
+    /// requires the seal timestamp to strictly exceed this, so a later persist
+    /// can never stamp the metadata chunks with a non-increasing timestamp the
+    /// reserve would refuse to overwrite in place.
+    #[cfg(feature = "seal")]
+    pub previous_timestamp: Option<u64>,
 }
 
 impl Snapshot {
@@ -177,6 +200,11 @@ impl Snapshot {
             table,
             sequence: 0,
             slots: Vec::new(),
+            // A genuinely fresh table has never persisted, so any prior issuance
+            // is unpersisted: no baseline yet.
+            issued_at_persist: None,
+            #[cfg(feature = "seal")]
+            last_seal_timestamp: None,
         }
     }
 
@@ -242,10 +270,20 @@ impl Snapshot {
             slots,
         } = parts;
         Self::validate_parts(&table, &slots)?;
+        // A recovered snapshot reflects a published persist, so it starts clean:
+        // its baseline is the recovered counter sum, and issuance afterwards makes
+        // it dirty again.
+        let issued_at_persist = Some(table.total_issued());
         Ok(Self {
             table,
             sequence,
             slots,
+            issued_at_persist,
+            // Recovery resets the in-process seal clock: the published timestamp
+            // lives in the reserve, and the cross-process guard is the
+            // `PublishedSequence` floor (nectar issue #70), not this field.
+            #[cfg(feature = "seal")]
+            last_seal_timestamp: None,
         })
     }
 
@@ -361,10 +399,65 @@ impl Snapshot {
         self.sequence
     }
 
+    /// Returns the stamp timestamp the previous persist was sealed with in this
+    /// process, or `None` if none has been sealed yet (including just after
+    /// recovery). This is the in-process monotonicity floor a new seal must
+    /// strictly exceed.
+    #[cfg(feature = "seal")]
+    pub const fn last_seal_timestamp(&self) -> Option<u64> {
+        self.last_seal_timestamp
+    }
+
+    /// Records the stamp timestamp a persist was sealed with, advancing the
+    /// in-process monotonicity floor. Crate-internal: [`seal_plan`](crate::seal_plan)
+    /// calls it after a successful seal so the next persist's
+    /// [`PersistPlan::previous_timestamp`] reflects it.
+    #[cfg(feature = "seal")]
+    pub(crate) const fn record_seal_timestamp(&mut self, timestamp: u64) {
+        self.last_seal_timestamp = Some(timestamp);
+    }
+
     /// Returns the within-bucket slots allocated to snapshot chunks, in
     /// chunk-index order (entry 0 is the root's own slot).
     pub fn allocated_slots(&self) -> &[u32] {
         &self.slots
+    }
+
+    /// Returns whether the snapshot has unpersisted issuance: stamps issued (or,
+    /// in mutable mode, ring churn) since the last planned persist.
+    ///
+    /// A fresh, never-persisted snapshot is dirty the moment it issues anything,
+    /// and stays dirty until its first persist. After a persist the snapshot is
+    /// clean until the next stamp. In mutable mode this tracks the counter
+    /// checksum, so any ring movement reads as dirty even though no lifetime
+    /// count is well-defined. Persisting through
+    /// [`plan_persist`](Validated::plan_persist) clears it.
+    pub const fn is_dirty(&self) -> bool {
+        match self.issued_at_persist {
+            Some(baseline) => self.table.total_issued() != baseline,
+            // Never persisted: dirty exactly when it has issued anything.
+            None => self.table.total_issued() != 0,
+        }
+    }
+
+    /// Returns the number of stamps issued since the last persist, if a count is
+    /// well-defined.
+    ///
+    /// Immutable: the rise in the monotone counter sum since the last persist
+    /// (the full count so far if never persisted), returned as `Some`. Mutable:
+    /// the counters are ring cursors whose sum is a checksum that can fall on
+    /// wrap, so there is no unpersisted *count* to give and this returns `None`;
+    /// use [`is_dirty`](Self::is_dirty) to tell whether a mutable snapshot has
+    /// unpersisted churn.
+    pub const fn stamps_since_persist(&self) -> Option<u64> {
+        if self.table.is_mutable() {
+            return None;
+        }
+        let baseline = match self.issued_at_persist {
+            Some(baseline) => baseline,
+            None => 0,
+        };
+        Some(self.table.total_issued().saturating_sub(baseline))
     }
 
     /// Returns the stamp indices the snapshot's own chunks occupy for `owner`,
@@ -485,10 +578,11 @@ impl Snapshot {
 
     /// Encodes the snapshot with its current sequence number.
     ///
-    /// Fails if the snapshot has never been persisted (no slot is allocated for
-    /// the root); use [`revalidate`](Self::revalidate) then
-    /// [`plan_persist`](Validated::plan_persist) instead.
-    pub fn encode(&self) -> Result<Encoded> {
+    /// Crate-internal: the only caller is
+    /// [`plan_persist`](Validated::plan_persist), which turns the [`Encoded`]
+    /// payloads into a public [`PersistPlan`]. Fails if the snapshot has never
+    /// been persisted (no slot is allocated for the root).
+    pub(crate) fn encode(&self) -> Result<Encoded> {
         codec::encode(&self.table, self.sequence, &self.slots)
     }
 
@@ -552,14 +646,36 @@ impl Validated<'_> {
     /// encoding by a leaf); slots are never freed, so steady-state persists
     /// allocate nothing. `owner` fixes the snapshot chunk addresses. On error
     /// (such as a full bucket on first allocation) the snapshot is unchanged.
+    ///
+    /// The common steady-state persist allocates nothing and so never mutates
+    /// the counter table; it encodes against the live table in place and never
+    /// clones the counts vector. A persist that must allocate a fresh snapshot
+    /// slot does its allocation on a working clone, so a mid-allocation failure
+    /// (a full bucket on a late leaf, say) leaves the snapshot untouched.
+    ///
+    /// The plan is the chunks to publish, so it is `#[must_use]`: dropping it on
+    /// the floor discards the persist (under the crate's `unused_must_use` deny,
+    /// ignoring it does not compile):
+    ///
+    /// ```compile_fail
+    /// # #![deny(unused_must_use)]
+    /// use alloy_primitives::{Address, B256};
+    /// use nectar_postage_usage::{Mutability, PublishedSequence, Snapshot, UsageTable};
+    ///
+    /// let owner = Address::repeat_byte(0x11);
+    /// let table = UsageTable::new(B256::repeat_byte(0x42), 20, 16, Mutability::Immutable).unwrap();
+    /// let mut snapshot = Snapshot::new(table);
+    /// // Ignoring the plan is a compile error: the persist would be silently lost.
+    /// snapshot.revalidate(PublishedSequence::NONE).unwrap().plan_persist(&owner);
+    /// ```
+    #[must_use = "the persist plan is the chunks to publish; dropping it discards the planned persist"]
     pub fn plan_persist(&mut self, owner: &Address) -> Result<PersistPlan> {
-        let mut work = self.snapshot.clone();
         // Defence in depth behind the structural guard: the emitted sequence
         // must strictly exceed the current one so a persist can never regress
         // the version at the snapshot's metadata chunk addresses. The only way
         // `self.snapshot.sequence + 1` fails to advance is a `u64` wrap at the
         // maximum, which we reject rather than fold back to 0.
-        work.sequence = self
+        let sequence = self
             .snapshot
             .sequence
             .checked_add(1)
@@ -567,41 +683,93 @@ impl Validated<'_> {
         // Re-assert the published floor against the sequence we are about to
         // emit. The `checked_add` above runs first so a wrap stays a Malformed
         // overflow rather than masquerading as a stale sequence.
-        if work.sequence <= self.floor {
+        if sequence <= self.floor {
             return Err(UsageError::StaleSequence {
-                next: work.sequence,
+                next: sequence,
                 floor: self.floor,
             });
         }
 
-        let batch_id = work.table.batch_id();
-        let bucket_depth = work.table.bucket_depth();
+        let batch_id = self.snapshot.table.batch_id();
+        let bucket_depth = self.snapshot.table.bucket_depth();
         let previously_allocated = self.snapshot.slots.len();
+        let previous_sequence = self.snapshot.sequence;
 
-        let allocate = |work: &mut Snapshot| -> Result<()> {
-            let index = work.slots.len() as u16;
-            let address = usage_chunk_address(&batch_id, owner, index);
-            let bucket = calculate_bucket(&address, bucket_depth);
-            // On a mutable batch the ring cursor would otherwise wrap onto a
-            // slot already held by an earlier snapshot chunk in the same
-            // bucket; carve out the reserved set so this allocation skips them.
-            let reserved = work.reserved_slots(owner);
-            let slot = work.record_bucket(bucket, &reserved)?;
-            work.slots.push(slot);
-            Ok(())
-        };
-
-        if work.slots.is_empty() {
-            allocate(&mut work)?;
-        }
-        let encoded = loop {
-            let encoded = work.encode()?;
-            if work.slots.len() > encoded.leaves.len() {
-                break encoded;
+        // Probe the encoding against the live snapshot. The new sequence goes
+        // into the root header, so bump it in place first, then encode once: when
+        // the existing slots already cover every leaf (the steady state) the
+        // counter table never changes, so there is nothing to clone for rollback
+        // and the bumped sequence stands. The root slot is allocated only once a
+        // snapshot has persisted, so a never-persisted snapshot (no slots) always
+        // takes the allocation path below; the encode probe needs a root slot.
+        let steady_state_encoded = if self.snapshot.slots.is_empty() {
+            None
+        } else {
+            self.snapshot.sequence = sequence;
+            let encoded = self.snapshot.encode()?;
+            // The existing slots already cover the root and every leaf chunk, so
+            // no further allocation is needed.
+            if self.snapshot.slots.len() > encoded.leaves.len() {
+                Some(encoded)
+            } else {
+                // Allocation is needed after all: undo the in-place sequence bump
+                // so the clone path below starts from the untouched snapshot and
+                // a failure there is a clean rollback.
+                self.snapshot.sequence = previous_sequence;
+                None
             }
-            allocate(&mut work)?;
         };
 
+        let encoded = if let Some(encoded) = steady_state_encoded {
+            // No allocation: the table is unchanged and the sequence is already
+            // bumped, so reuse the probe encoding.
+            encoded
+        } else {
+            // Allocation mutates the counter table (and may fail part way on a
+            // full bucket), so run it on a working clone and only commit the
+            // clone once the whole plan succeeds.
+            let mut work = self.snapshot.clone();
+            // Bump the sequence on the clone before encoding so the root payload
+            // carries the new sequence.
+            work.sequence = sequence;
+
+            let allocate = |work: &mut Snapshot| -> Result<()> {
+                let index = work.slots.len() as u16;
+                let address = usage_chunk_address(&batch_id, owner, index);
+                let bucket = calculate_bucket(&address, bucket_depth);
+                // On a mutable batch the ring cursor would otherwise wrap onto a
+                // slot already held by an earlier snapshot chunk in the same
+                // bucket; carve out the reserved set so this allocation skips
+                // them.
+                let reserved = work.reserved_slots(owner);
+                let slot = work.record_bucket(bucket, &reserved)?;
+                work.slots.push(slot);
+                Ok(())
+            };
+
+            if work.slots.is_empty() {
+                allocate(&mut work)?;
+            }
+            let encoded = loop {
+                let encoded = work.encode()?;
+                if work.slots.len() > encoded.leaves.len() {
+                    break encoded;
+                }
+                allocate(&mut work)?;
+            };
+
+            // Commit the allocation: the snapshot adopts the working clone's
+            // table, slots, and sequence. Up to here `self.snapshot` is
+            // untouched, so any earlier failure is a clean rollback.
+            *self.snapshot = work;
+            encoded
+        };
+
+        // The snapshot now reflects this persist, so capture the counter sum as
+        // the clean baseline: issuance after this point makes the snapshot dirty.
+        self.snapshot.issued_at_persist = Some(self.snapshot.table.total_issued());
+
+        let slots = &self.snapshot.slots;
         let mut chunks = Vec::with_capacity(1 + encoded.leaves.len());
         let payloads = core::iter::once(&encoded.root).chain(encoded.leaves.iter());
         for (index, payload) in payloads.enumerate() {
@@ -613,19 +781,19 @@ impl Validated<'_> {
                 index,
                 id,
                 address,
-                stamp_index: StampIndex::new(bucket, work.slots[index as usize]),
+                stamp_index: StampIndex::new(bucket, slots[index as usize]),
                 payload: payload.clone(),
                 newly_allocated: (index as usize) >= previously_allocated,
             });
         }
 
-        let plan = PersistPlan {
+        Ok(PersistPlan {
             batch_id,
-            sequence: work.sequence,
+            sequence,
             chunks,
-        };
-        *self.snapshot = work;
-        Ok(plan)
+            #[cfg(feature = "seal")]
+            previous_timestamp: self.snapshot.last_seal_timestamp,
+        })
     }
 
     /// Returns the published floor this admission was checked against.
@@ -660,9 +828,56 @@ impl Issuer<'_> {
     /// construction, so a mutable ring never re-emits a slot held by the
     /// snapshot's own chunks.
     pub fn record_address(&mut self, address: &SwarmAddress) -> Result<StampIndex> {
+        Ok(self.record_address_reporting_wrap(address)?.0)
+    }
+
+    /// Issues like [`record_address`](Self::record_address) but also reports
+    /// whether the write wrapped the ring onto a previously-used slot, evicting
+    /// whatever content held it.
+    ///
+    /// The boolean is `true` only for a mutable batch whose target bucket cursor
+    /// had reached the bucket bound, so the write wrapped and the assigned slot
+    /// was last used by an earlier stamp (the snapshot's own reserved slots are
+    /// skipped and never reported as evicted). It fires at the wrap boundary,
+    /// once per ring cycle: a wrap resets the cursor low, so an immediately
+    /// following overwrite is not re-flagged until the cursor climbs back to the
+    /// bound. An immutable bucket never wraps, so the flag is always `false`
+    /// there: a full immutable bucket fails instead of overwriting. A caller that
+    /// must not evict live content can stop or rotate batches when this reports
+    /// `true`.
+    pub fn record_address_reporting_wrap(
+        &mut self,
+        address: &SwarmAddress,
+    ) -> Result<(StampIndex, bool)> {
         let bucket = calculate_bucket(address, self.snapshot.table.bucket_depth());
+        // Decide before the write: afterwards the cursor has already advanced.
+        let wrapped = self.will_wrap(bucket)?;
         let index = self.snapshot.record_bucket(bucket, &self.reserved)?;
-        Ok(StampIndex::new(bucket, index))
+        Ok((StampIndex::new(bucket, index), wrapped))
+    }
+
+    /// Returns whether the next content write into `bucket` would wrap a mutable
+    /// ring onto a previously-used slot, overwriting whatever content held it.
+    ///
+    /// `true` only for a mutable batch whose bucket cursor sits at the bound (no
+    /// fresh slot left); `false` for an immutable bucket (which fails at capacity
+    /// rather than overwriting) and for a mutable bucket whose cursor is below the
+    /// bound. Because a wrap resets the cursor low, this predicts the wrap at the
+    /// boundary once per ring cycle rather than every overwrite within a cycle:
+    /// the underlying ring cursor records position, not whether the bucket has
+    /// ever filled. This is the look-before-you-leap companion to
+    /// [`record_address_reporting_wrap`](Self::record_address_reporting_wrap):
+    /// the same bucket, queried instead of written.
+    pub fn will_wrap(&self, bucket: u32) -> Result<bool> {
+        if !self.snapshot.table_ref().is_mutable() {
+            return Ok(false);
+        }
+        // A mutable ring is at its wrap boundary exactly when the bucket has no
+        // fresh slot left (the cursor sits at the bound).
+        self.snapshot
+            .table_ref()
+            .has_capacity(bucket)
+            .map(|free| !free)
     }
 
     /// Returns the batch owner this handle issues for.

--- a/crates/postage-usage/tests/seal.rs
+++ b/crates/postage-usage/tests/seal.rs
@@ -2,12 +2,30 @@
 
 #![cfg(feature = "seal")]
 
-use alloy_primitives::B256;
+use alloy_primitives::{Address, B256};
 use alloy_signer_local::PrivateKeySigner;
 use nectar_postage_usage::{
-    Mutability, PublishedSequence, Snapshot, UsageTable, seal_plan, usage_chunk_address,
+    Mutability, PublishedSequence, SealError, Snapshot, UsageTable, seal_plan, usage_chunk_address,
 };
 use nectar_primitives::Chunk;
+
+const BUCKET_DEPTH: u8 = 16;
+
+fn seeded_snapshot(owner: Address, batch_id: B256) -> Snapshot {
+    // Seed one stamp in bucket 123 via the inert constructor; the table itself
+    // has no record path.
+    let mut counts = vec![0u32; 1usize << BUCKET_DEPTH];
+    counts[123] = 1;
+    let table =
+        UsageTable::from_counts(batch_id, 20, BUCKET_DEPTH, counts, Mutability::Immutable).unwrap();
+    let mut snapshot = Snapshot::new(table);
+    let _ = snapshot
+        .revalidate(PublishedSequence::NONE)
+        .unwrap()
+        .plan_persist(&owner)
+        .unwrap();
+    snapshot
+}
 
 #[test]
 fn sealed_chunks_and_stamps_verify() {
@@ -15,20 +33,20 @@ fn sealed_chunks_and_stamps_verify() {
     let owner = signer.address();
     let batch_id = B256::repeat_byte(0x42);
 
-    // Seed one stamp in bucket 123 via the inert constructor; the table itself
-    // has no record path.
-    let mut counts = vec![0u32; 1usize << 16];
-    counts[123] = 1;
-    let table = UsageTable::from_counts(batch_id, 20, 16, counts, Mutability::Immutable).unwrap();
-    let mut snapshot = Snapshot::new(table);
+    let mut snapshot = seeded_snapshot(owner, batch_id);
     let plan = snapshot
         .revalidate(PublishedSequence::NONE)
         .unwrap()
         .plan_persist(&owner)
         .unwrap();
+    // No persist has been sealed yet in this process, so the plan carries no
+    // previous timestamp.
+    assert_eq!(plan.previous_timestamp, None);
 
-    let sealed = seal_plan(&plan, 1, &signer).unwrap();
+    let sealed = seal_plan(&mut snapshot, &plan, 1, &signer).unwrap();
     assert_eq!(sealed.len(), plan.chunks.len());
+    // The seal advanced the in-process monotonicity floor.
+    assert_eq!(snapshot.last_seal_timestamp(), Some(1));
 
     for (planned, sealed) in plan.chunks.iter().zip(sealed.iter()) {
         // The single-owner chunk sits at the predicted address and is owned
@@ -45,7 +63,72 @@ fn sealed_chunks_and_stamps_verify() {
         sealed.stamp.verify(&planned.address, owner).unwrap();
     }
 
-    // A different signer is rejected: the chunk address no longer matches.
+    // A different signer is rejected: the chunk address no longer matches. A
+    // strictly newer timestamp keeps the monotonicity guard out of the way.
     let other = PrivateKeySigner::random();
-    assert!(seal_plan(&plan, 2, &other).is_err());
+    let next = snapshot
+        .revalidate(PublishedSequence::NONE)
+        .unwrap()
+        .plan_persist(&owner)
+        .unwrap();
+    assert!(matches!(
+        seal_plan(&mut snapshot, &next, 2, &other),
+        Err(SealError::AddressMismatch)
+    ));
+    // The failed seal left the floor untouched so it can be retried.
+    assert_eq!(snapshot.last_seal_timestamp(), Some(1));
+}
+
+/// A seal whose timestamp does not strictly exceed the previous seal's timestamp
+/// is rejected: overwriting a metadata chunk in place needs a newer timestamp,
+/// so the reserve would otherwise leave the stale version standing. This is the
+/// in-process single-owner clock-skew guard for nectar issue #58.
+#[test]
+fn non_increasing_seal_timestamp_is_rejected() {
+    let signer = PrivateKeySigner::random();
+    let owner = signer.address();
+    let batch_id = B256::repeat_byte(0x42);
+
+    let mut snapshot = seeded_snapshot(owner, batch_id);
+
+    // First seal sets the floor at timestamp 100.
+    let first = snapshot
+        .revalidate(PublishedSequence::NONE)
+        .unwrap()
+        .plan_persist(&owner)
+        .unwrap();
+    assert_eq!(first.previous_timestamp, None);
+    seal_plan(&mut snapshot, &first, 100, &signer).unwrap();
+    assert_eq!(snapshot.last_seal_timestamp(), Some(100));
+
+    // The next plan surfaces the floor it must beat.
+    let second = snapshot
+        .revalidate(PublishedSequence::NONE)
+        .unwrap()
+        .plan_persist(&owner)
+        .unwrap();
+    assert_eq!(second.previous_timestamp, Some(100));
+
+    // An equal timestamp is rejected: it must strictly increase.
+    assert!(matches!(
+        seal_plan(&mut snapshot, &second, 100, &signer).unwrap_err(),
+        SealError::NonIncreasingTimestamp {
+            timestamp: 100,
+            previous: 100,
+        }
+    ));
+    // An older timestamp (clock skew) is rejected too.
+    assert!(matches!(
+        seal_plan(&mut snapshot, &second, 99, &signer).unwrap_err(),
+        SealError::NonIncreasingTimestamp {
+            timestamp: 99,
+            previous: 100,
+        }
+    ));
+    // The floor is unchanged by the rejected seals.
+    assert_eq!(snapshot.last_seal_timestamp(), Some(100));
+
+    // A strictly newer timestamp seals and advances the floor.
+    seal_plan(&mut snapshot, &second, 101, &signer).unwrap();
+    assert_eq!(snapshot.last_seal_timestamp(), Some(101));
 }

--- a/crates/postage-usage/tests/snapshot.rs
+++ b/crates/postage-usage/tests/snapshot.rs
@@ -363,13 +363,6 @@ fn reserved_indices_match_planned_stamps_and_guard_reuse() {
 }
 
 #[test]
-fn encode_requires_an_allocated_root() {
-    let table = UsageTable::new(batch_id(), 20, BUCKET_DEPTH, Mutability::Immutable).unwrap();
-    let snapshot = Snapshot::new(table);
-    assert!(snapshot.encode().is_err());
-}
-
-#[test]
 fn mutable_round_trips_and_decodes_as_mutable() {
     let buckets = 1usize << BUCKET_DEPTH;
     let counts = synthetic_counts(buckets, 10, 15);
@@ -641,6 +634,218 @@ fn table_view_exposes_counts_and_geometry_without_yielding_an_owned_table() {
     // yields another view, never an owned UsageTable that Snapshot::new accepts.
     let second = view;
     assert_eq!(second.depth(), view.depth());
+}
+
+/// Issuance since the last persist makes a snapshot dirty; persisting clears it.
+/// `stamps_since_persist` counts the unpersisted stamps in immutable mode.
+#[test]
+fn is_dirty_and_stamps_since_persist_track_unpersisted_issuance() {
+    let table = UsageTable::new(batch_id(), 20, BUCKET_DEPTH, Mutability::Immutable).unwrap();
+    let mut snapshot = Snapshot::new(table);
+
+    // A fresh snapshot that has issued nothing is clean.
+    assert!(!snapshot.is_dirty());
+    assert_eq!(snapshot.stamps_since_persist(), Some(0));
+
+    // Issuing makes it dirty before any persist.
+    let address = address_in_bucket(0x1234);
+    snapshot.issuer(owner()).record_address(&address).unwrap();
+    snapshot.issuer(owner()).record_address(&address).unwrap();
+    assert!(snapshot.is_dirty());
+    assert_eq!(snapshot.stamps_since_persist(), Some(2));
+
+    // Persisting clears the dirty flag and resets the count, even though the
+    // persist itself issues stamps for the snapshot's own chunks.
+    snapshot
+        .revalidate(PublishedSequence::NONE)
+        .unwrap()
+        .plan_persist(&owner())
+        .unwrap();
+    assert!(!snapshot.is_dirty());
+    assert_eq!(snapshot.stamps_since_persist(), Some(0));
+
+    // Further issuance makes it dirty again, counted from the persist baseline.
+    snapshot.issuer(owner()).record_address(&address).unwrap();
+    assert!(snapshot.is_dirty());
+    assert_eq!(snapshot.stamps_since_persist(), Some(1));
+
+    // Another persist clears it again.
+    snapshot
+        .revalidate(PublishedSequence::NONE)
+        .unwrap()
+        .plan_persist(&owner())
+        .unwrap();
+    assert!(!snapshot.is_dirty());
+    assert_eq!(snapshot.stamps_since_persist(), Some(0));
+}
+
+/// A mutable snapshot has no well-defined unpersisted count (the ring sum is a
+/// checksum), so `stamps_since_persist` is `None`, but `is_dirty` still flips on
+/// ring churn and clears on persist.
+#[test]
+fn mutable_is_dirty_tracks_churn_but_count_is_none() {
+    let table = UsageTable::new(batch_id(), 20, BUCKET_DEPTH, Mutability::Mutable).unwrap();
+    let mut snapshot = Snapshot::new(table);
+    assert!(snapshot.table().is_mutable());
+
+    assert!(!snapshot.is_dirty());
+    assert_eq!(snapshot.stamps_since_persist(), None);
+
+    snapshot
+        .issuer(owner())
+        .record_address(&address_in_bucket(0x1234))
+        .unwrap();
+    assert!(snapshot.is_dirty());
+    assert_eq!(snapshot.stamps_since_persist(), None);
+
+    snapshot
+        .revalidate(PublishedSequence::NONE)
+        .unwrap()
+        .plan_persist(&owner())
+        .unwrap();
+    assert!(!snapshot.is_dirty());
+}
+
+/// On a mutable ring whose cursor has reached the bucket bound, the next content
+/// write wraps onto a previously-used slot; `will_wrap` predicts it and
+/// `record_address_reporting_wrap` reports it. The signal fires at the wrap
+/// boundary (the cursor sitting at capacity), once per ring cycle: a wrap resets
+/// the cursor low, so the next overwrite is flagged again only once the cursor
+/// climbs back to the bound. An immutable bucket never wraps.
+#[test]
+fn mutable_ring_wrap_is_signalled() {
+    // Capacity 2 per bucket; fill the target bucket so the next write wraps.
+    let buckets = 1usize << BUCKET_DEPTH;
+    let counts = vec![0u32; buckets];
+    let table =
+        UsageTable::from_counts(batch_id(), 17, BUCKET_DEPTH, counts, Mutability::Mutable).unwrap();
+    let mut snapshot = Snapshot::new(table);
+    let capacity = snapshot.table().bucket_capacity();
+    assert_eq!(capacity, 2);
+
+    // Pick a content bucket clear of the snapshot's reserved slots.
+    let content = address_in_bucket(0x1234);
+    let bucket = calculate_bucket(&content, BUCKET_DEPTH);
+
+    let mut issuer = snapshot.issuer(owner());
+
+    // Fill the bucket to its bound: each fresh slot reports no wrap, and the
+    // cursor only reaches the wrap boundary on the last fill.
+    for slot in 0..capacity {
+        assert!(
+            !issuer.will_wrap(bucket).unwrap(),
+            "fresh slot {slot} is not a wrap"
+        );
+        let (_, wrapped) = issuer.record_address_reporting_wrap(&content).unwrap();
+        assert!(!wrapped, "filling fresh slot {slot} does not wrap");
+    }
+
+    // The cursor now sits at the bound: the next write wraps onto a used slot.
+    assert!(issuer.will_wrap(bucket).unwrap());
+    let (_, wrapped) = issuer.record_address_reporting_wrap(&content).unwrap();
+    assert!(wrapped, "the ring wrapped onto a previously-used slot");
+
+    // The wrap reset the cursor below the bound, so immediately overwriting is
+    // not re-flagged until the cursor climbs back; a full further cycle returns
+    // to the boundary and the wrap fires once more.
+    assert!(!issuer.will_wrap(bucket).unwrap());
+    for _ in 1..capacity {
+        let (_, wrapped) = issuer.record_address_reporting_wrap(&content).unwrap();
+        assert!(!wrapped);
+    }
+    assert!(
+        issuer.will_wrap(bucket).unwrap(),
+        "back at the bound after a full cycle"
+    );
+    assert!(issuer.record_address_reporting_wrap(&content).unwrap().1);
+}
+
+/// An immutable bucket never wraps: `will_wrap` is always false, and a full
+/// bucket fails rather than overwriting, so no eviction is ever signalled.
+#[test]
+fn immutable_never_wraps() {
+    let table = UsageTable::new(batch_id(), 17, BUCKET_DEPTH, Mutability::Immutable).unwrap();
+    let mut snapshot = Snapshot::new(table);
+    let content = address_in_bucket(0x1234);
+    let bucket = calculate_bucket(&content, BUCKET_DEPTH);
+
+    let mut issuer = snapshot.issuer(owner());
+    assert!(!issuer.will_wrap(bucket).unwrap());
+    // Capacity is 2; fill it.
+    assert!(!issuer.record_address_reporting_wrap(&content).unwrap().1);
+    assert!(!issuer.record_address_reporting_wrap(&content).unwrap().1);
+    // Full now: will_wrap stays false (immutable does not overwrite) and the
+    // next write fails instead.
+    assert!(!issuer.will_wrap(bucket).unwrap());
+    assert!(issuer.record_address(&content).is_err());
+}
+
+/// A steady-state persist (no new slot to allocate) changes only the sequence:
+/// the counter table and the allocated slots are byte-identical before and
+/// after, which is the observable signature of the no-clone fast path. A persist
+/// that must allocate is exercised by the dilution and growth tests elsewhere.
+#[test]
+fn steady_state_persist_changes_only_the_sequence() {
+    let buckets = 1usize << BUCKET_DEPTH;
+    let counts = synthetic_counts(buckets, 10, 15);
+    let table =
+        UsageTable::from_counts(batch_id(), 22, BUCKET_DEPTH, counts, Mutability::Immutable)
+            .unwrap();
+    let mut snapshot = Snapshot::new(table);
+
+    // First persist allocates the snapshot's own slots.
+    snapshot
+        .revalidate(PublishedSequence::NONE)
+        .unwrap()
+        .plan_persist(&owner())
+        .unwrap();
+    let counts_before = snapshot.table().counts().to_vec();
+    let slots_before = snapshot.allocated_slots().to_vec();
+    let issued_before = snapshot.table().total_issued();
+    let sequence_before = snapshot.sequence();
+
+    // The second persist is steady state: nothing to allocate, so the table is
+    // untouched and only the sequence advances.
+    snapshot
+        .revalidate(PublishedSequence::NONE)
+        .unwrap()
+        .plan_persist(&owner())
+        .unwrap();
+    assert_eq!(snapshot.table().counts(), counts_before.as_slice());
+    assert_eq!(snapshot.allocated_slots(), slots_before.as_slice());
+    assert_eq!(snapshot.table().total_issued(), issued_before);
+    assert_eq!(snapshot.sequence(), sequence_before + 1);
+}
+
+/// A persist that fails mid-allocation leaves the snapshot wholly unchanged: the
+/// clone-on-allocation path preserves rollback. A bucket pinned at capacity on a
+/// fresh table makes the very first (root) allocation fail.
+#[test]
+fn failed_allocation_rolls_back_the_snapshot() {
+    // Capacity 1 per bucket; fill every bucket so the root's own allocation
+    // immediately hits a full bucket.
+    let buckets = 1usize << BUCKET_DEPTH;
+    let counts = vec![1u32; buckets];
+    let table =
+        UsageTable::from_counts(batch_id(), 16, BUCKET_DEPTH, counts, Mutability::Immutable)
+            .unwrap();
+    let mut snapshot = Snapshot::new(table);
+    let counts_before = snapshot.table().counts().to_vec();
+    let issued_before = snapshot.table().total_issued();
+
+    let err = snapshot
+        .revalidate(PublishedSequence::NONE)
+        .unwrap()
+        .plan_persist(&owner())
+        .unwrap_err();
+    assert!(matches!(err, UsageError::BucketFull { .. }));
+
+    // The snapshot is untouched: no slot allocated, no counter moved, sequence
+    // still zero.
+    assert_eq!(snapshot.sequence(), 0);
+    assert!(snapshot.allocated_slots().is_empty());
+    assert_eq!(snapshot.table().counts(), counts_before.as_slice());
+    assert_eq!(snapshot.table().total_issued(), issued_before);
 }
 
 /// Returns a chunk address whose top `BUCKET_DEPTH` bits select `bucket`.


### PR DESCRIPTION
## What

A cohesive polish pass over the `nectar-postage-usage` API, bundling three small, related items:

- **Seal-timestamp monotonicity (#58).** `seal_plan` now takes `(&mut Snapshot, &PersistPlan, timestamp, signer)` and rejects any timestamp that is not strictly newer than the last sealed one, returning `SealError::NonIncreasingTimestamp { timestamp, previous }`. The in-process floor lives on `Snapshot::last_seal_timestamp` and is surfaced on `PersistPlan::previous_timestamp` (both `seal`-gated). The floor advances only after the entire plan seals, so a mid-plan failure leaves it untouched and the seal is retryable.
- **Dirty and evict signals (#59).** `Snapshot::is_dirty()` reports whether issuance has moved since the last persist (works in both mutability modes via the counter checksum). `stamps_since_persist()` returns `Some(count)` in immutable mode and `None` in mutable mode, where the ring sum is only a checksum rather than a lifetime count. `Issuer::will_wrap(bucket)` predicts a mutable ring wrap at the bucket boundary, and `record_address_reporting_wrap` returns `(StampIndex, bool)` reporting the wrap once per ring cycle.
- **`must_use` and steady-state no-clone (#60).** Message-bearing `#[must_use]` annotations on `plan_persist`, `encode`, `seal_plan`, and `RootInfo::assemble`. `plan_persist` no longer clones the whole table in steady state: it bumps the sequence in place and encodes against the live table when existing slots already cover every leaf, and only clones onto a working copy when an allocation will mutate the counter table. `Encoded` and `Snapshot::encode` are now `pub(crate)`, since no external consumer existed.

## Why

Closes #58
Closes #59
Closes #60

The maintainer approved bundling these three small, related items into one cohesive polish PR rather than landing three separate single-item changes.

## Testing

- `#58`: `tests/seal.rs::non_increasing_seal_timestamp_is_rejected` proves equal and older timestamps are rejected, the floor is unchanged on failure, and a strictly newer timestamp advances it; the updated `sealed_chunks_and_stamps_verify` confirms a failed seal leaves the floor untouched.
- `#59`: `is_dirty_and_stamps_since_persist_track_unpersisted_issuance`, `mutable_is_dirty_tracks_churn_but_count_is_none`, `mutable_ring_wrap_is_signalled`, and `immutable_never_wraps`.
- `#60`: `steady_state_persist_changes_only_the_sequence` (table and slots byte-identical, only the sequence advances), `failed_allocation_rolls_back_the_snapshot` (clone-on-allocation rollback preserved), a `plan_persist` `#[must_use]` compile_fail doctest, and the `encode_requires_an_allocated_root` codec unit test.
- The SBU1 golden vectors in `tests/vector.rs` are untouched and stay green, confirming the wire format is unchanged.
- `fmt`, `clippy --all-targets --all-features -D warnings`, `test --all-features`, and `rustdoc -D warnings` are all clean. Default-features clippy and no-default-features (`no_std`) builds also pass.

## Security and Correctness

- The steady-state skip-clone preserves failed-persist rollback. Allocation and never-persisted paths still run on a `work` clone committed only at the single `*self.snapshot = work` point after the whole plan succeeds; the steady-state branch undoes its in-place sequence bump before falling through to that clone path. A full bucket during self-allocation is a clean rollback, proven by `failed_allocation_rolls_back_the_snapshot`.
- The seal-timestamp guard is the in-process, single-owner complement to the cross-process published-floor compare-and-swap in #70. The two are orthogonal: #70 gates the persist sequence at plan time, while this guard gates the stamp timestamp at seal time. The in-process floor resets to `None` on recovery by design, since the cross-process protection lives on the sequence.

## AI Assistance

This change was produced by an automated multi-agent workflow: implementation, adversarial review, and QA were all AI-generated. The result is human-reviewed before merge.
