### PR TITLE
fix(postage-usage): reject zero bucket_depth (shift-overflow panic)

### DIFF
--- a/crates/postage-usage/src/codec.rs
+++ b/crates/postage-usage/src/codec.rs
@@ -769,6 +769,36 @@ mod tests {
     }
 
     #[test]
+    fn parse_rejects_zero_bucket_depth_as_corruption() {
+        // A handcrafted root that is valid in every other respect: depth 5,
+        // bucket depth 0 (one zero-width bucket), width 0, sequence 1, one
+        // allocated slot, no exceptions, no leaves. Before bucket depth 0 was
+        // rejected by `validate_geometry`, this payload parsed `Ok` and the
+        // recovered snapshot panicked downstream in `calculate_bucket`
+        // (`leading >> (32 - 0)` is a shift overflow) on the persist and
+        // issue paths.
+        let mut root = vec![0u8; ROOT_HEADER_SIZE + 4];
+        root[..4].copy_from_slice(&MAGIC);
+        root[4..36].copy_from_slice(B256::repeat_byte(0x42).as_slice());
+        root[36] = 5; // depth
+        root[37] = 0; // bucket_depth: the zero-width bucket under test
+        root[40..48].copy_from_slice(&1u64.to_be_bytes()); // sequence
+        root[60..62].copy_from_slice(&1u16.to_be_bytes()); // allocated = 1
+        // exceptions = 0, leaves = 0, base = 0, slot 0 already zeroed.
+
+        let err = RootInfo::parse(&root).unwrap_err();
+        assert_eq!(
+            err,
+            UsageError::CorruptGeometry {
+                depth: 5,
+                bucket_depth: 0,
+            }
+        );
+        assert!(err.is_corruption());
+        assert!(!err.is_recoverable());
+    }
+
+    #[test]
     fn parse_rejects_out_of_range_slot_as_corruption() {
         let mut root = root_with_one_exception();
         // Push the allocated slot to the capacity bound (valid slots are < 16).

--- a/crates/postage-usage/src/table.rs
+++ b/crates/postage-usage/src/table.rs
@@ -35,9 +35,15 @@ pub(crate) const fn map_counter_error(err: CounterError) -> UsageError {
 }
 
 /// Validates that a batch geometry is within the range supported by the
-/// snapshot format: `bucket_depth <= 16` and `depth - bucket_depth <= 31`.
+/// snapshot format: `1 <= bucket_depth <= 16` and `depth - bucket_depth <= 31`.
+///
+/// A zero bucket depth is rejected: a batch with no collision buckets is
+/// meaningless, and `nectar_postage::calculate_bucket` shifts a `u32` right by
+/// `32 - bucket_depth`, so `bucket_depth == 0` would overflow the shift on the
+/// persist and issue paths.
 pub(crate) const fn validate_geometry(depth: u8, bucket_depth: u8) -> Result<()> {
-    if bucket_depth > MAX_BUCKET_DEPTH
+    if bucket_depth == 0
+        || bucket_depth > MAX_BUCKET_DEPTH
         || depth < bucket_depth
         || depth - bucket_depth > MAX_COUNTER_BITS
     {
@@ -451,10 +457,11 @@ mod arbitrary_impls {
     impl<'a> Arbitrary<'a> for UsageTable {
         fn arbitrary(u: &mut Unstructured<'a>) -> ArbitraryResult<Self> {
             let batch_id = B256::from(u.arbitrary::<[u8; 32]>()?);
-            // The format itself allows `bucket_depth == 0`, but
-            // `nectar_postage::calculate_bucket` shifts a u32 right by
-            // `32 - bucket_depth`, so depth 0 overflows the shift and panics
-            // on every persist. Generate only persistable geometry here.
+            // `bucket_depth == 0` (a zero-width bucket) is invalid geometry:
+            // `validate_geometry` rejects it because `nectar_postage::
+            // calculate_bucket` shifts a u32 right by `32 - bucket_depth`, so
+            // depth 0 would overflow the shift. The range below is therefore
+            // exactly the format invariant, not a generator restriction.
             let bucket_depth = u.int_in_range(1..=MAX_BUCKET_DEPTH)?;
             let counter_bits = u.int_in_range(0..=MAX_COUNTER_BITS)?;
             let depth = bucket_depth + counter_bits;
@@ -514,6 +521,37 @@ mod tests {
         assert!(UsageTable::new(batch_id(), 48, 16, imm).is_err());
         assert!(UsageTable::new(batch_id(), 15, 16, imm).is_err());
         assert!(UsageTable::new(batch_id(), 20, 17, imm).is_err());
+    }
+
+    #[test]
+    fn geometry_rejects_zero_bucket_depth() {
+        // A zero bucket depth would overflow `calculate_bucket`'s
+        // `32 - bucket_depth` shift on the persist and issue paths, so the
+        // geometry validator rejects it outright.
+        for depth in [0u8, 1, 20, 31] {
+            assert_eq!(
+                validate_geometry(depth, 0),
+                Err(UsageError::InvalidGeometry {
+                    depth,
+                    bucket_depth: 0,
+                })
+            );
+        }
+        // Both constructors go through the validator.
+        assert_eq!(
+            UsageTable::new(batch_id(), 20, 0, Mutability::Immutable),
+            Err(UsageError::InvalidGeometry {
+                depth: 20,
+                bucket_depth: 0,
+            })
+        );
+        assert_eq!(
+            UsageTable::from_counts(batch_id(), 5, 0, vec![0u32], Mutability::Immutable),
+            Err(UsageError::InvalidGeometry {
+                depth: 5,
+                bucket_depth: 0,
+            })
+        );
     }
 
     #[test]

--- a/crates/postage/src/util.rs
+++ b/crates/postage/src/util.rs
@@ -40,6 +40,15 @@ pub const fn current_timestamp() -> u64 {
 ///
 /// The bucket number (0 to 2^bucket_depth - 1)
 ///
+/// # Panics
+///
+/// `bucket_depth` must be in `1..=32`: the implementation shifts a `u32`
+/// right by `32 - bucket_depth`, so `bucket_depth == 0` overflows the shift
+/// (and values above 32 overflow the subtraction), which panics with
+/// overflow checks enabled and yields an unspecified value without them.
+/// Callers validate the batch geometry (e.g. `nectar-postage-usage` rejects
+/// `bucket_depth == 0` at decode) before reaching this function.
+///
 /// # Example
 ///
 /// ```


### PR DESCRIPTION
## What

Rejects a decoded postage usage snapshot whose `bucket_depth == 0`, closing a shift-overflow panic the fuzzer found.

A snapshot with `bucket_depth == 0` previously passed `RootInfo::parse` and `assemble`, then panicked downstream when `calculate_bucket` shifts a `u32` by `32 - 0 = 32`.

Changes:

- `crates/postage-usage/src/table.rs`: `validate_geometry` now rejects `bucket_depth == 0`, covering both the decode path and `from_counts`. The `Arbitrary` generator's `1..=16` clamp is re-documented as a real format invariant rather than a workaround.
- `crates/postage-usage/src/codec.rs`: regression test; a 70-byte SBU1 root that parsed `Ok` before the fix is now rejected as `CorruptGeometry`.
- `crates/postage/src/util.rs`: `# Panics` doc on `calculate_bucket` recording the `1..=32` precondition.

A latent defence-in-depth gap on the issuer and `Batch` path (not reachable from untrusted input) is tracked separately.

## Why

Closes #138.

The wire format should never accept a zero-width bucket. Under the overflow checks enabled in fuzz and debug builds the shift overflow panics; in plain release it silently returns a wrong bucket.

## Testing

    cargo test -p nectar-postage-usage -p nectar-postage

Both crates pass. The regression test in `codec.rs` confirms the crafted 70-byte SBU1 root now returns `CorruptGeometry` instead of `Ok`. Originally found by the `usage_snapshot_roundtrip` fuzz target, which no longer panics on this input.

---
Stacked on #141 (`fuzz/2-cargo-fuzz-harness`).

AI Assistance: Claude (Anthropic) used for the fix, regression tests, and this PR description.
