### PR TITLE
refactor(postage-usage)!: rename ChunkSink/ChunkSource to SnapshotSink/SnapshotSource

### DIFF
--- a/crates/postage-usage/Cargo.toml
+++ b/crates/postage-usage/Cargo.toml
@@ -52,7 +52,7 @@ seal = ["dep:alloy-signer", "std"]
 
 # High-level async facade (`BatchStamper`) that collapses the open / stamp /
 # flush cross-machine roam into three calls. The consumer supplies the network
-# through the `ChunkSource` and `ChunkSink` traits. Implies `seal` (it seals
+# through the `SnapshotSource` and `SnapshotSink` traits. Implies `seal` (it seals
 # every persist) and `std` (it reads the wall clock for the seal timestamp).
 client = ["std", "seal", "dep:auto_impl", "dep:web-time"]
 

--- a/crates/postage-usage/examples/roam_between_machines.rs
+++ b/crates/postage-usage/examples/roam_between_machines.rs
@@ -16,7 +16,7 @@
 //!
 //! It uses no real network: "machine A" and "machine B" are two scopes in the
 //! same process sharing one in-memory [`MemNet`], which implements both
-//! [`ChunkSource`] and [`ChunkSink`]. Machine B starts from the key and batch id
+//! [`SnapshotSource`] and [`SnapshotSink`]. Machine B starts from the key and batch id
 //! alone, exactly as a real second device would, and the facade recovers the
 //! counters by fetching and parsing the chunks machine A uploaded.
 //!
@@ -33,8 +33,8 @@ use alloy_signer_local::PrivateKeySigner;
 use bytes::Bytes;
 use nectar_postage::Batch;
 use nectar_postage_usage::{
-    BatchStamper, ChunkSink, ChunkSource, Mutability, PublishedSequence, SealedChunk, Snapshot,
-    SwarmAddress, UsageError, UsageTable,
+    BatchStamper, Mutability, PublishedSequence, SealedChunk, Snapshot, SnapshotSink,
+    SnapshotSource, SwarmAddress, UsageError, UsageTable,
 };
 use nectar_primitives::Chunk;
 
@@ -45,7 +45,7 @@ const DEPTH: u8 = 20;
 const BUCKET_DEPTH: u8 = 16;
 
 /// A shared in-memory network keyed by single-owner-chunk address. The same
-/// value backs the [`ChunkSource`] machine B reads from and the [`ChunkSink`]
+/// value backs the [`SnapshotSource`] machine B reads from and the [`SnapshotSink`]
 /// machine A uploads to, so the only thing crossing between the two machines is
 /// the bytes on the wire.
 #[derive(Clone, Default)]
