### PR TITLE
feat(feeds): Swarm feeds (sequence + epoch) over single-owner chunks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2060,6 +2060,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "nectar-feeds"
+version = "0.2.1"
+dependencies = [
+ "alloy-primitives",
+ "alloy-signer",
+ "alloy-signer-local",
+ "arbitrary",
+ "bytes",
+ "derive_more",
+ "futures",
+ "nectar-primitives",
+ "proptest",
+ "serde",
+ "strum 0.28.0",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "nectar-mantaray"
 version = "0.2.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ nectar-swarms = { version = "0.2.1", path = "crates/swarms" }
 nectar-postage = { version = "0.2.1", path = "crates/postage" }
 nectar-postage-issuer = { version = "0.2.1", path = "crates/postage-issuer" }
 nectar-postage-usage = { version = "0.2.1", path = "crates/postage-usage" }
+nectar-feeds = { version = "0.2.1", path = "crates/feeds" }
 
 # alloy
 alloy-primitives = { version = "1.6", default-features = false }

--- a/crates/feeds/Cargo.toml
+++ b/crates/feeds/Cargo.toml
@@ -1,0 +1,58 @@
+[package]
+name = "nectar-feeds"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+description = "Swarm feeds over single-owner chunks for Ethereum Swarm"
+documentation = "https://docs.rs/nectar-feeds"
+readme = "README.md"
+keywords = ["swarm", "ethereum", "feeds", "soc"]
+categories = ["data-structures", "cryptography::cryptocurrencies"]
+
+[lints]
+workspace = true
+
+[dependencies]
+nectar-primitives = { workspace = true }
+alloy-primitives = { workspace = true }
+alloy-signer = { workspace = true }
+bytes = { workspace = true }
+thiserror = { workspace = true }
+strum = { workspace = true }
+derive_more = { workspace = true }
+futures = { workspace = true }
+
+# optional
+serde = { workspace = true, optional = true }
+arbitrary = { workspace = true, features = ["derive"], optional = true }
+
+[dev-dependencies]
+proptest = { workspace = true }
+alloy-signer-local = { workspace = true }
+alloy-primitives = { workspace = true, features = ["getrandom"] }
+tokio = { workspace = true, features = ["rt", "macros"] }
+
+[features]
+default = ["std"]
+
+# Standard library support. The async reader/writer paths build on the typed
+# chunk store traits, which require `std`.
+std = ["nectar-primitives/std", "alloy-primitives/std", "thiserror/std", "serde?/std"]
+
+# Serialization support with serde.
+serde = ["dep:serde", "nectar-primitives/serde", "alloy-primitives/serde"]
+
+# Arbitrary trait implementations for property-based testing.
+arbitrary = ["dep:arbitrary", "nectar-primitives/arbitrary", "alloy-primitives/arbitrary"]
+
+# Epoch-based feed scheme (time-indexed lookup over a binary epoch grid).
+epoch = []
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/feeds/src/epoch.rs
+++ b/crates/feeds/src/epoch.rs
@@ -1,0 +1,934 @@
+//! Epoch feed scheme: a time-indexed binary grid.
+//!
+//! An epoch is a half-open time interval `[start, start + 2^level)` on a binary
+//! grid. The scheme lets a reader find the update live at any timestamp with a
+//! logarithmic walk, at the cost of a stateful write cursor that must remember
+//! the previous update time to place the next epoch.
+//!
+//! # Grid math
+//!
+//! Each epoch spans `2^level` seconds. An epoch is partitioned into a left and
+//! a right child one level down; the child whose interval contains a target
+//! timestamp is selected by testing the `2^(level-1)` bit of the timestamp. The
+//! root epoch `{start: 0, level: 32}` covers the whole representable grid.
+//!
+//! The canonical comparison timestamp of an epoch is `2^level * start`, not the
+//! start alone. This is the value compared against the lookup target to decide
+//! whether an epoch was published at or before the target.
+//!
+//! # Finders
+//!
+//! Two latest-update searches are provided over the same grid:
+//!
+//! - A sequential finder that walks ancestors then descends, probing one epoch
+//!   at a time. It is the simple, allocation-free baseline walk.
+//! - A concurrent finder that fires overlapping store gets along the
+//!   descent path and resolves once it has bracketed the answer with a found
+//!   epoch directly above a not-found epoch. It drives its in-flight gets with
+//!   a self-contained, `core`-only poll set (no executor crate), cancels stale
+//!   gets, never assumes a multi-threaded runtime, and never adds a `Send`
+//!   bound, so it runs unchanged on a single-threaded wasm executor.
+//!
+//! Gated behind the `epoch` feature; the sequence scheme is the default.
+
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::future::Future;
+use core::pin::Pin;
+use core::task::Poll;
+
+use alloy_primitives::Keccak256;
+use nectar_primitives::store::ChunkGet;
+
+use crate::error::Result;
+use crate::feed::Feed;
+use crate::index::{Index, LatestFinder, WriteCursor};
+use crate::update::FeedUpdate;
+
+/// The top level of the epoch grid. The root epoch is `{start: 0, level: 32}`.
+const MAX_LEVEL: u8 = 32;
+
+/// An epoch index: the half-open interval `[start, start + 2^level)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct Epoch {
+    /// The epoch start time (Unix seconds), aligned to its level.
+    pub start: u64,
+    /// The epoch level: the interval spans `2^level` seconds.
+    pub level: u8,
+}
+
+impl Epoch {
+    /// The root epoch `{start: 0, level: 32}` that covers the whole grid.
+    pub const ROOT: Self = Self {
+        start: 0,
+        level: MAX_LEVEL,
+    };
+
+    /// Construct an epoch from its start and level.
+    pub const fn new(start: u64, level: u8) -> Self {
+        Self { start, level }
+    }
+
+    /// The span of the epoch in seconds: `2^level`.
+    ///
+    /// A level at or above 64 would shift past the width of a `u64`; such a
+    /// level is not representable on the grid (the root is level 32), so the
+    /// span saturates to `u64::MAX` rather than invoking undefined shift
+    /// behaviour.
+    pub const fn length(&self) -> u64 {
+        if self.level >= 64 {
+            u64::MAX
+        } else {
+            1u64 << self.level
+        }
+    }
+
+    /// The canonical comparison timestamp: `2^level * start`.
+    ///
+    /// This is the value compared against a lookup target, not `start` alone.
+    pub const fn timestamp(&self) -> u64 {
+        self.length().wrapping_mul(self.start)
+    }
+
+    /// The ancestor one level up.
+    ///
+    /// Caller responsibility: must not be called on a top-level epoch.
+    pub const fn parent(&self) -> Self {
+        let length = self.length() << 1;
+        Self {
+            start: (self.start / length) * length,
+            level: self.level + 1,
+        }
+    }
+
+    /// The left sister of this epoch.
+    ///
+    /// Caller responsibility: valid only for a right sister, not a left one.
+    pub const fn left(&self) -> Self {
+        Self {
+            start: self.start - self.length(),
+            level: self.level,
+        }
+    }
+
+    /// The child epoch (one level down) whose interval contains `at`.
+    ///
+    /// Level 0 is the finest grid resolution and has no child, so calling this
+    /// on a level-0 epoch floors: it returns the epoch unchanged rather than
+    /// underflowing the level. Callers descending the grid stop at level 0.
+    ///
+    /// Caller responsibility: `at` must fall within this epoch.
+    pub const fn child_at(&self, at: u64) -> Self {
+        let Some(child_level) = self.level.checked_sub(1) else {
+            return *self;
+        };
+        let child_length = 1u64 << child_level;
+        let mut start = self.start;
+        if at & child_length != 0 {
+            start |= child_length;
+        }
+        Self {
+            start,
+            level: child_level,
+        }
+    }
+
+    /// Whether this epoch is the left sister of its parent.
+    pub const fn is_left(&self) -> bool {
+        self.start & self.length() == 0
+    }
+
+    /// The lowest common ancestor epoch of two Unix times.
+    ///
+    /// With `after == 0` (no prior update is known) this is the root epoch.
+    pub const fn lca(at: u64, after: u64) -> Self {
+        if after == 0 {
+            return Self::ROOT;
+        }
+        let diff = at.saturating_sub(after);
+        let mut length = 1u64;
+        let mut level: u8 = 0;
+        while level < MAX_LEVEL && (length < diff || at / length != after / length) {
+            length <<= 1;
+            level += 1;
+        }
+        let start = (after / length) * length;
+        Self { start, level }
+    }
+
+    /// The next epoch to publish at time `at`, given the current epoch `prev`
+    /// (if any) and the time `last` of the previous update.
+    ///
+    /// With no previous epoch the next position is the root. Otherwise, if `at`
+    /// still falls within the current epoch the next position is the matching
+    /// child; if it has moved past the epoch, the descent restarts from the
+    /// lowest common ancestor of `at` and `last`.
+    ///
+    /// When the current epoch is already at level 0 (a sub-second republish onto
+    /// the finest grid resolution) there is no child to descend to, so the
+    /// level-0 epoch is returned unchanged. This floors the descent rather than
+    /// underflowing the level or shifting past the width of a `u64`.
+    pub const fn next(prev: Option<Self>, last: u64, at: u64) -> Self {
+        match prev {
+            None => Self::ROOT,
+            Some(e) if e.level == 0 => e,
+            Some(e) => {
+                if e.start.saturating_add(e.length()) > at {
+                    e.child_at(at)
+                } else {
+                    Self::lca(at, last).child_at(at)
+                }
+            }
+        }
+    }
+}
+
+impl Index for Epoch {
+    fn marshal(&self) -> impl AsRef<[u8]> {
+        let mut hasher = Keccak256::new();
+        hasher.update(self.start.to_be_bytes());
+        hasher.update([self.level]);
+        hasher.finalize()
+    }
+
+    fn first() -> Self {
+        Self::ROOT
+    }
+}
+
+/// The write head for the epoch scheme.
+///
+/// Unlike the sequence cursor, this carries the previous update epoch and time
+/// so that the next position can be placed on the grid relative to them. The
+/// epoch an update occupies is a function of the previous state and the new
+/// update's timestamp, which is why the scheme picks its index from `at` in
+/// [`index_for`](WriteCursor::index_for) rather than tracking a single "current"
+/// position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EpochCursor {
+    /// The previous published epoch, if any update has been published.
+    prev: Option<Epoch>,
+    /// The time of the last published update, if any.
+    last_time: u64,
+}
+
+impl EpochCursor {
+    /// A cursor with no prior update.
+    pub const fn new() -> Self {
+        Self {
+            prev: None,
+            last_time: 0,
+        }
+    }
+
+    /// The time of the last published update, `0` if none yet.
+    pub const fn last_time(&self) -> u64 {
+        self.last_time
+    }
+}
+
+impl Default for EpochCursor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WriteCursor for EpochCursor {
+    type Index = Epoch;
+
+    fn index_for(&self, at: Option<u64>) -> Self::Index {
+        // The grid position of an epoch update depends on the new update's
+        // timestamp, so an epoch write must carry one. With no timestamp the
+        // first publishable position is the root epoch.
+        let at = at.unwrap_or(0);
+        Epoch::next(self.prev, self.last_time, at)
+    }
+
+    fn record(&mut self, index: &Self::Index, at: Option<u64>) {
+        self.prev = Some(*index);
+        self.last_time = at.unwrap_or(0);
+    }
+}
+
+/// Fetch the update at `epoch`.
+///
+/// Delegates to the shared [`crate::reader::fetch_update`] so the epoch
+/// resolution path runs the identical chunk-to-update checks as the sequence
+/// path: single-owner decode, owner recovery against the feed owner, and
+/// address verification (`keccak256(id || owner)` pinned to the queried slot).
+/// The address verification is what rejects an owner-signed chunk whose id is
+/// for a different epoch than the one queried; without it such a chunk would be
+/// accepted as the queried slot.
+///
+/// A genuine store miss (classified through [`ChunkGet::is_not_found`]) resolves
+/// to `Ok(None)`, the empty-grid-slot signal the finders walk past. Every other
+/// store error propagates as [`crate::FeedError::StoreGet`]; it is never folded
+/// into absence. A present chunk that is not a single-owner chunk, is signed by
+/// an address other than the feed owner, or does not address to the queried
+/// epoch slot surfaces the corresponding [`crate::FeedError`].
+async fn get_epoch<const BS: usize, G: ChunkGet<BS>>(
+    feed: &Feed<BS>,
+    store: &G,
+    epoch: Epoch,
+) -> Result<Option<FeedUpdate<Epoch, BS>>> {
+    let address = feed.update_address(&epoch);
+    crate::reader::fetch_update(feed, store, epoch, &address).await
+}
+
+/// Sequential epoch finder: walk ancestors to the common epoch, then descend.
+///
+/// A two-phase grid search. `common` climbs from the lowest common ancestor of
+/// `at` and `after` until it finds an epoch whose update is present and not in
+/// the future, or reaches the root with nothing. `at_phase` then descends from
+/// that epoch toward the finest resolution, carrying the best (deepest,
+/// in-the-past) update found so far.
+///
+/// This is the allocation-free counterpart to the concurrent finder, kept as a
+/// reference walk that the finder-behaviour tests cross-check the concurrent
+/// path against. The concurrent path is the one wired into [`LatestFinder`], so
+/// the sequential chain compiles only under test.
+#[cfg(test)]
+async fn find_latest_sequential<const BS: usize, G: ChunkGet<BS>>(
+    feed: &Feed<BS>,
+    store: &G,
+    at: u64,
+    after: u64,
+) -> Result<Option<FeedUpdate<Epoch, BS>>> {
+    let (epoch, found) = common(feed, store, at, after).await?;
+    at_phase(feed, store, at, epoch, found).await
+}
+
+/// Climb from `lca(at, after)` to the lowest ancestor whose update exists and
+/// whose comparison timestamp is at or before `at`. Returns that epoch and its
+/// update, or the root epoch with `None` when the feed is empty.
+#[cfg(test)]
+async fn common<const BS: usize, G: ChunkGet<BS>>(
+    feed: &Feed<BS>,
+    store: &G,
+    at: u64,
+    after: u64,
+) -> Result<(Epoch, Option<FeedUpdate<Epoch, BS>>)> {
+    let mut e = Epoch::lca(at, after);
+    loop {
+        match get_epoch(feed, store, e).await? {
+            None => {
+                if e.level == MAX_LEVEL {
+                    return Ok((e, None));
+                }
+                e = e.parent();
+            }
+            Some(update) => {
+                if e.timestamp() <= at {
+                    return Ok((e, Some(update)));
+                }
+                e = e.parent();
+            }
+        }
+    }
+}
+
+/// Descend from `e` toward the finest resolution, carrying the best update
+/// found so far (`carry`). Returns the update live at `at`.
+#[cfg(test)]
+async fn at_phase<const BS: usize, G: ChunkGet<BS>>(
+    feed: &Feed<BS>,
+    store: &G,
+    mut at: u64,
+    mut e: Epoch,
+    mut carry: Option<FeedUpdate<Epoch, BS>>,
+) -> Result<Option<FeedUpdate<Epoch, BS>>> {
+    loop {
+        match get_epoch(feed, store, e).await? {
+            None => {
+                // Epoch not found on this branch.
+                if e.is_left() {
+                    return Ok(carry);
+                }
+                // Traverse the earlier (left sister) branch.
+                at = e.start - 1;
+                e = e.left();
+            }
+            Some(update) => {
+                if e.timestamp() > at {
+                    // Published in the future relative to the target.
+                    if e.is_left() {
+                        return Ok(carry);
+                    }
+                    at = e.start - 1;
+                    e = e.left();
+                } else if e.level == 0 {
+                    // Matching update time or finest resolution.
+                    return Ok(Some(update));
+                } else {
+                    // Continue descending toward `at`, keeping this update.
+                    let child = e.child_at(at);
+                    carry = Some(update);
+                    e = child;
+                }
+            }
+        }
+    }
+}
+
+/// One descent path in the concurrent finder.
+///
+/// A path tracks the deepest found epoch (`top`) and the deepest not-found
+/// epoch (`bottom`) seen along it. When `top` sits exactly one level above
+/// `bottom` the answer is bracketed: either `top` is the result, or the search
+/// recurses onto a fresh path through `bottom`'s left sister.
+struct Path<const BS: usize> {
+    /// Deepest found epoch and its update on this path.
+    top: Option<(Epoch, FeedUpdate<Epoch, BS>)>,
+    /// Deepest not-found epoch on this path.
+    bottom: Option<Epoch>,
+    /// Whether this path has been retired (its in-flight gets are stale).
+    cancelled: bool,
+}
+
+impl<const BS: usize> Path<BS> {
+    const fn new() -> Self {
+        Self {
+            top: None,
+            bottom: None,
+            cancelled: false,
+        }
+    }
+}
+
+/// The outcome of one store get fired along a path.
+struct Probe<const BS: usize> {
+    /// The path the probe belongs to.
+    path: usize,
+    /// The epoch probed.
+    epoch: Epoch,
+    /// The update if found and not published in the future, else `None`.
+    update: Option<FeedUpdate<Epoch, BS>>,
+}
+
+/// A boxed, non-`Send` future producing one probe result, or a store error to
+/// propagate.
+type ProbeFuture<'a, const BS: usize> = Pin<Box<dyn Future<Output = Result<Probe<BS>>> + 'a>>;
+
+/// A self-contained, non-`Send` poll set: a bag of probe futures polled
+/// concurrently without any executor crate. Each call to [`next`](Self::next)
+/// returns the first probe to complete.
+///
+/// Every inner future is polled with the outer task's waker, so a future
+/// pending on a real async store wakes the outer executor when its IO
+/// completes; synchronous stores complete in the first poll round. This keeps
+/// the finder free of any runtime dependency and free of a `Send` bound.
+struct ProbeSet<'a, const BS: usize> {
+    futures: Vec<ProbeFuture<'a, BS>>,
+}
+
+impl<'a, const BS: usize> ProbeSet<'a, BS> {
+    const fn new() -> Self {
+        Self {
+            futures: Vec::new(),
+        }
+    }
+
+    fn push(&mut self, fut: ProbeFuture<'a, BS>) {
+        self.futures.push(fut);
+    }
+
+    fn is_empty(&self) -> bool {
+        self.futures.is_empty()
+    }
+
+    /// Drive the set to the next completed probe, or `None` when empty. A probe
+    /// that hit a store error yields that error for the caller to propagate.
+    async fn next(&mut self) -> Option<Result<Probe<BS>>> {
+        if self.is_empty() {
+            return None;
+        }
+        core::future::poll_fn(|cx| {
+            let mut i = 0;
+            while i < self.futures.len() {
+                match self.futures[i].as_mut().poll(cx) {
+                    Poll::Ready(probe) => {
+                        // Drop the completed future; its result is in `probe`.
+                        drop(self.futures.swap_remove(i));
+                        return Poll::Ready(Some(probe));
+                    }
+                    Poll::Pending => i += 1,
+                }
+            }
+            Poll::Pending
+        })
+        .await
+    }
+}
+
+/// Concurrent epoch finder.
+///
+/// Descends the `child_at(at)` chain from the root, firing a store get at every
+/// epoch on the path concurrently through a self-contained [`ProbeSet`]. Per
+/// path it tracks the deepest found epoch and the deepest not-found epoch; once
+/// a found epoch sits one level above a not-found epoch the answer is
+/// bracketed. Stale in-flight gets are dropped by marking their path cancelled
+/// and ignoring their results. No timer or runtime assumption is made and no
+/// `Send` bound is imposed, so this drives on any executor including
+/// single-threaded wasm.
+async fn find_latest_concurrent<const BS: usize, G: ChunkGet<BS>>(
+    feed: &Feed<BS>,
+    store: &G,
+    at: u64,
+) -> Result<Option<FeedUpdate<Epoch, BS>>> {
+    let mut paths: Vec<Path<BS>> = Vec::new();
+    let mut inflight: ProbeSet<'_, BS> = ProbeSet::new();
+
+    // Spawn the descent chain for `path_idx` starting at `start`.
+    fn spawn_chain<'a, const BS: usize, G: ChunkGet<BS>>(
+        feed: &'a Feed<BS>,
+        store: &'a G,
+        inflight: &mut ProbeSet<'a, BS>,
+        path_idx: usize,
+        at: u64,
+        start: Epoch,
+    ) {
+        let mut e = start;
+        loop {
+            inflight.push(Box::pin(async move {
+                // A genuine miss is absence; a real store error propagates.
+                let update = match get_epoch(feed, store, e).await? {
+                    // Found but published in the future is treated as absence.
+                    Some(u) if e.timestamp() <= at => Some(u),
+                    _ => None,
+                };
+                Ok(Probe {
+                    path: path_idx,
+                    epoch: e,
+                    update,
+                })
+            }));
+            if e.level == 0 {
+                break;
+            }
+            e = e.child_at(at);
+        }
+    }
+
+    paths.push(Path::new());
+    spawn_chain(feed, store, &mut inflight, 0, at, Epoch::ROOT);
+
+    while let Some(probe) = inflight.next().await {
+        let probe = probe?;
+        let path = &mut paths[probe.path];
+        if path.cancelled {
+            continue;
+        }
+
+        match probe.update {
+            Some(update) => {
+                if probe.epoch.level == 0 {
+                    return Ok(Some(update));
+                }
+                // Ignore a shallower find than the deepest already seen.
+                if let Some((top_epoch, _)) = &path.top
+                    && top_epoch.level <= probe.epoch.level
+                {
+                    continue;
+                }
+                path.top = Some((probe.epoch, update));
+            }
+            None => {
+                if probe.epoch.level == MAX_LEVEL {
+                    path.cancelled = true;
+                    return Ok(None);
+                }
+                match &path.bottom {
+                    Some(b) if b.level >= probe.epoch.level => {}
+                    _ => path.bottom = Some(probe.epoch),
+                }
+            }
+        }
+
+        // Bracketed: a found epoch directly above a not-found epoch.
+        let (top_level, bottom) = match (&paths[probe.path].top, paths[probe.path].bottom) {
+            (Some((te, _)), Some(be)) => (te.level, be),
+            _ => continue,
+        };
+        if top_level == bottom.level + 1 {
+            paths[probe.path].cancelled = true;
+            if bottom.is_left() {
+                let top = paths[probe.path].top.take().map(|(_, u)| u);
+                return Ok(top);
+            }
+            // Recurse on a fresh path through the left sister, carrying the
+            // found update forward as the new path's top.
+            let carried = paths[probe.path].top.take();
+            let new_at = bottom.start - 1;
+            let new_idx = paths.len();
+            let mut new_path = Path::new();
+            new_path.top = carried;
+            paths.push(new_path);
+            spawn_chain(feed, store, &mut inflight, new_idx, new_at, bottom.left());
+        }
+    }
+
+    Ok(None)
+}
+
+/// The largest representable lookup target on the grid: the span of the root
+/// epoch minus one, the last second the root `{0, 32}` covers.
+///
+/// Used as the lookup target when a caller asks for the latest update without
+/// naming a time (`at = None`). A search at the top of the grid tracks the most
+/// recent published epoch. No system clock is read in this crate; a caller that
+/// wants "live at a specific moment" passes that moment through
+/// [`FeedReader::find_at`](crate::FeedReader::find_at).
+const GRID_MAX_TIME: u64 = (1u64 << MAX_LEVEL) - 1;
+
+impl Epoch {
+    /// Find the latest update at an explicit target time `at`, using the
+    /// concurrent grid walk.
+    ///
+    /// `after` is an advisory lower-bound hint (an epoch start, `0` for none).
+    /// The concurrent path may ignore it: it re-walks from the grid root rather
+    /// than starting the descent above `after`. The sequential counterpart
+    /// honours the hint to prune its walk. For a well-formed hint (one that
+    /// names a position at or before the answer) both paths resolve to the same
+    /// update; the hint only ever changes how much of the grid is probed, never
+    /// the result.
+    ///
+    /// Precondition: `at` must be within the representable grid, i.e.
+    /// `at <= (1 << 32) - 1` (the span of the root epoch `{0, 32}`, around the
+    /// year 2106 in Unix seconds). A target above the root epoch span has its
+    /// high time bits silently masked off by the `child_at` descent and resolves
+    /// against a partially covered grid rather than failing, so callers must not
+    /// pass an out-of-grid timestamp.
+    ///
+    /// This is the time-parameterised entry the grid search needs;
+    /// [`LatestFinder::find_latest`] forwards a caller-supplied target here.
+    /// Both finders resolve to the same update for a given `at`; the concurrent
+    /// walk is the primary path.
+    pub(crate) async fn find_at<const BS: usize, G: ChunkGet<BS>>(
+        feed: &Feed<BS>,
+        store: &G,
+        at: u64,
+        after: u64,
+    ) -> Result<Option<FeedUpdate<Self, BS>>> {
+        debug_assert!(
+            at <= GRID_MAX_TIME,
+            "find_at target {at} exceeds the representable grid (GRID_MAX_TIME); high time bits are silently masked off by the descent",
+        );
+        let _ = after;
+        find_latest_concurrent(feed, store, at).await
+    }
+
+    /// Find the latest update at `at` via the sequential grid walk.
+    ///
+    /// The single-probe walk: ancestors first, then a descent. `after` is an
+    /// advisory lower-bound hint (an epoch start) that this path honours to
+    /// prune its walk. It resolves identically to [`find_at`](Self::find_at) and
+    /// exists as the allocation-free counterpart the finder-behaviour tests
+    /// cross-check the concurrent path against, so it compiles only under test.
+    #[cfg(test)]
+    pub(crate) async fn find_at_sequential<const BS: usize, G: ChunkGet<BS>>(
+        feed: &Feed<BS>,
+        store: &G,
+        at: u64,
+        after: u64,
+    ) -> Result<Option<FeedUpdate<Self, BS>>> {
+        find_latest_sequential(feed, store, at, after).await
+    }
+}
+
+impl LatestFinder for Epoch {
+    fn find_latest<const BS: usize, G: ChunkGet<BS>>(
+        feed: &Feed<BS>,
+        store: &G,
+        at: Option<u64>,
+        after: Option<&Self>,
+    ) -> impl core::future::Future<Output = Result<Option<FeedUpdate<Self, BS>>>> {
+        // `after` is an advisory lower-bound hint expressed as an epoch; its
+        // start time is the floor. The concurrent (primary) path may ignore it
+        // and re-walk from the grid root; the sequential path honours it to
+        // prune. With no hint the search runs from the root (`after = 0`).
+        let after_time = after.map(|e| e.start).unwrap_or(0);
+        // No clock is read here: with no caller-supplied target the search runs
+        // at the top of the grid and tracks the most recent published epoch.
+        let at = at.unwrap_or(GRID_MAX_TIME);
+        async move { Self::find_at(feed, store, at, after_time).await }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_signer_local::PrivateKeySigner;
+    use nectar_primitives::DEFAULT_BODY_SIZE;
+    use nectar_primitives::DefaultContentChunk;
+    use nectar_primitives::chunk::{AnyChunk, Chunk, ChunkAddress, SingleOwnerChunk};
+    use nectar_primitives::store::{ChunkStoreError, SyncChunkGet, SyncChunkPut};
+
+    use super::*;
+    use crate::FeedError;
+    use crate::topic::Topic;
+
+    /// A single-update feed resolves to that update at and after its publish
+    /// time on both finders. The first update lands on the root epoch.
+    #[tokio::test]
+    async fn finder_single_update() {
+        let signer = PrivateKeySigner::random();
+        let owner = signer.address();
+        let feed = Feed::<DEFAULT_BODY_SIZE>::new(Topic::from_bytes(b"testtopic"), owner);
+        let store = nectar_primitives::store::MemoryStore::<DEFAULT_BODY_SIZE>::new();
+
+        let at = 123_456u64;
+        let cursor = EpochCursor::new();
+        let epoch = cursor.index_for(Some(at));
+        assert_eq!(epoch, Epoch::ROOT, "first update lands on the root epoch");
+
+        let id = feed.update_id(&epoch);
+        let soc =
+            SingleOwnerChunk::<DEFAULT_BODY_SIZE>::new(id, at.to_be_bytes().to_vec(), &signer)
+                .expect("build soc");
+        assert_eq!(soc.address(), &feed.update_address(&epoch));
+        SyncChunkPut::put(&store, soc.into()).expect("put");
+
+        for query in [at, at + 1, at * 2] {
+            let found = Epoch::find_at(&feed, &store, query, 0)
+                .await
+                .expect("concurrent find")
+                .expect("update present");
+            assert_eq!(found.chunk().id(), id, "concurrent at {query}");
+
+            let found_seq = Epoch::find_at_sequential(&feed, &store, query, 0)
+                .await
+                .expect("sequential find")
+                .expect("update present");
+            assert_eq!(found_seq.chunk().id(), id, "sequential at {query}");
+        }
+    }
+
+    /// Publish updates at strictly increasing timestamps, then assert both
+    /// finders resolve to the latest published update for any query at or after
+    /// the last publish time. An empty feed resolves to no update.
+    #[tokio::test]
+    async fn finder_resolves_latest_update() {
+        let signer = PrivateKeySigner::random();
+        let owner = signer.address();
+        let feed = Feed::<DEFAULT_BODY_SIZE>::new(Topic::from_bytes(b"testtopic"), owner);
+        let store = nectar_primitives::store::MemoryStore::<DEFAULT_BODY_SIZE>::new();
+
+        let times: [u64; 5] = [5, 9, 17, 100, 1000];
+        let mut cursor = EpochCursor::new();
+        let mut last_epoch = Epoch::ROOT;
+
+        for &at in &times {
+            let epoch = cursor.index_for(Some(at));
+            let id = feed.update_id(&epoch);
+            let soc =
+                SingleOwnerChunk::<DEFAULT_BODY_SIZE>::new(id, at.to_be_bytes().to_vec(), &signer)
+                    .expect("build soc");
+            assert_eq!(soc.address(), &feed.update_address(&epoch));
+            SyncChunkPut::put(&store, soc.into()).expect("put");
+            cursor.record(&epoch, Some(at));
+            last_epoch = epoch;
+        }
+
+        let expected_id = feed.update_id(&last_epoch);
+        for query in [*times.last().unwrap(), 2000, 100_000] {
+            let found = Epoch::find_at(&feed, &store, query, 0)
+                .await
+                .expect("concurrent find")
+                .expect("update present");
+            assert_eq!(
+                found.chunk().id(),
+                expected_id,
+                "concurrent finder at {query} did not resolve the latest update",
+            );
+
+            let found_seq = Epoch::find_at_sequential(&feed, &store, query, 0)
+                .await
+                .expect("sequential find")
+                .expect("update present");
+            assert_eq!(
+                found_seq.chunk().id(),
+                expected_id,
+                "sequential finder at {query} did not resolve the latest update",
+            );
+        }
+
+        let empty_feed = Feed::<DEFAULT_BODY_SIZE>::new(Topic::from_bytes(b"empty"), owner);
+        assert!(
+            Epoch::find_at(&empty_feed, &store, 1000, 0)
+                .await
+                .expect("concurrent find on empty")
+                .is_none(),
+        );
+        assert!(
+            Epoch::find_at_sequential(&empty_feed, &store, 1000, 0)
+                .await
+                .expect("sequential find on empty")
+                .is_none(),
+        );
+    }
+
+    /// A store that always returns one planted chunk for any address, modelling
+    /// a backend that substitutes a foreign or mis-addressed chunk for an epoch
+    /// slot.
+    struct SubstitutingStore {
+        chunk: AnyChunk<DEFAULT_BODY_SIZE>,
+    }
+
+    impl SyncChunkGet<DEFAULT_BODY_SIZE> for SubstitutingStore {
+        type Error = ChunkStoreError;
+
+        fn get(
+            &self,
+            _address: &ChunkAddress,
+        ) -> core::result::Result<AnyChunk<DEFAULT_BODY_SIZE>, Self::Error> {
+            Ok(self.chunk.clone())
+        }
+    }
+
+    /// A foreign-owner single-owner chunk returned for an epoch slot is rejected
+    /// on the owner check by both epoch finders.
+    #[tokio::test]
+    async fn epoch_foreign_owner_chunk_is_rejected_with_owner_mismatch() {
+        let owner_signer = PrivateKeySigner::random();
+        let owner = owner_signer.address();
+        let feed = Feed::<DEFAULT_BODY_SIZE>::new(Topic::from_bytes(b"epoch-owner-check"), owner);
+
+        let foreign = PrivateKeySigner::random();
+        assert_ne!(
+            foreign.address(),
+            owner,
+            "foreign signer differs from owner"
+        );
+
+        let id = feed.update_id(&Epoch::ROOT);
+        let foreign_soc =
+            SingleOwnerChunk::<DEFAULT_BODY_SIZE>::new(id, b"forged".to_vec(), &foreign)
+                .expect("build foreign soc");
+        let store = SubstitutingStore {
+            chunk: foreign_soc.into(),
+        };
+
+        for which in ["concurrent", "sequential"] {
+            let result = if which == "concurrent" {
+                Epoch::find_at(&feed, &store, 1000, 0).await
+            } else {
+                Epoch::find_at_sequential(&feed, &store, 1000, 0).await
+            };
+            match result {
+                Err(FeedError::OwnerMismatch { expected, actual }) => {
+                    assert_eq!(expected, owner);
+                    assert_eq!(actual, foreign.address());
+                }
+                other => panic!("{which} finder must reject a foreign owner, got {other:?}"),
+            }
+        }
+    }
+
+    /// A content-addressed (non-SOC) chunk returned for an epoch slot is
+    /// rejected on the SOC discrimination by both epoch finders.
+    #[tokio::test]
+    async fn epoch_content_chunk_is_rejected_as_not_single_owner() {
+        let owner_signer = PrivateKeySigner::random();
+        let owner = owner_signer.address();
+        let feed = Feed::<DEFAULT_BODY_SIZE>::new(Topic::from_bytes(b"epoch-cac-check"), owner);
+
+        let cac = DefaultContentChunk::new(b"not a soc".to_vec()).expect("build cac");
+        let store = SubstitutingStore { chunk: cac.into() };
+
+        for which in ["concurrent", "sequential"] {
+            let result = if which == "concurrent" {
+                Epoch::find_at(&feed, &store, 1000, 0).await
+            } else {
+                Epoch::find_at_sequential(&feed, &store, 1000, 0).await
+            };
+            match result {
+                Err(FeedError::NotSingleOwner) => {}
+                other => panic!("{which} finder must reject a content chunk, got {other:?}"),
+            }
+        }
+    }
+
+    /// Address verification on the epoch read path: an owner-signed chunk whose
+    /// id is for a *different* epoch than the one queried must be rejected, not
+    /// silently accepted as the queried slot. The owner check alone passes (the
+    /// feed owner signed it); only `verify(&queried_address)`, which pins
+    /// `keccak256(id || owner)` to the queried slot, catches the substitution.
+    /// Exercises both finders.
+    #[tokio::test]
+    async fn epoch_owner_signed_wrong_epoch_chunk_is_rejected() {
+        let signer = PrivateKeySigner::random();
+        let owner = signer.address();
+        let feed = Feed::<DEFAULT_BODY_SIZE>::new(Topic::from_bytes(b"epoch-wrong-slot"), owner);
+
+        // The feed owner signs an update id derived from a level-1 epoch, but
+        // the store hands it back for every queried slot (including the root the
+        // finders probe first). Its address is `keccak256(Id(other_epoch) ||
+        // owner)`, which does not match the queried slot's address, so address
+        // verification must reject it.
+        let other_epoch = Epoch::new(2, 1);
+        let wrong_id = feed.update_id(&other_epoch);
+        let wrong_soc =
+            SingleOwnerChunk::<DEFAULT_BODY_SIZE>::new(wrong_id, b"wrong-slot".to_vec(), &signer)
+                .expect("build wrong-slot soc");
+        // Sanity: the chunk addresses to the other epoch, not the root slot the
+        // finders probe first.
+        assert_eq!(wrong_soc.address(), &feed.update_address(&other_epoch));
+        assert_ne!(wrong_soc.address(), &feed.update_address(&Epoch::ROOT));
+
+        let store = SubstitutingStore {
+            chunk: wrong_soc.into(),
+        };
+
+        for which in ["concurrent", "sequential"] {
+            let result = if which == "concurrent" {
+                Epoch::find_at(&feed, &store, 1000, 0).await
+            } else {
+                Epoch::find_at_sequential(&feed, &store, 1000, 0).await
+            };
+            assert!(
+                result.is_err(),
+                "{which} finder must reject an owner-signed chunk for a different epoch, got {result:?}",
+            );
+        }
+    }
+
+    /// A level-0 epoch is the finest grid resolution and has no child. Advancing
+    /// the cursor at the same second (a sub-second republish onto a level-0
+    /// epoch) must not panic or shift past the width of a `u64`; it returns a
+    /// defined level-0 epoch.
+    #[test]
+    fn level_zero_republish_floors_without_panic() {
+        let at = 1_700_000_000u64;
+
+        // Walk the cursor down to a level-0 epoch by republishing at the same
+        // second repeatedly; each step descends one level until it floors.
+        let mut cursor = EpochCursor::new();
+        let mut last = Epoch::ROOT;
+        for _ in 0..(MAX_LEVEL as usize + 4) {
+            let epoch = cursor.index_for(Some(at));
+            cursor.record(&epoch, Some(at));
+            last = epoch;
+        }
+        assert_eq!(
+            last.level, 0,
+            "republishing at one second floors at level 0"
+        );
+
+        // The level-0 epoch contains the second and spans exactly one second.
+        assert_eq!(last.length(), 1);
+        assert!(last.start <= at && at < last.start + last.length());
+
+        // next() on a level-0 epoch returns it unchanged rather than
+        // underflowing the level.
+        let floored = Epoch::next(Some(last), at, at);
+        assert_eq!(floored, last, "next on a level-0 epoch is the epoch itself");
+
+        // child_at on a level-0 epoch floors to the same epoch.
+        assert_eq!(last.child_at(at), last);
+
+        // length() never shifts past the width of a u64 for an out-of-grid level.
+        assert_eq!(Epoch::new(0, 64).length(), u64::MAX);
+        assert_eq!(Epoch::new(0, 200).length(), u64::MAX);
+    }
+}

--- a/crates/feeds/src/error.rs
+++ b/crates/feeds/src/error.rs
@@ -1,0 +1,83 @@
+//! Error types for feed operations.
+
+use alloc::sync::Arc;
+
+use alloy_primitives::Address;
+use nectar_primitives::PrimitivesError;
+use nectar_primitives::chunk::ChunkAddress;
+
+/// Result type alias for feed operations.
+pub type Result<T> = core::result::Result<T, FeedError>;
+
+/// Errors that can occur while reading from or writing to a feed.
+///
+/// [`strum::IntoStaticStr`] gives every variant a stable snake_case label for
+/// metrics, with explicit overrides on the variants that wrap an upstream error
+/// so the label does not leak field names.
+#[derive(thiserror::Error, Debug, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+pub enum FeedError {
+    /// No update chunk was found at the expected address.
+    #[error("feed update not found at {address}")]
+    NotFound {
+        /// The address that was queried.
+        address: ChunkAddress,
+    },
+    /// The retrieved chunk is owned by an address other than the feed owner.
+    #[error("owner mismatch: expected {expected}, got {actual}")]
+    OwnerMismatch {
+        /// The expected feed owner.
+        expected: Address,
+        /// The owner recovered from the retrieved chunk.
+        actual: Address,
+    },
+    /// The retrieved chunk is not a single-owner chunk.
+    #[error("retrieved chunk is not a single-owner chunk")]
+    NotSingleOwner,
+    /// The index space for this feed scheme is exhausted.
+    #[error("feed index exhausted")]
+    IndexExhausted,
+    /// An index could not be parsed or is out of range.
+    #[error("invalid index: {0}")]
+    InvalidIndex(&'static str),
+    /// Error from primitives (chunk creation, signing, BMT, etc.).
+    #[error(transparent)]
+    #[strum(serialize = "primitives")]
+    Primitives(#[from] PrimitivesError),
+    /// Error from the typed chunk store during a get operation.
+    #[error("store get error: {source}")]
+    #[strum(serialize = "store_get")]
+    StoreGet {
+        /// Original store error, preserved for downcasting.
+        source: Arc<dyn core::error::Error + Send + Sync>,
+    },
+    /// Error from the typed chunk store during a put operation.
+    #[error("store put error: {source}")]
+    #[strum(serialize = "store_put")]
+    StorePut {
+        /// Original store error, preserved for downcasting.
+        source: Arc<dyn core::error::Error + Send + Sync>,
+    },
+}
+
+/// These two constructors exist instead of `#[from]` because both store
+/// variants ([`FeedError::StoreGet`] and [`FeedError::StorePut`]) wrap the same
+/// erased source type (`Arc<dyn Error + Send + Sync>`). A single blanket
+/// `#[from]` could not disambiguate which of the two variants to build, and the
+/// constructors are not trivial renames: each performs the `Arc::new` erasure
+/// from a concrete store error into the trait object.
+impl FeedError {
+    /// Wrap a chunk store get error.
+    pub fn store_get<E: core::error::Error + Send + Sync + 'static>(source: E) -> Self {
+        Self::StoreGet {
+            source: Arc::new(source),
+        }
+    }
+
+    /// Wrap a chunk store put error.
+    pub fn store_put<E: core::error::Error + Send + Sync + 'static>(source: E) -> Self {
+        Self::StorePut {
+            source: Arc::new(source),
+        }
+    }
+}

