### PR TITLE
feat(postage-usage): BatchStamper open/stamp/flush client facade

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -106,6 +106,9 @@ jobs:
                   cache-on-failure: true
             - name: Check postage-usage builds for wasm32
               env:
+                  # Override the workspace rust-toolchain.toml (stable) so -Z
+                  # build-std runs on the nightly the toolchain step installed.
+                  RUSTUP_TOOLCHAIN: nightly
                   RUSTFLAGS: "-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--shared-memory -C link-arg=--import-memory"
               run: |
                   cargo check \

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -86,11 +86,38 @@ jobs:
               # run: cargo test --doc --workspace --features "${{ matrix.network }}"
               run: cargo test --doc --workspace
 
+    wasm:
+        # The postage-usage client facade is meant to run in a browser. The
+        # primitives it builds on pull wasm-bindgen-rayon, so the only faithful
+        # wasm check is the threaded build the wasm demo uses: nightly, build-std,
+        # and the atomics / bulk-memory target features.
+        name: wasm / postage-usage
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+            - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444  # v1
+            - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2  # nightly
+              with:
+                  targets: wasm32-unknown-unknown
+                  components: rust-src
+            - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+              with:
+                  cache-on-failure: true
+            - name: Check postage-usage builds for wasm32
+              env:
+                  RUSTFLAGS: "-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--shared-memory -C link-arg=--import-memory"
+              run: |
+                  cargo check \
+                    -Z build-std=panic_abort,std \
+                    -p nectar-postage-usage --features client \
+                    --target wasm32-unknown-unknown
+
     unit-success:
         name: unit success
         runs-on: ubuntu-latest
         if: always()
-        needs: [test]
+        needs: [test, wasm]
         timeout-minutes: 30
         steps:
             - name: Decide whether the needed jobs succeeded or failed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2129,6 +2129,7 @@ dependencies = [
  "nectar-primitives",
  "thiserror",
  "tokio",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2122,11 +2122,13 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
+ "auto_impl",
  "bytes",
  "nectar-postage",
  "nectar-postage-issuer",
  "nectar-primitives",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ hybrid-array = { version = "0.4", features = ["extra-sizes"] }
 
 # derive macros
 derive_more = { version = "2.1", default-features = false, features = ["display", "from", "into", "as_ref"] }
+auto_impl = "1.3"
 
 # enums
 strum = { version = "0.28", default-features = false, features = ["derive"] }

--- a/crates/postage-usage/Cargo.toml
+++ b/crates/postage-usage/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = { workspace = true }
 # optional
 alloy-signer = { workspace = true, optional = true }
 auto_impl = { workspace = true, optional = true }
+web-time = { workspace = true, optional = true }
 
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = ["getrandom"] }
@@ -53,7 +54,7 @@ seal = ["dep:alloy-signer", "std"]
 # flush cross-machine roam into three calls. The consumer supplies the network
 # through the `ChunkSource` and `ChunkSink` traits. Implies `seal` (it seals
 # every persist) and `std` (it reads the wall clock for the seal timestamp).
-client = ["std", "seal", "dep:auto_impl"]
+client = ["std", "seal", "dep:auto_impl", "dep:web-time"]
 
 [[example]]
 name = "roam_between_machines"

--- a/crates/postage-usage/Cargo.toml
+++ b/crates/postage-usage/Cargo.toml
@@ -27,10 +27,12 @@ thiserror = { workspace = true }
 
 # optional
 alloy-signer = { workspace = true, optional = true }
+auto_impl = { workspace = true, optional = true }
 
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = ["getrandom"] }
 alloy-signer-local = { workspace = true }
+tokio = { workspace = true, features = ["rt", "macros"] }
 
 [features]
 default = ["std"]
@@ -47,9 +49,15 @@ issuer = ["std"]
 # Turns persist plans into signed single-owner chunks and stamps.
 seal = ["dep:alloy-signer", "std"]
 
+# High-level async facade (`BatchStamper`) that collapses the open / stamp /
+# flush cross-machine roam into three calls. The consumer supplies the network
+# through the `ChunkSource` and `ChunkSink` traits. Implies `seal` (it seals
+# every persist) and `std` (it reads the wall clock for the seal timestamp).
+client = ["std", "seal", "dep:auto_impl"]
+
 [[example]]
 name = "roam_between_machines"
