### PR TITLE
refactor(primitives)!: decouple the splitter from the store and produce chunks

### DIFF
--- a/crates/postage-issuer/benches/upload_pipeline.rs
+++ b/crates/postage-issuer/benches/upload_pipeline.rs
@@ -63,10 +63,10 @@ fn bench_pipeline_mock_sequential(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::from_parameter(name), &data, |b, data| {
             b.iter(|| {
                 // Split file into chunks
-                let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-                let mut splitter = SyncSplitter::new(store, data.len() as u64);
+                let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
                 splitter.write_all(data).unwrap();
-                let (root, store) = splitter.finish().unwrap();
+                let (root, chunks) = splitter.finish().unwrap();
+                let store = MemoryStore::from_chunks(chunks);
 
                 // Stamp each chunk
                 let issuer = MemoryIssuer::new(B256::ZERO, 32, 16);
@@ -98,10 +98,9 @@ fn bench_pipeline_mock_parallel_split(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::from_parameter(name), &data, |b, data| {
             b.iter(|| {
                 // Parallel split
-                let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-                let splitter = SyncParallelSplitter::new(store);
-                let root = splitter.split(data).unwrap();
-                let store = splitter.into_store();
+                let (root, chunks) =
+                    SyncParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap();
+                let store = MemoryStore::from_chunks(chunks);
 
                 // Stamp each chunk (sequential)
                 let issuer = MemoryIssuer::new(B256::ZERO, 32, 16);
@@ -137,10 +136,10 @@ fn bench_pipeline_ecdsa_sequential(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::from_parameter(name), &data, |b, data| {
             b.iter(|| {
                 // Split file into chunks
-                let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-                let mut splitter = SyncSplitter::new(store, data.len() as u64);
+                let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
                 splitter.write_all(data).unwrap();
-                let (root, store) = splitter.finish().unwrap();
+                let (root, chunks) = splitter.finish().unwrap();
+                let store = MemoryStore::from_chunks(chunks);
 
                 // Stamp each chunk with real signatures
                 let issuer = MemoryIssuer::new(B256::ZERO, 32, 16);
@@ -182,10 +181,9 @@ fn bench_pipeline_fully_parallel(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::from_parameter(name), &data, |b, data| {
             b.iter(|| {
                 // Parallel split
-                let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-                let splitter = SyncParallelSplitter::new(store);
-                let root = splitter.split(data).unwrap();
-                let store = splitter.into_store();
+                let (root, chunks) =
+                    SyncParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap();
+                let store = MemoryStore::from_chunks(chunks);
 
                 // Collect addresses for parallel signing
                 let chunks = store.into_chunks();
@@ -223,10 +221,10 @@ fn bench_pipeline_comparison(c: &mut Criterion) {
     // Fully sequential
     group.bench_function("sequential", |b| {
         b.iter(|| {
-            let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-            let mut splitter = SyncSplitter::new(store, data.len() as u64);
+            let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
             splitter.write_all(&data).unwrap();
-            let (root, store) = splitter.finish().unwrap();
+            let (root, chunks) = splitter.finish().unwrap();
+            let store = MemoryStore::from_chunks(chunks);
 
             let issuer = MemoryIssuer::new(B256::ZERO, 32, 16);
             let mut stamper = BatchStamper::new(issuer, &signer);
@@ -244,10 +242,9 @@ fn bench_pipeline_comparison(c: &mut Criterion) {
     // Parallel split only
     group.bench_function("parallel_split", |b| {
         b.iter(|| {
-            let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-            let splitter = SyncParallelSplitter::new(store);
-            let root = splitter.split(&data).unwrap();
-            let store = splitter.into_store();
+            let (root, chunks) =
+                SyncParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(&data).unwrap();
+            let store = MemoryStore::from_chunks(chunks);
 
             let issuer = MemoryIssuer::new(B256::ZERO, 32, 16);
             let mut stamper = BatchStamper::new(issuer, &signer);
@@ -265,10 +262,9 @@ fn bench_pipeline_comparison(c: &mut Criterion) {
     // Fully parallel
     group.bench_function("fully_parallel", |b| {
         b.iter(|| {
-            let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-            let splitter = SyncParallelSplitter::new(store);
-            let root = splitter.split(&data).unwrap();
-            let store = splitter.into_store();
+            let (root, chunks) =
+                SyncParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(&data).unwrap();
+            let store = MemoryStore::from_chunks(chunks);
 
             let chunks = store.into_chunks();
             let addresses: Vec<_> = chunks.keys().copied().collect();
@@ -297,8 +293,7 @@ fn bench_pipeline_stages(c: &mut Criterion) {
     // Stage 1: Split only (sequential)
     group.bench_function("1_split_sequential", |b| {
         b.iter(|| {
-            let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-            let mut splitter = SyncSplitter::new(store, data.len() as u64);
+            let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
             splitter.write_all(&data).unwrap();
             black_box(splitter.finish().unwrap())
         });
@@ -307,18 +302,15 @@ fn bench_pipeline_stages(c: &mut Criterion) {
     // Stage 1: Split only (parallel)
     group.bench_function("1_split_parallel", |b| {
         b.iter(|| {
-            let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-            let splitter = SyncParallelSplitter::new(store);
-            let root = splitter.split(&data).unwrap();
-            black_box((root, splitter.into_store()))
+            black_box(SyncParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(&data).unwrap())
         });
     });
 
     // Pre-split for stamp benchmarks
-    let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-    let mut splitter = SyncSplitter::new(store, data.len() as u64);
+    let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
     splitter.write_all(&data).unwrap();
-    let (_, store) = splitter.finish().unwrap();
+    let (_, chunks) = splitter.finish().unwrap();
+    let store = MemoryStore::from_chunks(chunks);
     let chunks = store.into_chunks();
     let addresses: Vec<_> = chunks.keys().copied().collect();
     let num_chunks = addresses.len();

--- a/crates/primitives/benches/encryption_bench.rs
+++ b/crates/primitives/benches/encryption_bench.rs
@@ -155,8 +155,8 @@ fn bench_encrypted_streaming_splitter(c: &mut Criterion) {
         group.throughput(Throughput::Bytes(size));
         group.bench_with_input(BenchmarkId::from_parameter(name), &data, |b, data| {
             b.iter(|| {
-                let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-                let mut splitter = EncryptedSyncSplitter::new(store, data.len() as u64);
+                let mut splitter =
+                    EncryptedSyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
                 splitter.write_all(data).unwrap();
                 black_box(splitter.finish().unwrap())
             });
@@ -175,10 +175,9 @@ fn bench_encrypted_parallel_splitter(c: &mut Criterion) {
         group.throughput(Throughput::Bytes(size));
         group.bench_with_input(BenchmarkId::from_parameter(name), &data, |b, data| {
             b.iter(|| {
-                let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-                let splitter = EncryptedSyncParallelSplitter::new(store);
-                let root_ref = splitter.split(data).unwrap();
-                black_box((root_ref, splitter.into_store()))
+                black_box(
+                    EncryptedSyncParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap(),
+                )
             });
         });
     }
@@ -223,8 +222,7 @@ fn bench_plain_vs_encrypted_split(c: &mut Criterion) {
             &data,
             |b, data| {
                 b.iter(|| {
-                    let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-                    let mut splitter = SyncSplitter::new(store, data.len() as u64);
+                    let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
                     splitter.write_all(data).unwrap();
                     black_box(splitter.finish().unwrap())
                 });
@@ -236,8 +234,8 @@ fn bench_plain_vs_encrypted_split(c: &mut Criterion) {
             &data,
             |b, data| {
                 b.iter(|| {
-                    let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-                    let mut splitter = EncryptedSyncSplitter::new(store, data.len() as u64);
+                    let mut splitter =
+                        EncryptedSyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
                     splitter.write_all(data).unwrap();
                     black_box(splitter.finish().unwrap())
                 });
@@ -246,10 +244,7 @@ fn bench_plain_vs_encrypted_split(c: &mut Criterion) {
 
         group.bench_with_input(BenchmarkId::new("plain_direct", name), &data, |b, data| {
             b.iter(|| {
-                let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-                let splitter = SyncParallelSplitter::new(store);
-                let root = splitter.split(data).unwrap();
-                black_box((root, splitter.into_store()))
+                black_box(SyncParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap())
             });
         });
 
@@ -258,10 +253,10 @@ fn bench_plain_vs_encrypted_split(c: &mut Criterion) {
             &data,
             |b, data| {
                 b.iter(|| {
-                    let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-                    let splitter = EncryptedSyncParallelSplitter::new(store);
-                    let root_ref = splitter.split(data).unwrap();
-                    black_box((root_ref, splitter.into_store()))
+                    black_box(
+                        EncryptedSyncParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data)
+                            .unwrap(),
+                    )
                 });
             },
         );
@@ -330,10 +325,9 @@ fn bench_encrypted_roundtrip(c: &mut Criterion) {
 
         group.bench_with_input(BenchmarkId::new("direct", name), &data, |b, data| {
             b.iter(|| {
-                let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-                let splitter = EncryptedSyncParallelSplitter::new(store);
-                let root_ref = splitter.split(data).unwrap();
-                let store = splitter.into_store();
+                let (root_ref, chunks) =
+                    EncryptedSyncParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap();
+                let store = MemoryStore::from_chunks(chunks);
                 let joiner = EncryptedSyncJoiner::new(store, root_ref).unwrap();
                 black_box(joiner.read_all().unwrap())
             });

--- a/crates/primitives/benches/file_bench.rs
+++ b/crates/primitives/benches/file_bench.rs
@@ -59,8 +59,7 @@ fn bench_streaming_splitter(c: &mut Criterion) {
         group.throughput(Throughput::Bytes(size));
         group.bench_with_input(BenchmarkId::from_parameter(name), &data, |b, data| {
             b.iter(|| {
-                let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-                let mut splitter = SyncSplitter::new(store, data.len() as u64);
+                let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
                 splitter.write_all(data).unwrap();
                 black_box(splitter.finish().unwrap())
             });
@@ -80,10 +79,7 @@ fn bench_parallel_splitter(c: &mut Criterion) {
         group.throughput(Throughput::Bytes(size));
         group.bench_with_input(BenchmarkId::from_parameter(name), &data, |b, data| {
             b.iter(|| {
-                let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-                let splitter = SyncParallelSplitter::new(store);
-                let root = splitter.split(data).unwrap();
-                black_box((root, splitter.into_store()))
+                black_box(SyncParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap())
             });
         });
     }
@@ -102,8 +98,7 @@ fn bench_splitter_comparison(c: &mut Criterion) {
 
         group.bench_with_input(BenchmarkId::new("streaming", name), &data, |b, data| {
             b.iter(|| {
-                let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-                let mut splitter = SyncSplitter::new(store, data.len() as u64);
+                let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
                 splitter.write_all(data).unwrap();
                 black_box(splitter.finish().unwrap())
             });
@@ -111,10 +106,7 @@ fn bench_splitter_comparison(c: &mut Criterion) {
 
         group.bench_with_input(BenchmarkId::new("direct", name), &data, |b, data| {
             b.iter(|| {
-                let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-                let splitter = SyncParallelSplitter::new(store);
-                let root = splitter.split(data).unwrap();
-                black_box((root, splitter.into_store()))
+                black_box(SyncParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap())
             });
         });
     }
@@ -133,8 +125,7 @@ fn bench_incremental_writes(c: &mut Criterion) {
 
     group.bench_function("single_write", |b| {
         b.iter(|| {
-            let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-            let mut splitter = SyncSplitter::new(store, data.len() as u64);
+            let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
             splitter.write_all(&data).unwrap();
             black_box(splitter.finish().unwrap())
         });
@@ -142,8 +133,7 @@ fn bench_incremental_writes(c: &mut Criterion) {
 
     group.bench_function("4kb_chunks", |b| {
         b.iter(|| {
-            let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-            let mut splitter = SyncSplitter::new(store, data.len() as u64);
+            let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
             for chunk in data.chunks(4096) {
                 splitter.write_all(chunk).unwrap();
             }
@@ -153,8 +143,7 @@ fn bench_incremental_writes(c: &mut Criterion) {
 
     group.bench_function("64kb_chunks", |b| {
         b.iter(|| {
-            let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-            let mut splitter = SyncSplitter::new(store, data.len() as u64);
+            let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
             for chunk in data.chunks(65536) {
                 splitter.write_all(chunk).unwrap();
             }
@@ -213,10 +202,9 @@ fn bench_roundtrip(c: &mut Criterion) {
 
         group.bench_with_input(BenchmarkId::new("direct_split", name), &data, |b, data| {
             b.iter(|| {
-                let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-                let splitter = SyncParallelSplitter::new(store);
-                let root = splitter.split(data).unwrap();
-                let store = splitter.into_store();
+                let (root, chunks) =
+                    SyncParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap();
+                let store = MemoryStore::from_chunks(chunks);
                 let joiner = SyncJoiner::new(store, root).unwrap();
                 black_box(joiner.read_all().unwrap())
             });

--- a/crates/primitives/src/file/mod.rs
+++ b/crates/primitives/src/file/mod.rs
@@ -165,10 +165,8 @@ where
 pub fn sync_split<const BODY_SIZE: usize>(
     data: &[u8],
 ) -> error::Result<(ChunkAddress, crate::store::MemoryStore<BODY_SIZE>)> {
-    let store = crate::store::MemoryStore::<BODY_SIZE>::new();
-    let splitter = SyncParallelSplitter::new(store);
-    let root = splitter.split(&data)?;
-    Ok((root, splitter.into_store()))
+    let (root, chunks) = SyncParallelSplitter::<BODY_SIZE>::split_to_vec(&data)?;
+    Ok((root, crate::store::MemoryStore::from_chunks(chunks)))
 }
 
 /// Split data into encrypted chunks synchronously.
@@ -176,10 +174,8 @@ pub fn sync_split<const BODY_SIZE: usize>(
 pub fn sync_split_encrypted<const BODY_SIZE: usize>(
     data: &[u8],
 ) -> error::Result<(EncryptedChunkRef, crate::store::MemoryStore<BODY_SIZE>)> {
-    let store = crate::store::MemoryStore::<BODY_SIZE>::new();
-    let splitter = EncryptedSyncParallelSplitter::new(store);
-    let root_ref = splitter.split(&data)?;
-    Ok((root_ref, splitter.into_store()))
+    let (root_ref, chunks) = EncryptedSyncParallelSplitter::<BODY_SIZE>::split_to_vec(&data)?;
+    Ok((root_ref, crate::store::MemoryStore::from_chunks(chunks)))
 }
 
 /// Join chunks synchronously. Dispatches plain/encrypted via [`JoinRef`].
@@ -291,21 +287,15 @@ impl<T, const BODY_SIZE: usize> SyncChunkGetExt<BODY_SIZE> for T where T: SyncCh
 /// ```
 pub trait SyncChunkPutExt<const BODY_SIZE: usize>: SyncChunkPut<BODY_SIZE> {
     /// Create a writer for streaming data. Returns a `SyncSplitter` implementing `Write`.
-    /// Call `.finish()` on the returned writer to get the root address.
-    fn writer(&self, size: u64) -> SyncSplitter<&Self, BODY_SIZE>
-    where
-        Self: Sized,
-    {
-        SyncSplitter::new(self, size)
+    /// Call `.finish()` on the returned writer to get the root and produced chunks.
+    fn writer(&self, size: u64) -> SyncSplitter<BODY_SIZE> {
+        SyncSplitter::new(size)
     }
 
     /// Create an encrypted writer. Returns an `EncryptedSyncSplitter` implementing `Write`.
     #[cfg(feature = "encryption")]
-    fn encrypted_writer(&self, size: u64) -> EncryptedSyncSplitter<&Self, BODY_SIZE>
-    where
-        Self: Sized,
-    {
-        EncryptedSyncSplitter::new(self, size)
+    fn encrypted_writer(&self, size: u64) -> EncryptedSyncSplitter<BODY_SIZE> {
+        EncryptedSyncSplitter::new(size)
     }
 
     /// Write file data into the store (like `fs::write`).
@@ -313,7 +303,11 @@ pub trait SyncChunkPutExt<const BODY_SIZE: usize>: SyncChunkPut<BODY_SIZE> {
     where
         Self: Send + Sync + Sized,
     {
-        SyncParallelSplitter::<&Self, BODY_SIZE>::new(self).split(&data)
+        let (root, chunks) = SyncParallelSplitter::<BODY_SIZE>::split_to_vec(&data)?;
+        for chunk in chunks {
+            self.put(chunk).map_err(FileError::store)?;
+        }
+        Ok(root)
     }
 
     /// Write encrypted file data into the store.
@@ -322,7 +316,11 @@ pub trait SyncChunkPutExt<const BODY_SIZE: usize>: SyncChunkPut<BODY_SIZE> {
     where
         Self: Send + Sync + Sized,
     {
-        EncryptedSyncParallelSplitter::<&Self, BODY_SIZE>::new(self).split(&data)
+        let (root_ref, chunks) = EncryptedSyncParallelSplitter::<BODY_SIZE>::split_to_vec(&data)?;
+        for chunk in chunks {
+            self.put(chunk).map_err(FileError::store)?;
+        }
+        Ok(root_ref)
     }
 }
 

--- a/crates/primitives/src/file/mode.rs
+++ b/crates/primitives/src/file/mode.rs
@@ -7,7 +7,7 @@ use bytes::Bytes;
 use crate::bmt::SPAN_SIZE;
 use crate::chunk::encryption::{EncryptedChunkRef, EncryptionKey, decrypt_chunk_data};
 use crate::chunk::{BmtChunk, Chunk, ChunkAddress, ContentChunk};
-use crate::store::{MaybeSend, SyncChunkGet, SyncChunkPut};
+use crate::store::{MaybeSend, SyncChunkGet};
 
 use super::constants::{ENCRYPTED_REF_SIZE, REF_SIZE, compute_spans_inline, subspan_for_spans};
 use super::error::{FileError, Result};
@@ -24,16 +24,6 @@ fn chunk_creation_error(e: crate::error::PrimitivesError) -> FileError {
 #[inline]
 fn create_chunk<const BS: usize>(data: Bytes) -> Result<ContentChunk<BS>> {
     ContentChunk::<BS>::try_from(data).map_err(chunk_creation_error)
-}
-
-/// Store a chunk and return its address (derived from the chunk).
-fn store_chunk<const BS: usize, S: SyncChunkPut<BS>>(
-    chunk: ContentChunk<BS>,
-    store: &S,
-) -> Result<ChunkAddress> {
-    let address = *chunk.address();
-    store.put(chunk.into()).map_err(FileError::store)?;
-    Ok(address)
 }
 
 /// Joiner-side chunk mode operations.
@@ -171,24 +161,12 @@ pub trait SplitMode: JoinMode {
     /// Fixed-size byte array for a reference: `[u8; 32]` or `[u8; 64]`.
     type RefBytes: AsRef<[u8]> + AsMut<[u8]> + Clone + Debug + Send + Sync;
 
-    /// Prepare chunk data (span + body) for storage, returning chunk and reference bytes.
+    /// Prepare chunk data (span + body), returning chunk and reference bytes.
     /// Takes ownership of the payload to avoid an extra allocation.
     fn prepare_chunk<const BS: usize>(data: Vec<u8>) -> Result<(ContentChunk<BS>, Self::RefBytes)>;
 
-    /// Process chunk data (span + body), store it, return reference bytes.
-    /// Takes ownership of the payload to avoid an extra allocation.
-    #[inline]
-    fn process_chunk<const BS: usize, S: SyncChunkPut<BS>>(
-        data: Vec<u8>,
-        store: &S,
-    ) -> Result<Self::RefBytes> {
-        let (chunk, ref_bytes) = Self::prepare_chunk::<BS>(data)?;
-        store.put(chunk.into()).map_err(FileError::store)?;
-        Ok(ref_bytes)
-    }
-
-    /// Process empty file, store chunk, return root ref.
-    fn process_empty<const BS: usize, S: SyncChunkPut<BS>>(store: &S) -> Result<Self::RootRef>;
+    /// Produce the chunk for an empty file, returning it and the root ref.
+    fn empty_chunk<const BS: usize>() -> Result<(ContentChunk<BS>, Self::RootRef)>;
 
     /// Extract root reference from top of buffer.
     fn extract_root(buffer: &[u8]) -> Result<Self::RootRef>;
@@ -245,11 +223,12 @@ impl SplitMode for PlainMode {
         Ok((chunk, ref_bytes))
     }
 
-    fn process_empty<const BS: usize, S: SyncChunkPut<BS>>(store: &S) -> Result<ChunkAddress> {
+    fn empty_chunk<const BS: usize>() -> Result<(ContentChunk<BS>, ChunkAddress)> {
         // Use `new` (not `try_from`) because Bytes::new() is raw content,
         // not pre-formatted span+body data.
         let chunk = ContentChunk::<BS>::new(Bytes::new()).map_err(chunk_creation_error)?;
-        store_chunk::<BS, S>(chunk, store)
+        let address = *chunk.address();
+        Ok((chunk, address))
     }
 
     fn extract_root(buffer: &[u8]) -> Result<ChunkAddress> {
@@ -345,15 +324,15 @@ impl SplitMode for EncryptedMode {
         Ok((chunk, ref_bytes))
     }
 
-    fn process_empty<const BS: usize, S: SyncChunkPut<BS>>(store: &S) -> Result<EncryptedChunkRef> {
+    fn empty_chunk<const BS: usize>() -> Result<(ContentChunk<BS>, EncryptedChunkRef)> {
         use crate::chunk::encryption::encrypt_chunk;
 
         let key = EncryptionKey::generate();
         let chunk_bytes = 0u64.to_le_bytes().to_vec();
         let ciphertext = encrypt_chunk::<BS>(&chunk_bytes, &key)?;
         let chunk = create_chunk::<BS>(Bytes::from(ciphertext))?;
-        let address = store_chunk::<BS, S>(chunk, store)?;
-        Ok(EncryptedChunkRef::new(address, key))
+        let address = *chunk.address();
+        Ok((chunk, EncryptedChunkRef::new(address, key)))
     }
 
     fn extract_root(buffer: &[u8]) -> Result<EncryptedChunkRef> {

--- a/crates/primitives/src/file/sync_splitter.rs
+++ b/crates/primitives/src/file/sync_splitter.rs
@@ -1,18 +1,19 @@
 //! File splitter for producing BMT chunks from data streams.
 //!
 //! Buffers data via `Write`, then delegates to `GenericSyncParallelSplitter`
-//! on `finish()` for parallel chunk hashing.
+//! on `finish()` for parallel chunk hashing. Produces chunks; the caller
+//! decides where they go.
 
 use std::fmt;
 use std::io::{self, Write};
 use std::marker::PhantomData;
 
 use crate::bmt::DEFAULT_BODY_SIZE;
+use crate::chunk::AnyChunk;
 
 use super::error::{FileError, Result};
 use super::mode::{PlainMode, SplitMode};
 use super::sync_splitter_parallel::GenericSyncParallelSplitter;
-use crate::store::SyncChunkPut;
 
 #[cfg(feature = "encryption")]
 use super::mode::EncryptedMode;
@@ -21,28 +22,23 @@ use super::mode::EncryptedMode;
 ///
 /// Buffers data written via `Write` and delegates to `GenericSyncParallelSplitter`
 /// on `finish()` for parallel chunk hashing.
-pub struct GenericSyncSplitter<S, M: SplitMode, const BODY_SIZE: usize = DEFAULT_BODY_SIZE>
-where
-    S: SyncChunkPut<BODY_SIZE>,
-{
-    store: S,
+pub struct GenericSyncSplitter<M: SplitMode, const BODY_SIZE: usize = DEFAULT_BODY_SIZE> {
     span_length: u64,
     buffer: Vec<u8>,
     _mode: PhantomData<M>,
 }
 
 /// Plain (unencrypted) file splitter.
-pub type SyncSplitter<S, const BODY_SIZE: usize = DEFAULT_BODY_SIZE> =
-    GenericSyncSplitter<S, PlainMode, BODY_SIZE>;
+pub type SyncSplitter<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> =
+    GenericSyncSplitter<PlainMode, BODY_SIZE>;
 
 /// Encrypted file splitter.
 #[cfg(feature = "encryption")]
-pub type EncryptedSyncSplitter<S, const BODY_SIZE: usize = DEFAULT_BODY_SIZE> =
-    GenericSyncSplitter<S, EncryptedMode, BODY_SIZE>;
+pub type EncryptedSyncSplitter<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> =
+    GenericSyncSplitter<EncryptedMode, BODY_SIZE>;
 
-impl<S, M, const BODY_SIZE: usize> fmt::Debug for GenericSyncSplitter<S, M, BODY_SIZE>
+impl<M, const BODY_SIZE: usize> fmt::Debug for GenericSyncSplitter<M, BODY_SIZE>
 where
-    S: SyncChunkPut<BODY_SIZE>,
     M: SplitMode,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -53,17 +49,15 @@ where
     }
 }
 
-impl<S, M, const BODY_SIZE: usize> GenericSyncSplitter<S, M, BODY_SIZE>
+impl<M, const BODY_SIZE: usize> GenericSyncSplitter<M, BODY_SIZE>
 where
-    S: SyncChunkPut<BODY_SIZE>,
     M: SplitMode,
 {
     /// Create a splitter for data of known size.
-    pub fn new(store: S, span_length: u64) -> Self {
+    pub fn new(span_length: u64) -> Self {
         const { super::constants::assert_valid_body_size::<BODY_SIZE>() };
 
         Self {
-            store,
             span_length,
             buffer: Vec::with_capacity(span_length.min(BODY_SIZE as u64 * 2) as usize),
             _mode: PhantomData,
@@ -86,13 +80,12 @@ where
     }
 }
 
-impl<S, M, const BODY_SIZE: usize> GenericSyncSplitter<S, M, BODY_SIZE>
+impl<M, const BODY_SIZE: usize> GenericSyncSplitter<M, BODY_SIZE>
 where
-    S: SyncChunkPut<BODY_SIZE> + Send + Sync,
     M: SplitMode + Send + Sync,
 {
-    /// Finalize and return the root reference and store.
-    pub fn finish(self) -> Result<(M::RootRef, S)> {
+    /// Finalize, returning the root reference and the produced chunks.
+    pub fn finish(self) -> Result<(M::RootRef, Vec<AnyChunk<BODY_SIZE>>)> {
         if self.buffer.len() as u64 != self.span_length {
             return Err(FileError::SpanMismatch {
                 expected: self.span_length,
@@ -101,20 +94,16 @@ where
         }
 
         if self.buffer.is_empty() {
-            let root = M::process_empty::<BODY_SIZE, S>(&self.store)?;
-            return Ok((root, self.store));
+            let (chunk, root) = M::empty_chunk::<BODY_SIZE>()?;
+            return Ok((root, vec![chunk.into()]));
         }
 
-        let parallel = GenericSyncParallelSplitter::<S, M, BODY_SIZE>::new(self.store);
-        let root = parallel.split(&self.buffer)?;
-        let store = parallel.into_store();
-        Ok((root, store))
+        GenericSyncParallelSplitter::<M, BODY_SIZE>::split_to_vec(&self.buffer)
     }
 }
 
-impl<S, M, const BODY_SIZE: usize> Write for GenericSyncSplitter<S, M, BODY_SIZE>
+impl<M, const BODY_SIZE: usize> Write for GenericSyncSplitter<M, BODY_SIZE>
 where
-    S: SyncChunkPut<BODY_SIZE>,
     M: SplitMode,
 {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
@@ -146,10 +135,10 @@ mod tests {
     fn split_and_store(
         data: &[u8],
     ) -> (crate::chunk::ChunkAddress, MemoryStore<DEFAULT_BODY_SIZE>) {
-        let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-        let mut splitter = SyncSplitter::new(store, data.len() as u64);
+        let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
         splitter.write_all(data).unwrap();
-        splitter.finish().unwrap()
+        let (root, chunks) = splitter.finish().unwrap();
+        (root, MemoryStore::from_chunks(chunks))
     }
 
     generate_plain_splitter_tests!(split_and_store);
@@ -158,13 +147,13 @@ mod tests {
     fn test_splitter_incremental_writes() {
         let mut data = vec![0u8; DEFAULT_BODY_SIZE * 2 + 100];
         rand::RngExt::fill(&mut rand::rng(), &mut data);
-        let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-        let mut splitter = SyncSplitter::new(store, data.len() as u64);
+        let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
 
         for chunk in data.chunks(100) {
             splitter.write_all(chunk).unwrap();
         }
-        let (root, store) = splitter.finish().unwrap();
+        let (root, chunks) = splitter.finish().unwrap();
+        let store = MemoryStore::from_chunks(chunks);
 
         assert_eq!(store.len(), 4);
         assert!(!root.is_zero());
@@ -174,18 +163,16 @@ mod tests {
     fn test_splitter_deterministic() {
         let data = vec![0x56; DEFAULT_BODY_SIZE * 3];
 
-        let (root1, _) = {
-            let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-            let mut splitter = SyncSplitter::new(store, data.len() as u64);
+        let root1 = {
+            let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
             splitter.write_all(&data).unwrap();
-            splitter.finish().unwrap()
+            splitter.finish().unwrap().0
         };
 
-        let (root2, _) = {
-            let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-            let mut splitter = SyncSplitter::new(store, data.len() as u64);
+        let root2 = {
+            let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
             splitter.write_all(&data).unwrap();
-            splitter.finish().unwrap()
+            splitter.finish().unwrap().0
         };
 
         assert_eq!(root1, root2);
@@ -193,8 +180,7 @@ mod tests {
 
     #[test]
     fn test_splitter_write_past_span() {
-        let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-        let mut splitter = SyncSplitter::new(store, 10);
+        let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(10);
 
         let result = splitter.write_all(b"this is more than 10 bytes");
         assert!(result.is_err());
@@ -202,8 +188,7 @@ mod tests {
 
     #[test]
     fn test_splitter_span_mismatch() {
-        let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-        let mut splitter = SyncSplitter::new(store, 100);
+        let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(100);
 
         splitter.write_all(b"short").unwrap();
         let result = splitter.finish();
@@ -221,18 +206,17 @@ mod tests {
             crate::chunk::encryption::EncryptedChunkRef,
             MemoryStore<DEFAULT_BODY_SIZE>,
         ) {
-            let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-            let mut splitter = EncryptedSyncSplitter::new(store, data.len() as u64);
+            let mut splitter = EncryptedSyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
             splitter.write_all(data).unwrap();
-            splitter.finish().unwrap()
+            let (root_ref, chunks) = splitter.finish().unwrap();
+            (root_ref, MemoryStore::from_chunks(chunks))
         }
 
         generate_encrypted_splitter_tests!(encrypted_split_and_store);
 
         #[test]
         fn test_encrypted_splitter_write_past_span() {
-            let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-            let mut splitter = EncryptedSyncSplitter::<_, DEFAULT_BODY_SIZE>::new(store, 10);
+            let mut splitter = EncryptedSyncSplitter::<DEFAULT_BODY_SIZE>::new(10);
 
             let result = splitter.write_all(b"this is more than 10 bytes");
             assert!(result.is_err());
@@ -240,8 +224,7 @@ mod tests {
 
         #[test]
         fn test_encrypted_splitter_span_mismatch() {
-            let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-            let mut splitter = EncryptedSyncSplitter::<_, DEFAULT_BODY_SIZE>::new(store, 100);
+            let mut splitter = EncryptedSyncSplitter::<DEFAULT_BODY_SIZE>::new(100);
 
             splitter.write_all(b"short").unwrap();
             let result = splitter.finish();
@@ -252,13 +235,12 @@ mod tests {
         #[test]
         fn test_encrypted_differs_from_plaintext() {
             let data = b"test data for encryption comparison";
-            let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-            let mut splitter = SyncSplitter::new(store, data.len() as u64);
+            let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
             splitter.write_all(data).unwrap();
             let (plain_root, _) = splitter.finish().unwrap();
 
-            let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-            let mut enc_splitter = EncryptedSyncSplitter::new(store, data.len() as u64);
+            let mut enc_splitter =
+                EncryptedSyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
             enc_splitter.write_all(data).unwrap();
             let (enc_root, _) = enc_splitter.finish().unwrap();
 

--- a/crates/primitives/src/file/sync_splitter_parallel.rs
+++ b/crates/primitives/src/file/sync_splitter_parallel.rs
@@ -5,42 +5,36 @@ use std::marker::PhantomData;
 use rayon::prelude::*;
 
 use crate::bmt::DEFAULT_BODY_SIZE;
-use crate::chunk::ContentChunk;
+use crate::chunk::AnyChunk;
 
 use super::constants::{LEVEL_LIMIT, compute_spans_inline};
 use super::error::{FileError, Result};
 use super::mode::{PlainMode, SplitMode};
 use super::sync_read_at::SyncReadAt;
 use super::tree::TreeParams;
-use crate::store::SyncChunkPut;
 
 #[cfg(feature = "encryption")]
 use super::mode::EncryptedMode;
 
 /// Parallel file splitter using random-access data sources.
 ///
-/// Splits files by reading chunks at known offsets in parallel,
-/// then building intermediate levels.
-pub struct GenericSyncParallelSplitter<S, M: SplitMode, const BODY_SIZE: usize = DEFAULT_BODY_SIZE>
-where
-    S: SyncChunkPut<BODY_SIZE> + Send + Sync,
-{
-    store: S,
+/// Produces chunks by reading data at known offsets in parallel, then building
+/// intermediate levels. The caller decides where produced chunks go.
+pub struct GenericSyncParallelSplitter<M: SplitMode, const BODY_SIZE: usize = DEFAULT_BODY_SIZE> {
     _mode: PhantomData<M>,
 }
 
 /// Plain (unencrypted) parallel splitter.
-pub type SyncParallelSplitter<S, const BODY_SIZE: usize = DEFAULT_BODY_SIZE> =
-    GenericSyncParallelSplitter<S, PlainMode, BODY_SIZE>;
+pub type SyncParallelSplitter<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> =
+    GenericSyncParallelSplitter<PlainMode, BODY_SIZE>;
 
 /// Encrypted parallel splitter.
 #[cfg(feature = "encryption")]
-pub type EncryptedSyncParallelSplitter<S, const BODY_SIZE: usize = DEFAULT_BODY_SIZE> =
-    GenericSyncParallelSplitter<S, EncryptedMode, BODY_SIZE>;
+pub type EncryptedSyncParallelSplitter<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> =
+    GenericSyncParallelSplitter<EncryptedMode, BODY_SIZE>;
 
-impl<S, M, const BODY_SIZE: usize> std::fmt::Debug for GenericSyncParallelSplitter<S, M, BODY_SIZE>
+impl<M, const BODY_SIZE: usize> std::fmt::Debug for GenericSyncParallelSplitter<M, BODY_SIZE>
 where
-    S: SyncChunkPut<BODY_SIZE> + Send + Sync,
     M: SplitMode,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -49,52 +43,59 @@ where
     }
 }
 
-impl<S, M, const BODY_SIZE: usize> GenericSyncParallelSplitter<S, M, BODY_SIZE>
+impl<M, const BODY_SIZE: usize> GenericSyncParallelSplitter<M, BODY_SIZE>
 where
-    S: SyncChunkPut<BODY_SIZE> + Send + Sync,
     M: SplitMode + Send + Sync,
 {
-    /// Create a parallel splitter with the given chunk store.
-    pub const fn new(store: S) -> Self {
-        Self {
-            store,
-            _mode: PhantomData,
-        }
-    }
-
-    /// Split data from a random-access source.
-    pub fn split<R: SyncReadAt + Sync>(&self, source: &R) -> Result<M::RootRef> {
+    /// Split `source`, invoking `sink` for every produced chunk.
+    ///
+    /// `sink` is called from rayon worker threads, so it must be `Fn + Sync`.
+    /// Returns the root reference.
+    pub fn split_into<R, F>(source: &R, sink: F) -> Result<M::RootRef>
+    where
+        R: SyncReadAt + Sync,
+        F: Fn(AnyChunk<BODY_SIZE>) + Sync,
+    {
         const { super::constants::assert_valid_body_size::<BODY_SIZE>() };
         let size = source.len();
         let tree = TreeParams::<BODY_SIZE>::new(size);
 
         if size == 0 {
-            return self.handle_empty();
+            let (chunk, root) = M::empty_chunk::<BODY_SIZE>()?;
+            sink(chunk.into());
+            return Ok(root);
         }
 
         let spans = compute_spans_inline(BODY_SIZE / M::REF_SIZE);
 
-        // Level 0: Create data chunks in parallel
-        let level0_refs = self.create_data_chunks(source, &tree)?;
+        // Level 0: produce data chunks in parallel.
+        let level0_refs = Self::create_data_chunks(source, &tree, &sink)?;
 
-        // Build intermediate levels
-        self.build_intermediate_levels(level0_refs, size, &spans)
+        // Build intermediate levels.
+        Self::build_intermediate_levels(level0_refs, size, &spans, &sink)
     }
 
-    /// Consume the splitter and return the store.
-    pub fn into_store(self) -> S {
-        self.store
+    /// Split `source`, collecting every produced chunk into a `Vec`.
+    ///
+    /// Chunk order is irrelevant; callers key by address. Returns the root
+    /// reference and the produced chunks.
+    pub fn split_to_vec<R: SyncReadAt + Sync>(
+        source: &R,
+    ) -> Result<(M::RootRef, Vec<AnyChunk<BODY_SIZE>>)> {
+        let chunks = std::sync::Mutex::new(Vec::new());
+        let root = Self::split_into(source, |chunk| chunks.lock().unwrap().push(chunk))?;
+        Ok((root, chunks.into_inner().unwrap()))
     }
 
-    fn handle_empty(&self) -> Result<M::RootRef> {
-        M::process_empty::<BODY_SIZE, S>(&self.store)
-    }
-
-    fn create_data_chunks<R: SyncReadAt + Sync>(
-        &self,
+    fn create_data_chunks<R, F>(
         source: &R,
         tree: &TreeParams<BODY_SIZE>,
-    ) -> Result<Vec<M::RefBytes>> {
+        sink: &F,
+    ) -> Result<Vec<M::RefBytes>>
+    where
+        R: SyncReadAt + Sync,
+        F: Fn(AnyChunk<BODY_SIZE>) + Sync,
+    {
         let data_chunks = tree.data_chunks();
         let size = tree.size();
 
@@ -118,7 +119,7 @@ where
                 let chunk_bytes = super::helpers::build_intermediate_payload(span, &buf);
 
                 let (chunk, ref_bytes) = M::prepare_chunk::<BODY_SIZE>(chunk_bytes)?;
-                self.put_chunk(chunk)?;
+                sink(chunk.into());
                 Ok(ref_bytes)
             })
             .collect();
@@ -126,30 +127,36 @@ where
         results.into_iter().collect()
     }
 
-    fn build_intermediate_levels(
-        &self,
+    fn build_intermediate_levels<F>(
         mut refs: Vec<M::RefBytes>,
         total_size: u64,
         spans: &[u64; LEVEL_LIMIT],
-    ) -> Result<M::RootRef> {
+        sink: &F,
+    ) -> Result<M::RootRef>
+    where
+        F: Fn(AnyChunk<BODY_SIZE>) + Sync,
+    {
         let mut level = 1;
 
         while refs.len() > 1 {
-            refs = self.build_level(&refs, level, total_size, spans)?;
+            refs = Self::build_level(&refs, level, total_size, spans, sink)?;
             level += 1;
         }
 
-        // Extract root reference from the single remaining ref
+        // Extract root reference from the single remaining ref.
         M::extract_root(refs[0].as_ref())
     }
 
-    fn build_level(
-        &self,
+    fn build_level<F>(
         refs: &[M::RefBytes],
         level: usize,
         total_size: u64,
         spans: &[u64; LEVEL_LIMIT],
-    ) -> Result<Vec<M::RefBytes>> {
+        sink: &F,
+    ) -> Result<Vec<M::RefBytes>>
+    where
+        F: Fn(AnyChunk<BODY_SIZE>) + Sync,
+    {
         let refs_per_chunk = M::refs_per_chunk(BODY_SIZE);
         let chunks_at_level = refs.len().div_ceil(refs_per_chunk);
         let max_span = spans[level] * BODY_SIZE as u64;
@@ -161,7 +168,7 @@ where
                 let end = (start + refs_per_chunk).min(refs.len());
                 let child_refs = &refs[start..end];
 
-                // Single reference: carry up without wrapping (dangling chunk optimization)
+                // Single reference: carry up without wrapping (dangling chunk optimization).
                 if child_refs.len() == 1 {
                     return Ok(child_refs[0].clone());
                 }
@@ -180,33 +187,27 @@ where
                 let chunk_bytes = super::helpers::build_intermediate_payload(span, &ref_data);
 
                 let (chunk, ref_bytes) = M::prepare_chunk::<BODY_SIZE>(chunk_bytes)?;
-                self.put_chunk(chunk)?;
+                sink(chunk.into());
                 Ok(ref_bytes)
             })
             .collect();
 
         results.into_iter().collect()
     }
-
-    fn put_chunk(&self, chunk: ContentChunk<BODY_SIZE>) -> Result<()> {
-        self.store.put(chunk.into()).map_err(FileError::store)
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::file::sync_join;
+    use crate::file::{join, sync_join};
     use crate::store::MemoryStore;
 
     fn split_and_store(
         data: &[u8],
     ) -> (crate::chunk::ChunkAddress, MemoryStore<DEFAULT_BODY_SIZE>) {
-        let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-        let splitter = SyncParallelSplitter::new(store);
-        let root = splitter.split(&data).unwrap();
-        let store = splitter.into_store();
-        (root, store)
+        let (root, chunks) =
+            SyncParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(&data).unwrap();
+        (root, MemoryStore::from_chunks(chunks))
     }
 
     generate_plain_splitter_tests!(split_and_store);
@@ -222,14 +223,29 @@ mod tests {
         let (seq_root, _) = crate::file::sync_split::<DEFAULT_BODY_SIZE>(&data).unwrap();
         assert_eq!(root, seq_root);
 
-        let recovered = sync_join(&store, root).unwrap();
+        let recovered = futures::executor::block_on(join(&store, root)).unwrap();
         assert_eq!(recovered, data);
+    }
+
+    #[test]
+    fn test_split_into_lock_free_sink() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let data = vec![0xAB; DEFAULT_BODY_SIZE + 1];
+        let count = AtomicUsize::new(0);
+        let root =
+            SyncParallelSplitter::<DEFAULT_BODY_SIZE>::split_into(&data.as_slice(), |_chunk| {
+                count.fetch_add(1, Ordering::Relaxed);
+            })
+            .unwrap();
+        assert!(!root.is_zero());
+        assert_eq!(count.load(Ordering::Relaxed), 3);
     }
 
     #[cfg(feature = "encryption")]
     mod encrypted {
         use super::*;
-        use crate::file::{EncryptedSyncParallelSplitter, sync_join, sync_split_encrypted};
+        use crate::file::{EncryptedSyncParallelSplitter, sync_split_encrypted};
         use crate::store::MemoryStore;
 
         fn encrypted_split_and_store(
@@ -238,11 +254,9 @@ mod tests {
             crate::chunk::encryption::EncryptedChunkRef,
             MemoryStore<DEFAULT_BODY_SIZE>,
         ) {
-            let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-            let splitter = EncryptedSyncParallelSplitter::new(store);
-            let root_ref = splitter.split(&data).unwrap();
-            let store = splitter.into_store();
-            (root_ref, store)
+            let (root_ref, chunks) =
+                EncryptedSyncParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(&data).unwrap();
+            (root_ref, MemoryStore::from_chunks(chunks))
         }
 
         generate_encrypted_splitter_tests!(encrypted_split_and_store);
@@ -271,7 +285,7 @@ mod tests {
             let (ref1, _) = encrypted_split_and_store(data);
             let (ref2, _) = encrypted_split_and_store(data);
 
-            // Different random keys each time
+            // Different random keys each time.
             assert_ne!(ref1.address(), ref2.address());
         }
     }

--- a/crates/primitives/src/file/tests.rs
+++ b/crates/primitives/src/file/tests.rs
@@ -8,7 +8,6 @@ use alloy_primitives::hex;
 
 use crate::bmt::DEFAULT_BODY_SIZE;
 use crate::file::SyncSplitter;
-use crate::store::MemoryStore;
 
 const CHUNK_SIZE: usize = DEFAULT_BODY_SIZE;
 
@@ -112,8 +111,7 @@ const LARGE_TEST_VECTORS: &[(usize, &str)] = &[
 fn run_vector_test(size: usize, expected_hex: &str) {
     let data = sequential_bytes(size);
 
-    let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
-    let mut splitter = SyncSplitter::new(store, data.len() as u64);
+    let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
     splitter.write_all(&data).unwrap();
     let (root, _) = splitter.finish().unwrap();
 
@@ -242,11 +240,16 @@ mod write_file_ext {
     #[test]
     fn writer_roundtrip() {
         use std::io::Write;
+
+        use crate::store::SyncChunkPut;
         let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
         let data = b"streaming via writer";
         let mut writer = store.writer(data.len() as u64);
         writer.write_all(data).unwrap();
-        let (root, _) = writer.finish().unwrap();
+        let (root, chunks) = writer.finish().unwrap();
+        for chunk in chunks {
+            store.put(chunk).unwrap();
+        }
         let recovered = store.read_file(root).unwrap();
         assert_eq!(recovered, data);
     }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -132,7 +132,7 @@ pub use file::{
 };
 
 /// Default sync file splitter.
-pub type DefaultSyncSplitter<S> = file::SyncSplitter<S, DEFAULT_BODY_SIZE>;
+pub type DefaultSyncSplitter = file::SyncSplitter<DEFAULT_BODY_SIZE>;
 /// Default async file joiner.
 pub type DefaultJoiner<G> = file::Joiner<G, DEFAULT_BODY_SIZE>;
 /// Default sync file joiner.

--- a/crates/primitives/src/store/memory.rs
+++ b/crates/primitives/src/store/memory.rs
@@ -41,6 +41,13 @@ impl<const BODY_SIZE: usize> MemoryStore<BODY_SIZE> {
         }
     }
 
+    /// Build a store from a collection of chunks, keyed by address.
+    pub fn from_chunks(chunks: impl IntoIterator<Item = AnyChunk<BODY_SIZE>>) -> Self {
+        Self {
+            chunks: RwLock::new(chunks.into_iter().map(|c| (*c.address(), c)).collect()),
+        }
+    }
+
     /// Get a cloned chunk by address.
     pub fn get(&self, address: &ChunkAddress) -> Option<AnyChunk<BODY_SIZE>> {
         self.chunks.read().get(address).cloned()


### PR DESCRIPTION
## What
Reshapes the parallel splitter to produce chunks instead of writing them into a store. `split_into` invokes a `Fn` sink per chunk and `split_to_vec` collects them, both keeping the rayon parallelism. The splitter no longer depends on any store trait; `sync_split` stays as a memory-store fixture.

## Why
Closes #107. The splitter was generic over `SyncChunkPut`, coupling chunk production to a store trait. This is a prerequisite for collapsing the store traits to async only.

## Testing
`cargo test --workspace` (default features) is green, including the splitter round-trip tests (produced chunks reassemble byte for byte via the async joiner, plain and encrypted) and the go-vector conformance test, which pins identical addresses and root references.

## Breaking change
The splitter type signatures change (no store generic). Justified: it removes incidental coupling and unblocks the async-only store family.

## Notes
Stacked on #110 and https://github.com/nxm-rs/nectar/pull/111.

## AI Assistance
AI Assistance: Claude Code used for the design, implementation, and testing of this change.