--- a/crates/feeds/src/feed.rs
+++ b/crates/feeds/src/feed.rs
@@ -1,0 +1,62 @@
+//! Feed identity and address derivation.
+
+use alloy_primitives::{Address, B256, Keccak256};
+use nectar_primitives::DEFAULT_BODY_SIZE;
+use nectar_primitives::chunk::ChunkAddress;
+
+use crate::index::Index;
+use crate::topic::Topic;
+
+/// A feed: the `{ topic, owner }` pair that names a mutable sequence of
+/// owner-signed updates.
+///
+/// Every update lives at a deterministic single-owner chunk address derived
+/// from the feed identity and an [`Index`]:
+///
+/// - `id = keccak256(topic || index.marshal())`
+/// - `address = keccak256(id || owner)`
+///
+/// The body size `BS` is carried so address derivation and the reader/writer
+/// agree on the chunk geometry, though feed addressing itself does not depend
+/// on the body bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Feed<const BS: usize = DEFAULT_BODY_SIZE> {
+    topic: Topic,
+    owner: Address,
+}
+
+impl<const BS: usize> Feed<BS> {
+    /// Create a feed from its topic and owner.
+    pub const fn new(topic: Topic, owner: Address) -> Self {
+        Self { topic, owner }
+    }
+
+    /// The feed topic.
+    pub const fn topic(&self) -> Topic {
+        self.topic
+    }
+
+    /// The feed owner.
+    pub const fn owner(&self) -> Address {
+        self.owner
+    }
+
+    /// The single-owner chunk id for an update at `index`:
+    /// `keccak256(topic || index.marshal())`.
+    pub fn update_id<I: Index>(&self, index: &I) -> B256 {
+        let mut hasher = Keccak256::new();
+        hasher.update(self.topic.as_ref());
+        hasher.update(index.marshal().as_ref());
+        hasher.finalize()
+    }
+
+    /// The single-owner chunk address for an update at `index`:
+    /// `keccak256(update_id || owner)`.
+    pub fn update_address<I: Index>(&self, index: &I) -> ChunkAddress {
+        let mut hasher = Keccak256::new();
+        hasher.update(self.update_id(index));
+        hasher.update(self.owner.as_slice());
+        ChunkAddress::from(hasher.finalize())
+    }
+}

