### PR TITLE
feat(primitives): add bounded streaming joiner consumption (range, reader, folds, download)

### DIFF
--- a/crates/primitives/src/file/error.rs
+++ b/crates/primitives/src/file/error.rs
@@ -28,6 +28,12 @@ pub enum FileError {
     #[error("store error: {0}")]
     Store(Box<dyn std::error::Error + Send + Sync>),
 
+    /// Write sink failed. Rendered to a string so the error stays `Send + Sync`
+    /// even when the sink's own error is not (a single-threaded browser
+    /// writable).
+    #[error("sink error: {0}")]
+    Sink(String),
+
     /// Chunk getter failed to retrieve a chunk.
     #[error("getter error: {0}")]
     Getter(Box<dyn std::error::Error + Send + Sync>),
@@ -84,6 +90,12 @@ impl FileError {
     /// Create a getter error from any error type.
     pub fn getter<E: std::error::Error + Send + Sync + 'static>(err: E) -> Self {
         Self::Getter(Box::new(err))
+    }
+
+    /// Create a sink error by rendering any sink error to a string. Keeps
+    /// `FileError: Send + Sync` while accepting a `!Send` wasm sink error.
+    pub fn sink<E: std::error::Error>(err: E) -> Self {
+        Self::Sink(err.to_string())
     }
 }
 

--- a/crates/primitives/src/file/fold.rs
+++ b/crates/primitives/src/file/fold.rs
@@ -1,0 +1,290 @@
+//! Closure-driven fold combinators over the async joiner.
+//!
+//! Thin adapters that let a consumer scan the whole file through a closure
+//! without buffering it: [`for_each_chunk`](GenericJoiner::for_each_chunk)
+//! visits each leaf out of order at full throughput, and
+//! [`try_for_each_window`](GenericJoiner::try_for_each_window) folds contiguous
+//! in-order byte runs with bounded memory. Both compose over the existing
+//! streaming methods, so neither re-walks the tree.
+
+use core::ops::ControlFlow;
+
+use bytes::Bytes;
+use futures::stream::StreamExt;
+
+use super::error::Result;
+use super::joiner::GenericJoiner;
+use super::mode::JoinMode;
+use crate::store::{ChunkGet, MaybeSend};
+
+impl<G, M, const BODY_SIZE: usize> GenericJoiner<G, M, BODY_SIZE>
+where
+    G: ChunkGet<BODY_SIZE> + 'static,
+    M: JoinMode + MaybeSend + Sync,
+{
+    /// Visit each leaf body as it lands, out of order, tagged with its absolute
+    /// offset. Peak memory is the in-flight width. `f` returns `Break` to stop
+    /// early, which drops the stream and cancels in-flight fetches.
+    pub async fn for_each_chunk<F>(self, mut f: F) -> Result<()>
+    where
+        F: FnMut(u64, &Bytes) -> ControlFlow<()>,
+    {
+        let s = self.into_offset_stream_chunked();
+        futures::pin_mut!(s);
+        while let Some(p) = s.next().await {
+            let (off, body) = p?;
+            if f(off, &body).is_break() {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    /// Fold contiguous in-order byte runs through `f` without buffering the
+    /// file. `window` bounds peak memory (see
+    /// [`into_windowed_reader`](Self::into_windowed_reader)). `f` returns
+    /// `Break(acc)` to stop early with the carried accumulator; otherwise the
+    /// final accumulator is returned at stream end.
+    pub async fn try_for_each_window<B, F>(self, window: usize, init: B, mut f: F) -> Result<B>
+    where
+        F: FnMut(B, &[u8]) -> ControlFlow<B, B>,
+    {
+        let mut reader = self.into_windowed_reader(window);
+        let s = reader.stream();
+        futures::pin_mut!(s);
+        let mut acc = init;
+        while let Some(run) = s.next().await {
+            let bytes = run?;
+            match f(acc, &bytes) {
+                ControlFlow::Continue(b) => acc = b,
+                ControlFlow::Break(b) => return Ok(b),
+            }
+        }
+        Ok(acc)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bmt::DEFAULT_BODY_SIZE;
+    use crate::chunk::{AnyChunk, ChunkAddress};
+    use crate::file::Joiner;
+    use crate::file::sync_split;
+    use futures::executor::block_on;
+    use std::collections::HashMap;
+
+    fn split_and_store(data: &[u8]) -> (ChunkAddress, HashMap<ChunkAddress, AnyChunk>) {
+        let (root, store) = sync_split::<DEFAULT_BODY_SIZE>(data).unwrap();
+        (root, store.into_chunks())
+    }
+
+    /// `for_each_chunk` visits every leaf exactly once; reassembling by offset
+    /// equals `read_all`.
+    fn assert_for_each_chunk_matches(data: &[u8], width: usize) {
+        let (root, store) = split_and_store(data);
+        block_on(async {
+            let expected = Joiner::new(store.clone(), root)
+                .await
+                .unwrap()
+                .read_all()
+                .await
+                .unwrap();
+
+            let joiner = Joiner::new(store, root)
+                .await
+                .unwrap()
+                .with_concurrency(width);
+            let total = joiner.size();
+
+            let mut reassembled = vec![0u8; total as usize];
+            let mut covered = 0u64;
+            let mut seen = std::collections::HashSet::new();
+            joiner
+                .for_each_chunk(|off, body| {
+                    assert!(seen.insert(off), "offset {off} visited more than once");
+                    let start = off as usize;
+                    reassembled[start..start + body.len()].copy_from_slice(body);
+                    covered += body.len() as u64;
+                    ControlFlow::Continue(())
+                })
+                .await
+                .unwrap();
+
+            assert_eq!(covered, total, "every byte covered exactly once");
+            assert_eq!(reassembled, expected, "reassembly equals read_all");
+            assert_eq!(reassembled, data, "reassembly equals input");
+        });
+    }
+
+    #[test]
+    fn for_each_chunk_reassembles() {
+        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3 + 123)
+            .map(|i| (i % 256) as u8)
+            .collect();
+        assert_for_each_chunk_matches(b"hello world", 8);
+        assert_for_each_chunk_matches(&data, 8);
+        // width 1 (degenerate concurrent path) still visits every leaf.
+        assert_for_each_chunk_matches(&data, 1);
+    }
+
+    #[test]
+    fn for_each_chunk_break_stops_early() {
+        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5)
+            .map(|i| (i % 256) as u8)
+            .collect();
+        let (root, store) = split_and_store(&data);
+        block_on(async {
+            let joiner = Joiner::new(store, root).await.unwrap();
+            let mut visited = 0usize;
+            let res = joiner
+                .for_each_chunk(|_off, _body| {
+                    visited += 1;
+                    if visited == 2 {
+                        ControlFlow::Break(())
+                    } else {
+                        ControlFlow::Continue(())
+                    }
+                })
+                .await;
+            assert!(res.is_ok(), "early break returns Ok");
+            assert_eq!(visited, 2, "stops on the breaking leaf");
+        });
+    }
+
+    /// Concatenating the in-order runs equals the file.
+    fn assert_window_concat_matches(data: &[u8], window: usize) {
+        let (root, store) = split_and_store(data);
+        block_on(async {
+            let joiner = Joiner::new(store, root).await.unwrap();
+            let out = joiner
+                .try_for_each_window(window, Vec::new(), |mut acc: Vec<u8>, run| {
+                    acc.extend_from_slice(run);
+                    ControlFlow::Continue(acc)
+                })
+                .await
+                .unwrap();
+            assert_eq!(out, data, "window concat equals file (window {window})");
+        });
+    }
+
+    #[test]
+    fn try_for_each_window_concat_equals_file() {
+        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 321)
+            .map(|i| (i % 256) as u8)
+            .collect();
+        assert_window_concat_matches(&data, 16);
+        // window 1 is the tightest in-order path.
+        assert_window_concat_matches(&data, 1);
+    }
+
+    #[test]
+    fn try_for_each_window_byte_count_equals_size() {
+        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 4 + 7)
+            .map(|i| (i % 256) as u8)
+            .collect();
+        let (root, store) = split_and_store(&data);
+        block_on(async {
+            let joiner = Joiner::new(store, root).await.unwrap();
+            let size = joiner.size();
+            let count = joiner
+                .try_for_each_window(8, 0u64, |acc, run| {
+                    ControlFlow::Continue(acc + run.len() as u64)
+                })
+                .await
+                .unwrap();
+            assert_eq!(count, size, "folded byte count equals size()");
+        });
+    }
+
+    #[test]
+    fn try_for_each_window_break_returns_accumulator() {
+        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5)
+            .map(|i| (i % 256) as u8)
+            .collect();
+        let (root, store) = split_and_store(&data);
+        block_on(async {
+            let joiner = Joiner::new(store, root).await.unwrap();
+            // Stop once at least one body has been seen; the carried count comes
+            // back through `Break`.
+            let count = joiner
+                .try_for_each_window(8, 0u64, |acc, _run| {
+                    let acc = acc + 1;
+                    ControlFlow::Break(acc)
+                })
+                .await
+                .unwrap();
+            assert_eq!(count, 1, "break carries the accumulator and stops");
+        });
+    }
+
+    #[cfg(feature = "encryption")]
+    mod encrypted {
+        use super::*;
+        use crate::file::EncryptedJoiner;
+        use crate::file::sync_split_encrypted;
+
+        fn enc_split_and_store(
+            data: &[u8],
+        ) -> (
+            crate::chunk::encryption::EncryptedChunkRef,
+            HashMap<ChunkAddress, AnyChunk>,
+        ) {
+            let (root_ref, store) = sync_split_encrypted::<DEFAULT_BODY_SIZE>(data).unwrap();
+            (root_ref, store.into_chunks())
+        }
+
+        #[test]
+        fn for_each_chunk_reassembles_encrypted() {
+            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3 + 123)
+                .map(|i| (i % 256) as u8)
+                .collect();
+            let (root_ref, store) = enc_split_and_store(&data);
+            block_on(async {
+                let expected = EncryptedJoiner::new(store.clone(), root_ref.clone())
+                    .await
+                    .unwrap()
+                    .read_all()
+                    .await
+                    .unwrap();
+
+                let joiner = EncryptedJoiner::new(store, root_ref).await.unwrap();
+                let total = joiner.size();
+                let mut reassembled = vec![0u8; total as usize];
+                let mut seen = std::collections::HashSet::new();
+                joiner
+                    .for_each_chunk(|off, body| {
+                        assert!(seen.insert(off), "offset {off} visited more than once");
+                        let start = off as usize;
+                        reassembled[start..start + body.len()].copy_from_slice(body);
+                        ControlFlow::Continue(())
+                    })
+                    .await
+                    .unwrap();
+                assert_eq!(
+                    reassembled, expected,
+                    "encrypted reassembly equals read_all"
+                );
+            });
+        }
+
+        #[test]
+        fn try_for_each_window_concat_equals_file_encrypted() {
+            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 321)
+                .map(|i| (i % 256) as u8)
+                .collect();
+            let (root_ref, store) = enc_split_and_store(&data);
+            block_on(async {
+                let joiner = EncryptedJoiner::new(store, root_ref).await.unwrap();
+                let out = joiner
+                    .try_for_each_window(16, Vec::new(), |mut acc: Vec<u8>, run| {
+                        acc.extend_from_slice(run);
+                        ControlFlow::Continue(acc)
+                    })
+                    .await
+                    .unwrap();
+                assert_eq!(out, data, "encrypted window concat equals file");
+            });
+        }
+    }
+}

