### PR TITLE
feat(bmt): apply prefix to every node for bee parity

### DIFF
--- a/crates/primitives/src/bmt/hasher.rs
+++ b/crates/primitives/src/bmt/hasher.rs
@@ -79,10 +79,42 @@ impl<const BODY_SIZE: usize> Hasher<BODY_SIZE> {
         self.span
     }
 
-    /// Add a prefix to the hash calculation
+    /// Add a prefix to the hash calculation.
+    ///
+    /// The prefix is applied to *every* Keccak256 invocation in the tree (leaf
+    /// sections, internal nodes and the final span wrap), matching bee's
+    /// `swarm.NewPrefixHasher` semantics where `Reset()` re-writes the prefix as
+    /// the first bytes before each node hash. This makes the resulting root
+    /// byte-identical to bee's `transformedAddress`.
     #[inline]
     pub fn prefix_with(&mut self, prefix: &[u8]) {
         self.prefix = Some(prefix.to_vec());
+    }
+
+    /// Create a new BMT hasher pre-configured with an anchor `prefix`.
+    ///
+    /// Equivalent to [`Hasher::new`] followed by [`Hasher::prefix_with`]. The
+    /// prefix is mixed into every node hash (see [`Hasher::prefix_with`]), so
+    /// the produced root matches bee's anchor-keyed `transformedAddress`.
+    #[inline]
+    pub fn with_prefix(prefix: &[u8]) -> Self {
+        let mut hasher = Self::new();
+        hasher.prefix_with(prefix);
+        hasher
+    }
+
+    /// Construct a fresh Keccak256, seeded with the prefix when one is set.
+    ///
+    /// Every node in the tree is hashed as `keccak(prefix || data)`; this helper
+    /// centralises that so the prefix can never be forgotten at an individual
+    /// hash site.
+    #[inline(always)]
+    fn node_hasher(prefix: Option<&[u8]>) -> Keccak256 {
+        let mut hasher = Keccak256::new();
+        if let Some(p) = prefix {
+            hasher.update(p);
+        }
+        hasher
     }
 
     /// Get the current prefix