--- a/crates/feeds/src/index.rs
+++ b/crates/feeds/src/index.rs
@@ -1,0 +1,102 @@
+//! Feed indexing traits.
+//!
+//! A feed scheme is defined by three traits:
+//!
+//! - [`Index`] turns a position into the bytes mixed into the update id. It is
+//!   deliberately minimal: it marshals to bytes and names a first position, and
+//!   nothing else. There is no `next`, because choosing the next position is the
+//!   cursor's job.
+//! - [`WriteCursor`] is the stateful write head. It is a separate type from the
+//!   index so that schemes which need history to place the next update (the
+//!   epoch scheme needs the previous update time) have somewhere to keep it. A
+//!   time-indexed scheme must derive the publish index from the new update's
+//!   timestamp, so the cursor chooses the index before the write
+//!   ([`index_for`](WriteCursor::index_for)) and records what was published
+//!   afterward ([`record`](WriteCursor::record)). The writer is generic over the
+//!   cursor and never inspects the scheme directly.
+//! - [`LatestFinder`] is the scheme-owned latest-update lookup. Rather than
+//!   exposing a generic probe iterator, each scheme implements its own async
+//!   search over a [`ChunkGet`], because the optimal walk differs per scheme
+//!   (linear for sequence, binary over the grid for epoch).
+
+use nectar_primitives::store::ChunkGet;
+
+use crate::error::Result;
+use crate::feed::Feed;
+use crate::update::FeedUpdate;
+
+/// A position within a feed.
+///
+/// The marshalled bytes are mixed into the update id as
+/// `keccak256(topic || index.marshal())`. Marshalling is **not** hashed; the
+/// raw bytes go straight into the id preimage, so the byte layout is wire
+/// conformance critical and must match the Swarm wire spec exactly.
+pub trait Index: Clone {
+    /// The wire bytes for this index, appended after the topic in the id
+    /// preimage. The sequence scheme uses 8 big-endian bytes.
+    fn marshal(&self) -> impl AsRef<[u8]>;
+
+    /// The first index in the scheme (e.g. sequence number zero).
+    fn first() -> Self;
+}
+
+/// A stateful write head over a feed scheme.
+///
+/// The cursor owns whatever state a scheme needs to choose the next publish
+/// index. A write is two steps: [`index_for`](WriteCursor::index_for) computes
+/// the index to publish at from the cursor's history and the new update's
+/// timestamp `at`, then [`record`](WriteCursor::record) folds the published
+/// index and timestamp back into the cursor. Splitting selection from recording
+/// lets a time-indexed scheme derive the index from `at` (which a single
+/// "advance after write" step could not), and lets the writer drive the cursor
+/// through `&self` then `&mut self` without moving it out.
+///
+/// `at` is the update's timestamp in Unix seconds. Time-indexed schemes use it;
+/// the sequence scheme ignores it.
+pub trait WriteCursor {
+    /// The index type this cursor produces.
+    type Index: Index;
+
+    /// The index to publish the next update at, given the new update's
+    /// timestamp `at` (when the scheme is time-indexed).
+    fn index_for(&self, at: Option<u64>) -> Self::Index;
+
+    /// Record that an update was published at `index` with timestamp `at`,
+    /// advancing the cursor so the following [`index_for`](Self::index_for)
+    /// reflects it.
+    fn record(&mut self, index: &Self::Index, at: Option<u64>);
+
+    /// Whether the scheme's index space is spent, so a further publish has no
+    /// valid index. The writer checks this before a publish and surfaces
+    /// [`crate::FeedError::IndexExhausted`] instead of producing a wrong index
+    /// or panicking. The default is `false`; an unbounded scheme never exhausts.
+    fn exhausted(&self) -> bool {
+        false
+    }
+}
+
+/// A scheme-owned search for the latest update in a feed.
+///
+/// Implemented on the index type itself: given a feed, a chunk store, an
+/// explicit target time `at`, and an optional lower bound (`after`, an index
+/// already known to exist), locate the most recent update at or before `at` and
+/// return it, or `None` if the feed is empty (or has no update past `after`).
+///
+/// The target time `at` is supplied by the caller, never read from a system
+/// clock inside this crate: a primitive must be deterministic and `no_std`/wasm
+/// clean. The sequence scheme ignores `at`; the epoch scheme uses it as the
+/// lookup target on the grid.
+///
+/// The search is async because it probes the store, and generic over the body
+/// size `BS` and the store `G` so a scheme works at any chunk size against any
+/// retrieval backend.
+pub trait LatestFinder: Index + Sized {
+    /// Find the latest update in `feed` at or before `at`, searching strictly
+    /// after `after` when it is `Some`.
+    fn find_latest<const BS: usize, G: ChunkGet<BS>>(
+        feed: &Feed<BS>,
+        store: &G,
+        at: Option<u64>,
+        after: Option<&Self>,
+    ) -> impl core::future::Future<Output = Result<Option<FeedUpdate<Self, BS>>>>;
+}