--- a/crates/primitives/src/file/joiner.rs
+++ b/crates/primitives/src/file/joiner.rs
@@ -551,6 +551,35 @@ where
         })
     }
 
+    /// Like [`into_offset_stream_chunked`](Self::into_offset_stream_chunked) but
+    /// restricted to the byte range `[start, start + len)`.
+    ///
+    /// Only subtrees and intermediate children overlapping the range are walked,
+    /// and the first and last partial leaves are clipped so each emitted
+    /// `(offset, body)` lies inside the range. Offsets stay absolute in the file,
+    /// so reassembling the pairs over `[start, start + len)` reproduces
+    /// [`read_range`](Self::read_range) byte-for-byte. A whole-file range equals
+    /// [`into_offset_stream_chunked`](Self::into_offset_stream_chunked); an empty
+    /// or out-of-bounds range yields an empty stream.
+    pub fn into_offset_stream_chunked_range(
+        self,
+        start: u64,
+        len: u64,
+    ) -> impl Stream<Item = Result<(u64, Bytes)>>
+    where
+        G: 'static,
+    {
+        chunked_range_stream_from::<G, M, BODY_SIZE>(
+            self.getter,
+            self.subtrees,
+            self.tree,
+            self.span,
+            self.concurrency,
+            start,
+            len,
+        )
+    }
+
     /// Convert into an `AsyncRead` reader.
     #[cfg(feature = "tokio")]
     pub fn into_reader(self) -> JoinerReader<G, M, BODY_SIZE> {
@@ -560,6 +589,191 @@ where
             future: None,
         }
     }
+}
+
+/// Build the chunk-granular range stream from already-decomposed joiner parts.
+///
+/// The single home of the chunk-granular walk: both
+/// [`GenericJoiner::into_offset_stream_chunked_range`] (which moves its parts
+/// in) and consumers that retain reusable joiner state (which clone their parts
+/// in) drive the same implementation. Walks only the subtrees and intermediate
+/// children overlapping `[start, start + len)`, clips boundary leaves to the
+/// range, and keeps absolute offsets, so the returned stream is identical to the
+/// inherent method.
+pub(crate) fn chunked_range_stream_from<G, M, const BODY_SIZE: usize>(
+    getter: Arc<G>,
+    subtrees: Vec<SubtreeNode<M>>,
+    tree: TreeParams<BODY_SIZE>,
+    span: u64,
+    concurrency: usize,
+    start: u64,
+    len: u64,
+) -> impl Stream<Item = Result<(u64, Bytes)>> + 'static
+where
+    G: ChunkGet<BODY_SIZE> + 'static,
+    M: JoinMode + MaybeSend + Sync,
+{
+    let width = concurrency.max(1);
+
+    // Clamp the requested window to the file and derive the chunk range that
+    // seeds the queue and prunes intermediate children, exactly as the full
+    // walk uses the whole-file chunk range.
+    let range_start = start.min(span);
+    let range_end = (start.saturating_add(len)).min(span);
+    let chunk_range = tree.chunks_for_range(range_start, range_end - range_start);
+
+    // One unit of pending work: a tree node plus its remaining retry budget.
+    // The budget only decrements on a failed leaf fetch.
+    struct Pending<M: JoinMode> {
+        node: SubtreeNode<M>,
+        retries: u32,
+    }
+
+    // What a worker future resolves to once its chunk lands.
+    enum Resolved<M: JoinMode> {
+        /// A leaf: its absolute byte offset and decoded body.
+        Leaf(u64, Bytes),
+        /// An intermediate: its overlapping children to re-queue.
+        Children(Vec<SubtreeNode<M>>),
+        /// A leaf fetch failed with retries left: re-queue this node.
+        Retry(Pending<M>),
+        /// A fetch failed terminally (retries exhausted or intermediate error).
+        Failed(FileError),
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    type BoxResolvedFuture<M> =
+        std::pin::Pin<Box<dyn std::future::Future<Output = Resolved<M>> + Send>>;
+    #[cfg(target_arch = "wasm32")]
+    type BoxResolvedFuture<M> = std::pin::Pin<Box<dyn std::future::Future<Output = Resolved<M>>>>;
+
+    // Fetch one node: a leaf yields its body, an intermediate yields its
+    // overlapping children. A leaf error consumes one retry, then re-queues
+    // or fails.
+    async fn fetch_one<G, M, const BS: usize>(
+        getter: &G,
+        chunk_range: &ChunkRange,
+        pending: Pending<M>,
+    ) -> Resolved<M>
+    where
+        G: ChunkGet<BS>,
+        M: JoinMode + MaybeSend + Sync,
+    {
+        let node = &pending.node;
+        let body = match super::mode::read_chunk_body_async::<M, G, BS>(
+            getter,
+            &node.addr,
+            &node.context,
+            node.span,
+        )
+        .await
+        {
+            Ok(body) => body,
+            Err(e) => {
+                if node.span <= BS as u64 && pending.retries > 0 {
+                    return Resolved::Retry(Pending {
+                        node: pending.node,
+                        retries: pending.retries - 1,
+                    });
+                }
+                return Resolved::Failed(e);
+            }
+        };
+
+        if node.span <= BS as u64 {
+            return Resolved::Leaf(node.byte_offset, body);
+        }
+        match overlapping_children::<M, BS>(&body, node, chunk_range) {
+            Ok(children) => Resolved::Children(children),
+            Err(e) => Resolved::Failed(e),
+        }
+    }
+
+    struct State<G, M: JoinMode> {
+        getter: Arc<G>,
+        chunk_range: ChunkRange,
+        range_start: u64,
+        range_end: u64,
+        width: usize,
+        queue: std::collections::VecDeque<Pending<M>>,
+        in_flight: FuturesUnordered<BoxResolvedFuture<M>>,
+    }
+
+    // Seed the queue with only the subtrees overlapping the range; an empty
+    // range leaves the queue empty and the stream finishes at once.
+    let mut queue = std::collections::VecDeque::new();
+    if range_end > range_start {
+        let range_start_byte = chunk_range.start * BODY_SIZE as u64;
+        let range_end_byte = chunk_range.end * BODY_SIZE as u64;
+        for st in subtrees {
+            if st.byte_offset < range_end_byte && st.byte_offset + st.span > range_start_byte {
+                queue.push_back(Pending {
+                    node: st,
+                    retries: DEFAULT_LEAF_RETRIES,
+                });
+            }
+        }
+    }
+
+    let state = State::<G, M> {
+        getter,
+        chunk_range,
+        range_start,
+        range_end,
+        width,
+        queue,
+        in_flight: FuturesUnordered::new(),
+    };
+
+    stream::unfold(state, move |mut state| async move {
+        loop {
+            // Refill the in-flight pool from the pending queue up to the
+            // width, so at most `width` chunks are fetching at once.
+            while state.in_flight.len() < state.width {
+                let Some(pending) = state.queue.pop_front() else {
+                    break;
+                };
+                let getter = Arc::clone(&state.getter);
+                let range = state.chunk_range;
+                state.in_flight.push(Box::pin(async move {
+                    fetch_one::<G, M, BODY_SIZE>(&*getter, &range, pending).await
+                }) as BoxResolvedFuture<M>);
+            }
+
+            // Nothing in flight and nothing queued: the range is drained.
+            let resolved = state.in_flight.next().await?;
+            match resolved {
+                Resolved::Leaf(leaf_start, body) => {
+                    // Clip the leaf to the range. Offsets stay absolute, so a
+                    // boundary leaf emits only its in-range slice, and the
+                    // emitted offset is the later of the leaf start and the
+                    // range start.
+                    let leaf_end = leaf_start + body.len() as u64;
+                    if leaf_end <= state.range_start || leaf_start >= state.range_end {
+                        continue;
+                    }
+                    let clip_lo = state.range_start.saturating_sub(leaf_start) as usize;
+                    let clip_hi = (state.range_end - leaf_start).min(body.len() as u64) as usize;
+                    let offset = leaf_start.max(state.range_start);
+                    return Some((Ok((offset, body.slice(clip_lo..clip_hi))), state));
+                }
+                Resolved::Children(children) => {
+                    for child in children {
+                        state.queue.push_back(Pending {
+                            node: child,
+                            retries: DEFAULT_LEAF_RETRIES,
+                        });
+                    }
+                }
+                Resolved::Retry(pending) => {
+                    // Re-enqueue at the back so the worker pulls fresh work
+                    // first; the failed chunk retries without holding a slot.
+                    state.queue.push_back(pending);
+                }
+                Resolved::Failed(e) => return Some((Err(e), state)),
+            }
+        }
+    })
 }
 
 /// Wrapper providing `tokio::io::AsyncRead` over a [`GenericJoiner`].
@@ -979,6 +1193,132 @@ mod tests {
         );
     }
 
