### PR TITLE
feat(postage): add StampedChunk and its typed/wire codec; add AnyChunk::from_wire_bytes

### DIFF
--- a/crates/postage/src/error.rs
+++ b/crates/postage/src/error.rs
@@ -66,4 +66,15 @@ pub enum StampError {
     /// Signature verification failed.
     #[error("invalid signature")]
     InvalidSignature,
+
+    /// A chunk operation in `nectar-primitives` failed (for example decoding or
+    /// address verification of the chunk half of a stamped chunk).
+    ///
+    /// The variant carries a `&'static str` context rather than embedding the
+    /// underlying [`nectar_primitives::PrimitivesError`]: [`StampError`] is
+    /// `Clone`, `PartialEq` and `Eq`, whereas `PrimitivesError` is none of these
+    /// (it carries `std::io::Error` among others), and this crate is `no_std`
+    /// without `alloc`, so an owned `String` message is not available either.
+    #[error("chunk error: {0}")]
+    Chunk(&'static str),
 }

--- a/crates/postage/src/lib.rs
+++ b/crates/postage/src/lib.rs
@@ -36,9 +36,15 @@
 #[cfg(not(test))]
 use k256 as _;
 
+// `alloc` is required by the stamped-chunk codec (`Vec`). `nectar-primitives`,
+// a hard dependency, also already requires an allocator, so this adds no new
+// constraint to the `no_std` build.
+extern crate alloc;
+
 mod batch;
 mod error;
 mod stamp;
+mod stamped;
 mod util;
 mod validation;
 
@@ -58,6 +64,7 @@ pub mod parallel;
 pub use batch::{Batch, BatchId, BatchParams};
 pub use error::StampError;
 pub use stamp::{STAMP_SIZE, Stamp, StampBytes, StampDigest, StampIndex};
+pub use stamped::StampedChunk;
 pub use util::{PostageContext, calculate_bucket, current_timestamp};
 pub use validation::StampValidator;
 #[cfg(feature = "std")]

--- a/crates/postage/src/stamped.rs
+++ b/crates/postage/src/stamped.rs
@@ -1,0 +1,313 @@
+//! A chunk paired with the postage stamp that authorises its storage.
+//!
+//! [`StampedChunk`] is the pairing of an [`AnyChunk`] (a `nectar-primitives`
+//! type) with a [`Stamp`] (a `nectar-postage` type). A retrieval, a pushsync
+//! delivery, and an upload all move a *chunk plus its proof of payment* as one
+//! unit, so this pairing is the cohesive value that flows across those
+//! boundaries instead of two loose fields.
+//!
+//! Both halves are nectar types, so the pairing and its serialisation belong
+//! here. The wire codec is pure serialisation layered on top of the
+//! type-tagged [`AnyChunk`] codec and the fixed-size [`Stamp`] codec.
+
+use alloc::vec::Vec;
+
+use nectar_primitives::{AnyChunk, ChunkAddress, DEFAULT_BODY_SIZE, bytes::Bytes};
+
+use crate::{BatchId, STAMP_SIZE, Stamp, StampError};
+
+/// A chunk together with its postage stamp.
+///
+/// [`AnyChunk`] holds the chunk bytes but carries no stamp, so this pairing is
+/// the always-stamped currency on the network paths (pushsync, upload, the
+/// stamped reserve). The address is the chunk's own address;
+/// [`address`](Self::address) delegates to it.
+///
+/// # Equality
+///
+/// `PartialEq`/`Eq` are derived. The chunk component therefore inherits
+/// [`AnyChunk`]'s own equality, which compares chunks *by address only* (a
+/// chunk's address is the cryptographic commitment to its bytes, so equal
+/// addresses mean equal chunks), and the stamp component compares all stamp
+/// fields. Two stamped chunks are equal when their chunks share an address and
+/// their stamps are field-for-field identical. This matches the semantics of
+/// the original vertex `StampedChunk`, which also derived equality over the
+/// same two fields.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StampedChunk<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> {
+    chunk: AnyChunk<BODY_SIZE>,
+    stamp: Stamp,
+}
+
+impl<const BODY_SIZE: usize> StampedChunk<BODY_SIZE> {
+    /// Pair a chunk with its stamp.
+    #[inline]
+    #[must_use]
+    pub const fn new(chunk: AnyChunk<BODY_SIZE>, stamp: Stamp) -> Self {
+        Self { chunk, stamp }
+    }
+
+    /// The chunk.
+    #[inline]
+    #[must_use]
+    pub const fn chunk(&self) -> &AnyChunk<BODY_SIZE> {
+        &self.chunk
+    }
+
+    /// The postage stamp.
+    #[inline]
+    #[must_use]
+    pub const fn stamp(&self) -> &Stamp {
+        &self.stamp
+    }
+
+    /// The chunk's address (delegates to the chunk).
+    #[inline]
+    #[must_use]
+    pub fn address(&self) -> &ChunkAddress {
+        self.chunk.address()
+    }
+
+    /// Split into the chunk and its stamp.
+    #[inline]
+    #[must_use]
+    pub fn into_parts(self) -> (AnyChunk<BODY_SIZE>, Stamp) {
+        (self.chunk, self.stamp)
+    }
+
+    /// Encode to a self-describing byte string: the stamp followed by the
+    /// type-tagged chunk.
+    ///
+    /// The layout is `[stamp: STAMP_SIZE][type_id: 1][chunk wire bytes]`, the
+    /// stamp's fixed-size encoding ([`Stamp::to_bytes`], `STAMP_SIZE = 113`
+    /// bytes) followed by the chunk's type-tagged encoding
+    /// ([`AnyChunk::to_typed_bytes`]). Decode with
+    /// [`from_typed_bytes`](Self::from_typed_bytes).
+    #[must_use]
+    pub fn to_typed_bytes(&self) -> Vec<u8> {
+        let stamp = self.stamp.to_bytes();
+        let chunk = self.chunk.to_typed_bytes();
+        let mut out = Vec::with_capacity(stamp.len() + chunk.len());
+        out.extend_from_slice(&stamp);
+        out.extend_from_slice(&chunk);
+        out
+    }
+
+    /// Decode a stamped chunk produced by [`to_typed_bytes`](Self::to_typed_bytes).
+    ///
+    /// The first `STAMP_SIZE` bytes are the stamp ([`Stamp::from_bytes`]); the
+    /// remainder is the type-tagged chunk ([`AnyChunk::from_typed_bytes`]),
+    /// verified against `address`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error (and never panics) when the input is shorter than a
+    /// stamp, the stamp bytes are invalid, the chunk payload cannot be decoded,
+    /// or the chunk's computed address does not match `address`.
+    pub fn from_typed_bytes(address: &ChunkAddress, bytes: &[u8]) -> Result<Self, StampError> {
+        if bytes.len() < STAMP_SIZE {
+            return Err(StampError::InvalidData(
+                "stamped chunk shorter than a stamp",
+            ));
+        }
+        let (stamp_bytes, chunk_bytes) = bytes.split_at(STAMP_SIZE);
+        let stamp = Stamp::try_from_slice(stamp_bytes)?;
+        let chunk = AnyChunk::<BODY_SIZE>::from_typed_bytes(address, chunk_bytes)
+            .map_err(|_| StampError::Chunk("failed to decode typed chunk"))?;
+        Ok(Self::new(chunk, stamp))
+    }
+
+    /// Rebuild a stamped chunk from the bare chunk wire bytes, its expected
+    /// address, and a separately-carried stamp.
+    ///
+    /// `data` is the bare chunk wire bytes (no type tag), as carried in a
+    /// `Delivery { data, stamp }` wire message; the address disambiguates the
+    /// chunk variant (see [`AnyChunk::from_wire_bytes`]).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error (and never panics) when `data` does not hash to
+    /// `expected` as either a content or a single-owner chunk.
+    pub fn reconstruct(
+        expected: ChunkAddress,
+        data: Bytes,
+        stamp: Stamp,
+    ) -> Result<Self, StampError> {
+        let chunk = AnyChunk::<BODY_SIZE>::from_wire_bytes(&expected, data)
+            .map_err(|_| StampError::Chunk("chunk bytes do not match expected address"))?;
+        Ok(Self::new(chunk, stamp))
+    }
+
+    /// Read the batch id from a [`to_typed_bytes`](Self::to_typed_bytes) value
+    /// without a full decode.
+    ///
+    /// The stamp leads the encoding and [`Stamp::to_bytes`] places the batch id
+    /// in its first 32 bytes, so the batch id is `typed_bytes[0..32]`. This lets
+    /// a store index a stamped chunk by batch without decoding the chunk.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error (and never panics) when `typed_bytes` is shorter than 32
+    /// bytes.
+    pub fn batch_id(typed_bytes: &[u8]) -> Result<BatchId, StampError> {
+        let id = typed_bytes.get(..32).ok_or(StampError::InvalidData(
+            "typed bytes shorter than a batch id",
+        ))?;
+        Ok(BatchId::from_slice(id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{B256, Signature};
+    use alloy_signer_local::PrivateKeySigner;
+    use nectar_primitives::{Chunk, ContentChunk, SingleOwnerChunk, bytes::Bytes};
+
+    use super::*;
+
+    type DefaultStampedChunk = StampedChunk<DEFAULT_BODY_SIZE>;
+
+    fn test_stamp() -> Stamp {
+        let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
+        Stamp::new(B256::repeat_byte(0xaa), 3, 7, 42, sig)
+    }
+
+    fn content_chunk() -> ContentChunk<DEFAULT_BODY_SIZE> {
+        ContentChunk::new(&b"hello swarm"[..]).expect("valid content chunk")
+    }
+
+    fn single_owner_chunk() -> SingleOwnerChunk<DEFAULT_BODY_SIZE> {
+        let signer = PrivateKeySigner::from_bytes(&B256::repeat_byte(0x11)).expect("valid signer");
+        SingleOwnerChunk::new(B256::repeat_byte(0x22), &b"soc payload"[..], &signer)
+            .expect("valid soc")
+    }
+
+    #[test]
+    fn into_parts_round_trips_the_fields() {
+        let chunk: AnyChunk = content_chunk().into();
+        let stamp = test_stamp();
+        let stamped = DefaultStampedChunk::new(chunk.clone(), stamp.clone());
+        assert_eq!(stamped.address(), chunk.address());
+        let (got_chunk, got_stamp) = stamped.into_parts();
+        assert_eq!(got_chunk, chunk);
+        assert_eq!(got_stamp, stamp);
+    }
+
+    #[test]
+    fn typed_content_round_trip() {
+        let chunk = content_chunk();
+        let address = *chunk.address();
+        let stamp = test_stamp();
+        let stamped = DefaultStampedChunk::new(chunk.into(), stamp.clone());
+
+        let bytes = stamped.to_typed_bytes();
+        let decoded = DefaultStampedChunk::from_typed_bytes(&address, &bytes).expect("decode");
+
+        assert!(decoded.chunk().is_content());
+        assert_eq!(*decoded.address(), address);
+        assert_eq!(decoded.stamp().batch(), stamp.batch());
+        assert_eq!(decoded.stamp().timestamp(), stamp.timestamp());
+        assert_eq!(decoded, stamped);
+    }
+
+    #[test]
+    fn typed_single_owner_round_trip() {
+        let chunk = single_owner_chunk();
+        let address = *chunk.address();
+        let stamp = test_stamp();
+        let stamped = DefaultStampedChunk::new(chunk.into(), stamp.clone());
+
+        let bytes = stamped.to_typed_bytes();
+        let decoded = DefaultStampedChunk::from_typed_bytes(&address, &bytes).expect("decode");
+
+        assert!(decoded.chunk().is_single_owner());
+        assert_eq!(*decoded.address(), address);
+        assert_eq!(decoded.stamp().batch(), stamp.batch());
+        assert_eq!(decoded.stamp().timestamp(), stamp.timestamp());
+        assert_eq!(decoded, stamped);
+    }
+
+    #[test]
+    fn reconstruct_round_trips_from_wire() {
+        let chunk = content_chunk();
+        let address = *chunk.address();
+        let data = Bytes::from(chunk);
+        let stamp = test_stamp();
+
+        let rebuilt = DefaultStampedChunk::reconstruct(address, data.clone(), stamp.clone())
+            .expect("rebuild");
+        assert!(rebuilt.chunk().is_content());
+        assert_eq!(*rebuilt.address(), address);
+        assert_eq!(rebuilt.stamp(), &stamp);
+        assert_eq!(rebuilt.into_parts().0.into_bytes(), data);
+    }
+
+    #[test]
+    fn reconstruct_single_owner_from_wire() {
+        let chunk = single_owner_chunk();
+        let address = *chunk.address();
+        let data = Bytes::from(chunk);
+        let stamp = test_stamp();
+
+        let rebuilt =
+            DefaultStampedChunk::reconstruct(address, data, stamp.clone()).expect("rebuild");
+        assert!(rebuilt.chunk().is_single_owner());
+        assert_eq!(*rebuilt.address(), address);
+        assert_eq!(rebuilt.stamp(), &stamp);
+    }
+
+    #[test]
+    fn batch_id_matches_stamp_and_leading_bytes() {
+        let chunk = content_chunk();
+        let stamp = test_stamp();
+        let stamped = DefaultStampedChunk::new(chunk.into(), stamp.clone());
+        let bytes = stamped.to_typed_bytes();
+
+        let id = DefaultStampedChunk::batch_id(&bytes).expect("batch id");
+        assert_eq!(id, stamp.batch());
+        assert_eq!(id.as_slice(), &bytes[0..32]);
+    }
+
+    #[test]
+    fn from_typed_bytes_empty_errors() {
+        let address: ChunkAddress = [0u8; 32].into();
+        assert!(DefaultStampedChunk::from_typed_bytes(&address, &[]).is_err());
+    }
+
+    #[test]
+    fn from_typed_bytes_shorter_than_stamp_errors() {
+        let address: ChunkAddress = [0u8; 32].into();
+        let short = [0u8; STAMP_SIZE - 1];
+        let err = DefaultStampedChunk::from_typed_bytes(&address, &short)
+            .expect_err("short input must error");
+        assert!(matches!(err, StampError::InvalidData(_)));
+    }
+
+    #[test]
+    fn from_typed_bytes_address_mismatch_errors() {
+        let chunk = content_chunk();
+        let stamped = DefaultStampedChunk::new(chunk.into(), test_stamp());
+        let bytes = stamped.to_typed_bytes();
+
+        let wrong: ChunkAddress = [0xFFu8; 32].into();
+        let err = DefaultStampedChunk::from_typed_bytes(&wrong, &bytes)
+            .expect_err("address mismatch must error");
+        assert!(matches!(err, StampError::Chunk(_)));
+    }
+
+    #[test]
+    fn reconstruct_rejects_wrong_address() {
+        let chunk = content_chunk();
+        let data = Bytes::from(chunk);
+        let wrong: ChunkAddress = [0xFFu8; 32].into();
+        let err = DefaultStampedChunk::reconstruct(wrong, data, test_stamp())
+            .expect_err("wrong address must error");
+        assert!(matches!(err, StampError::Chunk(_)));
+    }
+
+    #[test]
+    fn batch_id_short_errors() {
+        let short = [0u8; 31];
+        assert!(DefaultStampedChunk::batch_id(&short).is_err());
+    }
+}

--- a/crates/primitives/src/chunk/any_chunk.rs
+++ b/crates/primitives/src/chunk/any_chunk.rs
@@ -271,6 +271,39 @@ impl<const BODY_SIZE: usize> AnyChunk<BODY_SIZE> {
             }),
         }
     }
