### PR TITLE
refactor(primitives)!: tighten error source-preservation and drop hand-rolled error impls

### DIFF
--- a/crates/mantaray/src/codec.rs
+++ b/crates/mantaray/src/codec.rs
@@ -440,9 +440,7 @@ impl<E: NodeEntry> Fork<E> {
 
         if self.node.is_with_metadata() {
             let mut metadata_json = serde_json::to_string(&self.node.metadata)
-                .map_err(|e| MantarayError::InvalidMetadata {
-                    message: e.to_string(),
-                })?
+                .map_err(MantarayError::Metadata)?
                 .into_bytes();
 
             let metadata_bytes_size_with_header =
@@ -509,11 +507,7 @@ impl<E: NodeEntry> Fork<E> {
             let metadata_start =
                 ForkHeader::PRE_REFERENCE_SIZE + ref_bytes_size + ForkHeader::METADATA_LEN_SIZE;
             let metadata_bytes = &data[metadata_start..];
-            self.node.metadata = serde_json::from_slice(metadata_bytes).map_err(|e| {
-                MantarayError::InvalidMetadata {
-                    message: e.to_string(),
-                }
-            })?;
+            self.node.metadata = serde_json::from_slice(metadata_bytes)?;
         }
 
         Ok(())

--- a/crates/mantaray/src/error.rs
+++ b/crates/mantaray/src/error.rs
@@ -84,11 +84,8 @@ pub enum MantarayError {
         actual: usize,
     },
     /// Metadata could not be parsed.
-    #[error("invalid metadata: {message}")]
-    InvalidMetadata {
-        /// Description of the error.
-        message: String,
-    },
+    #[error("invalid metadata")]
+    Metadata(#[from] serde_json::Error),
     /// Node has not been saved yet (reference is empty).
     #[error("missing reference")]
     MissingReference,

--- a/crates/postage-issuer/src/factory.rs
+++ b/crates/postage-issuer/src/factory.rs
@@ -112,44 +112,6 @@ impl Default for MemoryBatchFactory {
     }
 }
 
-/// Error type for memory batch factory operations.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum MemoryBatchError {
-    /// The batch was not found.
-    NotFound(BatchId),
-    /// The batch is immutable and cannot be diluted.
-    Immutable(BatchId),
-    /// Invalid depth for dilution.
-    InvalidDepth {
-        /// The batch ID.
-        batch_id: BatchId,
-        /// Current depth.
-        current: u8,
-        /// Requested depth.
-        requested: u8,
-    },
-}
-
-impl std::fmt::Display for MemoryBatchError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::NotFound(id) => write!(f, "batch not found: {}", id),
-            Self::Immutable(id) => write!(f, "batch is immutable: {}", id),
-            Self::InvalidDepth {
-                batch_id,
-                current,
-                requested,
-            } => write!(
-                f,
-                "invalid depth for batch {}: current {}, requested {}",
-                batch_id, current, requested
-            ),
-        }
-    }
-}
-
-impl std::error::Error for MemoryBatchError {}
-
 impl BatchFactory for MemoryBatchFactory {
     type Error = std::convert::Infallible;
 

--- a/crates/postage-issuer/src/lib.rs
+++ b/crates/postage-issuer/src/lib.rs
@@ -107,7 +107,7 @@ pub use sharded_ring::ShardedRingIssuer;
 
 // Factory (std only)
 #[cfg(feature = "std")]
-pub use factory::{BatchFactory, CreateResult, MemoryBatchError, MemoryBatchFactory};
+pub use factory::{BatchFactory, CreateResult, MemoryBatchFactory};
 
 // Parallel signing (requires parallel feature)
 #[cfg(feature = "parallel")]

--- a/crates/postage/src/store.rs
+++ b/crates/postage/src/store.rs
@@ -97,11 +97,15 @@ pub trait BatchStoreExt: BatchStore {
 impl<T: BatchStore> BatchStoreExt for T {}
 
 /// Errors that can occur when working with a batch store.
-#[derive(Debug)]
-pub enum BatchStoreError<E> {
+#[derive(Debug, thiserror::Error)]
+pub enum BatchStoreError<E: std::error::Error> {
     /// The batch was not found in the store.
+    #[error("batch not found: {0}")]
     NotFound(BatchId),
     /// The batch is not yet usable (needs more confirmations).
+    #[error(
+        "batch {batch_id} not usable: created at block {created}, current block {current}, need {threshold} confirmations"
+    )]
     NotUsable {
         /// The batch ID.
         batch_id: BatchId,
@@ -113,6 +117,7 @@ pub enum BatchStoreError<E> {
         threshold: u64,
     },
     /// The batch has expired.
+    #[error("batch {batch_id} expired: value {value} <= total_amount {total_amount}")]
     Expired {
         /// The batch ID.
         batch_id: BatchId,
@@ -122,42 +127,6 @@ pub enum BatchStoreError<E> {
         total_amount: u128,
     },
     /// An error from the underlying store.
-    Store(E),
-}
-
-impl<E: std::fmt::Display> std::fmt::Display for BatchStoreError<E> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::NotFound(id) => write!(f, "batch not found: {}", id),
-            Self::NotUsable {
-                batch_id,
-                created,
-                current,
-                threshold,
-            } => write!(
-                f,
-                "batch {} not usable: created at block {}, current block {}, need {} confirmations",
-                batch_id, created, current, threshold
-            ),
-            Self::Expired {
-                batch_id,
-                value,
-                total_amount,
-            } => write!(
-                f,
-                "batch {} expired: value {} <= total_amount {}",
-                batch_id, value, total_amount
-            ),
-            Self::Store(e) => write!(f, "store error: {}", e),
-        }
-    }
-}
-
-impl<E: std::error::Error + 'static> std::error::Error for BatchStoreError<E> {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::Store(e) => Some(e),
-            _ => None,
-        }
-    }
+    #[error("store error: {0}")]
+    Store(#[from] E),
 }