--- a/crates/feeds/src/lib.rs
+++ b/crates/feeds/src/lib.rs
@@ -1,0 +1,96 @@
+//! Swarm feeds over single-owner chunks.
+//!
+//! A feed is a mutable, owner-controlled sequence of updates published to
+//! deterministic single-owner chunk (SOC) addresses. A reader who knows the
+//! feed `topic` and `owner` can reconstruct every update address without any
+//! out-of-band coordination, because each update lives at a content address
+//! derived purely from the feed identity and an index.
+//!
+//! # Identity and addressing
+//!
+//! A [`Feed`] is the pair `{ topic, owner }`. For an update at some index `i`:
+//!
+//! - `id = keccak256(topic_bytes || index.marshal())`
+//! - `address = keccak256(id || owner)`
+//!
+//! The `id` is the SOC id and the `address` is the SOC (and therefore the
+//! network) address. The topic is used raw: callers that want a string topic
+//! must pre-hash it (see [`Topic::from_bytes`]). The index marshalling is
+//! scheme-specific and defined by the [`Index`] trait.
+//!
+//! # Schemes and versioning stance
+//!
+//! Two indexing schemes exist:
+//!
+//! - **Sequence** ([`Sequence`]): a monotonic big-endian `u64` counter. This is
+//!   the canonical scheme, used for append-only logs, and the one exercised on
+//!   the live network.
+//! - **Epoch** ([`Epoch`], behind the `epoch` cargo feature): a time-indexed
+//!   binary grid that supports efficient lookup of the update live at a given
+//!   timestamp. It is experimental and is not used on the live network; build
+//!   with `--features epoch` to opt in.
+//!
+//! Update payloads are V2 bare data: the published bytes are the update payload
+//! verbatim, with no envelope. The V1 legacy payload (a timestamp prefix
+//! followed by a reference) is not implemented here; reading it back is
+//! deferred to nectar issue #92. The mutable resource update (MRU) construct is
+//! not supported.
+//!
+//! Writing and latest-lookup are scheme-owned: a writer drives a stateful
+//! [`WriteCursor`], and the latest update is located by a scheme-specific
+//! [`LatestFinder`]. The cursor chooses the publish index from the new update's
+//! timestamp, which is what lets the time-indexed epoch scheme place an update
+//! on the grid. Both traits are generic over the body size and the chunk store
+//! traits so a scheme never reaches into the writer or reader internals. No
+//! clock is read inside this crate: a caller that wants the update live at a
+//! specific moment passes that time to [`FeedReader::find_at`].
+//!
+//! # Reading and writing
+//!
+//! - [`FeedWriter`] signs and publishes updates through a [`ChunkPut`].
+//! - [`FeedReader`] fetches updates through a [`ChunkGet`] and resolves the
+//!   latest update through a [`LatestFinder`].
+//!
+//! The convenience aliases [`SequenceFeedReader`] and [`SequenceFeedWriter`]
+//! pin the sequence scheme at [`DEFAULT_BODY_SIZE`].
+
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+extern crate alloc;
+
+mod error;
+mod feed;
+mod index;
+mod reader;
+mod sequence;
+mod topic;
+mod update;
+mod writer;
+
+#[cfg(feature = "epoch")]
+mod epoch;
+
+pub use error::{FeedError, Result};
+pub use feed::Feed;
+pub use index::{Index, LatestFinder, WriteCursor};
+pub use reader::FeedReader;
+pub use sequence::{Sequence, SequenceCursor};
+pub use topic::Topic;
+pub use update::FeedUpdate;
+pub use writer::FeedWriter;
+
+#[cfg(feature = "epoch")]
+pub use epoch::{Epoch, EpochCursor};
+
+// Re-export the store surface and a memory store so consumers can wire a feed
+// reader or writer without depending on `nectar-primitives` directly.
+pub use nectar_primitives::store::{ChunkGet, ChunkPut, MemoryStore};
+pub use nectar_primitives::{DEFAULT_BODY_SIZE, SingleOwnerChunk};
+
+/// A [`FeedReader`] using the sequence scheme at [`DEFAULT_BODY_SIZE`].
+pub type SequenceFeedReader<G> = FeedReader<Sequence, G, DEFAULT_BODY_SIZE>;
+
+/// A [`FeedWriter`] using the sequence scheme at [`DEFAULT_BODY_SIZE`].
+pub type SequenceFeedWriter<P, S> = FeedWriter<SequenceCursor, P, S, DEFAULT_BODY_SIZE>;

--- a/crates/feeds/src/reader.rs
+++ b/crates/feeds/src/reader.rs
@@ -1,0 +1,136 @@
+//! Feed reader: fetch and resolve updates.
+
+use core::marker::PhantomData;
+
+use nectar_primitives::chunk::{Chunk, ChunkAddress};
+use nectar_primitives::store::ChunkGet;
+
+use crate::error::{FeedError, Result};
+use crate::feed::Feed;
+use crate::index::{Index, LatestFinder};
+use crate::update::FeedUpdate;
+
+/// Fetch and resolve the update at `address` from `store` for `feed`.
+///
+/// Shared between [`FeedReader::get`] and every [`LatestFinder`] probe so the
+/// chunk-to-update resolution (single-owner decode, address verification, owner
+/// check) lives in exactly one place.
+///
+/// A store get that the backend classifies as a genuine miss (via
+/// [`ChunkGet::is_not_found`]) resolves to `Ok(None)`, the empty-slot signal a
+/// finder walks past. Every other store error propagates as
+/// [`FeedError::StoreGet`]; it is never folded into absence.
+pub(crate) async fn fetch_update<I: Index, G: ChunkGet<BS>, const BS: usize>(
+    feed: &Feed<BS>,
+    store: &G,
+    index: I,
+    address: &ChunkAddress,
+) -> Result<Option<FeedUpdate<I, BS>>> {
+    let chunk = match store.get(address).await {
+        Ok(chunk) => chunk,
+        Err(err) if store.is_not_found(&err) => return Ok(None),
+        Err(err) => return Err(FeedError::store_get(err)),
+    };
+    let soc = chunk.into_single_owner().ok_or(FeedError::NotSingleOwner)?;
+
+    // Recover the signer and compare it to the feed owner before integrity
+    // verification. A single-owner chunk addresses as `keccak256(id || owner)`,
+    // so a chunk a backend hands back for this address whose recovered owner is
+    // not the feed owner is a deliberate substitution; surface it as an owner
+    // mismatch rather than letting the downstream address check report a generic
+    // verification failure.
+    let owner = soc.owner().map_err(|e| FeedError::Primitives(e.into()))?;
+    if owner != feed.owner() {
+        return Err(FeedError::OwnerMismatch {
+            expected: feed.owner(),
+            actual: owner,
+        });
+    }
+
+    // Owner matches: verify the chunk is internally consistent and addresses to
+    // the queried slot (id, span, and any dispersed-replica constraints).
+    soc.verify(address)?;
+    Ok(Some(FeedUpdate::new(index, soc)))
+}
+
+/// Reads updates from a feed.
+///
+/// Generic over the index type `I`, the chunk store `G` updates are fetched
+/// through, and the body size `BS`. [`get`](FeedReader::get) fetches a known
+/// index; [`latest`](FeedReader::latest) and [`find_at`](FeedReader::find_at)
+/// resolve the most recent update via the scheme's [`LatestFinder`].
+#[derive(Debug)]
+pub struct FeedReader<I, G, const BS: usize> {
+    feed: Feed<BS>,
+    store: G,
+    _index: PhantomData<fn() -> I>,
+}
+
+impl<I, G, const BS: usize> FeedReader<I, G, BS>
+where
+    I: Index,
+    G: ChunkGet<BS>,
+{
+    /// Create a reader for `feed`, fetching through `store`.
+    pub const fn new(feed: Feed<BS>, store: G) -> Self {
+        Self {
+            feed,
+            store,
+            _index: PhantomData,
+        }
+    }
+
+    /// The feed this reader reads from.
+    pub const fn feed(&self) -> &Feed<BS> {
+        &self.feed
+    }
+
+    /// Fetch the update at `index`.
+    ///
+    /// Returns [`crate::FeedError::NotFound`] if no chunk exists at the derived
+    /// address, [`crate::FeedError::NotSingleOwner`] if the stored chunk is not
+    /// a single-owner chunk, and [`crate::FeedError::OwnerMismatch`] if it is
+    /// signed by an address other than the feed owner.
+    pub async fn get(&self, index: &I) -> Result<FeedUpdate<I, BS>> {
+        let address = self.feed.update_address(index);
+        fetch_update(&self.feed, &self.store, index.clone(), &address)
+            .await?
+            .ok_or(FeedError::NotFound { address })
+    }
+
+    /// Resolve the latest update, searching strictly after `after` when given.
+    ///
+    /// `after` is an exclusive floor: it names an index already known to exist,
+    /// and the search begins at the slot immediately above it.
+    ///
+    /// This is the sequence-style entry that has no time target (`at = None`).
+    /// For a time-indexed scheme that needs to search at a specific moment, use
+    /// [`find_at`](Self::find_at) and pass the clock-derived target.
+    ///
+    /// Returns `Ok(None)` for an empty feed (or one with no update past
+    /// `after`). Available only when the index scheme implements
+    /// [`LatestFinder`].
+    pub async fn latest(&self, after: Option<&I>) -> Result<Option<FeedUpdate<I, BS>>>
+    where
+        I: LatestFinder,
+    {
+        I::find_latest(&self.feed, &self.store, None, after).await
+    }
+
+    /// Resolve the update live at the explicit target time `at`, searching
+    /// strictly after `after` when given.
+    ///
+    /// The caller supplies the target time (this crate never reads a system
+    /// clock), so a time-indexed scheme like the epoch grid can be searched
+    /// deterministically. A scheme that does not index by time ignores `at`.
+    ///
+    /// Returns `Ok(None)` for an empty feed (or one with no update at or before
+    /// `at` past `after`). Available only when the index scheme implements
+    /// [`LatestFinder`].
+    pub async fn find_at(&self, at: u64, after: Option<&I>) -> Result<Option<FeedUpdate<I, BS>>>
+    where
+        I: LatestFinder,
+    {
+        I::find_latest(&self.feed, &self.store, Some(at), after).await
+    }
+}