+    /// Drain `into_offset_stream_chunked_range(start, len)`, reassemble the
+    /// clipped `(offset, bytes)` pairs over `[start, start + len)`, and assert it
+    /// equals `read_range(start, len)` byte-for-byte. Runs at the default width
+    /// and at width 1.
+    async fn assert_offset_stream_chunked_range_matches(data: &[u8], start: u64, len: u64) {
+        for width in [DEFAULT_ASYNC_CONCURRENCY, 1] {
+            let (root, store) = split_and_store(data);
+
+            let expected = Joiner::new(store.clone(), root)
+                .await
+                .unwrap()
+                .read_range(start, len as usize)
+                .await
+                .unwrap();
+
+            let joiner = Joiner::new(store, root)
+                .await
+                .unwrap()
+                .with_concurrency(width);
+            let pairs: Vec<Result<(u64, Bytes)>> = joiner
+                .into_offset_stream_chunked_range(start, len)
+                .collect()
+                .await;
+
+            let mut reassembled = vec![0u8; expected.len()];
+            let mut seen_offsets = std::collections::HashSet::new();
+            for pair in pairs {
+                let (offset, body) = pair.unwrap();
+                assert!(
+                    offset >= start && offset + body.len() as u64 <= start + len,
+                    "offset {offset} (+{}) outside [{start}, {})",
+                    body.len(),
+                    start + len
+                );
+                assert!(
+                    seen_offsets.insert(offset),
+                    "offset {offset} yielded more than once (width {width})"
+                );
+                let rel = (offset - start) as usize;
+                reassembled[rel..rel + body.len()].copy_from_slice(&body);
+            }
+
+            assert_eq!(
+                reassembled, expected,
+                "range reassembly equals read_range (width {width}, start {start}, len {len})"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_offset_stream_chunked_range_windows() {
+        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 321)
+            .map(|i| (i % 256) as u8)
+            .collect();
+        let bs = DEFAULT_BODY_SIZE as u64;
+        let total = data.len() as u64;
+
+        // sub-leaf: start and len both inside one leaf
+        assert_offset_stream_chunked_range_matches(&data, bs + 10, 50).await;
+        // leaf-aligned single leaf
+        assert_offset_stream_chunked_range_matches(&data, bs, bs).await;
+        // spans several leaves, partial at both ends
+        assert_offset_stream_chunked_range_matches(&data, bs / 2, bs * 3 + 7).await;
+        // last partial leaf
+        assert_offset_stream_chunked_range_matches(&data, bs * 5, total - bs * 5).await;
+        // whole file (must equal read_all)
+        assert_offset_stream_chunked_range_matches(&data, 0, total).await;
+        // zero-len (empty)
+        assert_offset_stream_chunked_range_matches(&data, bs, 0).await;
+    }
+
+    #[tokio::test]
+    async fn test_offset_stream_chunked_range_whole_equals_chunked() {
+        // A whole-file range must reproduce `into_offset_stream_chunked` exactly:
+        // same leaves, same absolute offsets, same bodies.
+        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3 + 99)
+            .map(|i| (i % 256) as u8)
+            .collect();
+        let (root, store) = split_and_store(&data);
+
+        let full = Joiner::new(store.clone(), root).await.unwrap();
+        let total = full.size();
+        let mut from_full: Vec<(u64, Vec<u8>)> = full
+            .into_offset_stream_chunked()
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .map(|p| {
+                let (o, b) = p.unwrap();
+                (o, b.to_vec())
+            })
+            .collect();
+        from_full.sort_by_key(|(o, _)| *o);
+
+        let ranged = Joiner::new(store, root).await.unwrap();
+        let mut from_range: Vec<(u64, Vec<u8>)> = ranged
+            .into_offset_stream_chunked_range(0, total)
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .map(|p| {
+                let (o, b) = p.unwrap();
+                (o, b.to_vec())
+            })
+            .collect();
+        from_range.sort_by_key(|(o, _)| *o);
+
+        assert_eq!(
+            from_range, from_full,
+            "whole-file range equals chunked walk"
+        );
+
+        // And the reassembly equals read_all.
+        let expected = Joiner::new(split_and_store(&data).1, root)
+            .await
+            .unwrap()
+            .read_all()
+            .await
+            .unwrap();
+        let mut reassembled = vec![0u8; total as usize];
+        for (o, b) in &from_range {
+            reassembled[*o as usize..*o as usize + b.len()].copy_from_slice(b);
+        }
+        assert_eq!(reassembled, expected);
+    }
+
     #[cfg(feature = "tokio")]
     #[tokio::test]
     async fn test_async_reader_small() {
@@ -1098,6 +1438,76 @@ mod tests {
                 recovered.extend_from_slice(&chunk.unwrap());
             }
             assert_eq!(recovered, data);
+        }
+
+        /// Encrypted analogue of `assert_offset_stream_chunked_range_matches`.
+        /// Encrypted leaf bodies are shorter than `BODY_SIZE` (the span is
+        /// stripped), so clipping must key off `body.len()`, never a stride.
+        async fn assert_encrypted_range_matches(data: &[u8], start: u64, len: u64) {
+            for width in [DEFAULT_ASYNC_CONCURRENCY, 1] {
+                let (root_ref, store) = encrypted_split_and_store(data);
+
+                let expected = EncryptedJoiner::new(store.clone(), root_ref.clone())
+                    .await
+                    .unwrap()
+                    .read_range(start, len as usize)
+                    .await
+                    .unwrap();
+
+                let joiner = EncryptedJoiner::new(store, root_ref)
+                    .await
+                    .unwrap()
+                    .with_concurrency(width);
+                let pairs: Vec<Result<(u64, Bytes)>> = joiner
+                    .into_offset_stream_chunked_range(start, len)
+                    .collect()
+                    .await;
+
+                let mut reassembled = vec![0u8; expected.len()];
+                let mut seen_offsets = std::collections::HashSet::new();
+                for pair in pairs {
+                    let (offset, body) = pair.unwrap();
+                    assert!(
+                        offset >= start && offset + body.len() as u64 <= start + len,
+                        "offset {offset} (+{}) outside [{start}, {})",
+                        body.len(),
+                        start + len
+                    );
+                    assert!(
+                        seen_offsets.insert(offset),
+                        "offset {offset} yielded more than once (width {width})"
+                    );
+                    let rel = (offset - start) as usize;
+                    reassembled[rel..rel + body.len()].copy_from_slice(&body);
+                }
+
+                assert_eq!(
+                    reassembled, expected,
+                    "encrypted range equals read_range (width {width}, start {start}, len {len})"
+                );
+            }
+        }
+
+        #[tokio::test]
+        async fn test_encrypted_offset_stream_chunked_range_windows() {
+            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 321)
+                .map(|i| (i % 256) as u8)
+                .collect();
+            let bs = DEFAULT_BODY_SIZE as u64;
+            let total = data.len() as u64;
+
+            // sub-leaf
+            assert_encrypted_range_matches(&data, bs + 10, 50).await;
+            // leaf-aligned single leaf
+            assert_encrypted_range_matches(&data, bs, bs).await;
+            // spans several leaves
+            assert_encrypted_range_matches(&data, bs / 2, bs * 3 + 7).await;
+            // last partial leaf
+            assert_encrypted_range_matches(&data, bs * 5, total - bs * 5).await;
+            // whole file
+            assert_encrypted_range_matches(&data, 0, total).await;
+            // zero-len
+            assert_encrypted_range_matches(&data, bs, 0).await;
         }
     }
 }

--- a/crates/primitives/src/file/mod.rs
+++ b/crates/primitives/src/file/mod.rs
@@ -48,6 +48,7 @@
 mod constants;
 pub mod entry_ref;
 pub mod error;
+mod fold;
 mod frontier;
 mod helpers;
 #[cfg(test)]
@@ -62,6 +63,7 @@ mod sync_read_at;
 mod sync_splitter;
 mod sync_splitter_parallel;
 mod tree;
+mod windowed;
 mod write_at;
 
 use crate::chunk::ChunkAddress;
@@ -75,6 +77,9 @@ pub use joiner::EncryptedJoiner;
 #[cfg(feature = "tokio")]
 pub use joiner::JoinerReader;
 pub use joiner::{GenericJoiner, Joiner};
+#[cfg(feature = "tokio")]
+pub use windowed::WindowedJoinerReader;
+pub use windowed::WindowedReader;
 // Splitter re-exports
 pub use sync_read_at::SyncReadAt;
 #[cfg(feature = "encryption")]

