### PR TITLE
refactor(primitives)!: mark public error enums non_exhaustive

### DIFF
--- a/crates/mantaray/src/error.rs
+++ b/crates/mantaray/src/error.rs
@@ -9,6 +9,7 @@ use nectar_primitives::error::PrimitivesError;
 pub type Result<T> = std::result::Result<T, MantarayError>;
 
 /// Errors that can occur during mantaray trie operations.
+#[non_exhaustive]
 #[derive(thiserror::Error, Debug)]
 pub enum MantarayError {
     /// Node is not a value type (has no entry).

--- a/crates/postage-issuer/src/counter.rs
+++ b/crates/postage-issuer/src/counter.rs
@@ -44,6 +44,7 @@ pub enum CounterMode {
 }
 
 /// An error advancing or constructing a [`CounterTable`].
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
 pub enum CounterError {
     /// A bucket index is outside the table's bucket range.

--- a/crates/postage-issuer/src/error.rs
+++ b/crates/postage-issuer/src/error.rs
@@ -3,6 +3,7 @@
 use thiserror::Error;
 
 /// Errors that can occur when constructing a stamp issuer.
+#[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum IssuerError {
     /// Mutable batches require reserved-slot awareness that this primitive issuer cannot provide.
@@ -42,6 +43,7 @@ pub enum IssuerError {
 }
 
 /// Errors that can occur when signing stamps.
+#[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum SigningError {
     /// A stamp-related error occurred.

--- a/crates/postage-usage/src/client.rs
+++ b/crates/postage-usage/src/client.rs
@@ -98,6 +98,7 @@ pub trait SnapshotSink {
 /// [`Source`](Self::Source) and [`Sink`](Self::Sink) variants carry the
 /// transport failures that abort `open` and `flush` rather than degrading into a
 /// fresh or [`PublishedSequence::NONE`] persist.
+#[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum ClientError<SrcErr, SnkErr>
 where

--- a/crates/postage-usage/src/error.rs
+++ b/crates/postage-usage/src/error.rs
@@ -3,6 +3,7 @@
 use thiserror::Error;
 
 /// Errors produced by usage table operations and snapshot encoding/decoding.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum UsageError {
     /// The batch geometry is outside the range supported by the format.

--- a/crates/postage-usage/src/seal.rs
+++ b/crates/postage-usage/src/seal.rs
@@ -10,6 +10,7 @@ use thiserror::Error;
 use crate::snapshot::{PersistPlan, Snapshot};
 
 /// Errors produced while sealing a persist plan.
+#[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum SealError {
     /// The signer failed to produce a signature.

--- a/crates/postage-usage/src/table.rs
+++ b/crates/postage-usage/src/table.rs
@@ -30,6 +30,7 @@ pub(crate) const fn map_counter_error(err: CounterError) -> UsageError {
             count,
             capacity,
         },
+        _ => UsageError::Malformed("unexpected counter error"),
     }
 }
 

--- a/crates/postage/src/error.rs
+++ b/crates/postage/src/error.rs
@@ -5,6 +5,7 @@ use alloy_primitives::Address;
 use thiserror::Error;
 
 /// Errors that can occur when working with stamps.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum StampError {
     /// The owner recovered from the signature doesn't match the batch owner.

--- a/crates/postage/src/store.rs
+++ b/crates/postage/src/store.rs
@@ -97,6 +97,7 @@ pub trait BatchStoreExt: BatchStore {
 impl<T: BatchStore> BatchStoreExt for T {}
 
 /// Errors that can occur when working with a batch store.
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum BatchStoreError<E: std::error::Error> {
     /// The batch was not found in the store.

--- a/crates/primitives/src/bmt/error.rs
+++ b/crates/primitives/src/bmt/error.rs
@@ -1,6 +1,7 @@
 use thiserror::Error;
 
 /// Errors specific to BMT operations
+#[non_exhaustive]
 #[derive(Error, Debug)]
 pub enum BmtError {
     /// Input size is invalid for the operation

--- a/crates/primitives/src/chunk/encryption/error.rs
+++ b/crates/primitives/src/chunk/encryption/error.rs
@@ -3,6 +3,7 @@
 use thiserror::Error;
 
 /// Errors from encryption operations.
+#[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum EncryptionError {
     /// Input data is shorter than the required minimum.

--- a/crates/primitives/src/chunk/error.rs
+++ b/crates/primitives/src/chunk/error.rs
@@ -7,6 +7,7 @@ use super::type_id::ChunkTypeId;
 pub(crate) type Result<T> = std::result::Result<T, ChunkError>;
 
 /// Errors specific to chunk operations
+#[non_exhaustive]
 #[derive(Error, Debug)]
 pub enum ChunkError {
     /// Chunk size is invalid

--- a/crates/primitives/src/error.rs
+++ b/crates/primitives/src/error.rs
@@ -46,6 +46,7 @@ pub type Result<T> = std::result::Result<T, PrimitivesError>;
 /// This enum represents all the possible errors that can occur when using
 /// the nectar-primitives crate. It wraps component-specific errors like
 /// `BmtError` and `ChunkError` to provide a unified error interface.
+#[non_exhaustive]
 #[derive(Error, Debug)]
 pub enum PrimitivesError {
     /// Errors from BMT operations

--- a/crates/primitives/src/file/error.rs
+++ b/crates/primitives/src/file/error.rs
@@ -4,6 +4,7 @@ use crate::ChunkAddress;
 use thiserror::Error;
 
 /// Errors from file splitting and joining operations.
+#[non_exhaustive]
 #[derive(Error, Debug)]
 pub enum FileError {
     /// Write exceeded the declared span length.

--- a/crates/primitives/src/store/mod.rs
+++ b/crates/primitives/src/store/mod.rs
@@ -15,6 +15,7 @@ use crate::bmt::DEFAULT_BODY_SIZE;
 use crate::chunk::{AnyChunk, ChunkAddress};
 
 /// Errors from chunk storage operations.
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum ChunkStoreError {
     /// Chunk not found at the given address.


### PR DESCRIPTION
## What
Adds `#[non_exhaustive]` to the 15 public `*Error` enums that lacked it (`FileError`, `PrimitivesError`, `ChunkError`, `EncryptionError`, `BmtError`, `ChunkStoreError`, `MantarayError`, `StampError`, `BatchStoreError`, `CounterError`, `IssuerError`, `SigningError`, `UsageError`, `SealError`, `ClientError`), completing a convention three enums already followed. One cross-crate exhaustive match (`map_counter_error` in postage-usage over `CounterError`) gains a `_` arm that cannot fire today.

## Why
Closes #121. Lets the error enums gain variants later without breaking external matchers.

## Testing
`cargo clippy --workspace --all-targets --all-features -D warnings`, all crate test suites (primitives 274, mantaray 56, postage/issuer/usage), doctests, `cargo build --workspace`, and the wasm32 build are green. Attribute-and-match-arm only; no logic or error-shape changes.

## Breaking change
External crates can no longer match these enums exhaustively without a wildcard arm. Justified: forward-compatibility, lands in the same breaking cycle as the rest of the error work.

## AI Assistance
AI Assistance: Claude Code used for the implementation and testing of this change.