### PR TITLE
perf(primitives): batch BMT keccak across SIMD lanes via keccak-batch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1973,6 +1973,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak-batch"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4172542d4f7233006681ac8d6ed65bf689a67e96eaa3d5dc27655d513fccb8cc"
+
+[[package]]
 name = "konst"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2150,6 +2156,7 @@ dependencies = [
  "getrandom 0.4.2",
  "hybrid-array",
  "js-sys",
+ "keccak-batch",
  "once_cell",
  "parking_lot",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,10 @@ k256 = { version = "0.13", default-features = false, features = ["ecdsa", "preco
 # hashing
 digest = "0.11"
 hybrid-array = { version = "0.4", features = ["extra-sizes"] }
+# Batched Keccak-256: hashes independent inputs across SIMD lanes (AVX-512/
+# AVX2/SSE2/NEON/wasm-simd128 with runtime dispatch). Used for BMT tree levels;
+# single hashes stay on alloy's asm keccak.
+keccak-batch = { version = "0.1", default-features = false }
 
 # derive macros
 derive_more = { version = "2.1", default-features = false, features = ["display", "from", "into", "as_ref"] }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -26,6 +26,7 @@ alloy-signer-local.workspace = true
 ## rust crypto
 digest.workspace = true
 hybrid-array.workspace = true
+keccak-batch.workspace = true
 
 # derive macros
 derive_more.workspace = true

--- a/crates/primitives/benches/bmt_bench.rs
+++ b/crates/primitives/benches/bmt_bench.rs
@@ -32,6 +32,29 @@ fn bench_bmt_hash(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_bmt_hash_prefixed(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bmt_hash_prefixed");
+
+    // 32-byte anchor, matching the transformed-address (sampler) use.
+    let anchor = B256::random();
+
+    for size in [1024, 4096].iter() {
+        let mut data = vec![0u8; *size];
+        rng().fill_bytes(&mut data);
+
+        group.bench_with_input(BenchmarkId::from_parameter(size), &data, |b, data| {
+            b.iter(|| {
+                let mut hasher = DefaultHasher::with_prefix(anchor.as_slice());
+                hasher.set_span(data.len() as u64);
+                hasher.update(data);
+                hasher.sum()
+            });
+        });
+    }
+
+    group.finish();
+}
+
 fn bench_content_chunk_creation(c: &mut Criterion) {
     let mut group = c.benchmark_group("content_chunk");
 
@@ -282,6 +305,7 @@ fn bench_bmt_zero_tree_optimization(c: &mut Criterion) {
 criterion_group!(
     benches,
     bench_bmt_hash,
+    bench_bmt_hash_prefixed,
     bench_content_chunk_creation,
     bench_single_owner_chunk_creation,
     bench_chunk_deserialization,

--- a/crates/primitives/src/bmt/hasher.rs
+++ b/crates/primitives/src/bmt/hasher.rs
@@ -10,10 +10,6 @@ use hybrid_array::{Array, sizes::U32};
 use std::io::{self, Write};
 use std::sync::LazyLock;
 
-// Use rayon for parallel processing on non-WASM platforms
-#[cfg(not(target_arch = "wasm32"))]
-use rayon;
-
 use super::constants::*;
 
 /// Number of zero tree levels for the default body size.
@@ -38,6 +34,32 @@ static ZERO_HASHES: LazyLock<[B256; ZERO_TREE_LEVELS]> = LazyLock::new(|| {
 
     hashes
 });
+
+/// Hash consecutive 64-byte sibling pairs of a tree level, batched across SIMD
+/// lanes.
+///
+/// `pairs` is the flat byte view of the level (`out.len()` pairs of two
+/// 32-byte nodes); each output is `keccak(prefix || left || right)`.
+pub(super) fn hash_pairs(prefix: Option<&[u8]>, pairs: &[u8], out: &mut [[u8; 32]]) {
+    debug_assert_eq!(pairs.len(), out.len() * SEGMENT_PAIR_LENGTH);
+
+    let Some(p) = prefix else {
+        let inputs: Vec<&[u8]> = pairs.chunks_exact(SEGMENT_PAIR_LENGTH).collect();
+        return keccak_batch::keccak256_many_into(&inputs, out);
+    };
+
+    let entry = p.len() + SEGMENT_PAIR_LENGTH;
+    let mut scratch = vec![0u8; entry * out.len()];
+    for (slot, pair) in scratch
+        .chunks_exact_mut(entry)
+        .zip(pairs.chunks_exact(SEGMENT_PAIR_LENGTH))
+    {
+        slot[..p.len()].copy_from_slice(p);
+        slot[p.len()..].copy_from_slice(pair);
+    }
+    let inputs: Vec<&[u8]> = scratch.chunks_exact(entry).collect();
+    keccak_batch::keccak256_many_into(&inputs, out);
+}
 
 /// BMT hasher with configurable body size.
 #[derive(Debug, Clone)]
@@ -222,19 +244,7 @@ impl<const BODY_SIZE: usize> Hasher<BODY_SIZE> {
             .min(BODY_SIZE);
 
         // Hash only the effective subtree (which contains all actual data).
-        // The parallel zero-shortcut path uses the prefix-independent
-        // ZERO_HASHES; with a prefix set we recurse fully via the sequential
-        // path so every zero section is hashed under the prefix.
-        #[cfg(not(target_arch = "wasm32"))]
-        let mut result = if prefix.is_some() {
-            self.hash_subtree_sequential(&self.buffer[..effective_size], effective_size)
-        } else {
-            self.hash_subtree_parallel(&self.buffer[..effective_size], effective_size)
-        };
-
-        #[cfg(target_arch = "wasm32")]
-        let mut result =
-            self.hash_subtree_sequential(&self.buffer[..effective_size], effective_size);
+        let mut result = self.hash_subtree(&self.buffer[..effective_size], &zero_hashes);
 
         // Roll up with zero hashes until we reach the full tree size
         let mut current_size = effective_size;
@@ -280,104 +290,54 @@ impl<const BODY_SIZE: usize> Hasher<BODY_SIZE> {
         hashes
     }
 
-    /// Hash a subtree of exactly `length` bytes (must be power of 2, >= 64)
+    /// Hash a power-of-two subtree (>= 64 bytes) level by level, batching each
+    /// level's sibling pairs across SIMD lanes.
     ///
-    /// For sizes < BODY_SIZE: uses sequential hashing (no rayon overhead).
-    /// For BODY_SIZE (4096): uses recursive parallel hashing for maximum throughput.
-    #[cfg(not(target_arch = "wasm32"))]
-    #[inline(always)]
-    fn hash_subtree_parallel(&self, data: &[u8], length: usize) -> B256 {
-        debug_assert!(length.is_power_of_two());
-        debug_assert!(length >= SEGMENT_PAIR_LENGTH);
-
-        // For sizes < BODY_SIZE, use sequential (avoids rayon overhead for small/medium sizes)
-        if length < BODY_SIZE {
-            return self.hash_subtree_sequential(data, length);
-        }
-
-        // For BODY_SIZE (4096): use recursive parallel hashing
-        // Pass cursor as parameter to avoid self indirection in hot loop
-        Self::hash_subtree_recursive_parallel_inner(data, length, self.cursor)
-    }
-
-    /// Recursively hash a subtree using rayon for parallelism.
-    /// Only called for full BODY_SIZE chunks where parallelism pays off.
-    /// Takes cursor as parameter to avoid self indirection in recursive calls.
-    #[cfg(not(target_arch = "wasm32"))]
-    #[inline(always)]
-    fn hash_subtree_recursive_parallel_inner(data: &[u8], length: usize, cursor: usize) -> B256 {
-        debug_assert!(length.is_power_of_two());
-        debug_assert!(length >= SEGMENT_PAIR_LENGTH);
-
-        // Base case: 64 bytes (one segment pair)
-        if length == SEGMENT_PAIR_LENGTH {
-            let mut hasher = Keccak256::new();
-            hasher.update(data);
-            return B256::from_slice(hasher.finalize().as_slice());
-        }
-
-        let half = length / 2;
-        let (left, right) = data.split_at(half);
-
-        // Check if right half is entirely beyond cursor (all zeros in buffer)
-        // cursor is relative to the start of this subtree
-        let (left_hash, right_hash) = if half >= cursor {
-            // Right side is all zeros - compute left only, use precomputed right
-            let left_hash = Self::hash_subtree_recursive_parallel_inner(left, half, cursor);
-            let right_hash = ZERO_HASHES[Self::zero_tree_level(half)];
-            (left_hash, right_hash)
-        } else {
-            // Both sides have data, use parallel execution
-            // Left cursor is capped at half (can't exceed subtree size)
-            // Right cursor is adjusted by half (relative to right subtree start)
-            rayon::join(
-                || Self::hash_subtree_recursive_parallel_inner(left, half, half),
-                || Self::hash_subtree_recursive_parallel_inner(right, half, cursor - half),
-            )
-        };
-
-        let mut hasher = Keccak256::new();
-        hasher.update(left_hash.as_slice());
-        hasher.update(right_hash.as_slice());
-        B256::from_slice(hasher.finalize().as_slice())
-    }
-
-    /// Hash a subtree of exactly `length` bytes (must be power of 2, >= 64) - sequential version
-    #[inline(always)]
-    fn hash_subtree_sequential(&self, data: &[u8], length: usize) -> B256 {
-        debug_assert!(length.is_power_of_two());
-        debug_assert!(length >= SEGMENT_PAIR_LENGTH);
+    /// Only pairs that overlap live data (the cursor) cost a Keccak; everything
+    /// past them is an all-zero subtree taken from `zero_hashes`, which the
+    /// caller has already made prefix-aware.
+    fn hash_subtree(&self, data: &[u8], zero_hashes: &[B256; ZERO_TREE_LEVELS]) -> B256 {
+        debug_assert!(data.len().is_power_of_two());
+        debug_assert!(data.len() >= SEGMENT_PAIR_LENGTH);
 
         let prefix = self.prefix.as_deref();
 
-        if length == SEGMENT_PAIR_LENGTH {
+        if data.len() == SEGMENT_PAIR_LENGTH {
             let mut hasher = Self::node_hasher(prefix);
             hasher.update(data);
             return B256::from_slice(hasher.finalize().as_slice());
         }
 
-        let half = length / 2;
-        let (left, right) = data.split_at(half);
+        // Level 0: pairs that overlap live data (the caller guarantees
+        // cursor > 0); the rest of the level is zero pairs.
+        let pairs = data.len() / SEGMENT_PAIR_LENGTH;
+        let mut live = self.cursor.div_ceil(SEGMENT_PAIR_LENGTH).min(pairs);
+        let mut level = vec![[0u8; 32]; pairs];
+        hash_pairs(
+            prefix,
+            &data[..live * SEGMENT_PAIR_LENGTH],
+            &mut level[..live],
+        );
+        for slot in &mut level[live..] {
+            slot.copy_from_slice(zero_hashes[0].as_slice());
+        }
 
-        // Check if right half is entirely beyond cursor (all zeros in buffer).
-        // The zero-sibling shortcut is only safe when the zero table matches the
-        // prefix; under a prefix we recurse over the literal zero section so it
-        // is hashed as keccak(prefix||...).
-        let (left_hash, right_hash) = if half >= self.cursor && prefix.is_none() {
-            // Right side is all zeros (plain hashing only)
-            let left_hash = self.hash_subtree_sequential(left, half);
-            let right_hash = ZERO_HASHES[Self::zero_tree_level(half)];
-            (left_hash, right_hash)
-        } else {
-            let left_hash = self.hash_subtree_sequential(left, half);
-            let right_hash = self.hash_subtree_sequential(right, half);
-            (left_hash, right_hash)
-        };
+        // Combine sibling digests level by level until one root remains.
+        let mut next = vec![[0u8; 32]; pairs / 2];
+        let mut count = pairs;
+        let mut depth = 1;
+        while count > 1 {
+            count /= 2;
+            live = live.div_ceil(2);
+            hash_pairs(prefix, level[..live * 2].as_flattened(), &mut next[..live]);
+            for slot in &mut next[live..count] {
+                slot.copy_from_slice(zero_hashes[depth].as_slice());
+            }
+            std::mem::swap(&mut level, &mut next);
+            depth += 1;
+        }
 
-        let mut hasher = Self::node_hasher(prefix);
-        hasher.update(left_hash.as_slice());
-        hasher.update(right_hash.as_slice());
-        B256::from_slice(hasher.finalize().as_slice())
+        B256::from(level[0])
     }
 
     /// Calculate the zero-tree level for a given subtree length.

--- a/crates/primitives/src/bmt/proof.rs
+++ b/crates/primitives/src/bmt/proof.rs
@@ -5,6 +5,7 @@
 
 use alloy_primitives::{B256, Keccak256};
 
+use super::hasher::hash_pairs;
 use crate::bmt::{Hasher, constants::*, error::BmtError};
 use crate::error::Result;
 
@@ -19,25 +20,6 @@ fn new_node_hasher(prefix: Option<&[u8]>) -> Keccak256 {
         hasher.update(p);
     }
     hasher
-}
-
-/// Compute the prefix-aware zero subtree hash for `level`.
-///
-/// `level` 0 is `keccak(prefix || 64 zero bytes)`; each higher level doubles the
-/// previous. With no prefix this equals the plain zero tree used by the hasher.
-fn prefixed_zero_hash(prefix: Option<&[u8]>, level: usize) -> B256 {
-    let mut hash = {
-        let mut hasher = new_node_hasher(prefix);
-        hasher.update([0u8; 2 * SEGMENT_SIZE]);
-        B256::from_slice(hasher.finalize().as_slice())
-    };
-    for _ in 0..level {
-        let mut hasher = new_node_hasher(prefix);
-        hasher.update(hash.as_slice());
-        hasher.update(hash.as_slice());
-        hash = B256::from_slice(hasher.finalize().as_slice());
-    }
-    hash
 }
 
 /// Represents a proof for a specific segment in a Binary Merkle Tree
@@ -147,51 +129,15 @@ impl Prover for Hasher {
             .into());
         }
 
-        // Create segments from data, padding with zeros if needed
-        let data_len = data.len();
-
-        // Use platform-specific optimizations for segment generation
-        #[cfg(not(target_arch = "wasm32"))]
-        let segments = {
-            use rayon::prelude::*;
-            (0..BRANCHES)
-                .into_par_iter()
-                .map(|i| {
-                    let start = i * SEGMENT_SIZE;
-                    let mut segment = [0u8; SEGMENT_SIZE];
-
-                    if start < data_len {
-                        let end = (start + SEGMENT_SIZE).min(data_len);
-                        let copy_len = end - start;
-                        segment[..copy_len].copy_from_slice(&data[start..end]);
-                    }
-
-                    B256::from_slice(&segment)
-                })
-                .collect::<Vec<_>>()
-        };
-
-        #[cfg(target_arch = "wasm32")]
-        let segments = {
-            let mut segs = Vec::with_capacity(BRANCHES);
-            for i in 0..BRANCHES {
-                let start = i * SEGMENT_SIZE;
-                let mut segment = [0u8; SEGMENT_SIZE];
-
-                if start < data_len {
-                    let end = (start + SEGMENT_SIZE).min(data_len);
-                    let copy_len = end - start;
-                    segment[..copy_len].copy_from_slice(&data[start..end]);
-                }
-
-                segs.push(B256::from_slice(&segment));
-            }
-
-            segs
-        };
+        // Materialise the BRANCHES zero-padded 32-byte leaf segments.
+        let mut leaves = [[0u8; SEGMENT_SIZE]; BRANCHES];
+        let n = data.len().min(BRANCHES * SEGMENT_SIZE);
+        for (leaf, chunk) in leaves.iter_mut().zip(data[..n].chunks(SEGMENT_SIZE)) {
+            leaf[..chunk.len()].copy_from_slice(chunk);
+        }
 
         // Get the segment being proven
-        let segment = segments[segment_index];
+        let segment = B256::from(leaves[segment_index]);
 
         // Include the prefix in the proof if there is one
         let prefix = if self.prefix().is_empty() {
@@ -201,73 +147,24 @@ impl Prover for Hasher {
         };
         let prefix_ref = prefix.as_deref();
 
-        // Generate proof segments
-        let mut proof_segments = Vec::with_capacity(PROOF_LENGTH);
-
-        // Build the Merkle tree level by level
-        let mut current_level = segments;
-        let mut current_index = segment_index;
-        // Tree level of the nodes in `current_level`: 0 = raw leaf segments,
-        // 1 = leaf-pair hashes, etc. Used to pick the right prefix-aware zero
-        // hash when padding an odd/short level.
-        let mut level: usize = 0;
-
-        // Continue until we reach the root (or until we have BMT_PROOF_LENGTH segments)
-        while proof_segments.len() < PROOF_LENGTH {
-            // Get sibling's index
-            let sibling_index = if current_index.is_multiple_of(2) {
-                current_index + 1
-            } else {
-                current_index - 1
-            };
-
-            // Add sibling to proof. A missing sibling is an all-zero subtree at
-            // this level, which under a prefix hashes differently from B256::ZERO.
-            if sibling_index < current_level.len() {
-                proof_segments.push(current_level[sibling_index]);
-            } else if level == 0 {
-                // Missing raw leaf segment is 32 zero bytes (not a hash).
-                proof_segments.push(B256::ZERO);
-            } else {
-                proof_segments.push(prefixed_zero_hash(prefix_ref, level - 1));
-            }
-
-            // Compute the next level up in the tree
-            let mut next_level = Vec::with_capacity(current_level.len().div_ceil(2));
-
-            for i in (0..current_level.len()).step_by(2) {
-                let left = &current_level[i];
-                let right = if i + 1 < current_level.len() {
-                    current_level[i + 1]
-                } else if level == 0 {
-                    B256::ZERO
-                } else {
-                    prefixed_zero_hash(prefix_ref, level - 1)
-                };
-
-                // Hash the pair to create the parent node (prefix-aware)
-                let mut hasher = new_node_hasher(prefix_ref);
-                hasher.update(left.as_slice());
-                hasher.update(right.as_slice());
-
-                let parent = B256::from_slice(hasher.finalize().as_slice());
-                next_level.push(parent);
-            }
-
-            // Move up to the next level
-            current_level = next_level;
-            current_index /= 2;
-            level += 1;
-
-            // If we've reached the root or have only one node, break
-            if current_level.len() <= 1 {
-                break;
-            }
+        // Build every tree level below the root, batching each level's sibling
+        // pairs across SIMD lanes. Zero padding is hashed literally, so under a
+        // prefix every zero subtree comes out as keccak(prefix || ...).
+        let mut levels: Vec<Vec<[u8; 32]>> = Vec::with_capacity(PROOF_LENGTH);
+        let mut current = leaves.to_vec();
+        while current.len() > 1 {
+            let mut next = vec![[0u8; 32]; current.len() / 2];
+            hash_pairs(prefix_ref, current.as_flattened(), &mut next);
+            levels.push(current);
+            current = next;
         }
 
-        // Ensure we have exactly BMT_PROOF_LENGTH segments in our proof
-        while proof_segments.len() < PROOF_LENGTH {
-            proof_segments.push(B256::ZERO);
+        // The proof is the sibling of the proven node at every level.
+        let mut proof_segments = Vec::with_capacity(PROOF_LENGTH);
+        let mut index = segment_index;
+        for level in &levels {
+            proof_segments.push(B256::from(level[index ^ 1]));
+            index /= 2;
         }
 
         Ok(Proof::new(


### PR DESCRIPTION
## What

Replaces the recursive rayon/sequential BMT subtree walk with a level-by-level walk that hashes each level's sibling pairs in a single [`keccak-batch`](https://github.com/nxm-rs/keccak-batch) call, dispatched at runtime to AVX-512/AVX2/SSE2/NEON/wasm-simd128 (`keccak-batch = "0.1"` from crates.io, `default-features = false`). Proof generation builds its tree levels through the same helper. Proof verification, single 64-byte subtrees, the zero tables, and the span wrap stay on alloy's asm keccak: a lone hash has nothing to batch and the asm single-hash path is faster than any scalar Rust. Zero-subtree shortcuts are preserved by counting live pairs from the cursor and padding levels from the (prefix-aware) zero table; the anchor-prefixed path, previously fully sequential, now batches too. Also adds a `bmt_hash_prefixed` bench covering the transformed-address path. Net -108 lines; rayon is gone from the BMT hot path entirely.

## Why

Closes #102.

## Testing

All 200 unit tests plus doctests pass, including the bee parity vectors (plain chunk address and anchor-prefixed transformed address byte-identical) and the naive-reference cross-checks for dense, sparse, and all-zero prefixed payloads. `cargo clippy --all-targets --all-features -- -D warnings` clean; `wasm32-unknown-unknown` builds.

Criterion A/B against a saved baseline of current main (AVX-512 host, medians):

| bench | main | this PR | speedup |
|---|---|---|---|
| bmt_hash/4096 | 26.4 us | 7.5 us | 3.5x |
| bmt_hash/1024 | 8.0 us | 2.9 us | 2.7x |
| bmt_hash_prefixed/4096 | 34.0 us | 9.6 us | 3.6x |
| proofs/generate_proof (0/32/64/127) | 92-146 us | ~7.5 us | 12-20x |
| proofs/full_proof_cycle | 137.8 us | 9.6 us | 14.3x |
| proofs/verify_proof | ~2.1 us | ~1.9 us | ~1.1x |
| bmt_hash/64-128, all-zero fast paths | - | - | flat |

The old parallel full-chunk path barely beat sequential (rayon join overhead); the batched version reaches 7.5 us on a single core and frees the thread pool.

AI Assistance: Claude Code used for the implementation, benches, and benchmarking.