### PR TITLE
primitives,postage: two-tier arbitrary generators

### DIFF
--- a/crates/postage/Cargo.toml
+++ b/crates/postage/Cargo.toml
@@ -41,8 +41,9 @@ proptest-arbitrary-interop = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }
 alloy-signer-local = { workspace = true }
-alloy-primitives = { workspace = true, features = ["getrandom"] }
+alloy-primitives = { workspace = true, features = ["getrandom", "arbitrary"] }
 arbitrary = { workspace = true, features = ["derive"] }
+nectar-primitives = { workspace = true, features = ["arbitrary"] }
 
 [[bench]]
 name = "verify"
@@ -61,7 +62,8 @@ serde = ["dep:serde", "nectar-primitives/serde", "alloy-primitives/serde"]
 # Parallel verification using rayon (sync, CPU-bound).
 parallel = ["dep:rayon", "std"]
 
-# Arbitrary trait implementations for property-based testing.
+# Arbitrary trait implementations and valid-by-construction generators for
+# property-based testing and fuzzing.
 arbitrary = ["dep:arbitrary", "nectar-primitives/arbitrary", "alloy-primitives/arbitrary"]
 
 [package.metadata.docs.rs]

--- a/crates/postage/src/batch.rs
+++ b/crates/postage/src/batch.rs
@@ -245,7 +245,7 @@ impl Batch {
 
 // Arbitrary implementations for property-based testing
 
-#[cfg(feature = "arbitrary")]
+#[cfg(any(test, feature = "arbitrary"))]
 impl<'a> arbitrary::Arbitrary<'a> for BatchParams {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         // Generate valid depth values (bucket_depth must be <= depth)
@@ -262,7 +262,7 @@ impl<'a> arbitrary::Arbitrary<'a> for BatchParams {
     }
 }
 
-#[cfg(feature = "arbitrary")]
+#[cfg(any(test, feature = "arbitrary"))]
 impl<'a> arbitrary::Arbitrary<'a> for Batch {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         // Generate valid depth values (bucket_depth must be <= depth)

--- a/crates/postage/src/generators.rs
+++ b/crates/postage/src/generators.rs
@@ -1,0 +1,109 @@
+//! Valid-by-construction test-value generators.
+//!
+//! Two tiers exist for test values. The raw tier is the `arbitrary::Arbitrary`
+//! impls on the types themselves (a [`Stamp`] whose signature is well-formed
+//! but signs nothing, say), which is what fuzzing rejection paths needs. This
+//! module is the valid tier: stamps are really signed over the chunk address
+//! with a bucket and index coherent with their batch, so
+//! [`Stamp::verify`] passes against the batch owner. Generators stay
+//! deterministic in `u`, so shrinking and replay work.
+//!
+//! See `nectar_primitives::generators` for the chunk-side generators and the
+//! deterministic signer.
+
+use alloy_primitives::Address;
+use alloy_signer::SignerSync;
+use arbitrary::Unstructured;
+use nectar_primitives::SwarmAddress;
+
+use crate::{Batch, BatchId, Stamp, StampDigest, StampIndex, StampedChunk};
+
+/// A batch with valid depth invariants and the given owner.
+///
+/// `bucket_depth` is drawn in `1..=min(depth, 31)`, so bucket count and
+/// per-bucket capacity both stay within `u32`.
+pub fn batch(u: &mut Unstructured<'_>, owner: Address) -> arbitrary::Result<Batch> {
+    let depth: u8 = u.int_in_range(1..=32)?;
+    let bucket_depth: u8 = u.int_in_range(1..=depth.min(31))?;
+    Ok(Batch::new(
+        BatchId::from(u.arbitrary::<[u8; 32]>()?),
+        u.arbitrary()?,
+        u.arbitrary()?,
+        owner,
+        depth,
+        bucket_depth,
+        u.arbitrary()?,
+    ))
+}
+
+/// A stamp for `address`, signed by `signer` and coherent with `batch`.
+///
+/// The bucket is the one `batch` assigns to `address`; the position is drawn
+/// within the bucket capacity, so [`Batch::validate_index`] and
+/// [`Batch::validate_bucket`] both pass. [`Stamp::verify`] passes when
+/// `signer` controls the batch owner address.
+pub fn signed_stamp(
+    u: &mut Unstructured<'_>,
+    signer: &impl SignerSync,
+    batch: &Batch,
+    address: &SwarmAddress,
+) -> arbitrary::Result<Stamp> {
+    let bucket = batch.bucket_for_address(address);
+    let position = u.int_in_range(0..=batch.bucket_upper_bound() - 1)?;
+    let index = StampIndex::new(bucket, position);
+    let timestamp = u.arbitrary()?;
+
+    let digest = StampDigest::new(*address, batch.id(), index, timestamp);
+    let signature = signer
+        .sign_message_sync(digest.to_prehash().as_slice())
+        .map_err(|_| arbitrary::Error::IncorrectFormat)?;
+
+    Ok(Stamp::with_index(batch.id(), index, timestamp, signature))
+}
+
+/// A fully coherent stamped chunk: a valid chunk paired with a stamp that
+/// verifies against the returned batch's owner.
+///
+/// The signer is drawn from `u` (see `nectar_primitives::generators::signer`);
+/// its address is the batch owner, so
+/// `stamped.stamp().verify(stamped.address(), batch.owner())` passes.
+pub fn signed_stamped_chunk<const BODY_SIZE: usize>(
+    u: &mut Unstructured<'_>,
+) -> arbitrary::Result<(StampedChunk<BODY_SIZE>, Batch)> {
+    let signer = nectar_primitives::generators::signer(u)?;
+    let batch = batch(u, signer.address())?;
+    let chunk = nectar_primitives::generators::any_chunk::<BODY_SIZE>(u)?;
+    let stamp = signed_stamp(u, &signer, &batch, chunk.address())?;
+    Ok((StampedChunk::new(chunk, stamp), batch))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn generated_stamp_verifies_and_is_coherent(
+            seed in proptest::collection::vec(any::<u8>(), 128..2048),
+        ) {
+            let mut u = Unstructured::new(&seed);
+            let (stamped, batch): (StampedChunk, Batch) =
+                signed_stamped_chunk(&mut u).unwrap();
+
+            let address = *stamped.address();
+            let stamp = stamped.stamp();
+
+            // Signature really covers the chunk address and stamp fields.
+            prop_assert!(stamp.verify(&address, batch.owner()).is_ok());
+
+            // Bucket and position are coherent with the batch geometry.
+            prop_assert!(batch.validate_index(&stamp.stamp_index()).is_ok());
+            prop_assert!(batch.validate_bucket(&stamp.stamp_index(), &address).is_ok());
+
+            // The stamp round-trips its fixed-size wire encoding.
+            let decoded = Stamp::from_bytes(&stamp.to_bytes()).unwrap();
+            prop_assert_eq!(stamp, &decoded);
+        }
+    }
+}

--- a/crates/postage/src/lib.rs
+++ b/crates/postage/src/lib.rs
@@ -30,6 +30,8 @@
 //! - `std` (default): Enable standard library support, BatchStore, events
 //! - `serde`: Enable serde serialization/deserialization
 //! - `parallel`: Enable parallel verification with rayon
+//! - `arbitrary`: Raw `Arbitrary` impls plus the valid-by-construction
+//!   `generators` module for property-based testing and fuzzing
 
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(feature = "std"), no_std)]
@@ -46,6 +48,8 @@ extern crate alloc;
 
 mod batch;
 mod error;
