### PR TITLE
test(fuzz): cover the 64-byte encrypted-ref mantaray decode path

### DIFF
--- a/crates/mantaray/src/codec.rs
+++ b/crates/mantaray/src/codec.rs
@@ -855,9 +855,63 @@ mod tests {
         ));
     }
 
+    /// Same as `truncated_node_bytes` but with `ref_size = 64`, the width of
+    /// the `EncryptedChunkRef` entry, so the 64-byte slicing arithmetic in
+    /// `decode_v01`/`decode_v02` is exercised on stable (the fuzz target
+    /// drives this width too, but only under libfuzzer mutation on nightly).
+    #[cfg(feature = "encryption")]
+    fn truncated_encref_node_bytes(version: &VersionHash, len: usize) -> Vec<u8> {
+        assert!(len >= NodeHeader::SIZE);
+        let mut data = vec![0u8; len];
+        data[NodeHeader::VERSION_HASH_OFFSET..NodeHeader::VERSION_HASH_OFFSET + VersionHash::SIZE]
+            .copy_from_slice(version.as_bytes());
+        data[NodeHeader::REF_SIZE_OFFSET] = 64;
+        data
+    }
+
+    /// Regression for the 64-byte entry width: with `ref_size = 64` the entry
+    /// slot is `data[64..128]` and the forks index `data[128..160]`, so every
+    /// length below 160 must return `Err` (the PR bounds check, exercised for
+    /// the encrypted-ref path), never panic.
+    #[cfg(feature = "encryption")]
+    #[test]
+    fn decode_encref_truncated_lengths_return_err() {
+        use nectar_primitives::EncryptedChunkRef;
+        for (label, version) in [("v01", VersionHash::V01), ("v02", VersionHash::V02)] {
+            for len in NodeHeader::SIZE..NodeHeader::SIZE + 64 + 32 {
+                let data = truncated_encref_node_bytes(&version, len);
+                let result = Node::<EncryptedChunkRef>::try_from(data.as_slice());
+                assert!(
+                    matches!(result, Err(MantarayError::DataTooShort)),
+                    "encref {label} length {len} must yield DataTooShort"
+                );
+            }
+        }
+    }
+
+    /// A full 160-byte encrypted-ref node whose index demands a fork ref that
+    /// is not present must hit the guarded error path, not panic.
+    #[cfg(feature = "encryption")]
+    #[test]
+    fn decode_encref_index_demands_missing_fork_returns_err() {
+        use nectar_primitives::EncryptedChunkRef;
+        for (label, version) in [("v01", VersionHash::V01), ("v02", VersionHash::V02)] {
+            let mut data = truncated_encref_node_bytes(&version, NodeHeader::SIZE + 64 + 32);
+            // Set bit 0 of the forks index (LE bitfield at offset 128).
+            data[NodeHeader::SIZE + 64] = 0x01;
+            let result = Node::<EncryptedChunkRef>::try_from(data.as_slice());
+            assert!(
+                matches!(result, Err(MantarayError::InsufficientForkBytes { .. })),
+                "encref {label} missing fork body must yield InsufficientForkBytes"
+            );
+        }
+    }
+
     /// Replay the committed seed corpus of the `mantaray_node_decode` fuzz
-    /// target through the exact decode entry point the fuzzer exercises
-    /// (`Node::<ChunkAddress>::try_from(&[u8])`). The oracle is "no panic";
+    /// target through the exact decode entry points the fuzzer exercises
+    /// (`Node::<ChunkAddress>` for 32-byte plain entries and, under the
+    /// `encryption` feature, `Node::<EncryptedChunkRef>` for 64-byte
+    /// entries). The oracle is "no panic";
     /// `Err` is an acceptable outcome for any seed. Additionally pin the
     /// intent of each seed by name: `crash-*` seeds must stay `Err` (they
     /// are fixed panic reproducers), `valid-*` seeds must decode `Ok`.