--- a/crates/primitives/src/file/windowed.rs
+++ b/crates/primitives/src/file/windowed.rs
@@ -1,0 +1,1006 @@
+//! Bounded seek-and-play reader over the async joiner.
+//!
+//! [`WindowedReader`] seeks to a byte offset then streams forward in file order
+//! with peak memory bounded by `window` leaf bodies rather than the file size.
+//! The window slides with the read cursor: at most `window` leaf fetches plus
+//! buffered leaves are held at once, and the lowest-offset (head) leaf is always
+//! fetched first, so emission makes progress and the bound holds regardless of
+//! resolve order. Reseeking drops the window and repositions against the
+//! retained frontier, so no intermediate chunk is re-fetched.
+
+use std::collections::{BTreeMap, VecDeque};
+use std::io::SeekFrom;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use futures::stream::{self, FuturesUnordered, Stream, StreamExt};
+
+use crate::bmt::DEFAULT_BODY_SIZE;
+use crate::chunk::ChunkAddress;
+
+use super::error::{FileError, Result};
+use super::frontier::{SubtreeNode, overlapping_children};
+use super::joiner::GenericJoiner;
+use super::mode::JoinMode;
+use super::tree::{ChunkRange, TreeParams};
+use crate::store::{ChunkGet, MaybeSend};
+
+/// Number of times a failed leaf fetch is re-enqueued before the walk surfaces
+/// the error.
+const DEFAULT_LEAF_RETRIES: u32 = 4;
+
+#[cfg(test)]
+thread_local! {
+    /// Test hook: peak observed `leaf_in_flight + buffered.len()` across a walk
+    /// on this thread, so a test can assert the true window bound on leaf bodies
+    /// held at once. Thread-local because `block_on` runs each test's walk on its
+    /// own thread, so the parallel test runner never interleaves the counter.
+    static PEAK_LEAF_OCCUPANCY: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+/// Record a sampled occupancy, keeping the running peak for this thread.
+#[cfg(test)]
+fn record_occupancy(occupancy: usize) {
+    PEAK_LEAF_OCCUPANCY.with(|p| p.set(p.get().max(occupancy)));
+}
+
+/// Seek-and-play reader: forward in-order delivery over a window that slides
+/// with the read cursor, bounded to `window` in-flight plus buffered leaves.
+///
+/// Retains the joiner's reusable state (getter, pre-expanded frontier, tree
+/// params) so each [`stream`](Self::stream) rebuilds a fresh window-bounded walk
+/// from `[position, size)` without re-expanding the frontier. [`seek`](Self::seek)
+/// only repositions; it never re-fetches intermediates.
+pub struct WindowedReader<G, M: JoinMode, const BODY_SIZE: usize = DEFAULT_BODY_SIZE>
+where
+    G: ChunkGet<BODY_SIZE>,
+{
+    getter: Arc<G>,
+    subtrees: Vec<SubtreeNode<M>>,
+    tree: TreeParams<BODY_SIZE>,
+    span: u64,
+    concurrency: usize,
+    position: u64,
+    window: usize,
+    #[allow(
+        dead_code,
+        reason = "retained reusable joiner state for re-stream-on-seek"
+    )]
+    root: ChunkAddress,
+}
+
+impl<G, M, const BODY_SIZE: usize> std::fmt::Debug for WindowedReader<G, M, BODY_SIZE>
+where
+    G: ChunkGet<BODY_SIZE>,
+    M: JoinMode,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WindowedReader")
+            .field("span", &self.span)
+            .field("position", &self.position)
+            .field("concurrency", &self.concurrency)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<G, M, const BODY_SIZE: usize> GenericJoiner<G, M, BODY_SIZE>
+where
+    G: ChunkGet<BODY_SIZE> + 'static,
+    M: JoinMode + MaybeSend + Sync,
+{
+    /// Seek-and-play reader over a window that slides with the read cursor. Peak
+    /// memory is `window` leaf bodies: in-flight plus buffered leaves never
+    /// exceed `window`. `window` is clamped to at least 1; a value of at least
+    /// `2 * concurrency` keeps the pool full even while the head leaf is the
+    /// straggler.
+    pub fn into_windowed_reader(self, window: usize) -> WindowedReader<G, M, BODY_SIZE> {
+        WindowedReader {
+            getter: Arc::clone(self.getter()),
+            subtrees: self.subtrees().to_vec(),
+            tree: self.tree(),
+            span: self.size(),
+            concurrency: self.concurrency(),
+            position: self.position(),
+            root: *self.root(),
+            window: window.max(1),
+        }
+    }
+}
+
+impl<G, M, const BODY_SIZE: usize> WindowedReader<G, M, BODY_SIZE>
+where
+    G: ChunkGet<BODY_SIZE> + 'static,
+    M: JoinMode + MaybeSend + Sync,
+{
+    /// In-order leaf bodies from the current position to EOF. Each item is one
+    /// contiguous run; reassembly is pure concatenation. Peak memory is `window`
+    /// leaf bodies: the window slides with the emit cursor, so only leaves within
+    /// `window` spans ahead of it are ever fetched or held.
+    pub fn stream(&mut self) -> impl Stream<Item = Result<Bytes>> + '_ {
+        windowed_walk::<G, M, BODY_SIZE>(
+            Arc::clone(&self.getter),
+            self.subtrees.clone(),
+            self.tree,
+            self.span,
+            self.concurrency,
+            self.position,
+            self.window,
+        )
+    }
+
+    /// Reposition: drop the window and restart the walk from `pos`. Cheap; reuses
+    /// the frontier, no intermediate re-fetch.
+    pub fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        self.position = super::resolve_seek_position(pos, self.position, self.span)?;
+        Ok(self.position)
+    }
+
+    /// Current read position.
+    #[inline]
+    pub const fn position(&self) -> u64 {
+        self.position
+    }
+
+    /// Total file size.
+    #[inline]
+    pub const fn size(&self) -> u64 {
+        self.span
+    }
+}
+
+/// Cfg-gated boxed resolved-future alias: `+ Send` on native, unbounded on wasm.
+#[cfg(not(target_arch = "wasm32"))]
+type BoxResolvedFuture<M> = Pin<Box<dyn std::future::Future<Output = Resolved<M>> + Send>>;
+#[cfg(target_arch = "wasm32")]
+type BoxResolvedFuture<M> = Pin<Box<dyn std::future::Future<Output = Resolved<M>>>>;
+
+/// One unit of pending work: a tree node plus its remaining retry budget. The
+/// budget only decrements on a failed leaf fetch.
+struct Pending<M: JoinMode> {
+    node: SubtreeNode<M>,
+    retries: u32,
+}
+
+/// What a worker future resolves to once its chunk lands.
+enum Resolved<M: JoinMode> {
+    /// A leaf: its absolute byte offset and decoded body.
+    Leaf(u64, Bytes),
+    /// An intermediate: its overlapping children to re-queue.
+    Children(Vec<SubtreeNode<M>>),
+    /// A leaf fetch failed with retries left: re-queue this node.
+    Retry(Pending<M>),
+    /// A fetch failed terminally (retries exhausted or intermediate error).
+    Failed(FileError),
+}
+
+/// Is this node a leaf?
+#[inline]
+fn is_leaf<M: JoinMode, const BS: usize>(node: &SubtreeNode<M>) -> bool {
+    node.span <= BS as u64
+}
+
+/// Fetch one node: a leaf yields its body, an intermediate yields its children.
+/// A leaf error consumes one retry, then re-queues or fails.
+async fn fetch_one<G, M, const BS: usize>(
+    getter: &G,
+    chunk_range: &ChunkRange,
+    pending: Pending<M>,
+) -> Resolved<M>
+where
+    G: ChunkGet<BS>,
+    M: JoinMode + MaybeSend + Sync,
+{
+    let node = &pending.node;
+    let body = match super::mode::read_chunk_body_async::<M, G, BS>(
+        getter,
+        &node.addr,
+        &node.context,
+        node.span,
+    )
+    .await
+    {
+        Ok(body) => body,
+        Err(e) => {
+            if is_leaf::<M, BS>(node) && pending.retries > 0 {
+                return Resolved::Retry(Pending {
+                    node: pending.node,
+                    retries: pending.retries - 1,
+                });
+            }
+            return Resolved::Failed(e);
+        }
+    };
+
+    if is_leaf::<M, BS>(node) {
+        return Resolved::Leaf(node.byte_offset, body);
+    }
+    match overlapping_children::<M, BS>(&body, node, chunk_range) {
+        Ok(children) => Resolved::Children(children),
+        Err(e) => Resolved::Failed(e),
+    }
+}
+
+/// Window-bounded in-order walk from `start` to EOF.
+///
+/// A single walk integrating fetch and reorder: intermediate nodes are always
+/// descended (few and small), but a leaf is moved from the pending queue into
+/// the in-flight pool only while in-flight plus buffered leaves are below
+/// `window`, and always the lowest-offset pending leaf first. Resolved leaves
+/// land in a `BTreeMap` reorder buffer keyed by absolute offset; the head is
+/// emitted when its offset equals `next_emit_offset`, which then advances by
+/// `body.len()` (never a fixed stride, so shorter encrypted leaves stay aligned)
+/// and frees a slot, sliding the window forward.
+///
+/// The head leaf is always the lowest-offset pending leaf, so it is admitted as
+/// soon as a slot is free and emission always makes progress: no deadlock. The
+/// count gate enforces the invariant that in-flight leaf fetches plus buffered
+/// leaves never exceed `window`, so peak memory is `window` leaf bodies
+/// regardless of resolve order, leaf span, or file size.
+fn windowed_walk<G, M, const BODY_SIZE: usize>(
+    getter: Arc<G>,
+    subtrees: Vec<SubtreeNode<M>>,
+    tree: TreeParams<BODY_SIZE>,
+    span: u64,
+    concurrency: usize,
+    start: u64,
+    window: usize,
+) -> impl Stream<Item = Result<Bytes>>
+where
+    G: ChunkGet<BODY_SIZE> + 'static,
+    M: JoinMode + MaybeSend + Sync,
+{
+    let width = concurrency.max(1);
+    let window = window.max(1);
+
+    let range_start = start.min(span);
+    let chunk_range = tree.chunks_for_range(range_start, span - range_start);
+
+    struct State<G, M: JoinMode> {
+        getter: Arc<G>,
+        chunk_range: ChunkRange,
+        range_start: u64,
+        width: usize,
+        window: usize,
+        next_emit_offset: u64,
+        /// Leaves not yet admitted to the pool, kept in offset order so the
+        /// lowest-offset (head) leaf is always admitted first.
+        leaf_queue: VecDeque<Pending<M>>,
+        /// Intermediate nodes pending descent; always admissible.
+        node_queue: VecDeque<Pending<M>>,
+        /// Count of in-flight leaf fetches (excludes intermediates).
+        leaf_in_flight: usize,
+        in_flight: FuturesUnordered<BoxResolvedFuture<M>>,
+        buffered: BTreeMap<u64, Bytes>,
+    }
+
+    // Seed the queues with the subtrees overlapping `[range_start, span)`,
+    // separating leaves (offset-gated) from intermediates (always admissible).
+    let mut leaf_queue = VecDeque::new();
+    let mut node_queue = VecDeque::new();
+    let range_start_byte = chunk_range.start * BODY_SIZE as u64;
+    let range_end_byte = chunk_range.end * BODY_SIZE as u64;
+    for st in subtrees {
+        if st.byte_offset >= range_end_byte || st.byte_offset + st.span <= range_start_byte {
+            continue;
+        }
+        let pending = Pending {
+            node: st,
+            retries: DEFAULT_LEAF_RETRIES,
+        };
+        if is_leaf::<M, BODY_SIZE>(&pending.node) {
+            leaf_queue.push_back(pending);
+        } else {
+            node_queue.push_back(pending);
+        }
+    }
+
+    let state = State::<G, M> {
+        getter,
+        chunk_range,
+        range_start,
+        width,
+        window,
+        next_emit_offset: range_start,
+        leaf_queue,
+        node_queue,
+        leaf_in_flight: 0,
+        in_flight: FuturesUnordered::new(),
+        buffered: BTreeMap::new(),
+    };
+
+    stream::unfold(state, move |mut state| async move {
+        loop {
+            // Emit the head leaf as soon as it is buffered, advancing the cursor
+            // and sliding the window so the refill below admits newly-in-range
+            // leaves on the next turn.
+            let head_ready = state
+                .buffered
+                .first_key_value()
+                .is_some_and(|(&k, _)| k == state.next_emit_offset);
+            if head_ready {
+                let (_, body) = state.buffered.pop_first().expect("head just observed");
+                state.next_emit_offset += body.len() as u64;
+                return Some((Ok(body), state));
+            }
+
+            // Refill the pool: intermediates always; a leaf only while a leaf slot
+            // is free, that is while in-flight plus buffered leaves are below
+            // `window`, and always the lowest-offset (head) leaf first. The head
+            // is therefore admitted as soon as a slot frees, so progress is
+            // guaranteed and at most `window` leaf bodies are ever held.
+            loop {
+                if state.in_flight.len() >= state.width {
+                    break;
+                }
+                if let Some(pending) = state.node_queue.pop_front() {
+                    let getter = Arc::clone(&state.getter);
+                    let range = state.chunk_range;
+                    state.in_flight.push(Box::pin(async move {
+                        fetch_one::<G, M, BODY_SIZE>(&*getter, &range, pending).await
+                    }) as BoxResolvedFuture<M>);
+                    continue;
+                }
+                if state.leaf_in_flight + state.buffered.len() >= state.window
+                    || state.leaf_queue.is_empty()
+                {
+                    break;
+                }
+                let pending = state
+                    .leaf_queue
+                    .pop_front()
+                    .expect("non-empty just observed");
+                state.leaf_in_flight += 1;
+                let getter = Arc::clone(&state.getter);
+                let range = state.chunk_range;
+                state.in_flight.push(Box::pin(async move {
+                    fetch_one::<G, M, BODY_SIZE>(&*getter, &range, pending).await
+                }) as BoxResolvedFuture<M>);
+            }
+
+            // In-flight leaf fetches plus buffered leaves never exceed `window`.
+            let occupancy = state.leaf_in_flight + state.buffered.len();
+            debug_assert!(
+                occupancy <= state.window,
+                "windowed walk exceeded the leaf-body bound"
+            );
+            #[cfg(test)]
+            record_occupancy(occupancy);
+
+            // Pool empty and nothing left to admit: the file is drained.
+            let resolved = match state.in_flight.next().await {
+                Some(r) => r,
+                None => return None,
+            };
+            match resolved {
+                Resolved::Leaf(leaf_start, body) => {
+                    state.leaf_in_flight -= 1;
+                    // Clip the first partial leaf at the read position; offsets
+                    // stay absolute, so a boundary leaf buffers only its in-range
+                    // tail keyed at the read position.
+                    let leaf_end = leaf_start + body.len() as u64;
+                    if leaf_end <= state.range_start {
+                        continue;
+                    }
+                    let clip_lo = state.range_start.saturating_sub(leaf_start) as usize;
+                    let offset = leaf_start.max(state.range_start);
+                    state.buffered.insert(offset, body.slice(clip_lo..));
+                }
+                Resolved::Children(children) => {
+                    for child in children {
+                        let pending = Pending {
+                            node: child,
+                            retries: DEFAULT_LEAF_RETRIES,
+                        };
+                        if is_leaf::<M, BODY_SIZE>(&pending.node) {
+                            // Keep the leaf queue ordered by offset so the front
+                            // is always the lowest, which the window gate tests.
+                            let pos = state
+                                .leaf_queue
+                                .partition_point(|p| p.node.byte_offset < pending.node.byte_offset);
+                            state.leaf_queue.insert(pos, pending);
+                        } else {
+                            state.node_queue.push_back(pending);
+                        }
+                    }
+                }
+                Resolved::Retry(pending) => {
+                    // Re-enqueue in offset order so the gate still sees the lowest
+                    // leaf at the front and the slot it held is freed for refill.
+                    state.leaf_in_flight -= 1;
+                    let pos = state
+                        .leaf_queue
+                        .partition_point(|p| p.node.byte_offset < pending.node.byte_offset);
+                    state.leaf_queue.insert(pos, pending);
+                }
+                Resolved::Failed(e) => return Some((Err(e), state)),
+            }
+        }
+    })
+}
+
+/// Native `AsyncRead` + `AsyncSeek` shim, draining [`WindowedReader::stream`]
+/// into a residual buffer.
+#[cfg(feature = "tokio")]
+pub struct WindowedJoinerReader<G, M: JoinMode, const BODY_SIZE: usize = DEFAULT_BODY_SIZE>
+where
+    G: ChunkGet<BODY_SIZE>,
+{
+    reader: WindowedReader<G, M, BODY_SIZE>,
+    residual: Bytes,
+    #[allow(clippy::type_complexity)]
+    stream: Option<Pin<Box<dyn Stream<Item = Result<Bytes>> + Send>>>,
+}
+
+#[cfg(feature = "tokio")]
+impl<G, M, const BODY_SIZE: usize> std::fmt::Debug for WindowedJoinerReader<G, M, BODY_SIZE>
+where
+    G: ChunkGet<BODY_SIZE>,
+    M: JoinMode,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WindowedJoinerReader")
+            .field("reader", &self.reader)
+            .field("residual_len", &self.residual.len())
+            .field("has_stream", &self.stream.is_some())
+            .finish()
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl<G, M, const BODY_SIZE: usize> WindowedReader<G, M, BODY_SIZE>
+where
+    G: ChunkGet<BODY_SIZE> + 'static,
+    M: JoinMode + Send + Sync + 'static,
+{
+    /// Wrap as a tokio `AsyncRead` + `AsyncSeek` reader. Native-only.
+    pub fn into_async_reader(self) -> WindowedJoinerReader<G, M, BODY_SIZE> {
+        WindowedJoinerReader {
+            reader: self,
+            residual: Bytes::new(),
+            stream: None,
+        }
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl<G: ChunkGet<BODY_SIZE>, M: JoinMode, const BODY_SIZE: usize> Unpin
+    for WindowedJoinerReader<G, M, BODY_SIZE>
+{
+}
+
+#[cfg(feature = "tokio")]
+impl<G, M, const BODY_SIZE: usize> tokio::io::AsyncRead for WindowedJoinerReader<G, M, BODY_SIZE>
+where
+    G: ChunkGet<BODY_SIZE> + 'static,
+    M: JoinMode + Send + Sync + 'static,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        use bytes::Buf;
+        use std::task::Poll;
+
+        let this = self.get_mut();
+
+        if !this.residual.is_empty() {
+            let to_copy = this.residual.len().min(buf.remaining());
+            buf.put_slice(&this.residual[..to_copy]);
+            this.residual.advance(to_copy);
+            return Poll::Ready(Ok(()));
+        }
+
+        if this.stream.is_none() {
+            // Rebuild an owned `'static` stream from the retained joiner parts,
+            // so the boxed stream does not borrow `this`. Cloning the parts is the
+            // same cost as `stream()`; no frontier re-expansion.
+            let r = &this.reader;
+            this.stream = Some(Box::pin(windowed_walk::<G, M, BODY_SIZE>(
+                Arc::clone(&r.getter),
+                r.subtrees.clone(),
+                r.tree,
+                r.span,
+                r.concurrency,
+                r.position,
+                r.window,
+            )));
+        }
+
+        let stream = this.stream.as_mut().expect("stream just set");
+        match stream.as_mut().poll_next(cx) {
+            Poll::Ready(Some(Ok(body))) => {
+                let to_copy = body.len().min(buf.remaining());
+                buf.put_slice(&body[..to_copy]);
+                this.reader.position += body.len() as u64;
+                if to_copy < body.len() {
+                    this.residual = body.slice(to_copy..);
+                }
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Some(Err(e))) => Poll::Ready(Err(std::io::Error::other(e))),
+            Poll::Ready(None) => Poll::Ready(Ok(())),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl<G, M, const BODY_SIZE: usize> tokio::io::AsyncSeek for WindowedJoinerReader<G, M, BODY_SIZE>
+where
+    G: ChunkGet<BODY_SIZE> + 'static,
+    M: JoinMode + Send + Sync + 'static,
+{
+    fn start_seek(self: Pin<&mut Self>, pos: SeekFrom) -> std::io::Result<()> {
+        let this = self.get_mut();
+        this.stream = None;
+        this.residual = Bytes::new();
+        this.reader.seek(pos)?;
+        Ok(())
+    }
+
+    fn poll_complete(
+        self: Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<u64>> {
+        std::task::Poll::Ready(Ok(self.get_mut().reader.position))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bmt::DEFAULT_BODY_SIZE;
+    use crate::chunk::AnyChunk;
+    use crate::file::Joiner;
+    use crate::file::sync_split;
+    use futures::executor::block_on;
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn split_and_store(data: &[u8]) -> (ChunkAddress, HashMap<ChunkAddress, AnyChunk>) {
+        let (root, store) = sync_split::<DEFAULT_BODY_SIZE>(data).unwrap();
+        (root, store.into_chunks())
+    }
+
+    async fn drain(
+        reader: &mut WindowedReader<HashMap<ChunkAddress, AnyChunk>, super::super::mode::PlainMode>,
+    ) -> Vec<u8> {
+        let stream = reader.stream();
+        futures::pin_mut!(stream);
+        let mut out = Vec::new();
+        while let Some(item) = stream.next().await {
+            out.extend_from_slice(&item.unwrap());
+        }
+        out
+    }
+
+    #[test]
+    fn stream_from_zero_equals_whole_file() {
+        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 321)
+            .map(|i| (i % 256) as u8)
+            .collect();
+        let (root, store) = split_and_store(&data);
+        block_on(async {
+            let joiner = Joiner::new(store, root).await.unwrap();
+            let mut reader = joiner.into_windowed_reader(16);
+            let got = drain(&mut reader).await;
+            assert_eq!(got, data);
+        });
+    }
+
+    #[test]
+    fn seek_then_stream_yields_suffix() {
+        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 321)
+            .map(|i| (i % 256) as u8)
+            .collect();
+        let bs = DEFAULT_BODY_SIZE as u64;
+        let cases = [bs + 10, bs, bs * 3, bs / 2, data.len() as u64 - 1];
+        let (root, store) = split_and_store(&data);
+        block_on(async {
+            for k in cases {
+                let joiner = Joiner::new(store.clone(), root).await.unwrap();
+                let mut reader = joiner.into_windowed_reader(16);
+                reader.seek(SeekFrom::Start(k)).unwrap();
+                let got = drain(&mut reader).await;
+                assert_eq!(got, &data[k as usize..], "suffix from {k}");
+            }
+        });
+    }
+
+    #[test]
+    fn backward_seek_then_read_is_correct() {
+        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 4 + 17)
+            .map(|i| (i % 256) as u8)
+            .collect();
+        let bs = DEFAULT_BODY_SIZE as u64;
+        let (root, store) = split_and_store(&data);
+        block_on(async {
+            let joiner = Joiner::new(store, root).await.unwrap();
+            let mut reader = joiner.into_windowed_reader(16);
+            reader.seek(SeekFrom::Start(bs * 3)).unwrap();
+            let _ = drain(&mut reader).await;
+            reader.seek(SeekFrom::Start(bs)).unwrap();
+            let got = drain(&mut reader).await;
+            assert_eq!(got, &data[bs as usize..]);
+        });
+    }
+
+    #[test]
+    fn width_one_correct() {
+        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 7)
+            .map(|i| (i % 256) as u8)
+            .collect();
+        let (root, store) = split_and_store(&data);
+        block_on(async {
+            let joiner = Joiner::new(store, root).await.unwrap().with_concurrency(1);
+            let mut reader = joiner.into_windowed_reader(1);
+            let got = drain(&mut reader).await;
+            assert_eq!(got, data);
+        });
+    }
+
+    /// A self-waking yield: returns `Pending` once and immediately schedules a
+    /// re-poll, so it makes progress under `futures::executor::block_on`.
+    async fn yield_now() {
+        struct YieldNow(bool);
+        impl std::future::Future for YieldNow {
+            type Output = ();
+            fn poll(
+                mut self: Pin<&mut Self>,
+                cx: &mut std::task::Context<'_>,
+            ) -> std::task::Poll<()> {
+                if self.0 {
+                    std::task::Poll::Ready(())
+                } else {
+                    self.0 = true;
+                    cx.waker().wake_by_ref();
+                    std::task::Poll::Pending
+                }
+            }
+        }
+        YieldNow(false).await
+    }
+
+    /// A getter that records peak concurrent fetches so a test can assert the
+    /// reorder buffer never admits more than `window` leaves at once.
+    #[derive(Clone)]
+    struct BoundProbe {
+        chunks: Arc<HashMap<ChunkAddress, AnyChunk>>,
+        in_flight: Arc<AtomicUsize>,
+        max_in_flight: Arc<AtomicUsize>,
+    }
+
+    impl ChunkGet<DEFAULT_BODY_SIZE> for BoundProbe {
+        type Error = crate::store::ChunkStoreError;
+
+        async fn get(&self, address: &ChunkAddress) -> std::result::Result<AnyChunk, Self::Error> {
+            let now = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+            self.max_in_flight.fetch_max(now, Ordering::SeqCst);
+            // Hold the fetch open across several self-waking yields so
+            // concurrently admitted leaves overlap here before any resolves.
+            for _ in 0..4 {
+                yield_now().await;
+            }
+            self.in_flight.fetch_sub(1, Ordering::SeqCst);
+            self.chunks
+                .get(address)
+                .cloned()
+                .ok_or_else(|| crate::store::ChunkStoreError::not_found(address))
+        }
+    }
+
+    #[test]
+    fn reorder_buffer_never_exceeds_window() {
+        // Many leaves, small window: leaf fetches overlap, so without the bound
+        // the in-flight peak would climb to the leaf count. The window caps it.
+        let leaves = 40usize;
+        let window = 6usize;
+        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * leaves)
+            .map(|i| (i % 256) as u8)
+            .collect();
+        let (root, store) = split_and_store(&data);
+
+        let probe = BoundProbe {
+            chunks: Arc::new(store),
+            in_flight: Arc::new(AtomicUsize::new(0)),
+            max_in_flight: Arc::new(AtomicUsize::new(0)),
+        };
+        let max_seen = Arc::clone(&probe.max_in_flight);
+
+        block_on(async {
+            let joiner = Joiner::new(probe, root)
+                .await
+                .unwrap()
+                .with_concurrency(leaves);
+            let mut reader = joiner.into_windowed_reader(window);
+            let stream = reader.stream();
+            futures::pin_mut!(stream);
+            let mut total = 0usize;
+            while let Some(item) = stream.next().await {
+                total += item.unwrap().len();
+            }
+            assert_eq!(total, data.len());
+        });
+
+        // The reorder buffer admits at most `window` leaves, so concurrent leaf
+        // fetches (plus the intermediate node fetches that seed children) never
+        // climb far above the window. Allow a small slack for in-flight
+        // intermediates, but assert it is nowhere near the leaf count.
+        let peak = max_seen.load(Ordering::SeqCst);
+        assert!(
+            peak <= window + 2,
+            "in-flight peak {peak} exceeds window {window} (+slack)"
+        );
+    }
+
+    /// A getter that delays the leaf at `slow_offset` until `gate` other leaves
+    /// have resolved. This is the adversarial resolve order the original reorder
+    /// buffer mishandled: with the head leaf landing last, the old buffer kept
+    /// fetching and buffering later leaves, so resident leaf bodies (in-flight
+    /// plus buffered) climbed to roughly twice the window. The sliding window
+    /// refuses to fetch past a free slot, holding the total at the window.
+    #[derive(Clone)]
+    struct HeadSlow {
+        chunks: Arc<HashMap<ChunkAddress, AnyChunk>>,
+        /// File offset of the head leaf to delay.
+        slow_offset: u64,
+        /// Number of leaves released so far (used to gate the slow leaf).
+        released: Arc<AtomicUsize>,
+        /// How many other leaves must release before the slow leaf may.
+        gate: usize,
+        /// Address-to-offset map so the getter can recognise the head leaf.
+        leaf_offsets: Arc<HashMap<ChunkAddress, u64>>,
+    }
+
+    impl ChunkGet<DEFAULT_BODY_SIZE> for HeadSlow {
+        type Error = crate::store::ChunkStoreError;
+
+        async fn get(&self, address: &ChunkAddress) -> std::result::Result<AnyChunk, Self::Error> {
+            let is_slow = self.leaf_offsets.get(address) == Some(&self.slow_offset);
+            if is_slow {
+                // Park until the gate of other leaves has released, then a few
+                // more yields so a buffer would overflow if it were unbounded.
+                while self.released.load(Ordering::SeqCst) < self.gate {
+                    yield_now().await;
+                }
+                for _ in 0..4 {
+                    yield_now().await;
+                }
+            } else {
+                for _ in 0..4 {
+                    yield_now().await;
+                }
+                if self.leaf_offsets.contains_key(address) {
+                    self.released.fetch_add(1, Ordering::SeqCst);
+                }
+            }
+
+            self.chunks
+                .get(address)
+                .cloned()
+                .ok_or_else(|| crate::store::ChunkStoreError::not_found(address))
+        }
+    }
+
+    /// Distinct byte per file position, so every leaf body (and thus its
+    /// content address) is unique. A `(i % 256)` fill would make all full leaves
+    /// identical, collapsing the address-to-offset map and defeating the
+    /// per-leaf delay below.
+    fn unique_byte(i: u64) -> u8 {
+        (i.wrapping_mul(2_654_435_761) >> 11) as u8
+    }
+
+    /// Map each leaf chunk address to its file offset. Leaf bodies are
+    /// content-addressed, so rebuilding each leaf from `unique_byte` reproduces
+    /// the stored address.
+    fn leaf_offsets_of(total: u64) -> HashMap<ChunkAddress, u64> {
+        use crate::chunk::Chunk;
+        let mut map = HashMap::new();
+        let leaves = total.div_ceil(DEFAULT_BODY_SIZE as u64);
+        for i in 0..leaves {
+            let off = i * DEFAULT_BODY_SIZE as u64;
+            let end = (off + DEFAULT_BODY_SIZE as u64).min(total);
+            let body: Vec<u8> = (off..end).map(unique_byte).collect();
+            let chunk = crate::chunk::ContentChunk::<DEFAULT_BODY_SIZE>::new(body).unwrap();
+            map.insert(*chunk.address(), off);
+        }
+        map
+    }
+
+    #[test]
+    fn head_slowest_in_order_and_bounded() {
+        // The head leaf at `position` resolves last among the leaves in its
+        // window. Under the old buffer this leaks: with the head missing, the
+        // walk kept `window` leaf fetches in flight while also buffering the
+        // resolved stragglers, so resident leaf bodies reached roughly twice the
+        // window. The sliding window keeps in-flight plus buffered at `window` and
+        // delivery in order. A naive run at `gate = window` instead would deadlock
+        // the correct walk (the head can never release), so the gate is the most a
+        // non-deadlocking adversary can demand, and the old buffer still overruns
+        // it.
+        let leaves = 40usize;
+        let window = 6usize;
+        let total = (DEFAULT_BODY_SIZE * leaves) as u64;
+        let data: Vec<u8> = (0..total).map(unique_byte).collect();
+        let (root, store) = split_and_store(&data);
+
+        PEAK_LEAF_OCCUPANCY.with(|p| p.set(0));
+        let leaf_offsets = leaf_offsets_of(total);
+        let getter = HeadSlow {
+            chunks: Arc::new(store),
+            slow_offset: 0,
+            released: Arc::new(AtomicUsize::new(0)),
+            gate: window - 1,
+            leaf_offsets: Arc::new(leaf_offsets),
+        };
+
+        block_on(async {
+            let joiner = Joiner::new(getter, root)
+                .await
+                .unwrap()
+                .with_concurrency(leaves);
+            let mut reader = joiner.into_windowed_reader(window);
+            let stream = reader.stream();
+            futures::pin_mut!(stream);
+            let mut got = Vec::new();
+            while let Some(item) = stream.next().await {
+                got.extend_from_slice(&item.unwrap());
+            }
+            assert_eq!(got, data, "head-slowest still yields whole file in order");
+        });
+
+        let peak = PEAK_LEAF_OCCUPANCY.with(std::cell::Cell::get);
+        assert!(
+            peak <= window,
+            "leaf-body occupancy peak {peak} exceeds window {window}"
+        );
+    }
+
+    #[cfg(feature = "encryption")]
+    #[test]
+    fn head_slowest_encrypted_in_order_and_bounded() {
+        // Encrypted leaf bodies are shorter than BODY_SIZE, so the slide must
+        // advance by body.len(), not the stride. Encrypted leaf addresses hash
+        // the ciphertext and are not reconstructible from plaintext here, so the
+        // head cannot be singled out; a uniform delay across all fetches still
+        // overlaps concurrently admitted leaves, and the occupancy hook proves a
+        // correct walk holds at most `window` leaf bodies on short bodies.
+        use crate::file::EncryptedJoiner;
+        use crate::file::sync_split_encrypted;
+
+        let leaves = 30usize;
+        let window = 5usize;
+        let total = (DEFAULT_BODY_SIZE * leaves) as u64;
+        let data: Vec<u8> = (0..total).map(unique_byte).collect();
+        let (root_ref, store) = sync_split_encrypted::<DEFAULT_BODY_SIZE>(&data).unwrap();
+        let store = store.into_chunks();
+
+        PEAK_LEAF_OCCUPANCY.with(|p| p.set(0));
+        let getter = UniformSlow {
+            chunks: Arc::new(store),
+        };
+
+        block_on(async {
+            let joiner = EncryptedJoiner::new(getter, root_ref)
+                .await
+                .unwrap()
+                .with_concurrency(leaves);
+            let mut reader = joiner.into_windowed_reader(window);
+            let stream = reader.stream();
+            futures::pin_mut!(stream);
+            let mut out = Vec::new();
+            while let Some(item) = stream.next().await {
+                out.extend_from_slice(&item.unwrap());
+            }
+            assert_eq!(out, data, "encrypted short-body slide stays in order");
+        });
+
+        let peak = PEAK_LEAF_OCCUPANCY.with(std::cell::Cell::get);
+        assert!(
+            peak <= window,
+            "encrypted leaf-body occupancy peak {peak} exceeds window {window}"
+        );
+    }
+
+    /// A getter that holds every fetch open across several self-waking yields so
+    /// concurrently admitted leaves overlap. Used where addresses cannot be
+    /// mapped to offsets (encrypted leaves), so the head cannot be singled out;
+    /// the occupancy hook still proves the window bound.
+    #[cfg(feature = "encryption")]
+    #[derive(Clone)]
+    struct UniformSlow {
+        chunks: Arc<HashMap<ChunkAddress, AnyChunk>>,
+    }
+
+    #[cfg(feature = "encryption")]
+    impl ChunkGet<DEFAULT_BODY_SIZE> for UniformSlow {
+        type Error = crate::store::ChunkStoreError;
+
+        async fn get(&self, address: &ChunkAddress) -> std::result::Result<AnyChunk, Self::Error> {
+            for _ in 0..4 {
+                yield_now().await;
+            }
+            self.chunks
+                .get(address)
+                .cloned()
+                .ok_or_else(|| crate::store::ChunkStoreError::not_found(address))
+        }
+    }
+
+    #[cfg(feature = "encryption")]
+    mod encrypted {
+        use super::*;
+        use crate::file::EncryptedJoiner;
+        use crate::file::sync_split_encrypted;
+
+        async fn drain_enc(
+            reader: &mut WindowedReader<
+                HashMap<ChunkAddress, AnyChunk>,
+                crate::file::mode::EncryptedMode,
+            >,
+        ) -> Vec<u8> {
+            let stream = reader.stream();
+            futures::pin_mut!(stream);
+            let mut out = Vec::new();
+            while let Some(item) = stream.next().await {
+                out.extend_from_slice(&item.unwrap());
+            }
+            out
+        }
+
+        #[test]
+        fn encrypted_stream_and_seek() {
+            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 321)
+                .map(|i| (i % 256) as u8)
+                .collect();
+            let bs = DEFAULT_BODY_SIZE as u64;
+            let (root_ref, store) = sync_split_encrypted::<DEFAULT_BODY_SIZE>(&data).unwrap();
+            let store = store.into_chunks();
+            block_on(async {
+                // whole file
+                let joiner = EncryptedJoiner::new(store.clone(), root_ref.clone())
+                    .await
+                    .unwrap();
+                let mut reader = joiner.into_windowed_reader(16);
+                assert_eq!(drain_enc(&mut reader).await, data);
+
+                // mid-leaf and leaf-aligned suffixes
+                for k in [bs + 10, bs, bs * 3] {
+                    let joiner = EncryptedJoiner::new(store.clone(), root_ref.clone())
+                        .await
+                        .unwrap();
+                    let mut reader = joiner.into_windowed_reader(16);
+                    reader.seek(SeekFrom::Start(k)).unwrap();
+                    assert_eq!(drain_enc(&mut reader).await, &data[k as usize..]);
+                }
+            });
+        }
+    }
+
+    #[cfg(feature = "tokio")]
+    #[tokio::test]
+    async fn async_reader_seek_and_read() {
+        use tokio::io::{AsyncReadExt, AsyncSeekExt};
+
+        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3 + 50)
+            .map(|i| (i % 256) as u8)
+            .collect();
+        let (root, store) = split_and_store(&data);
+        let joiner = Joiner::new(store, root).await.unwrap();
+        let mut reader = joiner.into_windowed_reader(16).into_async_reader();
+
+        let mut all = Vec::new();
+        reader.read_to_end(&mut all).await.unwrap();
+        assert_eq!(all, data);
+
+        reader
+            .seek(SeekFrom::Start(DEFAULT_BODY_SIZE as u64))
+            .await
+            .unwrap();
+        let mut tail = Vec::new();
+        reader.read_to_end(&mut tail).await.unwrap();
+        assert_eq!(tail, &data[DEFAULT_BODY_SIZE..]);
+    }
+}