+#[cfg(any(test, feature = "arbitrary"))]
+pub mod generators;
 mod stamp;
 mod stamped;
 mod util;

--- a/crates/postage/src/stamp.rs
+++ b/crates/postage/src/stamp.rs
@@ -496,14 +496,14 @@ impl TryFrom<StampBytes> for Stamp {
 
 // Arbitrary implementations for property-based testing
 
-#[cfg(feature = "arbitrary")]
+#[cfg(any(test, feature = "arbitrary"))]
 impl<'a> arbitrary::Arbitrary<'a> for StampIndex {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self::new(u.arbitrary()?, u.arbitrary()?))
     }
 }
 
-#[cfg(feature = "arbitrary")]
+#[cfg(any(test, feature = "arbitrary"))]
 impl<'a> arbitrary::Arbitrary<'a> for Stamp {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         use alloy_primitives::U256;

--- a/crates/postage/src/stamped.rs
+++ b/crates/postage/src/stamped.rs
@@ -157,6 +157,19 @@ impl<const BODY_SIZE: usize> StampedChunk<BODY_SIZE> {
     }
 }
 
+#[cfg(any(test, feature = "arbitrary"))]
+impl<'a, const BODY_SIZE: usize> arbitrary::Arbitrary<'a> for StampedChunk<BODY_SIZE> {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        // Raw tier: the stamp is structurally valid but not signed over the
+        // chunk's address. Use `crate::generators::signed_stamped_chunk` for a
+        // pairing whose stamp verifies.
+        Ok(Self::new(
+            nectar_primitives::AnyChunk::arbitrary(u)?,
+            Stamp::arbitrary(u)?,
+        ))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{B256, Signature};

--- a/crates/primitives/src/address.rs
+++ b/crates/primitives/src/address.rs
@@ -346,7 +346,7 @@ impl From<SwarmAddress> for [u8; 32] {
     }
 }
 
