### PR TITLE
feat(postage-usage): cross-machine example, error taxonomy, caller docs

### DIFF
--- a/crates/postage-usage/Cargo.toml
+++ b/crates/postage-usage/Cargo.toml
@@ -47,6 +47,10 @@ issuer = ["std"]
 # Turns persist plans into signed single-owner chunks and stamps.
 seal = ["dep:alloy-signer", "std"]
 
+[[example]]
+name = "roam_between_machines"
+required-features = ["seal"]
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/postage-usage/README.md
+++ b/crates/postage-usage/README.md
@@ -13,6 +13,25 @@ This crate defines a snapshot format for that state which is:
 - **Predictably addressed.** Chunk `n` of the snapshot has SOC id `keccak256("swarm-batch-usage" || batch_id || u16_be(n))` and owner equal to the batch owner. Anyone holding the batch id and owner address can locate, fetch, and verify the state. A user can roam between machines with nothing but their key and batch id.
 - **Dilution-proof.** Increasing batch depth does not change any counter, any chunk boundary, or any byte of the leaf payloads. The structure grows only when the data does, so no slots are reserved up front for growth that may never happen.
 
+## Choosing an issuance path
+
+Where the issuer counters live depends on the batch and on whether you want them stored on the network. Pick the row that matches your batch and tracking model:
+
+| Batch | Counters tracked | Issuance path |
+|---|---|---|
+| Immutable | Self-hosted (inside the batch) | Fill watermark. `Snapshot` over a `UsageTable::new(.., Mutability::Immutable)`; issue through `Snapshot::issuer`. |
+| Mutable | Self-hosted (inside the batch) | Ring cursor. `Snapshot` over a mutable `UsageTable`; issue through `Snapshot::issuer`, which carves out the snapshot's own reserved slots. |
+| Mutable | External (tracked outside the batch) | `nectar_postage_issuer::RingIssuer::external`. No usage state is stored in the batch, so there is nothing for this crate to persist; use it when the cursor lives in your own store. |
+
+Self-hosted usage state, immutable or mutable, goes through this crate's `Snapshot`: that is the whole point, the state roams with the batch. Reach for `RingIssuer::external` only when the mutable issuance is tracked outside the batch and you do not want a self-hosted snapshot.
+
+## Persistence cadence
+
+The snapshot in memory is the only durable record of counter advances since the last persist. Issuing a stamp advances a counter; if the process exits before the next persist, those advances are lost, and re-issuing the same index silently overwrites data on a mutable batch (or is rejected on an immutable one). So:
+
+- **Persist after a batch of issuance, and always before dropping the snapshot.** Batch the writes, then `revalidate` -> `plan_persist` -> `seal_plan` -> upload. The cadence is yours to tune (every N stamps, every T seconds), but a snapshot must never be dropped while `Snapshot::is_dirty` is true without a final persist.
+- **Read the published-sequence floor live every time.** The floor handed to `Snapshot::revalidate` must come from a fresh network read of the live root chunk (parse it with `RootInfo::parse` and take `PublishedSequence::from(&root)`), never from a cache and never from the snapshot being persisted. A stale floor is exactly the value the floor exists to defeat; caching it reopens the downgrade window it closes.
+
 ## Why this works on the network
 
 Snapshot chunks are SOCs whose ids, and therefore addresses, never change. The Swarm reserve allows a chunk with the same address and the same stamp index to be overwritten by a version carrying a newer stamp timestamp, regardless of batch mutability, replacing the SOC payload in place. Consequently each snapshot chunk consumes **exactly one storage slot for the lifetime of the batch**, no matter how many times the state is updated. The slot is assigned on first allocation, recorded in the root chunk, and reused for every subsequent persist.