-required-features = ["seal"]
+required-features = ["client", "seal"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/postage-usage/examples/roam_between_machines.rs
+++ b/crates/postage-usage/examples/roam_between_machines.rs
@@ -4,25 +4,37 @@
 //! batch on one machine, persist the per-bucket counters *inside the batch
 //! itself* as single-owner chunks, and then resume issuing from a completely
 //! fresh machine holding nothing but their key and the batch id. This example
-//! walks that story end to end against an immutable batch.
+//! walks that story end to end against an immutable batch through the high-level
+//! [`BatchStamper`] facade, which collapses the cross-machine ceremony into
+//! `open` / `stamp` / `flush`.
 //!
 //! Run it with:
 //!
 //! ```text
-//! cargo run -p nectar-postage-usage --example roam_between_machines --features seal
+//! cargo run -p nectar-postage-usage --example roam_between_machines --features "client seal"
 //! ```
 //!
-//! It uses no network: "machine A" and "machine B" are two scopes in the same
-//! process, and the only thing that crosses between them is the bytes machine A
-//! would have uploaded to the network (the sealed snapshot chunks). Machine B
-//! starts from the key and batch id alone, exactly as a real second device
-//! would, and recovers the counters by parsing those bytes.
+//! It uses no real network: "machine A" and "machine B" are two scopes in the
+//! same process sharing one in-memory [`MemNet`], which implements both
+//! [`ChunkSource`] and [`ChunkSink`]. Machine B starts from the key and batch id
+//! alone, exactly as a real second device would, and the facade recovers the
+//! counters by fetching and parsing the chunks machine A uploaded.
+//!
+//! Power users who need partial persists, a custom seal timestamp policy, or
+//! direct access to the [`PersistPlan`](nectar_postage_usage::PersistPlan) can
+//! drop to the low-level `Snapshot` / `revalidate` / `seal_plan` path the facade
+//! is built on; it stays public and unchanged.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 use alloy_primitives::{Address, B256, hex};
 use alloy_signer_local::PrivateKeySigner;
+use bytes::Bytes;
+use nectar_postage::Batch;
 use nectar_postage_usage::{
-    Mutability, PublishedSequence, RootInfo, SealedChunk, Snapshot, SwarmAddress, UsageError,
-    UsageTable, seal_plan, usage_chunk_address,
+    BatchStamper, ChunkSink, ChunkSource, Mutability, PublishedSequence, SealedChunk, Snapshot,
+    SwarmAddress, UsageError, UsageTable,
 };
 use nectar_primitives::Chunk;
 
@@ -32,25 +44,57 @@ use nectar_primitives::Chunk;
 const DEPTH: u8 = 20;
 const BUCKET_DEPTH: u8 = 16;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// A shared in-memory network keyed by single-owner-chunk address. The same
+/// value backs the [`ChunkSource`] machine B reads from and the [`ChunkSink`]
+/// machine A uploads to, so the only thing crossing between the two machines is
+/// the bytes on the wire.
+#[derive(Clone, Default)]
+struct MemNet {
+    chunks: Arc<Mutex<HashMap<SwarmAddress, Bytes>>>,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("in-memory network error")]
+struct MemError;
+
+impl ChunkSource for MemNet {
+    type Error = MemError;
+    async fn fetch(&self, address: &SwarmAddress) -> Result<Option<Bytes>, Self::Error> {
+        Ok(self.chunks.lock().unwrap().get(address).cloned())
+    }
+}
+
+impl ChunkSink for MemNet {
+    type Error = MemError;
+    async fn push(&self, sealed: &SealedChunk) -> Result<(), Self::Error> {
+        let address = *sealed.chunk.address();
+        let payload = Bytes::copy_from_slice(sealed.chunk.data().as_ref());
+        self.chunks.lock().unwrap().insert(address, payload);
+        Ok(())
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // The owner key is the one secret a user carries between machines. The batch
     // id is public and recoverable; together they pin every snapshot chunk
     // address, so machine B can find the state without any local store.
     let signer = PrivateKeySigner::random();
     let owner: Address = signer.address();
     let batch_id = B256::repeat_byte(0x42);
+    let batch = Batch::new(batch_id, 0, 0, owner, DEPTH, BUCKET_DEPTH, true);
 
     println!("Postage batch usage: roaming between machines");
     println!("==============================================\n");
     println!("owner    {}", hex::encode_prefixed(owner));
     println!("batch id {}\n", hex::encode_prefixed(batch_id));
 
-    // The bytes that travel from machine A to machine B: the sealed snapshot
-    // chunks machine A uploads to the network. Machine B fetches the root and
-    // any leaves back from these same addresses.
-    let uploaded = machine_a(&signer, owner, batch_id)?;
+    // The shared in-memory network. Machine A uploads into it; machine B reads
+    // back out of it.
+    let net = MemNet::default();
 
-    machine_b(&signer, owner, batch_id, &uploaded)?;
+    machine_a(&signer, &batch, &net).await?;
+    machine_b(&signer, &batch, &net).await?;
 
     stale_persist_is_rejected(owner, batch_id)?;
 
@@ -59,156 +103,97 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-/// Machine A: a fresh immutable batch. Issue one content stamp, persist, seal,
-/// and return the chunk bytes that would be uploaded to the network.
-fn machine_a(
+/// Machine A: a fresh immutable batch. Open, issue one content stamp, flush.
+async fn machine_a(
     signer: &PrivateKeySigner,
-    owner: Address,
-    batch_id: B256,
-) -> Result<Vec<SealedChunk>, Box<dyn std::error::Error>> {
+    batch: &Batch,
+    net: &MemNet,
+) -> Result<(), Box<dyn std::error::Error>> {
     println!("Machine A: fresh batch, first issuance");
     println!("-------------------------------------");
 
-    // A genuinely new, never-persisted batch starts at sequence 0 with no slots.
-    let table = UsageTable::new(batch_id, DEPTH, BUCKET_DEPTH, Mutability::Immutable)?;
-    let mut snapshot = Snapshot::new(table);
+    // Open the stamper. The network read returns nothing for a never-published
+    // batch, so the facade starts fresh at sequence 0.
+    let mut stamper = BatchStamper::open(signer.clone(), batch, net.clone(), net.clone()).await?;
+    println!("opened fresh at sequence {}", stamper.snapshot().sequence());
 
-    // Issue a stamp for a content chunk through the snapshot's issuing handle.
-    // The handle is the sole counter-advance path and is reserved-aware by
-    // construction, so a stamp can never land on the snapshot's own slots.
+    // Issue a content stamp. This is local: no network round trip, and the
+    // reserved snapshot slots can never be assigned to content.
     let content = SwarmAddress::from(B256::repeat_byte(0x99));
-    let stamp_index = snapshot.issuer(owner).record_address(&content)?;
+    let stamp_index = stamper.stamp(&content)?;
     println!(
         "issued a content stamp at bucket {}, slot {}",
         stamp_index.bucket(),
         stamp_index.index()
     );
 
-    // Plan a persist. This is a brand new batch that has never been published,
-    // so a live network read of the root chunk address would return nothing and
-    // the floor is `NONE`. The first persist therefore emits sequence 1.
-    let plan = snapshot
-        .revalidate(PublishedSequence::NONE)?
-        .plan_persist(&owner)?;
+    // Flush: re-read the live floor (NONE for a fresh batch), revalidate, plan,
+    // seal, and upload. The first persist emits sequence 1.
+    stamper.flush().await?;
     println!(
-        "planned persist sequence {} ({} chunk(s) to publish)",
-        plan.sequence,
-        plan.chunks.len()
+        "flushed: published sequence {} with slots {:?}\n",
+        stamper.snapshot().sequence(),
+        stamper.snapshot().allocated_slots()
     );
 
-    // Seal the plan: sign each snapshot chunk as a single-owner chunk and stamp
-    // it with its planned slot. The timestamp is the wall clock the reserve uses
-    // to overwrite the previous version in place; it must strictly increase
-    // across persists, which the seal enforces in process.
-    let sealed = seal_plan(&mut snapshot, &plan, 1_000, signer)?;
-
-    println!("sealed {} snapshot chunk(s), uploading to:", sealed.len());
-    for (planned, chunk) in plan.chunks.iter().zip(sealed.iter()) {
-        // The sealed single-owner chunk lands at exactly the address derived from
-        // the batch id and owner, so machine B can recompute it blind.
-        let derived = usage_chunk_address(&batch_id, &owner, planned.index);
-        assert_eq!(*chunk.chunk.address(), derived);
-        println!(
-            "  chunk {} -> {}  (stamp bucket {}, slot {})",
-            planned.index,
-            hex::encode_prefixed(derived),
-            planned.stamp_index.bucket(),
-            planned.stamp_index.index()
-        );
-    }
-    println!();
-
-    Ok(sealed)
+    Ok(())
 }
 
-/// Machine B: a fresh start with only the key and batch id. Recover the state
-/// from the bytes machine A uploaded, then issue and persist again.
-fn machine_b(
+/// Machine B: a fresh start with only the key and batch id. Open against the
+/// same in-memory network to recover the state, then issue and flush again.
+async fn machine_b(
     signer: &PrivateKeySigner,
-    owner: Address,
-    batch_id: B256,
-    uploaded: &[SealedChunk],
+    batch: &Batch,
+    net: &MemNet,
 ) -> Result<(), Box<dyn std::error::Error>> {
     println!("Machine B: fresh start, recover and resume");
     println!("------------------------------------------");
 
-    // Machine B knows where the root lives from the key and batch id alone:
-    // chunk index 0 of this batch.
-    let root_address = usage_chunk_address(&batch_id, &owner, 0);
-    println!("root chunk address {}", hex::encode_prefixed(root_address));
-
-    // Fetch the root chunk bytes back (here, straight from what A uploaded). On a
-    // real network this is a single chunk retrieval at the address above.
-    let root_bytes =
-        chunk_payload(uploaded, &root_address).expect("machine A uploaded the root chunk");
-
-    // Parse the root. This is also the live network read that supplies the
-    // published-sequence floor for the next persist: whatever sequence is
-    // already published is the floor a fresh persist must strictly exceed.
-    let root = RootInfo::parse(root_bytes)?;
-    let floor = PublishedSequence::from(&root);
-    println!(
-        "parsed root: published sequence {}, {} leaf chunk(s) to fetch",
-        floor.get(),
-        root.leaf_count()
-    );
-
-    // Fetch each leaf the root commits to and reassemble. This snapshot is small
-    // enough to be inline, so there are no leaves, but the recovery path is the
-    // same at any size: `assemble` rebuilds the snapshot through `from_parts`,
-    // preserving the recovered sequence and slots.
-    let leaves: Vec<&[u8]> = (0..root.leaf_count())
-        .map(|leaf| {
-            let address = usage_chunk_address(&batch_id, &owner, leaf + 1);
-            chunk_payload(uploaded, &address).expect("machine A uploaded every leaf")
-        })
-        .collect();
-    let mut snapshot = root.assemble(&leaves)?;
+    // Open recovers the published root and any leaves, preserving the recovered
+    // sequence and slots. Machine B holds no local store; the key and batch id
+    // are enough.
+    let mut stamper = BatchStamper::open(signer.clone(), batch, net.clone(), net.clone()).await?;
+    let recovered_slots = stamper.snapshot().allocated_slots().to_vec();
     println!(
         "recovered snapshot at sequence {} with slots {:?}",
-        snapshot.sequence(),
-        snapshot.allocated_slots()
+        stamper.snapshot().sequence(),
+        recovered_slots
     );
-
-    let recovered_slots = snapshot.allocated_slots().to_vec();
 
     // Resume issuing from the recovered state. A different content chunk lands in
     // a different bucket, advancing that counter without disturbing the
     // snapshot's own reserved slots.
     let content = SwarmAddress::from(B256::repeat_byte(0xab));
-    let stamp_index = snapshot.issuer(owner).record_address(&content)?;
+    let stamp_index = stamper.stamp(&content)?;
     println!(
         "issued a content stamp at bucket {}, slot {}",
         stamp_index.bucket(),
         stamp_index.index()
     );
 
-    // Persist again against the floor read from the live root. The next sequence
-    // (2) strictly exceeds the published floor (1), so the persist is admitted.
-    let plan = snapshot.revalidate(floor)?.plan_persist(&owner)?;
-    println!("planned persist sequence {}", plan.sequence);
-    assert_eq!(plan.sequence, floor.get() + 1, "sequence advanced by one");
+    // Flush again. The live floor read from the root is 1, so the next sequence
+    // (2) is admitted, and the snapshot's own slots are reused rather than
+    // re-allocated.
+    stamper.flush().await?;
+    assert_eq!(stamper.snapshot().sequence(), 2, "sequence advanced by one");
     assert_eq!(
-        snapshot.allocated_slots(),
+        stamper.snapshot().allocated_slots(),
         recovered_slots.as_slice(),
         "the snapshot's own slots were reused, not re-allocated",
     );
     println!(
-        "slots reused: {:?} (no new metadata slot burned)",
-        snapshot.allocated_slots()
+        "flushed: sequence {}, slots reused {:?} (no new metadata slot burned)\n",
+        stamper.snapshot().sequence(),
+        stamper.snapshot().allocated_slots()
     );
-
-    // Seal the resumed persist with a strictly newer timestamp than machine A
-    // used, so the reserve overwrites the previous version in place.
-    let sealed = seal_plan(&mut snapshot, &plan, 2_000, signer)?;
-    println!("sealed {} snapshot chunk(s) for upload\n", sealed.len());
 
     Ok(())
 }
 
 /// Show that a persist whose next sequence does not strictly exceed the live
 /// published floor is rejected, so it can never overwrite a newer published
-/// version in place.
+/// version in place. This is the low-level guard the facade enforces on every
+/// flush.
 fn stale_persist_is_rejected(
     owner: Address,
     batch_id: B256,
@@ -228,8 +213,7 @@ fn stale_persist_is_rejected(
     // there first). Reading that as the floor rejects this snapshot's persist:
     // its next sequence (2) does not strictly exceed the floor (2).
     let floor = PublishedSequence::new(2);
-    let result = snapshot.revalidate(floor);
-    match result {
+    match snapshot.revalidate(floor) {
         Err(UsageError::StaleSequence { next, floor }) => {
             println!("refused: next sequence {next} does not exceed published floor {floor}");
         }
@@ -237,13 +221,4 @@ fn stale_persist_is_rejected(
     }
 
     Ok(())
-}
-
-/// Look up the payload of an uploaded snapshot chunk by its single-owner chunk
-/// address, simulating a network chunk retrieval.
-fn chunk_payload<'a>(uploaded: &'a [SealedChunk], address: &SwarmAddress) -> Option<&'a [u8]> {
-    uploaded
-        .iter()
-        .find(|sealed| sealed.chunk.address() == address)
-        .map(|sealed| sealed.chunk.data().as_ref())
 }

--- a/crates/postage-usage/src/client.rs
+++ b/crates/postage-usage/src/client.rs
@@ -27,7 +27,8 @@
 //! a batch that already has a published root.
 
 use alloc::vec::Vec;
-use std::time::{SystemTime, UNIX_EPOCH};
+
+use web_time::{SystemTime, UNIX_EPOCH};
 
 use alloy_primitives::Address;
 use alloy_signer::SignerSync;
@@ -60,10 +61,15 @@ pub trait ChunkSource {
 
     /// Fetches the data payload of the chunk at `address`, or `Ok(None)` if the
     /// network confirms no such chunk exists.
+    ///
+    /// The returned future intentionally carries no `Send` bound: a native
+    /// transport whose future is `Send` propagates that through
+    /// [`BatchStamper::open`] and [`BatchStamper::flush`] automatically, while a
+    /// browser transport with a `!Send` future can still implement this trait.
     fn fetch(
         &self,
         address: &SwarmAddress,
-    ) -> impl core::future::Future<Output = Result<Option<Bytes>, Self::Error>> + Send;
+    ) -> impl core::future::Future<Output = Result<Option<Bytes>, Self::Error>>;
 }
 
 /// Publishes a sealed snapshot chunk (the single-owner chunk and its stamp) to
@@ -74,10 +80,14 @@ pub trait ChunkSink {
     type Error: core::error::Error + Send + Sync + 'static;
 
     /// Uploads a sealed snapshot chunk.
+    ///
+    /// As with [`ChunkSource::fetch`], the returned future carries no `Send`
+    /// bound so a `!Send` browser transport can implement it; native `Send`-ness
+    /// propagates through the facade on its own.
     fn push(
         &self,
         sealed: &SealedChunk,
-    ) -> impl core::future::Future<Output = Result<(), Self::Error>> + Send;
+    ) -> impl core::future::Future<Output = Result<(), Self::Error>>;
 }
 
 /// Errors produced by the [`BatchStamper`] facade.
@@ -369,6 +379,52 @@ mod tests {
         async fn push(&self, _sealed: &SealedChunk) -> Result<(), Self::Error> {
             Ok(())
         }
+    }
+
+    /// A transport whose futures capture an [`Rc`](std::rc::Rc) and are therefore
+    /// `!Send`, standing in for a browser transport (`fetch`, websocket) that
+    /// cannot produce `Send` futures.
+    struct LocalNet(std::rc::Rc<()>);
+
+    impl ChunkSource for LocalNet {
+        type Error = MemError;
+        fn fetch(
+            &self,
+            _address: &SwarmAddress,
+        ) -> impl core::future::Future<Output = Result<Option<Bytes>, Self::Error>> {
+            let hold = self.0.clone();
+            async move {
+                let _hold = &hold;
+                Ok(None)
+            }
+        }
+    }
+
+    impl ChunkSink for LocalNet {
+        type Error = MemError;
+        fn push(
+            &self,
+            _sealed: &SealedChunk,
+        ) -> impl core::future::Future<Output = Result<(), Self::Error>> {
+            let hold = self.0.clone();
+            async move {
+                let _hold = &hold;
+                Ok(())
+            }
+        }
+    }
+
+    /// Compile-time proof that a `!Send` transport satisfies [`ChunkSource`] and
+    /// [`ChunkSink`]. This only type-checks while neither trait bounds its future
+    /// with `Send`, which is exactly what lets a single-threaded browser
+    /// transport implement the facade. Re-adding a `+ Send` bound breaks here.
+    #[test]
+    fn non_send_transport_satisfies_the_traits() {
+        fn assert_source<S: ChunkSource>(_: &S) {}
+        fn assert_sink<K: ChunkSink>(_: &K) {}
+        let local = LocalNet(std::rc::Rc::new(()));
+        assert_source(&local);
+        assert_sink(&local);
     }
 
     fn test_batch(signer: &PrivateKeySigner, immutable: bool) -> Batch {

--- a/crates/postage-usage/src/client.rs
+++ b/crates/postage-usage/src/client.rs
@@ -1,0 +1,567 @@
+//! A high-level async facade over the snapshot persistence machinery.
+//!
+//! The low-level path ([`Snapshot`], [`revalidate`](Snapshot::revalidate),
+//! [`Validated::plan_persist`], [`seal_plan`], and the chunk-address helpers) is
+//! a cross-machine ceremony of roughly a dozen calls: derive the root address,
+//! fetch and parse the root, fetch every leaf, reassemble, issue, re-read the
+//! live floor, revalidate, plan, choose a strictly increasing timestamp, seal,
+//! and upload each sealed chunk. [`BatchStamper`] collapses that into
+//! `open` / `stamp` / `flush`, leaving the consumer to supply only the network
+//! through the [`ChunkSource`] and [`ChunkSink`] traits.
+//!
+//! Power users who need partial persists, custom timestamp policies, or direct
+//! access to the [`PersistPlan`] should keep reaching for the low-level
+//! [`Snapshot`] / [`revalidate`](Snapshot::revalidate) / [`seal_plan`] path; the
+//! facade is purely additive and never hides it.
+//!
+//! # Floor safety
+//!
+//! The whole point of the published-sequence floor (nectar issue #70) is that a
+//! persist can never regress the version published at a snapshot's own chunk
+//! addresses. That guarantee survives only if a failed network read is never
+//! mistaken for "the chunk is absent". [`ChunkSource::fetch`] therefore
+//! distinguishes `Ok(None)` (the network definitively agrees the chunk does not
+//! exist) from `Err` (the read could not be completed). [`BatchStamper::open`]
+//! and [`BatchStamper::flush`] both abort on `Err`: a transport failure never
+//! becomes a fresh sequence-0 start nor a [`PublishedSequence::NONE`] floor over
+//! a batch that already has a published root.
+
+use alloc::vec::Vec;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use alloy_primitives::Address;
+use alloy_signer::SignerSync;
+use bytes::Bytes;
+use nectar_postage::{Batch, BatchId, StampIndex};
+use nectar_primitives::SwarmAddress;
+use thiserror::Error;
+
+use crate::codec::RootInfo;
+use crate::seal::{SealError, SealedChunk, seal_plan};
+use crate::snapshot::{PublishedSequence, Snapshot};
+use crate::{UsageError, usage_chunk_address};
+
+/// Reads a chunk's payload from the network by its single-owner-chunk address.
+///
+/// The returned [`Bytes`] are the chunk's data payload, the snapshot payload
+/// [`RootInfo::parse`] consumes, not the full single-owner-chunk wire form.
+///
+/// `Ok(None)` means the chunk is *definitively* absent: the network agrees it
+/// does not exist. `Err` means the read could not be completed and the caller
+/// must *not* treat the chunk as absent. This distinction is load-bearing:
+/// treating a transport failure as absence would read the published-sequence
+/// floor as [`PublishedSequence::NONE`] and reopen the downgrade that nectar
+/// issue #70 closes.
+#[auto_impl::auto_impl(&, Arc, Box)]
+pub trait ChunkSource {
+    /// The error a failed read reports. A value of this type means the read did
+    /// not complete; it never means the chunk is absent.
+    type Error: core::error::Error + Send + Sync + 'static;
+
+    /// Fetches the data payload of the chunk at `address`, or `Ok(None)` if the
+    /// network confirms no such chunk exists.
+    fn fetch(
+        &self,
+        address: &SwarmAddress,
+    ) -> impl core::future::Future<Output = Result<Option<Bytes>, Self::Error>> + Send;
+}
+
+/// Publishes a sealed snapshot chunk (the single-owner chunk and its stamp) to
+/// the network.
+#[auto_impl::auto_impl(&, Arc, Box)]
+pub trait ChunkSink {
+    /// The error a failed publish reports.
+    type Error: core::error::Error + Send + Sync + 'static;
+
+    /// Uploads a sealed snapshot chunk.
+    fn push(
+        &self,
+        sealed: &SealedChunk,
+    ) -> impl core::future::Future<Output = Result<(), Self::Error>> + Send;
+}
+
+/// Errors produced by the [`BatchStamper`] facade.
+///
+/// The variants unify the lower-level error taxonomies ([`UsageError`],
+/// [`SealError`]) with the consumer-supplied source and sink errors, so a caller
+/// matches one enum across the whole `open` / `stamp` / `flush` cycle. The
+/// [`Source`](Self::Source) and [`Sink`](Self::Sink) variants carry the
+/// transport failures that abort `open` and `flush` rather than degrading into a
+/// fresh or [`PublishedSequence::NONE`] persist.
+#[derive(Debug, Error)]
+pub enum ClientError<SrcErr, SnkErr>
+where
+    SrcErr: core::error::Error + Send + Sync + 'static,
+    SnkErr: core::error::Error + Send + Sync + 'static,
+{
+    /// A usage-table operation failed (issuance, revalidation against the floor,
+    /// or planning the persist).
+    #[error(transparent)]
+    Usage(#[from] UsageError),
+    /// Sealing the persist plan failed.
+    #[error(transparent)]
+    Seal(#[from] SealError),
+    /// The [`ChunkSource`] read could not be completed. This is *not* an absence:
+    /// `open` and `flush` abort here rather than starting fresh or persisting
+    /// against a [`PublishedSequence::NONE`] floor.
+    #[error("chunk source read failed")]
+    Source(#[source] SrcErr),
+    /// The [`ChunkSink`] publish failed.
+    #[error("chunk sink publish failed")]
+    Sink(#[source] SnkErr),
+    /// A published root committed to a leaf the source reported as absent. A
+    /// missing leaf for a published root is corruption, never a fresh batch.
+    #[error("published root commits to leaf {index} but the source reports it absent")]
+    MissingLeaf {
+        /// The snapshot chunk index of the absent leaf (1 is the first leaf).
+        index: u16,
+    },
+}
+
+/// A high-level, async facade that collapses the cross-machine roam into
+/// `open` / `stamp` / `flush`.
+///
+/// [`open`](Self::open) recovers a snapshot already published for this
+/// `batch` + owner, or starts a fresh one when the network confirms none exists.
+/// [`stamp`](Self::stamp) issues a content stamp locally, with no network round
+/// trip. [`flush`](Self::flush) re-reads the live published floor, revalidates,
+/// plans, seals with a strictly increasing timestamp, and uploads every sealed
+/// chunk through the sink.
+///
+/// The owner is fixed at `open` from the signer's address, and every snapshot
+/// chunk address is derived from it and the batch id, so a second machine
+/// holding only the same key and batch id recovers the same state.
+#[derive(Debug)]
+pub struct BatchStamper<Sg, Src, Snk> {
+    signer: Sg,
+    owner: Address,
+    batch_id: BatchId,
+    source: Src,
+    sink: Snk,
+    snapshot: Snapshot,
+    /// Whether a persist has been emitted in this session. A clean snapshot that
+    /// has already persisted once this session makes [`flush`](Self::flush) a
+    /// no-op; a clean but never-persisted snapshot still flushes once so a fresh
+    /// batch publishes its sequence-1 root.
+    persisted_this_session: bool,
+}
+
+impl<Sg, Src, Snk> BatchStamper<Sg, Src, Snk>
+where
+    Sg: SignerSync + alloy_signer::Signer,
+    Src: ChunkSource,
+    Snk: ChunkSink,
+{
+    /// Opens a stamper for `batch`, recovering published state or starting fresh.
+    ///
+    /// The owner is taken from `signer.address()`. The root chunk address is
+    /// derived from the batch id, owner, and index 0, then read through `source`:
+    ///
+    /// - `Ok(Some(bytes))`: a published root exists. The root is parsed and every
+    ///   leaf it commits to is fetched (a leaf the source reports absent is
+    ///   corruption, surfaced as [`ClientError::MissingLeaf`], never a fresh
+    ///   batch) and the snapshot is reassembled, preserving the recovered
+    ///   sequence and slots.
+    /// - `Ok(None)`: the network confirms no root exists, so a fresh snapshot is
+    ///   built from the batch (picking fill-watermark or ring mutability from
+    ///   `batch.immutable()`).
+    /// - `Err`: the read could not be completed. This aborts; it never starts
+    ///   fresh, so a transport failure cannot downgrade a batch that already has
+    ///   a published root.
+    pub async fn open(
+        signer: Sg,
+        batch: &Batch,
+        source: Src,
+        sink: Snk,
+    ) -> Result<Self, ClientError<Src::Error, Snk::Error>> {
+        let owner = signer.address();
+        let batch_id = batch.id();
+        let root_addr = usage_chunk_address(&batch_id, &owner, 0);
+
+        let snapshot = match source
+            .fetch(&root_addr)
+            .await
+            .map_err(ClientError::Source)?
+        {
+            Some(root_bytes) => {
+                // A published root exists: recover its sequence and slots. Every
+                // committed leaf must be present; a missing leaf is corruption,
+                // not a reason to start over.
+                let root = RootInfo::parse(&root_bytes)?;
+                let mut leaves: Vec<Bytes> = Vec::with_capacity(root.leaf_count() as usize);
+                for leaf in 0..root.leaf_count() {
+                    let index = leaf + 1;
+                    let leaf_addr = usage_chunk_address(&batch_id, &owner, index);
+                    match source
+                        .fetch(&leaf_addr)
+                        .await
+                        .map_err(ClientError::Source)?
+                    {
+                        Some(bytes) => leaves.push(bytes),
+                        None => return Err(ClientError::MissingLeaf { index }),
+                    }
+                }
+                root.assemble(&leaves)?
+            }
+            // The network confirms no published root: a genuinely fresh batch.
+            None => Snapshot::from_batch(batch)?,
+        };
+
+        Ok(Self {
+            signer,
+            owner,
+            batch_id,
+            source,
+            sink,
+            snapshot,
+            persisted_this_session: false,
+        })
+    }
+
+    /// Issues a content stamp for `content`, advancing the matching bucket
+    /// counter and returning the assigned stamp index.
+    ///
+    /// This is local issuance: it touches no network. The reserved snapshot slots
+    /// are skipped by construction, so a stamp never lands on the snapshot's own
+    /// chunks. Persist the resulting state with [`flush`](Self::flush).
+    pub fn stamp(
+        &mut self,
+        content: &SwarmAddress,
+    ) -> Result<StampIndex, ClientError<Src::Error, Snk::Error>> {
+        Ok(self.snapshot.issuer(self.owner).record_address(content)?)
+    }
+
+    /// Persists the snapshot: re-reads the live floor, revalidates, plans, seals,
+    /// and uploads every sealed chunk.
+    ///
+    /// A no-op (returns `Ok`) when the snapshot is clean and a persist has already
+    /// happened this session. Otherwise the live root chunk is re-read through the
+    /// source to derive the published floor:
+    ///
+    /// - `Ok(Some(bytes))`: the floor is the published root's sequence.
+    /// - `Ok(None)`: the network confirms no published root, so the floor is
+    ///   [`PublishedSequence::NONE`].
+    /// - `Err`: the read could not be completed. This aborts; it never persists
+    ///   against a floor it could not read.
+    ///
+    /// The seal timestamp is the wall clock, nudged past the previous seal so the
+    /// in-process monotonicity guard in [`seal_plan`] never trips and the reserve
+    /// overwrites each metadata chunk in place. A persist whose next sequence does
+    /// not strictly exceed the live floor surfaces as
+    /// [`UsageError::StaleSequence`].
+    pub async fn flush(&mut self) -> Result<(), ClientError<Src::Error, Snk::Error>> {
+        if !self.snapshot.is_dirty() && self.persisted_this_session {
+            return Ok(());
+        }
+
+        let root_addr = usage_chunk_address(&self.batch_id, &self.owner, 0);
+        let floor = match self
+            .source
+            .fetch(&root_addr)
+            .await
+            .map_err(ClientError::Source)?
+        {
+            Some(root_bytes) => PublishedSequence::from(&RootInfo::parse(&root_bytes)?),
+            // The network confirms no published root: the floor is NONE.
+            None => PublishedSequence::NONE,
+        };
+
+        let plan = self.snapshot.revalidate(floor)?.plan_persist(&self.owner)?;
+
+        // The seal timestamp must strictly increase across flushes so the reserve
+        // overwrites each metadata chunk in place. Take the wall clock, but lift
+        // it past the previous seal so a coarse or non-advancing clock never trips
+        // the in-process guard in `seal_plan`.
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let timestamp = self
+            .snapshot
+            .last_seal_timestamp()
+            .map_or(now, |previous| now.max(previous + 1));
+
+        let sealed = seal_plan(&mut self.snapshot, &plan, timestamp, &self.signer)?;
+        for chunk in &sealed {
+            self.sink.push(chunk).await.map_err(ClientError::Sink)?;
+        }
+
+        self.persisted_this_session = true;
+        Ok(())
+    }
+
+    /// Returns the wrapped snapshot.
+    pub const fn snapshot(&self) -> &Snapshot {
+        &self.snapshot
+    }
+
+    /// Returns the batch owner, fixed at [`open`](Self::open) from the signer.
+    pub const fn owner(&self) -> Address {
+        self.owner
+    }
+
+    /// Returns the batch id this stamper persists into.
+    pub const fn batch_id(&self) -> BatchId {
+        self.batch_id
+    }
+
+    /// Returns whether the snapshot has unpersisted issuance since the last
+    /// [`flush`](Self::flush).
+    pub const fn is_dirty(&self) -> bool {
+        self.snapshot.is_dirty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::collections::BTreeMap;
+    use std::sync::Mutex;
+
+    use alloy_primitives::B256;
+    use alloy_signer_local::PrivateKeySigner;
+
+    use super::*;
+    use crate::{Mutability, UsageTable};
+
+    /// A shared in-memory network backing both a [`ChunkSource`] and a
+    /// [`ChunkSink`], keyed by single-owner-chunk address.
+    #[derive(Debug, Default, Clone)]
+    struct MemNet {
+        chunks: std::sync::Arc<Mutex<BTreeMap<SwarmAddress, Bytes>>>,
+    }
+
+    #[derive(Debug, Error)]
+    #[error("mem net error")]
+    struct MemError;
+
+    impl ChunkSource for MemNet {
+        type Error = MemError;
+        async fn fetch(&self, address: &SwarmAddress) -> Result<Option<Bytes>, Self::Error> {
+            Ok(self.chunks.lock().unwrap().get(address).cloned())
+        }
+    }
+
+    impl ChunkSink for MemNet {
+        type Error = MemError;
+        async fn push(&self, sealed: &SealedChunk) -> Result<(), Self::Error> {
+            use nectar_primitives::Chunk;
+            let address = *sealed.chunk.address();
+            let payload = Bytes::copy_from_slice(sealed.chunk.data().as_ref());
+            self.chunks.lock().unwrap().insert(address, payload);
+            Ok(())
+        }
+    }
+
+    /// A source whose every read fails, to prove a transport failure never
+    /// degrades into a fresh start or a NONE floor.
+    #[derive(Debug, Default, Clone)]
+    struct FailingSource;
+
+    impl ChunkSource for FailingSource {
+        type Error = MemError;
+        async fn fetch(&self, _address: &SwarmAddress) -> Result<Option<Bytes>, Self::Error> {
+            Err(MemError)
+        }
+    }
+
+    impl ChunkSink for FailingSource {
+        type Error = MemError;
+        async fn push(&self, _sealed: &SealedChunk) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    }
+
+    fn test_batch(signer: &PrivateKeySigner, immutable: bool) -> Batch {
+        Batch::new(
+            B256::repeat_byte(0x42),
+            0,
+            0,
+            signer.address(),
+            20,
+            16,
+            immutable,
+        )
+    }
+
+    #[tokio::test]
+    async fn open_miss_starts_fresh_and_flush_publishes() {
+        let signer = PrivateKeySigner::random();
+        let batch = test_batch(&signer, true);
+        let net = MemNet::default();
+
+        let mut stamper = BatchStamper::open(signer, &batch, net.clone(), net.clone())
+            .await
+            .unwrap();
+        assert_eq!(stamper.snapshot().sequence(), 0);
+
+        let content = SwarmAddress::from(B256::repeat_byte(0x99));
+        stamper.stamp(&content).unwrap();
+        assert!(stamper.is_dirty());
+
+        stamper.flush().await.unwrap();
+        assert_eq!(stamper.snapshot().sequence(), 1);
+        assert!(!stamper.is_dirty());
+
+        // A clean, already-persisted snapshot flushes as a no-op.
+        stamper.flush().await.unwrap();
+        assert_eq!(stamper.snapshot().sequence(), 1);
+    }
+
+    #[tokio::test]
+    async fn open_recovers_published_batch() {
+        let signer = PrivateKeySigner::random();
+        let owner = signer.address();
+        let batch = test_batch(&signer, true);
+        let net = MemNet::default();
+
+        // Machine A: fresh, stamp, flush.
+        {
+            let mut a = BatchStamper::open(signer.clone(), &batch, net.clone(), net.clone())
+                .await
+                .unwrap();
+            a.stamp(&SwarmAddress::from(B256::repeat_byte(0x99)))
+                .unwrap();
+            a.flush().await.unwrap();
+        }
+
+        // Machine B: same key and batch id, recovers the published state.
+        let b = BatchStamper::open(signer, &batch, net.clone(), net.clone())
+            .await
+            .unwrap();
+        assert_eq!(
+            b.snapshot().sequence(),
+            1,
+            "recovered the published sequence"
+        );
+        assert_eq!(b.owner(), owner);
+        assert!(!b.snapshot().allocated_slots().is_empty());
+    }
+
+    #[tokio::test]
+    async fn open_aborts_on_source_error() {
+        let signer = PrivateKeySigner::random();
+        let batch = test_batch(&signer, true);
+
+        let result = BatchStamper::open(signer, &batch, FailingSource, FailingSource).await;
+        assert!(
+            matches!(result, Err(ClientError::Source(_))),
+            "a failed read must abort open, not start fresh",
+        );
+    }
+
+    #[tokio::test]
+    async fn flush_aborts_on_floor_read_error() {
+        let signer = PrivateKeySigner::random();
+        let owner = signer.address();
+        let batch = test_batch(&signer, true);
+
+        // Open against a working empty network so the snapshot starts fresh, then
+        // swap in a source whose floor read fails on flush.
+        let net = MemNet::default();
+        let mut stamper = BatchStamper {
+            signer: signer.clone(),
+            owner,
+            batch_id: batch.id(),
+            source: FailingSource,
+            sink: net.clone(),
+            snapshot: Snapshot::from_batch(&batch).unwrap(),
+            persisted_this_session: false,
+        };
+        stamper
+            .stamp(&SwarmAddress::from(B256::repeat_byte(0x99)))
+            .unwrap();
+
+        let result = stamper.flush().await;
+        assert!(
+            matches!(result, Err(ClientError::Source(_))),
+            "a failed floor read must abort flush, not persist against NONE",
+        );
+        // Nothing was published.
+        assert!(net.chunks.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn stamp_then_flush_advances_sequence_and_reuses_slots() {
+        let signer = PrivateKeySigner::random();
+        let net = MemNet::default();
+        let batch = test_batch(&signer, true);
+
+        let mut stamper = BatchStamper::open(signer, &batch, net.clone(), net.clone())
+            .await
+            .unwrap();
+        stamper
+            .stamp(&SwarmAddress::from(B256::repeat_byte(0x99)))
+            .unwrap();
+        stamper.flush().await.unwrap();
+        let slots_after_first = stamper.snapshot().allocated_slots().to_vec();
+        assert_eq!(stamper.snapshot().sequence(), 1);
+
+        stamper
+            .stamp(&SwarmAddress::from(B256::repeat_byte(0xab)))
+            .unwrap();
+        stamper.flush().await.unwrap();
+        assert_eq!(stamper.snapshot().sequence(), 2, "sequence advanced");
+        assert_eq!(
+            stamper.snapshot().allocated_slots(),
+            slots_after_first.as_slice(),
+            "the snapshot's own slots were reused, not re-allocated",
+        );
+    }
+
+    #[tokio::test]
+    async fn flush_rejects_stale_sequence() {
+        let signer = PrivateKeySigner::random();
+        let owner = signer.address();
+        let batch = test_batch(&signer, true);
+        let net = MemNet::default();
+
+        // Publish sequence 1 and 2 from machine A so the live floor sits at 2.
+        {
+            let mut a = BatchStamper::open(signer.clone(), &batch, net.clone(), net.clone())
+                .await
+                .unwrap();
+            a.stamp(&SwarmAddress::from(B256::repeat_byte(0x01)))
+                .unwrap();
+            a.flush().await.unwrap();
+            a.stamp(&SwarmAddress::from(B256::repeat_byte(0x02)))
+                .unwrap();
+            a.flush().await.unwrap();
+            assert_eq!(a.snapshot().sequence(), 2);
+        }
+
+        // A stale machine B sitting at sequence 1: open it, but rewind its
+        // snapshot to a sequence-1 state, then issue and flush. The live floor (2)
+        // rejects the next sequence (2).
+        let table = UsageTable::new(batch.id(), 20, 16, Mutability::Immutable).unwrap();
+        let mut stale = Snapshot::new(table);
+        stale
+            .revalidate(PublishedSequence::NONE)
+            .unwrap()
+            .plan_persist(&owner)
+            .unwrap();
+        assert_eq!(stale.sequence(), 1);
+
+        let mut b = BatchStamper {
+            signer,
+            owner,
+            batch_id: batch.id(),
+            source: net.clone(),
+            sink: net.clone(),
+            snapshot: stale,
+            persisted_this_session: false,
+        };
+        b.stamp(&SwarmAddress::from(B256::repeat_byte(0x03)))
+            .unwrap();
+        let result = b.flush().await;
+        assert!(
+            matches!(
+                result,
+                Err(ClientError::Usage(UsageError::StaleSequence {
+                    next: 2,
+                    floor: 2
+                })),
+            ),
+            "a persist whose next sequence does not exceed the live floor is rejected",
+        );
+    }
+}

--- a/crates/postage-usage/src/lib.rs
+++ b/crates/postage-usage/src/lib.rs
@@ -103,6 +103,8 @@ mod error;
 mod snapshot;
 mod table;
 
+#[cfg(feature = "client")]
+mod client;
 #[cfg(feature = "issuer")]
 mod issuer;
 #[cfg(feature = "seal")]
@@ -120,6 +122,9 @@ pub use issuer::SnapshotIssuer;
 
 #[cfg(feature = "seal")]
 pub use seal::{SealError, SealedChunk, seal_plan};
+
+#[cfg(feature = "client")]
+pub use client::{BatchStamper, ChunkSink, ChunkSource, ClientError};
 
 pub use nectar_primitives::SwarmAddress;
 


### PR DESCRIPTION
## What

Adds a high-level async facade, `BatchStamper`, to `nectar-postage-usage` behind a new, purely additive `client` feature. The facade collapses the multi-step, cross-machine roam (parse the published root, fetch every leaf at its `+1` offset, assemble a snapshot, revalidate against the live floor, plan a persist, seal each chunk, push each chunk: roughly sixteen low-level calls) into three: `open`, `stamp`, `flush`.

- `BatchStamper::open(signer, batch, source, sink)` binds the signer, owner, and batch id once, recovers a published snapshot from the network, or starts fresh only when the root is definitively absent.
- `BatchStamper::stamp(content)` is synchronous and local: no network, no `.await`.
- `BatchStamper::flush()` re-reads the live floor, revalidates, plans, seals with a strictly increasing timestamp, and pushes every sealed chunk.

Two new async traits, `ChunkSource` and `ChunkSink`, supply the network. They are defined in this crate so that a node (vertex) implements them; nectar does not depend on the node. Both use the RPITIT `impl Future<...> + Send` style to match the primitives `ChunkGet` convention and stay wasm-friendly, and both carry `#[auto_impl::auto_impl(&, Arc, Box)]`. `ClientError` is a `thiserror` enum generic over the source and sink error types, unifying `UsageError` and `SealError`.

The low-level `Snapshot` / `revalidate` / `plan_persist` / `seal_plan` / `usage_chunk_address` API is unchanged and remains public for power users. The example was rewritten over the facade with an in-memory `MemNet` implementing both traits.

## Why

Closes #77.

## Testing

- The `roam_between_machines` example runs to completion, printing a legible machine A to machine B roam over a shared `MemNet`.
- Floor-safety tests: `open_aborts_on_source_error` and `flush_aborts_on_floor_read_error` prove a transport `Err` aborts rather than degrading into a fresh start or a `PublishedSequence::NONE` floor; the latter also asserts nothing is published.
- Lifecycle tests: `open_miss_starts_fresh_and_flush_publishes`, `open_recovers_published_batch`, `stamp_then_flush_advances_sequence_and_reuses_slots`, and `flush_rejects_stale_sequence`.
- SBU1 golden vectors (`readme_worked_example_vector`, `readme_large_batch_multi_leaf_vector`, `mutable_vector_flags_byte_and_round_trip`) are byte-untouched and green; `codec.rs`, `snapshot.rs`, `seal.rs`, and `table.rs` are not modified.
- `cargo fmt`, `cargo clippy --all-targets --all-features -D warnings`, `cargo test --all-features`, and `cargo rustdoc -D warnings` are all clean. Default and seal-only (no client) builds also verified clean, confirming additivity.

## Security

The `ChunkSource::fetch` contract is load-bearing and enforced: `Ok(None)` means definitively absent, and `Err` means the read did not complete. In `open`, the root and leaf reads propagate `Err` via `.map_err(ClientError::Source)?` before any `Snapshot::from_batch` fresh-start can run, so only literal `Ok(None)` starts fresh; a missing leaf for a published root is `ClientError::MissingLeaf` (corruption), never a fresh start. In `flush`, the live floor re-read propagates `Err` before revalidate, seal, or push run, so a failed read never persists; only `Ok(None)` maps to `PublishedSequence::NONE`. This preserves the #70 downgrade protection. `revalidate` enforces that the next sequence strictly exceeds the floor.

There is no nectar to vertex dependency and no cycle: the new traits add no edge back toward the node, `auto_impl` is an optional crate dependency gated behind `client`, and `tokio` is a dev-dependency only.

## Follow-up

The vertex-side `ChunkSource` / `ChunkSink` implementation (over retrieval and pushsync) is out of scope here and pending the nectar rev bump in the node workspace.

## AI Assistance

Produced by an automated multi-agent workflow and human-reviewed before merge.
