### PR TITLE
refactor(mantaray)!: drive manifests over the async chunk-store traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2067,6 +2067,7 @@ dependencies = [
  "bitflags",
  "bytes",
  "codspeed-criterion-compat",
+ "futures",
  "nectar-primitives",
  "rand 0.10.1",
  "serde",

--- a/crates/mantaray/Cargo.toml
+++ b/crates/mantaray/Cargo.toml
@@ -21,6 +21,7 @@ workspace = true
 alloy-primitives = { workspace = true, features = ["map"] }
 bitflags.workspace = true
 bytes.workspace = true
+futures.workspace = true
 nectar-primitives = { workspace = true }
 thiserror.workspace = true
 serde_json.workspace = true

--- a/crates/mantaray/benches/mantaray_bench.rs
+++ b/crates/mantaray/benches/mantaray_bench.rs
@@ -1,6 +1,7 @@
 #![allow(missing_docs)]
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use futures::executor::block_on;
 use nectar_mantaray::node::Node;
 use nectar_mantaray::{MemoryStore, PlainManifest};
 use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
@@ -37,7 +38,7 @@ fn build_spa_manifest() -> PlainManifest<Store> {
     let mut m = PlainManifest::new(store);
     for &p in SPA_PATHS {
         let addr = make_addr(p.as_bytes());
-        m.add(p, addr).unwrap();
+        block_on(m.add(p, addr)).unwrap();
     }
     m
 }
@@ -49,7 +50,7 @@ fn build_large_manifest(count: usize) -> PlainManifest<Store> {
     for i in 0..count {
         let path = format!("dir{}/subdir{}/file{}.dat", i / 100, i / 10, i);
         let addr = make_addr(path.as_bytes());
-        m.add(&path, addr).unwrap();
+        block_on(m.add(&path, addr)).unwrap();
     }
     m
 }
@@ -74,7 +75,7 @@ fn bench_add(c: &mut Criterion) {
             let mut m = PlainManifest::new(store);
             for &p in paths {
                 let addr = make_addr(p.as_bytes());
-                m.add(p, addr).unwrap();
+                block_on(m.add(p, addr)).unwrap();
             }
             m
         });
@@ -94,7 +95,7 @@ fn bench_add(c: &mut Criterion) {
                 let store = Store::new();
                 let mut m = PlainManifest::new(store);
                 for (path, addr) in entries {
-                    m.add(path, *addr).unwrap();
+                    block_on(m.add(path, *addr)).unwrap();
                 }
                 m
             });
