### PR TITLE
refactor(primitives)!: drop dead sync/async qualifiers from names

### DIFF
--- a/crates/postage-issuer/benches/upload_pipeline.rs
+++ b/crates/postage-issuer/benches/upload_pipeline.rs
@@ -20,7 +20,7 @@ use nectar_postage_issuer::{
     BatchStamper, MemoryIssuer, ShardedIssuer, SigningError, Stamper, sign_stamps_parallel,
 };
 use nectar_primitives::DEFAULT_BODY_SIZE;
-use nectar_primitives::file::{SyncParallelSplitter, SyncSplitter};
+use nectar_primitives::file::{ParallelSplitter, Splitter};
 use nectar_primitives::store::MemoryStore;
 
 /// File sizes to benchmark, representing realistic upload scenarios.
@@ -63,7 +63,7 @@ fn bench_pipeline_mock_sequential(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::from_parameter(name), &data, |b, data| {
             b.iter(|| {
                 // Split file into chunks
-                let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
+                let mut splitter = Splitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
                 splitter.write_all(data).unwrap();
                 let (root, chunks) = splitter.finish().unwrap();
                 let store = MemoryStore::from_chunks(chunks);
@@ -99,7 +99,7 @@ fn bench_pipeline_mock_parallel_split(c: &mut Criterion) {
             b.iter(|| {
                 // Parallel split
                 let (root, chunks) =
-                    SyncParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap();
+                    ParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap();
                 let store = MemoryStore::from_chunks(chunks);
 
                 // Stamp each chunk (sequential)
@@ -136,7 +136,7 @@ fn bench_pipeline_ecdsa_sequential(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::from_parameter(name), &data, |b, data| {
             b.iter(|| {
                 // Split file into chunks
-                let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
+                let mut splitter = Splitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
                 splitter.write_all(data).unwrap();
                 let (root, chunks) = splitter.finish().unwrap();
                 let store = MemoryStore::from_chunks(chunks);
@@ -182,7 +182,7 @@ fn bench_pipeline_fully_parallel(c: &mut Criterion) {
             b.iter(|| {
                 // Parallel split
                 let (root, chunks) =
-                    SyncParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap();
+                    ParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap();
                 let store = MemoryStore::from_chunks(chunks);
 
                 // Collect addresses for parallel signing
@@ -221,7 +221,7 @@ fn bench_pipeline_comparison(c: &mut Criterion) {
     // Fully sequential
     group.bench_function("sequential", |b| {
         b.iter(|| {
-            let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
+            let mut splitter = Splitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
             splitter.write_all(&data).unwrap();
             let (root, chunks) = splitter.finish().unwrap();
             let store = MemoryStore::from_chunks(chunks);
@@ -243,7 +243,7 @@ fn bench_pipeline_comparison(c: &mut Criterion) {
     group.bench_function("parallel_split", |b| {
         b.iter(|| {
             let (root, chunks) =
-                SyncParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(&data).unwrap();
+                ParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(&data).unwrap();
             let store = MemoryStore::from_chunks(chunks);
 
             let issuer = MemoryIssuer::new(B256::ZERO, 32, 16);
@@ -263,7 +263,7 @@ fn bench_pipeline_comparison(c: &mut Criterion) {
     group.bench_function("fully_parallel", |b| {
         b.iter(|| {
             let (root, chunks) =
-                SyncParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(&data).unwrap();
+                ParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(&data).unwrap();
             let store = MemoryStore::from_chunks(chunks);
 
             let chunks = store.into_chunks();
@@ -293,7 +293,7 @@ fn bench_pipeline_stages(c: &mut Criterion) {
     // Stage 1: Split only (sequential)
     group.bench_function("1_split_sequential", |b| {
         b.iter(|| {
-            let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
+            let mut splitter = Splitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
             splitter.write_all(&data).unwrap();
             black_box(splitter.finish().unwrap())
         });
@@ -301,13 +301,11 @@ fn bench_pipeline_stages(c: &mut Criterion) {
 
     // Stage 1: Split only (parallel)
     group.bench_function("1_split_parallel", |b| {
-        b.iter(|| {
-            black_box(SyncParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(&data).unwrap())
-        });
+        b.iter(|| black_box(ParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(&data).unwrap()));
     });
 
     // Pre-split for stamp benchmarks
-    let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
+    let mut splitter = Splitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
     splitter.write_all(&data).unwrap();
     let (_, chunks) = splitter.finish().unwrap();
     let store = MemoryStore::from_chunks(chunks);

--- a/crates/primitives/benches/encryption_bench.rs
+++ b/crates/primitives/benches/encryption_bench.rs
@@ -11,8 +11,8 @@ use nectar_primitives::chunk::encryption::{
 };
 use nectar_primitives::chunk::{AnyChunk, ChunkAddress};
 use nectar_primitives::file::{
-    EncryptedJoiner, EncryptedSyncParallelSplitter, EncryptedSyncSplitter, Joiner,
-    SyncParallelSplitter, SyncSplitter, sync_split, sync_split_encrypted,
+    EncryptedJoiner, EncryptedParallelSplitter, EncryptedSplitter, Joiner, ParallelSplitter,
+    Splitter, split, split_encrypted,
 };
 use nectar_primitives::store::MemoryStore;
 use nectar_primitives::{ContentChunk, DEFAULT_BODY_SIZE};
@@ -133,7 +133,7 @@ fn random_data(size: u64) -> Vec<u8> {
 }
 
 fn split_to_store(data: &[u8]) -> (ChunkAddress, HashMap<ChunkAddress, AnyChunk>) {
-    let (root, store) = sync_split::<DEFAULT_BODY_SIZE>(data).unwrap();
+    let (root, store) = split::<DEFAULT_BODY_SIZE>(data).unwrap();
     (root, store.into_chunks())
 }
 
@@ -143,7 +143,7 @@ fn encrypted_split_to_store(
     encryption::EncryptedChunkRef,
     HashMap<ChunkAddress, AnyChunk>,
 ) {
-    let (root_ref, store) = sync_split_encrypted::<DEFAULT_BODY_SIZE>(data).unwrap();
+    let (root_ref, store) = split_encrypted::<DEFAULT_BODY_SIZE>(data).unwrap();
     (root_ref, store.into_chunks())
 }
 
@@ -156,8 +156,7 @@ fn bench_encrypted_streaming_splitter(c: &mut Criterion) {
         group.throughput(Throughput::Bytes(size));
         group.bench_with_input(BenchmarkId::from_parameter(name), &data, |b, data| {
             b.iter(|| {
-                let mut splitter =
-                    EncryptedSyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
+                let mut splitter = EncryptedSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
                 splitter.write_all(data).unwrap();
                 black_box(splitter.finish().unwrap())
             });
@@ -177,7 +176,7 @@ fn bench_encrypted_parallel_splitter(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::from_parameter(name), &data, |b, data| {
             b.iter(|| {
                 black_box(
-                    EncryptedSyncParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap(),
+                    EncryptedParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap(),
                 )
             });
         });
@@ -224,7 +223,7 @@ fn bench_plain_vs_encrypted_split(c: &mut Criterion) {
             &data,
             |b, data| {
                 b.iter(|| {
-                    let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
+                    let mut splitter = Splitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
                     splitter.write_all(data).unwrap();
                     black_box(splitter.finish().unwrap())
                 });
@@ -237,7 +236,7 @@ fn bench_plain_vs_encrypted_split(c: &mut Criterion) {
             |b, data| {
                 b.iter(|| {
                     let mut splitter =
-                        EncryptedSyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
+                        EncryptedSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
                     splitter.write_all(data).unwrap();
                     black_box(splitter.finish().unwrap())
                 });
@@ -246,7 +245,7 @@ fn bench_plain_vs_encrypted_split(c: &mut Criterion) {
 
         group.bench_with_input(BenchmarkId::new("plain_direct", name), &data, |b, data| {
             b.iter(|| {
-                black_box(SyncParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap())
+                black_box(ParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap())
             });
         });
 
@@ -256,8 +255,7 @@ fn bench_plain_vs_encrypted_split(c: &mut Criterion) {
             |b, data| {
                 b.iter(|| {
                     black_box(
-                        EncryptedSyncParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data)
-                            .unwrap(),
+                        EncryptedParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap(),
                     )
                 });
             },
@@ -329,7 +327,7 @@ fn bench_encrypted_roundtrip(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("direct", name), &data, |b, data| {
             b.iter(|| {
                 let (root_ref, chunks) =
-                    EncryptedSyncParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap();
+                    EncryptedParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap();
                 let store = MemoryStore::from_chunks(chunks);
                 let joiner = block_on(EncryptedJoiner::new(store, root_ref)).unwrap();
                 black_box(block_on(joiner.read_all()).unwrap())

--- a/crates/primitives/benches/file_bench.rs
+++ b/crates/primitives/benches/file_bench.rs
@@ -15,7 +15,7 @@ use futures::executor::block_on;
 
 use nectar_primitives::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{AnyChunk, ChunkAddress};
-use nectar_primitives::file::{Joiner, SyncParallelSplitter, SyncSplitter, sync_split};
+use nectar_primitives::file::{Joiner, ParallelSplitter, Splitter, split};
 use nectar_primitives::store::MemoryStore;
 
 /// File sizes to benchmark, covering typical use cases.
@@ -47,7 +47,7 @@ fn random_data(size: u64) -> Vec<u8> {
 }
 
 fn split_to_store(data: &[u8]) -> (ChunkAddress, HashMap<ChunkAddress, AnyChunk>) {
-    let (root, store) = sync_split::<DEFAULT_BODY_SIZE>(data).unwrap();
+    let (root, store) = split::<DEFAULT_BODY_SIZE>(data).unwrap();
     (root, store.into_chunks())
 }
 
@@ -61,7 +61,7 @@ fn bench_streaming_splitter(c: &mut Criterion) {
         group.throughput(Throughput::Bytes(size));
         group.bench_with_input(BenchmarkId::from_parameter(name), &data, |b, data| {
             b.iter(|| {
-                let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
+                let mut splitter = Splitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
                 splitter.write_all(data).unwrap();
                 black_box(splitter.finish().unwrap())
             });
@@ -81,7 +81,7 @@ fn bench_parallel_splitter(c: &mut Criterion) {
         group.throughput(Throughput::Bytes(size));
         group.bench_with_input(BenchmarkId::from_parameter(name), &data, |b, data| {
             b.iter(|| {
-                black_box(SyncParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap())
+                black_box(ParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap())
             });
         });
     }
@@ -100,7 +100,7 @@ fn bench_splitter_comparison(c: &mut Criterion) {
 
         group.bench_with_input(BenchmarkId::new("streaming", name), &data, |b, data| {
             b.iter(|| {
-                let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
+                let mut splitter = Splitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
                 splitter.write_all(data).unwrap();
                 black_box(splitter.finish().unwrap())
             });
@@ -108,7 +108,7 @@ fn bench_splitter_comparison(c: &mut Criterion) {
 
         group.bench_with_input(BenchmarkId::new("direct", name), &data, |b, data| {
             b.iter(|| {
-                black_box(SyncParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap())
+                black_box(ParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap())
             });
         });
     }
@@ -127,7 +127,7 @@ fn bench_incremental_writes(c: &mut Criterion) {
 
     group.bench_function("single_write", |b| {
         b.iter(|| {
-            let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
+            let mut splitter = Splitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
             splitter.write_all(&data).unwrap();
             black_box(splitter.finish().unwrap())
         });
@@ -135,7 +135,7 @@ fn bench_incremental_writes(c: &mut Criterion) {
 
     group.bench_function("4kb_chunks", |b| {
         b.iter(|| {
-            let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
+            let mut splitter = Splitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
             for chunk in data.chunks(4096) {
                 splitter.write_all(chunk).unwrap();
             }
@@ -145,7 +145,7 @@ fn bench_incremental_writes(c: &mut Criterion) {
 
     group.bench_function("64kb_chunks", |b| {
         b.iter(|| {
-            let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
+            let mut splitter = Splitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
             for chunk in data.chunks(65536) {
                 splitter.write_all(chunk).unwrap();
             }
@@ -205,7 +205,7 @@ fn bench_roundtrip(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("direct_split", name), &data, |b, data| {
             b.iter(|| {
                 let (root, chunks) =
-                    SyncParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap();
+                    ParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap();
                 let store = MemoryStore::from_chunks(chunks);
                 let joiner = block_on(Joiner::new(store, root)).unwrap();
                 black_box(block_on(joiner.read_all()).unwrap())

--- a/crates/primitives/src/bmt/tests.rs
+++ b/crates/primitives/src/bmt/tests.rs
@@ -70,7 +70,7 @@ fn test_hasher_empty_data() {
 }
 
 #[test]
-fn test_sync_hasher_correctness() {
+fn test_hasher_correctness() {
     let mut rng = rand::rng();
     let data: Vec<u8> = (0..DEFAULT_BODY_SIZE)
         .map(|_| rand::random::<u8>())

--- a/crates/primitives/src/chunk/wasm.rs
+++ b/crates/primitives/src/chunk/wasm.rs
@@ -118,7 +118,7 @@ impl WasmSplitResult {
 #[wasm_bindgen(js_name = splitFile)]
 pub fn split_file(data: &Uint8Array) -> Result<WasmSplitResult, JsValue> {
     let bytes = data.to_vec();
-    let (root, store) = crate::file::sync_split::<DEFAULT_BODY_SIZE>(&bytes)
+    let (root, store) = crate::file::split::<DEFAULT_BODY_SIZE>(&bytes)
         .map_err(|e| JsValue::from_str(&e.to_string()))?;
 
     Ok(WasmSplitResult {

--- a/crates/primitives/src/file/fold.rs
+++ b/crates/primitives/src/file/fold.rs
@@ -70,12 +70,12 @@ mod tests {
     use crate::bmt::DEFAULT_BODY_SIZE;
     use crate::chunk::{AnyChunk, ChunkAddress};
     use crate::file::Joiner;
-    use crate::file::sync_split;
+    use crate::file::split;
     use futures::executor::block_on;
     use std::collections::HashMap;
 
     fn split_and_store(data: &[u8]) -> (ChunkAddress, HashMap<ChunkAddress, AnyChunk>) {
-        let (root, store) = sync_split::<DEFAULT_BODY_SIZE>(data).unwrap();
+        let (root, store) = split::<DEFAULT_BODY_SIZE>(data).unwrap();
         (root, store.into_chunks())
     }
 
@@ -222,7 +222,7 @@ mod tests {
     mod encrypted {
         use super::*;
         use crate::file::EncryptedJoiner;
-        use crate::file::sync_split_encrypted;
+        use crate::file::split_encrypted;
 
         fn enc_split_and_store(
             data: &[u8],
@@ -230,7 +230,7 @@ mod tests {
             crate::chunk::encryption::EncryptedChunkRef,
             HashMap<ChunkAddress, AnyChunk>,
         ) {
-            let (root_ref, store) = sync_split_encrypted::<DEFAULT_BODY_SIZE>(data).unwrap();
+            let (root_ref, store) = split_encrypted::<DEFAULT_BODY_SIZE>(data).unwrap();
             (root_ref, store.into_chunks())
         }
 

--- a/crates/primitives/src/file/frontier.rs
+++ b/crates/primitives/src/file/frontier.rs
@@ -156,7 +156,7 @@ impl<M: JoinMode, const BS: usize> BfsExpander<M, BS> {
 /// producing a frontier of roughly equal-sized subtrees. All expandable nodes
 /// within a BFS level are fetched concurrently. Only children overlapping
 /// `chunk_range` are retained.
-pub(crate) async fn expand_frontier_async<G, M, const BS: usize>(
+pub(crate) async fn expand_frontier<G, M, const BS: usize>(
     getter: &G,
     root: &ChunkAddress,
     context: &M::JoinerContext,
@@ -189,7 +189,7 @@ where
             .iter()
             .map(|&i| {
                 let n = &bfs.frontier[i];
-                super::mode::read_chunk_body_async::<M, G, BS>(getter, &n.addr, &n.context, n.span)
+                super::mode::read_chunk_body::<M, G, BS>(getter, &n.addr, &n.context, n.span)
             })
             .collect();
 
@@ -208,7 +208,7 @@ where
 }
 
 /// Async iterative DFS descent within a subtree, collecting leaf bodies.
-pub(crate) async fn read_subtree_bodies_async<G, M, const BS: usize>(
+pub(crate) async fn read_subtree_bodies<G, M, const BS: usize>(
     getter: &G,
     node: &SubtreeNode<M>,
     chunk_range: &ChunkRange,
@@ -220,7 +220,7 @@ where
     let mut out = Vec::new();
     let mut stack = vec![node.clone()];
     while let Some(current) = stack.pop() {
-        let body = super::mode::read_chunk_body_async::<M, G, BS>(
+        let body = super::mode::read_chunk_body::<M, G, BS>(
             getter,
             &current.addr,
             &current.context,

--- a/crates/primitives/src/file/joiner.rs
+++ b/crates/primitives/src/file/joiner.rs
@@ -20,9 +20,7 @@ use crate::bmt::DEFAULT_BODY_SIZE;
 use crate::chunk::ChunkAddress;
 
 use super::error::{FileError, Result};
-use super::frontier::{
-    SubtreeNode, expand_frontier_async, overlapping_children, read_subtree_bodies_async,
-};
+use super::frontier::{SubtreeNode, expand_frontier, overlapping_children, read_subtree_bodies};
 use super::mode::{JoinMode, PlainMode};
 use super::tree::{ChunkRange, TreeParams};
 use crate::store::{ChunkGet, MaybeSend};
@@ -72,7 +70,7 @@ where
 }
 
 /// Collect leaf bodies for a set of subtrees with concurrent fetching.
-async fn collect_subtree_bodies_async<G, M, const BODY_SIZE: usize>(
+async fn collect_subtree_bodies<G, M, const BODY_SIZE: usize>(
     getter: &Arc<G>,
     subtrees: Vec<SubtreeNode<M>>,
     chunk_range: ChunkRange,
@@ -85,9 +83,7 @@ where
     let bodies: Vec<Bytes> = stream::iter(subtrees)
         .map(|st| {
             let getter = Arc::clone(getter);
-            async move {
-                read_subtree_bodies_async::<G, M, BODY_SIZE>(&*getter, &st, &chunk_range).await
-            }
+            async move { read_subtree_bodies::<G, M, BODY_SIZE>(&*getter, &st, &chunk_range).await }
         })
         .buffered(concurrency)
         .collect::<Vec<_>>()
@@ -110,20 +106,14 @@ where
         const { super::constants::assert_valid_body_size::<BODY_SIZE>() };
 
         let (root, span, context) =
-            super::mode::joiner_init_async::<M, G, BODY_SIZE>(&getter, input).await?;
+            super::mode::joiner_init::<M, G, BODY_SIZE>(&getter, input).await?;
         let tree = TreeParams::<BODY_SIZE>::new(span);
 
         let target = DEFAULT_ASYNC_CONCURRENCY * 2;
         let full_range = tree.chunks_for_range(0, span);
-        let subtrees = expand_frontier_async::<G, M, BODY_SIZE>(
-            &getter,
-            &root,
-            &context,
-            span,
-            &full_range,
-            target,
-        )
-        .await?;
+        let subtrees =
+            expand_frontier::<G, M, BODY_SIZE>(&getter, &root, &context, span, &full_range, target)
+                .await?;
 
         Ok(Self {
             getter: Arc::new(getter),
@@ -250,13 +240,9 @@ where
             .cloned()
             .collect();
 
-        let bodies = collect_subtree_bodies_async::<G, M, BODY_SIZE>(
-            getter,
-            relevant,
-            chunk_range,
-            concurrency,
-        )
-        .await?;
+        let bodies =
+            collect_subtree_bodies::<G, M, BODY_SIZE>(getter, relevant, chunk_range, concurrency)
+                .await?;
 
         Ok(super::tree::assemble_range(
             &tree,
@@ -298,9 +284,7 @@ where
 
                 // Fetch the next subtree's leaf bodies.
                 let st = state.subtrees.next()?;
-                match read_subtree_bodies_async::<G, M, BODY_SIZE>(&*getter, &st, &chunk_range)
-                    .await
-                {
+                match read_subtree_bodies::<G, M, BODY_SIZE>(&*getter, &st, &chunk_range).await {
                     Ok(bodies) => {
                         let mut iter = bodies.into_iter();
                         match iter.next() {
@@ -341,8 +325,7 @@ where
                 async move {
                     let base = st.byte_offset;
                     let bodies =
-                        read_subtree_bodies_async::<G, M, BODY_SIZE>(&*getter, &st, &chunk_range)
-                            .await?;
+                        read_subtree_bodies::<G, M, BODY_SIZE>(&*getter, &st, &chunk_range).await?;
                     Ok::<(u64, Vec<Bytes>), FileError>((base, bodies))
                 }
             })
@@ -458,7 +441,7 @@ where
             M: JoinMode + MaybeSend + Sync,
         {
             let node = &pending.node;
-            let body = match super::mode::read_chunk_body_async::<M, G, BS>(
+            let body = match super::mode::read_chunk_body::<M, G, BS>(
                 getter,
                 &node.addr,
                 &node.context,
@@ -660,7 +643,7 @@ where
         M: JoinMode + MaybeSend + Sync,
     {
         let node = &pending.node;
-        let body = match super::mode::read_chunk_body_async::<M, G, BS>(
+        let body = match super::mode::read_chunk_body::<M, G, BS>(
             getter,
             &node.addr,
             &node.context,
@@ -921,11 +904,11 @@ where
 mod tests {
     use super::*;
     use crate::chunk::AnyChunk;
-    use crate::file::sync_split;
+    use crate::file::split;
     use std::collections::HashMap;
 
     fn split_and_store(data: &[u8]) -> (ChunkAddress, HashMap<ChunkAddress, AnyChunk>) {
-        let (root, store) = sync_split::<DEFAULT_BODY_SIZE>(data).unwrap();
+        let (root, store) = split::<DEFAULT_BODY_SIZE>(data).unwrap();
         (root, store.into_chunks())
     }
 
@@ -935,7 +918,7 @@ mod tests {
     // --- Async-only tests: Stream, AsyncRead, AsyncSeek ---
 
     #[tokio::test]
-    async fn test_async_joiner_stream() {
+    async fn test_joiner_stream() {
         let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3)
             .map(|i| (i % 256) as u8)
             .collect();
@@ -1321,7 +1304,7 @@ mod tests {
 
     #[cfg(feature = "tokio")]
     #[tokio::test]
-    async fn test_async_reader_small() {
+    async fn test_reader_small() {
         use tokio::io::AsyncReadExt;
 
         let data = b"hello world";
@@ -1336,7 +1319,7 @@ mod tests {
 
     #[cfg(feature = "tokio")]
     #[tokio::test]
-    async fn test_async_reader_multi_chunk() {
+    async fn test_reader_multi_chunk() {
         use tokio::io::AsyncReadExt;
 
         let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3 + 123)
@@ -1353,7 +1336,7 @@ mod tests {
 
     #[cfg(feature = "tokio")]
     #[tokio::test]
-    async fn test_async_reader_seek() {
+    async fn test_reader_seek() {
         use tokio::io::{AsyncReadExt, AsyncSeekExt};
 
         let data = b"hello world";
@@ -1370,7 +1353,7 @@ mod tests {
 
     #[cfg(feature = "tokio")]
     #[tokio::test]
-    async fn test_async_reader_seek_back_and_forth() {
+    async fn test_reader_seek_back_and_forth() {
         use tokio::io::{AsyncReadExt, AsyncSeekExt};
 
         let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3)
@@ -1406,7 +1389,7 @@ mod tests {
     #[cfg(feature = "encryption")]
     mod encrypted {
         use super::*;
-        use crate::file::sync_split_encrypted;
+        use crate::file::split_encrypted;
 
         fn encrypted_split_and_store(
             data: &[u8],
@@ -1414,7 +1397,7 @@ mod tests {
             crate::chunk::encryption::EncryptedChunkRef,
             HashMap<ChunkAddress, AnyChunk>,
         ) {
-            let (root_ref, store) = sync_split_encrypted::<DEFAULT_BODY_SIZE>(data).unwrap();
+            let (root_ref, store) = split_encrypted::<DEFAULT_BODY_SIZE>(data).unwrap();
             (root_ref, store.into_chunks())
         }
 
@@ -1424,7 +1407,7 @@ mod tests {
         // --- Async-only tests: Stream ---
 
         #[tokio::test]
-        async fn test_encrypted_async_joiner_stream() {
+        async fn test_encrypted_joiner_stream() {
             let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3)
                 .map(|i| (i % 256) as u8)
                 .collect();

--- a/crates/primitives/src/file/mod.rs
+++ b/crates/primitives/src/file/mod.rs
@@ -1,6 +1,6 @@
 //! File splitting and joining for arbitrary-size data.
 //!
-//! Joining is async; splitting is CPU-bound and runs on rayon. `SyncSplitter`
+//! Joining is async; splitting is CPU-bound and runs on rayon. `Splitter`
 //! implements `Write` for streaming producers.
 //!
 //! # Store-centric API (extension traits)
@@ -21,11 +21,11 @@
 //!
 //! ```
 //! use futures::executor::block_on;
-//! use nectar_primitives::file::{sync_split, join};
+//! use nectar_primitives::file::{split, join};
 //! use nectar_primitives::DEFAULT_BODY_SIZE;
 //!
 //! let data = b"Hello, Swarm!";
-//! let (root, store) = sync_split::<DEFAULT_BODY_SIZE>(data).unwrap();
+//! let (root, store) = split::<DEFAULT_BODY_SIZE>(data).unwrap();
 //! let recovered = block_on(join(&store, root)).unwrap();
 //! assert_eq!(recovered, data);
 //! ```
@@ -35,11 +35,11 @@
 //! ```
 //! # #[cfg(feature = "encryption")] {
 //! use futures::executor::block_on;
-//! use nectar_primitives::file::{sync_split_encrypted, join};
+//! use nectar_primitives::file::{split_encrypted, join};
 //! use nectar_primitives::DEFAULT_BODY_SIZE;
 //!
 //! let data = b"secret data";
-//! let (root_ref, store) = sync_split_encrypted::<DEFAULT_BODY_SIZE>(data).unwrap();
+//! let (root_ref, store) = split_encrypted::<DEFAULT_BODY_SIZE>(data).unwrap();
 //! let recovered = block_on(join(&store, root_ref)).unwrap();
 //! assert_eq!(recovered, data);
 //! # }
@@ -59,9 +59,9 @@ mod joiner_tests;
 mod splitter_tests;
 mod joiner;
 pub mod mode;
-mod sync_read_at;
-mod sync_splitter;
-mod sync_splitter_parallel;
+mod read_at;
+mod splitter;
+mod splitter_parallel;
 mod tree;
 mod windowed;
 mod write_at;
@@ -81,13 +81,13 @@ pub use joiner::{GenericJoiner, Joiner};
 pub use windowed::WindowedJoinerReader;
 pub use windowed::WindowedReader;
 // Splitter re-exports
-pub use sync_read_at::SyncReadAt;
+pub use read_at::ReadAt;
 #[cfg(feature = "encryption")]
-pub use sync_splitter::EncryptedSyncSplitter;
-pub use sync_splitter::SyncSplitter;
+pub use splitter::EncryptedSplitter;
+pub use splitter::Splitter;
 #[cfg(feature = "encryption")]
-pub use sync_splitter_parallel::EncryptedSyncParallelSplitter;
-pub use sync_splitter_parallel::SyncParallelSplitter;
+pub use splitter_parallel::EncryptedParallelSplitter;
+pub use splitter_parallel::ParallelSplitter;
 pub use write_at::WriteAt;
 
 pub use entry_ref::EntryRef;
@@ -165,20 +165,20 @@ where
 
 /// Split data into chunks, returning root address and chunk store.
 ///
-/// Uses `SyncParallelSplitter` for best performance on in-memory data.
-pub fn sync_split<const BODY_SIZE: usize>(
+/// Uses `ParallelSplitter` for best performance on in-memory data.
+pub fn split<const BODY_SIZE: usize>(
     data: &[u8],
 ) -> error::Result<(ChunkAddress, crate::store::MemoryStore<BODY_SIZE>)> {
-    let (root, chunks) = SyncParallelSplitter::<BODY_SIZE>::split_to_vec(&data)?;
+    let (root, chunks) = ParallelSplitter::<BODY_SIZE>::split_to_vec(&data)?;
     Ok((root, crate::store::MemoryStore::from_chunks(chunks)))
 }
 
 /// Split data into encrypted chunks.
 #[cfg(feature = "encryption")]
-pub fn sync_split_encrypted<const BODY_SIZE: usize>(
+pub fn split_encrypted<const BODY_SIZE: usize>(
     data: &[u8],
 ) -> error::Result<(EncryptedChunkRef, crate::store::MemoryStore<BODY_SIZE>)> {
-    let (root_ref, chunks) = EncryptedSyncParallelSplitter::<BODY_SIZE>::split_to_vec(&data)?;
+    let (root_ref, chunks) = EncryptedParallelSplitter::<BODY_SIZE>::split_to_vec(&data)?;
     Ok((root_ref, crate::store::MemoryStore::from_chunks(chunks)))
 }
 
@@ -244,14 +244,14 @@ pub trait ChunkPutExt<const BODY_SIZE: usize>: ChunkPut<BODY_SIZE> {
     ///
     /// Splitting runs on rayon up front; `data` is dropped before the first
     /// store await, so the returned future never holds the source.
-    fn write_file<D: SyncReadAt + Sync>(
+    fn write_file<D: ReadAt + Sync>(
         &self,
         data: D,
     ) -> impl std::future::Future<Output = error::Result<ChunkAddress>> + MaybeSend
     where
         Self: Sized + MaybeSync,
     {
-        let split = SyncParallelSplitter::<BODY_SIZE>::split_to_vec(&data);
+        let split = ParallelSplitter::<BODY_SIZE>::split_to_vec(&data);
         async move {
             let (root, chunks) = split?;
             for chunk in chunks {
@@ -263,14 +263,14 @@ pub trait ChunkPutExt<const BODY_SIZE: usize>: ChunkPut<BODY_SIZE> {
 
     /// Split `data` into encrypted chunks and store them, returning the root reference.
     #[cfg(feature = "encryption")]
-    fn write_encrypted_file<D: SyncReadAt + Sync>(
+    fn write_encrypted_file<D: ReadAt + Sync>(
         &self,
         data: D,
     ) -> impl std::future::Future<Output = error::Result<EncryptedChunkRef>> + MaybeSend
     where
         Self: Sized + MaybeSync,
     {
-        let split = EncryptedSyncParallelSplitter::<BODY_SIZE>::split_to_vec(&data);
+        let split = EncryptedParallelSplitter::<BODY_SIZE>::split_to_vec(&data);
         async move {
             let (root_ref, chunks) = split?;
             for chunk in chunks {

--- a/crates/primitives/src/file/mode.rs
+++ b/crates/primitives/src/file/mode.rs
@@ -92,7 +92,7 @@ pub trait JoinMode: Sized + 'static {
 }
 
 /// Initialize joiner: fetch root chunk, extract span and context.
-pub(crate) async fn joiner_init_async<
+pub(crate) async fn joiner_init<
     M: JoinMode + MaybeSend + Sync,
     G: crate::store::ChunkGet<BS>,
     const BS: usize,
@@ -109,7 +109,7 @@ pub(crate) async fn joiner_init_async<
 }
 
 /// Read chunk body at address with context. Returns body bytes (after decryption if needed).
-pub(crate) async fn read_chunk_body_async<
+pub(crate) async fn read_chunk_body<
     M: JoinMode + MaybeSend + Sync,
     G: crate::store::ChunkGet<BS>,
     const BS: usize,

--- a/crates/primitives/src/file/read_at.rs
+++ b/crates/primitives/src/file/read_at.rs
@@ -7,7 +7,7 @@ use bytes::Bytes;
 /// Sync data source supporting offset-based reads.
 ///
 /// Enables parallel splitting by allowing concurrent reads at different offsets.
-pub trait SyncReadAt {
+pub trait ReadAt {
     /// Read data at offset into buffer, returning bytes read.
     fn read_at(&self, offset: u64, buf: &mut [u8]) -> io::Result<usize>;
 
@@ -20,7 +20,7 @@ pub trait SyncReadAt {
     }
 }
 
-impl SyncReadAt for [u8] {
+impl ReadAt for [u8] {
     fn read_at(&self, offset: u64, buf: &mut [u8]) -> io::Result<usize> {
         let offset = offset as usize;
         if offset >= self.len() {
@@ -37,7 +37,7 @@ impl SyncReadAt for [u8] {
     }
 }
 
-impl SyncReadAt for Vec<u8> {
+impl ReadAt for Vec<u8> {
     fn read_at(&self, offset: u64, buf: &mut [u8]) -> io::Result<usize> {
         self.as_slice().read_at(offset, buf)
     }
@@ -47,7 +47,7 @@ impl SyncReadAt for Vec<u8> {
     }
 }
 
-impl SyncReadAt for Bytes {
+impl ReadAt for Bytes {
     fn read_at(&self, offset: u64, buf: &mut [u8]) -> io::Result<usize> {
         self.as_ref().read_at(offset, buf)
     }
@@ -57,7 +57,7 @@ impl SyncReadAt for Bytes {
     }
 }
 
-impl<T: SyncReadAt + ?Sized> SyncReadAt for &T {
+impl<T: ReadAt + ?Sized> ReadAt for &T {
     fn read_at(&self, offset: u64, buf: &mut [u8]) -> io::Result<usize> {
         (**self).read_at(offset, buf)
     }
@@ -68,7 +68,7 @@ impl<T: SyncReadAt + ?Sized> SyncReadAt for &T {
 }
 
 #[cfg(unix)]
-impl SyncReadAt for std::fs::File {
+impl ReadAt for std::fs::File {
     fn read_at(&self, offset: u64, buf: &mut [u8]) -> io::Result<usize> {
         use std::os::unix::fs::FileExt;
         FileExt::read_at(self, buf, offset)
@@ -80,7 +80,7 @@ impl SyncReadAt for std::fs::File {
 }
 
 #[cfg(windows)]
-impl SyncReadAt for std::fs::File {
+impl ReadAt for std::fs::File {
     fn read_at(&self, offset: u64, buf: &mut [u8]) -> io::Result<usize> {
         use std::os::windows::fs::FileExt;
         FileExt::seek_read(self, buf, offset)
@@ -137,7 +137,7 @@ mod tests {
         assert_eq!(n, 4);
         assert_eq!(&buf, b"data");
 
-        assert_eq!(SyncReadAt::len(&data), 9);
+        assert_eq!(ReadAt::len(&data), 9);
     }
 
     #[test]

--- a/crates/primitives/src/file/splitter.rs
+++ b/crates/primitives/src/file/splitter.rs
@@ -1,6 +1,6 @@
 //! File splitter for producing BMT chunks from data streams.
 //!
-//! Buffers data via `Write`, then delegates to `GenericSyncParallelSplitter`
+//! Buffers data via `Write`, then delegates to `GenericParallelSplitter`
 //! on `finish()` for parallel chunk hashing. Produces chunks; the caller
 //! decides where they go.
 
@@ -13,43 +13,43 @@ use crate::chunk::AnyChunk;
 
 use super::error::{FileError, Result};
 use super::mode::{PlainMode, SplitMode};
-use super::sync_splitter_parallel::GenericSyncParallelSplitter;
+use super::splitter_parallel::GenericParallelSplitter;
 
 #[cfg(feature = "encryption")]
 use super::mode::EncryptedMode;
 
 /// Generic splitter parameterized by chunk mode.
 ///
-/// Buffers data written via `Write` and delegates to `GenericSyncParallelSplitter`
+/// Buffers data written via `Write` and delegates to `GenericParallelSplitter`
 /// on `finish()` for parallel chunk hashing.
-pub struct GenericSyncSplitter<M: SplitMode, const BODY_SIZE: usize = DEFAULT_BODY_SIZE> {
+pub struct GenericSplitter<M: SplitMode, const BODY_SIZE: usize = DEFAULT_BODY_SIZE> {
     span_length: u64,
     buffer: Vec<u8>,
     _mode: PhantomData<M>,
 }
 
 /// Plain (unencrypted) file splitter.
-pub type SyncSplitter<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> =
-    GenericSyncSplitter<PlainMode, BODY_SIZE>;
+pub type Splitter<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> =
+    GenericSplitter<PlainMode, BODY_SIZE>;
 
 /// Encrypted file splitter.
 #[cfg(feature = "encryption")]
-pub type EncryptedSyncSplitter<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> =
-    GenericSyncSplitter<EncryptedMode, BODY_SIZE>;
+pub type EncryptedSplitter<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> =
+    GenericSplitter<EncryptedMode, BODY_SIZE>;
 
-impl<M, const BODY_SIZE: usize> fmt::Debug for GenericSyncSplitter<M, BODY_SIZE>
+impl<M, const BODY_SIZE: usize> fmt::Debug for GenericSplitter<M, BODY_SIZE>
 where
     M: SplitMode,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("GenericSyncSplitter")
+        f.debug_struct("GenericSplitter")
             .field("span_length", &self.span_length)
             .field("length", &self.buffer.len())
             .finish_non_exhaustive()
     }
 }
 
-impl<M, const BODY_SIZE: usize> GenericSyncSplitter<M, BODY_SIZE>
+impl<M, const BODY_SIZE: usize> GenericSplitter<M, BODY_SIZE>
 where
     M: SplitMode,
 {
@@ -80,7 +80,7 @@ where
     }
 }
 
-impl<M, const BODY_SIZE: usize> GenericSyncSplitter<M, BODY_SIZE>
+impl<M, const BODY_SIZE: usize> GenericSplitter<M, BODY_SIZE>
 where
     M: SplitMode + Send + Sync,
 {
@@ -98,11 +98,11 @@ where
             return Ok((root, vec![chunk.into()]));
         }
 
-        GenericSyncParallelSplitter::<M, BODY_SIZE>::split_to_vec(&self.buffer)
+        GenericParallelSplitter::<M, BODY_SIZE>::split_to_vec(&self.buffer)
     }
 }
 
-impl<M, const BODY_SIZE: usize> Write for GenericSyncSplitter<M, BODY_SIZE>
+impl<M, const BODY_SIZE: usize> Write for GenericSplitter<M, BODY_SIZE>
 where
     M: SplitMode,
 {
@@ -135,7 +135,7 @@ mod tests {
     fn split_and_store(
         data: &[u8],
     ) -> (crate::chunk::ChunkAddress, MemoryStore<DEFAULT_BODY_SIZE>) {
-        let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
+        let mut splitter = Splitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
         splitter.write_all(data).unwrap();
         let (root, chunks) = splitter.finish().unwrap();
         (root, MemoryStore::from_chunks(chunks))
@@ -147,7 +147,7 @@ mod tests {
     fn test_splitter_incremental_writes() {
         let mut data = vec![0u8; DEFAULT_BODY_SIZE * 2 + 100];
         rand::RngExt::fill(&mut rand::rng(), &mut data);
-        let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
+        let mut splitter = Splitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
 
         for chunk in data.chunks(100) {
             splitter.write_all(chunk).unwrap();
@@ -164,13 +164,13 @@ mod tests {
         let data = vec![0x56; DEFAULT_BODY_SIZE * 3];
 
         let root1 = {
-            let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
+            let mut splitter = Splitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
             splitter.write_all(&data).unwrap();
             splitter.finish().unwrap().0
         };
 
         let root2 = {
-            let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
+            let mut splitter = Splitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
             splitter.write_all(&data).unwrap();
             splitter.finish().unwrap().0
         };
@@ -180,7 +180,7 @@ mod tests {
 
     #[test]
     fn test_splitter_write_past_span() {
-        let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(10);
+        let mut splitter = Splitter::<DEFAULT_BODY_SIZE>::new(10);
 
         let result = splitter.write_all(b"this is more than 10 bytes");
         assert!(result.is_err());
@@ -188,7 +188,7 @@ mod tests {
 
     #[test]
     fn test_splitter_span_mismatch() {
-        let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(100);
+        let mut splitter = Splitter::<DEFAULT_BODY_SIZE>::new(100);
 
         splitter.write_all(b"short").unwrap();
         let result = splitter.finish();
@@ -206,7 +206,7 @@ mod tests {
             crate::chunk::encryption::EncryptedChunkRef,
             MemoryStore<DEFAULT_BODY_SIZE>,
         ) {
-            let mut splitter = EncryptedSyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
+            let mut splitter = EncryptedSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
             splitter.write_all(data).unwrap();
             let (root_ref, chunks) = splitter.finish().unwrap();
             (root_ref, MemoryStore::from_chunks(chunks))
@@ -216,7 +216,7 @@ mod tests {
 
         #[test]
         fn test_encrypted_splitter_write_past_span() {
-            let mut splitter = EncryptedSyncSplitter::<DEFAULT_BODY_SIZE>::new(10);
+            let mut splitter = EncryptedSplitter::<DEFAULT_BODY_SIZE>::new(10);
 
             let result = splitter.write_all(b"this is more than 10 bytes");
             assert!(result.is_err());
@@ -224,7 +224,7 @@ mod tests {
 
         #[test]
         fn test_encrypted_splitter_span_mismatch() {
-            let mut splitter = EncryptedSyncSplitter::<DEFAULT_BODY_SIZE>::new(100);
+            let mut splitter = EncryptedSplitter::<DEFAULT_BODY_SIZE>::new(100);
 
             splitter.write_all(b"short").unwrap();
             let result = splitter.finish();
@@ -235,12 +235,11 @@ mod tests {
         #[test]
         fn test_encrypted_differs_from_plaintext() {
             let data = b"test data for encryption comparison";
-            let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
+            let mut splitter = Splitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
             splitter.write_all(data).unwrap();
             let (plain_root, _) = splitter.finish().unwrap();
 
-            let mut enc_splitter =
-                EncryptedSyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
+            let mut enc_splitter = EncryptedSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
             enc_splitter.write_all(data).unwrap();
             let (enc_root, _) = enc_splitter.finish().unwrap();
 

--- a/crates/primitives/src/file/splitter_parallel.rs
+++ b/crates/primitives/src/file/splitter_parallel.rs
@@ -10,7 +10,7 @@ use crate::chunk::AnyChunk;
 use super::constants::{LEVEL_LIMIT, compute_spans_inline};
 use super::error::{FileError, Result};
 use super::mode::{PlainMode, SplitMode};
-use super::sync_read_at::SyncReadAt;
+use super::read_at::ReadAt;
 use super::tree::TreeParams;
 
 #[cfg(feature = "encryption")]
@@ -20,30 +20,30 @@ use super::mode::EncryptedMode;
 ///
 /// Produces chunks by reading data at known offsets in parallel, then building
 /// intermediate levels. The caller decides where produced chunks go.
-pub struct GenericSyncParallelSplitter<M: SplitMode, const BODY_SIZE: usize = DEFAULT_BODY_SIZE> {
+pub struct GenericParallelSplitter<M: SplitMode, const BODY_SIZE: usize = DEFAULT_BODY_SIZE> {
     _mode: PhantomData<M>,
 }
 
 /// Plain (unencrypted) parallel splitter.
-pub type SyncParallelSplitter<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> =
-    GenericSyncParallelSplitter<PlainMode, BODY_SIZE>;
+pub type ParallelSplitter<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> =
+    GenericParallelSplitter<PlainMode, BODY_SIZE>;
 
 /// Encrypted parallel splitter.
 #[cfg(feature = "encryption")]
-pub type EncryptedSyncParallelSplitter<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> =
-    GenericSyncParallelSplitter<EncryptedMode, BODY_SIZE>;
+pub type EncryptedParallelSplitter<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> =
+    GenericParallelSplitter<EncryptedMode, BODY_SIZE>;
 
-impl<M, const BODY_SIZE: usize> std::fmt::Debug for GenericSyncParallelSplitter<M, BODY_SIZE>
+impl<M, const BODY_SIZE: usize> std::fmt::Debug for GenericParallelSplitter<M, BODY_SIZE>
 where
     M: SplitMode,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("GenericSyncParallelSplitter")
+        f.debug_struct("GenericParallelSplitter")
             .finish_non_exhaustive()
     }
 }
 
-impl<M, const BODY_SIZE: usize> GenericSyncParallelSplitter<M, BODY_SIZE>
+impl<M, const BODY_SIZE: usize> GenericParallelSplitter<M, BODY_SIZE>
 where
     M: SplitMode + Send + Sync,
 {
@@ -53,7 +53,7 @@ where
     /// Returns the root reference.
     pub fn split_into<R, F>(source: &R, sink: F) -> Result<M::RootRef>
     where
-        R: SyncReadAt + Sync,
+        R: ReadAt + Sync,
         F: Fn(AnyChunk<BODY_SIZE>) + Sync,
     {
         const { super::constants::assert_valid_body_size::<BODY_SIZE>() };
@@ -79,7 +79,7 @@ where
     ///
     /// Chunk order is irrelevant; callers key by address. Returns the root
     /// reference and the produced chunks.
-    pub fn split_to_vec<R: SyncReadAt + Sync>(
+    pub fn split_to_vec<R: ReadAt + Sync>(
         source: &R,
     ) -> Result<(M::RootRef, Vec<AnyChunk<BODY_SIZE>>)> {
         let chunks = std::sync::Mutex::new(Vec::new());
@@ -93,7 +93,7 @@ where
         sink: &F,
     ) -> Result<Vec<M::RefBytes>>
     where
-        R: SyncReadAt + Sync,
+        R: ReadAt + Sync,
         F: Fn(AnyChunk<BODY_SIZE>) + Sync,
     {
         let data_chunks = tree.data_chunks();
@@ -205,8 +205,7 @@ mod tests {
     fn split_and_store(
         data: &[u8],
     ) -> (crate::chunk::ChunkAddress, MemoryStore<DEFAULT_BODY_SIZE>) {
-        let (root, chunks) =
-            SyncParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(&data).unwrap();
+        let (root, chunks) = ParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(&data).unwrap();
         (root, MemoryStore::from_chunks(chunks))
     }
 
@@ -220,7 +219,7 @@ mod tests {
 
         let (root, store) = split_and_store(&data);
 
-        let (seq_root, _) = crate::file::sync_split::<DEFAULT_BODY_SIZE>(&data).unwrap();
+        let (seq_root, _) = crate::file::split::<DEFAULT_BODY_SIZE>(&data).unwrap();
         assert_eq!(root, seq_root);
 
         let recovered = futures::executor::block_on(join(&store, root)).unwrap();
@@ -233,11 +232,10 @@ mod tests {
 
         let data = vec![0xAB; DEFAULT_BODY_SIZE + 1];
         let count = AtomicUsize::new(0);
-        let root =
-            SyncParallelSplitter::<DEFAULT_BODY_SIZE>::split_into(&data.as_slice(), |_chunk| {
-                count.fetch_add(1, Ordering::Relaxed);
-            })
-            .unwrap();
+        let root = ParallelSplitter::<DEFAULT_BODY_SIZE>::split_into(&data.as_slice(), |_chunk| {
+            count.fetch_add(1, Ordering::Relaxed);
+        })
+        .unwrap();
         assert!(!root.is_zero());
         assert_eq!(count.load(Ordering::Relaxed), 3);
     }
@@ -245,7 +243,7 @@ mod tests {
     #[cfg(feature = "encryption")]
     mod encrypted {
         use super::*;
-        use crate::file::{EncryptedSyncParallelSplitter, sync_split_encrypted};
+        use crate::file::{EncryptedParallelSplitter, split_encrypted};
         use crate::store::MemoryStore;
 
         fn encrypted_split_and_store(
@@ -255,7 +253,7 @@ mod tests {
             MemoryStore<DEFAULT_BODY_SIZE>,
         ) {
             let (root_ref, chunks) =
-                EncryptedSyncParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(&data).unwrap();
+                EncryptedParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(&data).unwrap();
             (root_ref, MemoryStore::from_chunks(chunks))
         }
 
@@ -268,7 +266,7 @@ mod tests {
                 .collect();
 
             let (par_ref, par_store) = encrypted_split_and_store(&data);
-            let (seq_ref, seq_store) = sync_split_encrypted::<DEFAULT_BODY_SIZE>(&data).unwrap();
+            let (seq_ref, seq_store) = split_encrypted::<DEFAULT_BODY_SIZE>(&data).unwrap();
 
             assert_eq!(par_store.len(), seq_store.len());
 

--- a/crates/primitives/src/file/tests.rs
+++ b/crates/primitives/src/file/tests.rs
@@ -7,7 +7,7 @@ use std::io::Write;
 use alloy_primitives::hex;
 
 use crate::bmt::DEFAULT_BODY_SIZE;
-use crate::file::SyncSplitter;
+use crate::file::Splitter;
 
 const CHUNK_SIZE: usize = DEFAULT_BODY_SIZE;
 
@@ -111,7 +111,7 @@ const LARGE_TEST_VECTORS: &[(usize, &str)] = &[
 fn run_vector_test(size: usize, expected_hex: &str) {
     let data = sequential_bytes(size);
 
-    let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
+    let mut splitter = Splitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
     splitter.write_all(&data).unwrap();
     let (root, _) = splitter.finish().unwrap();
 
@@ -145,7 +145,7 @@ fn test_go_vectors_large() {
 #[cfg(feature = "encryption")]
 mod encrypted {
     use crate::bmt::DEFAULT_BODY_SIZE;
-    use crate::file::{join, sync_split_encrypted};
+    use crate::file::{join, split_encrypted};
     use futures::executor::block_on;
 
     /// Test sizes covering various boundary conditions.
@@ -167,7 +167,7 @@ mod encrypted {
     fn run_encrypted_roundtrip(size: usize) {
         let data: Vec<u8> = (0..size).map(|i| (i % 255) as u8).collect();
 
-        let (root_ref, store) = sync_split_encrypted::<DEFAULT_BODY_SIZE>(&data).unwrap();
+        let (root_ref, store) = split_encrypted::<DEFAULT_BODY_SIZE>(&data).unwrap();
 
         assert_eq!(
             Vec::from(&root_ref).len(),
@@ -191,7 +191,7 @@ mod encrypted {
     fn encrypted_chunk_count_single() {
         // Single chunk file: 1 encrypted chunk stored
         let data = b"small data";
-        let (_, store) = sync_split_encrypted::<DEFAULT_BODY_SIZE>(data).unwrap();
+        let (_, store) = split_encrypted::<DEFAULT_BODY_SIZE>(data).unwrap();
         assert_eq!(store.len(), 1);
     }
 
@@ -199,7 +199,7 @@ mod encrypted {
     fn encrypted_chunk_count_two_data() {
         // 4097 bytes → 2 data chunks + 1 intermediate = 3
         let data = vec![0xAB; 4097];
-        let (_, store) = sync_split_encrypted::<DEFAULT_BODY_SIZE>(&data).unwrap();
+        let (_, store) = split_encrypted::<DEFAULT_BODY_SIZE>(&data).unwrap();
         assert_eq!(store.len(), 3);
     }
 
@@ -208,8 +208,8 @@ mod encrypted {
         // Two encryptions of the same data produce different ciphertexts
         // (different random keys each time)
         let data = b"test determinism";
-        let (ref1, _) = sync_split_encrypted::<DEFAULT_BODY_SIZE>(data).unwrap();
-        let (ref2, _) = sync_split_encrypted::<DEFAULT_BODY_SIZE>(data).unwrap();
+        let (ref1, _) = split_encrypted::<DEFAULT_BODY_SIZE>(data).unwrap();
+        let (ref2, _) = split_encrypted::<DEFAULT_BODY_SIZE>(data).unwrap();
 
         // Root addresses differ because encryption keys are random
         assert_ne!(ref1.address(), ref2.address());
@@ -243,12 +243,12 @@ mod write_file_ext {
     fn splitter_chunks_roundtrip() {
         use std::io::Write;
 
-        use crate::file::SyncSplitter;
+        use crate::file::Splitter;
         use crate::store::ChunkPut;
 
         let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
         let data = b"streaming via splitter";
-        let mut splitter = SyncSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
+        let mut splitter = Splitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
         splitter.write_all(data).unwrap();
         let (root, chunks) = splitter.finish().unwrap();
         for chunk in chunks {

--- a/crates/primitives/src/file/windowed.rs
+++ b/crates/primitives/src/file/windowed.rs
@@ -192,7 +192,7 @@ where
     M: JoinMode + MaybeSend + Sync,
 {
     let node = &pending.node;
-    let body = match super::mode::read_chunk_body_async::<M, G, BS>(
+    let body = match super::mode::read_chunk_body::<M, G, BS>(
         getter,
         &node.addr,
         &node.context,
@@ -454,7 +454,7 @@ where
     M: JoinMode + Send + Sync + 'static,
 {
     /// Wrap as a tokio `AsyncRead` + `AsyncSeek` reader. Native-only.
-    pub fn into_async_reader(self) -> WindowedJoinerReader<G, M, BODY_SIZE> {
+    pub fn into_reader(self) -> WindowedJoinerReader<G, M, BODY_SIZE> {
         WindowedJoinerReader {
             reader: self,
             residual: Bytes::new(),
@@ -554,13 +554,13 @@ mod tests {
     use crate::bmt::DEFAULT_BODY_SIZE;
     use crate::chunk::AnyChunk;
     use crate::file::Joiner;
-    use crate::file::sync_split;
+    use crate::file::split;
     use futures::executor::block_on;
     use std::collections::HashMap;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     fn split_and_store(data: &[u8]) -> (ChunkAddress, HashMap<ChunkAddress, AnyChunk>) {
-        let (root, store) = sync_split::<DEFAULT_BODY_SIZE>(data).unwrap();
+        let (root, store) = split::<DEFAULT_BODY_SIZE>(data).unwrap();
         (root, store.into_chunks())
     }
 
@@ -868,13 +868,13 @@ mod tests {
         // overlaps concurrently admitted leaves, and the occupancy hook proves a
         // correct walk holds at most `window` leaf bodies on short bodies.
         use crate::file::EncryptedJoiner;
-        use crate::file::sync_split_encrypted;
+        use crate::file::split_encrypted;
 
         let leaves = 30usize;
         let window = 5usize;
         let total = (DEFAULT_BODY_SIZE * leaves) as u64;
         let data: Vec<u8> = (0..total).map(unique_byte).collect();
-        let (root_ref, store) = sync_split_encrypted::<DEFAULT_BODY_SIZE>(&data).unwrap();
+        let (root_ref, store) = split_encrypted::<DEFAULT_BODY_SIZE>(&data).unwrap();
         let store = store.into_chunks();
 
         PEAK_LEAF_OCCUPANCY.with(|p| p.set(0));
@@ -933,7 +933,7 @@ mod tests {
     mod encrypted {
         use super::*;
         use crate::file::EncryptedJoiner;
-        use crate::file::sync_split_encrypted;
+        use crate::file::split_encrypted;
 
         async fn drain_enc(
             reader: &mut WindowedReader<
@@ -956,7 +956,7 @@ mod tests {
                 .map(|i| (i % 256) as u8)
                 .collect();
             let bs = DEFAULT_BODY_SIZE as u64;
-            let (root_ref, store) = sync_split_encrypted::<DEFAULT_BODY_SIZE>(&data).unwrap();
+            let (root_ref, store) = split_encrypted::<DEFAULT_BODY_SIZE>(&data).unwrap();
             let store = store.into_chunks();
             block_on(async {
                 // whole file
@@ -981,7 +981,7 @@ mod tests {
 
     #[cfg(feature = "tokio")]
     #[tokio::test]
-    async fn async_reader_seek_and_read() {
+    async fn reader_seek_and_read() {
         use tokio::io::{AsyncReadExt, AsyncSeekExt};
 
         let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3 + 50)
@@ -989,7 +989,7 @@ mod tests {
             .collect();
         let (root, store) = split_and_store(&data);
         let joiner = Joiner::new(store, root).await.unwrap();
-        let mut reader = joiner.into_windowed_reader(16).into_async_reader();
+        let mut reader = joiner.into_windowed_reader(16).into_reader();
 
         let mut all = Vec::new();
         reader.read_to_end(&mut all).await.unwrap();

--- a/crates/primitives/src/file/write_at.rs
+++ b/crates/primitives/src/file/write_at.rs
@@ -235,14 +235,14 @@ mod download_tests {
 
     use crate::DEFAULT_BODY_SIZE;
     use crate::chunk::AnyChunk;
-    use crate::file::{Joiner, sync_split};
+    use crate::file::{Joiner, split};
     use futures::executor::block_on;
     use std::collections::HashMap;
 
     type Store = HashMap<crate::ChunkAddress, AnyChunk>;
 
     fn split_and_store(data: &[u8]) -> (crate::ChunkAddress, Store) {
-        let (root, store) = sync_split::<DEFAULT_BODY_SIZE>(data).unwrap();
+        let (root, store) = split::<DEFAULT_BODY_SIZE>(data).unwrap();
         (root, store.into_chunks())
     }
 
@@ -325,10 +325,10 @@ mod download_tests {
     mod encrypted {
         use super::*;
         use crate::chunk::encryption::EncryptedChunkRef;
-        use crate::file::{EncryptedJoiner, sync_split_encrypted};
+        use crate::file::{EncryptedJoiner, split_encrypted};
 
         fn encrypted_split_and_store(data: &[u8]) -> (EncryptedChunkRef, Store) {
-            let (root_ref, store) = sync_split_encrypted::<DEFAULT_BODY_SIZE>(data).unwrap();
+            let (root_ref, store) = split_encrypted::<DEFAULT_BODY_SIZE>(data).unwrap();
             (root_ref, store.into_chunks())
         }
 

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -121,10 +121,10 @@ pub use file::{
 
 // File splitting (CPU-bound, rayon)
 #[cfg(feature = "encryption")]
-pub use file::{EncryptedSyncParallelSplitter, EncryptedSyncSplitter, sync_split_encrypted};
-pub use file::{SyncParallelSplitter, SyncReadAt, SyncSplitter, sync_split};
+pub use file::{EncryptedParallelSplitter, EncryptedSplitter, split_encrypted};
+pub use file::{ParallelSplitter, ReadAt, Splitter, split};
 
 /// Default sync file splitter.
-pub type DefaultSyncSplitter = file::SyncSplitter<DEFAULT_BODY_SIZE>;
+pub type DefaultSplitter = file::Splitter<DEFAULT_BODY_SIZE>;
 /// Default async file joiner.
 pub type DefaultJoiner<G> = file::Joiner<G, DEFAULT_BODY_SIZE>;


### PR DESCRIPTION
## What
Rename-only cleanup, no behaviour change. Drops sync/async qualifiers that no longer disambiguate anything after the async-only collapse removed their siblings:
- `*_async` internal helpers lose the suffix (`joiner_init`, `read_chunk_body`, `expand_frontier`, `read_subtree_bodies`, `collect_subtree_bodies`).
- Splitter family drops `Sync`: `Splitter`/`ParallelSplitter`/`Generic*`/`Encrypted*`/`DefaultSplitter`; modules `splitter`/`splitter_parallel`; free functions `split`/`split_encrypted`.
- `SyncReadAt` becomes `ReadAt` (sync is the unqualified default in Rust, like `std::io::Read`; it reads naturally beside the async `WriteAt` sink).
- `WindowedReader::into_async_reader` becomes `into_reader`; misleading `test_async_*`/`test_sync_*` test names tidied.

Deliberately kept: `MaybeSend`/`MaybeSync`/`NotSendSync` (they reference the `Send`/`Sync` auto-traits) and alloy's `SignerSync` method names (external trait).

## Why
Closes #117. In Rust an `async fn` advertises itself in its signature, and sync is the unqualified default, so these qualifiers were pure noise once the collapse left a single family.

## Testing
`cargo clippy --all-targets --all-features -D warnings`, `cargo test -p nectar-primitives --features tokio,encryption` (274 pass), `cargo test -p nectar-mantaray --all-features` (56 pass), `cargo test --doc --workspace`, `cargo build --workspace`, and the wasm32 build are all green. A workspace grep confirms zero remaining `SyncSplitter`/`SyncReadAt`/`sync_split`/`_async`/`into_async_reader` identifiers.

## Breaking change
Public type, trait, function, and module names change. Justified: rename-only, lands in the same breaking cycle as the async-only collapse, and removes non-idiomatic noise.

## Notes
Stacked on #115 (base `nectar/06-joiner-dx`); the tail of the train.

## AI Assistance
AI Assistance: Claude Code used for the analysis, implementation, and testing of this change.