--- a/crates/feeds/src/sequence.rs
+++ b/crates/feeds/src/sequence.rs
@@ -1,0 +1,578 @@
+//! Sequence feed scheme: a monotonic big-endian `u64` counter.
+//!
+//! The default feed scheme. Updates are appended at sequence numbers
+//! `0, 1, 2, ...`; the index marshals to 8 big-endian bytes (never hashed)
+//! mixed into the update id. Latest-lookup walks forward from a known floor.
+
+use futures::stream::{FuturesUnordered, StreamExt};
+use nectar_primitives::store::ChunkGet;
+
+use crate::error::Result;
+use crate::feed::Feed;
+use crate::index::{Index, LatestFinder, WriteCursor};
+use crate::reader::fetch_update;
+use crate::update::FeedUpdate;
+
+/// The number of concurrent lookaheads the async finder launches per interval.
+///
+/// A level `l` probes the offset `2^l - 1` from the interval base, so eight
+/// levels span `2^8` updates per round of concurrent gets.
+const DEFAULT_LEVELS: u32 = 8;
+
+/// A sequence index: a monotonic `u64` counter.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, derive_more::From, derive_more::Into,
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct Sequence(pub u64);
+
+impl Sequence {
+    /// The sequence number.
+    pub const fn get(&self) -> u64 {
+        self.0
+    }
+}
+
+impl Index for Sequence {
+    fn marshal(&self) -> impl AsRef<[u8]> {
+        self.0.to_be_bytes()
+    }
+
+    fn first() -> Self {
+        Self(0)
+    }
+}
+
+/// The write head for the sequence scheme: the next sequence number to publish.
+///
+/// The cursor ignores the update timestamp and increments a monotonic counter.
+/// When the last published index is `u64::MAX` the counter has no successor; the
+/// cursor reports itself [`exhausted`](WriteCursor::exhausted) so the writer
+/// surfaces [`crate::FeedError::IndexExhausted`] rather than wrapping or
+/// panicking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct SequenceCursor {
+    /// The next sequence number to publish, or `None` once the space is spent.
+    next: Option<u64>,
+}
+
+impl SequenceCursor {
+    /// A cursor starting at sequence number zero.
+    pub const fn new() -> Self {
+        Self { next: Some(0) }
+    }
+
+    /// A cursor starting at a specific sequence number.
+    pub const fn at(next: u64) -> Self {
+        Self { next: Some(next) }
+    }
+}
+
+impl WriteCursor for SequenceCursor {
+    type Index = Sequence;
+
+    fn index_for(&self, _at: Option<u64>) -> Self::Index {
+        // On an exhausted cursor the writer short-circuits on `exhausted()`
+        // before reaching here; `u64::MAX` is a defensive fallback.
+        Sequence(self.next.unwrap_or(u64::MAX))
+    }
+
+    fn record(&mut self, index: &Self::Index, _at: Option<u64>) {
+        // `None` once the published index has no successor; the next publish
+        // then trips `exhausted()` in the writer.
+        self.next = index.0.checked_add(1);
+    }
+
+    fn exhausted(&self) -> bool {
+        self.next.is_none()
+    }
+}
+
+impl LatestFinder for Sequence {
+    fn find_latest<const BS: usize, G: ChunkGet<BS>>(
+        feed: &Feed<BS>,
+        store: &G,
+        at: Option<u64>,
+        after: Option<&Self>,
+    ) -> impl core::future::Future<Output = Result<Option<FeedUpdate<Self, BS>>>> {
+        // The sequence scheme is not time-indexed: the latest update is the
+        // highest present counter, independent of any target time.
+        let _ = at;
+        // `after` is an index already known to exist, so the first candidate is
+        // the slot immediately above it; with no hint the search starts at zero.
+        let from = after.map_or(0, |a| a.0.saturating_add(1));
+        find_latest_async(feed, store, from)
+    }
+}
+
+/// Probe the update at sequence `idx`.
+///
+/// A genuine store miss resolves to `Ok(None)` (the floor of the feed);
+/// [`fetch_update`] classifies that through [`ChunkGet::is_not_found`]. Every
+/// other error propagates so the search surfaces a backend failure rather than
+/// mistaking it for the end of the feed.
+async fn probe<const BS: usize, G: ChunkGet<BS>>(
+    feed: &Feed<BS>,
+    store: &G,
+    idx: u64,
+) -> Result<Option<FeedUpdate<Sequence, BS>>> {
+    let address = feed.update_address(&Sequence(idx));
+    fetch_update(feed, store, Sequence(idx), &address).await
+}
+
+/// Linear baseline scan from `from` upward.
+///
+/// Walks one slot at a time: the first miss stops the scan and the last present
+/// chunk is the latest. Returns `(latest, current, next)` where `current` is the
+/// index of the last present update (or `None` if `from` itself is missing) and
+/// `next` is the first missing index. This is the simple, allocation-free
+/// definition the concurrent finder is measured against.
+#[cfg(test)]
+async fn find_latest_linear<const BS: usize, G: ChunkGet<BS>>(
+    feed: &Feed<BS>,
+    store: &G,
+    from: u64,
+) -> Result<(Option<FeedUpdate<Sequence, BS>>, Option<Sequence>, Sequence)> {
+    let mut latest = None;
+    let mut current = None;
+    let mut idx = from;
+    loop {
+        match probe(feed, store, idx).await? {
+            Some(update) => {
+                latest = Some(update);
+                current = Some(Sequence(idx));
+                idx += 1;
+            }
+            None => return Ok((latest, current, Sequence(idx))),
+        }
+    }
+}
+
+/// A single probe outcome collected from a concurrent interval round: the level
+/// within the interval, the absolute sequence index, and the update if present.
+struct Probe<const BS: usize> {
+    level: u32,
+    index: u64,
+    update: Option<FeedUpdate<Sequence, BS>>,
+}
+
+/// The highest level at which an update was found within the current interval.
+struct Found<const BS: usize> {
+    level: u32,
+    index: u64,
+    update: FeedUpdate<Sequence, BS>,
+}
+
+/// Async exponential-then-binary latest-update search.
+///
+/// Probes the interval base first; if it is absent the feed has no update at or
+/// past the search floor, so the latest is `None`. Otherwise it launches
+/// `DEFAULT_LEVELS` concurrent gets at offsets `base + (2^l - 1)` for descending
+/// levels, tracking the highest found level and the lowest not-found level with
+/// stale-result guards. When those two levels meet, a level-0 match is the
+/// answer and any higher match brackets the latest into a sub-interval that is
+/// searched the same way. A match at a sub-interval's maximum level proves the
+/// very next slot is empty, so the search can return immediately.
+async fn find_latest_async<const BS: usize, G: ChunkGet<BS>>(
+    feed: &Feed<BS>,
+    store: &G,
+    from: u64,
+) -> Result<Option<FeedUpdate<Sequence, BS>>> {
+    // Probe the base of the search. Absent base means an empty feed (or nothing
+    // past the hint), matching the linear scan's `from` miss.
+    let Some(base_update) = probe(feed, store, from).await? else {
+        return Ok(None);
+    };
+
+    let mut base = from;
+    // The maximum level to probe within the current interval. The top-level
+    // interval always uses the full `DEFAULT_LEVELS` lookahead; sub-intervals
+    // narrow it to the bracket that contains the latest update.
+    let mut level = DEFAULT_LEVELS;
+    let mut not_found = DEFAULT_LEVELS;
+    let mut found = Found {
+        level: 0,
+        index: base,
+        update: base_update,
+    };
+
+    loop {
+        // Launch concurrent gets across the interval at descending levels.
+        let mut round = FuturesUnordered::new();
+        for l in (1..=level).rev() {
+            // A probe offset past `u64::MAX` cannot address a real slot, so skip
+            // out-of-range levels rather than overflowing the add. The probe
+            // space is naturally bounded once a slot misses, so the search still
+            // converges on the highest present index.
+            let Some(index) = base.checked_add((1u64 << l) - 1) else {
+                continue;
+            };
+            round.push(async move {
+                let update = probe(feed, store, index).await?;
+                Ok::<_, crate::FeedError>(Probe {
+                    level: l,
+                    index,
+                    update,
+                })
+            });
+        }
+
+        let mut bracket = None;
+        while let Some(result) = round.next().await {
+            let Probe {
+                level: l,
+                index,
+                update,
+            } = result?;
+            match update {
+                None => {
+                    // Ignore a miss above an already-recorded miss: the lower
+                    // not-found level is the tighter bound.
+                    if not_found < l {
+                        continue;
+                    }
+                    not_found = l - 1;
+                }
+                Some(update) => {
+                    // Ignore a hit below the highest found level: a higher level
+                    // already proved a later update exists.
+                    if found.level > l {
+                        continue;
+                    }
+                    // A hit at the interval's maximum level inside a sub-interval
+                    // proves `index + 1` is empty (the parent interval already
+                    // bounded the latest below the next level), so return now.
+                    if level == l && l < DEFAULT_LEVELS {
+                        return Ok(Some(update));
+                    }
+                    found = Found {
+                        level: l,
+                        index,
+                        update,
+                    };
+                }
+            }
+
+            // Found and not-found levels meet: the latest is bracketed.
+            if found.level == not_found {
+                if found.level == 0 {
+                    // The base of this interval is itself the latest update.
+                    bracket = Some(Bracket::Done);
+                } else {
+                    // Recurse into the sub-interval rooted at the latest hit.
+                    bracket = Some(Bracket::Recurse);
+                }
+                break;
+            }
+
+            // Inconsistent feed: a miss landed below a confirmed hit. Rescan the
+            // sub-interval up to the found level to resolve the contradiction.
+            if not_found < found.level {
+                bracket = Some(Bracket::Retry);
+                break;
+            }
+        }
+
+        match bracket {
+            // The interval drained without the levels meeting: the full
+            // lookahead found nothing past the base, so the base is the latest.
+            None | Some(Bracket::Done) => return Ok(Some(found.update)),
+            Some(Bracket::Recurse) => {
+                base = found.index;
+                level = found.level;
+                not_found = found.level;
+                found.level = 0;
+            }
+            Some(Bracket::Retry) => {
+                let resume = level;
+                base = found.index;
+                level = resume;
+                not_found = resume;
+                found.level = 0;
+            }
+        }
+    }
+}
+
+/// How an interval round resolved: the latest is the base, recurse into the
+/// bracketed sub-interval, or rescan to resolve an inconsistent feed.
+enum Bracket {
+    Done,
+    Recurse,
+    Retry,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::Address;
+    use proptest::prelude::*;
+
+    use crate::topic::Topic;
+
+    #[test]
+    fn marshal_is_8_be_bytes() {
+        assert_eq!(Sequence(0).marshal().as_ref(), [0u8; 8].as_slice());
+        assert_eq!(
+            Sequence(1).marshal().as_ref(),
+            1u64.to_be_bytes().as_slice()
+        );
+        assert_eq!(
+            Sequence(u64::MAX).marshal().as_ref(),
+            [0xffu8; 8].as_slice()
+        );
+    }
+
+    #[test]
+    fn first_is_zero() {
+        assert_eq!(Sequence::first(), Sequence(0));
+    }
+
+    #[test]
+    fn cursor_advances_monotonically() {
+        let mut c = SequenceCursor::new();
+        assert_eq!(c.index_for(None), Sequence(0));
+        c.record(&Sequence(0), None);
+        assert_eq!(c.index_for(None), Sequence(1));
+        c.record(&Sequence(1), Some(12345));
+        assert_eq!(c.index_for(None), Sequence(2));
+        assert!(!c.exhausted());
+    }
+
+    #[test]
+    fn cursor_reports_exhaustion_at_max() {
+        let mut c = SequenceCursor::at(u64::MAX);
+        assert_eq!(c.index_for(None), Sequence(u64::MAX));
+        assert!(!c.exhausted());
+        c.record(&Sequence(u64::MAX), None);
+        assert!(c.exhausted(), "no successor to u64::MAX");
+    }
+
+    proptest! {
+        #[test]
+        fn marshal_round_trips_be(n in any::<u64>()) {
+            let seq = Sequence(n);
+            let bytes = seq.marshal();
+            let arr: [u8; 8] = bytes.as_ref().try_into().unwrap();
+            prop_assert_eq!(u64::from_be_bytes(arr), n);
+        }
+
+        #[test]
+        fn address_is_deterministic(n in any::<u64>(), topic in any::<[u8; 32]>(), owner in any::<[u8; 20]>()) {
+            let feed: Feed = Feed::new(Topic::new(topic.into()), Address::from(owner));
+            let a = feed.update_address(&Sequence(n));
+            let b = feed.update_address(&Sequence(n));
+            prop_assert_eq!(a, b);
+        }
+    }
+
+    mod finder {
+        use super::*;
+        use alloy_signer_local::PrivateKeySigner;
+        use nectar_primitives::DEFAULT_BODY_SIZE;
+        use nectar_primitives::chunk::SingleOwnerChunk;
+        use nectar_primitives::store::{MemoryStore, SyncChunkPut};
+
+        // A fixed signer so the feed owner and the SOC signatures agree across a
+        // test, and the derived addresses are reproducible.
+        fn signer() -> PrivateKeySigner {
+            PrivateKeySigner::from_slice(&alloy_primitives::hex!(
+                "2c7536e3605d9c16a7a3d7b1898e529396a65c23a3bcbd4012a11cf2731b0fbc"
+            ))
+            .unwrap()
+        }
+
+        fn feed_for(s: &PrivateKeySigner) -> Feed {
+            Feed::new(Topic::from_bytes(b"latest-finder"), s.address())
+        }
+
+        // Publish contiguous updates at indices `0..n` into a fresh store.
+        fn store_with(feed: &Feed, s: &PrivateKeySigner, n: u64) -> MemoryStore {
+            let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
+            for i in 0..n {
+                let id = feed.update_id(&Sequence(i));
+                let soc = SingleOwnerChunk::<DEFAULT_BODY_SIZE>::new(id, vec![i as u8], s).unwrap();
+                SyncChunkPut::put(&store, soc.into()).unwrap();
+            }
+            store
+        }
+
+        // Publish an update at one explicit index into `store`, with `payload`.
+        fn put_at(store: &MemoryStore, feed: &Feed, s: &PrivateKeySigner, idx: u64, payload: u8) {
+            let id = feed.update_id(&Sequence(idx));
+            let soc = SingleOwnerChunk::<DEFAULT_BODY_SIZE>::new(id, vec![payload], s).unwrap();
+            SyncChunkPut::put(store, soc.into()).unwrap();
+        }
+
+        // Publish updates at an explicit set of (possibly non-contiguous) indices.
+        fn store_with_indices(feed: &Feed, s: &PrivateKeySigner, indices: &[u64]) -> MemoryStore {
+            let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
+            for &i in indices {
+                put_at(&store, feed, s, i, i as u8);
+            }
+            store
+        }
+
+        // Run a future to completion on a single-threaded current-thread runtime;
+        // the finder inherits no `Send` bound, so a current-thread executor is the
+        // honest harness.
+        fn block_on<F: core::future::Future>(fut: F) -> F::Output {
+            tokio::runtime::Builder::new_current_thread()
+                .build()
+                .unwrap()
+                .block_on(fut)
+        }
+
+        #[test]
+        fn async_finds_last_of_many() {
+            let s = signer();
+            let feed = feed_for(&s);
+            // Span more than one DEFAULT_LEVELS round to exercise sub-interval
+            // recursion.
+            const N: u64 = 300;
+            let store = store_with(&feed, &s, N);
+
+            let got = block_on(Sequence::find_latest(&feed, &store, None, None)).unwrap();
+            let update = got.expect("non-empty feed has a latest update");
+            assert_eq!(*update.index(), Sequence(N - 1));
+
+            let next = block_on(Sequence::find_latest(
+                &feed,
+                &store,
+                None,
+                Some(&Sequence(N - 1)),
+            ))
+            .unwrap();
+            assert!(next.is_none(), "nothing exists past the last index");
+        }
+
+        #[test]
+        fn async_matches_linear_scan() {
+            let s = signer();
+            let feed = feed_for(&s);
+            for n in [1u64, 2, 3, 5, 8, 9, 16, 17, 100] {
+                let store = store_with(&feed, &s, n);
+                let async_got = block_on(Sequence::find_latest(&feed, &store, None, None)).unwrap();
+                let (linear_got, current, next) =
+                    block_on(find_latest_linear(&feed, &store, 0)).unwrap();
+
+                assert_eq!(current, Some(Sequence(n - 1)), "n = {n}");
+                assert_eq!(next, Sequence(n), "n = {n}");
+                let async_index = async_got.as_ref().map(|u| *u.index());
+                assert_eq!(
+                    async_index,
+                    linear_got.map(|u| *u.index()),
+                    "async and linear disagree at n = {n}",
+                );
+                assert_eq!(async_index, Some(Sequence(n - 1)), "n = {n}");
+            }
+        }
+
+        #[test]
+        fn single_update() {
+            let s = signer();
+            let feed = feed_for(&s);
+            let store = store_with(&feed, &s, 1);
+
+            let got = block_on(Sequence::find_latest(&feed, &store, None, None)).unwrap();
+            assert_eq!(got.map(|u| *u.index()), Some(Sequence(0)));
+        }
+
+        #[test]
+        fn empty_feed() {
+            let s = signer();
+            let feed = feed_for(&s);
+            let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
+
+            let got = block_on(Sequence::find_latest(&feed, &store, None, None)).unwrap();
+            assert!(got.is_none());
+
+            let (linear, current, next) = block_on(find_latest_linear(&feed, &store, 0)).unwrap();
+            assert!(linear.is_none());
+            assert_eq!(current, None);
+            assert_eq!(next, Sequence(0));
+        }
+
+        // A near-`u64::MAX` search floor with a present update at `u64::MAX`. The
+        // concurrent finder must not overflow when computing probe offsets above
+        // the present index, and must resolve the extreme index without panic.
+        #[test]
+        fn async_handles_index_near_u64_max() {
+            let s = signer();
+            let feed = feed_for(&s);
+            let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
+            put_at(&store, &feed, &s, u64::MAX, 0xab);
+
+            // Floor at `u64::MAX - 1`, so the search starts at `u64::MAX` and the
+            // first concurrent round would otherwise add a positive offset to it.
+            let got = block_on(Sequence::find_latest(
+                &feed,
+                &store,
+                None,
+                Some(&Sequence(u64::MAX - 1)),
+            ))
+            .unwrap();
+            assert_eq!(got.map(|u| *u.index()), Some(Sequence(u64::MAX)));
+
+            // A floor of `u64::MAX` itself saturates the start back to `u64::MAX`
+            // (there is no successor slot to begin at), so the search probes that
+            // extreme index without overflowing the probe offset.
+            let at_max = block_on(Sequence::find_latest(
+                &feed,
+                &store,
+                None,
+                Some(&Sequence(u64::MAX)),
+            ))
+            .unwrap();
+            assert_eq!(at_max.map(|u| *u.index()), Some(Sequence(u64::MAX)));
+        }
+
+        // A sparse feed (present at 0,1,2; hole at 3; present at 4) exercises the
+        // inconsistent-feed Retry branch and the stale-result guards. The finder
+        // defines "latest" as the highest present index reachable from the floor
+        // without crossing a hole, so it converges on index 2.
+        #[test]
+        fn async_sparse_feed_stops_at_first_hole() {
+            let s = signer();
+            let feed = feed_for(&s);
+            let store = store_with_indices(&feed, &s, &[0, 1, 2, 4]);
+
+            let async_got = block_on(Sequence::find_latest(&feed, &store, None, None)).unwrap();
+            let (linear_got, current, next) =
+                block_on(find_latest_linear(&feed, &store, 0)).unwrap();
+
+            assert_eq!(current, Some(Sequence(2)), "contiguous prefix ends at 2");
+            assert_eq!(next, Sequence(3), "first hole is at index 3");
+            assert_eq!(
+                async_got.map(|u| *u.index()),
+                linear_got.map(|u| *u.index()),
+                "async and linear agree on the sparse feed",
+            );
+        }
+
+        // Two updates signed for the same index share one SOC address, so the
+        // address-keyed store keeps whichever was put last. The finder has no
+        // freshness signal to detect this and returns the last writer's payload.
+        // This pins the address-keyed last-writer-wins behaviour as intended.
+        #[test]
+        fn equivocating_index_is_last_writer_wins() {
+            let s = signer();
+            let feed = feed_for(&s);
+            let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
+
+            put_at(&store, &feed, &s, 0, 0x01);
+            put_at(&store, &feed, &s, 0, 0x02);
+
+            let got = block_on(Sequence::find_latest(&feed, &store, None, None))
+                .unwrap()
+                .expect("a present update");
+            assert_eq!(*got.index(), Sequence(0));
+            assert_eq!(
+                got.payload().as_ref(),
+                &[0x02],
+                "the later put for the same index wins",
+            );
+        }
+    }
+}

--- a/crates/feeds/src/topic.rs
+++ b/crates/feeds/src/topic.rs
@@ -1,0 +1,37 @@
+//! Feed topic.
+
+use alloy_primitives::{B256, keccak256};
+
+/// A feed topic: a 32-byte value mixed into every update id.
+///
+/// The topic is used **raw** in id derivation. A caller that wants to derive a
+/// topic from an arbitrary-length label (a string, a path, an application
+/// namespace) must hash it first with [`Topic::from_bytes`]. [`Topic::new`]
+/// wraps an already-32-byte value verbatim.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, derive_more::From, derive_more::Into)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct Topic(pub B256);
+
+impl Topic {
+    /// Wrap a raw 32-byte topic value verbatim.
+    pub const fn new(raw: B256) -> Self {
+        Self(raw)
+    }
+
+    /// Derive a topic by hashing arbitrary input with keccak256.
+    pub fn from_bytes(input: impl AsRef<[u8]>) -> Self {
+        Self(keccak256(input))
+    }
+
+    /// The raw 32-byte topic value.
+    pub const fn as_bytes(&self) -> &B256 {
+        &self.0
+    }
+}
+
+impl AsRef<[u8]> for Topic {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+}

--- a/crates/feeds/src/update.rs
+++ b/crates/feeds/src/update.rs
@@ -1,0 +1,58 @@
+//! A single feed update.
+
+use alloy_primitives::Address;
+use bytes::Bytes;
+use nectar_primitives::chunk::{Chunk, ChunkAddress, SingleOwnerChunk};
+
+use crate::error::Result;
+use crate::index::Index;
+
+/// One published feed update: the index it occupies and the single-owner chunk
+/// that carries it.
+///
+/// The payload is the SOC body data (the bytes the publisher signed over). The
+/// address and owner are read straight off the chunk.
+#[derive(Debug, Clone)]
+pub struct FeedUpdate<I, const BS: usize> {
+    index: I,
+    soc: SingleOwnerChunk<BS>,
+}
+
+impl<I: Index, const BS: usize> FeedUpdate<I, BS> {
+    /// Construct an update from its index and single-owner chunk.
+    pub const fn new(index: I, soc: SingleOwnerChunk<BS>) -> Self {
+        Self { index, soc }
+    }
+
+    /// The index this update occupies.
+    pub const fn index(&self) -> &I {
+        &self.index
+    }
+
+    /// The single-owner chunk carrying this update.
+    pub const fn chunk(&self) -> &SingleOwnerChunk<BS> {
+        &self.soc
+    }
+
+    /// The update payload (the SOC body data).
+    pub fn payload(&self) -> &Bytes {
+        self.soc.data()
+    }
+
+    /// The single-owner chunk address of this update.
+    pub fn address(&self) -> &ChunkAddress {
+        self.soc.address()
+    }
+
+    /// The owner recovered from the update signature.
+    pub fn owner(&self) -> Result<Address> {
+        self.soc
+            .owner()
+            .map_err(|e| crate::FeedError::Primitives(e.into()))
+    }
+
+    /// Consume the update, returning its index and single-owner chunk.
+    pub fn into_parts(self) -> (I, SingleOwnerChunk<BS>) {
+        (self.index, self.soc)
+    }
+}