--- a/crates/primitives/src/file/write_at.rs
+++ b/crates/primitives/src/file/write_at.rs
@@ -3,7 +3,12 @@
 use std::io;
 use std::sync::Mutex;
 
-use crate::store::{MaybeSend, MaybeSync};
+use futures::StreamExt;
+
+use super::error::FileError;
+use super::joiner::GenericJoiner;
+use super::mode::JoinMode;
+use crate::store::{ChunkGet, MaybeSend, MaybeSync};
 
 /// Async random-access write sink. Each leaf body is written at its absolute
 /// offset; when every offset is written the sink is whole. Not `Send`-bound so
@@ -124,6 +129,44 @@ impl<T: WriteAt + ?Sized> WriteAt for &T {
     }
 }
 
+impl<G, M, const BODY_SIZE: usize> GenericJoiner<G, M, BODY_SIZE>
+where
+    G: ChunkGet<BODY_SIZE> + 'static,
+    M: JoinMode + MaybeSend + Sync,
+{
+    /// Reassemble the whole file into `sink`, writing each out-of-order leaf at
+    /// its offset. Peak memory is the in-flight width, never the file size.
+    /// Cancel-safe: dropping the returned future drops the chunk stream
+    /// (cancelling in-flight fetches) and the sink; a partially-written sink is
+    /// sparse-valid and safe to resume.
+    pub async fn download_into<S: WriteAt>(self, sink: S) -> super::error::Result<()> {
+        self.download_into_with_progress(sink, |_, _| {}).await
+    }
+
+    /// As [`download_into`](Self::download_into), invoking
+    /// `on_progress(written, total)` after each leaf lands.
+    pub async fn download_into_with_progress<S: WriteAt, F: FnMut(u64, u64)>(
+        self,
+        sink: S,
+        mut on_progress: F,
+    ) -> super::error::Result<()> {
+        let total = self.size();
+        sink.set_len(total).await.map_err(FileError::sink)?;
+        let mut stream = std::pin::pin!(self.into_offset_stream_chunked());
+        let mut written = 0u64;
+        while let Some(item) = stream.next().await {
+            let (offset, body) = item?;
+            sink.write_at(offset, &body)
+                .await
+                .map_err(FileError::sink)?;
+            written += body.len() as u64;
+            on_progress(written, total);
+        }
+        sink.flush().await.map_err(FileError::sink)?;
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -183,5 +226,151 @@ mod tests {
             sink.set_len(8).await.unwrap();
             assert_eq!(sink.into_inner().unwrap(), vec![0u8; 8]);
         });
+    }
+}
+
+#[cfg(all(test, feature = "tokio"))]
+mod download_tests {
+    use super::*;
+
+    use crate::DEFAULT_BODY_SIZE;
+    use crate::chunk::AnyChunk;
+    use crate::file::{Joiner, sync_split};
+    use futures::executor::block_on;
+    use std::collections::HashMap;
+
+    type Store = HashMap<crate::ChunkAddress, AnyChunk>;
+
+    fn split_and_store(data: &[u8]) -> (crate::ChunkAddress, Store) {
+        let (root, store) = sync_split::<DEFAULT_BODY_SIZE>(data).unwrap();
+        (root, store.into_chunks())
+    }
+
+    fn sample(len: usize) -> Vec<u8> {
+        (0..len).map(|i| (i % 256) as u8).collect()
+    }
+
+    /// `download_into` reassembles bytes equal to `read_all` across tree shapes.
+    fn assert_download_matches(data: &[u8], width: usize) {
+        block_on(async {
+            let (root, store) = split_and_store(data);
+
+            let expected = Joiner::new(store.clone(), root)
+                .await
+                .unwrap()
+                .read_all()
+                .await
+                .unwrap();
+
+            let joiner = Joiner::new(store, root)
+                .await
+                .unwrap()
+                .with_concurrency(width);
+            let sink = Mutex::new(Vec::new());
+            joiner.download_into(&sink).await.unwrap();
+
+            assert_eq!(sink.into_inner().unwrap(), expected);
+        });
+    }
+
+    #[test]
+    fn download_into_small() {
+        assert_download_matches(b"hello world", DEFAULT_BODY_SIZE);
+    }
+
+    #[test]
+    fn download_into_exact_chunk() {
+        assert_download_matches(&sample(DEFAULT_BODY_SIZE), 8);
+    }
+
+    #[test]
+    fn download_into_multi_level() {
+        let refs_per_chunk = DEFAULT_BODY_SIZE / super::super::constants::REF_SIZE;
+        assert_download_matches(&sample(DEFAULT_BODY_SIZE * (refs_per_chunk + 1) + 17), 8);
+    }
+
+    #[test]
+    fn download_into_width_one() {
+        assert_download_matches(&sample(DEFAULT_BODY_SIZE * 5 + 7), 1);
+    }
+
+    #[test]
+    fn download_with_progress_monotonic() {
+        block_on(async {
+            let data = sample(DEFAULT_BODY_SIZE * 4 + 99);
+            let (root, store) = split_and_store(&data);
+            let joiner = Joiner::new(store, root).await.unwrap();
+            let total = joiner.size();
+
+            let sink = Mutex::new(Vec::new());
+            let mut last = 0u64;
+            let mut last_total = None;
+            joiner
+                .download_into_with_progress(&sink, |written, t| {
+                    assert!(written >= last, "written must be non-decreasing");
+                    assert!(written <= t, "written must not exceed total");
+                    last = written;
+                    last_total = Some(t);
+                })
+                .await
+                .unwrap();
+
+            assert_eq!(last, total, "final written equals size");
+            assert_eq!(last_total, Some(total));
+            assert_eq!(sink.into_inner().unwrap(), data);
+        });
+    }
+
+    #[cfg(feature = "encryption")]
+    mod encrypted {
+        use super::*;
+        use crate::chunk::encryption::EncryptedChunkRef;
+        use crate::file::{EncryptedJoiner, sync_split_encrypted};
+
+        fn encrypted_split_and_store(data: &[u8]) -> (EncryptedChunkRef, Store) {
+            let (root_ref, store) = sync_split_encrypted::<DEFAULT_BODY_SIZE>(data).unwrap();
+            (root_ref, store.into_chunks())
+        }
+
+        fn assert_encrypted_download_matches(data: &[u8], width: usize) {
+            block_on(async {
+                let (root_ref, store) = encrypted_split_and_store(data);
+
+                let expected = EncryptedJoiner::new(store.clone(), root_ref.clone())
+                    .await
+                    .unwrap()
+                    .read_all()
+                    .await
+                    .unwrap();
+
+                let joiner = EncryptedJoiner::new(store, root_ref)
+                    .await
+                    .unwrap()
+                    .with_concurrency(width);
+                let sink = Mutex::new(Vec::new());
+                joiner.download_into(&sink).await.unwrap();
+
+                assert_eq!(sink.into_inner().unwrap(), expected);
+            });
+        }
+
+        #[test]
+        fn encrypted_download_into_small() {
+            assert_encrypted_download_matches(b"hello world", DEFAULT_BODY_SIZE);
+        }
+
+        #[test]
+        fn encrypted_download_into_multi_level() {
+            let refs_per_chunk = DEFAULT_BODY_SIZE / super::super::super::constants::REF_SIZE;
+            assert_encrypted_download_matches(
+                &sample(DEFAULT_BODY_SIZE * (refs_per_chunk + 1) + 17),
+                8,
+            );
+        }
+
+        #[test]
+        fn encrypted_download_into_width_one() {
+            assert_encrypted_download_matches(&sample(DEFAULT_BODY_SIZE * 5 + 7), 1);
+        }
     }
 }