--- a/crates/postage-usage/examples/roam_between_machines.rs
+++ b/crates/postage-usage/examples/roam_between_machines.rs
@@ -1,0 +1,249 @@
+//! Roam a postage batch's issuer state between machines.
+//!
+//! The headline of `nectar-postage-usage` is that a user can issue stamps from a
+//! batch on one machine, persist the per-bucket counters *inside the batch
+//! itself* as single-owner chunks, and then resume issuing from a completely
+//! fresh machine holding nothing but their key and the batch id. This example
+//! walks that story end to end against an immutable batch.
+//!
+//! Run it with:
+//!
+//! ```text
+//! cargo run -p nectar-postage-usage --example roam_between_machines --features seal
+//! ```
+//!
+//! It uses no network: "machine A" and "machine B" are two scopes in the same
+//! process, and the only thing that crosses between them is the bytes machine A
+//! would have uploaded to the network (the sealed snapshot chunks). Machine B
+//! starts from the key and batch id alone, exactly as a real second device
+//! would, and recovers the counters by parsing those bytes.
+
+use alloy_primitives::{Address, B256, hex};
+use alloy_signer_local::PrivateKeySigner;
+use nectar_postage_usage::{
+    Mutability, PublishedSequence, RootInfo, SealedChunk, Snapshot, SwarmAddress, UsageError,
+    UsageTable, seal_plan, usage_chunk_address,
+};
+use nectar_primitives::Chunk;
+
+/// A depth-20 batch with 65536 buckets of 16 slots each. Small enough that the
+/// whole snapshot fits inline in a single root chunk, so the cross-machine hop
+/// carries exactly one payload.
+const DEPTH: u8 = 20;
+const BUCKET_DEPTH: u8 = 16;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // The owner key is the one secret a user carries between machines. The batch
+    // id is public and recoverable; together they pin every snapshot chunk
+    // address, so machine B can find the state without any local store.
+    let signer = PrivateKeySigner::random();
+    let owner: Address = signer.address();
+    let batch_id = B256::repeat_byte(0x42);
+
+    println!("Postage batch usage: roaming between machines");
+    println!("==============================================\n");
+    println!("owner    {}", hex::encode_prefixed(owner));
+    println!("batch id {}\n", hex::encode_prefixed(batch_id));
+
+    // The bytes that travel from machine A to machine B: the sealed snapshot
+    // chunks machine A uploads to the network. Machine B fetches the root and
+    // any leaves back from these same addresses.
+    let uploaded = machine_a(&signer, owner, batch_id)?;
+
+    machine_b(&signer, owner, batch_id, &uploaded)?;
+
+    stale_persist_is_rejected(owner, batch_id)?;
+
+    println!("\nDone: state roamed from A to B, the sequence advanced, the");
+    println!("snapshot's own slots were reused, and a stale persist was refused.");
+    Ok(())
+}
+
+/// Machine A: a fresh immutable batch. Issue one content stamp, persist, seal,
+/// and return the chunk bytes that would be uploaded to the network.
+fn machine_a(
+    signer: &PrivateKeySigner,
+    owner: Address,
+    batch_id: B256,
+) -> Result<Vec<SealedChunk>, Box<dyn std::error::Error>> {
+    println!("Machine A: fresh batch, first issuance");
+    println!("-------------------------------------");
+
+    // A genuinely new, never-persisted batch starts at sequence 0 with no slots.
+    let table = UsageTable::new(batch_id, DEPTH, BUCKET_DEPTH, Mutability::Immutable)?;
+    let mut snapshot = Snapshot::new(table);
+
+    // Issue a stamp for a content chunk through the snapshot's issuing handle.
+    // The handle is the sole counter-advance path and is reserved-aware by
+    // construction, so a stamp can never land on the snapshot's own slots.
+    let content = SwarmAddress::from(B256::repeat_byte(0x99));
+    let stamp_index = snapshot.issuer(owner).record_address(&content)?;
+    println!(
+        "issued a content stamp at bucket {}, slot {}",
+        stamp_index.bucket(),
+        stamp_index.index()
+    );
+
+    // Plan a persist. This is a brand new batch that has never been published,
+    // so a live network read of the root chunk address would return nothing and
+    // the floor is `NONE`. The first persist therefore emits sequence 1.
+    let plan = snapshot
+        .revalidate(PublishedSequence::NONE)?
+        .plan_persist(&owner)?;
+    println!(
+        "planned persist sequence {} ({} chunk(s) to publish)",
+        plan.sequence,
+        plan.chunks.len()
+    );
+
+    // Seal the plan: sign each snapshot chunk as a single-owner chunk and stamp
+    // it with its planned slot. The timestamp is the wall clock the reserve uses
+    // to overwrite the previous version in place; it must strictly increase
+    // across persists, which the seal enforces in process.
+    let sealed = seal_plan(&mut snapshot, &plan, 1_000, signer)?;
+
+    println!("sealed {} snapshot chunk(s), uploading to:", sealed.len());
+    for (planned, chunk) in plan.chunks.iter().zip(sealed.iter()) {
+        // The sealed single-owner chunk lands at exactly the address derived from
+        // the batch id and owner, so machine B can recompute it blind.
+        let derived = usage_chunk_address(&batch_id, &owner, planned.index);
+        assert_eq!(*chunk.chunk.address(), derived);
+        println!(
+            "  chunk {} -> {}  (stamp bucket {}, slot {})",
+            planned.index,
+            hex::encode_prefixed(derived),
+            planned.stamp_index.bucket(),
+            planned.stamp_index.index()
+        );
+    }
+    println!();
+
+    Ok(sealed)
+}
+
+/// Machine B: a fresh start with only the key and batch id. Recover the state
+/// from the bytes machine A uploaded, then issue and persist again.
+fn machine_b(
+    signer: &PrivateKeySigner,
+    owner: Address,
+    batch_id: B256,
+    uploaded: &[SealedChunk],
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!("Machine B: fresh start, recover and resume");
+    println!("------------------------------------------");
+
+    // Machine B knows where the root lives from the key and batch id alone:
+    // chunk index 0 of this batch.
+    let root_address = usage_chunk_address(&batch_id, &owner, 0);
+    println!("root chunk address {}", hex::encode_prefixed(root_address));
+
+    // Fetch the root chunk bytes back (here, straight from what A uploaded). On a
+    // real network this is a single chunk retrieval at the address above.
+    let root_bytes =
+        chunk_payload(uploaded, &root_address).expect("machine A uploaded the root chunk");
+
+    // Parse the root. This is also the live network read that supplies the
+    // published-sequence floor for the next persist: whatever sequence is
+    // already published is the floor a fresh persist must strictly exceed.
+    let root = RootInfo::parse(root_bytes)?;
+    let floor = PublishedSequence::from(&root);
+    println!(
+        "parsed root: published sequence {}, {} leaf chunk(s) to fetch",
+        floor.get(),
+        root.leaf_count()
+    );
+
+    // Fetch each leaf the root commits to and reassemble. This snapshot is small
+    // enough to be inline, so there are no leaves, but the recovery path is the
+    // same at any size: `assemble` rebuilds the snapshot through `from_parts`,
+    // preserving the recovered sequence and slots.
+    let leaves: Vec<&[u8]> = (0..root.leaf_count())
+        .map(|leaf| {
+            let address = usage_chunk_address(&batch_id, &owner, leaf + 1);
+            chunk_payload(uploaded, &address).expect("machine A uploaded every leaf")
+        })
+        .collect();
+    let mut snapshot = root.assemble(&leaves)?;
+    println!(
+        "recovered snapshot at sequence {} with slots {:?}",
+        snapshot.sequence(),
+        snapshot.allocated_slots()
+    );
+
+    let recovered_slots = snapshot.allocated_slots().to_vec();
+
+    // Resume issuing from the recovered state. A different content chunk lands in
+    // a different bucket, advancing that counter without disturbing the
+    // snapshot's own reserved slots.
+    let content = SwarmAddress::from(B256::repeat_byte(0xab));
+    let stamp_index = snapshot.issuer(owner).record_address(&content)?;
+    println!(
+        "issued a content stamp at bucket {}, slot {}",
+        stamp_index.bucket(),
+        stamp_index.index()
+    );
+
+    // Persist again against the floor read from the live root. The next sequence
+    // (2) strictly exceeds the published floor (1), so the persist is admitted.
+    let plan = snapshot.revalidate(floor)?.plan_persist(&owner)?;
+    println!("planned persist sequence {}", plan.sequence);
+    assert_eq!(plan.sequence, floor.get() + 1, "sequence advanced by one");
+    assert_eq!(
+        snapshot.allocated_slots(),
+        recovered_slots.as_slice(),
+        "the snapshot's own slots were reused, not re-allocated",
+    );
+    println!(
+        "slots reused: {:?} (no new metadata slot burned)",
+        snapshot.allocated_slots()
+    );
+
+    // Seal the resumed persist with a strictly newer timestamp than machine A
+    // used, so the reserve overwrites the previous version in place.
+    let sealed = seal_plan(&mut snapshot, &plan, 2_000, signer)?;
+    println!("sealed {} snapshot chunk(s) for upload\n", sealed.len());
+
+    Ok(())
+}
+
+/// Show that a persist whose next sequence does not strictly exceed the live
+/// published floor is rejected, so it can never overwrite a newer published
+/// version in place.
+fn stale_persist_is_rejected(
+    owner: Address,
+    batch_id: B256,
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!("Stale persist: rejected by the published floor");
+    println!("----------------------------------------------");
+
+    // A snapshot sitting at sequence 1 (its next persist would emit 2).
+    let table = UsageTable::new(batch_id, DEPTH, BUCKET_DEPTH, Mutability::Immutable)?;
+    let mut snapshot = Snapshot::new(table);
+    snapshot
+        .revalidate(PublishedSequence::NONE)?
+        .plan_persist(&owner)?;
+    assert_eq!(snapshot.sequence(), 1);
+
+    // Suppose the live network already published sequence 2 (another device got
+    // there first). Reading that as the floor rejects this snapshot's persist:
+    // its next sequence (2) does not strictly exceed the floor (2).
+    let floor = PublishedSequence::new(2);
+    let result = snapshot.revalidate(floor);
+    match result {
+        Err(UsageError::StaleSequence { next, floor }) => {
+            println!("refused: next sequence {next} does not exceed published floor {floor}");
+        }
+        other => panic!("expected StaleSequence, got {other:?}"),
+    }
+
+    Ok(())
+}
+
+/// Look up the payload of an uploaded snapshot chunk by its single-owner chunk
+/// address, simulating a network chunk retrieval.
+fn chunk_payload<'a>(uploaded: &'a [SealedChunk], address: &SwarmAddress) -> Option<&'a [u8]> {
+    uploaded
+        .iter()
+        .find(|sealed| sealed.chunk.address() == address)
+        .map(|sealed| sealed.chunk.data().as_ref())
+}

