### PR TITLE
feat(primitives): add anchor-keyed transformed address and SOC unwrap

### DIFF
--- a/crates/primitives/src/chunk/any_chunk.rs
+++ b/crates/primitives/src/chunk/any_chunk.rs
@@ -3,9 +3,10 @@
 //! This module provides [`AnyChunk`], an enum that can hold any chunk type
 //! for runtime polymorphism without requiring trait objects.
 
+use alloy_primitives::Keccak256;
 use bytes::Bytes;
 
-use crate::bmt::DEFAULT_BODY_SIZE;
+use crate::bmt::{DEFAULT_BODY_SIZE, Hasher};
 use crate::error::Result;
 
 use super::chunk_type::ChunkType;
@@ -108,6 +109,69 @@ impl<const BODY_SIZE: usize> AnyChunk<BODY_SIZE> {
             Self::Content(c) => super::traits::BmtChunk::span(c),
             Self::SingleOwner(c) => super::traits::BmtChunk::span(c),
             Self::Custom { .. } => 0, // Custom chunks don't have span info
+        }
+    }
+
+    /// Compute the anchor-keyed *transformed address* of this chunk.
+    ///
+    /// The transformed address is the redistribution sampler's per-round,
+    /// per-node re-hash of a chunk. It is a prefixed BMT root keyed by the
+    /// node's `anchor`, used to order reserve chunks deterministically while
+    /// binding the ordering to the proving node. This reproduces bee's
+    /// `storer.transformedAddress` (`pkg/storer/sample.go`) byte-for-byte.
+    ///
+    /// # Derivation
+    ///
+    /// - For a content-addressed chunk (CAC) the transformed address is the
+    ///   prefixed BMT of the chunk body, i.e. `BMT(prefix = anchor, span,
+    ///   payload)`. This is computed by
+    ///   [`BmtBody::transformed_root`](super::bmt_body::BmtBody::transformed_root) on the
+    ///   chunk's borrowed body, which mixes the anchor into *every* node hash,
+    ///   matching bee's prefix hasher.
+    /// - For a single-owner chunk (SOC) the wrapped content body is re-hashed
+    ///   the same way to obtain `inner`, then the SOC's transformed address is
+    ///   a **plain, unprefixed** `keccak256(soc_address || inner)`. The outer
+    ///   wrap is a flat Keccak256, *not* a prefixed BMT, mirroring bee's
+    ///   `transformedAddressSOC` which uses `swarm.NewHasher()` (no anchor) for
+    ///   the final combine.
+    /// - A custom chunk type has no [`BmtBody`](super::bmt_body::BmtBody), so it
+    ///   cannot reuse the typed body path. It is hashed as a prefixed BMT over
+    ///   its raw `span()`/`data()` (identical bytes to the CAC case), keeping
+    ///   the variant well-defined and non-panicking.
+    ///
+    /// # Endianness
+    ///
+    /// The span is serialised little-endian inside the BMT. Do not confuse this
+    /// with the big-endian encodings used elsewhere on the redistribution wire
+    /// (e.g. proof witness indices); the BMT span is always LE.
+    ///
+    /// # Borrowing
+    ///
+    /// The CAC and SOC paths dispatch through borrowed body accessors
+    /// ([`ContentChunk::body`] and [`SingleOwnerChunk::inner_body`]), so no
+    /// chunk or body is cloned. For a SOC the wrapped body already *is* the
+    /// content chunk's `span || payload`, so the inner root needs no
+    /// `32 + 65` (id + signature) header slicing.
+    pub fn transformed_address(&self, anchor: &[u8]) -> ChunkAddress {
+        match self {
+            // CAC: the prefixed BMT root of the (borrowed) body is the address.
+            Self::Content(c) => ChunkAddress::from(c.body().transformed_root(anchor)),
+            // SOC: re-hash the (borrowed) wrapped body, then take the plain
+            // (unprefixed) keccak256(soc_address || inner).
+            Self::SingleOwner(c) => {
+                let inner = c.inner_body().transformed_root(anchor);
+                let mut hasher = Keccak256::new();
+                hasher.update(c.address().as_slice());
+                hasher.update(inner.as_slice());
+                ChunkAddress::from(hasher.finalize())
+            }
+            // Custom: no BmtBody, so hash its raw span/data as a prefixed BMT.
+            Self::Custom { .. } => {
+                let mut hasher: Hasher<BODY_SIZE> = Hasher::with_prefix(anchor);
+                hasher.set_span(self.span());
+                hasher.update(self.data());
+                ChunkAddress::from(hasher.sum())
+            }
         }
     }
 
