### PR TITLE
fix(contracts): correct deployment addresses and guard against upstream drift

### DIFF
--- a/.github/workflows/upstream-addresses.yml
+++ b/.github/workflows/upstream-addresses.yml
@@ -1,0 +1,74 @@
+name: Upstream addresses
+
+# Guards against drift between the contract addresses / deploy blocks hard-coded
+# in nectar-contracts and the canonical values ethersphere publishes in
+# go-storage-incentives-abi (what the bee node compiles against). The Rust side
+# emits its constants as JSON and the Go side emits the upstream values; the two
+# are compared structurally, so there is no source parsing. Runs weekly so a
+# redeployment upstream turns this red and we get notified.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "crates/contracts/src/lib.rs"
+      - "crates/contracts/examples/dump_deployments.rs"
+      - "tools/upstream-check/**"
+      - ".github/workflows/upstream-addresses.yml"
+  push:
+    branches: [main]
+    paths:
+      - "crates/contracts/src/lib.rs"
+      - "crates/contracts/examples/dump_deployments.rs"
+      - "tools/upstream-check/**"
+      - ".github/workflows/upstream-addresses.yml"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: compare against go-storage-incentives-abi
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: . -> target
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version: stable
+
+      - name: Emit nectar-contracts deployments
+        run: cargo run -p nectar-contracts --example dump_deployments --quiet > nectar.json
+
+      - name: Fetch latest go-storage-incentives-abi and compare
+        working-directory: tools/upstream-check
+        run: |
+          set -o pipefail
+          go get github.com/ethersphere/go-storage-incentives-abi@latest
+          go mod tidy
+          go run . -nectar "$GITHUB_WORKSPACE/nectar.json"
+
+      - name: Open or update drift issue
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title="Upstream contract address/block drift detected"
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          body=$(printf 'The scheduled upstream-addresses check failed: nectar-contracts no longer matches the latest go-storage-incentives-abi.\n\nFailed run: %s\n\nUpdate the address and/or deploy block in crates/contracts/src/lib.rs to the upstream values shown in the run log.' "$run_url")
+          existing=$(gh issue list --state open --search "in:title \"$title\"" --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$title" --body "$body"
+          fi

--- a/crates/contracts/examples/dump_deployments.rs
+++ b/crates/contracts/examples/dump_deployments.rs
@@ -1,0 +1,45 @@
+//! Print nectar-contracts' deployed addresses and blocks as JSON.
+//!
+//! Emitted from the real typed `mainnet`/`testnet` constants, so this output can
+//! never drift from the crate. Consumed by `tools/upstream-check` to compare
+//! against ethersphere's go-storage-incentives-abi without parsing source.
+//!
+//! Run: `cargo run -p nectar-contracts --example dump_deployments`
+
+use nectar_contracts::{mainnet, testnet};
+
+/// Render the five storage-incentives deployments of one network as a JSON object.
+/// Every deployment struct exposes `address` (EIP-55 `Display`) and `block`.
+macro_rules! network_json {
+    ($net:ident) => {
+        format!(
+            concat!(
+                "{{",
+                r#""bzz_token":{{"address":"{}","block":{}}},"#,
+                r#""postage_stamp":{{"address":"{}","block":{}}},"#,
+                r#""price_oracle":{{"address":"{}","block":{}}},"#,
+                r#""redistribution":{{"address":"{}","block":{}}},"#,
+                r#""staking":{{"address":"{}","block":{}}}"#,
+                "}}"
+            ),
+            $net::BZZ_TOKEN.address,
+            $net::BZZ_TOKEN.block,
+            $net::POSTAGE_STAMP.address,
+            $net::POSTAGE_STAMP.block,
+            $net::STORAGE_PRICE_ORACLE.address,
+            $net::STORAGE_PRICE_ORACLE.block,
+            $net::REDISTRIBUTION.address,
+            $net::REDISTRIBUTION.block,
+            $net::STAKING.address,
+            $net::STAKING.block,
+        )
+    };
+}
+
+fn main() {
+    println!(
+        r#"{{"mainnet":{},"testnet":{}}}"#,
+        network_json!(mainnet),
+        network_json!(testnet)
+    );
+}

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -344,19 +344,19 @@ pub mod mainnet {
 
     /// Postage stamp contract.
     pub const POSTAGE_STAMP: PostageStamp = PostageStamp::new(
-        address!("5b53f7a1975eb212d4b20b7cdd443baa189af7c9"),
+        address!("45a1502382541Cd610CC9068e88727426b696293"),
         31305656,
     );
 
     /// Stake registry contract.
     pub const STAKING: StakeRegistry = StakeRegistry::new(
-        address!("0c6aa197271466f0afe3818ca03ac47d8f5c2f8a"),
+        address!("da2a16EE889E7F04980A8d597b48c8D51B9518F4"),
         40430237,
     );
 
     /// Redistribution contract.
     pub const REDISTRIBUTION: Redistribution = Redistribution::new(
-        address!("eb210c2e166f61b3fd32246d53893f8b9d2a624c"),
+        address!("5069cdfB3D9E56d23B1cAeE83CE6109A7E4fd62d"),
         41105199,
     );
 
@@ -387,23 +387,23 @@ pub mod testnet {
 
     /// BZZ token (sBZZ on Sepolia).
     pub const BZZ_TOKEN: Token =
-        Token::new(address!("6e01ee6183721ae9a006fd4906970c1583863765"), 0);
+        Token::new(address!("543dDb01Ba47acB11de34891cD86B675F04840db"), 0);
 
     /// Postage stamp contract.
     pub const POSTAGE_STAMP: PostageStamp = PostageStamp::new(
-        address!("621c2e0fa5ed488c7124eb55cc7eb3af75d0d9e8"),
+        address!("cdfdC3752caaA826fE62531E0000C40546eC56A6"),
         6596277,
     );
 
     /// Stake registry contract.
     pub const STAKING: StakeRegistry = StakeRegistry::new(
-        address!("6f252dd6f340f6c6d2f6ee8954b011dd5aba4350"),
+        address!("EEF13Ef9eD9cDD169701eeF3cd832df298dD1bB4"),
         8262529,
     );
 
     /// Redistribution contract.
     pub const REDISTRIBUTION: Redistribution = Redistribution::new(
-        address!("fb6c7d33be1fb12f4c5da71df7c9d5c22970ba7a"),
+        address!("5b718E36F5Ce2F2F7e25A397040436Ce6af3e89e"),
         8646721,
     );
 

--- a/tools/upstream-check/README.md
+++ b/tools/upstream-check/README.md
@@ -1,0 +1,31 @@
+# upstream-check
+
+Guards against drift between the contract addresses and deploy blocks hard-coded
+in `nectar-contracts` and the canonical values ethersphere publishes in
+[`go-storage-incentives-abi`](https://github.com/ethersphere/go-storage-incentives-abi),
+the package the bee node compiles against.
+
+Rather than parsing each other's source, the two sides emit structured data and
+compare it:
+
+- the `nectar-contracts` `dump_deployments` example prints its `mainnet` /
+  `testnet` constants as JSON, straight from the real typed constants;
+- this Go program imports `go-storage-incentives-abi` and compares the upstream
+  address + deploy block against that JSON.
+
+The deploy block is compared as well as the address (the block is the start point
+for on-chain event indexing such as postage-stamp scanning). The BZZ token block
+is the one exception: nectar stores `0` (the token is not event-indexed), so it
+is printed but not compared.
+
+Run locally:
+
+```sh
+cargo run -p nectar-contracts --example dump_deployments --quiet > nectar.json
+cd tools/upstream-check && go run . -nectar ../../nectar.json
+```
+
+A non-zero exit means nectar's constants need updating to match upstream. In CI
+the `Upstream addresses` workflow runs this weekly (and on changes to the
+relevant files), fetching the latest `go-storage-incentives-abi` release first so
+a redeployment upstream turns the check red.

--- a/tools/upstream-check/go.mod
+++ b/tools/upstream-check/go.mod
@@ -1,0 +1,5 @@
+module github.com/nxm-rs/nectar/tools/upstream-check
+
+go 1.23
+
+require github.com/ethersphere/go-storage-incentives-abi v0.9.4

--- a/tools/upstream-check/go.sum
+++ b/tools/upstream-check/go.sum
@@ -1,0 +1,2 @@
+github.com/ethersphere/go-storage-incentives-abi v0.9.4 h1:mSIWXQXg5OQmH10QvXMV5w0vbSibFMaRlBL37gPLTM0=
+github.com/ethersphere/go-storage-incentives-abi v0.9.4/go.mod h1:SXvJVtM4sEsaSKD0jc1ClpDLw8ErPoROZDme4Wrc/Nc=

--- a/tools/upstream-check/main.go
+++ b/tools/upstream-check/main.go
@@ -1,0 +1,146 @@
+// Command upstream-check establishes that the deployed contract addresses and
+// deploy blocks hard-coded in nectar-contracts match the canonical values
+// published by ethersphere's go-storage-incentives-abi, the same package the
+// bee node compiles against.
+//
+// The two sides emit structured data rather than parsing each other's source:
+// the nectar-contracts `dump_deployments` example prints its constants as JSON
+// (from the real typed constants, so it can never drift from the crate), and
+// this program prints the upstream values from the imported Go package. This
+// program reads the nectar JSON (via -nectar) and compares the two, so there is
+// no fragile source grepping on either side.
+//
+// It is meant to run in CI on a schedule: when ethersphere ships a redeployment
+// (a new release with a changed address or deploy block), this check flips red
+// so we know to update nectar's constants. The workflow fetches the latest
+// release before running, so "upstream" always means the newest tag.
+//
+// Scope: the five storage-incentives contracts the abi package exports
+// (BZZ token, PostageStamp, PriceOracle, Redistribution, Staking) on mainnet and
+// testnet. The swap contracts (chequebook factory, swap price oracle) are not in
+// this package and are not checked. Both address and deploy block are compared;
+// the block is the start point for on-chain event indexing (e.g. postage-stamp
+// scanning), so a moved block matters on its own. The BZZ token block is the one
+// exception: nectar stores 0 (the token is not event-indexed), so it is printed
+// but not compared.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/ethersphere/go-storage-incentives-abi/abi"
+)
+
+// contract is one comparable deployment slot. checkBlock is false for the token,
+// whose block nectar deliberately stores as 0.
+type contract struct {
+	key        string
+	checkBlock bool
+}
+
+var contracts = []contract{
+	{"bzz_token", false},
+	{"postage_stamp", true},
+	{"price_oracle", true},
+	{"redistribution", true},
+	{"staking", true},
+}
+
+// deployment is the JSON shape both sides speak: an address and its deploy block.
+type deployment struct {
+	Address string `json:"address"`
+	Block   uint64 `json:"block"`
+}
+
+// upstream returns the canonical address + block from go-storage-incentives-abi.
+func upstream() map[string]map[string]deployment {
+	return map[string]map[string]deployment{
+		"mainnet": {
+			"bzz_token":      {abi.MainnetBzzTokenAddress, uint64(abi.MainnetBzzTokenBlockNumber)},
+			"postage_stamp":  {abi.MainnetPostageStampAddress, uint64(abi.MainnetPostageStampBlockNumber)},
+			"price_oracle":   {abi.MainnetPriceOracleAddress, uint64(abi.MainnetPriceOracleBlockNumber)},
+			"redistribution": {abi.MainnetRedistributionAddress, uint64(abi.MainnetRedistributionBlockNumber)},
+			"staking":        {abi.MainnetStakingAddress, uint64(abi.MainnetStakingBlockNumber)},
+		},
+		"testnet": {
+			"bzz_token":      {abi.TestnetBzzTokenAddress, uint64(abi.TestnetBzzTokenBlockNumber)},
+			"postage_stamp":  {abi.TestnetPostageStampAddress, uint64(abi.TestnetPostageStampBlockNumber)},
+			"price_oracle":   {abi.TestnetPriceOracleAddress, uint64(abi.TestnetPriceOracleBlockNumber)},
+			"redistribution": {abi.TestnetRedistributionAddress, uint64(abi.TestnetRedistributionBlockNumber)},
+			"staking":        {abi.TestnetStakingAddress, uint64(abi.TestnetStakingBlockNumber)},
+		},
+	}
+}
+
+// norm lowercases an address and strips an optional 0x prefix so checksummed and
+// un-prefixed forms compare equal.
+func norm(a string) string {
+	return strings.TrimPrefix(strings.ToLower(a), "0x")
+}
+
+func main() {
+	nectarPath := flag.String("nectar", "nectar.json", "path to the JSON emitted by the nectar-contracts dump_deployments example")
+	flag.Parse()
+
+	raw, err := os.ReadFile(*nectarPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error reading nectar JSON:", err)
+		os.Exit(2)
+	}
+	var nec map[string]map[string]deployment
+	if err := json.Unmarshal(raw, &nec); err != nil {
+		fmt.Fprintln(os.Stderr, "error parsing nectar JSON:", err)
+		os.Exit(2)
+	}
+
+	up := upstream()
+	drift := false
+	for _, net := range []string{"mainnet", "testnet"} {
+		fmt.Printf("== %s ==\n", net)
+		nn, ok := nec[net]
+		if !ok {
+			fmt.Fprintf(os.Stderr, "nectar JSON is missing network %q\n", net)
+			os.Exit(2)
+		}
+		for _, c := range contracts {
+			u := up[net][c.key]
+			n, ok := nn[c.key]
+			if !ok {
+				fmt.Fprintf(os.Stderr, "nectar JSON is missing %s/%s\n", net, c.key)
+				os.Exit(2)
+			}
+
+			addrOK := norm(u.Address) == norm(n.Address)
+			blockOK := !c.checkBlock || u.Block == n.Block
+			if !addrOK || !blockOK {
+				drift = true
+			}
+
+			addrField := "addr ok"
+			if !addrOK {
+				addrField = fmt.Sprintf("addr DRIFT (nectar=%s upstream=%s)", n.Address, u.Address)
+			}
+			var blockField string
+			switch {
+			case !c.checkBlock:
+				blockField = fmt.Sprintf("block %d (token, not compared)", n.Block)
+			case blockOK:
+				blockField = fmt.Sprintf("block ok (%d)", n.Block)
+			default:
+				blockField = fmt.Sprintf("block DRIFT (nectar=%d upstream=%d)", n.Block, u.Block)
+			}
+			fmt.Printf("  %-15s %-58s %s\n", c.key, addrField, blockField)
+		}
+	}
+
+	if drift {
+		fmt.Fprintln(os.Stderr, "\nUPSTREAM DRIFT DETECTED: nectar-contracts no longer matches go-storage-incentives-abi.")
+		fmt.Fprintln(os.Stderr, "Update the address and/or block in crates/contracts/src/lib.rs to the upstream values above.")
+		os.Exit(1)
+	}
+	fmt.Println("\nAll addresses and deploy blocks match go-storage-incentives-abi.")
+}


### PR DESCRIPTION
## Summary

Two related changes:

1. **Fix wrong deployment addresses.** The `mainnet` and `testnet` address constants did not match the canonical Swarm deployments. The deploy **block numbers were already correct**; only the **address literals** were wrong (they appear in no canonical source, so a copy error, not a redeployment). These constants feed **vertex** (`crates/chain/src/config.rs`) and the **dipper** CLI, so the wrong values pointed on-chain postage operations at contracts that exist on no network.

2. **Add an upstream drift guard** so this cannot silently regress. A scheduled CI check compares nectar's addresses **and deploy blocks** against ethersphere's `go-storage-incentives-abi` (what bee compiles against) and turns red on any divergence.

## Corrected addresses

| Network | Contract | Old (wrong) | New (canonical) |
| --- | --- | --- | --- |
| Mainnet | PostageStamp | `0x5b53f7a1…af7c9` | `0x45a1502382541Cd610CC9068e88727426b696293` |
| Mainnet | StakeRegistry | `0x0c6aa197…2f8a` | `0xda2a16EE889E7F04980A8d597b48c8D51B9518F4` |
| Mainnet | Redistribution | `0xeb210c2e…624c` | `0x5069cdfB3D9E56d23B1cAeE83CE6109A7E4fd62d` |
| Testnet | BZZ token | `0x6e01ee61…3765` | `0x543dDb01Ba47acB11de34891cD86B675F04840db` |
| Testnet | PostageStamp | `0x621c2e0f…d9e8` | `0xcdfdC3752caaA826fE62531E0000C40546eC56A6` |
| Testnet | StakeRegistry | `0x6f252dd6…4350` | `0xEEF13Ef9eD9cDD169701eeF3cd832df298dD1bB4` |
| Testnet | Redistribution | `0xfb6c7d33…ba7a` | `0x5b718E36F5Ce2F2F7e25A397040436Ce6af3e89e` |

Block numbers were already correct and are unchanged. Each address was cross-checked against bee's pinned `go-storage-incentives-abi` (v0.9.4) and the ethersphere `storage-incentives` deployment artifacts; the `address!` macro validates the EIP-55 checksums at compile time.

## Drift guard

To prevent silent regressions, the two sides exchange structured data instead of parsing each other's source:

- a new `nectar-contracts` example (`cargo run -p nectar-contracts --example dump_deployments`) prints the typed `mainnet`/`testnet` constants as JSON;
- `tools/upstream-check` (Go) imports `go-storage-incentives-abi` and compares the upstream **address + deploy block** against that JSON.

The deploy block is compared as well as the address, since the block is the start point for on-chain event indexing (e.g. postage-stamp scanning) and a redeployment moves it. The BZZ token block is excepted (nectar stores `0` for the un-indexed token).

The `Upstream addresses` workflow runs this **weekly** (and on changes to the relevant files / on dispatch), fetching the **latest** `go-storage-incentives-abi` release first, and opens a tracking issue on scheduled failure.

Scope note: the guard covers the five storage-incentives contracts the abi package exports (BZZ token, PostageStamp, PriceOracle, Redistribution, Staking). The swap contracts (chequebook factory, swap price oracle) are not in that package and are not covered.