@@ -876,8 +930,12 @@ mod tests {
             let name = path.file_name().unwrap().to_string_lossy().into_owned();
             let data = std::fs::read(&path).unwrap();
 
-            // The fuzz oracle: must not panic.
+            // The fuzz oracle: must not panic. Drive both entry widths the
+            // fuzz target drives; the 64-byte `EncryptedChunkRef` path only
+            // exists under the `encryption` feature.
             let result = Node::<ChunkAddress>::try_from(data.as_slice());
+            #[cfg(feature = "encryption")]
+            let _ = Node::<nectar_primitives::EncryptedChunkRef>::try_from(data.as_slice());
 
             if name.starts_with("crash-") {
                 assert!(result.is_err(), "seed {name} must remain an Err reproducer");

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,7 +14,12 @@ alloy-primitives = { version = "1.6", default-features = false }
 arbitrary = { version = "1", features = ["derive"] }
 alloy-signer-local = { version = "2.0", default-features = false }
 libfuzzer-sys = "0.4"
-nectar-mantaray = { path = "../crates/mantaray", features = ["arbitrary"] }
+# `encryption` gates the `NodeEntry for EncryptedChunkRef` impl that
+# `mantaray_node_decode` uses to drive the 64-byte entry path.
+nectar-mantaray = { path = "../crates/mantaray", features = [
+	"arbitrary",
+	"encryption",
+] }
 nectar-postage = { path = "../crates/postage", features = ["arbitrary"] }
 nectar-postage-usage = { path = "../crates/postage-usage", features = [
 	"arbitrary",

--- a/fuzz/fuzz_targets/mantaray_node_decode.rs
+++ b/fuzz/fuzz_targets/mantaray_node_decode.rs
@@ -1,10 +1,13 @@
 //! Fuzz the mantaray node wire decoder with raw attacker-controlled bytes.
 //!
-//! `Node::<ChunkAddress>::try_from(&[u8])` is the entry point through which
-//! untrusted manifest chunks from the network are parsed (plain manifests,
-//! 32-byte entries). The decoder is the structure recoverer, so the target
-//! takes raw bytes; any returned `Err` is success. The oracle is "no panic,
-//! no OOM, no hang".
+//! `Node::<E>::try_from(&[u8])` is the entry point through which untrusted
+//! manifest chunks from the network are parsed. Both entry widths are
+//! exercised on every input: `ChunkAddress` (plain manifests, 32-byte
+//! entries) and `EncryptedChunkRef` (encrypted manifests, 64-byte entries),
+//! each of which drives its own `ref_bytes_size` slicing arithmetic in
+//! `decode_v01`/`decode_v02`. The decoder is the structure recoverer, so the
+//! target takes raw bytes; any returned `Err` is success. The oracle is "no
+//! panic, no OOM, no hang".
 //!
 //! Seeds live in `fuzz/seeds/mantaray_node_decode/` and are replayed on
 //! stable by `seed_replay_mantaray_node_decode` in
@@ -14,8 +17,10 @@
 
 use libfuzzer_sys::fuzz_target;
 use nectar_mantaray::Node;
+use nectar_primitives::EncryptedChunkRef;
 use nectar_primitives::chunk::ChunkAddress;
 
 fuzz_target!(|data: &[u8]| {
     let _ = Node::<ChunkAddress>::try_from(data);
+    let _ = Node::<EncryptedChunkRef>::try_from(data);
 });


### PR DESCRIPTION
## What

Broadens the `mantaray_node_decode` fuzz target to drive both entry widths: `Node::<ChunkAddress>` (32-byte plain refs) and `Node::<EncryptedChunkRef>` (64-byte encrypted refs). Previously only the 32-byte monomorphization was exercised, leaving the `ref_bytes_size == 64` slicing arithmetic in `decode_v01`/`decode_v02` unfuzzed. The change also pins that 64-byte path deterministically on stable so regressions are caught without a nightly fuzz run.

- `fuzz/fuzz_targets/mantaray_node_decode.rs`: runs both monomorphizations on every input.
- `fuzz/Cargo.toml`: enables `nectar-mantaray/encryption`, since the `EncryptedChunkRef` `NodeEntry` impl is gated on that feature.
- `crates/mantaray/src/codec.rs`: adds feature-gated regression tests `decode_encref_truncated_lengths_return_err` and `decode_encref_index_demands_missing_fork_returns_err` that exercise the `ref_size == 64` bounds; `seed_replay` now replays through both widths under `encryption`.

## Why

The encrypted-ref decode path has its own 64-byte slicing arithmetic that was never covered by the fuzz target or by any deterministic test. Closes #139.

## Testing

    cargo test -p nectar-mantaray --features encryption

All tests pass, including the two new `decode_encref_*` cases and the widened `seed_replay`. The commits are GPG-signed.

---
Stacked on #142 (`fuzz/3-postage-bucket-depth`).

AI Assistance: Claude (Anthropic) used for the implementation, tests, and this PR description.