@@ -328,7 +392,7 @@ impl<const BODY_SIZE: usize> Eq for AnyChunk<BODY_SIZE> {}
 
 #[cfg(test)]
 mod tests {
-    use super::super::traits::Chunk;
+    use super::super::traits::{BmtChunk, Chunk};
     use super::*;
 
     type DefaultContentChunk = ContentChunk<DEFAULT_BODY_SIZE>;
@@ -554,5 +618,95 @@ mod tests {
         let opaque = Bytes::from_static(b"opaque custom-looking payload bytes");
         let addr: ChunkAddress = [0x11u8; 32].into();
         assert!(DefaultAnyChunk::from_wire_bytes(&addr, opaque).is_err());
+    }
+
+    // --- transformed address (redistribution sampler) bee parity -------------
+    //
+    // nectar owns the parity oracle for the anchor-keyed transformed address.
+    // The vectors below are taken from bee so that any drift in the prefixed
+    // BMT or the single-owner outer wrap is caught here, at the primitive.
+
+    /// bee `TestSampleVectorCAC` (`pkg/storer/sample_test.go`): a 4096-byte CAC
+    /// whose payload is the repeating pattern `i % 256`, transformed under the
+    /// anchor `swarm-test-anchor-deterministic!`.
+    #[test]
+    fn transformed_address_reproduces_bee_cac_vector() {
+        use alloy_primitives::hex;
+
+        const ANCHOR: &[u8] = b"swarm-test-anchor-deterministic!";
+        // Plain (unprefixed) BMT root: the chunk's own content address.
+        const WANT_CHUNK_ADDR: &str =
+            "902406053a7a2f3a17f16097e1d0b4b6a4abeae6b84968f5503ae621f9522e16";
+        // Anchor-keyed transformed address.
+        const WANT_TRANSFORMED: &str =
+            "9dee91d1ed794460474ffc942996bd713176731db4581a3c6470fe9862905a60";
+
+        let mut payload = vec![0u8; 4096];
+        for (i, b) in payload.iter_mut().enumerate() {
+            *b = (i % 256) as u8;
+        }
+
+        let content = DefaultContentChunk::new(payload).unwrap();
+
+        // The chunk's plain BMT address is the unprefixed root.
+        assert_eq!(
+            hex::encode(content.address().as_slice()),
+            WANT_CHUNK_ADDR,
+            "plain BMT address must match bee's published vector",
+        );
+
+        let any: DefaultAnyChunk = content.into();
+        let tr = any.transformed_address(ANCHOR);
+        assert_eq!(
+            hex::encode(tr.as_slice()),
+            WANT_TRANSFORMED,
+            "CAC transformed address must match bee byte-for-byte",
+        );
+    }
+
+    /// A single-owner chunk vector from bee's `TestMakeInclusionProofsRegression`
+    /// oracle (anchor1 = `0x64`). Exercises the SOC path: the wrapped content
+    /// chunk is re-hashed under the anchor, then the SOC transformed address is
+    /// the plain `keccak256(soc_address || inner)`.
+    #[test]
+    fn transformed_address_reproduces_bee_soc_vector() {
+        use alloy_primitives::hex;
+
+        // anchor1 from the oracle, a single byte 0x64 (== 100).
+        const ANCHOR: &[u8] = &[0x64];
+        const WANT_CHUNK_ADDR: &str =
+            "71d5144d0525b82cd550aa9254245c6195fdac9ccbb625eb45a0bfe244cb131f";
+        const WANT_TRANSFORMED: &str =
+            "521f50f895dc1deea14448c09ba8d9c510c5db09cd84c7ed8413b66f15fbc110";
+        // Full SOC wire bytes: id(32) || signature(65) || span(8) || payload.
+        const SOC_WIRE: &str = "82d0ed66f956ed70445d02df922606e02c11a79014cc441f9cc678275d260703\
+            15c7157590f599a81b38834786f79f57a6a6626bbe8bf48fbbd6db3e55ad41c0\
+            277d7d310bbefbb5d81d74605a5950171229ebdd320249ef5f8fd6b8dfe2bc7d\
+            1c1a00000000000000556e73746f707061626c65206461746121204368756e6b\
+            202331";
+
+        let wire = hex::decode(SOC_WIRE.replace([' ', '\n'], "")).unwrap();
+        let soc = DefaultSingleOwnerChunk::try_from(wire.as_slice()).unwrap();
+
+        // Sanity: this SOC's own address matches the oracle.
+        assert_eq!(
+            hex::encode(soc.address().as_slice()),
+            WANT_CHUNK_ADDR,
+            "SOC address must match bee's oracle",
+        );
+
+        // `unwrap_cac` must expose the wrapped content body with no manual
+        // 32 + 65 header slicing; its span/payload feed the inner BMT.
+        let cac = soc.unwrap_cac();
+        assert_eq!(cac.span(), soc.inner_body().span());
+        assert_eq!(cac.data(), soc.inner_body().data());
+
+        let any: DefaultAnyChunk = soc.into();
+        let tr = any.transformed_address(ANCHOR);
+        assert_eq!(
+            hex::encode(tr.as_slice()),
+            WANT_TRANSFORMED,
+            "SOC transformed address must match bee byte-for-byte",
+        );
     }
 }