-#[cfg(feature = "arbitrary")]
+#[cfg(any(test, feature = "arbitrary"))]
 impl<'a> arbitrary::Arbitrary<'a> for SwarmAddress {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self(B256::arbitrary(u)?))

--- a/crates/primitives/src/bin.rs
+++ b/crates/primitives/src/bin.rs
@@ -91,6 +91,14 @@ impl From<ProximityOrder> for Bin {
     }
 }
 
+#[cfg(any(test, feature = "arbitrary"))]
+impl<'a> arbitrary::Arbitrary<'a> for Bin {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        // Uniform over the representable range; every Bin is valid.
+        Ok(Self(u.int_in_range(0..=MAX_PO)?))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/primitives/src/chunk/any_chunk.rs
+++ b/crates/primitives/src/chunk/any_chunk.rs
@@ -343,6 +343,20 @@ impl<const BODY_SIZE: usize> PartialEq for AnyChunk<BODY_SIZE> {
 
 impl<const BODY_SIZE: usize> Eq for AnyChunk<BODY_SIZE> {}
 
+#[cfg(any(test, feature = "arbitrary"))]
+impl<'a, const BODY_SIZE: usize> arbitrary::Arbitrary<'a> for AnyChunk<BODY_SIZE> {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        // Raw tier: delegates to the variant impls, so the single-owner arm
+        // may carry a signature that does not verify. Use
+        // `crate::generators::any_chunk` for a valid-by-construction value.
+        if u.arbitrary()? {
+            Ok(ContentChunk::<BODY_SIZE>::arbitrary(u)?.into())
+        } else {
+            Ok(SingleOwnerChunk::<BODY_SIZE>::arbitrary(u)?.into())
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::traits::{BmtChunk, Chunk};

--- a/crates/primitives/src/chunk/content.rs
+++ b/crates/primitives/src/chunk/content.rs
@@ -400,6 +400,8 @@ impl<const BODY_SIZE: usize> ContentChunkBuilderImpl<BODY_SIZE, ReadyToBuild> {
 #[cfg(any(test, feature = "arbitrary"))]
 impl<'a, const BODY_SIZE: usize> arbitrary::Arbitrary<'a> for ContentChunk<BODY_SIZE> {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        // Every content chunk is valid by construction: the address is the
+        // BMT hash of the drawn body, so this impl serves both tiers.
         Ok(Self::from_body(BmtBody::<BODY_SIZE>::arbitrary(u)?))
     }
 }

--- a/crates/primitives/src/chunk/single_owner.rs
+++ b/crates/primitives/src/chunk/single_owner.rs
@@ -614,19 +614,41 @@ impl<const BODY_SIZE: usize> SingleOwnerChunkBuilderImpl<BODY_SIZE, ReadyToBuild
 }
 
 #[cfg(any(test, feature = "arbitrary"))]
-impl<'a, const BODY_SIZE: usize> arbitrary::Arbitrary<'a> for SingleOwnerChunk<BODY_SIZE> {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+impl<const BODY_SIZE: usize> SingleOwnerChunk<BODY_SIZE> {
+    /// Valid-by-construction generator: a chunk with a `u`-drawn id and body,
+    /// signed by `signer` so ownership recovery and `verify` succeed.
+    ///
+    /// Deterministic in `u` for a deterministic signer; contrast with the raw
+    /// `Arbitrary` impl, whose signature is unconstrained.
+    pub fn arbitrary_signed(
+        u: &mut arbitrary::Unstructured<'_>,
+        signer: &impl SignerSync,
+    ) -> arbitrary::Result<Self> {
+        use arbitrary::Arbitrary;
+
         let id = B256::arbitrary(u)?;
         let body = BmtBody::<BODY_SIZE>::arbitrary(u)?;
-        let signer = alloy_signer_local::PrivateKeySigner::random();
 
-        Ok(SingleOwnerChunkBuilderImpl::<BODY_SIZE, Initial>::default()
+        SingleOwnerChunkBuilderImpl::<BODY_SIZE, Initial>::default()
             .with_body(body)
             .with_id(id)
-            .with_signer(&signer)
-            .unwrap()
-            .build()
-            .unwrap())
+            .with_signer(signer)
+            .and_then(SingleOwnerChunkBuilderImpl::build)
+            .map_err(|_| arbitrary::Error::IncorrectFormat)
+    }
+}
+
+#[cfg(any(test, feature = "arbitrary"))]
+impl<'a, const BODY_SIZE: usize> arbitrary::Arbitrary<'a> for SingleOwnerChunk<BODY_SIZE> {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        // Raw tier: the signature is an unconstrained well-formed signature,
+        // not a signature over the id and body, so ownership recovery and
+        // address verification may fail. Use [`Self::arbitrary_signed`] or
+        // `crate::generators` for a valid-by-construction chunk.
+        let id = B256::arbitrary(u)?;
+        let signature = Signature::arbitrary(u)?;
+        let body = BmtBody::<BODY_SIZE>::arbitrary(u)?;
+        Ok(Self::from_parts(id, signature, body))
     }
 }
 
@@ -647,9 +669,22 @@ mod tests {
         PrivateKeySigner::from_slice(&pk).unwrap()
     }
 
-    // Strategy for generating SingleOwnerChunk using the Arbitrary implementation
+    // Strategy for generating SingleOwnerChunk using the raw Arbitrary
+    // implementation (signature unconstrained, so no verify assertions).
     fn chunk_strategy() -> impl Strategy<Value = DefaultSingleOwnerChunk> {
         arb::<DefaultSingleOwnerChunk>()
+    }
+
+    // Strategy for valid-by-construction chunks via `arbitrary_signed`.
+    fn signed_chunk_strategy() -> impl Strategy<Value = DefaultSingleOwnerChunk> {
+        proptest::collection::vec(any::<u8>(), 64..1024).prop_filter_map(
+            "arbitrary_signed needs a signable draw",
+            |bytes| {
+                let mut u = arbitrary::Unstructured::new(&bytes);
+                let signer = crate::generators::signer(&mut u).ok()?;
+                DefaultSingleOwnerChunk::arbitrary_signed(&mut u, &signer).ok()
+            },
+        )
     }
 
     proptest! {
@@ -657,15 +692,22 @@ mod tests {
         fn test_chunk_properties(chunk in chunk_strategy()) {
             prop_assert!(chunk.size() >= MIN_SOC_FIELDS_SIZE);
 
-            // Test round-trip conversion
+            // Test round-trip conversion of the raw parts
             let bytes: Bytes = chunk.clone().into();
             let decoded = DefaultSingleOwnerChunk::try_from(bytes.as_ref()).unwrap();
             prop_assert_eq!(chunk.id(), decoded.id());
             prop_assert_eq!(chunk.signature(), decoded.signature());
             prop_assert_eq!(chunk.data(), decoded.data());
+        }
+
+        #[test]
+        fn test_signed_chunk_verifies(chunk in signed_chunk_strategy()) {
+            // Owner recovery succeeds and survives the round-trip
+            let bytes: Bytes = chunk.clone().into();
+            let decoded = DefaultSingleOwnerChunk::try_from(bytes.as_ref()).unwrap();
             prop_assert_eq!(chunk.owner().unwrap(), decoded.owner().unwrap());
 
-            // Test address verification
+            // Address verification succeeds
             let address = chunk.address();
             prop_assert!(chunk.verify(address).is_ok());
         }

--- a/crates/primitives/src/generators.rs
+++ b/crates/primitives/src/generators.rs
@@ -1,0 +1,97 @@
+//! Valid-by-construction test-value generators.
+//!
+//! Two tiers exist for test values. The raw tier is the `arbitrary::Arbitrary`
+//! impls on the types themselves: deterministic in the input bytes but free to
+//! produce values that fail validation (an unconstrained single-owner chunk
+//! signature, say), which is what fuzzing rejection paths needs. This module
+//! is the valid tier: every value it returns passes the corresponding
+//! validation (a content chunk hashes to its own address, a single-owner
+//! chunk's signature recovers its owner). Generators stay deterministic in
+//! `u`, so shrinking and replay work.
+//!
+//! Bridge to proptest with `proptest-arbitrary-interop` for the raw tier, or
+//! by mapping a byte-vector strategy through [`arbitrary::Unstructured`] for
+//! these generators.
+
+use alloy_primitives::keccak256;
+use alloy_signer::SignerSync;
+use alloy_signer_local::PrivateKeySigner;
+use arbitrary::{Arbitrary, Unstructured};
+
+use crate::{AnyChunk, ContentChunk, SingleOwnerChunk};
+
+/// A deterministic signer drawn from `u`.
+///
+/// The key is the keccak-256 of 32 drawn bytes, so it is uniformly
+/// distributed and valid except with negligible probability.
+pub fn signer(u: &mut Unstructured<'_>) -> arbitrary::Result<PrivateKeySigner> {
+    let seed: [u8; 32] = u.arbitrary()?;
+    PrivateKeySigner::from_bytes(&keccak256(seed)).map_err(|_| arbitrary::Error::IncorrectFormat)
+}
+
+/// A valid content-addressed chunk.
+///
+/// Every representable content chunk is valid (the address is derived from
+/// span and payload), so this delegates to the `Arbitrary` impl; it exists so
+/// valid-tier call sites read uniformly.
+pub fn content_chunk<const BODY_SIZE: usize>(
+    u: &mut Unstructured<'_>,
+) -> arbitrary::Result<ContentChunk<BODY_SIZE>> {
+    ContentChunk::arbitrary(u)
+}
+
+/// A valid single-owner chunk signed by a signer drawn from `u`.
+///
+/// Recover the owner from the chunk itself via
+/// [`SingleOwnerChunk::owner`]. To pin the owner, use
+/// [`single_owner_chunk_signed_by`].
+pub fn single_owner_chunk<const BODY_SIZE: usize>(
+    u: &mut Unstructured<'_>,
+) -> arbitrary::Result<SingleOwnerChunk<BODY_SIZE>> {
+    let signer = signer(u)?;
+    SingleOwnerChunk::arbitrary_signed(u, &signer)
+}
+
+/// A valid single-owner chunk signed by the given signer.
+pub fn single_owner_chunk_signed_by<const BODY_SIZE: usize>(
+    u: &mut Unstructured<'_>,
+    signer: &impl SignerSync,
+) -> arbitrary::Result<SingleOwnerChunk<BODY_SIZE>> {
+    SingleOwnerChunk::arbitrary_signed(u, signer)
+}
+
+/// A valid chunk of either kind: content-addressed, or single-owner signed by
+/// a signer drawn from `u`.
+pub fn any_chunk<const BODY_SIZE: usize>(
+    u: &mut Unstructured<'_>,
+) -> arbitrary::Result<AnyChunk<BODY_SIZE>> {
+    if u.arbitrary()? {
+        Ok(content_chunk::<BODY_SIZE>(u)?.into())
+    } else {
+        Ok(single_owner_chunk::<BODY_SIZE>(u)?.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::DEFAULT_BODY_SIZE;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn generated_chunks_verify(seed in proptest::collection::vec(any::<u8>(), 64..2048)) {
+            let mut u = Unstructured::new(&seed);
+            let chunk = any_chunk::<DEFAULT_BODY_SIZE>(&mut u).unwrap();
+            let address = *chunk.address();
+            prop_assert!(chunk.verify(&address).is_ok());
+        }
+
+        #[test]
+        fn signer_is_deterministic(seed in any::<[u8; 32]>()) {
+            let a = signer(&mut Unstructured::new(&seed)).unwrap();
+            let b = signer(&mut Unstructured::new(&seed)).unwrap();
+            prop_assert_eq!(a.address(), b.address());
+        }
+    }
+}

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -40,6 +40,8 @@ mod cache;
 pub mod chunk;
 pub mod error;
 pub mod file;
+#[cfg(any(test, feature = "arbitrary"))]
+pub mod generators;
 pub mod neighborhood_depth;
 pub mod network_id;
 pub mod nonce;

--- a/crates/primitives/src/network_id.rs
+++ b/crates/primitives/src/network_id.rs
@@ -54,6 +54,13 @@ impl NetworkId {
     }
 }
 
+#[cfg(any(test, feature = "arbitrary"))]
+impl<'a> arbitrary::Arbitrary<'a> for NetworkId {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self::new(u.arbitrary()?))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/primitives/src/nonce.rs
+++ b/crates/primitives/src/nonce.rs
@@ -48,6 +48,13 @@ impl Nonce {
     }
 }
 
+#[cfg(any(test, feature = "arbitrary"))]
+impl<'a> arbitrary::Arbitrary<'a> for Nonce {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self::new(u.arbitrary()?))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/primitives/src/proximity_order.rs
+++ b/crates/primitives/src/proximity_order.rs
@@ -77,6 +77,14 @@ impl TryFrom<u8> for ProximityOrder {
     }
 }
 
+#[cfg(any(test, feature = "arbitrary"))]
+impl<'a> arbitrary::Arbitrary<'a> for ProximityOrder {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        // Uniform over the representable range; every ProximityOrder is valid.
+        Ok(Self(u.int_in_range(0..=MAX_PO)?))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/primitives/src/timestamp.rs
+++ b/crates/primitives/src/timestamp.rs
@@ -90,6 +90,15 @@ impl Timestamp {
     }
 }
 
+#[cfg(any(test, feature = "arbitrary"))]
+impl<'a> arbitrary::Arbitrary<'a> for Timestamp {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        // Any i64 is representable, including pre-1970 values; validity
+        // policies (skew windows) are the caller's concern.
+        Ok(Self::from_seconds(u.arbitrary()?))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## What

Extends the existing optional `arbitrary` features on `nectar-primitives` and `nectar-postage` (off by default, zero cost when disabled) into an explicit two-tier design: raw deterministic `arbitrary::Arbitrary` impls for fuzz and validation-path testing, and new valid-by-construction `generators` modules whose output provably passes verification (a generated CAC hashes its own payload, a generated SOC's signature recovers its owner, a generated stamp signs the chunk address with batch-coherent bucket and index).

Fixes a pre-existing tier blur along the way: `SingleOwnerChunk`'s `Arbitrary` previously signed with a fresh random key on every call, which is valid but non-deterministic and therefore the wrong shape for a raw impl. It is now raw with an unconstrained signature; signed validity moves to the new `SingleOwnerChunk::arbitrary_signed` and to the `generators` modules.

Raw `Arbitrary` coverage: `nectar-primitives` `SwarmAddress` (`ChunkAddress` is an alias), `Bin`, `ProximityOrder`, `Nonce`, `Timestamp`, `NetworkId`, `BmtBody` (leaf and intermediate span encoding), `ContentChunk` (inherently valid, doubles as the valid tier), `SingleOwnerChunk` (now raw), `AnyChunk`; `nectar-postage` `Stamp` (well-formed, unverified signature), `StampIndex`, `Batch`, `BatchParams`, `StampedChunk` (new). `B256`/`Address`/`Signature` delegate to alloy-primitives' own `arbitrary` feature, enabled transitively by both crates' features; `SwarmAddress`/`Nonce`/`BatchId` delegate to `B256`.

Valid-by-construction additions: `nectar_primitives::generators::{signer, content_chunk, single_owner_chunk, single_owner_chunk_signed_by, any_chunk}` plus `SingleOwnerChunk::arbitrary_signed`; `nectar_postage::generators::{batch, signed_stamp, signed_stamped_chunk}`.

Feature surface is unchanged: `nectar-primitives/arbitrary` and `nectar-postage/arbitrary` are the same pre-existing features, extended, with no new features and no new dependencies. `nectar-swarms` already delegates to `alloy-chains`' `arbitrary` feature and is untouched; mantaray, contracts, postage-issuer and postage-usage are out of scope.

New proof tests confirm generated CACs and SOCs verify, and generated stamps verify against the batch owner and geometry. They run in the default CI test pass via `any(test, feature)` gates.

## Why

Closes #132. Downstream consumers of nectar-owned types hand-roll their own construction helpers and re-derive validity invariants for fuzzing and property tests; vertex is the first consumer of this shared surface.

## Testing

`cargo fmt --all` clean. `cargo clippy --all-targets --all-features -- -D warnings` clean. `cargo nextest run --workspace -E '!kind(test)'`: 409 passed, matching the CI test job. `cargo nextest run -p nectar-primitives -p nectar-postage --features arbitrary`: 249 passed. `cargo test --doc --workspace`: all ok, matching the CI doc job. CI wasm gate reproduced locally via `nix develop`: `cargo check -p nectar-postage-usage --features client --target wasm32-unknown-unknown` passes. no_std checks: `cargo check -p nectar-postage --no-default-features` and `--no-default-features --features arbitrary` both pass. Feature-off default checks of both crates pass, confirming zero cost when disabled.

Known pre-existing issue, not a regression (reproduced on an unchanged `origin/main` worktree): `wasm32` with `--features arbitrary` fails because `alloy-primitives/arbitrary` pulls in `proptest`, whose default `fork` feature pulls `wait-timeout`, which has no wasm support. The wasm cone stays clean with the feature off, exactly as before this branch.

AI Assistance: Claude Code used for implementation and PR text (Fable 5 implementation, Sonnet 5 PR text) under human direction.