### PR TITLE
feat(postage): make BatchStore/StoreValidator/SnapshotStore synchronous

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2092,7 +2092,6 @@ dependencies = [
  "rayon",
  "serde",
  "thiserror",
- "tokio",
  "web-time",
 ]
 

--- a/crates/postage/Cargo.toml
+++ b/crates/postage/Cargo.toml
@@ -40,7 +40,6 @@ proptest = { workspace = true }
 proptest-arbitrary-interop = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 alloy-signer-local = { workspace = true }
 alloy-primitives = { workspace = true, features = ["getrandom"] }
 arbitrary = { workspace = true, features = ["derive"] }

--- a/crates/postage/src/lib.rs
+++ b/crates/postage/src/lib.rs
@@ -18,7 +18,10 @@
 //! # Traits
 //!
 //! - [`StampValidator`]: Validate stamps against batches
-//! - [`BatchStore`]: Persist and retrieve batches (requires `std`)
+//! - [`BatchStore`]: Persist and retrieve batches (requires `std`). The trait is
+//!   synchronous and, having an associated `Error` and no generic methods, is
+//!   naturally object-safe; drive it from an async edge (a gRPC service, an FFI
+//!   boundary) where async is genuinely needed, rather than colouring the core.
 //! - [`SnapshotStore`]: Cache recovered issuer snapshot state by batch id (requires `std`)
 //! - [`BatchEventHandler`]: Handle batch events from the blockchain (requires `std`)
 //!

--- a/crates/postage/src/snapshot_store.rs
+++ b/crates/postage/src/snapshot_store.rs
@@ -32,19 +32,22 @@ use crate::BatchId;
 /// reported as `Ok(None)` rather than an error and the caller recovers from the
 /// network instead.
 ///
-/// # Async Design
+/// # Synchronous Design
 ///
-/// The methods are async so an implementation may sit in front of a slow
-/// backend (disk, a key-value database) without forcing callers to block.
+/// The methods are synchronous. The known cache backends (in memory, a
+/// key-value database such as redb) are themselves synchronous, so there is no
+/// genuinely async work to drive here; any async behaviour belongs at the true
+/// edges where it is added by the edge, not by this cache. Keeping the trait
+/// synchronous avoids colouring callers with `async` and keeps it object-safe.
 ///
 /// # Example
 ///
 /// ```ignore
 /// use nectar_postage::{BatchId, SnapshotStore};
 ///
-/// async fn warm<S, T: SnapshotStore<S>>(store: &T, id: &BatchId) -> Option<S> {
+/// fn warm<S, T: SnapshotStore<S>>(store: &T, id: &BatchId) -> Option<S> {
 ///     // Try the cache; on a miss the caller would recover from the network.