--- a/crates/primitives/src/chunk/bmt_body.rs
+++ b/crates/primitives/src/chunk/bmt_body.rs
@@ -60,6 +60,24 @@ impl<const BODY_SIZE: usize> BmtBody<BODY_SIZE> {
         hasher.update(self.data.as_ref());
         hasher.sum().into()
     }
+
+    /// Compute the anchor-keyed *transformed* BMT root of this body.
+    ///
+    /// This is the prefixed BMT of the body (`span` + `payload`), where the
+    /// `anchor` is mixed into *every* node hash via [`Hasher::with_prefix`].
+    /// It mirrors bee's `transformedAddressCAC` (`pkg/storer/sample.go`) and is
+    /// the redistribution sampler's per-round, per-node re-hash of a chunk
+    /// body. The span is serialised little-endian by the hasher.
+    ///
+    /// The body already carries everything the hash needs — `span()`,
+    /// `data()`, and the `BODY_SIZE` const — so callers pass only the
+    /// `anchor`, and the body is borrowed (nothing is cloned).
+    pub fn transformed_root(&self, anchor: &[u8]) -> alloy_primitives::B256 {
+        let mut hasher: Hasher<BODY_SIZE> = Hasher::with_prefix(anchor);
+        hasher.set_span(self.span);
+        hasher.update(self.data.as_ref());
+        hasher.sum()
+    }
 }
 
 fn validate_data<const BODY_SIZE: usize>(data: impl Into<Bytes>) -> error::Result<Bytes> {

--- a/crates/primitives/src/chunk/content.rs
+++ b/crates/primitives/src/chunk/content.rs
@@ -136,6 +136,16 @@ impl<const BODY_SIZE: usize> ContentChunk<BODY_SIZE> {
         }
     }
 
+    /// Borrow the BMT body of this content chunk.
+    ///
+    /// The body carries the chunk's `span`, `payload`, and the `BODY_SIZE`
+    /// const, so this is the zero-copy accessor callers use to feed the body
+    /// into BMT operations (e.g. [`BmtBody::transformed_root`]) without
+    /// re-slicing the span/payload back out of the wire form.
+    pub const fn body(&self) -> &BmtBody<BODY_SIZE> {
+        &self.body
+    }
+
     /// Create a ContentChunk from a pre-existing BmtBody with a known address.
     ///
     /// This is an advanced method for when you already have both the body

--- a/crates/primitives/src/chunk/single_owner.rs
+++ b/crates/primitives/src/chunk/single_owner.rs
@@ -17,6 +17,7 @@ use crate::chunk::error::{self, ChunkError};
 use crate::error::Result;
 
 use super::bmt_body::BmtBody;