+
+    /// Decode a chunk from its bare wire bytes (NO type tag) given the expected
+    /// address, disambiguating content vs single-owner by which one hashes to
+    /// `address`. This is the type-less wire form (e.g. a Delivery `data`
+    /// field); prefer [`from_typed_bytes`](Self::from_typed_bytes) for
+    /// self-describing storage. A custom chunk type cannot be recovered from
+    /// bare bytes, so it is not produced.
+    ///
+    /// Reconstructing an [`AnyChunk`] from raw bytes is ambiguous without the
+    /// address: a [`ContentChunk`] parse almost always succeeds structurally (a
+    /// span plus an arbitrary payload), so the expected address is the
+    /// disambiguator. The chunk is whichever variant parses *and* hashes to
+    /// `address`. Content is tried first, then single-owner; a lying address
+    /// makes both attempts fail, so the address is self-validating against the
+    /// bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns a verification error (and never panics) when neither the content
+    /// nor the single-owner interpretation of `data` hashes to `address`.
+    pub fn from_wire_bytes(address: &ChunkAddress, data: Bytes) -> crate::error::Result<Self> {
+        if let Ok(content) = ContentChunk::try_from(data.clone())
+            && content.address() == address
+        {
+            return Ok(Self::Content(content));
+        }
+        if let Ok(soc) = SingleOwnerChunk::try_from(data)
+            && soc.address() == address
+        {
+            return Ok(Self::SingleOwner(soc));
+        }
+        Err(super::error::ChunkError::verification_failed(*address, *address).into())
+    }
 }
 
 impl<const BODY_SIZE: usize> From<ContentChunk<BODY_SIZE>> for AnyChunk<BODY_SIZE> {
@@ -464,5 +497,62 @@ mod tests {
         let bad = vec![ChunkTypeId::CONTENT.as_u8(), 0x00];
         let result = DefaultAnyChunk::from_typed_bytes(&address, &bad);
         assert!(result.is_err(), "corrupt content payload must error");
+    }
+
+    #[test]
+    fn test_from_wire_bytes_content_round_trip() {
+        let content = DefaultContentChunk::new(&b"hello wire world"[..]).unwrap();
+        let address = *content.address();
+        let any: DefaultAnyChunk = content.into();
+        // Bare wire bytes carry no type tag.
+        let wire = any.clone().into_bytes();
+
+        let decoded = DefaultAnyChunk::from_wire_bytes(&address, wire.clone()).unwrap();
+        assert!(decoded.is_content());
+        assert_eq!(decoded.address(), any.address());
+        assert_eq!(decoded.into_bytes(), wire);
+    }
+
+    #[test]
+    fn test_from_wire_bytes_single_owner_round_trip() {
+        let soc = sample_single_owner();
+        let address = *soc.address();
+        let any: DefaultAnyChunk = soc.into();
+        let wire = any.clone().into_bytes();
+
+        let decoded = DefaultAnyChunk::from_wire_bytes(&address, wire.clone()).unwrap();
+        assert!(decoded.is_single_owner());
+        assert_eq!(decoded.address(), any.address());
+        assert_eq!(decoded.into_bytes(), wire);
+    }
+
+    #[test]
+    fn test_from_wire_bytes_address_mismatch_errors() {
+        let content = DefaultContentChunk::new(&b"chunk A"[..]).unwrap();
+        let wire = DefaultAnyChunk::from(content).into_bytes();
+
+        let wrong: ChunkAddress = [0xFFu8; 32].into();
+        let result = DefaultAnyChunk::from_wire_bytes(&wrong, wire);
+        assert!(result.is_err(), "address mismatch must error, not panic");
+    }
+
+    #[test]
+    fn test_from_wire_bytes_never_yields_custom() {
+        // A custom chunk type cannot be recovered from bare bytes: there is no
+        // type tag to identify it, so decoding can only ever produce Content or
+        // SingleOwner. We assert this by decoding both standard shapes and
+        // confirming neither is Custom, and that opaque bytes that are neither a
+        // valid content nor single-owner chunk for the address simply error.
+        let content = DefaultContentChunk::new(&b"not custom"[..]).unwrap();
+        let address = *content.address();
+        let wire = DefaultAnyChunk::from(content).into_bytes();
+        let decoded = DefaultAnyChunk::from_wire_bytes(&address, wire).unwrap();
+        assert!(!decoded.is_custom(), "bare bytes must never yield Custom");
+
+        // Opaque bytes for an arbitrary address: no Custom variant is produced,
+        // it errors instead.
+        let opaque = Bytes::from_static(b"opaque custom-looking payload bytes");
+        let addr: ChunkAddress = [0x11u8; 32].into();
+        assert!(DefaultAnyChunk::from_wire_bytes(&addr, opaque).is_err());
     }
 }