@@ -162,15 +194,24 @@ impl<const BODY_SIZE: usize> Hasher<BODY_SIZE> {
     /// 3. Iteratively combines with pre-computed zero hashes to reach the root
     #[inline(always)]
     fn hash_internal(&self) -> B256 {
+        let prefix = self.prefix.as_deref();
+
+        // Zero fast paths rely on the precomputed prefix-independent ZERO_HASHES
+        // table, which is only valid for plain (unprefixed) hashing. Under a
+        // non-empty prefix every zero section hashes as keccak(prefix||zeros),
+        // so we must compute the zero subtrees with the prefix instead.
+        let zero_hashes = self.zero_hashes(prefix);
+
         // Special case: no data means entire tree is zeros
         if self.cursor == 0 {
-            return ZERO_HASHES[ZERO_TREE_LEVELS - 1];
+            return zero_hashes[ZERO_TREE_LEVELS - 1];
         }
 
-        // Fast path: if all data is zeros, return pre-computed zero tree root
-        // This avoids hashing entirely when the input is all zeros
+        // Fast path: if all data is zeros, return the zero tree root.
+        // Valid for both plain and prefixed hashing because `zero_hashes`
+        // already accounts for the prefix.
         if Self::is_all_zeros(&self.buffer[..self.cursor]) {
-            return ZERO_HASHES[ZERO_TREE_LEVELS - 1];
+            return zero_hashes[ZERO_TREE_LEVELS - 1];
         }
 
         // Find the smallest power-of-2 subtree that contains all data
@@ -180,9 +221,16 @@ impl<const BODY_SIZE: usize> Hasher<BODY_SIZE> {
             .max(SEGMENT_PAIR_LENGTH)
             .min(BODY_SIZE);
 
-        // Hash only the effective subtree (which contains all actual data)
+        // Hash only the effective subtree (which contains all actual data).
+        // The parallel zero-shortcut path uses the prefix-independent
+        // ZERO_HASHES; with a prefix set we recurse fully via the sequential
+        // path so every zero section is hashed under the prefix.
         #[cfg(not(target_arch = "wasm32"))]
-        let mut result = self.hash_subtree_parallel(&self.buffer[..effective_size], effective_size);
+        let mut result = if prefix.is_some() {
+            self.hash_subtree_sequential(&self.buffer[..effective_size], effective_size)
+        } else {
+            self.hash_subtree_parallel(&self.buffer[..effective_size], effective_size)
+        };
 
         #[cfg(target_arch = "wasm32")]
         let mut result =
@@ -193,14 +241,43 @@ impl<const BODY_SIZE: usize> Hasher<BODY_SIZE> {
         while current_size < BODY_SIZE {
             // The current result is a left child, combine with zero hash for right sibling
             let sibling_level = Self::zero_tree_level(current_size);
-            let mut hasher = Keccak256::new();
+            let mut hasher = Self::node_hasher(prefix);
             hasher.update(result.as_slice());
-            hasher.update(ZERO_HASHES[sibling_level].as_slice());
+            hasher.update(zero_hashes[sibling_level].as_slice());
             result = B256::from_slice(hasher.finalize().as_slice());
             current_size *= 2;
         }
 
         result
+    }
+
+    /// Return the per-level zero subtree hashes for the current prefix.
+    ///
+    /// With no prefix this returns the shared precomputed [`ZERO_HASHES`]. With
+    /// a prefix set it computes the table on demand so that each level is
+    /// `keccak(prefix || left || right)` (the level-0 entry being
+    /// `keccak(prefix || 64 zero bytes)`), matching bee's per-prefix
+    /// `zerohashes`.
+    #[inline(always)]
+    fn zero_hashes(&self, prefix: Option<&[u8]>) -> [B256; ZERO_TREE_LEVELS] {
+        let Some(p) = prefix else {
+            return *ZERO_HASHES;
+        };
+
+        let mut hashes = [B256::ZERO; ZERO_TREE_LEVELS];
+
+        let mut hasher = Self::node_hasher(Some(p));
+        hasher.update([0u8; SEGMENT_PAIR_LENGTH]);
+        hashes[0] = B256::from_slice(hasher.finalize().as_slice());
+
+        for i in 1..ZERO_TREE_LEVELS {
+            let mut hasher = Self::node_hasher(Some(p));
+            hasher.update(hashes[i - 1].as_slice());
+            hasher.update(hashes[i - 1].as_slice());
+            hashes[i] = B256::from_slice(hasher.finalize().as_slice());
+        }
+
+        hashes
     }
 
     /// Hash a subtree of exactly `length` bytes (must be power of 2, >= 64)
@@ -271,8 +348,10 @@ impl<const BODY_SIZE: usize> Hasher<BODY_SIZE> {
         debug_assert!(length.is_power_of_two());
         debug_assert!(length >= SEGMENT_PAIR_LENGTH);
 
+        let prefix = self.prefix.as_deref();
+
         if length == SEGMENT_PAIR_LENGTH {
-            let mut hasher = Keccak256::new();
+            let mut hasher = Self::node_hasher(prefix);
             hasher.update(data);
             return B256::from_slice(hasher.finalize().as_slice());
         }
@@ -280,9 +359,12 @@ impl<const BODY_SIZE: usize> Hasher<BODY_SIZE> {
         let half = length / 2;
         let (left, right) = data.split_at(half);
 
-        // Check if right half is entirely beyond cursor (all zeros in buffer)
-        let (left_hash, right_hash) = if half >= self.cursor {
-            // Right side is all zeros
+        // Check if right half is entirely beyond cursor (all zeros in buffer).
+        // The zero-sibling shortcut is only safe when the zero table matches the
+        // prefix; under a prefix we recurse over the literal zero section so it
+        // is hashed as keccak(prefix||...).
+        let (left_hash, right_hash) = if half >= self.cursor && prefix.is_none() {
+            // Right side is all zeros (plain hashing only)
             let left_hash = self.hash_subtree_sequential(left, half);
             let right_hash = ZERO_HASHES[Self::zero_tree_level(half)];
             (left_hash, right_hash)
@@ -292,7 +374,7 @@ impl<const BODY_SIZE: usize> Hasher<BODY_SIZE> {
             (left_hash, right_hash)
         };
 
-        let mut hasher = Keccak256::new();
+        let mut hasher = Self::node_hasher(prefix);
         hasher.update(left_hash.as_slice());
         hasher.update(right_hash.as_slice());
         B256::from_slice(hasher.finalize().as_slice())
@@ -373,7 +455,7 @@ impl<const BODY_SIZE: usize> Hasher<BODY_SIZE> {
     #[inline(always)]
     fn compute_segment_hash(&self, data: &[u8], i: usize) -> B256 {
         let start = i << SEGMENT_SIZE_LOG2; // Equivalent to i * SEGMENT_SIZE
-        let mut hasher = Keccak256::new();
+        let mut hasher = Self::node_hasher(self.prefix.as_deref());
 
         if start < data.len() {
             let end = (start + SEGMENT_SIZE).min(data.len());

--- a/crates/primitives/src/bmt/proof.rs
+++ b/crates/primitives/src/bmt/proof.rs
@@ -8,6 +8,38 @@ use alloy_primitives::{B256, Keccak256};
 use crate::bmt::{Hasher, constants::*, error::BmtError};
 use crate::error::Result;
 
+/// Construct a Keccak256 seeded with the prefix when one is present.
+///
+/// Mirrors the hasher's per-node prefixing so that every node in a proof path is
+/// `keccak(prefix || data)`, byte-identical to bee's prefix BMT.
+#[inline(always)]
+fn new_node_hasher(prefix: Option<&[u8]>) -> Keccak256 {
+    let mut hasher = Keccak256::new();
+    if let Some(p) = prefix {
+        hasher.update(p);
+    }
+    hasher
+}
+
+/// Compute the prefix-aware zero subtree hash for `level`.
+///
+/// `level` 0 is `keccak(prefix || 64 zero bytes)`; each higher level doubles the
+/// previous. With no prefix this equals the plain zero tree used by the hasher.
+fn prefixed_zero_hash(prefix: Option<&[u8]>, level: usize) -> B256 {
+    let mut hash = {
+        let mut hasher = new_node_hasher(prefix);
+        hasher.update([0u8; 2 * SEGMENT_SIZE]);
+        B256::from_slice(hasher.finalize().as_slice())
+    };
+    for _ in 0..level {
+        let mut hasher = new_node_hasher(prefix);
+        hasher.update(hash.as_slice());
+        hasher.update(hash.as_slice());
+        hash = B256::from_slice(hasher.finalize().as_slice());
+    }
+    hash
+}
+
 /// Represents a proof for a specific segment in a Binary Merkle Tree
 #[derive(Clone, Debug)]
 pub struct Proof {
@@ -53,9 +85,14 @@ impl Proof {
         let mut current_hash = self.segment;
         let mut current_index = self.segment_index;
 
+        let prefix = self.prefix.as_deref();
+
         // Apply each proof segment to compute the root
         for proof_segment in &self.proof_segments {
-            let mut hasher = Keccak256::new();
+            // Every intermediate node is keccak(prefix || left || right) to match
+            // bee's per-node prefix hasher; verifying without the prefix at each
+            // level would reject a valid anchor-keyed proof on-chain.
+            let mut hasher = new_node_hasher(prefix);
 
             // Order matters - left then right
             if current_index.is_multiple_of(2) {
@@ -156,12 +193,24 @@ impl Prover for Hasher {
         // Get the segment being proven
         let segment = segments[segment_index];
 
+        // Include the prefix in the proof if there is one
+        let prefix = if self.prefix().is_empty() {
+            None
+        } else {
+            Some(self.prefix().to_vec())
+        };
+        let prefix_ref = prefix.as_deref();
+
         // Generate proof segments
         let mut proof_segments = Vec::with_capacity(PROOF_LENGTH);
 
         // Build the Merkle tree level by level
         let mut current_level = segments;
         let mut current_index = segment_index;
+        // Tree level of the nodes in `current_level`: 0 = raw leaf segments,
+        // 1 = leaf-pair hashes, etc. Used to pick the right prefix-aware zero
+        // hash when padding an odd/short level.
+        let mut level: usize = 0;
 
         // Continue until we reach the root (or until we have BMT_PROOF_LENGTH segments)
         while proof_segments.len() < PROOF_LENGTH {
@@ -172,11 +221,15 @@ impl Prover for Hasher {
                 current_index - 1
             };
 
-            // Add sibling to proof
+            // Add sibling to proof. A missing sibling is an all-zero subtree at
+            // this level, which under a prefix hashes differently from B256::ZERO.
             if sibling_index < current_level.len() {
                 proof_segments.push(current_level[sibling_index]);
-            } else {
+            } else if level == 0 {
+                // Missing raw leaf segment is 32 zero bytes (not a hash).
                 proof_segments.push(B256::ZERO);
+            } else {
+                proof_segments.push(prefixed_zero_hash(prefix_ref, level - 1));
             }
 
             // Compute the next level up in the tree
@@ -185,13 +238,15 @@ impl Prover for Hasher {
             for i in (0..current_level.len()).step_by(2) {
                 let left = &current_level[i];
                 let right = if i + 1 < current_level.len() {
-                    &current_level[i + 1]
+                    current_level[i + 1]
+                } else if level == 0 {
+                    B256::ZERO
                 } else {
-                    &B256::ZERO
+                    prefixed_zero_hash(prefix_ref, level - 1)
                 };
 
-                // Hash the pair to create the parent node
-                let mut hasher = Keccak256::new();
+                // Hash the pair to create the parent node (prefix-aware)
+                let mut hasher = new_node_hasher(prefix_ref);
                 hasher.update(left.as_slice());
                 hasher.update(right.as_slice());
 
@@ -202,6 +257,7 @@ impl Prover for Hasher {
             // Move up to the next level
             current_level = next_level;
             current_index /= 2;
+            level += 1;
 
             // If we've reached the root or have only one node, break
             if current_level.len() <= 1 {
@@ -213,13 +269,6 @@ impl Prover for Hasher {
         while proof_segments.len() < PROOF_LENGTH {
             proof_segments.push(B256::ZERO);
         }
-
-        // Include the prefix in the proof if there is one
-        let prefix = if !self.prefix().is_empty() {
-            Some(self.prefix().to_vec())
-        } else {
-            None
-        };
 
         Ok(Proof::new(
             segment_index,

--- a/crates/primitives/src/bmt/tests.rs
+++ b/crates/primitives/src/bmt/tests.rs
@@ -116,6 +116,174 @@ fn test_bmt_hasher_with_prefix() {
 
     // Results should be different
     assert_ne!(result_with_prefix, result_without_prefix);
+
+    // with_prefix is equivalent to new + prefix_with
+    let mut hasher3 = DefaultHasher::with_prefix(b"prefix-");
+    hasher3.set_span(11);
+    hasher3.update(data);
+    assert_eq!(result_with_prefix, hasher3.sum());
+}
+
+/// Reference (non-optimized) prefix BMT root: hashes the full 4096-byte tree
+/// bottom-up with no zero fast paths, applying `keccak(prefix || ...)` at every
+/// node. Used to prove the optimized hasher matches a naive implementation,
+/// independently of the zero-subtree shortcuts.
+fn reference_prefix_root(prefix: Option<&[u8]>, span: u64, payload: &[u8]) -> B256 {
+    use alloy_primitives::Keccak256;
+
+    let node = |left: &[u8], right: &[u8]| {
+        let mut h = Keccak256::new();
+        if let Some(p) = prefix {
+            h.update(p);
+        }
+        h.update(left);
+        h.update(right);
+        B256::from_slice(h.finalize().as_slice())
+    };
+
+    // Materialise 128 leaf segments of 32 bytes (zero-padded).
+    let mut buf = [0u8; DEFAULT_BODY_SIZE];
+    let n = payload.len().min(DEFAULT_BODY_SIZE);
+    buf[..n].copy_from_slice(&payload[..n]);
+
+    let mut level: Vec<B256> = (0..DEFAULT_BODY_SIZE / 32)
+        .map(|i| B256::from_slice(&buf[i * 32..i * 32 + 32]))
+        .collect();
+
+    while level.len() > 1 {
+        level = level
+            .chunks(2)
+            .map(|pair| node(pair[0].as_slice(), pair[1].as_slice()))
+            .collect();
+    }
+
+    // Final span wrap.
+    let mut h = Keccak256::new();
+    if let Some(p) = prefix {
+        h.update(p);
+    }
+    h.update(span.to_le_bytes());
+    h.update(level[0].as_slice());
+    B256::from_slice(h.finalize().as_slice())
+}
+
+/// Cross-implementation parity gate against bee's published deterministic
+/// vector (pkg/storer/sample_test.go TestSampleVectorCAC).
+///
+/// Chunk content is 4096 bytes with byte[i] = i % 256; the CAC span is 4096
+/// (little-endian). The plain BMT root is the chunk address and the
+/// anchor-prefixed BMT root is bee's transformed address. Reproducing both
+/// byte-for-byte proves nectar's per-node prefixing is bee-identical.
+#[test]
+fn test_bee_sample_vector_cac_parity() {
+    const ANCHOR: &[u8] = b"swarm-test-anchor-deterministic!";
+    const WANT_CHUNK_ADDR: &str =
+        "902406053a7a2f3a17f16097e1d0b4b6a4abeae6b84968f5503ae621f9522e16";
+    const WANT_TRANSFORMED_ADDR: &str =
+        "9dee91d1ed794460474ffc942996bd713176731db4581a3c6470fe9862905a60";
+
+    assert_eq!(ANCHOR.len(), 32, "anchor must be exactly 32 bytes");
+
+    // 4096-byte payload with the repeating i % 256 pattern.
+    let payload: Vec<u8> = (0..DEFAULT_BODY_SIZE).map(|i| (i % 256) as u8).collect();
+    let span = DEFAULT_BODY_SIZE as u64;
+
+    // Plain BMT => chunk address.
+    let mut plain = DefaultHasher::new();
+    plain.set_span(span);
+    plain.update(&payload);
+    let chunk_addr = plain.sum();
+    assert_eq!(
+        chunk_addr.encode_hex(),
+        WANT_CHUNK_ADDR,
+        "plain BMT chunk address must match bee"
+    );
+
+    // Anchor-prefixed BMT => transformed address.
+    let mut prefixed = DefaultHasher::with_prefix(ANCHOR);
+    prefixed.set_span(span);
+    prefixed.update(&payload);
+    let transformed = prefixed.sum();
+    assert_eq!(
+        transformed.encode_hex(),
+        WANT_TRANSFORMED_ADDR,
+        "anchor-prefixed BMT transformed address must match bee"
+    );
+
+    // The optimized hasher must agree with the naive full-recursion reference.
+    assert_eq!(
+        transformed,
+        reference_prefix_root(Some(ANCHOR), span, &payload)
+    );
+}
+
+/// Zero-subtree parity guard. The dense i%256 vector has no trailing zeros, so
+/// it cannot catch a prefix-independent zero table. A sparse payload (data only
+/// in the first segment, the rest zero) forces the prefixed zero subtrees to be
+/// exercised; the optimized path must still match the naive reference.
+#[test]
+fn test_prefix_sparse_trailing_zeros_parity() {
+    const ANCHOR: &[u8] = b"swarm-test-anchor-deterministic!";
+
+    // Only the first 5 bytes are non-zero; the remaining 4091 bytes are zero.
+    let mut payload = vec![0u8; DEFAULT_BODY_SIZE];
+    payload[..5].copy_from_slice(b"hello");
+    let span = DEFAULT_BODY_SIZE as u64;
+
+    let mut prefixed = DefaultHasher::with_prefix(ANCHOR);
+    prefixed.set_span(span);
+    prefixed.update(&payload);
+    let optimized = prefixed.sum();
+
+    assert_eq!(
+        optimized,
+        reference_prefix_root(Some(ANCHOR), span, &payload),
+        "prefixed hash of a sparse chunk must match the naive reference (zero \
+         subtrees must be hashed under the prefix, not via the plain zero table)"
+    );
+
+    // An all-zero prefixed chunk must also match the reference.
+    let zero_payload = vec![0u8; DEFAULT_BODY_SIZE];
+    let mut zero_hasher = DefaultHasher::with_prefix(ANCHOR);
+    zero_hasher.set_span(span);
+    zero_hasher.update(&zero_payload);
+    assert_eq!(
+        zero_hasher.sum(),
+        reference_prefix_root(Some(ANCHOR), span, &zero_payload)
+    );
+}
+
+/// A prefixed proof must verify against the prefixed root and only against it.
+#[test]
+fn test_prefix_proof_roundtrip() {
+    const ANCHOR: &[u8] = b"swarm-test-anchor-deterministic!";
+
+    let payload: Vec<u8> = (0..DEFAULT_BODY_SIZE).map(|i| (i % 256) as u8).collect();
+    let span = DEFAULT_BODY_SIZE as u64;
+
+    let mut hasher = DefaultHasher::with_prefix(ANCHOR);
+    hasher.set_span(span);
+    hasher.update(&payload);
+    let root = hasher.sum();
+
+    for seg in [0usize, 1, 63, 127] {
+        let proof = hasher.generate_proof(&payload, seg).unwrap();
+        assert_eq!(proof.prefix.as_deref(), Some(ANCHOR));
+        assert!(
+            DefaultHasher::verify_proof(&proof, root.as_slice()).unwrap(),
+            "prefixed proof for segment {seg} must verify against the prefixed root"
+        );
+
+        // The same proof must NOT verify against the plain (unprefixed) root.
+        let mut plain = DefaultHasher::new();
+        plain.set_span(span);
+        plain.update(&payload);
+        let plain_root = plain.sum();
+        assert!(
+            !DefaultHasher::verify_proof(&proof, plain_root.as_slice()).unwrap(),
+            "prefixed proof must not verify against the plain root"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The BMT prefix hasher mixed the anchor into the final span wrap only, leaving every leaf and internal node as a plain Keccak256. For any tree deeper than one level (every 4 KiB chunk, depth 7) this diverged from bee, whose `swarm.PrefixHasher` re-writes the prefix before each node hash so that every node is `keccak(prefix || data)`. The consequence: nectar's prefixed root did not match bee's `transformedAddress`, and a transformed-address or transformed-BMT proof produced by nectar would be rejected by the on-chain storage-incentives game.

This PR threads the prefix through every Keccak invocation in the tree so the prefixed root is byte-identical to bee.

## Changes

- `prefix_with` now applies the prefix at every node (leaf sections, internal nodes, the span wrap) rather than the wrap alone. A `Hasher::with_prefix(anchor)` constructor is added for clarity.
- The precomputed zero-hash table is prefix-independent and therefore invalid under a non-empty prefix. When a prefix is set, the zero fast paths are disabled and zero subtrees are recomputed as `keccak(prefix || ...)`, matching bee's per-prefix `zerohashes`. The dense parity vector cannot catch this, so a sparse trailing-zero guard is included.
- Proof generation and verification apply the prefix at every level, not just the final wrap, so an anchor-keyed proof verifies against the prefixed root (and is rejected against the plain root). The single-application (CAC) wrap path is unchanged for the no-prefix case.

The CAC-prefixed / SOC-outer-plain distinction lives in the consumer (the sampler), not here; this change only makes the prefix BMT itself bee-identical.

## Parity proof

A new cross-implementation test asserts bee's published deterministic vector (`pkg/storer/sample_test.go` `TestSampleVectorCAC`): anchor `swarm-test-anchor-deterministic!` over the 4096-byte `i % 256` chunk yields

- plain BMT chunk address `902406053a7a2f3a17f16097e1d0b4b6a4abeae6b84968f5503ae621f9522e16`
- anchor-prefixed transformed address `9dee91d1ed794460474ffc942996bd713176731db4581a3c6470fe9862905a60`

Both reproduce byte for byte. The optimized hasher is additionally cross-checked against a naive full-recursion reference for the dense, sparse, and all-zero cases, and a prefixed proof round-trip is asserted.

`cargo test -p nectar-primitives`, `cargo clippy -p nectar-primitives --all-targets`, and `cargo fmt --check` are clean (toolchain 1.92).

## AI-assistance disclosure

This change was prepared with AI assistance (Claude). All code, tests, and the parity verification against bee's published vector were reviewed by the author.