### PR TITLE
feat(primitives): default-off wasm-threads plus a parallel feature

### DIFF
--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -65,7 +65,12 @@ alloy-primitives = { workspace = true, features = ["asm-keccak", "getrandom"] }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 alloy-primitives = { workspace = true, features = ["getrandom"] }
 wasm-bindgen.workspace = true
-wasm-bindgen-rayon = "1.3"
+# Gated behind the `wasm-threads` feature (default-off). Its presence forces
+# wasm-bindgen's threads transform, which requires a SharedArrayBuffer memory
+# (and thus COOP/COEP cross-origin isolation on the hosting page). Omitting it
+# yields a wasm that needs no shared memory; the plain `rayon` usage elsewhere
+# then runs inline (no thread pool) on wasm.
+wasm-bindgen-rayon = { version = "1.3", optional = true }
 js-sys.workspace = true
 getrandom.workspace = true
 getrandom_02.workspace = true
@@ -85,6 +90,14 @@ rand.workspace = true
 [features]
 default = ["std"]
 std = []
+# WASM thread pool via wasm-bindgen-rayon. OFF by default so the default wasm
+# build needs no SharedArrayBuffer / cross-origin isolation — letting it run on
+# hosts that can't set COOP/COEP (e.g. the eth.limo ENS gateway). Enable it
+# (`--features wasm-threads`) for the threaded build (faster BMT hashing, but
+# requires shared memory). Must stay out of `default`: dependents pull this
+# crate with default features, so a default-on threads feature would be forced
+# on transitively and couldn't be opted out.
+wasm-threads = ["dep:wasm-bindgen-rayon"]
 serde = ["dep:serde"]
 arbitrary = [
 	"std",

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -98,6 +98,14 @@ std = []
 # crate with default features, so a default-on threads feature would be forced
 # on transitively and couldn't be opted out.
 wasm-threads = ["dep:wasm-bindgen-rayon"]
+# Plain-terminology umbrella for "run in parallel", matching the `parallel`
+# feature on nectar-postage and nectar-postage-issuer. Native builds already
+# parallelize through rayon, so this is a no-op there; on wasm32 it opts into the
+# wasm-bindgen-rayon thread pool by enabling `wasm-threads` (inheriting its
+# shared-memory / cross-origin-isolation requirement). Reach for `parallel` to
+# express intent; use `wasm-threads` directly only to toggle the wasm thread pool
+# on its own.
+parallel = ["wasm-threads"]
 serde = ["dep:serde"]
 arbitrary = [
 	"std",

--- a/crates/primitives/src/wasm.rs
+++ b/crates/primitives/src/wasm.rs
@@ -19,7 +19,14 @@
 //! This uses [wasm-bindgen-rayon](https://github.com/RReverser/wasm-bindgen-rayon)
 //! for rayon-based parallelism via SharedArrayBuffer and Web Workers.
 
-// Re-export thread pool initialization from wasm-bindgen-rayon
+// Re-export thread pool initialization from wasm-bindgen-rayon.
+//
+// Gated behind the `wasm-threads` feature (default-off). The mere PRESENCE of
+// this re-export in the linked artifact makes wasm-bindgen run its threads
+// transform and require a SharedArrayBuffer memory (hence COOP/COEP on the
+// host) — independent of whether JS ever calls it. Without `wasm-threads`, the
+// wasm needs no shared memory; the plain `rayon` code paths run inline.
+#[cfg(feature = "wasm-threads")]
 pub use wasm_bindgen_rayon::init_thread_pool;
 
 // Re-export WASM bindings from each submodule


### PR DESCRIPTION
Lands @v1rtl's `wasm-threads` change from #55, plus a `parallel` feature for DX.

The first commit is @v1rtl's work from #55: it gates `wasm-bindgen-rayon` behind a default-off `wasm-threads` feature, so the default wasm build needs no SharedArrayBuffer or cross-origin isolation and can run on hosts that cannot set COOP/COEP (notably ENS gateways like eth.limo / bzz.limo).

The second commit adds a plain-terminology `parallel` feature that enables `wasm-threads`. It matches the `parallel` feature already on `nectar-postage` and `nectar-postage-issuer`, so consumers meet one consistent word for "run in parallel" across the workspace. `wasm-threads` stays as the precise low-level lever. `parallel` is a no-op on native (rayon already parallelizes) and on wasm32 pulls the `wasm-bindgen-rayon` thread pool by turning on `wasm-threads`.

Verified: native `--features parallel` builds; the default wasm graph has no `wasm-bindgen-rayon`; wasm `--features parallel` pulls it and builds under the threaded config exactly like `--features wasm-threads`.

Supersedes #55. Cherry-picked here so the work can land through a branch the maintainers can push to and run CI on; @v1rtl retains authorship of the original commit and is co-author on the feature commit.