### PR DESCRIPTION
## Summary

This adds `StampedChunk`, the pairing of an `AnyChunk` (`nectar-primitives`) with its postage `Stamp` (`nectar-postage`), and its serialisation to nectar as a canonical primitive. It also adds `AnyChunk::from_wire_bytes`, the bare-wire counterpart to the type-tagged chunk codec.

A retrieval, a pushsync delivery, and an upload all move a *chunk plus its proof of payment* as one unit. `AnyChunk` carries the chunk bytes but no stamp, so this pairing is the cohesive, always-stamped value that flows across those boundaries instead of two loose fields. Both halves are already nectar types and the codec is pure serialisation, so the pairing belongs here rather than being redefined downstream. This complements the type-tagged chunk codec from #95 (`AnyChunk::to_typed_bytes`/`from_typed_bytes`) and underpins the vertex storer, which currently defines a local `StampedChunk` with a "migrate to nectar" TODO and will consume this and delete its local definition.

## Changes

### `nectar-primitives`

- `AnyChunk::from_wire_bytes(address, data)`: decodes a chunk from its bare wire bytes (no type tag) given the expected address, disambiguating content versus single-owner by which one hashes to `address`. This is the type-less wire form (for example a `Delivery` `data` field); `from_typed_bytes` remains preferred for self-describing storage. A custom chunk type cannot be recovered from bare bytes, so it is never produced. The function reuses the chunk `VerificationFailed` error variant and never panics.