--- a/crates/feeds/src/writer.rs
+++ b/crates/feeds/src/writer.rs
@@ -1,0 +1,247 @@
+//! Feed writer: sign and publish updates.
+
+use alloy_signer::{Signer, SignerSync};
+use bytes::Bytes;
+use nectar_primitives::chunk::{Chunk, ChunkAddress, SingleOwnerChunk};
+use nectar_primitives::store::ChunkPut;
+
+use crate::error::{FeedError, Result};
+use crate::feed::Feed;
+use crate::index::WriteCursor;
+
+/// Publishes signed updates to a feed.
+///
+/// Generic over the write cursor `C` (the scheme's stateful write head), the
+/// chunk store `P` updates are published through, the signer `S`, and the body
+/// size `BS`. The signer's address must equal the feed owner; this is checked
+/// at construction.
+///
+/// Each published update is a single-owner chunk at
+/// `keccak256(keccak256(topic || index.marshal()) || owner)`, signed by `S`.
+#[derive(Debug)]
+pub struct FeedWriter<C, P, S, const BS: usize> {
+    feed: Feed<BS>,
+    cursor: C,
+    store: P,
+    signer: S,
+}
+
+impl<C, P, S, const BS: usize> FeedWriter<C, P, S, BS>
+where
+    C: WriteCursor,
+    P: ChunkPut<BS>,
+    S: SignerSync + Signer,
+{
+    /// Create a writer for `feed`, publishing through `store`, signing with
+    /// `signer`, starting at the position `cursor` points to.
+    ///
+    /// Returns [`crate::FeedError::OwnerMismatch`] if the signer's address does
+    /// not match the feed owner.
+    pub fn new(feed: Feed<BS>, cursor: C, store: P, signer: S) -> Result<Self> {
+        let actual = signer.address();
+        if actual != feed.owner() {
+            return Err(FeedError::OwnerMismatch {
+                expected: feed.owner(),
+                actual,
+            });
+        }
+        Ok(Self {
+            feed,
+            cursor,
+            store,
+            signer,
+        })
+    }
+
+    /// The feed this writer publishes to.
+    pub const fn feed(&self) -> &Feed<BS> {
+        &self.feed
+    }
+
+    /// The index the writer would publish to next for an update timestamped
+    /// `at`. For a time-indexed scheme the index depends on `at`; the sequence
+    /// scheme ignores it and returns the current counter.
+    pub fn next_index(&self, at: Option<u64>) -> C::Index {
+        self.cursor.index_for(at)
+    }
+
+    /// Publish `payload` at an explicit `index` without touching the cursor.
+    ///
+    /// Because this bypasses the cursor entirely, it also bypasses the cursor's
+    /// exhaustion check by design: an explicit-index publish can land at any
+    /// index (including `Sequence(u64::MAX)`) regardless of whether
+    /// [`exhausted`](WriteCursor::exhausted) would be true on the cursor path.
+    ///
+    /// Returns the published single-owner chunk address.
+    pub async fn update_at(
+        &self,
+        index: &C::Index,
+        payload: impl Into<Bytes>,
+    ) -> Result<ChunkAddress> {
+        let id = self.feed.update_id(index);
+        let soc = SingleOwnerChunk::<BS>::new(id, payload, &self.signer)?;
+        let address = *soc.address();
+        self.store
+            .put(soc.into())
+            .await
+            .map_err(FeedError::store_put)?;
+        Ok(address)
+    }
+
+    /// Publish `payload` for an update timestamped `at`, choosing the publish
+    /// index from `at` and recording it on the cursor.
+    ///
+    /// The cursor picks the index ([`WriteCursor::index_for`]) before the write
+    /// and records the publication ([`WriteCursor::record`]) after it succeeds,
+    /// so a time-indexed scheme derives the grid position from the new update's
+    /// timestamp. The cursor is driven through `&self` then `&mut self` with no
+    /// move-out.
+    ///
+    /// Returns the published single-owner chunk address.
+    pub async fn append_at(
+        &mut self,
+        at: Option<u64>,
+        payload: impl Into<Bytes>,
+    ) -> Result<ChunkAddress> {
+        if self.cursor.exhausted() {
+            return Err(FeedError::IndexExhausted);
+        }
+        let index = self.cursor.index_for(at);
+        let address = self.update_at(&index, payload).await?;
+        self.cursor.record(&index, at);
+        Ok(address)
+    }
+
+    /// Publish `payload` without a timestamp. Equivalent to
+    /// `append_at(None, payload)`.
+    pub async fn append(&mut self, payload: impl Into<Bytes>) -> Result<ChunkAddress> {
+        self.append_at(None, payload).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_signer_local::PrivateKeySigner;
+    use nectar_primitives::DEFAULT_BODY_SIZE;
+    use nectar_primitives::chunk::Chunk;
+    use nectar_primitives::store::{ChunkGet, MemoryStore};
+
+    use crate::feed::Feed;
+    use crate::sequence::{Sequence, SequenceCursor};
+    use crate::topic::Topic;
+
+    use super::*;
+
+    fn signer() -> PrivateKeySigner {
+        // Fixed key so the derived owner is stable across runs.
+        let pk = [
+            0x2c, 0x75, 0x36, 0xe3, 0x60, 0x5d, 0x9c, 0x16, 0xa7, 0xa3, 0xd7, 0xb1, 0x89, 0x8e,
+            0x52, 0x93, 0x96, 0xa6, 0x5c, 0x23, 0xa3, 0xbc, 0xbd, 0x40, 0x12, 0xa1, 0x1c, 0xf2,
+            0x73, 0x1b, 0x0f, 0xbc,
+        ];
+        PrivateKeySigner::from_slice(&pk).unwrap()
+    }
+
+    fn feed_for(signer: &PrivateKeySigner) -> Feed<DEFAULT_BODY_SIZE> {
+        Feed::new(Topic::from_bytes(b"feeds-writer-test"), signer.address())
+    }
+
+    #[tokio::test]
+    async fn update_at_publishes_a_readable_soc() {
+        let signer = signer();
+        let owner = signer.address();
+        let feed = feed_for(&signer);
+        let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
+
+        let payload = Bytes::from_static(b"hello feeds");
+        let writer =
+            FeedWriter::new(feed, SequenceCursor::new(), &store, signer).expect("owner matches");
+        let address = writer
+            .update_at(&Sequence(0), payload.clone())
+            .await
+            .expect("publish");
+
+        // The published address is the deterministic feed update address.
+        assert_eq!(address, feed.update_address(&Sequence(0)));
+
+        // Read the chunk straight back out of the store and verify it.
+        let any = ChunkGet::get(&store, &address).await.expect("stored");
+        let soc = any.as_single_owner().expect("single-owner chunk");
+        assert_eq!(soc.owner().unwrap(), owner);
+        assert_eq!(soc.data(), &payload);
+        assert_eq!(soc.address(), &address);
+    }
+
+    #[tokio::test]
+    async fn append_advances_the_sequence_index() {
+        let signer = signer();
+        let feed = feed_for(&signer);
+        let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
+
+        let mut writer =
+            FeedWriter::new(feed, SequenceCursor::new(), &store, signer).expect("owner matches");
+
+        assert_eq!(writer.next_index(None), Sequence(0));
+        let a0 = writer.append(Bytes::from_static(b"v0")).await.expect("v0");
+        assert_eq!(writer.next_index(None), Sequence(1));
+        let a1 = writer.append(Bytes::from_static(b"v1")).await.expect("v1");
+        assert_eq!(writer.next_index(None), Sequence(2));
+
+        // Each append lands at the address the index derives, and they differ.
+        assert_eq!(a0, feed.update_address(&Sequence(0)));
+        assert_eq!(a1, feed.update_address(&Sequence(1)));
+        assert_ne!(a0, a1);
+
+        // Both updates are retrievable with the right payloads.
+        let v0 = ChunkGet::get(&store, &a0).await.expect("get v0");
+        let v1 = ChunkGet::get(&store, &a1).await.expect("get v1");
+        assert_eq!(v0.data().as_ref(), b"v0");
+        assert_eq!(v1.data().as_ref(), b"v1");
+    }
+
+    #[tokio::test]
+    async fn append_at_surfaces_index_exhausted() {
+        let signer = signer();
+        let feed = feed_for(&signer);
+        let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
+
+        // A cursor seated at the last representable sequence number: the first
+        // append lands at `u64::MAX`, after which the counter has no successor.
+        let mut writer = FeedWriter::new(feed, SequenceCursor::at(u64::MAX), &store, signer)
+            .expect("owner matches");
+
+        let address = writer
+            .append(Bytes::from_static(b"last"))
+            .await
+            .expect("the final index is publishable");
+        assert_eq!(address, feed.update_address(&Sequence(u64::MAX)));
+
+        // The cursor is now exhausted; the next append is refused before any
+        // write, so nothing is published at a wrapped or duplicate index.
+        let err = writer
+            .append(Bytes::from_static(b"overflow"))
+            .await
+            .expect_err("exhausted cursor refuses a further publish");
+        assert!(matches!(err, FeedError::IndexExhausted));
+
+        // No second chunk was written for the exhausted publish: the store still
+        // holds only the single update at `u64::MAX`.
+        let any = ChunkGet::get(&store, &feed.update_address(&Sequence(u64::MAX)))
+            .await
+            .expect("the final update is stored");
+        assert_eq!(any.data().as_ref(), b"last");
+    }
+
+    #[tokio::test]
+    async fn new_rejects_a_foreign_signer() {
+        let owner_signer = signer();
+        let feed = feed_for(&owner_signer);
+        let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
+
+        // A different signer (a distinct fixed key) cannot author this feed.
+        let foreign = PrivateKeySigner::from_slice(&[0x11u8; 32]).unwrap();
+        let err = FeedWriter::new(feed, SequenceCursor::new(), &store, foreign)
+            .expect_err("foreign signer rejected");
+        assert!(matches!(err, FeedError::OwnerMismatch { .. }));
+    }
+}

--- a/crates/feeds/tests/epoch_vectors.rs
+++ b/crates/feeds/tests/epoch_vectors.rs
@@ -1,0 +1,223 @@
+//! Cross-client conformance vectors and end-to-end behaviour for the epoch
+//! scheme, exercised through the public reader and writer surface.
+//!
+//! Regression vectors: for a fixed topic and owner, the marshalled index bytes,
+//! derived update id, and update address for two epochs on the grid. The
+//! marshalling is `keccak256(start_be8 || level)` and the id/address derivation
+//! is `keccak256(topic || marshal) -> keccak256(id || owner)`, pinning our epoch
+//! byte layout against the Swarm reference. The finder-behaviour tests live
+//! next to the finder code in `src/epoch.rs`, which can reach the crate-private
+//! grid walks directly; this file covers the public entry points.
+
+#![cfg(feature = "epoch")]
+
+use alloy_primitives::{B256, address, b256};
+use alloy_signer_local::PrivateKeySigner;
+use nectar_feeds::{Epoch, EpochCursor, Feed, FeedReader, FeedWriter, MemoryStore, Topic};
+use nectar_primitives::DEFAULT_BODY_SIZE;
+
+/// A distinct payload per update index in the roundtrip.
+fn payload_for(i: usize) -> Vec<u8> {
+    format!("epoch-update-{i}").into_bytes()
+}
+
+/// Fixed-topic, fixed-owner regression vectors for two epochs on the grid:
+/// the root epoch `{0, 32}` and a level-1 epoch `{2, 1}`.
+#[test]
+fn epoch_feed_vectors() {
+    let topic = Topic::from_bytes(b"testtopic");
+    let owner = address!("8d3766440f0d7b949a5e32995d09619a7f86e632");
+    let feed = Feed::<DEFAULT_BODY_SIZE>::new(topic, owner);
+
+    // topic = keccak256("testtopic"), shared with the sequence vectors.
+    assert_eq!(
+        topic.as_bytes(),
+        &b256!("65cf9694019c5d902d773447898b875265abd8c57e6b95e926cf491254e3ad8e"),
+    );
+
+    // (epoch, expected marshal, expected id, expected address).
+    let cases: [(Epoch, B256, B256, B256); 2] = [
+        (
+            Epoch::new(0, 32),
+            b256!("2a28926b78c626adb7a249a23e9769bf038b52447e60543086a797f9b3061c70"),
+            b256!("95ad0ab574b50fe560d9c09d75476c6c339b6edb477caacb151a2e58832dca54"),
+            b256!("aade3ad8ffce03aa9432d0461462759f6722e896c3a9913c432fae966a7137f1"),
+        ),
+        (
+            Epoch::new(2, 1),
+            b256!("f87baae5dd89c9a2f298888318d026514532f41501b2f9e5f1642cb10dd717b8"),
+            b256!("fb08ab90ceb2f53c608740502ded3304a4738a215c0a5f2fcdeadd8ea169e897"),
+            b256!("1565091350e47d86c5a84c2d9105d4d46e43cafc50732471b0075adf22242edd"),
+        ),
+    ];
+
+    for (epoch, expected_marshal, expected_id, expected_address) in cases {
+        use nectar_feeds::Index;
+        assert_eq!(
+            epoch.marshal().as_ref(),
+            expected_marshal.as_slice(),
+            "marshal for {epoch:?}",
+        );
+        assert_eq!(feed.update_id(&epoch), expected_id, "id for {epoch:?}");
+        assert_eq!(
+            feed.update_address(&epoch).0,
+            expected_address,
+            "address for {epoch:?}",
+        );
+    }
+
+    // The root epoch is the scheme's first index.
+    assert_eq!(<Epoch as nectar_feeds::Index>::first(), Epoch::ROOT);
+    assert_eq!(Epoch::ROOT, Epoch::new(0, 32));
+}
+
+/// Grid helper checks for the epoch grid math.
+#[test]
+fn epoch_grid_math() {
+    // length = 2^level, comparison timestamp = 2^level * start.
+    assert_eq!(Epoch::new(0, 32).length(), 1u64 << 32);
+    assert_eq!(Epoch::new(2, 1).length(), 2);
+    assert_eq!(Epoch::new(2, 1).timestamp(), 4);
+
+    // child_at picks the child whose interval contains the target.
+    let root = Epoch::ROOT;
+    let c = root.child_at(0);
+    assert_eq!(c.level, 31);
+    assert_eq!(c.start, 0);
+    assert!(c.is_left());
+
+    // lca of two equal-ish times climbs only as far as needed.
+    let l = Epoch::lca(10, 8);
+    assert!(l.level <= 32);
+
+    // lca with no prior update is the root.
+    assert_eq!(Epoch::lca(1000, 0), Epoch::ROOT);
+
+    // left sister of a right child sits one length earlier at the same level.
+    let right = Epoch::new(2, 1); // start & length(=2) != 0 -> right sister
+    assert!(!right.is_left());
+    assert_eq!(right.left(), Epoch::new(0, 1));
+
+    // child_at descends one level per call and terminates at level 0 (the finest
+    // grid resolution the finders stop at). Walking the full root->leaf chain for
+    // a representative target must not underflow the level.
+    let mut e = Epoch::ROOT;
+    let target = 123_456u64;
+    while e.level > 0 {
+        e = e.child_at(target);
+    }
+    assert_eq!(e.level, 0, "descent stops at the finest resolution");
+    assert_eq!(e.length(), 1, "a level-0 epoch spans one second");
+    assert!(
+        e.start <= target && target < e.start + e.length(),
+        "the level-0 epoch contains the target",
+    );
+
+    // is_left / left round-trip at the grid floor (level 0): a right level-0
+    // epoch's left sister is the adjacent second below it.
+    let right0 = Epoch::new(target | 1, 0);
+    assert!(
+        !right0.is_left(),
+        "an odd start is a right sister at level 0"
+    );
+    assert_eq!(right0.left(), Epoch::new((target | 1) - 1, 0));
+    assert!(right0.left().is_left(), "the left sister has an even start");
+
+    // parent() climbs toward the root without overflowing the level; the topmost
+    // climb reaches the root epoch.
+    let mut up = Epoch::new(0, MAX_LEVEL_MINUS_ONE);
+    up = up.parent();
+    assert_eq!(up.level, 32, "parent of a level-31 epoch is the root level");
+}
+
+/// One below the top level, used to drive `parent()` up to the root in tests.
+const MAX_LEVEL_MINUS_ONE: u8 = 31;
+
+/// End-to-end epoch roundtrip through the generic [`FeedWriter`].
+///
+/// Publishing through the writer exercises the epoch write path that the cursor
+/// redesign enables: the writer asks the cursor to choose the publish index
+/// from each update's timestamp ([`WriteCursor::index_for`]), publishes, and
+/// records the placement so the next index descends from it. This is what a
+/// single advance-after-write step could not do, and it is the path the
+/// pre-redesign writer drove with `unsafe`.
+///
+/// The roundtrip then proves two things through the generic reader and writer:
+///
+/// 1. Every update the writer published is retrievable at exactly the index the
+///    writer chose ([`FeedReader::get`]), with the payload that was signed.
+/// 2. [`FeedReader::find_at`] at a time at or after the last publish resolves to
+///    the most recent update. (Start-anchored comparison timestamps mean every
+///    update nests at the same `start`, so the version live at the present is
+///    always the latest published, which is the property the dedicated finder
+///    test pins.)
+#[tokio::test]
+async fn epoch_roundtrip_through_writer() {
+    let signer = PrivateKeySigner::random();
+    let owner = signer.address();
+    let feed = Feed::<DEFAULT_BODY_SIZE>::new(Topic::from_bytes(b"epoch-roundtrip"), owner);
+    let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
+
+    // A shared store: the writer borrows it to publish, the reader borrows it to
+    // resolve, so every publish is visible to the read-back without copying.
+    let mut writer = FeedWriter::new(feed, EpochCursor::new(), &store, signer.clone())
+        .expect("signer owns the feed");
+
+    let times: [u64; 5] = [5, 9, 17, 100, 1000];
+    let mut published = Vec::with_capacity(times.len());
+
+    for (i, &at) in times.iter().enumerate() {
+        // The writer chooses the grid index from the update timestamp, then
+        // publishes and records it. Capture the chosen index for the read-back.
+        let index = writer.next_index(Some(at));
+        let payload = payload_for(i);
+        let address = writer
+            .append_at(Some(at), payload.clone())
+            .await
+            .expect("append");
+        assert_eq!(
+            address,
+            feed.update_address(&index),
+            "published address matches the index the writer chose at {at}",
+        );
+        published.push((at, index, payload));
+    }
+
+    // Each update timestamp descended to a distinct grid epoch.
+    for (a, (_, ia, _)) in published.iter().enumerate() {
+        for (b, (_, ib, _)) in published.iter().enumerate() {
+            if a != b {
+                assert_ne!(ia, ib, "epochs {a} and {b} collided");
+            }
+        }
+    }
+
+    let reader: FeedReader<Epoch, &MemoryStore, DEFAULT_BODY_SIZE> = FeedReader::new(feed, &store);
+
+    // Every update the writer published reads back at the exact index it chose,
+    // with the payload that was signed over.
+    for (at, index, payload) in &published {
+        let update = reader
+            .get(index)
+            .await
+            .unwrap_or_else(|e| panic!("read back the update published at {at}: {e}"));
+        assert_eq!(update.index(), index, "index roundtrips at {at}");
+        assert_eq!(update.payload().as_ref(), payload.as_slice());
+        assert_eq!(update.owner().expect("recover owner"), owner);
+    }
+
+    // A query at or past the last publish time resolves to the final update.
+    let (last_at, last_index, _) = published.last().unwrap();
+    for query in [*last_at, last_at * 10, 100_000] {
+        let latest = reader
+            .find_at(query, None)
+            .await
+            .expect("find_at latest")
+            .expect("a feed with updates has a latest");
+        assert_eq!(
+            latest.chunk().id(),
+            feed.update_id(last_index),
+            "find_at at {query} did not resolve the latest update",
+        );
+    }
+}

--- a/crates/feeds/tests/feed_roundtrip.rs
+++ b/crates/feeds/tests/feed_roundtrip.rs
@@ -1,0 +1,161 @@
+//! End-to-end roundtrip across the feed writer, an in-memory store, and the
+//! feed reader.
+//!
+//! A [`FeedWriter`] signs and publishes a run of sequence updates into a shared
+//! [`MemoryStore`]; a [`FeedReader`] over the same store reads each one back,
+//! verifying the payload and the owner recovered from the single-owner chunk
+//! signature. The reader's latest-update lookup must converge on the last
+//! published index, and a foreign-owner chunk returned for a feed address is
+//! rejected with [`FeedError::OwnerMismatch`].
+//!
+//! The writer and reader hold their store by value, so both borrow the same
+//! [`MemoryStore`] by shared reference: `&MemoryStore` implements the typed
+//! chunk store traits and is `Send + Sync`, so a single store backs both ends
+//! without cloning divergent copies.
+
+use alloy_signer_local::PrivateKeySigner;
+use bytes::Bytes;
+use nectar_feeds::{Feed, FeedError, FeedReader, FeedWriter, Sequence, SequenceCursor, Topic};
+use nectar_primitives::DEFAULT_BODY_SIZE;
+use nectar_primitives::DefaultContentChunk;
+use nectar_primitives::chunk::{AnyChunk, ChunkAddress, SingleOwnerChunk};
+use nectar_primitives::store::{ChunkStoreError, MemoryStore, SyncChunkGet};
+
+/// Number of sequence updates published and read back in the roundtrip.
+const N: u64 = 12;
+
+fn payload_for(i: u64) -> Bytes {
+    Bytes::from(format!("feed-update-{i}").into_bytes())
+}
+
+#[tokio::test]
+async fn sequence_roundtrip_reads_back_and_converges_to_latest() {
+    let signer = PrivateKeySigner::random();
+    let owner = signer.address();
+    let feed = Feed::<DEFAULT_BODY_SIZE>::new(Topic::from_bytes(b"feed-roundtrip"), owner);
+    let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
+
+    // Writer and reader share one store by borrowing it: `&MemoryStore`
+    // implements the typed chunk store traits, so publishes are visible to the
+    // reader without copying the store.
+    let mut writer = FeedWriter::new(feed, SequenceCursor::new(), &store, signer.clone())
+        .expect("signer owns the feed");
+
+    let mut addresses = Vec::with_capacity(N as usize);
+    for i in 0..N {
+        assert_eq!(writer.next_index(None), Sequence(i));
+        let address = writer.append(payload_for(i)).await.expect("append");
+        assert_eq!(address, feed.update_address(&Sequence(i)));
+        addresses.push(address);
+    }
+    assert_eq!(writer.next_index(None), Sequence(N));
+
+    let reader: FeedReader<Sequence, &MemoryStore, DEFAULT_BODY_SIZE> =
+        FeedReader::new(feed, &store);
+
+    // Each index reads back with its payload and the recovered owner.
+    for i in 0..N {
+        let update = reader.get(&Sequence(i)).await.expect("read back");
+        assert_eq!(update.index(), &Sequence(i));
+        assert_eq!(update.payload(), &payload_for(i));
+        assert_eq!(update.owner().expect("recover owner"), owner);
+        assert_eq!(update.address(), &addresses[i as usize]);
+    }
+
+    // The latest lookup converges on the final published index.
+    let latest = reader
+        .latest(None)
+        .await
+        .expect("latest lookup")
+        .expect("non-empty feed has a latest update");
+    assert_eq!(latest.index(), &Sequence(N - 1));
+    assert_eq!(latest.payload(), &payload_for(N - 1));
+
+    // Nothing exists strictly past the last index.
+    let past_last = reader
+        .latest(Some(&Sequence(N - 1)))
+        .await
+        .expect("latest past last");
+    assert!(past_last.is_none(), "no update exists past the final index");
+}
+
+/// A store that always returns one planted chunk for any address, modelling a
+/// backend that substitutes a foreign-owner chunk for a feed slot. The reader
+/// must reject what it gets back on the owner check, not trust the substitution.
+struct SubstitutingStore {
+    chunk: AnyChunk<DEFAULT_BODY_SIZE>,
+}
+
+impl SyncChunkGet<DEFAULT_BODY_SIZE> for SubstitutingStore {
+    type Error = ChunkStoreError;
+
+    fn get(&self, _address: &ChunkAddress) -> Result<AnyChunk<DEFAULT_BODY_SIZE>, Self::Error> {
+        Ok(self.chunk.clone())
+    }
+}
+
+#[tokio::test]
+async fn foreign_owner_chunk_is_rejected_with_owner_mismatch() {
+    let owner_signer = PrivateKeySigner::random();
+    let owner = owner_signer.address();
+    let feed = Feed::<DEFAULT_BODY_SIZE>::new(Topic::from_bytes(b"feed-owner-check"), owner);
+
+    // A foreign key signs a single-owner chunk over the feed's index-0 id. Its
+    // recovered owner is the foreign address, not the feed owner.
+    let foreign = PrivateKeySigner::random();
+    assert_ne!(
+        foreign.address(),
+        owner,
+        "foreign signer differs from owner"
+    );
+
+    let id = feed.update_id(&Sequence(0));
+    let foreign_soc =
+        SingleOwnerChunk::<DEFAULT_BODY_SIZE>::new(id, Bytes::from_static(b"forged"), &foreign)
+            .expect("build foreign soc");
+    assert_eq!(
+        foreign_soc.owner().expect("recover foreign owner"),
+        foreign.address(),
+    );
+
+    // A backend hands this foreign chunk back for the feed address. The reader
+    // recovers the signer, finds it is not the feed owner, and rejects it.
+    let store = SubstitutingStore {
+        chunk: foreign_soc.into(),
+    };
+    let reader: FeedReader<Sequence, SubstitutingStore, DEFAULT_BODY_SIZE> =
+        FeedReader::new(feed, store);
+
+    let result = reader.get(&Sequence(0)).await;
+    match result {
+        Err(FeedError::OwnerMismatch { expected, actual }) => {
+            assert_eq!(expected, owner, "expected owner is the feed owner");
+            assert_eq!(
+                actual,
+                foreign.address(),
+                "actual owner is the foreign signer"
+            );
+        }
+        other => panic!("foreign-owner chunk must be rejected with OwnerMismatch, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn content_chunk_at_feed_address_is_rejected_as_not_single_owner() {
+    let owner_signer = PrivateKeySigner::random();
+    let owner = owner_signer.address();
+    let feed = Feed::<DEFAULT_BODY_SIZE>::new(Topic::from_bytes(b"feed-cac-check"), owner);
+
+    // A backend returns a content-addressed chunk (not a single-owner chunk) for
+    // the feed slot. Feed resolution must reject it on the SOC discrimination,
+    // not attempt to treat it as an update.
+    let cac = DefaultContentChunk::new(b"not a soc".to_vec()).expect("build cac");
+    let store = SubstitutingStore { chunk: cac.into() };
+    let reader: FeedReader<Sequence, SubstitutingStore, DEFAULT_BODY_SIZE> =
+        FeedReader::new(feed, store);
+
+    match reader.get(&Sequence(0)).await {
+        Err(FeedError::NotSingleOwner) => {}
+        other => panic!("a content chunk must be rejected with NotSingleOwner, got {other:?}"),
+    }
+}

--- a/crates/feeds/tests/sequence_vectors.rs
+++ b/crates/feeds/tests/sequence_vectors.rs
@@ -1,0 +1,186 @@
+//! Cross-client conformance vectors for the sequence feed scheme.
+//!
+//! Two layers of vectors:
+//!
+//! 1. Single-owner chunk anchors from the Swarm SOC test vectors, pinning the
+//!    SOC address and inner content-addressed chunk address for a known id,
+//!    payload, and signature. These tie our chunk substrate to the Swarm wire
+//!    spec byte for byte.
+//! 2. Feed-level vectors: for a fixed topic and owner, the derived update id and
+//!    update address at several sequence numbers. These pin our id and address
+//!    derivation (`keccak256(topic || index) -> keccak256(id || owner)`).
+//!
+//! The feed-level vectors below were computed by this implementation and are
+//! the shared cross-client baseline for the sequence scheme.
+
+use alloy_primitives::{B256, Signature, address, b256, hex};
+use alloy_signer_local::PrivateKeySigner;
+use bytes::Bytes;
+use nectar_feeds::{Feed, Sequence, Topic};
+use nectar_primitives::chunk::{Chunk, SingleOwnerChunk};
+use nectar_primitives::{DEFAULT_BODY_SIZE, DefaultContentChunk, DefaultSingleOwnerChunk};
+
+/// The SOC test anchor: id of all zeroes, payload `"foo"`, and the known good
+/// signature from the Swarm SOC vectors. The SOC address and the inner CAC
+/// address are pinned.
+#[test]
+fn reference_soc_anchor() {
+    let id = B256::ZERO;
+    let payload = b"foo".to_vec();
+    let sig = hex!(
+        "5acd384febc133b7b245e5ddc62d82d2cded9182d2716126cd8844509af65a05\
+         3deb418208027f548e3e88343af6f84a8772fb3cebc0a1833a0ea7ec0c134831\
+         1b"
+    );
+    assert_eq!(sig.len(), 65, "reference signature is 65 bytes");
+    let signature = Signature::try_from(sig.as_slice()).unwrap();
+
+    let soc = DefaultSingleOwnerChunk::with_signature(id, signature, payload.clone()).unwrap();
+
+    // SOC address = keccak256(id || owner).
+    let expected_soc_address =
+        b256!("9d453ebb73b2fedaaf44ceddcf7a0aa37f3e3d6453fea5841c31f0ea6d61dc85");
+    assert_eq!(soc.address().as_ref(), &expected_soc_address);
+
+    // Inner content-addressed chunk address (the wrapped CAC for `"foo"`).
+    let cac = DefaultContentChunk::new(payload).unwrap();
+    let expected_cac_address =
+        b256!("2387e8e7d8a48c2a9339c97c1dc3461a9a7aa07e994c5cb8b38fd7c1b3e6ea48");
+    assert_eq!(cac.address().as_ref(), &expected_cac_address);
+}
+
+/// Feed-level regression vectors: fixed topic and owner, derived update id and
+/// address at sequence numbers 0, 1, and 42.
+///
+/// The owner is the address of the key used in `reference_sequence_update_vector`
+/// so every feed-level vector in this file shares one identity; the sequence-0
+/// address therefore matches the bee-captured chunk address there.
+#[test]
+fn sequence_feed_vectors() {
+    let topic = Topic::from_bytes(b"testtopic");
+    let owner = address!("654bFE2E030Ff82B8741c7a0BF9eC26Ea523b31C");
+    let feed = Feed::<DEFAULT_BODY_SIZE>::new(topic, owner);
+
+    // topic = keccak256("testtopic")
+    assert_eq!(
+        topic.as_bytes(),
+        &b256!("65cf9694019c5d902d773447898b875265abd8c57e6b95e926cf491254e3ad8e"),
+    );
+
+    let cases: [(u64, B256, B256); 3] = [
+        (
+            0,
+            b256!("115cba53a31da205fbcbe3e367c7ff9e6ed5a3bf602d34c4204cc0352c68a817"),
+            b256!("d8020d494642ee61d705dab9b68a050a6fed29c25b3924986c02ff1c5f7a0241"),
+        ),
+        (
+            1,
+            b256!("5e756defc3f5631327eed03099dcf3e6532292483465ca8903a3c528ebd465d3"),
+            b256!("83776e6c2310c4036f4f6e9f10a67c84b574b7e4fd19329f3608e2d11cbc04ed"),
+        ),
+        (
+            42,
+            b256!("59ffcd1f278b875f7352fc3cd6e9048ae22da2d8c05a36f3cd941ff9ce6fc230"),
+            b256!("f26d4798f6eb23493cfc7c5b453805de421f578e518445d244270ecf10c7fae3"),
+        ),
+    ];
+
+    for (n, expected_id, expected_address) in cases {
+        let index = Sequence(n);
+        assert_eq!(feed.update_id(&index), expected_id, "id for seq {n}");
+        assert_eq!(
+            feed.update_address(&index).0,
+            expected_address,
+            "address for seq {n}",
+        );
+    }
+}
+
+/// Canonical Swarm-reference fixture for a full signed sequence update.
+///
+/// Captured from the Go reference for a fixed input: topic
+/// `keccak256("testtopic")`, the fixed secp256k1 key whose address is
+/// `0x654bFE2E030Ff82B8741c7a0BF9eC26Ea523b31C`, sequence index 0, and payload
+/// `"data"`. It anchors the full update path end to end: the
+/// `topic || index || owner` derivation, the single-owner chunk id, the
+/// deterministic (RFC 6979) signature over `keccak256(id || wrapped-cac-bmt)`,
+/// the single-owner chunk address, and the exact serialized chunk bytes
+/// (`id || signature || span || payload`).
+///
+/// Re-signing the same input in this implementation reproduces the reference
+/// signature byte for byte, proving the signing preimage and curve parameters
+/// agree with the reference.
+#[test]
+fn reference_sequence_update_vector() {
+    // Fixed secp256k1 private key from the Swarm reference SOC test vectors.
+    let key = hex!("2c7536e3605d9c16a7a3d7b1898e529396a65c23a3bcbd4012a11cf2731b0fbc");
+    let signer = PrivateKeySigner::from_slice(&key).expect("decode key");
+    let owner = signer.address();
+    assert_eq!(
+        owner,
+        address!("654bFE2E030Ff82B8741c7a0BF9eC26Ea523b31C"),
+        "owner derived from the fixed key",
+    );
+
+    let topic = Topic::from_bytes(b"testtopic");
+    assert_eq!(
+        topic.as_bytes(),
+        &b256!("65cf9694019c5d902d773447898b875265abd8c57e6b95e926cf491254e3ad8e"),
+    );
+    let feed = Feed::<DEFAULT_BODY_SIZE>::new(topic, owner);
+
+    // Sequence index 0: id = keccak256(topic || 8 big-endian zero bytes).
+    let index = Sequence(0);
+    let expected_id = b256!("115cba53a31da205fbcbe3e367c7ff9e6ed5a3bf602d34c4204cc0352c68a817");
+    assert_eq!(feed.update_id(&index), expected_id, "reference feed id");
+
+    // Reference signature over keccak256(id || wrapped-cac-bmt) for payload "data".
+    let expected_sig = hex!(
+        "22027e843e0f65f3f1f061be80f2c4fc1ae7cc2e11a8260d44068b6ecb753cd6\
+         7408358be2dca9d0ed020cdc7ad1598aeef1636a0452be4386981692ca930811\
+         1b"
+    );
+    let expected_sig = Signature::try_from(expected_sig.as_slice()).expect("decode sig");
+
+    // Reference single-owner chunk address and full serialized chunk bytes.
+    let expected_soc_address =
+        b256!("d8020d494642ee61d705dab9b68a050a6fed29c25b3924986c02ff1c5f7a0241");
+    let expected_chunk = hex!(
+        "115cba53a31da205fbcbe3e367c7ff9e6ed5a3bf602d34c4204cc0352c68a817\
+         22027e843e0f65f3f1f061be80f2c4fc1ae7cc2e11a8260d44068b6ecb753cd6\
+         7408358be2dca9d0ed020cdc7ad1598aeef1636a0452be4386981692ca930811\
+         1b040000000000000064617461"
+    );
+
+    // Build the same update in this implementation and re-sign deterministically.
+    let soc = SingleOwnerChunk::<DEFAULT_BODY_SIZE>::new(expected_id, b"data".to_vec(), &signer)
+        .expect("sign update");
+
+    assert_eq!(
+        soc.signature(),
+        &expected_sig,
+        "re-signed signature matches the reference byte for byte",
+    );
+    assert_eq!(
+        soc.address().as_ref(),
+        &expected_soc_address,
+        "single-owner chunk address matches the reference",
+    );
+    assert_eq!(
+        soc.owner().expect("recover owner"),
+        owner,
+        "recovered owner matches the feed owner",
+    );
+    assert_eq!(
+        soc.address(),
+        &feed.update_address(&index),
+        "reference address matches the feed's derived update address",
+    );
+
+    let chunk_bytes: Bytes = soc.into();
+    assert_eq!(
+        chunk_bytes.as_ref(),
+        expected_chunk.as_slice(),
+        "serialized chunk bytes match the reference",
+    );
+}

--- a/crates/primitives/src/bmt/wasm.rs
+++ b/crates/primitives/src/bmt/wasm.rs
@@ -3,9 +3,6 @@
 //! This module provides JavaScript-friendly wrappers around Hasher types.
 
 use super::{Hasher, Proof, Prover};
-use crate::chunk::ChunkAddress;
-use alloy_primitives::B256;
-use digest::Digest;
 use js_sys::{Array, Uint8Array};
 use wasm_bindgen::prelude::*;
 

--- a/crates/primitives/src/chunk/single_owner.rs
+++ b/crates/primitives/src/chunk/single_owner.rs
@@ -618,7 +618,9 @@ mod tests {
     type DefaultSingleOwnerChunk = SingleOwnerChunk<DEFAULT_BODY_SIZE>;
 
     fn get_test_wallet() -> PrivateKeySigner {
-        // Test private key corresponding to address 0x8d3766440f0d7b949a5e32995d09619a7f86e632
+        // Test private key whose address is 0x654bFE2E030Ff82B8741c7a0BF9eC26Ea523b31C.
+        // (The 0x8d3766... owner elsewhere in these tests comes from the published
+        // SOC-test signature, which was produced by a different key.)
         let pk = hex!("2c7536e3605d9c16a7a3d7b1898e529396a65c23a3bcbd4012a11cf2731b0fbc");
         PrivateKeySigner::from_slice(&pk).unwrap()
     }

--- a/crates/primitives/src/file/mod.rs
+++ b/crates/primitives/src/file/mod.rs
@@ -64,7 +64,7 @@ mod tree;
 use crate::chunk::ChunkAddress;
 #[cfg(feature = "encryption")]
 use crate::chunk::encryption::EncryptedChunkRef;
-use crate::store::{SyncChunkGet, SyncChunkPut};
+use crate::store::{MaybeSend, MaybeSync, SyncChunkGet, SyncChunkPut};
 
 // Async (primary) re-exports
 #[cfg(feature = "encryption")]
@@ -96,7 +96,7 @@ mod join_ref_sealed {
 }
 
 /// Maps a reference type to its join mode.
-/// Sealed — implemented for `ChunkAddress` and `EncryptedChunkRef`.
+/// Sealed; implemented for `ChunkAddress` and `EncryptedChunkRef`.
 pub trait JoinRef: join_ref_sealed::Sealed + Clone + Send + Sync + 'static {
     /// The join mode associated with this reference type.
     type Mode: mode::JoinMode + Send + Sync;
@@ -205,9 +205,10 @@ pub trait ChunkGetExt<const BODY_SIZE: usize>: crate::store::ChunkGet<BODY_SIZE>
     fn joiner<R: JoinRef>(
         self,
         root: R,
-    ) -> impl std::future::Future<Output = error::Result<GenericJoiner<Self, R::Mode, BODY_SIZE>>> + Send
+    ) -> impl std::future::Future<Output = error::Result<GenericJoiner<Self, R::Mode, BODY_SIZE>>>
+    + MaybeSend
     where
-        Self: Sized + Clone + Send + Sync + 'static,
+        Self: Sized + Clone + MaybeSend + MaybeSync + 'static,
     {
         GenericJoiner::new(self, root.into_root_ref())
     }
@@ -216,9 +217,9 @@ pub trait ChunkGetExt<const BODY_SIZE: usize>: crate::store::ChunkGet<BODY_SIZE>
     fn read_file<R: JoinRef>(
         self,
         root: R,
-    ) -> impl std::future::Future<Output = error::Result<Vec<u8>>> + Send
+    ) -> impl std::future::Future<Output = error::Result<Vec<u8>>> + MaybeSend
     where
-        Self: Sized + Clone + Send + Sync + 'static,
+        Self: Sized + Clone + MaybeSend + MaybeSync + 'static,
     {
         join(self, root)
     }

--- a/crates/primitives/src/store/maybe_send.rs
+++ b/crates/primitives/src/store/maybe_send.rs
@@ -1,0 +1,38 @@
+//! Target-conditional `Send`/`Sync` marker aliases for the async store traits.
+//!
+//! On native targets the async store traits and their returned futures must be
+//! `Send + Sync` so they can be driven by a multi-threaded work-stealing
+//! executor. On `wasm32-unknown-unknown` the runtime is single-threaded and the
+//! underlying primitives (browser timers, libp2p swarm and stream futures) are
+//! `!Send`. Bounding the traits on these aliases lets a single crate compile on
+//! both: `MaybeSend`/`MaybeSync` carry the real `Send`/`Sync` requirement off
+//! wasm and collapse to no-op markers on wasm, so wasm consumers (feed finders,
+//! mantaray traversal) need no `SendWrapper` to satisfy the bounds.
+
+/// `Send` on native targets, a no-op marker on `wasm32`.
+#[cfg(not(target_arch = "wasm32"))]
+pub trait MaybeSend: Send {}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<T: Send> MaybeSend for T {}
+
+/// `Send` on native targets, a no-op marker on `wasm32`.
+#[cfg(target_arch = "wasm32")]
+pub trait MaybeSend {}
+
+#[cfg(target_arch = "wasm32")]
+impl<T> MaybeSend for T {}
+
+/// `Sync` on native targets, a no-op marker on `wasm32`.
+#[cfg(not(target_arch = "wasm32"))]
+pub trait MaybeSync: Sync {}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<T: Sync> MaybeSync for T {}
+
+/// `Sync` on native targets, a no-op marker on `wasm32`.
+#[cfg(target_arch = "wasm32")]
+pub trait MaybeSync {}
+
+#[cfg(target_arch = "wasm32")]
+impl<T> MaybeSync for T {}

--- a/crates/primitives/src/store/memory.rs
+++ b/crates/primitives/src/store/memory.rs
@@ -81,6 +81,10 @@ impl<const BODY_SIZE: usize> SyncChunkGet<BODY_SIZE> for MemoryStore<BODY_SIZE> 
             .cloned()
             .ok_or_else(|| ChunkStoreError::not_found(address))
     }
+
+    fn is_not_found(&self, error: &Self::Error) -> bool {
+        error.is_not_found()
+    }
 }
 
 impl<const BODY_SIZE: usize> SyncChunkHas<BODY_SIZE> for MemoryStore<BODY_SIZE> {
@@ -98,6 +102,10 @@ impl<const BODY_SIZE: usize> SyncChunkGet<BODY_SIZE>
         self.get(address)
             .cloned()
             .ok_or_else(|| ChunkStoreError::not_found(address))
+    }
+
+    fn is_not_found(&self, error: &Self::Error) -> bool {
+        error.is_not_found()
     }
 }
 