--- a/crates/postage-usage/src/codec.rs
+++ b/crates/postage-usage/src/codec.rs
@@ -302,7 +302,7 @@ impl RootInfo {
         let batch_id = B256::from_slice(&payload[4..36]);
         let depth = payload[36];
         let bucket_depth = payload[37];
-        validate_geometry(depth, bucket_depth)?;
+        validate_geometry(depth, bucket_depth).map_err(UsageError::into_corruption)?;
         let flags = payload[38];
         // Only bit 0 (mutable) is defined; any other bit set is rejected so a
         // future flag is never silently ignored by an older reader.
@@ -743,6 +743,25 @@ mod tests {
                 bucket: 5,
                 count: 17,
                 capacity: 16,
+            }
+        );
+        assert!(err.is_corruption());
+        assert!(!err.is_recoverable());
+    }
+
+    #[test]
+    fn parse_rejects_invalid_geometry_as_corruption() {
+        let mut root = root_with_one_exception();
+        // The geometry is read straight from the fetched bytes, so a corrupt
+        // bucket-depth byte (here past the supported maximum) is decode
+        // corruption, not a caller-input error.
+        root[37] = 17;
+        let err = RootInfo::parse(&root).unwrap_err();
+        assert_eq!(
+            err,
+            UsageError::CorruptGeometry {
+                depth: 12,
+                bucket_depth: 17,
             }
         );
         assert!(err.is_corruption());

--- a/crates/postage-usage/src/codec.rs
+++ b/crates/postage-usage/src/codec.rs
@@ -366,13 +366,13 @@ impl RootInfo {
             let count = read_u32(payload, offset + 4);
             offset += 8;
             if bucket as usize >= buckets {
-                return Err(UsageError::InvalidBucket { bucket });
+                return Err(UsageError::CorruptBucket { bucket });
             }
             if previous.is_some_and(|p| p >= bucket) {
                 return Err(UsageError::Malformed("exceptions not strictly ascending"));
             }
             if count > capacity {
-                return Err(UsageError::CounterOverflow {
+                return Err(UsageError::CorruptCounter {
                     bucket,
                     count,
                     capacity,
@@ -387,7 +387,7 @@ impl RootInfo {
             let slot = read_u32(payload, offset);
             offset += 4;
             if slot >= capacity {
-                return Err(UsageError::InvalidSlot { slot, capacity });
+                return Err(UsageError::CorruptSlot { slot, capacity });
             }
             slots.push(slot);
         }
@@ -513,7 +513,7 @@ impl RootInfo {
                 }
                 let value = u64::from(self.base) + read_bits(packed, i * width as usize, width);
                 if value > u64::from(capacity) {
-                    return Err(UsageError::CounterOverflow {
+                    return Err(UsageError::CorruptCounter {
                         bucket: bucket as u32,
                         count: value.min(u64::from(u32::MAX)) as u32,
                         capacity,
@@ -590,14 +590,23 @@ impl RootInfo {
         } else {
             Mutability::Immutable
         };
+        // These reconstruct the table and validate the recovered slots through
+        // the shared caller-input checks, so a corrupt decoded counter or slot
+        // would otherwise surface as the caller-input range variant. Map those to
+        // their corruption counterparts: reached from the decode path, they mean
+        // the fetched bytes are bad, not a caller input that can be adjusted. A
+        // direct `Snapshot::from_parts` caller still gets the caller-input variant.
         let table = UsageTable::from_counts(
             self.batch_id,
             self.depth,
             self.bucket_depth,
             counts,
             mutability,
-        )?;
-        Snapshot::from_parts(Snapshot::recovered_parts(table, self.sequence, self.slots)?)
+        )
+        .map_err(UsageError::into_corruption)?;
+        let parts = Snapshot::recovered_parts(table, self.sequence, self.slots)
+            .map_err(UsageError::into_corruption)?;
+        Snapshot::from_parts(parts).map_err(UsageError::into_corruption)
     }
 }
 
@@ -682,5 +691,145 @@ mod tests {
         root[38] = 0x00;
         let info = RootInfo::parse(&root).unwrap();
         assert!(!info.is_mutable());
+    }
+
+    /// Builds a valid immutable root with depth 12, bucket depth 8 (256 buckets
+    /// of capacity 16), a single exception bucket, and one allocated slot. The
+    /// encoder selects width 0 with one exception, so the layout is the 66-byte
+    /// header, one 8-byte exception (bucket then count), and one 4-byte slot.
+    fn root_with_one_exception() -> Vec<u8> {
+        let mut counts = vec![0u32; 256];
+        // A single full bucket becomes the lone exception; the rest stay at the
+        // base so the encoder packs nothing inline.
+        counts[5] = 16;
+        let table = UsageTable::from_counts(
+            B256::repeat_byte(0x42),
+            12,
+            8,
+            counts,
+            Mutability::Immutable,
+        )
+        .unwrap();
+        let root = encode(&table, 1, &[4]).unwrap().root.to_vec();
+        // Header(66) + one exception(8) + one slot(4), width 0 so no packed tail.
+        assert_eq!(root.len(), ROOT_HEADER_SIZE + 8 + 4);
+        // The exception is bucket 5; confirm the offsets the tests corrupt below.
+        assert_eq!(read_u32(&root, ROOT_HEADER_SIZE), 5);
+        assert_eq!(read_u32(&root, ROOT_HEADER_SIZE + 4), 16);
+        assert_eq!(read_u32(&root, ROOT_HEADER_SIZE + 8), 4);
+        root
+    }
+
+    #[test]
+    fn parse_rejects_out_of_range_exception_bucket_as_corruption() {
+        let mut root = root_with_one_exception();
+        // Push the exception bucket index past the 256-bucket range.
+        root[ROOT_HEADER_SIZE..ROOT_HEADER_SIZE + 4].copy_from_slice(&300u32.to_be_bytes());
+        let err = RootInfo::parse(&root).unwrap_err();
+        assert_eq!(err, UsageError::CorruptBucket { bucket: 300 });
+        assert!(err.is_corruption());
+        assert!(!err.is_recoverable());
+    }
+
+    #[test]
+    fn parse_rejects_over_capacity_exception_counter_as_corruption() {
+        let mut root = root_with_one_exception();
+        // Push the exception counter past the per-bucket capacity of 16.
+        root[ROOT_HEADER_SIZE + 4..ROOT_HEADER_SIZE + 8].copy_from_slice(&17u32.to_be_bytes());
+        let err = RootInfo::parse(&root).unwrap_err();
+        assert_eq!(
+            err,
+            UsageError::CorruptCounter {
+                bucket: 5,
+                count: 17,
+                capacity: 16,
+            }
+        );
+        assert!(err.is_corruption());
+        assert!(!err.is_recoverable());
+    }
+
+    #[test]
+    fn parse_rejects_out_of_range_slot_as_corruption() {
+        let mut root = root_with_one_exception();
+        // Push the allocated slot to the capacity bound (valid slots are < 16).
+        root[ROOT_HEADER_SIZE + 8..ROOT_HEADER_SIZE + 12].copy_from_slice(&16u32.to_be_bytes());
+        let err = RootInfo::parse(&root).unwrap_err();
+        assert_eq!(
+            err,
+            UsageError::CorruptSlot {
+                slot: 16,
+                capacity: 16,
+            }
+        );
+        assert!(err.is_corruption());
+        assert!(!err.is_recoverable());
+    }
+
+    #[test]
+    fn assemble_rejects_over_capacity_decoded_counter_as_corruption() {
+        // A table whose deltas span 0..16 packs inline at width 5 (no
+        // exceptions): every count is within the capacity of 16.
+        let counts: Vec<u32> = (0..256u32).map(|b| b % 17).collect();
+        let table = UsageTable::from_counts(
+            B256::repeat_byte(0x42),
+            12,
+            8,
+            counts,
+            Mutability::Immutable,
+        )
+        .unwrap();
+        let mut corrupt = encode(&table, 1, &[4]).unwrap().root.to_vec();
+        assert_eq!(
+            RootInfo::parse(&corrupt).unwrap().leaf_count(),
+            0,
+            "this geometry inlines the deltas"
+        );
+
+        // The packed deltas follow the header(66), the slot(4), and no
+        // exceptions, so they begin at offset 70. Force the first delta's high
+        // bits so it decodes to 31, above the capacity of 16.
+        let packed_start = ROOT_HEADER_SIZE + 4;
+        corrupt[packed_start] |= 0b1111_1000;
+
+        let info = RootInfo::parse(&corrupt).unwrap();
+        let err = info.assemble(&[] as &[&[u8]]).unwrap_err();
+        assert_eq!(
+            err,
+            UsageError::CorruptCounter {
+                bucket: 0,
+                count: 31,
+                capacity: 16,
+            }
+        );
+        assert!(err.is_corruption());
+        assert!(!err.is_recoverable());
+    }
+
+    #[test]
+    fn from_counts_over_capacity_is_caller_input_recoverable() {
+        // The same over-capacity condition supplied directly as caller input
+        // (not decoded from fetched bytes) stays the recoverable variant: the
+        // caller can fix the counts it passed.
+        let mut counts = vec![0u32; 256];
+        counts[5] = 17; // capacity is 16
+        let err = UsageTable::from_counts(
+            B256::repeat_byte(0x42),
+            12,
+            8,
+            counts,
+            Mutability::Immutable,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            UsageError::CounterOverflow {
+                bucket: 5,
+                count: 17,
+                capacity: 16,
+            }
+        );
+        assert!(err.is_recoverable());
+        assert!(!err.is_corruption());
     }
 }

--- a/crates/postage-usage/src/error.rs
+++ b/crates/postage-usage/src/error.rs
@@ -137,6 +137,19 @@ pub enum UsageError {
         capacity: u32,
     },
 
+    /// A decoded snapshot carries a batch geometry outside the supported range.
+    /// The decode counterpart of [`InvalidGeometry`](Self::InvalidGeometry): the
+    /// fetched bytes are corrupt, not a caller input that can be adjusted.
+    #[error(
+        "corrupt snapshot: unsupported batch geometry: depth {depth}, bucket depth {bucket_depth}"
+    )]
+    CorruptGeometry {
+        /// The batch depth.
+        depth: u8,
+        /// The bucket (uniformity) depth.
+        bucket_depth: u8,
+    },
+
     /// A leaf payload does not match the digest committed in the root.
     #[error("leaf {index} digest mismatch")]
     LeafDigestMismatch {
@@ -195,8 +208,9 @@ impl UsageError {
     /// same check reached through [`RootInfo::assemble`](crate::RootInfo::assemble)
     /// means the fetched bytes are corrupt. The codec maps the latter through
     /// here so the static taxonomy stays correct: the decode path yields
-    /// [`CorruptBucket`](Self::CorruptBucket), [`CorruptCounter`](Self::CorruptCounter)
-    /// or [`CorruptSlot`](Self::CorruptSlot), all in the corruption set.
+    /// [`CorruptBucket`](Self::CorruptBucket), [`CorruptCounter`](Self::CorruptCounter),
+    /// [`CorruptSlot`](Self::CorruptSlot) or [`CorruptGeometry`](Self::CorruptGeometry),
+    /// all in the corruption set.
     pub(crate) const fn into_corruption(self) -> Self {
         match self {
             Self::InvalidBucket { bucket } => Self::CorruptBucket { bucket },
@@ -210,6 +224,13 @@ impl UsageError {
                 capacity,
             },
             Self::InvalidSlot { slot, capacity } => Self::CorruptSlot { slot, capacity },
+            Self::InvalidGeometry {
+                depth,
+                bucket_depth,
+            } => Self::CorruptGeometry {
+                depth,
+                bucket_depth,
+            },
             other => other,
         }
     }
@@ -246,7 +267,8 @@ impl UsageError {
             | Self::LeafCount { .. }
             | Self::CorruptBucket { .. }
             | Self::CorruptCounter { .. }
-            | Self::CorruptSlot { .. } => true,
+            | Self::CorruptSlot { .. }
+            | Self::CorruptGeometry { .. } => true,
 
             // Caller-fixable or expected control flow, and the internal-invariant
             // bug: none of these say the fetched bytes are corrupt.
@@ -318,7 +340,8 @@ impl UsageError {
             | Self::LeafCount { .. }
             | Self::CorruptBucket { .. }
             | Self::CorruptCounter { .. }
-            | Self::CorruptSlot { .. } => false,
+            | Self::CorruptSlot { .. }
+            | Self::CorruptGeometry { .. } => false,
 
             // Internal invariant: a bug to report, not a recoverable condition.
             Self::RingExhausted { .. } => false,
@@ -424,6 +447,10 @@ mod tests {
                 slot: 0,
                 capacity: 0,
             },
+            UsageError::CorruptGeometry {
+                depth: 0,
+                bucket_depth: 0,
+            },
             UsageError::LeafDigestMismatch { index: 0 },
             UsageError::LeafLength {
                 index: 0,
@@ -452,7 +479,8 @@ mod tests {
                 | UsageError::LeafCount { .. }
                 | UsageError::CorruptBucket { .. }
                 | UsageError::CorruptCounter { .. }
-                | UsageError::CorruptSlot { .. } => {
+                | UsageError::CorruptSlot { .. }
+                | UsageError::CorruptGeometry { .. } => {
                     assert!(err.is_corruption() && !err.is_recoverable());
                 }
                 UsageError::BucketFull { .. }

--- a/crates/postage-usage/src/error.rs
+++ b/crates/postage-usage/src/error.rs
@@ -104,6 +104,39 @@ pub enum UsageError {
     #[error("malformed snapshot: {0}")]
     Malformed(&'static str),
 
+    /// A decoded snapshot names an exception bucket outside the table's bucket
+    /// range. The decode counterpart of [`InvalidBucket`](Self::InvalidBucket):
+    /// the fetched bytes are corrupt, not a caller input that can be adjusted.
+    #[error("corrupt snapshot: bucket {bucket} out of range")]
+    CorruptBucket {
+        /// The offending bucket index.
+        bucket: u32,
+    },
+
+    /// A decoded snapshot carries a counter past the per-bucket slot capacity.
+    /// The decode counterpart of [`CounterOverflow`](Self::CounterOverflow): the
+    /// fetched bytes are corrupt, not a caller input that can be adjusted.
+    #[error("corrupt snapshot: counter {count} for bucket {bucket} exceeds capacity {capacity}")]
+    CorruptCounter {
+        /// The offending bucket.
+        bucket: u32,
+        /// The counter value.
+        count: u32,
+        /// The bucket capacity.
+        capacity: u32,
+    },
+
+    /// A decoded snapshot names a within-bucket slot outside the bucket
+    /// capacity. The decode counterpart of [`InvalidSlot`](Self::InvalidSlot):
+    /// the fetched bytes are corrupt, not a caller input that can be adjusted.
+    #[error("corrupt snapshot: slot {slot} exceeds bucket capacity {capacity}")]
+    CorruptSlot {
+        /// The offending slot index.
+        slot: u32,
+        /// The bucket capacity.
+        capacity: u32,
+    },
+
     /// A leaf payload does not match the digest committed in the root.
     #[error("leaf {index} digest mismatch")]
     LeafDigestMismatch {
@@ -153,6 +186,34 @@ pub enum UsageError {
 }
 
 impl UsageError {
+    /// Reclassifies a caller-input range error raised on the decode path as its
+    /// corruption counterpart, leaving every other variant untouched.
+    ///
+    /// [`InvalidBucket`](Self::InvalidBucket), [`CounterOverflow`](Self::CounterOverflow)
+    /// and [`InvalidSlot`](Self::InvalidSlot) are dual-use: a direct caller that
+    /// supplies bad parts gets the caller-input variant (recoverable), but the
+    /// same check reached through [`RootInfo::assemble`](crate::RootInfo::assemble)
+    /// means the fetched bytes are corrupt. The codec maps the latter through
+    /// here so the static taxonomy stays correct: the decode path yields
+    /// [`CorruptBucket`](Self::CorruptBucket), [`CorruptCounter`](Self::CorruptCounter)
+    /// or [`CorruptSlot`](Self::CorruptSlot), all in the corruption set.
+    pub(crate) const fn into_corruption(self) -> Self {
+        match self {
+            Self::InvalidBucket { bucket } => Self::CorruptBucket { bucket },
+            Self::CounterOverflow {
+                bucket,
+                count,
+                capacity,
+            } => Self::CorruptCounter {
+                bucket,
+                count,
+                capacity,
+            },
+            Self::InvalidSlot { slot, capacity } => Self::CorruptSlot { slot, capacity },
+            other => other,
+        }
+    }
+
     /// Returns whether the error means the bytes a decode was handed are bad or
     /// stale: the snapshot the network served cannot be trusted as a faithful
     /// copy of what was published.
@@ -168,9 +229,11 @@ impl UsageError {
     ///
     /// The set is the decode-time integrity failures: [`BadMagic`](Self::BadMagic),
     /// [`Malformed`](Self::Malformed), [`LeafDigestMismatch`](Self::LeafDigestMismatch),
-    /// [`IssuedMismatch`](Self::IssuedMismatch), and the length and count
-    /// mismatches [`PayloadLength`](Self::PayloadLength),
-    /// [`LeafLength`](Self::LeafLength), and [`LeafCount`](Self::LeafCount).
+    /// [`IssuedMismatch`](Self::IssuedMismatch), the length and count mismatches
+    /// [`PayloadLength`](Self::PayloadLength), [`LeafLength`](Self::LeafLength) and
+    /// [`LeafCount`](Self::LeafCount), and the decode counterparts of the dual-use
+    /// range errors [`CorruptBucket`](Self::CorruptBucket),
+    /// [`CorruptCounter`](Self::CorruptCounter) and [`CorruptSlot`](Self::CorruptSlot).
     pub const fn is_corruption(&self) -> bool {
         match self {
             // Corruption: the fetched bytes are bad or stale.
@@ -180,7 +243,10 @@ impl UsageError {
             | Self::IssuedMismatch { .. }
             | Self::PayloadLength { .. }
             | Self::LeafLength { .. }
-            | Self::LeafCount { .. } => true,
+            | Self::LeafCount { .. }
+            | Self::CorruptBucket { .. }
+            | Self::CorruptCounter { .. }
+            | Self::CorruptSlot { .. } => true,
 
             // Caller-fixable or expected control flow, and the internal-invariant
             // bug: none of these say the fetched bytes are corrupt.
@@ -215,7 +281,11 @@ impl UsageError {
     ///   a wrong counter vector length ([`CounterLength`](Self::CounterLength)),
     ///   an out-of-range bucket ([`InvalidBucket`](Self::InvalidBucket)) or slot
     ///   ([`InvalidSlot`](Self::InvalidSlot)), or a counter past capacity
-    ///   ([`CounterOverflow`](Self::CounterOverflow)).
+    ///   ([`CounterOverflow`](Self::CounterOverflow)). These three are raised only
+    ///   on the caller-input paths ([`UsageTable::from_counts`](crate::UsageTable::from_counts),
+    ///   a direct [`Snapshot::from_parts`](crate::Snapshot::from_parts) caller, the
+    ///   record paths); the same checks reached through the decode path surface as
+    ///   the corruption counterparts below instead.
     /// - **Corruption** (`false`): the fetched bytes are bad or stale; see
     ///   [`is_corruption`](Self::is_corruption). The caller cannot fix the input,
     ///   only refetch or abandon the version.
@@ -245,7 +315,10 @@ impl UsageError {
             | Self::IssuedMismatch { .. }
             | Self::PayloadLength { .. }
             | Self::LeafLength { .. }
-            | Self::LeafCount { .. } => false,
+            | Self::LeafCount { .. }
+            | Self::CorruptBucket { .. }
+            | Self::CorruptCounter { .. }
+            | Self::CorruptSlot { .. } => false,
 
             // Internal invariant: a bug to report, not a recoverable condition.
             Self::RingExhausted { .. } => false,
@@ -341,6 +414,16 @@ mod tests {
             },
             UsageError::BadMagic,
             UsageError::Malformed("x"),
+            UsageError::CorruptBucket { bucket: 0 },
+            UsageError::CorruptCounter {
+                bucket: 0,
+                count: 0,
+                capacity: 0,
+            },
+            UsageError::CorruptSlot {
+                slot: 0,
+                capacity: 0,
+            },
             UsageError::LeafDigestMismatch { index: 0 },
             UsageError::LeafLength {
                 index: 0,
@@ -366,7 +449,10 @@ mod tests {
                 | UsageError::IssuedMismatch { .. }
                 | UsageError::PayloadLength { .. }
                 | UsageError::LeafLength { .. }
-                | UsageError::LeafCount { .. } => {
+                | UsageError::LeafCount { .. }
+                | UsageError::CorruptBucket { .. }
+                | UsageError::CorruptCounter { .. }
+                | UsageError::CorruptSlot { .. } => {
                     assert!(err.is_corruption() && !err.is_recoverable());
                 }
                 UsageError::BucketFull { .. }

--- a/crates/postage-usage/src/error.rs
+++ b/crates/postage-usage/src/error.rs
@@ -151,3 +151,241 @@ pub enum UsageError {
         floor: u64,
     },
 }
+
+impl UsageError {
+    /// Returns whether the error means the bytes a decode was handed are bad or
+    /// stale: the snapshot the network served cannot be trusted as a faithful
+    /// copy of what was published.
+    ///
+    /// A corruption error is not something the caller can fix by adjusting its
+    /// own input: the payload itself is wrong (a forged or truncated chunk, a
+    /// leaf that does not match the digest the root committed to, a counter sum
+    /// that does not add up). The right response is to refetch the chunk, or, if
+    /// it keeps failing verification, to treat that snapshot version as
+    /// unrecoverable rather than issue from it. These are exactly the errors
+    /// [`is_recoverable`](Self::is_recoverable) reports `false` for among the
+    /// decode failures.
+    ///
+    /// The set is the decode-time integrity failures: [`BadMagic`](Self::BadMagic),
+    /// [`Malformed`](Self::Malformed), [`LeafDigestMismatch`](Self::LeafDigestMismatch),
+    /// [`IssuedMismatch`](Self::IssuedMismatch), and the length and count
+    /// mismatches [`PayloadLength`](Self::PayloadLength),
+    /// [`LeafLength`](Self::LeafLength), and [`LeafCount`](Self::LeafCount).
+    pub const fn is_corruption(&self) -> bool {
+        match self {
+            // Corruption: the fetched bytes are bad or stale.
+            Self::BadMagic
+            | Self::Malformed(_)
+            | Self::LeafDigestMismatch { .. }
+            | Self::IssuedMismatch { .. }
+            | Self::PayloadLength { .. }
+            | Self::LeafLength { .. }
+            | Self::LeafCount { .. } => true,
+
+            // Caller-fixable or expected control flow, and the internal-invariant
+            // bug: none of these say the fetched bytes are corrupt.
+            Self::BucketFull { .. }
+            | Self::DepthDecrease { .. }
+            | Self::BatchMismatch
+            | Self::MutableMerge
+            | Self::StaleSequence { .. }
+            | Self::InvalidGeometry { .. }
+            | Self::CounterLength { .. }
+            | Self::InvalidBucket { .. }
+            | Self::InvalidSlot { .. }
+            | Self::CounterOverflow { .. }
+            | Self::RingExhausted { .. } => false,
+        }
+    }
+
+    /// Returns whether the caller can do something about the error: fix the
+    /// input it supplied, or back off and retry under different conditions.
+    ///
+    /// This is `true` for the caller-fixable and expected-control-flow errors and
+    /// `false` for both corruption and internal-invariant errors, so the three
+    /// groups partition cleanly:
+    ///
+    /// - **Recoverable** (`true`): the input or the timing is at fault and the
+    ///   caller can change it. A full bucket ([`BucketFull`](Self::BucketFull)),
+    ///   a depth that would decrease ([`DepthDecrease`](Self::DepthDecrease)),
+    ///   mismatched batches ([`BatchMismatch`](Self::BatchMismatch)), a mutable
+    ///   merge ([`MutableMerge`](Self::MutableMerge)), a stale persist
+    ///   ([`StaleSequence`](Self::StaleSequence): reread the live floor and
+    ///   retry), an unsupported geometry ([`InvalidGeometry`](Self::InvalidGeometry)),
+    ///   a wrong counter vector length ([`CounterLength`](Self::CounterLength)),
+    ///   an out-of-range bucket ([`InvalidBucket`](Self::InvalidBucket)) or slot
+    ///   ([`InvalidSlot`](Self::InvalidSlot)), or a counter past capacity
+    ///   ([`CounterOverflow`](Self::CounterOverflow)).
+    /// - **Corruption** (`false`): the fetched bytes are bad or stale; see
+    ///   [`is_corruption`](Self::is_corruption). The caller cannot fix the input,
+    ///   only refetch or abandon the version.
+    /// - **Internal invariant** (`false`): [`RingExhausted`](Self::RingExhausted)
+    ///   cannot occur for any supported geometry, so reaching it is a bug to
+    ///   report, not something a caller can recover from.
+    pub const fn is_recoverable(&self) -> bool {
+        match self {
+            // Caller-fixable or expected control flow: the caller can change its
+            // input or back off and retry.
+            Self::BucketFull { .. }
+            | Self::DepthDecrease { .. }
+            | Self::BatchMismatch
+            | Self::MutableMerge
+            | Self::StaleSequence { .. }
+            | Self::InvalidGeometry { .. }
+            | Self::CounterLength { .. }
+            | Self::InvalidBucket { .. }
+            | Self::InvalidSlot { .. }
+            | Self::CounterOverflow { .. } => true,
+
+            // Corruption: refetch or treat the snapshot as unrecoverable. Nothing
+            // the caller adjusts about its own input changes the outcome.
+            Self::BadMagic
+            | Self::Malformed(_)
+            | Self::LeafDigestMismatch { .. }
+            | Self::IssuedMismatch { .. }
+            | Self::PayloadLength { .. }
+            | Self::LeafLength { .. }
+            | Self::LeafCount { .. } => false,
+
+            // Internal invariant: a bug to report, not a recoverable condition.
+            Self::RingExhausted { .. } => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::UsageError;
+
+    #[test]
+    fn classification_of_a_representative_from_each_group() {
+        // Corruption: bad bytes, not recoverable by the caller.
+        let corruption = UsageError::BadMagic;
+        assert!(corruption.is_corruption());
+        assert!(!corruption.is_recoverable());
+
+        // Caller-fixable / expected control flow: recoverable, not corruption.
+        let recoverable = UsageError::StaleSequence { next: 1, floor: 1 };
+        assert!(!recoverable.is_corruption());
+        assert!(recoverable.is_recoverable());
+
+        // Internal invariant: neither corruption nor recoverable.
+        let internal = UsageError::RingExhausted { bucket: 0 };
+        assert!(!internal.is_corruption());
+        assert!(!internal.is_recoverable());
+    }
+
+    /// Guards that every variant is classified into exactly one of the three
+    /// groups. The match is exhaustive, so adding a variant without slotting it
+    /// here fails to compile, and the assertions confirm the groups stay
+    /// disjoint: corruption and recoverable are never both true, and every
+    /// variant lands in corruption, recoverable, or the internal-invariant
+    /// remainder.
+    #[test]
+    fn every_variant_is_classified_into_exactly_one_group() {
+        fn assert_classified(err: &UsageError) {
+            let corruption = err.is_corruption();
+            let recoverable = err.is_recoverable();
+            // No variant is both corrupt and caller-recoverable.
+            assert!(
+                !(corruption && recoverable),
+                "{err:?} is both corruption and recoverable"
+            );
+            // A variant that is neither corruption nor recoverable is the
+            // internal-invariant group; assert it really is the only member, so a
+            // future unclassified variant cannot hide here silently.
+            if !corruption && !recoverable {
+                assert!(
+                    matches!(err, UsageError::RingExhausted { .. }),
+                    "{err:?} is unclassified: neither corruption, recoverable, nor the known internal invariant"
+                );
+            }
+        }
+
+        // The compiler forces this match to cover every variant, so a new
+        // variant cannot be added without listing it here and giving it a
+        // representative value to classify.
+        let variants = [
+            UsageError::InvalidGeometry {
+                depth: 0,
+                bucket_depth: 0,
+            },
+            UsageError::InvalidBucket { bucket: 0 },
+            UsageError::BucketFull {
+                bucket: 0,
+                capacity: 0,
+            },
+            UsageError::CounterOverflow {
+                bucket: 0,
+                count: 0,
+                capacity: 0,
+            },
+            UsageError::CounterLength {
+                expected: 0,
+                got: 0,
+            },
+            UsageError::DepthDecrease {
+                current: 0,
+                requested: 0,
+            },
+            UsageError::BatchMismatch,
+            UsageError::MutableMerge,
+            UsageError::RingExhausted { bucket: 0 },
+            UsageError::InvalidSlot {
+                slot: 0,
+                capacity: 0,
+            },
+            UsageError::PayloadLength {
+                expected: 0,
+                got: 0,
+            },
+            UsageError::BadMagic,
+            UsageError::Malformed("x"),
+            UsageError::LeafDigestMismatch { index: 0 },
+            UsageError::LeafLength {
+                index: 0,
+                expected: 0,
+                got: 0,
+            },
+            UsageError::LeafCount {
+                expected: 0,
+                got: 0,
+            },
+            UsageError::IssuedMismatch { header: 0, sum: 0 },
+            UsageError::StaleSequence { next: 0, floor: 0 },
+        ];
+
+        // Exhaustiveness guard: this match must name every variant, so a new
+        // variant added to `UsageError` will not compile until it is handled.
+        // The arms double-check the array above covers each group.
+        for err in &variants {
+            match err {
+                UsageError::BadMagic
+                | UsageError::Malformed(_)
+                | UsageError::LeafDigestMismatch { .. }
+                | UsageError::IssuedMismatch { .. }
+                | UsageError::PayloadLength { .. }
+                | UsageError::LeafLength { .. }
+                | UsageError::LeafCount { .. } => {
+                    assert!(err.is_corruption() && !err.is_recoverable());
+                }
+                UsageError::BucketFull { .. }
+                | UsageError::DepthDecrease { .. }
+                | UsageError::BatchMismatch
+                | UsageError::MutableMerge
+                | UsageError::StaleSequence { .. }
+                | UsageError::InvalidGeometry { .. }
+                | UsageError::CounterLength { .. }
+                | UsageError::InvalidBucket { .. }
+                | UsageError::InvalidSlot { .. }
+                | UsageError::CounterOverflow { .. } => {
+                    assert!(!err.is_corruption() && err.is_recoverable());
+                }
+                UsageError::RingExhausted { .. } => {
+                    assert!(!err.is_corruption() && !err.is_recoverable());
+                }
+            }
+            assert_classified(err);
+        }
+    }
+}


### PR DESCRIPTION
## What

This PR rounds out the `nectar-postage-usage` crate with operator-facing material and a corrected error taxonomy.

- A runnable cross-machine example, `examples/roam_between_machines.rs`, gated behind the `seal` feature. It demonstrates the full lifecycle: machine A issues and persists at sequence 1, machine B recovers from the root bytes via `usage_chunk_address` and `RootInfo::parse`, reads the published floor, reassembles through `from_parts`, resumes issuance reusing freed slots, persists at sequence 2, and refuses a stale persist that does not exceed the floor.
- Completed caller-facing documentation: a README worked example, an issuance-path table, and a persistence-cadence section.
- An error taxonomy on `UsageError` with an explicit corruption-versus-caller-input split. `is_corruption` and `is_recoverable` are both `const fn` over exhaustive matches, with an exhaustiveness guard so a future variant cannot compile without being classified. Range failures that originate from corrupt decoded bytes (an out-of-range exception bucket, an over-capacity inline counter, an out-of-range slot) are now raised as dedicated decode-corruption variants (`CorruptBucket`, `CorruptCounter`, `CorruptSlot`) that classify as `is_corruption() == true` and `is_recoverable() == false`. The same logical range errors raised from genuine caller input (`UsageTable::from_counts`, direct `Snapshot::from_parts`, the record paths) keep their recoverable variants (`InvalidBucket`, `CounterOverflow`, `InvalidSlot`). A crate-internal `into_corruption()` remaps the caller-input range variants to their corruption counterparts on the reconstruction calls reachable from `RootInfo::assemble`, so a corrupt counter or slot reaching the shared validation checks is reclassified correctly while a direct caller still sees the recoverable error.

## Why

Closes #61.

The classification contract states that a decode or integrity failure on fetched bytes must surface as corruption (non-recoverable), while a caller supplying out-of-range input must surface as a recoverable, caller-fixable error. Before this change the three dual-use range errors were statically classified as recoverable, so a corrupt fetched snapshot was reported as caller-fixable and retryable, which contradicted the documented contract.

## Testing

- The example runs end to end with `cargo run -p nectar-postage-usage --example roam_between_machines --features seal`, printing the full cross-machine lifecycle and asserting slot reuse and stale-persist rejection.
- Taxonomy tests cover the decode-path corruption cases: `parse` rejects an out-of-range bucket, an over-capacity counter, and an out-of-range slot as corruption; `assemble` rejects an over-capacity decoded inline counter as corruption; each asserts `is_corruption() == true` and `is_recoverable() == false`. A genuine over-capacity caller input through `from_counts` asserts recoverable and not corruption.
- The classification guard test `every_variant_is_classified_into_exactly_one_group` enumerates every variant and asserts disjoint classification into exactly one group, so a new variant fails to compile until classified.
- `cargo fmt`, `cargo clippy`, `cargo test`, and `cargo doc` are clean.
- The SBU1 golden byte vectors are unchanged and green: `encode` is untouched and `tests/vector.rs` with all test-vector data is untouched.

## AI Assistance

This change was produced by an automated multi-agent workflow: implementation, review, and QA were all AI-generated. The work is human-reviewed before merge.