@@ -111,7 +112,7 @@ fn bench_lookup(c: &mut Criterion) {
 
     group.bench_function("existing_path", |b| {
         b.iter(|| {
-            let entry = m.lookup("js/app.js").unwrap();
+            let entry = block_on(m.lookup("js/app.js")).unwrap();
             entry.address().is_some()
         });
     });
@@ -121,7 +122,7 @@ fn bench_lookup(c: &mut Criterion) {
 
     group.bench_function("500_paths_deep", |b| {
         b.iter(|| {
-            let entry = large.lookup("dir4/subdir49/file499.dat").unwrap();
+            let entry = block_on(large.lookup("dir4/subdir49/file499.dat")).unwrap();
             entry.address().is_some()
         });
     });
@@ -136,7 +137,7 @@ fn bench_remove(c: &mut Criterion) {
         b.iter_batched(
             build_spa_manifest,
             |mut m| {
-                m.remove("js/app.js").unwrap();
+                block_on(m.remove("js/app.js")).unwrap();
                 m
             },
             criterion::BatchSize::SmallInput,
@@ -152,11 +153,11 @@ fn bench_has_prefix(c: &mut Criterion) {
     let mut m = build_spa_manifest();
 
     group.bench_function("existing_prefix", |b| {
-        b.iter(|| m.has_prefix("js/").unwrap());
+        b.iter(|| block_on(m.has_prefix("js/")).unwrap());
     });
 
     group.bench_function("missing_prefix", |b| {
-        b.iter(|| m.has_prefix("nonexistent/").unwrap());
+        b.iter(|| block_on(m.has_prefix("nonexistent/")).unwrap());
     });
 
     group.finish();
@@ -167,11 +168,11 @@ fn bench_encode(c: &mut Criterion) {
 
     // Build a trie via PlainManifest, save to get references assigned, reload.
     let mut m = build_spa_manifest();
-    let root_ref = m.save().unwrap();
+    let root_ref = block_on(m.save()).unwrap();
     let (_, store) = m.into_parts();
     let mut m2 = PlainManifest::open(root_ref, store);
     // Force-load the entire trie
-    m2.walk(&mut |_, _| Ok(())).unwrap();
+    block_on(m2.walk(&mut |_, _| Ok(()))).unwrap();
     let (n, _) = m2.into_parts();
 
     group.bench_function("spa_trie", |b| {
@@ -186,10 +187,10 @@ fn bench_decode(c: &mut Criterion) {
 
     // Build trie via PlainManifest, save, encode to get binary data.
     let mut m = build_spa_manifest();
-    let root_ref = m.save().unwrap();
+    let root_ref = block_on(m.save()).unwrap();
     let (_, store) = m.into_parts();
     let mut m2 = PlainManifest::open(root_ref, store);
-    m2.walk(&mut |_, _| Ok(())).unwrap();
+    block_on(m2.walk(&mut |_, _| Ok(()))).unwrap();
     let (n, _) = m2.into_parts();
     let data = Vec::<u8>::try_from(&n).unwrap();
 
@@ -209,10 +210,10 @@ fn bench_walk(c: &mut Criterion) {
         let mut m = build_spa_manifest();
         b.iter(|| {
             let mut count = 0u32;
-            m.walk(&mut |_path, _node| {
+            block_on(m.walk(&mut |_path, _node| {
                 count += 1;
                 Ok(())
-            })
+            }))
             .unwrap();
             count
         });
@@ -223,10 +224,10 @@ fn bench_walk(c: &mut Criterion) {
             let mut m = build_large_manifest(count);
             b.iter(|| {
                 let mut visited = 0u32;
-                m.walk(&mut |_path, _node| {
+                block_on(m.walk(&mut |_path, _node| {
                     visited += 1;
                     Ok(())
-                })
+                }))
                 .unwrap();
                 visited
             });
@@ -243,7 +244,7 @@ fn bench_save_load(c: &mut Criterion) {
         b.iter_batched(
             build_spa_manifest,
             |mut m| {
-                m.save().unwrap();
+                block_on(m.save()).unwrap();
                 m
             },
             criterion::BatchSize::SmallInput,
@@ -252,12 +253,12 @@ fn bench_save_load(c: &mut Criterion) {
 
     group.bench_function("load_spa_trie", |b| {
         let mut m = build_spa_manifest();
-        let root_ref = m.save().unwrap();
+        let root_ref = block_on(m.save()).unwrap();
         let (_, store) = m.into_parts();
 
         b.iter(|| {
             let mut m2 = PlainManifest::open(root_ref, store.clone());
-            let _ = m2.lookup("index.html").unwrap();
+            let _ = block_on(m2.lookup("index.html")).unwrap();
             m2
         });
     });
@@ -266,10 +267,10 @@ fn bench_save_load(c: &mut Criterion) {
         b.iter_batched(
             build_spa_manifest,
             |mut m| {
-                let root_ref = m.save().unwrap();
+                let root_ref = block_on(m.save()).unwrap();
                 let (_, store) = m.into_parts();
                 let mut m2 = PlainManifest::open(root_ref, store);
-                let _ = m2.lookup("index.html").unwrap();
+                let _ = block_on(m2.lookup("index.html")).unwrap();
                 m2
             },
             criterion::BatchSize::SmallInput,
@@ -285,7 +286,7 @@ fn bench_full_workflow(c: &mut Criterion) {
     group.bench_function("add_save_load_lookup", |b| {
         b.iter(|| {
             let mut m = build_spa_manifest();
-            let root_ref = m.save().unwrap();
+            let root_ref = block_on(m.save()).unwrap();
             let (_, store) = m.into_parts();
             let mut m2 = PlainManifest::open(root_ref, store);
 
@@ -297,7 +298,7 @@ fn bench_full_workflow(c: &mut Criterion) {
                 "js/app.js",
             ];
             for &p in paths {
-                m2.lookup(p).unwrap();
+                block_on(m2.lookup(p)).unwrap();
             }
         });
     });
@@ -313,29 +314,35 @@ fn bench_iter(c: &mut Criterion) {
         let mut m = build_spa_manifest();
 
         b.iter(|| {
-            let mut count = 0u32;
-            for result in m.iter() {
-                result.unwrap();
-                count += 1;
-            }
-            count
+            block_on(async {
+                let mut count = 0u32;
+                let mut iter = m.iter();
+                while let Some(result) = iter.next().await {
+                    result.unwrap();
+                    count += 1;
+                }
+                count
+            })
         });
     });
 
     // Lazy iteration after save/load (exercises storage loading)
     group.bench_function("spa_trie_lazy", |b| {
         let mut m = build_spa_manifest();
-        let root_ref = m.save().unwrap();
+        let root_ref = block_on(m.save()).unwrap();
         let (_, store) = m.into_parts();
 
         b.iter(|| {
             let mut m2 = PlainManifest::open(root_ref, store.clone());
-            let mut count = 0u32;
-            for result in m2.iter() {
-                result.unwrap();
-                count += 1;
-            }
-            count
+            block_on(async {
+                let mut count = 0u32;
+                let mut iter = m2.iter();
+                while let Some(result) = iter.next().await {
+                    result.unwrap();
+                    count += 1;
+                }
+                count
+            })
         });
     });
 
@@ -344,7 +351,7 @@ fn bench_iter(c: &mut Criterion) {
         let mut m = build_spa_manifest();
 
         b.iter(|| {
-            let entries = m.entries().unwrap();
+            let entries = block_on(m.entries()).unwrap();
             entries.len()
         });
     });

--- a/crates/mantaray/src/codec.rs
+++ b/crates/mantaray/src/codec.rs
@@ -425,7 +425,7 @@ impl<E: NodeEntry> Fork<E> {
         data.push(self.node.node_type.bits());
         data.push(self.prefix.len() as u8);
 
-        // write prefix padded to Prefix::MAX_LEN — Prefix is already zero-padded
+        // write prefix padded to Prefix::MAX_LEN; Prefix is already zero-padded
         data.extend_from_slice(self.prefix.padded_bytes());
 
         // Write E::SIZE bytes for the reference (chunk address + zero padding)
@@ -777,9 +777,12 @@ mod tests {
                 buf[32 - len..].copy_from_slice(&path[..len]);
                 ChunkAddress::from(buf)
             };
-            n.add::<nectar_primitives::store::NullLoader, { nectar_primitives::bmt::DEFAULT_BODY_SIZE }>(
+            futures::executor::block_on(n.add::<
+                nectar_primitives::store::NullLoader,
+                { nectar_primitives::bmt::DEFAULT_BODY_SIZE },
+            >(
                 path, Some(e), entry.metadata, &nectar_primitives::store::NullLoader,
-            )
+            ))
             .unwrap();
         }
 

--- a/crates/mantaray/src/lib.rs
+++ b/crates/mantaray/src/lib.rs
@@ -21,10 +21,11 @@
 //!
 //! # Unified Store
 //!
-//! Manifest operations use the typed chunk store traits from `nectar_primitives`:
-//! [`SyncChunkGet`](nectar_primitives::store::SyncChunkGet) for loading and
-//! [`SyncChunkPut`](nectar_primitives::store::SyncChunkPut) for saving. This means a single
-//! [`MemoryStore`] can hold both file chunks and manifest trie nodes.
+//! Manifest operations use the async typed chunk store traits from
+//! `nectar_primitives`: [`ChunkGet`](nectar_primitives::store::ChunkGet) for
+//! loading and [`ChunkPut`](nectar_primitives::store::ChunkPut) for saving.
+//! This means a single [`MemoryStore`] can hold both file chunks and manifest
+//! trie nodes.
 //!
 //! ```no_run
 //! # use nectar_mantaray::{PlainManifest, Entry, DefaultMemoryStore};
@@ -40,8 +41,10 @@
 //! # use nectar_mantaray::{PlainManifest, Entry, metadata, DefaultMemoryStore};
 //! # let store = DefaultMemoryStore::new();
 //! # let mut manifest = PlainManifest::new(store);
-//! manifest.set_index_document("index.html").unwrap();
-//! manifest.set_error_document("404.html").unwrap();
+//! # futures::executor::block_on(async {
+//! manifest.set_index_document("index.html").await.unwrap();
+//! manifest.set_error_document("404.html").await.unwrap();
+//! # });
 //! ```
 //!
 //! # Metadata Constants
@@ -90,7 +93,7 @@ pub use obfuscation::ObfuscationKey;
 
 // Re-export typed storage traits from primitives.
 pub use nectar_primitives::DefaultMemoryStore;
-pub use nectar_primitives::store::{MemoryStore, SyncChunkHas};
+pub use nectar_primitives::store::{ChunkGet, ChunkHas, ChunkPut, MemoryStore};
 
 /// Default manifest type using [`DEFAULT_BODY_SIZE`] and plain mode.
 pub type DefaultManifest<S> = PlainManifest<S, DEFAULT_BODY_SIZE>;

--- a/crates/mantaray/src/manifest.rs
+++ b/crates/mantaray/src/manifest.rs
@@ -2,9 +2,10 @@
 
 use std::collections::BTreeMap;
 
+use futures::Stream;
 use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::ChunkAddress;
-use nectar_primitives::store::{SyncChunkGet, SyncChunkPut};
+use nectar_primitives::store::{ChunkGet, ChunkPut, MaybeSend};
 
 use crate::entry::Entry;
 use crate::mode::NodeEntry;
@@ -85,16 +86,17 @@ impl<S, E: NodeEntry, const BS: usize> Manifest<S, E, BS> {
     }
 }
 
-impl<S: SyncChunkGet<BS>, E: NodeEntry, const BS: usize> Manifest<S, E, BS> {
+impl<S: ChunkGet<BS>, E: NodeEntry + MaybeSend, const BS: usize> Manifest<S, E, BS> {
     /// Add a path with a typed reference (compile-time enforced by entry type).
-    pub fn add(&mut self, path: &str, reference: impl Into<E>) -> Result<()> {
+    pub async fn add(&mut self, path: &str, reference: impl Into<E>) -> Result<()> {
         let entry = reference.into();
         self.trie
             .add::<S, BS>(path.as_bytes(), Some(entry), BTreeMap::new(), &self.store)
+            .await
     }
 
     /// Add a path with a typed reference and metadata.
-    pub fn add_with_metadata(
+    pub async fn add_with_metadata(
         &mut self,
         path: &str,
         reference: impl Into<E>,
@@ -103,10 +105,11 @@ impl<S: SyncChunkGet<BS>, E: NodeEntry, const BS: usize> Manifest<S, E, BS> {
         let entry = reference.into();
         self.trie
             .add::<S, BS>(path.as_bytes(), Some(entry), metadata, &self.store)
+            .await
     }
 
     /// Add a path with a pre-built [`Entry`] (metadata + reference).
-    pub fn add_entry(&mut self, path: &str, entry: Entry) -> Result<()> {
+    pub async fn add_entry(&mut self, path: &str, entry: Entry) -> Result<()> {
         let e = match entry.reference {
             Some(r) => {
                 let bytes = Vec::from(&r);
@@ -116,18 +119,22 @@ impl<S: SyncChunkGet<BS>, E: NodeEntry, const BS: usize> Manifest<S, E, BS> {
         };
         self.trie
             .add::<S, BS>(path.as_bytes(), e, entry.metadata, &self.store)
+            .await
     }
 
     /// Remove a path from the manifest.
-    pub fn remove(&mut self, path: &str) -> Result<()> {
-        self.trie.remove::<S, BS>(path.as_bytes(), &self.store)
+    pub async fn remove(&mut self, path: &str) -> Result<()> {
+        self.trie
+            .remove::<S, BS>(path.as_bytes(), &self.store)
+            .await
     }
 
     /// Look up a path in the manifest.
-    pub fn lookup(&mut self, path: &str) -> Result<Entry> {
+    pub async fn lookup(&mut self, path: &str) -> Result<Entry> {
         let node = self
             .trie
-            .lookup_node::<S, BS>(path.as_bytes(), &self.store)?;
+            .lookup_node::<S, BS>(path.as_bytes(), &self.store)
+            .await?;
 
         if !node.is_value() {
             return Err(MantarayError::NotValueType);
@@ -137,61 +144,71 @@ impl<S: SyncChunkGet<BS>, E: NodeEntry, const BS: usize> Manifest<S, E, BS> {
     }
 
     /// Test whether the manifest contains a prefix.
-    pub fn has_prefix(&mut self, prefix: &str) -> Result<bool> {
+    pub async fn has_prefix(&mut self, prefix: &str) -> Result<bool> {
         self.trie
             .has_prefix::<S, BS>(prefix.as_bytes(), &self.store)
+            .await
     }
 
     /// Walk all nodes depth-first, calling `f` for each node with its path.
-    pub fn walk<F>(&mut self, f: &mut F) -> Result<()>
+    pub async fn walk<F>(&mut self, f: &mut F) -> Result<()>
     where
         F: FnMut(&[u8], &Node<E>) -> Result<()>,
     {
-        self.trie.walk::<S, BS, _>(&self.store, f)
+        self.trie.walk::<S, BS, _>(&self.store, f).await
     }
 
     /// Walk the subtree rooted at `root`, calling `f` for each node with its path.
-    pub fn walk_from<F>(&mut self, root: &str, f: &mut F) -> Result<()>
+    pub async fn walk_from<F>(&mut self, root: &str, f: &mut F) -> Result<()>
     where
         F: FnMut(&[u8], &Node<E>) -> Result<()>,
     {
         self.trie
             .walk_from::<S, BS, _>(root.as_bytes(), &self.store, f)
+            .await
     }
 
     /// Collect all value entries from the manifest.
     ///
-    /// Convenience wrapper around [`iter()`](Self::iter). Prefer `iter()` for
-    /// lazy traversal.
-    pub fn entries(&mut self) -> Result<Vec<Entry>> {
-        self.iter().collect()
+    /// Convenience wrapper around the [`stream`](Self::stream) accessor.
+    pub async fn entries(&mut self) -> Result<Vec<Entry>> {
+        let mut iter = self.iter();
+        let mut out = Vec::new();
+        while let Some(item) = iter.next().await {
+            out.push(item?);
+        }
+        Ok(out)
     }
 
     /// Set the website index document on the root path metadata.
-    pub fn set_index_document(&mut self, filename: &str) -> Result<()> {
+    pub async fn set_index_document(&mut self, filename: &str) -> Result<()> {
         self.set_root_metadata(metadata::WEBSITE_INDEX_DOCUMENT, filename)
+            .await
     }
 
     /// Set the website error document on the root path metadata.
-    pub fn set_error_document(&mut self, path: &str) -> Result<()> {
+    pub async fn set_error_document(&mut self, path: &str) -> Result<()> {
         self.set_root_metadata(metadata::WEBSITE_ERROR_DOCUMENT, path)
+            .await
     }
 
     /// Get the website index document from root path metadata.
-    pub fn index_document(&mut self) -> Result<Option<String>> {
+    pub async fn index_document(&mut self) -> Result<Option<String>> {
         self.get_root_metadata(metadata::WEBSITE_INDEX_DOCUMENT)
+            .await
     }
 
     /// Get the website error document from root path metadata.
-    pub fn error_document(&mut self) -> Result<Option<String>> {
+    pub async fn error_document(&mut self) -> Result<Option<String>> {
         self.get_root_metadata(metadata::WEBSITE_ERROR_DOCUMENT)
+            .await
     }
 
     /// Walk all nodes, yielding both node references and entry references.
     ///
-    /// This is useful for garbage collection and pinning: it enumerates every
-    /// chunk address the manifest depends on.
-    pub fn iterate_addresses<F>(&mut self, mut f: F) -> Result<()>
+    /// Enumerates every chunk address the manifest depends on, for garbage
+    /// collection and pinning.
+    pub async fn iterate_addresses<F>(&mut self, mut f: F) -> Result<()>
     where
         F: FnMut(&[u8]) -> Result<()>,
     {
@@ -209,44 +226,56 @@ impl<S: SyncChunkGet<BS>, E: NodeEntry, const BS: usize> Manifest<S, E, BS> {
 
             Ok(())
         })
+        .await
     }
 
-    /// Create a lazy depth-first iterator over all entries in the manifest.
+    /// Create a lazy depth-first stream over all entries in the manifest.
     ///
     /// Nodes are loaded from storage on demand, so the entire trie does not
-    /// need to be in memory at once.
+    /// need to be in memory at once. Drive it with [`ManifestIter::next`] or
+    /// the [`Stream`] impl.
     pub const fn iter(&mut self) -> ManifestIter<'_, S, E, BS> {
         ManifestIter::new(&mut self.trie, &self.store)
     }
 
-    fn set_root_metadata(&mut self, key: &str, value: &str) -> Result<()> {
+    /// Lazy depth-first stream over all entries in the manifest.
+    pub fn stream(&mut self) -> impl Stream<Item = Result<Entry>> + '_ {
+        futures::stream::unfold(self.iter(), |mut iter| async move {
+            iter.next().await.map(|item| (item, iter))
+        })
+    }
+
+    async fn set_root_metadata(&mut self, key: &str, value: &str) -> Result<()> {
         // Ensure the root path node exists.
         match self
             .trie
             .lookup_node::<S, BS>(metadata::ROOT_PATH.as_bytes(), &self.store)
+            .await
         {
             Ok(node) => {
-                // Node exists — mutate metadata in place (no clone).
+                // Node exists; mutate metadata in place (no clone).
                 node.metadata_mut().insert(key.into(), value.into());
                 node.make_with_metadata();
                 node.mark_dirty();
                 Ok(())
             }
             Err(MantarayError::NoForkFound { .. }) => {
-                // Root path doesn't exist yet — create it with the metadata.
+                // Root path doesn't exist yet; create it with the metadata.
                 let mut meta = BTreeMap::new();
                 meta.insert(key.into(), value.into());
                 self.trie
                     .add::<S, BS>(metadata::ROOT_PATH.as_bytes(), None, meta, &self.store)
+                    .await
             }
             Err(e) => Err(e),
         }
     }
 
-    fn get_root_metadata(&mut self, key: &str) -> Result<Option<String>> {
+    async fn get_root_metadata(&mut self, key: &str) -> Result<Option<String>> {
         match self
             .trie
             .lookup_node::<S, BS>(metadata::ROOT_PATH.as_bytes(), &self.store)
+            .await
         {
             Ok(node) => Ok(node.metadata().get(key).cloned()),
             Err(MantarayError::NoForkFound { .. }) => Ok(None),
@@ -255,10 +284,10 @@ impl<S: SyncChunkGet<BS>, E: NodeEntry, const BS: usize> Manifest<S, E, BS> {
     }
 }
 
-impl<S: SyncChunkGet<BS> + SyncChunkPut<BS>, const BS: usize> Manifest<S, ChunkAddress, BS> {
+impl<S: ChunkGet<BS> + ChunkPut<BS>, const BS: usize> Manifest<S, ChunkAddress, BS> {
     /// Persist the plain manifest trie to storage, returning the root chunk address.
-    pub fn save(&mut self) -> Result<ChunkAddress> {
-        self.trie.save::<S, BS>(&self.store)?;
+    pub async fn save(&mut self) -> Result<ChunkAddress> {
+        self.trie.save::<S, BS>(&self.store).await?;
         Ok(*self
             .trie
             .reference()
@@ -267,12 +296,12 @@ impl<S: SyncChunkGet<BS> + SyncChunkPut<BS>, const BS: usize> Manifest<S, ChunkA
 }
 
 #[cfg(feature = "encryption")]
-impl<S: SyncChunkGet<BS> + SyncChunkPut<BS>, const BS: usize>
+impl<S: ChunkGet<BS> + ChunkPut<BS>, const BS: usize>
     Manifest<S, nectar_primitives::EncryptedChunkRef, BS>
 {
     /// Persist the encrypted manifest trie, returning a [`ManifestRef`](crate::ManifestRef).
-    pub fn save(&mut self) -> Result<crate::ManifestRef> {
-        self.trie.save::<S, BS>(&self.store)?;
+    pub async fn save(&mut self) -> Result<crate::ManifestRef> {
+        self.trie.save::<S, BS>(&self.store).await?;
         let addr = *self
             .trie
             .reference()
@@ -294,7 +323,7 @@ pub struct ManifestIter<'a, S, E: NodeEntry = ChunkAddress, const BS: usize = DE
     trie: &'a mut Node<E>,
     store: &'a S,
     stack: Vec<IterFrame<E>>,
-    /// Running path buffer — extended when pushing frames, truncated when popping.
+    /// Running path buffer; extended when pushing frames, truncated when popping.
     path_buf: Vec<u8>,
     root_visited: bool,
 }
@@ -324,7 +353,7 @@ struct IterFrame<E: NodeEntry> {
     key_idx: usize,
 }
 
-impl<'a, S: SyncChunkGet<BS>, E: NodeEntry, const BS: usize> ManifestIter<'a, S, E, BS> {
+impl<'a, S: ChunkGet<BS>, E: NodeEntry, const BS: usize> ManifestIter<'a, S, E, BS> {
     pub(crate) const fn new(trie: &'a mut Node<E>, store: &'a S) -> Self {
         Self {
             trie,
@@ -334,18 +363,17 @@ impl<'a, S: SyncChunkGet<BS>, E: NodeEntry, const BS: usize> ManifestIter<'a, S,
             root_visited: false,
         }
     }
-}
 
-impl<S: SyncChunkGet<BS>, E: NodeEntry, const BS: usize> Iterator for ManifestIter<'_, S, E, BS> {
-    type Item = Result<Entry>;
-
-    fn next(&mut self) -> Option<Self::Item> {
+    /// Advance the lazy traversal, returning the next entry (or `None` when done).
+    ///
+    /// Loads unvisited nodes from storage on demand.
+    pub async fn next(&mut self) -> Option<Result<Entry>> {
         loop {
             if !self.root_visited {
                 self.root_visited = true;
 
                 if !self.trie.loaded
-                    && let Err(e) = self.trie.load::<S, BS>(self.store)
+                    && let Err(e) = self.trie.load::<S, BS>(self.store).await
                 {
                     return Some(Err(e));
                 }
@@ -388,7 +416,7 @@ impl<S: SyncChunkGet<BS>, E: NodeEntry, const BS: usize> Iterator for ManifestIt
             };
 
             // SAFETY: parent_node points into the exclusively borrowed trie.
-            // No other mutable reference to this node exists — frames only hold
+            // No other mutable reference to this node exists; frames only hold
             // pointers to ancestors, which we do not dereference simultaneously.
             let parent = unsafe { &mut *parent_node };
             let fork = match parent.forks.get_mut(&key) {
@@ -405,7 +433,7 @@ impl<S: SyncChunkGet<BS>, E: NodeEntry, const BS: usize> Iterator for ManifestIt
             // SAFETY: child is a descendant of the exclusively borrowed trie.
             let child_ref = unsafe { &mut *child };
             if !child_ref.loaded
-                && let Err(e) = child_ref.load::<S, BS>(self.store)
+                && let Err(e) = child_ref.load::<S, BS>(self.store).await
             {
                 return Some(Err(e));
             }
@@ -434,26 +462,31 @@ impl<S: SyncChunkGet<BS>, E: NodeEntry, const BS: usize> Iterator for ManifestIt
     }
 }
 
-impl<'a, S: SyncChunkGet<BS>, E: NodeEntry, const BS: usize> IntoIterator
-    for &'a mut Manifest<S, E, BS>
-{
-    type Item = Result<Entry>;
-    type IntoIter = ManifestIter<'a, S, E, BS>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        ManifestIter::new(&mut self.trie, &self.store)
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use futures::executor::block_on;
     use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
     use nectar_primitives::chunk::ChunkAddress;
     use nectar_primitives::store::MemoryStore;
 
+    use super::*;
+
     type Store = MemoryStore<DEFAULT_BODY_SIZE>;
     type PlainManifest<S, const BS: usize = DEFAULT_BODY_SIZE> =
         super::Manifest<S, ChunkAddress, BS>;
+
+    /// Drain an async manifest iterator into a `Vec`, propagating the first error.
+    fn drain<S: ChunkGet<BS>, E: NodeEntry, const BS: usize>(
+        mut iter: ManifestIter<'_, S, E, BS>,
+    ) -> Result<Vec<Entry>> {
+        block_on(async move {
+            let mut out = Vec::new();
+            while let Some(item) = iter.next().await {
+                out.push(item?);
+            }
+            Ok(out)
+        })
+    }
 
     /// Create a ChunkAddress from a string, right-padded with zeroes.
     fn make_addr(s: &str) -> ChunkAddress {
@@ -482,15 +515,15 @@ mod tests {
         ];
 
         for &path in paths {
-            m.save().unwrap();
+            block_on(m.save()).unwrap();
             let addr = make_addr(path);
-            m.add(path, addr).unwrap();
+            block_on(m.add(path, addr)).unwrap();
         }
 
-        m.save().unwrap();
+        block_on(m.save()).unwrap();
 
         for &path in paths {
-            let entry = m.lookup(path).unwrap();
+            let entry = block_on(m.lookup(path)).unwrap();
             let expected = make_addr(path);
             assert_eq!(entry.address(), Some(&expected));
         }
@@ -504,10 +537,10 @@ mod tests {
         let paths = &["index.html", "img/1.png", "img/2.png", "robots.txt"];
         for &path in paths {
             let addr = make_addr(path);
-            m.add(path, addr).unwrap();
+            block_on(m.add(path, addr)).unwrap();
         }
 
-        let entries = m.entries().unwrap();
+        let entries = block_on(m.entries()).unwrap();
         assert_eq!(entries.len(), paths.len());
 
         for &path in paths {
@@ -524,13 +557,19 @@ mod tests {
         let mut m = PlainManifest::new(store);
 
         // Add a dummy entry so the root "/" path has an entry
-        m.add("/", ChunkAddress::from([0u8; 32])).unwrap();
+        block_on(m.add("/", ChunkAddress::from([0u8; 32]))).unwrap();
 
-        m.set_index_document("index.html").unwrap();
-        m.set_error_document("404.html").unwrap();
+        block_on(m.set_index_document("index.html")).unwrap();
+        block_on(m.set_error_document("404.html")).unwrap();
 
-        assert_eq!(m.index_document().unwrap(), Some("index.html".to_string()));
-        assert_eq!(m.error_document().unwrap(), Some("404.html".to_string()));
+        assert_eq!(
+            block_on(m.index_document()).unwrap(),
+            Some("index.html".to_string())
+        );
+        assert_eq!(
+            block_on(m.error_document()).unwrap(),
+            Some("404.html".to_string())
+        );
     }
 
     #[test]
@@ -538,11 +577,17 @@ mod tests {
         let store = Store::new();
         let mut m = PlainManifest::new(store);
 
-        m.set_index_document("index.html").unwrap();
-        m.set_error_document("404.html").unwrap();
+        block_on(m.set_index_document("index.html")).unwrap();
+        block_on(m.set_error_document("404.html")).unwrap();
 
-        assert_eq!(m.index_document().unwrap(), Some("index.html".to_string()));
-        assert_eq!(m.error_document().unwrap(), Some("404.html".to_string()));
+        assert_eq!(
+            block_on(m.index_document()).unwrap(),
+            Some("index.html".to_string())
+        );
+        assert_eq!(
+            block_on(m.error_document()).unwrap(),
+            Some("404.html".to_string())
+        );
     }
 
     #[test]
@@ -550,8 +595,8 @@ mod tests {
         let store = Store::new();
         let mut m = PlainManifest::new(store);
 
-        assert_eq!(m.index_document().unwrap(), None);
-        assert_eq!(m.error_document().unwrap(), None);
+        assert_eq!(block_on(m.index_document()).unwrap(), None);
+        assert_eq!(block_on(m.error_document()).unwrap(), None);
     }
 
     #[test]
@@ -562,18 +607,18 @@ mod tests {
         let paths = &["index.html", "img/1.png", "img/2.png", "robots.txt"];
         for &path in paths {
             let addr = make_addr(path);
-            m.add(path, addr).unwrap();
+            block_on(m.add(path, addr)).unwrap();
         }
 
-        let root_ref = m.save().unwrap();
+        let root_ref = block_on(m.save()).unwrap();
 
         let (_, store) = m.into_parts();
         let mut m2 = PlainManifest::open(root_ref, store);
         let mut addresses = Vec::new();
-        m2.iterate_addresses(|addr| {
+        block_on(m2.iterate_addresses(|addr| {
             addresses.push(addr.to_vec());
             Ok(())
-        })
+        }))
         .unwrap();
 
         assert!(!addresses.is_empty());
@@ -596,23 +641,23 @@ mod tests {
         for i in 0..100u32 {
             let path = format!("dir{}/file{}.txt", i / 10, i);
             let addr = make_addr_u32(i);
-            m.add(&path, addr).unwrap();
+            block_on(m.add(&path, addr)).unwrap();
         }
-        let root_ref_1 = m.save().unwrap();
+        let root_ref_1 = block_on(m.save()).unwrap();
 
         // Update a single path
         let updated_addr = make_addr_u32(999);
-        m.add("dir0/file0.txt", updated_addr).unwrap();
-        let root_ref_2 = m.save().unwrap();
+        block_on(m.add("dir0/file0.txt", updated_addr)).unwrap();
+        let root_ref_2 = block_on(m.save()).unwrap();
 
         assert_ne!(root_ref_1, root_ref_2);
 
-        let entry = m.lookup("dir0/file0.txt").unwrap();
+        let entry = block_on(m.lookup("dir0/file0.txt")).unwrap();
         assert_eq!(entry.address(), Some(&updated_addr));
 
         for i in 1..100u32 {
             let path = format!("dir{}/file{}.txt", i / 10, i);
-            let entry = m.lookup(&path).unwrap();
+            let entry = block_on(m.lookup(&path)).unwrap();
             let expected = make_addr_u32(i);
             assert_eq!(
                 entry.address(),
@@ -623,26 +668,26 @@ mod tests {
     }
 
     #[test]
-    fn into_iterator() {
+    fn stream_yields_all_entries() {
+        use futures::StreamExt;
+
         let store = Store::new();
         let mut m = PlainManifest::new(store);
 
         let paths = &["index.html", "img/1.png", "img/2.png", "robots.txt"];
         for &path in paths {
             let addr = make_addr(path);
-            m.add(path, addr).unwrap();
+            block_on(m.add(path, addr)).unwrap();
         }
 
-        let mut all_entries = Vec::new();
-        for result in &mut m {
-            all_entries.push(result.unwrap());
-        }
+        let all_entries: Vec<_> =
+            block_on(async { m.stream().map(|r| r.unwrap()).collect::<Vec<_>>().await });
 
         assert_eq!(all_entries.len(), paths.len());
         for &path in paths {
             assert!(
                 all_entries.iter().any(|e| e.path() == path.as_bytes()),
-                "path {path} not found via IntoIterator"
+                "path {path} not found via stream"
             );
         }
     }
@@ -655,17 +700,17 @@ mod tests {
         let paths = &["index.html", "img/1.png", "img/2.png", "robots.txt"];
         for &path in paths {
             let addr = make_addr(path);
-            m.add(path, addr).unwrap();
+            block_on(m.add(path, addr)).unwrap();
         }
 
         // Save and reload to exercise lazy loading
-        let root_ref = m.save().unwrap();
+        let root_ref = block_on(m.save()).unwrap();
 
         let (_, store) = m.into_parts();
         let mut m2 = PlainManifest::open(root_ref, store);
 
         let mut visited = Vec::new();
-        if let Some(result) = m2.iter().next() {
+        if let Some(result) = block_on(m2.iter().next()) {
             let entry = result.unwrap();
             visited.push(entry.path);
         }
@@ -674,10 +719,7 @@ mod tests {
         // Full iteration
         let (_, store) = m2.into_parts();
         let mut m3 = PlainManifest::open(root_ref, store);
-        let mut all_entries = Vec::new();
-        for result in m3.iter() {
-            all_entries.push(result.unwrap());
-        }
+        let all_entries = drain(m3.iter()).unwrap();
 
         assert_eq!(all_entries.len(), paths.len());
         for &path in paths {
@@ -692,7 +734,7 @@ mod tests {
     fn iter_empty_manifest() {
         let store = Store::new();
         let mut m = PlainManifest::new(store);
-        let entries: Vec<_> = m.iter().collect();
+        let entries = drain(m.iter()).unwrap();
         assert!(entries.is_empty(), "empty manifest should yield no entries");
     }
 
@@ -701,9 +743,9 @@ mod tests {
         let store = Store::new();
         let mut m = PlainManifest::new(store);
         let addr = make_addr("only");
-        m.add("only.txt", addr).unwrap();
+        block_on(m.add("only.txt", addr)).unwrap();
 
-        let entries: Vec<_> = m.iter().map(|r| r.unwrap()).collect();
+        let entries = drain(m.iter()).unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].path(), b"only.txt");
         assert_eq!(entries[0].address(), Some(&addr));
@@ -721,14 +763,14 @@ mod tests {
             .map(|i| format!("a/b/c/d/e/f/g/h/file{i:02}.dat"))
             .collect();
         for path in &deep_paths {
-            m.add(path, make_addr(path)).unwrap();
+            block_on(m.add(path, make_addr(path))).unwrap();
         }
 
-        let root_ref = m.save().unwrap();
+        let root_ref = block_on(m.save()).unwrap();
         let (_, store) = m.into_parts();
         let mut m2 = PlainManifest::open(root_ref, store);
 
-        let entries: Vec<_> = m2.iter().map(|r| r.unwrap()).collect();
+        let entries = drain(m2.iter()).unwrap();
         assert_eq!(entries.len(), deep_paths.len());
         for path in &deep_paths {
             assert!(
@@ -745,19 +787,19 @@ mod tests {
 
         let paths = &["a.txt", "b.txt", "c.txt", "d.txt", "e.txt"];
         for &path in paths {
-            m.add(path, make_addr(path)).unwrap();
+            block_on(m.add(path, make_addr(path))).unwrap();
         }
 
         // Partial iteration: take only 2 entries, then drop iterator.
         {
             let mut iter = m.iter();
-            let _first = iter.next().unwrap().unwrap();
-            let _second = iter.next().unwrap().unwrap();
-            // Iterator dropped here — must not corrupt trie state.
+            let _first = block_on(iter.next()).unwrap().unwrap();
+            let _second = block_on(iter.next()).unwrap().unwrap();
+            // Iterator dropped here; must not corrupt trie state.
         }
 
         // Full re-iteration should still yield all entries.
-        let all: Vec<_> = m.iter().map(|r| r.unwrap()).collect();
+        let all = drain(m.iter()).unwrap();
         assert_eq!(all.len(), paths.len());
         for &path in paths {
             assert!(
@@ -774,22 +816,22 @@ mod tests {
 
         let paths = &["x/1.txt", "x/2.txt", "y/1.txt", "y/2.txt", "z.txt"];
         for &path in paths {
-            m.add(path, make_addr(path)).unwrap();
+            block_on(m.add(path, make_addr(path))).unwrap();
         }
 
-        let root_ref = m.save().unwrap();
+        let root_ref = block_on(m.save()).unwrap();
         let (_, store) = m.into_parts();
         let mut m2 = PlainManifest::open(root_ref, store);
 
         // Partial iteration on a lazy-loaded manifest.
         {
             let mut iter = m2.iter();
-            let _first = iter.next().unwrap().unwrap();
+            let _first = block_on(iter.next()).unwrap().unwrap();
         }
 
         // Re-iterate: previously loaded nodes stay loaded, the rest
         // are lazily fetched again through the raw-pointer path.
-        let all: Vec<_> = m2.iter().map(|r| r.unwrap()).collect();
+        let all = drain(m2.iter()).unwrap();
         assert_eq!(all.len(), paths.len());
         for &path in paths {
             assert!(

--- a/crates/mantaray/src/node.rs
+++ b/crates/mantaray/src/node.rs
@@ -1,6 +1,8 @@
 //! Node and Fork types for the mantaray trie.
 
 use std::collections::BTreeMap;
+use std::future::Future;
+use std::pin::Pin;
 
 use crate::error::{MantarayError, Result};
 use crate::mode::NodeEntry;
@@ -8,11 +10,19 @@ use crate::obfuscation::ObfuscationKey;
 use crate::{PATH_SEPARATOR, PREFIX_MAX_LEN};
 use bytes::Bytes;
 use nectar_primitives::chunk::{Chunk, ChunkAddress, ContentChunk};
-use nectar_primitives::store::{SyncChunkGet, SyncChunkPut};
+use nectar_primitives::store::{ChunkGet, ChunkPut, MaybeSend};
+
+/// Boxed recursion future: `Send` on native, unbounded on wasm32 so `!Send`
+/// browser stores stay usable. `MaybeSend` cannot appear in a `dyn` bound
+/// directly (it is not an auto trait), so the auto trait is cfg-gated here.
+#[cfg(not(target_arch = "wasm32"))]
+type RecurseFuture<'a> = Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
+#[cfg(target_arch = "wasm32")]
+type RecurseFuture<'a> = Pin<Box<dyn Future<Output = Result<()>> + 'a>>;
 
 /// Inline-only byte buffer for fork prefixes (max 30 bytes).
 ///
-/// Always stores data inline — no heap allocation, no branching.
+/// Always stores data inline; no heap allocation, no branching.
 /// 31 bytes total (1 len + 30 data).
 #[derive(Clone, PartialEq, Eq)]
 pub struct Prefix {
@@ -271,15 +281,15 @@ impl<E: NodeEntry> Node<E> {
     }
 
     /// Load forks from storage if the node hasn't been loaded yet.
-    fn ensure_loaded<S: SyncChunkGet<BS>, const BS: usize>(&mut self, store: &S) -> Result<()> {
+    async fn ensure_loaded<S: ChunkGet<BS>, const BS: usize>(&mut self, store: &S) -> Result<()> {
         if !self.loaded {
-            self.load(store)?;
+            self.load(store).await?;
         }
         Ok(())
     }
 
     /// Load this node from storage by its reference.
-    pub(crate) fn load<S: SyncChunkGet<BS>, const BS: usize>(&mut self, store: &S) -> Result<()> {
+    pub(crate) async fn load<S: ChunkGet<BS>, const BS: usize>(&mut self, store: &S) -> Result<()> {
         let address = match self.reference {
             Some(addr) => addr,
             None => {
@@ -288,9 +298,12 @@ impl<E: NodeEntry> Node<E> {
             }
         };
 
-        let chunk = store.get(&address).map_err(|e| MantarayError::StoreGet {
-            source: std::sync::Arc::new(e),
-        })?;
+        let chunk = store
+            .get(&address)
+            .await
+            .map_err(|e| MantarayError::StoreGet {
+                source: std::sync::Arc::new(e),
+            })?;
         let mut loaded = Self::try_from(chunk.data().as_ref())?;
         loaded.reference = Some(address);
         // Preserve fields that live in the parent's fork data, not in this node's chunk:
@@ -302,43 +315,46 @@ impl<E: NodeEntry> Node<E> {
     }
 
     /// Look up the node at the given path, loading from storage as needed.
-    pub(crate) fn lookup_node<S: SyncChunkGet<BS>, const BS: usize>(
+    pub(crate) async fn lookup_node<S: ChunkGet<BS>, const BS: usize>(
         &mut self,
         path: &[u8],
         store: &S,
     ) -> Result<&mut Self> {
-        self.ensure_loaded(store)?;
+        // Iterative descent: reborrow `current` to the chosen child each step.
+        let mut current = self;
+        let mut rest = path;
+        loop {
+            current.ensure_loaded(store).await?;
 
-        if path.is_empty() {
-            return Ok(self);
-        }
+            if rest.is_empty() {
+                return Ok(current);
+            }
 
-        let first = path[0];
-        let fork = self
-            .forks
-            .get_mut(&first)
-            .ok_or_else(|| MantarayError::NoForkFound {
-                reference: self.reference,
-            })?;
+            let first = rest[0];
+            let reference = current.reference;
+            let fork = current
+                .forks
+                .get_mut(&first)
+                .ok_or(MantarayError::NoForkFound { reference })?;
 
-        let c = common_prefix_len(&fork.prefix, path);
-        if c == fork.prefix.len() {
-            fork.node.lookup_node(&path[c..], store)
-        } else {
-            Err(MantarayError::NoForkFound {
-                reference: self.reference,
-            })
+            let c = common_prefix_len(&fork.prefix, rest);
+            if c != fork.prefix.len() {
+                return Err(MantarayError::NoForkFound { reference });
+            }
+
+            current = &mut fork.node;
+            rest = &rest[c..];
         }
     }
 
     /// Look up the entry at the given path, loading from storage as needed.
     #[cfg(test)]
-    pub(crate) fn lookup<S: SyncChunkGet<BS>, const BS: usize>(
+    pub(crate) async fn lookup<S: ChunkGet<BS>, const BS: usize>(
         &mut self,
         path: &[u8],
         store: &S,
     ) -> Result<Option<&E>> {
-        let node = self.lookup_node(path, store)?;
+        let node = self.lookup_node(path, store).await?;
         if !node.is_value() && !path.is_empty() {
             return Err(MantarayError::NoEntryFound {
                 reference: node.reference,
@@ -348,48 +364,74 @@ impl<E: NodeEntry> Node<E> {
     }
 
     /// Add an entry at the given path with optional metadata, loading from storage as needed.
-    pub(crate) fn add<S: SyncChunkGet<BS>, const BS: usize>(
-        &mut self,
-        path: &[u8],
+    ///
+    /// Returns a boxed future so the `&mut self` recursion can name its own type.
+    /// The `MaybeSend` bound keeps `!Send` wasm stores usable.
+    pub(crate) fn add<'a, S: ChunkGet<BS>, const BS: usize>(
+        &'a mut self,
+        path: &'a [u8],
         entry: Option<E>,
         metadata: BTreeMap<String, String>,
-        store: &S,
-    ) -> Result<()> {
-        // empty path — set this node as a value
-        if path.is_empty() {
-            self.entry = entry;
-            self.make_value();
+        store: &'a S,
+    ) -> RecurseFuture<'a>
+    where
+        E: MaybeSend,
+    {
+        Box::pin(async move {
+            // empty path; set this node as a value
+            if path.is_empty() {
+                self.entry = entry;
+                self.make_value();
 
-            if !metadata.is_empty() {
-                self.metadata = metadata;
-                self.make_with_metadata();
+                if !metadata.is_empty() {
+                    self.metadata = metadata;
+                    self.make_with_metadata();
+                }
+
+                self.mark_dirty();
+                return Ok(());
             }
 
-            self.mark_dirty();
-            return Ok(());
-        }
+            // load forks if needed
+            if !self.loaded {
+                self.load(store).await?;
+                self.mark_dirty();
+            }
 
-        // load forks if needed
-        if !self.loaded {
-            self.load(store)?;
-            self.mark_dirty();
-        }
+            if !self.forks.contains_key(&path[0]) {
+                // no existing fork for this byte; create a new one
+                let mut nn = Self {
+                    obfuscation_key: self.obfuscation_key,
+                    ..Default::default()
+                };
 
-        if !self.forks.contains_key(&path[0]) {
-            // no existing fork for this byte — create a new one
-            let mut nn = Self {
-                obfuscation_key: self.obfuscation_key,
-                ..Default::default()
-            };
+                if path.len() > PREFIX_MAX_LEN {
+                    let (prefix, rest) = path.split_at(PREFIX_MAX_LEN);
+                    nn.add(rest, entry, metadata, store).await?;
+                    nn.update_is_with_path_separator(prefix);
+                    self.forks.insert(
+                        path[0],
+                        Fork {
+                            prefix: Prefix::from_slice(prefix),
+                            node: nn,
+                        },
+                    );
+                    self.make_edge();
+                    return Ok(());
+                }
 
-            if path.len() > PREFIX_MAX_LEN {
-                let (prefix, rest) = path.split_at(PREFIX_MAX_LEN);
-                nn.add(rest, entry, metadata, store)?;
-                nn.update_is_with_path_separator(prefix);
+                nn.entry = entry;
+                if !metadata.is_empty() {
+                    nn.metadata = metadata;
+                    nn.make_with_metadata();
+                }
+                nn.make_value();
+                nn.update_is_with_path_separator(path);
+
                 self.forks.insert(
                     path[0],
                     Fork {
-                        prefix: Prefix::from_slice(prefix),
+                        prefix: Prefix::from_slice(path),
                         node: nn,
                     },
                 );
@@ -397,178 +439,213 @@ impl<E: NodeEntry> Node<E> {
                 return Ok(());
             }
 
-            nn.entry = entry;
-            if !metadata.is_empty() {
-                nn.metadata = metadata;
-                nn.make_with_metadata();
-            }
-            nn.make_value();
+            // existing fork; need to split or extend
+            let fork = self.forks.get(&path[0]).expect("checked above");
+            let c = common_prefix_len(&fork.prefix, path);
+            let rest = Prefix::from_slice(&fork.prefix[c..]);
+            let common_prefix = Prefix::from_slice(&fork.prefix[..c]);
+
+            // Take ownership; avoids cloning the entire node subtree
+            let old_fork = self.forks.remove(&path[0]).expect("checked above");
+
+            let mut nn = if rest.is_empty() {
+                old_fork.node
+            } else {
+                // split: create intermediate node
+                let mut intermediate = Self {
+                    obfuscation_key: self.obfuscation_key,
+                    ..Default::default()
+                };
+
+                let mut old_fork_node = old_fork.node;
+                old_fork_node.update_is_with_path_separator(&rest);
+                intermediate.forks.insert(
+                    rest[0],
+                    Fork {
+                        prefix: rest,
+                        node: old_fork_node,
+                    },
+                );
+                intermediate.make_edge();
+
+                if c == path.len() {
+                    intermediate.make_value();
+                }
+                intermediate
+            };
+
             nn.update_is_with_path_separator(path);
+            nn.add(&path[c..], entry, metadata, store).await?;
 
             self.forks.insert(
                 path[0],
                 Fork {
-                    prefix: Prefix::from_slice(path),
+                    prefix: common_prefix,
                     node: nn,
                 },
             );
             self.make_edge();
-            return Ok(());
-        }
 
-        // existing fork — need to split or extend
-        let fork = self.forks.get(&path[0]).expect("checked above");
-        let c = common_prefix_len(&fork.prefix, path);
-        let rest = Prefix::from_slice(&fork.prefix[c..]);
-        let common_prefix = Prefix::from_slice(&fork.prefix[..c]);
-
-        // Take ownership — avoids cloning the entire node subtree
-        let old_fork = self.forks.remove(&path[0]).expect("checked above");
-
-        let mut nn = if rest.is_empty() {
-            old_fork.node
-        } else {
-            // split: create intermediate node
-            let mut intermediate = Self {
-                obfuscation_key: self.obfuscation_key,
-                ..Default::default()
-            };
-
-            let mut old_fork_node = old_fork.node;
-            old_fork_node.update_is_with_path_separator(&rest);
-            intermediate.forks.insert(
-                rest[0],
-                Fork {
-                    prefix: rest,
-                    node: old_fork_node,
-                },
-            );
-            intermediate.make_edge();
-
-            if c == path.len() {
-                intermediate.make_value();
-            }
-            intermediate
-        };
-
-        nn.update_is_with_path_separator(path);
-        nn.add(&path[c..], entry, metadata, store)?;
-
-        self.forks.insert(
-            path[0],
-            Fork {
-                prefix: common_prefix,
-                node: nn,
-            },
-        );
-        self.make_edge();
-
-        Ok(())
+            Ok(())
+        })
     }
 
     /// Remove the entry at the given path, loading from storage as needed.
-    pub(crate) fn remove<S: SyncChunkGet<BS>, const BS: usize>(
-        &mut self,
-        path: &[u8],
-        store: &S,
-    ) -> Result<()> {
-        if path.is_empty() {
-            return Err(MantarayError::EmptyPath);
-        }
+    ///
+    /// Returns a boxed future so the `&mut self` recursion can name its own type.
+    pub(crate) fn remove<'a, S: ChunkGet<BS>, const BS: usize>(
+        &'a mut self,
+        path: &'a [u8],
+        store: &'a S,
+    ) -> RecurseFuture<'a>
+    where
+        E: MaybeSend,
+    {
+        Box::pin(async move {
+            if path.is_empty() {
+                return Err(MantarayError::EmptyPath);
+            }
 
-        self.ensure_loaded(store)?;
+            self.ensure_loaded(store).await?;
 
-        let first = path[0];
+            let first = path[0];
 
-        // Clone prefix to release the borrow on self.forks
-        let prefix = match self.forks.get(&first) {
-            Some(f) => f.prefix.clone(),
-            None => {
+            // Clone prefix to release the borrow on self.forks
+            let prefix = match self.forks.get(&first) {
+                Some(f) => f.prefix.clone(),
+                None => {
+                    return Err(MantarayError::PathPrefixNotFound {
+                        prefix: String::from_utf8_lossy(&[first]).to_string(),
+                    });
+                }
+            };
+
+            if !path.starts_with(&prefix) {
                 return Err(MantarayError::PathPrefixNotFound {
-                    prefix: String::from_utf8_lossy(&[first]).to_string(),
+                    prefix: String::from_utf8_lossy(path).to_string(),
                 });
             }
-        };
 
-        if !path.starts_with(&prefix) {
-            return Err(MantarayError::PathPrefixNotFound {
-                prefix: String::from_utf8_lossy(path).to_string(),
-            });
-        }
+            let rest = &path[prefix.len()..];
+            let result = if rest.is_empty() {
+                self.forks.remove(&first);
+                Ok(())
+            } else {
+                let fork = self.forks.get_mut(&first).expect("checked above");
+                fork.node.remove(rest, store).await
+            };
 
-        let rest = &path[prefix.len()..];
-        let result = if rest.is_empty() {
-            self.forks.remove(&first);
-            Ok(())
-        } else {
-            let fork = self.forks.get_mut(&first).expect("checked above");
-            fork.node.remove(rest, store)
-        };
-
-        // Always clear reference so the node gets re-saved (matches Go's defer pattern)
-        self.mark_dirty();
-        result
+            // Always clear reference so the node gets re-saved.
+            self.mark_dirty();
+            result
+        })
     }
 
     /// Test whether a prefix exists in the trie, loading from storage as needed.
-    pub(crate) fn has_prefix<S: SyncChunkGet<BS>, const BS: usize>(
+    pub(crate) async fn has_prefix<S: ChunkGet<BS>, const BS: usize>(
         &mut self,
         path: &[u8],
         store: &S,
     ) -> Result<bool> {
-        if path.is_empty() {
-            return Ok(true);
+        // Iterative descent: reborrow `current` to the chosen child each step.
+        let mut current = self;
+        let mut rest = path;
+        loop {
+            if rest.is_empty() {
+                return Ok(true);
+            }
+
+            current.ensure_loaded(store).await?;
+
+            let fork = match current.forks.get_mut(&rest[0]) {
+                Some(f) => f,
+                None => return Ok(false),
+            };
+
+            let c = common_prefix_len(&fork.prefix, rest);
+
+            if c == fork.prefix.len() {
+                current = &mut fork.node;
+                rest = &rest[c..];
+                continue;
+            }
+
+            if fork.prefix.starts_with(rest) {
+                return Ok(true);
+            }
+
+            return Ok(false);
         }
-
-        self.ensure_loaded(store)?;
-
-        let fork = match self.forks.get_mut(&path[0]) {
-            Some(f) => f,
-            None => return Ok(false),
-        };
-
-        let c = common_prefix_len(&fork.prefix, path);
-
-        if c == fork.prefix.len() {
-            return fork.node.has_prefix(&path[c..], store);
-        }
-
-        if fork.prefix.starts_with(path) {
-            return Ok(true);
-        }
-
-        Ok(false)
     }
 
-    /// Recursively save this node and all children to storage.
+    /// Save this node and all children to storage in post-order.
     ///
-    /// Uses BMT content-addressing via `ContentChunk`.
-    pub(crate) fn save<S: SyncChunkPut<BS>, const BS: usize>(&mut self, store: &S) -> Result<()> {
+    /// Uses BMT content-addressing via `ContentChunk`. An explicit stack avoids
+    /// recursion: each frame visits its forks (pushing unsaved children) before
+    /// the node itself is encoded and put.
+    pub(crate) async fn save<S: ChunkPut<BS>, const BS: usize>(&mut self, store: &S) -> Result<()> {
         if self.reference.is_some() {
             return Ok(());
         }
 
-        for fork in self.forks.values_mut() {
-            fork.node.save(store)?;
+        struct SaveFrame<E: NodeEntry> {
+            /// Node owned by an ancestor's fork map, valid for this call.
+            node: *mut Node<E>,
+            /// Fork keys still to descend into.
+            keys: Vec<u8>,
+            /// Index into `keys`.
+            key_idx: usize,
         }
 
-        let data = Vec::<u8>::try_from(&*self)?;
-        let chunk = ContentChunk::<BS>::new(Bytes::from(data))?;
-        let address = *chunk.address();
-        store
-            .put(chunk.into())
-            .map_err(|e| MantarayError::StorePut {
-                source: std::sync::Arc::new(e),
-            })?;
-        self.reference = Some(address);
-        self.forks.clear();
-        self.loaded = false;
+        let mut stack: Vec<SaveFrame<E>> = vec![SaveFrame {
+            node: self as *mut Self,
+            keys: self.forks.keys().copied().collect(),
+            key_idx: 0,
+        }];
+
+        while let Some(frame) = stack.last_mut() {
+            // SAFETY: every frame's node points into the exclusively borrowed
+            // trie. Children are only pushed once, then their parent waits in
+            // the stack below them, so no two frames alias the same node.
+            let node = unsafe { &mut *frame.node };
+
+            if frame.key_idx < frame.keys.len() {
+                let key = frame.keys[frame.key_idx];
+                frame.key_idx += 1;
+                let child = node.forks.get_mut(&key).expect("key from this node");
+                if child.node.reference.is_none() {
+                    let child_ptr = &mut child.node as *mut Self;
+                    let child_keys = child.node.forks.keys().copied().collect();
+                    stack.push(SaveFrame {
+                        node: child_ptr,
+                        keys: child_keys,
+                        key_idx: 0,
+                    });
+                }
+                continue;
+            }
+
+            // All children saved; encode and put this node, then pop.
+            let data = Vec::<u8>::try_from(&*node)?;
+            let chunk = ContentChunk::<BS>::new(Bytes::from(data))?;
+            let address = *chunk.address();
+            store
+                .put(chunk.into())
+                .await
+                .map_err(|e| MantarayError::StorePut {
+                    source: std::sync::Arc::new(e),
+                })?;
+            node.reference = Some(address);
+            node.forks.clear();
+            node.loaded = false;
+            stack.pop();
+        }
 
         Ok(())
     }
 
     /// Walk all nodes depth-first, calling `f` for each node with its path.
-    pub(crate) fn walk<S: SyncChunkGet<BS>, const BS: usize, F>(
+    pub(crate) async fn walk<S: ChunkGet<BS>, const BS: usize, F>(
         &mut self,
         store: &S,
         f: &mut F,
@@ -577,11 +654,11 @@ impl<E: NodeEntry> Node<E> {
         F: FnMut(&[u8], &Self) -> Result<()>,
     {
         let mut path_buf = Vec::new();
-        walk_inner(&mut path_buf, self, store, f)
+        walk_inner(&mut path_buf, self, store, f).await
     }
 
     /// Walk the subtree at `root`, calling `f` for each node.
-    pub(crate) fn walk_from<S: SyncChunkGet<BS>, const BS: usize, F>(
+    pub(crate) async fn walk_from<S: ChunkGet<BS>, const BS: usize, F>(
         &mut self,
         root: &[u8],
         store: &S,
@@ -592,15 +669,18 @@ impl<E: NodeEntry> Node<E> {
     {
         let mut path_buf = root.to_vec();
         if root.is_empty() {
-            return walk_inner(&mut path_buf, self, store, f);
+            return walk_inner(&mut path_buf, self, store, f).await;
         }
 
-        let target = self.lookup_node(root, store)?;
-        walk_inner(&mut path_buf, target, store, f)
+        let target = self.lookup_node(root, store).await?;
+        walk_inner(&mut path_buf, target, store, f).await
     }
 }
 
-fn walk_inner<E: NodeEntry, S: SyncChunkGet<BS>, const BS: usize, F>(
+/// Pre-order DFS visitor over a loaded-on-demand trie via an explicit stack.
+///
+/// The visitor `f` only reads loaded nodes, so it stays a synchronous `FnMut`.
+async fn walk_inner<E: NodeEntry, S: ChunkGet<BS>, const BS: usize, F>(
     path_buf: &mut Vec<u8>,
     node: &mut Node<E>,
     store: &S,
@@ -609,23 +689,62 @@ fn walk_inner<E: NodeEntry, S: SyncChunkGet<BS>, const BS: usize, F>(
 where
     F: FnMut(&[u8], &Node<E>) -> Result<()>,
 {
-    node.ensure_loaded(store)?;
+    struct WalkFrame {
+        /// Node visited at this level (raw pointer into the exclusive borrow).
+        node: *mut (),
+        /// Length of `path_buf` before this frame's prefix was appended.
+        path_len_before: usize,
+        /// Sorted fork keys for this node.
+        keys: Vec<u8>,
+        /// Index into `keys`.
+        key_idx: usize,
+    }
 
+    node.ensure_loaded(store).await?;
     f(path_buf, node)?;
 
-    // collect keys to avoid borrow conflict
-    let keys: Vec<u8> = node.forks.keys().copied().collect();
-    for key in keys {
-        let fork = node
+    let mut stack: Vec<WalkFrame> = vec![WalkFrame {
+        node: (node as *mut Node<E>).cast::<()>(),
+        path_len_before: path_buf.len(),
+        keys: node.forks.keys().copied().collect(),
+        key_idx: 0,
+    }];
+
+    while let Some(frame) = stack.last_mut() {
+        if frame.key_idx >= frame.keys.len() {
+            path_buf.truncate(frame.path_len_before);
+            stack.pop();
+            continue;
+        }
+
+        let key = frame.keys[frame.key_idx];
+        frame.key_idx += 1;
+
+        // SAFETY: frame.node points into the exclusively borrowed trie. Each
+        // node appears in exactly one frame and is only dereferenced while at
+        // the top of the stack, so no two live references alias.
+        let parent = unsafe { &mut *frame.node.cast::<Node<E>>() };
+        let reference = parent.reference;
+        let fork = parent
             .forks
             .get_mut(&key)
-            .ok_or_else(|| MantarayError::NoForkFound {
-                reference: node.reference,
-            })?;
+            .ok_or(MantarayError::NoForkFound { reference })?;
+
         let prev_len = path_buf.len();
         path_buf.extend_from_slice(&fork.prefix);
-        walk_inner(path_buf, &mut fork.node, store, f)?;
-        path_buf.truncate(prev_len);
+
+        let child = &mut fork.node;
+        child.ensure_loaded(store).await?;
+        f(path_buf, child)?;
+
+        let child_ptr = (child as *mut Node<E>).cast::<()>();
+        let child_keys = child.forks.keys().copied().collect();
+        stack.push(WalkFrame {
+            node: child_ptr,
+            path_len_before: prev_len,
+            keys: child_keys,
+            key_idx: 0,
+        });
     }
 
     Ok(())
@@ -799,6 +918,8 @@ mod tests {
         ]
     }
 
+    use futures::executor::block_on;
+
     const NL: NullLoader = NullLoader;
     const BS: usize = DEFAULT_BODY_SIZE;
 
@@ -813,28 +934,27 @@ mod tests {
 
     /// In-memory add: delegates to `add` with NullLoader.
     fn node_add(n: &mut Node, path: &[u8], entry: ChunkAddress, meta: BTreeMap<String, String>) {
-        n.add::<NullLoader, BS>(path, Some(entry), meta, &NL)
-            .unwrap();
+        block_on(n.add::<NullLoader, BS>(path, Some(entry), meta, &NL)).unwrap();
     }
 
     /// In-memory lookup: delegates to `lookup` with NullLoader.
     fn node_lookup<'n>(n: &'n mut Node, path: &[u8]) -> Result<Option<&'n ChunkAddress>> {
-        n.lookup::<NullLoader, BS>(path, &NL)
+        block_on(n.lookup::<NullLoader, BS>(path, &NL))
     }
 
     /// In-memory lookup_node: delegates to `lookup_node` with NullLoader.
     fn node_lookup_node<'n>(n: &'n mut Node, path: &[u8]) -> Result<&'n mut Node> {
-        n.lookup_node::<NullLoader, BS>(path, &NL)
+        block_on(n.lookup_node::<NullLoader, BS>(path, &NL))
     }
 
     /// In-memory remove: delegates to `remove` with NullLoader.
     fn node_remove(n: &mut Node, path: &[u8]) -> Result<()> {
-        n.remove::<NullLoader, BS>(path, &NL)
+        block_on(n.remove::<NullLoader, BS>(path, &NL))
     }
 
     /// In-memory has_prefix: delegates to `has_prefix` with NullLoader.
     fn node_has_prefix(n: &mut Node, path: &[u8]) -> Result<bool> {
-        n.has_prefix::<NullLoader, BS>(path, &NL)
+        block_on(n.has_prefix::<NullLoader, BS>(path, &NL))
     }
 
     /// In-memory walk: delegates to `walk` with NullLoader.
@@ -842,7 +962,7 @@ mod tests {
     where
         F: FnMut(&[u8], &Node) -> Result<()>,
     {
-        n.walk::<NullLoader, BS, _>(&NL, f)
+        block_on(n.walk::<NullLoader, BS, _>(&NL, f))
     }
 
     /// In-memory walk_node: delegates to `walk_from` with NullLoader.
@@ -850,7 +970,7 @@ mod tests {
     where
         F: FnMut(&[u8], &Node) -> Result<()>,
     {
-        n.walk_from::<NullLoader, BS, _>(root, &NL, f)
+        block_on(n.walk_from::<NullLoader, BS, _>(root, &NL, f))
     }
 
     #[test]
@@ -929,12 +1049,12 @@ mod tests {
         }
 
         let store = MemoryStore::<{ DEFAULT_BODY_SIZE }>::new();
-        n.save(&store).unwrap();
+        block_on(n.save(&store)).unwrap();
 
         let mut n2: Node = Node::from_reference(n.reference.unwrap());
 
         for &d in items {
-            let node = n2.lookup_node(d.as_bytes(), &store).unwrap();
+            let node = block_on(n2.lookup_node(d.as_bytes(), &store)).unwrap();
             assert!(node.is_value());
             assert_eq!(node.entry(), Some(&make_entry(d)));
         }
@@ -1034,24 +1154,23 @@ mod tests {
         let mut n = Node::default();
         for c in &tc.items {
             let e = make_entry(&c.path);
-            n.add(c.path.as_bytes(), Some(e), c.metadata.clone(), &store)
-                .unwrap();
+            block_on(n.add(c.path.as_bytes(), Some(e), c.metadata.clone(), &store)).unwrap();
         }
-        n.save(&store).unwrap();
+        block_on(n.save(&store)).unwrap();
         let ref_ = n.reference.unwrap();
 
         // reload and remove
         let mut nn: Node = Node::from_reference(ref_);
         for path in &tc.remove {
-            nn.remove(path.as_bytes(), &store).unwrap();
+            block_on(nn.remove(path.as_bytes(), &store)).unwrap();
         }
-        nn.save(&store).unwrap();
+        block_on(nn.save(&store)).unwrap();
         let ref2 = nn.reference.unwrap();
 
         // reload and verify removed paths are gone
         let mut nnn: Node = Node::from_reference(ref2);
         for path in &tc.remove {
-            let result = nnn.lookup_node(path.as_bytes(), &store);
+            let result = block_on(nnn.lookup_node(path.as_bytes(), &store));
             assert!(
                 result.is_err(),
                 "expected removed path '{path}' to be not found"
@@ -1221,15 +1340,15 @@ mod tests {
         }
 
         let store = MemoryStore::<{ DEFAULT_BODY_SIZE }>::new();
-        n.save(&store).unwrap();
+        block_on(n.save(&store)).unwrap();
 
         let mut n2: Node = Node::from_reference(n.reference.unwrap());
 
         let mut walked: Vec<Vec<u8>> = Vec::new();
-        n2.walk_from(b"", &store, &mut |path: &[u8], _node: &Node| {
+        block_on(n2.walk_from(b"", &store, &mut |path: &[u8], _node: &Node| {
             walked.push(path.to_vec());
             Ok(())
-        })
+        }))
         .unwrap();
 
         assert_eq!(

--- a/crates/mantaray/tests/file_manifest_integration.rs
+++ b/crates/mantaray/tests/file_manifest_integration.rs
@@ -1,9 +1,10 @@
 //! Integration test: unified store for file splitting and manifest creation.
 
+use futures::executor::block_on;
 use nectar_mantaray::PlainManifest;
 use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::ChunkAddress;
-use nectar_primitives::file::{SyncChunkPutExt, sync_join};
+use nectar_primitives::file::{SyncChunkPutExt, join};
 use nectar_primitives::store::MemoryStore;
 
 type Store = MemoryStore<DEFAULT_BODY_SIZE>;
@@ -14,7 +15,7 @@ type Store = MemoryStore<DEFAULT_BODY_SIZE>;
 fn unified_store_workflow() {
     let store = Store::new();
 
-    // Split files into the store
+    // Seed file chunks synchronously into the store.
     let root_a = store.write_file(b"file A contents").unwrap();
     let root_b = store.write_file(b"file B contents").unwrap();
 
@@ -23,22 +24,20 @@ fn unified_store_workflow() {
 
     // Create manifest in the same store
     let mut manifest = PlainManifest::new(store);
-    manifest
-        .add_with_metadata(
-            "a.txt",
-            root_a,
-            [("Content-Type".to_string(), "text/plain".to_string())].into(),
-        )
-        .unwrap();
-    manifest
-        .add_with_metadata(
-            "b.txt",
-            root_b,
-            [("Content-Type".to_string(), "text/plain".to_string())].into(),
-        )
-        .unwrap();
+    block_on(manifest.add_with_metadata(
+        "a.txt",
+        root_a,
+        [("Content-Type".to_string(), "text/plain".to_string())].into(),
+    ))
+    .unwrap();
+    block_on(manifest.add_with_metadata(
+        "b.txt",
+        root_b,
+        [("Content-Type".to_string(), "text/plain".to_string())].into(),
+    ))
+    .unwrap();
 
-    let root_ref = manifest.save().unwrap();
+    let root_ref = block_on(manifest.save()).unwrap();
 
     // Now the store contains both file chunks AND manifest trie nodes
     let (_, store) = manifest.into_parts();
@@ -48,18 +47,18 @@ fn unified_store_workflow() {
     let mut manifest2 = PlainManifest::open(root_ref, store.clone());
 
     // Verify lookup
-    let entry_a = manifest2.lookup("a.txt").unwrap();
+    let entry_a = block_on(manifest2.lookup("a.txt")).unwrap();
     assert_eq!(entry_a.address(), Some(&root_a));
     assert_eq!(entry_a.content_type(), Some("text/plain"));
 
-    let entry_b = manifest2.lookup("b.txt").unwrap();
+    let entry_b = block_on(manifest2.lookup("b.txt")).unwrap();
     assert_eq!(entry_b.address(), Some(&root_b));
 
     // Verify file data round-trip through the same store
-    let recovered_a = sync_join(&store, root_a).unwrap();
+    let recovered_a = block_on(join(store.clone(), root_a)).unwrap();
     assert_eq!(recovered_a, b"file A contents");
 
-    let recovered_b = sync_join(&store, root_b).unwrap();
+    let recovered_b = block_on(join(store, root_b)).unwrap();
     assert_eq!(recovered_b, b"file B contents");
 }
 
@@ -73,8 +72,8 @@ fn entries_round_trip() {
 
     for &path in paths {
         let addr = make_addr(path);
-        manifest
-            .add_with_metadata(
+        block_on(
+            manifest.add_with_metadata(
                 path,
                 addr,
                 [(
@@ -82,16 +81,17 @@ fn entries_round_trip() {
                     "application/octet-stream".to_string(),
                 )]
                 .into(),
-            )
-            .unwrap();
+            ),
+        )
+        .unwrap();
     }
 
-    let root_ref = manifest.save().unwrap();
+    let root_ref = block_on(manifest.save()).unwrap();
 
     let (_, store) = manifest.into_parts();
     let mut manifest2 = PlainManifest::open(root_ref, store);
 
-    let entries = manifest2.entries().unwrap();
+    let entries = block_on(manifest2.entries()).unwrap();
     assert_eq!(entries.len(), paths.len());
 
     for &path in paths {
@@ -116,10 +116,17 @@ fn iterator_yields_all_entries() {
     let paths = &["a/1", "a/2", "b/1", "c"];
     for &path in paths {
         let addr = make_addr(path);
-        manifest.add(path, addr).unwrap();
+        block_on(manifest.add(path, addr)).unwrap();
     }
 
-    let entries: Vec<_> = manifest.iter().collect::<Result<Vec<_>, _>>().unwrap();
+    let entries = block_on(async {
+        let mut out = Vec::new();
+        let mut iter = manifest.iter();
+        while let Some(item) = iter.next().await {
+            out.push(item.unwrap());
+        }
+        out
+    });
     assert_eq!(entries.len(), paths.len());
 
     for &path in paths {
@@ -134,32 +141,30 @@ fn iterator_yields_all_entries() {
 #[test]
 fn ergonomic_api_workflow() {
     use nectar_mantaray::DefaultMemoryStore;
-    use nectar_primitives::file::{SyncChunkGetExt, SyncChunkPutExt};
+    use nectar_primitives::file::{ChunkGetExt, SyncChunkPutExt};
 
     let store = DefaultMemoryStore::new();
 
-    // Split files using extension trait
+    // Seed file chunks synchronously.
     let root_a = store.write_file(b"file A contents").unwrap();
     let root_b = store.write_file(b"file B contents").unwrap();
 
     // Create manifest in the same store
     let mut manifest = PlainManifest::new(store);
-    manifest
-        .add_with_metadata(
-            "a.txt",
-            root_a,
-            [("Content-Type".to_string(), "text/plain".to_string())].into(),
-        )
-        .unwrap();
-    manifest
-        .add_with_metadata(
-            "b.txt",
-            root_b,
-            [("Content-Type".to_string(), "text/plain".to_string())].into(),
-        )
-        .unwrap();
+    block_on(manifest.add_with_metadata(
+        "a.txt",
+        root_a,
+        [("Content-Type".to_string(), "text/plain".to_string())].into(),
+    ))
+    .unwrap();
+    block_on(manifest.add_with_metadata(
+        "b.txt",
+        root_b,
+        [("Content-Type".to_string(), "text/plain".to_string())].into(),
+    ))
+    .unwrap();
 
-    let root_addr = manifest.save().unwrap();
+    let root_addr = block_on(manifest.save()).unwrap();
 
     let (_, store) = manifest.into_parts();
 
@@ -167,7 +172,14 @@ fn ergonomic_api_workflow() {
     let mut manifest2 = PlainManifest::open(root_addr, store);
 
     // Iterate entries using convenience methods
-    let entries: Vec<_> = manifest2.iter().collect::<Result<Vec<_>, _>>().unwrap();
+    let entries = block_on(async {
+        let mut out = Vec::new();
+        let mut iter = manifest2.iter();
+        while let Some(item) = iter.next().await {
+            out.push(item.unwrap());
+        }
+        out
+    });
 
     assert_eq!(entries.len(), 2);
 
@@ -182,7 +194,7 @@ fn ergonomic_api_workflow() {
         // address() extracts ChunkAddress from reference
         let addr = entry.address().expect("32-byte reference yields address");
 
-        let data = manifest2.store().read_file(*addr).unwrap();
+        let data = block_on(manifest2.store().clone().read_file(*addr)).unwrap();
         if path == "a.txt" {
             assert_eq!(data, b"file A contents");
         } else {


### PR DESCRIPTION
## What
Async-ifies the mantaray manifest trie and iterator so manifests work over network and browser stores. Descent (`lookup_node`, `has_prefix`) becomes an iterative reborrow loop; `add`/`remove` use a cfg-gated boxed future (`Send` native, unbounded wasm); `save`/`walk` become explicit stacks; `ManifestIter` becomes an async `Stream`. The store-free codecs, accessors, and visitor callbacks stay synchronous.

## Why
Closes #37. The manifest was built on the sync store traits, so it could not traverse an async network or browser store. This also unblocks removing the sync store family.

## Testing
`cargo test --workspace` (default features) and the mantaray wasm32 build are green. The byte-exact walk-order tests pin that the explicit-stack rewrite visits nodes in the same order as the recursion, plain and encrypted.

## Breaking change
The manifest read and mutate methods become `async fn`. Justified: it is the only way to traverse async stores, which network and browser clients require.

## Notes
Stacked on #110, #111, #112.

## AI Assistance
AI Assistance: Claude Code used for the design, implementation, and testing of this change.