--- a/crates/primitives/src/store/mod.rs
+++ b/crates/primitives/src/store/mod.rs
@@ -5,9 +5,11 @@
 //! for CPU-bound paths (splitter, mantaray). Blanket impls bridge sync → async
 //! automatically for types that are `Send + Sync`.
 
+mod maybe_send;
 mod memory;
 mod typed;
 
+pub use maybe_send::{MaybeSend, MaybeSync};
 pub use memory::MemoryStore;
 pub use typed::{ChunkGet, ChunkHas, ChunkPut, SyncChunkGet, SyncChunkHas, SyncChunkPut};
 
@@ -35,6 +37,11 @@ impl ChunkStoreError {
             address_hex: format!("{address}"),
         }
     }
+
+    /// Whether this is a genuine miss (`NotFound`) rather than a backend error.
+    pub const fn is_not_found(&self) -> bool {
+        matches!(self, Self::NotFound { .. })
+    }
 }
 
 /// A no-op loader that always returns [`ChunkStoreError::NotFound`].
@@ -49,5 +56,9 @@ impl<const BODY_SIZE: usize> SyncChunkGet<BODY_SIZE> for NullLoader<BODY_SIZE> {
 
     fn get(&self, address: &ChunkAddress) -> Result<AnyChunk<BODY_SIZE>, Self::Error> {
         Err(ChunkStoreError::not_found(address))
+    }
+
+    fn is_not_found(&self, error: &Self::Error) -> bool {
+        error.is_not_found()
     }
 }