@@ -57,14 +57,14 @@ struct MemNet {
 #[error("in-memory network error")]
 struct MemError;
 
-impl ChunkSource for MemNet {
+impl SnapshotSource for MemNet {
     type Error = MemError;
     async fn fetch(&self, address: &SwarmAddress) -> Result<Option<Bytes>, Self::Error> {
         Ok(self.chunks.lock().unwrap().get(address).cloned())
     }
 }
 
-impl ChunkSink for MemNet {
+impl SnapshotSink for MemNet {
     type Error = MemError;
     async fn push(&self, sealed: &SealedChunk) -> Result<(), Self::Error> {
         let address = *sealed.chunk.address();

--- a/crates/postage-usage/src/client.rs
+++ b/crates/postage-usage/src/client.rs
@@ -7,7 +7,7 @@
 //! live floor, revalidate, plan, choose a strictly increasing timestamp, seal,
 //! and upload each sealed chunk. [`BatchStamper`] collapses that into
 //! `open` / `stamp` / `flush`, leaving the consumer to supply only the network
-//! through the [`ChunkSource`] and [`ChunkSink`] traits.
+//! through the [`SnapshotSource`] and [`SnapshotSink`] traits.
 //!
 //! Power users who need partial persists, custom timestamp policies, or direct
 //! access to the [`PersistPlan`] should keep reaching for the low-level
@@ -19,7 +19,7 @@
 //! The whole point of the published-sequence floor (nectar issue #70) is that a
 //! persist can never regress the version published at a snapshot's own chunk
 //! addresses. That guarantee survives only if a failed network read is never
-//! mistaken for "the chunk is absent". [`ChunkSource::fetch`] therefore
+//! mistaken for "the chunk is absent". [`SnapshotSource::fetch`] therefore
 //! distinguishes `Ok(None)` (the network definitively agrees the chunk does not
 //! exist) from `Err` (the read could not be completed). [`BatchStamper::open`]
 //! and [`BatchStamper::flush`] both abort on `Err`: a transport failure never
@@ -54,7 +54,7 @@ use crate::{UsageError, usage_chunk_address};
 /// floor as [`PublishedSequence::NONE`] and reopen the downgrade that nectar
 /// issue #70 closes.
 #[auto_impl::auto_impl(&, Arc, Box)]
-pub trait ChunkSource {
+pub trait SnapshotSource {
     /// The error a failed read reports. A value of this type means the read did
     /// not complete; it never means the chunk is absent.
     type Error: core::error::Error + Send + Sync + 'static;
@@ -75,13 +75,13 @@ pub trait ChunkSource {
 /// Publishes a sealed snapshot chunk (the single-owner chunk and its stamp) to
 /// the network.
 #[auto_impl::auto_impl(&, Arc, Box)]
-pub trait ChunkSink {
+pub trait SnapshotSink {
     /// The error a failed publish reports.
     type Error: core::error::Error + Send + Sync + 'static;
 
     /// Uploads a sealed snapshot chunk.
     ///
-    /// As with [`ChunkSource::fetch`], the returned future carries no `Send`
+    /// As with [`SnapshotSource::fetch`], the returned future carries no `Send`
     /// bound so a `!Send` browser transport can implement it; native `Send`-ness
     /// propagates through the facade on its own.
     fn push(
@@ -111,12 +111,12 @@ where
     /// Sealing the persist plan failed.
     #[error(transparent)]
     Seal(#[from] SealError),
-    /// The [`ChunkSource`] read could not be completed. This is *not* an absence:
+    /// The [`SnapshotSource`] read could not be completed. This is *not* an absence:
     /// `open` and `flush` abort here rather than starting fresh or persisting
     /// against a [`PublishedSequence::NONE`] floor.
     #[error("chunk source read failed")]
     Source(#[source] SrcErr),
-    /// The [`ChunkSink`] publish failed.
+    /// The [`SnapshotSink`] publish failed.
     #[error("chunk sink publish failed")]
     Sink(#[source] SnkErr),
     /// A published root committed to a leaf the source reported as absent. A
@@ -159,8 +159,8 @@ pub struct BatchStamper<Sg, Src, Snk> {
 impl<Sg, Src, Snk> BatchStamper<Sg, Src, Snk>
 where
     Sg: SignerSync + alloy_signer::Signer,
-    Src: ChunkSource,
-    Snk: ChunkSink,
+    Src: SnapshotSource,
+    Snk: SnapshotSink,
 {
     /// Opens a stamper for `batch`, recovering published state or starting fresh.
     ///
@@ -333,8 +333,8 @@ mod tests {
     use super::*;
     use crate::{Mutability, UsageTable};
 
-    /// A shared in-memory network backing both a [`ChunkSource`] and a
-    /// [`ChunkSink`], keyed by single-owner-chunk address.
+    /// A shared in-memory network backing both a [`SnapshotSource`] and a
+    /// [`SnapshotSink`], keyed by single-owner-chunk address.
     #[derive(Debug, Default, Clone)]
     struct MemNet {
         chunks: std::sync::Arc<Mutex<BTreeMap<SwarmAddress, Bytes>>>,
@@ -344,14 +344,14 @@ mod tests {
     #[error("mem net error")]
     struct MemError;
 
-    impl ChunkSource for MemNet {
+    impl SnapshotSource for MemNet {
         type Error = MemError;
         async fn fetch(&self, address: &SwarmAddress) -> Result<Option<Bytes>, Self::Error> {
             Ok(self.chunks.lock().unwrap().get(address).cloned())
         }
     }
 
-    impl ChunkSink for MemNet {
+    impl SnapshotSink for MemNet {
         type Error = MemError;
         async fn push(&self, sealed: &SealedChunk) -> Result<(), Self::Error> {
             use nectar_primitives::Chunk;
@@ -367,14 +367,14 @@ mod tests {
     #[derive(Debug, Default, Clone)]
     struct FailingSource;
 
-    impl ChunkSource for FailingSource {
+    impl SnapshotSource for FailingSource {
         type Error = MemError;
         async fn fetch(&self, _address: &SwarmAddress) -> Result<Option<Bytes>, Self::Error> {
             Err(MemError)
         }
     }
 
-    impl ChunkSink for FailingSource {
+    impl SnapshotSink for FailingSource {
         type Error = MemError;
         async fn push(&self, _sealed: &SealedChunk) -> Result<(), Self::Error> {
             Ok(())
@@ -386,7 +386,7 @@ mod tests {
     /// cannot produce `Send` futures.
     struct LocalNet(std::rc::Rc<()>);
 
-    impl ChunkSource for LocalNet {
+    impl SnapshotSource for LocalNet {
         type Error = MemError;
         fn fetch(
             &self,
@@ -400,7 +400,7 @@ mod tests {
         }
     }
 
-    impl ChunkSink for LocalNet {
+    impl SnapshotSink for LocalNet {
         type Error = MemError;
         fn push(
             &self,
@@ -414,14 +414,14 @@ mod tests {
         }
     }
 
-    /// Compile-time proof that a `!Send` transport satisfies [`ChunkSource`] and
-    /// [`ChunkSink`]. This only type-checks while neither trait bounds its future
+    /// Compile-time proof that a `!Send` transport satisfies [`SnapshotSource`] and
+    /// [`SnapshotSink`]. This only type-checks while neither trait bounds its future
     /// with `Send`, which is exactly what lets a single-threaded browser
     /// transport implement the facade. Re-adding a `+ Send` bound breaks here.
     #[test]
     fn non_send_transport_satisfies_the_traits() {
-        fn assert_source<S: ChunkSource>(_: &S) {}
-        fn assert_sink<K: ChunkSink>(_: &K) {}
+        fn assert_source<S: SnapshotSource>(_: &S) {}
+        fn assert_sink<K: SnapshotSink>(_: &K) {}
         let local = LocalNet(std::rc::Rc::new(()));
         assert_source(&local);
         assert_sink(&local);

--- a/crates/postage-usage/src/lib.rs
+++ b/crates/postage-usage/src/lib.rs
@@ -124,7 +124,7 @@ pub use issuer::SnapshotIssuer;
 pub use seal::{SealError, SealedChunk, seal_plan};
 
 #[cfg(feature = "client")]
-pub use client::{BatchStamper, ChunkSink, ChunkSource, ClientError};
+pub use client::{BatchStamper, ClientError, SnapshotSink, SnapshotSource};
 
 pub use nectar_primitives::SwarmAddress;
 


### PR DESCRIPTION
## What does this PR do?

Renames the `client`-feature traits in `nectar-postage-usage` from `ChunkSink` / `ChunkSource` to `SnapshotSink` / `SnapshotSource`, so their names advertise their actual domain.

## Why

These traits persist and read postage-usage snapshots. A snapshot chunk is a single-owner chunk written at an owner-bound, overwrite-in-place address (`keccak(usage_chunk_id(batch_id, index) || owner)`). A content-addressed chunk, whose address is the hash of its payload, physically cannot occupy one of those addresses, so the sink and source are single-owner-chunk only by construction (`seal_plan` only ever emits a `SingleOwnerChunk`).

The generic names `ChunkSink` / `ChunkSource` read as a general "publish or fetch any chunk" surface and invited misuse as one. They are not that. A general content-and-single-owner stamped publish path belongs one layer up, in the consumer (vertex's `SwarmChunkSender` over its stamped-chunk type), where the single-owner to stamped conversion already happens at the boundary. Renaming removes the name collision and makes the two-layer split legible. Widening the trait to accept any chunk was considered and rejected: it would manufacture an unrepresentable content-chunk-snapshot state for zero consumers.

## Changes

- `ChunkSink` to `SnapshotSink`, `ChunkSource` to `SnapshotSource` in `crates/postage-usage` (trait definitions, the `BatchStamper` bounds, the `lib.rs` re-export, doc comments, the `roam_between_machines` example, and the tests).
- Signatures are unchanged, including the deliberate no-`Send` bound on the `push` and `fetch` RPITIT futures. `SealedChunk` is left as-is (its name is already accurate).

## Breaking changes

Yes. `nectar-postage-usage::{ChunkSink, ChunkSource}` are renamed (behind the `client` feature). The only known external implementor is the vertex swarm-demo browser sink/source, which is updated in a coordinating change. Behaviour is identical.

## Testing

- [x] `cargo test -p nectar-postage-usage --features client` passes (29 unit tests, including `non_send_transport_satisfies_the_traits`, which is the compile-time guard that the futures carry no `Send` bound for the browser `!Send` path; plus doctests).
- [x] The `roam_between_machines` example builds.

## AI assistance disclosure

AI Assistance: a Claude Code agent proposed this rename (via a multi-agent architecture review that red-teamed whether the SOC-only sink was a smell), implemented it, and wrote this description. A human is accountable for the result and has reviewed it.