### PR DESCRIPTION
## What
Builds the consumer-facing streaming layer over the offset stream:
- `into_offset_stream_chunked_range(start, len)`: range-scoped and boundary-clipped, for partial reads.
- `WindowedReader`: an in-order seek-and-play reader with a true sliding window, so playback memory is bounded to the window of leaf bodies and the window slides with the read cursor. Seeking drops the window and repositions without re-expanding the frontier.
- `for_each_chunk` and `try_for_each_window`: closure folds over the file (unordered max-throughput, and ordered bounded).
- `download_into`: drives the stream into an async `WriteAt` sink, writing each out-of-order leaf at its offset with memory bounded by the in-flight width, never the file size.

## Why
Closes #109. Even with the concurrent offset streams, consumers still hand-rolled range reads, in-order bounded playback, folds, and the random-access download driver.

## Testing
`cargo test --workspace` (default features), the doctests, and the `nectar-postage-usage` wasm32 check are green. Under `--features tokio,encryption` the streaming paths reassemble byte for byte against `read_all`/`read_range`, plain and encrypted. A head-slowest adversarial test pins the `WindowedReader` memory bound: it delays the leaf at the read cursor and asserts in-order delivery with peak resident leaf bodies no greater than the window (this test fails against an earlier unbounded draft).

## Notes
Stacked on #110, #111, #112, #113, #114; the tail of the train.

## AI Assistance
AI Assistance: Claude Code used for the design, implementation, and testing of this change.