--- a/crates/primitives/src/store/typed.rs
+++ b/crates/primitives/src/store/typed.rs
@@ -9,8 +9,9 @@ use std::future::Future;
 
 use crate::bmt::DEFAULT_BODY_SIZE;
 use crate::chunk::{AnyChunk, ChunkAddress};
+use crate::store::{MaybeSend, MaybeSync};
 
-/// Stores chunks (synchronous, `&self` — implementors use interior mutability).
+/// Stores chunks (synchronous, `&self`; implementors use interior mutability).
 pub trait SyncChunkPut<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> {
     /// Error type for put operations.
     type Error: std::error::Error + Send + Sync + 'static;
@@ -26,6 +27,18 @@ pub trait SyncChunkGet<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> {
 
     /// Get a chunk by address.
     fn get(&self, address: &ChunkAddress) -> Result<AnyChunk<BODY_SIZE>, Self::Error>;
+
+    /// Whether `error` signals a genuine absence rather than a backend failure.
+    ///
+    /// Callers that treat a miss as "not present yet" (feed finders walking an
+    /// index, mantaray traversal probing for a node) use this to separate a
+    /// clean miss from an error they must propagate. The default returns
+    /// `false`, so an implementor that never distinguishes the two keeps every
+    /// error opaque.
+    fn is_not_found(&self, error: &Self::Error) -> bool {
+        let _ = error;
+        false
+    }
 }
 
 /// Checks chunk existence (synchronous).
@@ -53,12 +66,18 @@ impl<T: SyncChunkGet<BS>, const BS: usize> SyncChunkGet<BS> for &T {
     fn get(&self, address: &ChunkAddress) -> Result<AnyChunk<BS>, Self::Error> {
         (**self).get(address)
     }
+    fn is_not_found(&self, error: &Self::Error) -> bool {
+        (**self).is_not_found(error)
+    }
 }
 
 impl<T: SyncChunkGet<BS>, const BS: usize> SyncChunkGet<BS> for &mut T {
     type Error = T::Error;
     fn get(&self, address: &ChunkAddress) -> Result<AnyChunk<BS>, Self::Error> {
         (**self).get(address)
+    }
+    fn is_not_found(&self, error: &Self::Error) -> bool {
+        (**self).is_not_found(error)
     }
 }
 
@@ -80,7 +99,7 @@ impl<T: SyncChunkHas<BS>, const BS: usize> SyncChunkHas<BS> for &mut T {
 /// a blanket impl. Types needing genuinely async retrieval (e.g. network
 /// fetch) should implement `ChunkGet` directly without implementing
 /// `SyncChunkGet`.
-pub trait ChunkGet<const BODY_SIZE: usize = DEFAULT_BODY_SIZE>: Send + Sync {
+pub trait ChunkGet<const BODY_SIZE: usize = DEFAULT_BODY_SIZE>: MaybeSend + MaybeSync {
     /// Error type for get operations.
     type Error: std::error::Error + Send + Sync + 'static;
 
@@ -88,7 +107,18 @@ pub trait ChunkGet<const BODY_SIZE: usize = DEFAULT_BODY_SIZE>: Send + Sync {
     fn get(
         &self,
         address: &ChunkAddress,
-    ) -> impl Future<Output = Result<AnyChunk<BODY_SIZE>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<AnyChunk<BODY_SIZE>, Self::Error>> + MaybeSend;
+
+    /// Whether `error` signals a genuine absence rather than a backend failure.
+    ///
+    /// A finder that walks an address space (feed lookup, mantaray traversal)
+    /// uses this to treat a miss as absence and propagate every other error.
+    /// The default returns `false`; a network getter that knows its own
+    /// not-found variant should override it.
+    fn is_not_found(&self, error: &Self::Error) -> bool {
+        let _ = error;
+        false
+    }
 }
 
 impl<T, const BS: usize> ChunkGet<BS> for T
@@ -100,12 +130,16 @@ where
     async fn get(&self, address: &ChunkAddress) -> Result<AnyChunk<BS>, Self::Error> {
         SyncChunkGet::get(self, address)
     }
+
+    fn is_not_found(&self, error: &Self::Error) -> bool {
+        SyncChunkGet::is_not_found(self, error)
+    }
 }
 
 /// Async chunk existence check (primary API).
-pub trait ChunkHas<const BODY_SIZE: usize = DEFAULT_BODY_SIZE>: Send + Sync {
+pub trait ChunkHas<const BODY_SIZE: usize = DEFAULT_BODY_SIZE>: MaybeSend + MaybeSync {
     /// Check if a chunk exists.
-    fn has(&self, address: &ChunkAddress) -> impl Future<Output = bool> + Send;
+    fn has(&self, address: &ChunkAddress) -> impl Future<Output = bool> + MaybeSend;
 }
 
 impl<T, const BS: usize> ChunkHas<BS> for T
@@ -121,7 +155,7 @@ where
 ///
 /// Implementors should use interior mutability (e.g. `Mutex`, `RwLock`).
 /// Types implementing `SyncChunkPut + Send + Sync` get this automatically.
-pub trait ChunkPut<const BODY_SIZE: usize = DEFAULT_BODY_SIZE>: Send + Sync {
+pub trait ChunkPut<const BODY_SIZE: usize = DEFAULT_BODY_SIZE>: MaybeSend + MaybeSync {
     /// Error type for put operations.
     type Error: std::error::Error + Send + Sync + 'static;
 
@@ -129,7 +163,7 @@ pub trait ChunkPut<const BODY_SIZE: usize = DEFAULT_BODY_SIZE>: Send + Sync {
     fn put(
         &self,
         chunk: AnyChunk<BODY_SIZE>,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> impl Future<Output = Result<(), Self::Error>> + MaybeSend;
 }
 
 impl<T, const BS: usize> ChunkPut<BS> for T


### PR DESCRIPTION
## Summary

Adds `nectar-feeds`, implementing Swarm feeds as single-owner chunks, together with the nectar-primitives support it needs. A feed update is a single-owner chunk with id `keccak256(topic || index)` at address `keccak256(id || owner)`; the chunk body wraps a content-addressed chunk of the payload.

## What is included

`feat(primitives)`: relax the async store-trait Send bound to a target-conditional `MaybeSend`/`MaybeSync` so wasm32 consumers no longer need a `SendWrapper` hack while native keeps the Send guarantee; add `ChunkGet::is_not_found` so a genuine miss is distinguishable from a real backend error; make nectar-primitives build for `wasm32-unknown-unknown`.

`feat(feeds)`: the crate itself. Sequence indexing is the canonical scheme; epoch indexing is provided behind the `epoch` feature as experimental. The reader verifies the single-owner chunk address and binds the recovered owner to the feed owner. The writer signs the chunk and advances a scheme-specific write cursor that selects the publish index from the update time, so the time-indexed epoch scheme is driven correctly through the generic writer. Latest-update lookup is a per-scheme async finder over `ChunkGet` with no wall clock in the crate; the caller supplies the target time.

## Versioning decisions

Sequence is the canonical scheme. Epoch is experimental behind its feature (it is not used on the live network). Payloads are v2 bare-data only; reading the v1 legacy payload (timestamp plus reference) is deferred to #92. MRU is unsupported.

## Verification

`cargo fmt` and `cargo clippy --all-targets --all-features -- -D warnings` are clean. 32 feeds tests and the full primitives suite pass. nectar-feeds compiles on `wasm32-unknown-unknown` (default and `epoch`). Zero unsafe in the crate. Conformance vectors pin the single-owner chunk anchor, the topic and id derivation, and a reference-captured full signed-chunk fixture.

## Review

Designed across independent architecture reviews and hardened through a multi-agent audit (code quality, wire conformance, security, attack and QA) with adversarial verification of every finding. A notable fix: the epoch read path now runs the same address verification as the sequence path, so a foreign or wrong-epoch owner-signed chunk returned by an untrusted store is rejected rather than accepted as the queried slot.

Closes #39
Closes #83
Closes #84
Part of #82
Follow-up: #92