-///     store.load(id).await.ok().flatten()
+///     store.load(id).ok().flatten()
 /// }
 /// ```
 pub trait SnapshotStore<S> {
@@ -60,35 +63,22 @@ pub trait SnapshotStore<S> {
     /// trusted for issuance. When `S` is a `nectar-postage-usage` snapshot the
     /// loaded value is unvalidated and carries no persist capability; it must be
     /// admitted through that crate's network-floor check before any persist.
-    fn load(
-        &self,
-        id: &BatchId,
-    ) -> impl std::future::Future<Output = Result<Option<S>, Self::Error>> + Send;
+    fn load(&self, id: &BatchId) -> Result<Option<S>, Self::Error>;
 
     /// Persists the snapshot state for `id`, overwriting any cached entry.
     ///
     /// This only updates the local cache; it does not publish to the network
     /// and confers no authority on the stored value.
-    fn persist(
-        &self,
-        id: &BatchId,
-        snapshot: S,
-    ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send;
+    fn persist(&self, id: &BatchId, snapshot: S) -> Result<(), Self::Error>;
 
     /// Removes any cached snapshot state for `id`.
     ///
     /// Returns `true` if an entry existed and was removed. Dropping an entry is
     /// always safe: the state can be recovered from the network.
-    fn remove(
-        &self,
-        id: &BatchId,
-    ) -> impl std::future::Future<Output = Result<bool, Self::Error>> + Send;
+    fn remove(&self, id: &BatchId) -> Result<bool, Self::Error>;
 
     /// Returns whether a snapshot state is cached for `id`.
-    fn contains(
-        &self,
-        id: &BatchId,
-    ) -> impl std::future::Future<Output = Result<bool, Self::Error>> + Send;
+    fn contains(&self, id: &BatchId) -> Result<bool, Self::Error>;
 }
 
 #[cfg(test)]
@@ -121,23 +111,23 @@ mod tests {
         }
     }
 
-    impl<S: Clone + Send + Sync> SnapshotStore<S> for InMemorySnapshotStore<S> {
+    impl<S: Clone> SnapshotStore<S> for InMemorySnapshotStore<S> {
         type Error = Infallible;
 
-        async fn load(&self, id: &BatchId) -> Result<Option<S>, Self::Error> {
+        fn load(&self, id: &BatchId) -> Result<Option<S>, Self::Error> {
             Ok(self.entries.lock().expect("poisoned").get(id).cloned())
         }
 
-        async fn persist(&self, id: &BatchId, snapshot: S) -> Result<(), Self::Error> {
+        fn persist(&self, id: &BatchId, snapshot: S) -> Result<(), Self::Error> {
             self.entries.lock().expect("poisoned").insert(*id, snapshot);
             Ok(())
         }
 
-        async fn remove(&self, id: &BatchId) -> Result<bool, Self::Error> {
+        fn remove(&self, id: &BatchId) -> Result<bool, Self::Error> {
             Ok(self.entries.lock().expect("poisoned").remove(id).is_some())
         }
 
-        async fn contains(&self, id: &BatchId) -> Result<bool, Self::Error> {
+        fn contains(&self, id: &BatchId) -> Result<bool, Self::Error> {
             Ok(self.entries.lock().expect("poisoned").contains_key(id))
         }
     }
@@ -146,62 +136,62 @@ mod tests {
         B256::repeat_byte(byte)
     }
 
-    #[tokio::test]
-    async fn load_misses_on_cold_store() {
+    #[test]
+    fn load_misses_on_cold_store() {
         let store: InMemorySnapshotStore<u64> = InMemorySnapshotStore::new();
         // A cold load is a miss, not an error: the caller recovers from the
         // network instead.
-        assert_eq!(store.load(&id(1)).await.unwrap(), None);
-        assert!(!store.contains(&id(1)).await.unwrap());
+        assert_eq!(store.load(&id(1)).unwrap(), None);
+        assert!(!store.contains(&id(1)).unwrap());
     }
 
-    #[tokio::test]
-    async fn persist_then_load_round_trips() {
+    #[test]
+    fn persist_then_load_round_trips() {
         let store = InMemorySnapshotStore::new();
-        store.persist(&id(2), 42u64).await.unwrap();
+        store.persist(&id(2), 42u64).unwrap();
 
-        assert!(store.contains(&id(2)).await.unwrap());
-        assert_eq!(store.load(&id(2)).await.unwrap(), Some(42));
+        assert!(store.contains(&id(2)).unwrap());
+        assert_eq!(store.load(&id(2)).unwrap(), Some(42));
         // A different batch id is still a miss: entries are keyed by batch id.
-        assert_eq!(store.load(&id(3)).await.unwrap(), None);
+        assert_eq!(store.load(&id(3)).unwrap(), None);
     }
 
-    #[tokio::test]
-    async fn persist_overwrites_existing_entry() {
+    #[test]
+    fn persist_overwrites_existing_entry() {
         let store = InMemorySnapshotStore::new();
-        store.persist(&id(4), 1u64).await.unwrap();
-        store.persist(&id(4), 2u64).await.unwrap();
+        store.persist(&id(4), 1u64).unwrap();
+        store.persist(&id(4), 2u64).unwrap();
 
         // The later persist wins; the cache holds one entry per batch id.
-        assert_eq!(store.load(&id(4)).await.unwrap(), Some(2));
+        assert_eq!(store.load(&id(4)).unwrap(), Some(2));
         assert_eq!(store.len(), 1);
     }
 
-    #[tokio::test]
-    async fn remove_reports_prior_presence() {
+    #[test]
+    fn remove_reports_prior_presence() {
         let store = InMemorySnapshotStore::new();
-        store.persist(&id(5), 7u64).await.unwrap();
+        store.persist(&id(5), 7u64).unwrap();
 
         // Removing a present entry reports true and clears it; the state can
         // still be recovered from the network, so this is always safe.
-        assert!(store.remove(&id(5)).await.unwrap());
-        assert_eq!(store.load(&id(5)).await.unwrap(), None);
+        assert!(store.remove(&id(5)).unwrap());
+        assert_eq!(store.load(&id(5)).unwrap(), None);
         // Removing an absent entry reports false.
-        assert!(!store.remove(&id(5)).await.unwrap());
+        assert!(!store.remove(&id(5)).unwrap());
     }
 
-    #[tokio::test]
-    async fn entries_are_isolated_by_batch_id() {
+    #[test]
+    fn entries_are_isolated_by_batch_id() {
         let store = InMemorySnapshotStore::new();
-        store.persist(&id(6), 60u64).await.unwrap();
-        store.persist(&id(7), 70u64).await.unwrap();
+        store.persist(&id(6), 60u64).unwrap();
+        store.persist(&id(7), 70u64).unwrap();
 
         // Distinct batch ids do not alias one another.
-        assert_eq!(store.load(&id(6)).await.unwrap(), Some(60));
-        assert_eq!(store.load(&id(7)).await.unwrap(), Some(70));
-        assert!(store.remove(&id(6)).await.unwrap());
-        assert_eq!(store.load(&id(6)).await.unwrap(), None);
-        assert_eq!(store.load(&id(7)).await.unwrap(), Some(70));
+        assert_eq!(store.load(&id(6)).unwrap(), Some(60));
+        assert_eq!(store.load(&id(7)).unwrap(), Some(70));
+        assert!(store.remove(&id(6)).unwrap());
+        assert_eq!(store.load(&id(6)).unwrap(), None);
+        assert_eq!(store.load(&id(7)).unwrap(), Some(70));
         assert_eq!(store.len(), 1);
     }
 }

--- a/crates/postage/src/stamp.rs
+++ b/crates/postage/src/stamp.rs
@@ -330,6 +330,10 @@ impl Stamp {
     /// [`verify_with_pubkey`](Self::verify_with_pubkey) which is approximately
     /// 10x faster than full signature recovery.
     ///
+    /// This pair (`recover_pubkey` / `verify_with_pubkey`) is the primitive for a
+    /// future in-memory, never-persisted per-batch pubkey memoization; it is kept
+    /// deliberately even though no cache is wired up yet.
+    ///
     /// # Arguments
     ///
     /// * `chunk_address` - The address of the chunk this stamp is for

--- a/crates/postage/src/store.rs
+++ b/crates/postage/src/store.rs
@@ -7,10 +7,16 @@ use crate::{Batch, BatchId, PostageContext};
 /// Implementations may persist batches in memory, on disk, or retrieve
 /// them from a remote source such as a blockchain node.
 ///
-/// # Async Design
+/// # Synchronous Design
 ///
-/// This trait uses async methods to support both local (fast) and
-/// remote (potentially slow) storage backends without blocking.
+/// The methods are synchronous. The known backends (in memory, redb) are
+/// themselves synchronous, so there is no genuinely async work to drive here;
+/// any async behaviour belongs at the true edges (a gRPC service, an FFI
+/// boundary) where it is added by the edge, not by the store. Keeping the core
+/// synchronous avoids colouring every caller with `async`, keeps the futures
+/// `Send`-free on the wasm path, and makes this trait naturally object-safe (it
+/// has an associated `Error` and no generic methods), a property the previous
+/// async-in-trait shape did not have.
 pub trait BatchStore {
     /// The error type returned by store operations.
     type Error: std::error::Error;
@@ -18,53 +24,38 @@ pub trait BatchStore {
     /// Retrieves a batch by its ID.
     ///
     /// Returns `None` if the batch doesn't exist.
-    fn get(
-        &self,
-        id: &BatchId,
-    ) -> impl std::future::Future<Output = Result<Option<Batch>, Self::Error>> + Send;
+    fn get(&self, id: &BatchId) -> Result<Option<Batch>, Self::Error>;
 
     /// Stores or updates a batch.
-    fn put(
-        &self,
-        batch: Batch,
-    ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send;
+    fn put(&self, batch: Batch) -> Result<(), Self::Error>;
 
     /// Removes a batch from the store.
     ///
     /// Returns `true` if the batch existed and was removed.
-    fn remove(
-        &self,
-        id: &BatchId,
-    ) -> impl std::future::Future<Output = Result<bool, Self::Error>> + Send;
+    fn remove(&self, id: &BatchId) -> Result<bool, Self::Error>;
 
     /// Checks if a batch exists in the store.
-    fn contains(
-        &self,
-        id: &BatchId,
-    ) -> impl std::future::Future<Output = Result<bool, Self::Error>> + Send;
+    fn contains(&self, id: &BatchId) -> Result<bool, Self::Error>;
 
     /// Returns the current postage context.
-    fn context(
-        &self,
-    ) -> impl std::future::Future<Output = Result<PostageContext, Self::Error>> + Send;
+    fn context(&self) -> Result<PostageContext, Self::Error>;
 
     /// Updates the postage context.
-    fn set_context(
-        &self,
-        state: PostageContext,
-    ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send;
+    fn set_context(&self, state: PostageContext) -> Result<(), Self::Error>;
 
     /// Returns all batch IDs in the store.
-    fn batch_ids(
-        &self,
-    ) -> impl std::future::Future<Output = Result<Vec<BatchId>, Self::Error>> + Send;
+    fn batch_ids(&self) -> Result<Vec<BatchId>, Self::Error>;
 
     /// Returns the number of batches in the store.
-    fn count(&self) -> impl std::future::Future<Output = Result<usize, Self::Error>> + Send;
+    fn count(&self) -> Result<usize, Self::Error>;
 }
 
 /// Extension methods for [`BatchStore`].
-pub trait BatchStoreExt: BatchStore + Sync {
+///
+/// This is a plain synchronous extension trait; it carries no `Sync` bound,
+/// because the methods are no longer `async` and therefore never need their
+/// futures to be `Send` (which previously forced `Self: Sync`).
+pub trait BatchStoreExt: BatchStore {
     /// Gets a batch and verifies it's usable.
     ///
     /// Returns an error if the batch doesn't exist, isn't usable yet,
@@ -73,40 +64,37 @@ pub trait BatchStoreExt: BatchStore + Sync {
         &self,
         id: &BatchId,
         confirmation_threshold: u64,
-    ) -> impl std::future::Future<Output = Result<Batch, BatchStoreError<Self::Error>>> + Send {
-        async move {
-            let batch = self
-                .get(id)
-                .await
-                .map_err(BatchStoreError::Store)?
-                .ok_or(BatchStoreError::NotFound(*id))?;
+    ) -> Result<Batch, BatchStoreError<Self::Error>> {
+        let batch = self
+            .get(id)
+            .map_err(BatchStoreError::Store)?
+            .ok_or(BatchStoreError::NotFound(*id))?;
 
-            let state = self.context().await.map_err(BatchStoreError::Store)?;
+        let state = self.context().map_err(BatchStoreError::Store)?;
 
-            if !batch.is_usable(state.block(), confirmation_threshold) {
-                return Err(BatchStoreError::NotUsable {
-                    batch_id: *id,
-                    created: batch.start(),
-                    current: state.block(),
-                    threshold: confirmation_threshold,
-                });
-            }
-
-            if batch.is_expired(state.total_amount()) {
-                return Err(BatchStoreError::Expired {
-                    batch_id: *id,
-                    value: batch.value(),
-                    total_amount: state.total_amount(),
-                });
-            }
-
-            Ok(batch)
+        if !batch.is_usable(state.block(), confirmation_threshold) {
+            return Err(BatchStoreError::NotUsable {
+                batch_id: *id,
+                created: batch.start(),
+                current: state.block(),
+                threshold: confirmation_threshold,
+            });
         }
+
+        if batch.is_expired(state.total_amount()) {
+            return Err(BatchStoreError::Expired {
+                batch_id: *id,
+                value: batch.value(),
+                total_amount: state.total_amount(),
+            });
+        }
+
+        Ok(batch)
     }
 }
 
 // Blanket implementation
-impl<T: BatchStore + Sync> BatchStoreExt for T {}
+impl<T: BatchStore> BatchStoreExt for T {}
 
 /// Errors that can occur when working with a batch store.
 #[derive(Debug)]

--- a/crates/postage/src/validation.rs
+++ b/crates/postage/src/validation.rs
@@ -107,7 +107,7 @@ pub trait StampValidator {
 /// let store = MyBatchStore::new();
 /// let validator = StoreValidator::new(store, 50); // 50 block confirmations
 ///
-/// let result = validator.validate(&stamp, &address).await;
+/// let result = validator.validate(&stamp, &address);
 /// ```
 #[derive(Debug)]
 #[cfg(feature = "std")]
@@ -143,17 +143,17 @@ impl<S> StoreValidator<S> {
 }
 
 #[cfg(feature = "std")]
-impl<S: BatchStore + Sync> StoreValidator<S> {
-    /// Validates a stamp asynchronously.
+impl<S: BatchStore> StoreValidator<S> {
+    /// Validates a stamp.
     ///
     /// This performs full validation including signature verification.
     ///
     /// # Returns
     ///
     /// `Ok(())` if the stamp is valid, or a [`StampError`] describing the failure.
-    pub async fn validate(&self, stamp: &Stamp, address: &SwarmAddress) -> Result<(), StampError> {
+    pub fn validate(&self, stamp: &Stamp, address: &SwarmAddress) -> Result<(), StampError> {
         // Get the batch and verify it's usable
-        let batch = self.get_batch_for_stamp(stamp).await?;
+        let batch = self.get_batch_for_stamp(stamp)?;
 
         // Validate structure
         self.validate_structure_with_batch(stamp, address, &batch)?;
@@ -168,20 +168,19 @@ impl<S: BatchStore + Sync> StoreValidator<S> {
     ///
     /// This is faster than full validation when you only need to check
     /// that the stamp references a valid batch and bucket.
-    pub async fn validate_structure(
+    pub fn validate_structure(
         &self,
         stamp: &Stamp,
         address: &SwarmAddress,
     ) -> Result<(), StampError> {
-        let batch = self.get_batch_for_stamp(stamp).await?;
+        let batch = self.get_batch_for_stamp(stamp)?;
         self.validate_structure_with_batch(stamp, address, &batch)
     }
 
     /// Gets and validates the batch for a stamp.
-    async fn get_batch_for_stamp(&self, stamp: &Stamp) -> Result<Batch, StampError> {
+    fn get_batch_for_stamp(&self, stamp: &Stamp) -> Result<Batch, StampError> {
         self.store
             .get_usable(&stamp.batch(), self.confirmation_threshold)
-            .await
             .map_err(|e| match e {
                 crate::BatchStoreError::NotFound(id) => StampError::BatchNotFound(id),
                 crate::BatchStoreError::NotUsable {


### PR DESCRIPTION
## Summary

The async-in-trait shape of `BatchStore`, `BatchStoreExt`, `StoreValidator` and `SnapshotStore` was async theatre. None of the known backends does genuinely asynchronous work: the in-memory store is a map behind a mutex and the downstream redb store is synchronous. (The `StampValidator`, `BatchEventHandler`, `Stamp` and `Batch` types were already synchronous.) The `impl Future<...> + Send` return types and the `+ Send` bounds therefore bought nothing on the native path while imposing real costs:

- they coloured every caller with `async`, even though the body never yields;
- they forced `!Send` futures on the wasm path, where `Send` is not available;
- they pushed a `block_on` bridge into the downstream vertex storer to call a store that never actually suspends.

This change makes the core fully synchronous and keeps asynchrony only at the true edges (a gRPC service, an FFI boundary), where it is genuinely introduced by the edge rather than by the store.

## What changed

- `BatchStore`: all eight methods are now plain `fn` returning `Result<_, Self::Error>` (no `impl Future`, no `+ Send`). The associated `Error` type is retained.
- `BatchStoreExt` and `StoreValidator`: the `+ Sync` bound is dropped, so both are now `impl<S: BatchStore>`. `BatchStoreExt::get_usable` is a synchronous default that calls `get()` and `context()`.
- `StoreValidator::validate`, `validate_structure` and `get_batch_for_stamp`: synchronous; they previously only awaited the store. `validate_structure_with_batch` was already synchronous.
- `SnapshotStore`: all four methods are synchronous. The `InMemorySnapshotStore` test implementation and its tests are converted to plain `#[test]` rather than `#[tokio::test]`.
- Documentation that described an async design has been updated to describe the synchronous design.

## Validation semantics are unchanged

This is purely a colouring and shape change. A stamp is valid if and only if the recovered signer equals `batch.owner` and the index and bucket bounds hold, byte-identical to before. The signature recovery and digest primitives are untouched, and no test fixtures or vectors were altered.

## Regained object safety

With an associated `Error` and no generic methods, the synchronous `BatchStore` is now naturally object-safe, a property the async-in-trait shape did not have. This is noted in the trait documentation. No `dyn` machinery or `auto_impl` was added.

`Stamp::recover_pubkey` and `Stamp::verify_with_pubkey` are retained deliberately, with a doc note, as the primitive for a future in-memory, never-persisted per-batch public-key memoisation, even though no cache is wired up yet.

## Downstream

The vertex repository repins `nectar-postage` to this commit and flips `DbBatchStore` onto the synchronous trait by deleting its `async move { result }` wrappers, deletes the storer `block_on` / `batch_sync` bridge so the reserve calls the synchronous `BatchStore` directly with typed errors, and drops the now-needless async colouring on `DbReserve`. The blast radius within nectar itself is small: these traits are only referenced inside the postage crate, with no in-tree implementors other than the in-memory test stores.

## Merge order

This PR (`feat/postage-sync-core`) must merge first. Then the vertex car A repins `nectar-postage` from `rev = 89f48899` back to `branch = "main"` (a trivial follow-up), and the vertex train merges bottom-up from there. The vertex rev pin onto this commit is resolvable by CI now (the branch is on origin) but is explicitly temporary, pending this merge.

## Verification

`cargo build`, `cargo test`, `cargo clippy -D warnings` and `cargo fmt --check` are clean across the whole workspace with `--all-features`. (A pre-existing `unused-macros` lint in `nectar-primitives`, unrelated to this change, only surfaces under `--all-targets` without the `encryption` feature that consumes those test macros; it is present on `main` independently of this work and is tracked separately.)

## AI assistance disclosure

This change was prepared with the assistance of an AI coding tool. All changes have been reviewed by the author, who is accountable for the contribution.