+use super::content::ContentChunk;
 use super::traits::{BmtChunk, Chunk, ChunkAddress, ChunkHeader, ChunkMetadata};
 
 // Constants for field sizes
@@ -291,6 +292,29 @@ impl<const BODY_SIZE: usize> SingleOwnerChunk<BODY_SIZE> {
     /// Get the signature of this chunk.
     pub const fn signature(&self) -> &Signature {
         &self.header.metadata.signature
+    }
+
+    /// Borrow the inner content body wrapped by this single-owner chunk.
+    ///
+    /// A single-owner chunk is `id || signature || span || payload`; the
+    /// `span || payload` tail is exactly the [`BmtBody`] of the content chunk it
+    /// wraps. This is the zero-copy accessor for that body, so callers reading
+    /// the wrapped span/payload never re-slice past the `id`/`signature`
+    /// header.
+    pub const fn inner_body(&self) -> &BmtBody<BODY_SIZE> {
+        &self.body
+    }
+
+    /// Extract the content-addressed chunk (CAC) wrapped inside this SOC.
+    ///
+    /// Mirrors bee's `soc.UnwrapCAC` (`pkg/soc/soc.go`): the SOC body *is* a
+    /// CAC body (`span || payload`), so this rebuilds the [`ContentChunk`] from
+    /// it without any manual `HashSize + SignatureSize` cursor arithmetic. The
+    /// returned chunk's address is the wrapped content address, not the SOC
+    /// address.
+    #[must_use]
+    pub fn unwrap_cac(&self) -> ContentChunk<BODY_SIZE> {
+        ContentChunk::from_body(self.body.clone())
     }
 }
 


### PR DESCRIPTION
## Summary

Adds the anchor-keyed *transformed address* as a nectar primitive, so that nectar owns the bee parity oracle for the redistribution sampler instead of vertex hand-rolling it. This is PART A of an agreed refactor of vertex PR #397 (redistribution sampler and proof of entitlement); PART B shrinks vertex to consume these primitives.

## Changes

- `AnyChunk::transformed_address(&self, anchor: &[u8]) -> ChunkAddress`, an inherent method alongside `address()`/`span()`/`data()`. It reproduces bee's `storer.transformedAddress` (`pkg/storer/sample.go`) byte-for-byte:
  - For a content-addressed chunk (CAC), the result is the prefixed BMT of the chunk body, keyed by the anchor via `Hasher::with_prefix` (the per-node prefix from #98).
  - For a single-owner chunk (SOC), the wrapped content chunk is re-hashed the same way to obtain `inner`, then the SOC transformed address is a plain, unprefixed `keccak256(soc_address || inner)`, mirroring `transformedAddressSOC`.
  - The CAC core is factored into a private helper that mirrors bee's `transformedAddressCAC`.
  - `span()`/`data()` already delegate to the inner BMT body for both CAC and SOC, so the SOC inner-CAC needs no `id`/`signature` header slicing.
- `SingleOwnerChunk::unwrap_cac(&self) -> ContentChunk` and `inner_body(&self) -> &BmtBody`, mirroring `soc.UnwrapCAC` (`pkg/soc/soc.go`), so callers stop slicing the wrapped CAC at a fixed cursor.

## Parity

New unit tests reproduce bee's published vectors:

- CAC: bee's `TestSampleVectorCAC` (4096-byte `i % 256` payload, anchor `swarm-test-anchor-deterministic!`). Plain BMT address `902406053a7a2f3a17f16097e1d0b4b6a4abeae6b84968f5503ae621f9522e16`, transformed address `9dee91d1ed794460474ffc942996bd713176731db4581a3c6470fe9862905a60`.
- SOC: a single-owner item from bee's `TestMakeInclusionProofsRegression` oracle (anchor `0x64`), transformed address `521f50f895dc1deea14448c09ba8d9c510c5db09cd84c7ed8413b66f15fbc110`.

Both reproduce byte-for-byte. `cargo test -p nectar-primitives`, `cargo clippy`, and `cargo fmt` are clean.

## AI disclosure

This change was prepared with the assistance of an AI coding agent (Claude). All code, vectors, and the bee cross-check were reviewed by the author before submission.