### `nectar-postage`

- New `stamped` module exporting `StampedChunk<const BODY_SIZE: usize = DEFAULT_BODY_SIZE>`, generic over `BODY_SIZE` to match `AnyChunk`.
- Accessors: `new`, `chunk`, `stamp`, `address` (delegates to the chunk), `into_parts`.
- `to_typed_bytes`/`from_typed_bytes`: a self-describing codec with the layout `[stamp:113][type_id:1][chunk wire bytes]`, layered on the stamp's fixed-size codec and the #95 type-tagged chunk codec.
- `reconstruct(expected, data, stamp)`: rebuilds from the bare-wire delivery shape (`Delivery { data, stamp }`) using `AnyChunk::from_wire_bytes`.
- `batch_id(typed_bytes)`: reads the batch id from a `to_typed_bytes` value without a full decode (the stamp leads the encoding and places the batch id in its first 32 bytes).
- A new `StampError::Chunk(&'static str)` variant carries chunk-side failures. It holds a static context rather than embedding `PrimitivesError`, because `StampError` is `Clone`/`PartialEq`/`Eq` (whilst `PrimitivesError` is not) and the crate is `no_std` without an owned-string allocator on that path.

All public methods return `Result` and never panic on malformed input (length checks and `get`/`split_at` rather than panicking indexing).

## Equality semantics

`StampedChunk` derives `PartialEq`/`Eq`. The chunk component inherits `AnyChunk`'s own equality, which compares chunks *by address only* (a chunk's address is the cryptographic commitment to its bytes, so equal addresses mean equal chunks); the stamp component compares all stamp fields. Two stamped chunks are therefore equal when their chunks share an address and their stamps are identical. This matches the original vertex `StampedChunk`, which derived equality over the same two fields.

## Testing

- `nectar-primitives`: content and single-owner round-trips through `from_wire_bytes`, address-mismatch errors, and confirmation that bare bytes never yield a `Custom` variant.
- `nectar-postage`: typed round-trips for content and single-owner (asserting chunk address and stamp batch/timestamp survive), `reconstruct` round-trips, `batch_id` equality against `stamp.batch()` and the leading 32 bytes, and error paths (empty, shorter-than-a-stamp, address mismatch, short batch id).
- `cargo test -p nectar-primitives -p nectar-postage` is green; `cargo clippy` is clean on the changed files; the `no_std` build (`--no-default-features`) compiles.

## AI-assistance disclosure

This change was prepared with the assistance of an AI coding tool. All code, tests, and this description were reviewed before submission.