--- a/crates/primitives/src/file/error.rs
+++ b/crates/primitives/src/file/error.rs
@@ -25,8 +25,8 @@ pub enum FileError {
     },
 
     /// Chunk store failed to store a chunk.
-    #[error("store error: {0}")]
-    Store(Box<dyn std::error::Error + Send + Sync>),
+    #[error("store error")]
+    Store(#[source] Box<dyn std::error::Error + Send + Sync>),
 
     /// Write sink failed. Rendered to a string so the error stays `Send + Sync`
     /// even when the sink's own error is not (a single-threaded browser
@@ -35,8 +35,8 @@ pub enum FileError {
     Sink(String),
 
     /// Chunk getter failed to retrieve a chunk.
-    #[error("getter error: {0}")]
-    Getter(Box<dyn std::error::Error + Send + Sync>),
+    #[error("getter error")]
+    Getter(#[source] Box<dyn std::error::Error + Send + Sync>),
 
     /// Invalid chunk reference encountered during tree traversal.
     #[error("invalid reference at level {level}")]

--- a/crates/primitives/src/store/mod.rs
+++ b/crates/primitives/src/store/mod.rs
@@ -15,25 +15,20 @@ use crate::bmt::DEFAULT_BODY_SIZE;
 use crate::chunk::{AnyChunk, ChunkAddress};
 
 /// Errors from chunk storage operations.
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum ChunkStoreError {
     /// Chunk not found at the given address.
-    #[error("chunk not found: {address_hex}")]
-    NotFound {
-        /// Hex-encoded address of the missing chunk.
-        address_hex: String,
-    },
+    #[error("chunk not found: {0}")]
+    NotFound(ChunkAddress),
     /// Catch-all for backend-specific errors.
     #[error("{0}")]
-    Other(String),
+    Other(#[source] Box<dyn std::error::Error + Send + Sync>),
 }
 
 impl ChunkStoreError {
     /// Create a `NotFound` error for the given address.
-    pub fn not_found(address: &ChunkAddress) -> Self {
-        Self::NotFound {
-            address_hex: format!("{address}"),
-        }
+    pub const fn not_found(address: &ChunkAddress) -> Self {
+        Self::NotFound(*address)
     }
 }
 


### PR DESCRIPTION
## What
Improves error idiomacy without churn (net -83 lines):
- `FileError::Store`/`Getter`: add `#[source]` so the boxed cause shows in `Error::source()` (the chain was severed).
- `MantarayError::InvalidMetadata` becomes `Metadata(#[from] serde_json::Error)`: preserve the JSON error instead of stringifying it.
- `BatchStoreError`: replace 65 lines of hand-written `Display`/`Error` with `#[derive(thiserror::Error)]`, identical messages.
- Delete `MemoryBatchError`: dead (its factory uses `Infallible`), hand-rolled, never constructed.
- `ChunkStoreError::NotFound(ChunkAddress)`: carry the typed address instead of a rendered hex string.
- `ChunkStoreError::Other(#[source] Box<dyn Error + Send + Sync>)`: box the source; drop the unused `Clone + PartialEq + Eq` derive.

Deliberately left untouched (justified payloads): `FileError::Sink(String)` (a not-Send/not-Sync browser sink error cannot be a Send+Sync boxed source), `StampError`'s no_std `&'static str`, `UsageError::Malformed`, and `MantarayError::PathPrefixNotFound`.

## Why
Closes #119. Restores broken source chains and removes hand-rolled boilerplate; `UsageError`/`CounterError` remain the model (structured fields plus matcher functions).

## Testing
`cargo clippy --workspace --all-targets --all-features -D warnings`, the primitives (274), mantaray (56), and postage/postage-issuer (45/52) suites, doctests, `cargo build --workspace`, and the wasm32 build are all green. All affected error types remain Send + Sync.

## Breaking change
`MantarayError` and `ChunkStoreError` variant shapes change, and the dead `MemoryBatchError` export is removed. Justified: source-preservation and de-stringification, in the same breaking cycle as the rest of the train.

## Notes
Follow-up to the naming cleanup (#118). A `#[non_exhaustive]` sweep on the public error enums is left as a separate decision.

## AI Assistance
AI Assistance: Claude Code used for the audit, implementation, and testing of this change.