### PR TITLE
chore(lint): enforce runtime-safety clippy restriction lints and unused-dep checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,59 @@
+# Clippy (runtime-safety restriction lints) + unused-dependency checks.
+name: lint
+
+on:
+    pull_request:
+    merge_group:
+    push:
+        branches: [main]
+
+env:
+    CARGO_TERM_COLOR: always
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: true
+
+jobs:
+    clippy:
+        name: clippy
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+            - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444  # v1
+            - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+              with:
+                  components: clippy
+            - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+              with:
+                  cache-on-failure: true
+            # Lints lib+bins with default features; the `deny`-level restriction
+            # lints in `[workspace.lints.clippy]` make this fail on any
+            # panicking/overflowing operation in production code.
+            - name: cargo clippy
+              run: cargo clippy --workspace --locked
+            # `unused_crate_dependencies` is enforced per-library via `cargo
+            # rustc` (not `[workspace.lints]`) so the flag applies only to each
+            # crate's own lib target — never to benches/examples/tests (which
+            # inherit the package's full dependency set and would false-positive)
+            # or to third-party crates. cargo-machete (below) is the broader gate
+            # that also covers non-lib targets.
+            - name: unused lib dependencies
+              run: |
+                  for crate in nectar-primitives nectar-mantaray nectar-postage \
+                               nectar-postage-issuer nectar-postage-usage \
+                               nectar-swarms nectar-contracts; do
+                      cargo rustc --locked -p "$crate" --lib -- -D unused_crate_dependencies
+                  done
+
+    unused-deps:
+        name: unused-deps (machete)
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+            - uses: taiki-e/install-action@1b57bc699ba2af96a06eb2a2a0d32b43a7d8e8b8  # install-action
+              with:
+                  tool: cargo-machete
+            - name: cargo machete
+              run: cargo machete

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2076,7 +2076,6 @@ dependencies = [
  "futures",
  "nectar-primitives",
  "rand 0.10.1",
- "serde",
  "serde_json",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,12 +1153,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2156,7 +2150,6 @@ dependencies = [
  "hybrid-array",
  "js-sys",
  "keccak-batch",
- "once_cell",
  "parking_lot",
  "proptest",
  "proptest-arbitrary-interop",
@@ -2269,10 +2262,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-dependencies = [
- "critical-section",
- "portable-atomic",
-]
 
 [[package]]
 name = "oorandom"
@@ -2390,12 +2379,6 @@ checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "powerfmt"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2116,7 +2116,6 @@ dependencies = [
  "proptest-arbitrary-interop",
  "rand 0.10.1",
  "rayon",
- "serde",
  "thiserror",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,7 +800,6 @@ dependencies = [
  "alloy-signer-local",
  "bytes",
  "console_error_panic_hook",
- "digest 0.11.3",
  "getrandom 0.2.17",
  "js-sys",
  "nectar-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,25 @@ use-self = "warn"
 option-if-let-else = "warn"
 redundant-clone = "warn"
 
+# Runtime-safety restriction lints (deny in production code). These forbid
+# operations that can panic or overflow at runtime. Test code is exempted per
+# crate via `#![cfg_attr(test, allow(...))]`. Provably-safe internal sites carry
+# a justified `#[allow(...)]`; untrusted/parse paths are hardened for real.
+unwrap_used = "deny"
+expect_used = "deny"
+get_unwrap = "deny"
+indexing_slicing = "deny"
+string_slice = "deny"
+arithmetic_side_effects = "deny"
+panic = "deny"
+unreachable = "deny"
+todo = "deny"
+unimplemented = "deny"
+panic_in_result_fn = "deny"
+# Lossy/`as` casts: warn now; denied in the maximal follow-up PR.
+as_conversions = "warn"
+missing_panics_doc = "warn"
+
 [workspace.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,9 +105,6 @@ rayon = "1.10"
 bytes = { version = "1.11", default-features = false }
 byteorder = { version = "1.5", default-features = false }
 thiserror = { version = "2.0", default-features = false }
-once_cell = { version = "1.21", default-features = false, features = [
-    "critical-section",
-] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -32,6 +32,22 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+// Test code may freely unwrap/index/panic; the runtime-safety restriction
+// lints target production code paths.
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::get_unwrap,
+        clippy::indexing_slicing,
+        clippy::string_slice,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::panic_in_result_fn
+    )
+)]
 
 use alloy_primitives::{Address, address};
 use alloy_sol_types::sol;

--- a/crates/mantaray/Cargo.toml
+++ b/crates/mantaray/Cargo.toml
@@ -27,7 +27,6 @@ thiserror.workspace = true
 serde_json.workspace = true
 arbitrary = { workspace = true, features = ["derive"], optional = true }
 rand = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
 
 [dev-dependencies]
 arbitrary = { workspace = true, features = ["derive"] }
@@ -51,11 +50,6 @@ arbitrary = [
 	"dep:arbitrary",
 	"nectar-primitives/arbitrary",
 	"alloy-primitives/arbitrary",
-]
-serde = [
-	"dep:serde",
-	"alloy-primitives/serde",
-	"nectar-primitives/serde"
 ]
 encryption = ["nectar-primitives/encryption"]
 

--- a/crates/mantaray/src/codec.rs
+++ b/crates/mantaray/src/codec.rs
@@ -85,6 +85,7 @@ const VERSION_STRING_01: &str = "mantaray:0.1";
 const VERSION_STRING_02: &str = "mantaray:0.2";
 
 /// XOR `data` in-place with a repeating `key`.
+#[allow(clippy::indexing_slicing, clippy::arithmetic_side_effects)] // key is the 32-byte obfuscation key (never empty): `i % key_len` cannot divide by zero and is always < key_len
 fn xor_in_place(data: &mut [u8], key: &[u8]) {
     let key_len = key.len();
     for (i, byte) in data.iter_mut().enumerate() {
@@ -101,6 +102,7 @@ impl<E: NodeEntry> TryFrom<&Node<E>> for Vec<u8> {
     }
 }
 
+#[allow(clippy::indexing_slicing, clippy::arithmetic_side_effects)] // header offsets are compile-time constants within the freshly sized NodeHeader::SIZE buffer; size arithmetic sums in-memory buffer lengths (<= 256 forks) and cannot overflow usize
 fn encode_node<E: NodeEntry>(node: &Node<E>) -> Result<Vec<u8>> {
     let ref_size = E::SIZE;
     // Pre-allocate: header + entry + bitfield(32) + estimated fork data
@@ -150,6 +152,7 @@ fn encode_node<E: NodeEntry>(node: &Node<E>) -> Result<Vec<u8>> {
 impl<E: NodeEntry> TryFrom<&[u8]> for Node<E> {
     type Error = MantarayError;
 
+    #[allow(clippy::indexing_slicing)] // every slice lies within NodeHeader::SIZE, guaranteed by the length check below
     fn try_from(value: &[u8]) -> Result<Self> {
         if value.len() < NodeHeader::SIZE {
             return Err(MantarayError::DataTooShort);
@@ -217,6 +220,7 @@ fn decode_empty_terminal_node<E: NodeEntry>(data: &[u8]) -> Result<Node<E>> {
     if data.len() < bitfield_end {
         return Err(MantarayError::DataTooShort);
     }
+    #[allow(clippy::indexing_slicing)] // `bitfield_end` bounds-checked against data.len() above
     if data[bitfield_start..bitfield_end].iter().any(|&b| b != 0) {
         return Err(MantarayError::EntrySizeMismatch {
             expected: E::SIZE,
@@ -230,6 +234,12 @@ fn decode_empty_terminal_node<E: NodeEntry>(data: &[u8]) -> Result<Node<E>> {
     })
 }
 
+// Bounds safety: only called from `TryFrom<&[u8]>`, which guarantees
+// `data.len() >= NodeHeader::SIZE` (covers the ref-size byte at offset 63);
+// every further slice is preceded by an explicit `data.len()` check with an
+// error return, and offsets are sums of header constants and `E::SIZE`
+// (<= 64) that cannot overflow usize.
+#[allow(clippy::indexing_slicing, clippy::arithmetic_side_effects)]
 fn decode_v01<E: NodeEntry>(data: &[u8]) -> Result<Node<E>> {
     let ref_bytes_size = data[NodeHeader::REF_SIZE_OFFSET] as usize;
     // BEE-WORKAROUND(bee#5483): see HAZMAT block above `decode_empty_terminal_node`.
@@ -286,6 +296,12 @@ fn decode_v01<E: NodeEntry>(data: &[u8]) -> Result<Node<E>> {
     })
 }
 
+// Bounds safety: only called from `TryFrom<&[u8]>`, which guarantees
+// `data.len() >= NodeHeader::SIZE` (covers the ref-size byte at offset 63);
+// every further slice is preceded by an explicit `data.len()` check with an
+// error return, and offsets are sums of header constants, `E::SIZE` (<= 64)
+// and a metadata size (<= u16::MAX) that cannot overflow usize.
+#[allow(clippy::indexing_slicing, clippy::arithmetic_side_effects)]
 fn decode_v02<E: NodeEntry>(data: &[u8]) -> Result<Node<E>> {
     let ref_bytes_size = data[NodeHeader::REF_SIZE_OFFSET] as usize;
     // BEE-WORKAROUND(bee#5483): see HAZMAT block above `decode_empty_terminal_node`.
@@ -406,16 +422,19 @@ fn decode_v02<E: NodeEntry>(data: &[u8]) -> Result<Node<E>> {
 
 /// Parse and validate fork header. Returns (node_type, prefix).
 fn parse_fork_header(data: &[u8]) -> Result<(NodeType, Prefix)> {
-    let node_type = NodeType::from_bits_truncate(data[0]);
-    let prefix_length = data[1] as usize;
+    let node_type =
+        NodeType::from_bits_truncate(*data.first().ok_or(MantarayError::DataTooShort)?);
+    let prefix_length = usize::from(*data.get(1).ok_or(MantarayError::DataTooShort)?);
     if prefix_length == 0 || prefix_length > Prefix::MAX_LEN {
         return Err(MantarayError::InvalidPrefixLength {
             max: Prefix::MAX_LEN,
             actual: prefix_length,
         });
     }
+    #[allow(clippy::arithmetic_side_effects)] // PREFIX_OFFSET (2) + prefix_length (<= 30) cannot overflow
     let prefix = Prefix::from_slice(
-        &data[ForkHeader::PREFIX_OFFSET..ForkHeader::PREFIX_OFFSET + prefix_length],
+        data.get(ForkHeader::PREFIX_OFFSET..ForkHeader::PREFIX_OFFSET + prefix_length)
+            .ok_or(MantarayError::DataTooShort)?,
     );
     Ok((node_type, prefix))
 }
@@ -426,6 +445,7 @@ impl<E: NodeEntry> Fork<E> {
         if ref_data.len() < 32 {
             return Err(MantarayError::DataTooShort);
         }
+        #[allow(clippy::indexing_slicing)] // length >= 32 checked above
         let addr_bytes: [u8; 32] = ref_data[..32]
             .try_into()
             .map_err(|_| MantarayError::DataTooShort)?;
@@ -433,6 +453,7 @@ impl<E: NodeEntry> Fork<E> {
     }
 
     /// Encode this fork, appending to `buf`.
+    #[allow(clippy::arithmetic_side_effects)] // in-memory buffer length arithmetic; padding math is guarded (`SIZE - x` only when `x < SIZE`, `SIZE - rem` only when `rem != 0`) and `% ObfuscationKey::SIZE` has a nonzero constant divisor
     fn encode_into(&self, data: &mut Vec<u8>) -> Result<()> {
         data.push(self.node.node_type.bits());
         data.push(self.prefix.len() as u8);
@@ -493,6 +514,7 @@ impl<E: NodeEntry> Fork<E> {
         let (node_type, prefix) = parse_fork_header(data)?;
 
         self.prefix = prefix;
+        #[allow(clippy::indexing_slicing)] // callers (decode_v01/decode_v02) bounds-check `data` to PRE_REFERENCE_SIZE + ref size before calling
         let ref_data = &data[ForkHeader::PRE_REFERENCE_SIZE..];
         self.node = Self::node_from_ref_bytes(ref_data)?;
         self.node.node_type = node_type;
@@ -501,6 +523,12 @@ impl<E: NodeEntry> Fork<E> {
     }
 
     /// Decode a fork from v0.2 binary data (with metadata).
+    // Bounds safety: the only caller (`decode_v02`) sizes `data` to exactly
+    // PRE_REFERENCE_SIZE + ref_bytes_size + METADATA_LEN_SIZE +
+    // metadata_bytes_size before calling, so the slices below are in-bounds
+    // and the offset sums (constants + ref size + u16-bounded metadata size)
+    // cannot overflow usize.
+    #[allow(clippy::indexing_slicing, clippy::arithmetic_side_effects)]
     pub(crate) fn decode_v02(
         &mut self,
         data: &[u8],

--- a/crates/mantaray/src/lib.rs
+++ b/crates/mantaray/src/lib.rs
@@ -65,6 +65,8 @@
 //! number should be removed. Run `git grep -n BEE-WORKAROUND` to enumerate
 //! them.
 
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::get_unwrap, clippy::indexing_slicing, clippy::string_slice, clippy::arithmetic_side_effects, clippy::panic, clippy::unreachable, clippy::panic_in_result_fn))]
+
 use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::ChunkAddress;
 

--- a/crates/mantaray/src/manifest.rs
+++ b/crates/mantaray/src/manifest.rs
@@ -432,6 +432,7 @@ impl<'a, S: ChunkGet<BS>, E: NodeEntry, const BS: usize> ManifestIter<'a, S, E, 
     /// Advance the lazy traversal, returning the next entry (or `None` when done).
     ///
     /// Loads unvisited nodes from storage on demand.
+    #[allow(clippy::arithmetic_side_effects)] // the only arithmetic is the fork-cursor `key_idx += 1`, bounded by keys.len() <= 256
     pub async fn next(&mut self) -> Option<Result<Entry>> {
         loop {
             if !self.root_visited {
@@ -467,14 +468,14 @@ impl<'a, S: ChunkGet<BS>, E: NodeEntry, const BS: usize> ManifestIter<'a, S, E, 
             }
 
             // Pop exhausted frames, truncating path_buf as we go.
-            while self.stack.last().is_some_and(|f| f.key_idx >= f.keys.len()) {
-                let frame = self.stack.pop().unwrap();
+            while let Some(frame) = self.stack.pop_if(|f| f.key_idx >= f.keys.len()) {
                 self.path_buf.truncate(frame.path_len_before);
             }
 
             // Advance: get the next fork key and parent pointer from the top frame.
             let (key, parent_node) = {
                 let frame = self.stack.last_mut()?;
+                #[allow(clippy::indexing_slicing)] // the pop_if loop above removed every frame with key_idx >= keys.len()
                 let key = frame.keys[frame.key_idx];
                 frame.key_idx += 1;
                 (key, frame.node)

--- a/crates/mantaray/src/mode.rs
+++ b/crates/mantaray/src/mode.rs
@@ -48,6 +48,7 @@ impl NodeEntry for ChunkAddress {
                 actual: bytes.len(),
             });
         }
+        #[allow(clippy::expect_used)] // infallible: bytes.len() == Self::SIZE (32) checked above
         let arr: [u8; 32] = bytes.try_into().expect("length checked");
         Ok(Self::from(arr))
     }

--- a/crates/mantaray/src/node.rs
+++ b/crates/mantaray/src/node.rs
@@ -66,6 +66,7 @@ impl Prefix {
             PREFIX_MAX_LEN
         );
         let mut data = [0u8; PREFIX_MAX_LEN];
+        #[allow(clippy::indexing_slicing)] // src.len() <= PREFIX_MAX_LEN asserted above (documented # Panics contract)
         data[..src.len()].copy_from_slice(src);
         Self {
             len: src.len() as u8,
@@ -96,6 +97,7 @@ impl std::ops::Deref for Prefix {
     type Target = [u8];
 
     #[inline]
+    #[allow(clippy::indexing_slicing)] // invariant: self.len <= PREFIX_MAX_LEN, the backing array length
     fn deref(&self) -> &[u8] {
         &self.data[..self.len as usize]
     }
@@ -278,6 +280,7 @@ impl<E: NodeEntry> Node<E> {
     }
 
     fn update_is_with_path_separator(&mut self, path: &[u8]) {
+        #[allow(clippy::indexing_slicing)] // PATH_SEPARATOR is a non-empty str constant
         let sep = PATH_SEPARATOR.as_bytes()[0];
         if path.iter().skip(1).any(|&b| b == sep) {
             self.node_type = self.node_type.union(NodeType::PATH_SEPARATOR);
@@ -326,6 +329,7 @@ impl<E: NodeEntry> Node<E> {
     }
 
     /// Look up the node at the given path, loading from storage as needed.
+    #[allow(clippy::indexing_slicing)] // `rest` is checked non-empty before `rest[0]`; `c <= rest.len()` from common_prefix_len
     pub(crate) async fn lookup_node<S: ChunkGet<BS>, const BS: usize>(
         &mut self,
         path: &[u8],
@@ -378,6 +382,11 @@ impl<E: NodeEntry> Node<E> {
     ///
     /// Returns a boxed future so the `&mut self` recursion can name its own type.
     /// The `MaybeSend` bound keeps `!Send` wasm stores usable.
+    // Panic-freedom: `path` is non-empty past the empty-path guard, so
+    // `path[0]` is in-bounds; `c = common_prefix_len(prefix, path)` is
+    // <= min(prefix.len(), path.len()), bounding every split; the fork at
+    // `path[0]` is checked present (`contains_key`) before each get/expect.
+    #[allow(clippy::indexing_slicing, clippy::expect_used)]
     pub(crate) fn add<'a, S: ChunkGet<BS>, const BS: usize>(
         &'a mut self,
         path: &'a [u8],
@@ -504,6 +513,10 @@ impl<E: NodeEntry> Node<E> {
     /// Remove the entry at the given path, loading from storage as needed.
     ///
     /// Returns a boxed future so the `&mut self` recursion can name its own type.
+    // Panic-freedom: `path` is non-empty past the EmptyPath guard;
+    // `path.starts_with(&prefix)` guarantees `prefix.len() <= path.len()`;
+    // the fork at `first` is checked present before the get_mut/expect.
+    #[allow(clippy::indexing_slicing, clippy::expect_used)]
     pub(crate) fn remove<'a, S: ChunkGet<BS>, const BS: usize>(
         &'a mut self,
         path: &'a [u8],
@@ -553,6 +566,7 @@ impl<E: NodeEntry> Node<E> {
     }
 
     /// Test whether a prefix exists in the trie, loading from storage as needed.
+    #[allow(clippy::indexing_slicing)] // `rest` is checked non-empty before `rest[0]`; `c <= rest.len()` from common_prefix_len
     pub(crate) async fn has_prefix<S: ChunkGet<BS>, const BS: usize>(
         &mut self,
         path: &[u8],
@@ -594,6 +608,7 @@ impl<E: NodeEntry> Node<E> {
     /// Uses BMT content-addressing via `ContentChunk`. An explicit stack avoids
     /// recursion: each frame visits its forks (pushing unsaved children) before
     /// the node itself is encoded and put.
+    #[allow(clippy::arithmetic_side_effects)] // the only arithmetic is the fork-cursor `key_idx += 1`, bounded by keys.len() <= 256
     pub(crate) async fn save<S: ChunkPut<BS>, const BS: usize>(&mut self, store: &S) -> Result<()> {
         if self.reference.is_some() {
             return Ok(());
@@ -621,8 +636,10 @@ impl<E: NodeEntry> Node<E> {
             let node = unsafe { &mut *frame.node };
 
             if frame.key_idx < frame.keys.len() {
+                #[allow(clippy::indexing_slicing)] // key_idx < keys.len() checked above
                 let key = frame.keys[frame.key_idx];
                 frame.key_idx += 1;
+                #[allow(clippy::expect_used)] // key was collected from this node's fork map, which is not mutated while the frame is live
                 let child = node.forks.get_mut(&key).expect("key from this node");
                 if child.node.reference.is_none() {
                     let child_ptr = &mut child.node as *mut Self;
@@ -691,6 +708,7 @@ impl<E: NodeEntry> Node<E> {
 /// Pre-order DFS visitor over a loaded-on-demand trie via an explicit stack.
 ///
 /// The visitor `f` only reads loaded nodes, so it stays a synchronous `FnMut`.
+#[allow(clippy::arithmetic_side_effects)] // the only arithmetic is the fork-cursor `key_idx += 1`, bounded by keys.len() <= 256
 async fn walk_inner<E: NodeEntry, S: ChunkGet<BS>, const BS: usize, F>(
     path_buf: &mut Vec<u8>,
     node: &mut Node<E>,
@@ -728,6 +746,7 @@ where
             continue;
         }
 
+        #[allow(clippy::indexing_slicing)] // key_idx < keys.len() checked above
         let key = frame.keys[frame.key_idx];
         frame.key_idx += 1;
 

--- a/crates/postage-issuer/Cargo.toml
+++ b/crates/postage-issuer/Cargo.toml
@@ -25,7 +25,6 @@ alloy-signer = { workspace = true }
 thiserror = { workspace = true }
 
 # optional
-serde = { workspace = true, optional = true }
 alloy-signer-local = { workspace = true, optional = true }
 rayon = { workspace = true, optional = true }
 
@@ -53,13 +52,6 @@ default = ["std"]
 
 # Standard library support
 std = ["nectar-postage/std"]
-
-# Serialization support with serde
-serde = [
-	"dep:serde",
-	"nectar-postage/serde",
-	"nectar-primitives/serde"
-]
 
 # Local key signing for testing and development
 local-signer = ["dep:alloy-signer-local", "std"]

--- a/crates/postage-issuer/src/counter.rs
+++ b/crates/postage-issuer/src/counter.rs
@@ -160,6 +160,8 @@ impl CounterTable {
                 got: counts.len(),
             });
         }
+        // Batch geometry invariant: depth >= bucket_depth, enforced by callers.
+        #[allow(clippy::arithmetic_side_effects)]
         let capacity = 1u32 << (depth - bucket_depth);
         let mut issued = 0u64;
         for (bucket, &count) in counts.iter().enumerate() {
@@ -170,7 +172,11 @@ impl CounterTable {
                     capacity,
                 });
             }
-            issued += u64::from(count);
+            // Sum of at most 2^bucket_depth u32 counters cannot overflow a u64.
+            #[allow(clippy::arithmetic_side_effects)]
+            {
+                issued += u64::from(count);
+            }
         }
         Ok(Self {
             depth,
@@ -202,6 +208,8 @@ impl CounterTable {
     }
 
     /// Returns the number of slots per bucket (`2^(depth - bucket_depth)`).
+    // Batch geometry invariant: depth >= bucket_depth, enforced at construction.
+    #[allow(clippy::arithmetic_side_effects)]
     pub const fn bucket_capacity(&self) -> u32 {
         1u32 << (self.depth - self.bucket_depth)
     }
@@ -269,16 +277,25 @@ impl CounterTable {
         let capacity = self.bucket_capacity();
 
         if matches!(self.mode, CounterMode::Fill) {
+            // Indexing guarded by the bucket range check at the top of `record`.
+            #[allow(clippy::indexing_slicing)]
             let count = &mut self.counts[bucket as usize];
             if *count >= capacity {
                 return Err(CounterError::BucketFull { bucket, capacity });
             }
             let index = *count;
-            *count += 1;
-            self.issued += 1;
+            // `*count < capacity <= u32::MAX` (checked above) and the u64 issued
+            // total cannot overflow before the u32 counters do.
+            #[allow(clippy::arithmetic_side_effects)]
+            {
+                *count += 1;
+                self.issued += 1;
+            }
             return Ok(index);
         }
 
+        // Indexing guarded by the bucket range check at the top of `record`.
+        #[allow(clippy::indexing_slicing)]
         let old_cursor = self.counts[bucket as usize];
         // Start at the cursor; a cursor equal to capacity means "wrap on the next
         // write", resetting to 0 when the bucket bound is reached.
@@ -290,6 +307,10 @@ impl CounterTable {
         // Skip protected slots, wrapping. Bounded by `capacity` steps: if every
         // slot is protected we fail rather than loop.
         let mut steps = 0u32;
+        // `candidate < capacity` throughout (initial value and the modulo keep it
+        // there), `capacity >= 1` (a power of two), and `steps < capacity`, so
+        // neither increment can overflow and the modulo divisor is nonzero.
+        #[allow(clippy::arithmetic_side_effects)]
         while is_protected(candidate) {
             candidate = (candidate + 1) % capacity;
             steps += 1;
@@ -301,11 +322,22 @@ impl CounterTable {
         // The new cursor points just past the slot we returned. Storing
         // `capacity` (rather than wrapping to 0 here) defers the wrap to the next
         // write, keeping the cursor in [0, capacity] as on the wire.
+        // `index < capacity <= u32::MAX`, so the increment cannot overflow.
+        #[allow(clippy::arithmetic_side_effects)]
         let new_cursor = index + 1;
-        self.counts[bucket as usize] = new_cursor;
+        // Indexing guarded by the bucket range check at the top of `record`.
+        #[allow(clippy::indexing_slicing)]
+        {
+            self.counts[bucket as usize] = new_cursor;
+        }
         // Keep issued == sum(counts): fold in the signed delta (it decreases on
-        // wrap, when new_cursor < old_cursor).
-        self.issued = self.issued - u64::from(old_cursor) + u64::from(new_cursor);
+        // wrap, when new_cursor < old_cursor). `issued == sum(counts) >=
+        // old_cursor` (it is one of the summands), so the subtraction cannot
+        // underflow, and the sum of 2^bucket_depth u32 counters fits a u64.
+        #[allow(clippy::arithmetic_side_effects)]
+        {
+            self.issued = self.issued - u64::from(old_cursor) + u64::from(new_cursor);
+        }
         Ok(index)
     }
 
@@ -331,7 +363,11 @@ impl CounterTable {
         let mut issued = 0u64;
         for (mine, theirs) in self.counts.iter_mut().zip(other.counts.iter()) {
             *mine = (*mine).max(*theirs);
-            issued += u64::from(*mine);
+            // Sum of at most 2^bucket_depth u32 counters cannot overflow a u64.
+            #[allow(clippy::arithmetic_side_effects)]
+            {
+                issued += u64::from(*mine);
+            }
         }
         self.issued = issued;
     }

--- a/crates/postage-issuer/src/issuer.rs
+++ b/crates/postage-issuer/src/issuer.rs
@@ -110,6 +110,8 @@ pub trait StampIssuer {
     }
 
     /// Returns the bucket capacity (2^(depth - bucket_depth)).
+    // Batch geometry invariant: depth >= bucket_depth for every issuer.
+    #[allow(clippy::arithmetic_side_effects)]
     fn bucket_capacity(&self) -> u32 {
         1u32 << (self.batch_depth() - self.bucket_depth())
     }

--- a/crates/postage-issuer/src/lib.rs
+++ b/crates/postage-issuer/src/lib.rs
@@ -47,7 +47,6 @@
 //! # Features
 //!
 //! - `std` (default) - Enables standard library support
-//! - `serde` - Enables serialization/deserialization
 //! - `local-signer` - Enables local key signing with `alloy-signer-local`
 //! - `parallel` - Enables parallel signing with rayon
 //!
@@ -71,6 +70,20 @@
 //! ```
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::get_unwrap,
+        clippy::indexing_slicing,
+        clippy::string_slice,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::panic_in_result_fn
+    )
+)]
 
 mod counter;
 #[cfg(feature = "std")]

--- a/crates/postage-issuer/src/ring.rs
+++ b/crates/postage-issuer/src/ring.rs
@@ -225,6 +225,10 @@ impl<R: Reservation> RingIssuer<R> {
     ///
     /// This saturates at the bucket capacity, so a wrapped ring reports the
     /// bucket as full rather than counting overwrites as fresh utilization.
+    // Every caller guarantees `bucket_idx` is within the bucket count (either by
+    // an explicit bounds check or via a successful `record` on the counter
+    // table), and `saturated` and `counts()` share that length by construction.
+    #[allow(clippy::indexing_slicing)]
     fn bucket_fill(&self, bucket_idx: usize) -> u32 {
         if self.saturated[bucket_idx] {
             self.counters.bucket_capacity()
@@ -257,7 +261,12 @@ impl<R: Reservation> RingIssuer<R> {
         // A cursor sitting at the capacity has just filled the bucket's last
         // fresh slot, so the bucket is saturated from here on.
         if self.counters.count(bucket).unwrap_or(0) == self.counters.bucket_capacity() {
-            self.saturated[bucket as usize] = true;
+            // `record` above succeeded, so `bucket` is within the bucket count and
+            // `saturated` has that same length by construction.
+            #[allow(clippy::indexing_slicing)]
+            {
+                self.saturated[bucket as usize] = true;
+            }
         }
         Ok(position)
     }
@@ -280,7 +289,12 @@ impl<R: Reservation> RingIssuer<R> {
         let bucket = calculate_bucket(address, self.counters.bucket_depth());
         let position = self.next_slot(bucket)?;
 
-        self.stamps_issued += 1;
+        // Monotone u64 issuance counter; one increment per stamp cannot
+        // realistically overflow 2^64.
+        #[allow(clippy::arithmetic_side_effects)]
+        {
+            self.stamps_issued += 1;
+        }
 
         let fill = self.bucket_fill(bucket as usize);
         if fill > self.max_utilization {
@@ -318,7 +332,10 @@ impl<R: Reservation> StampIssuer for RingIssuer<R> {
                     bucket,
                     capacity: self.counters.bucket_capacity(),
                 },
-                // `prepare_ring_stamp` only ever yields RingExhausted.
+                // Invariant: `prepare_ring_stamp` only ever yields RingExhausted
+                // (its sole error source is `next_slot`, which maps every counter
+                // error to RingExhausted).
+                #[allow(clippy::unreachable)]
                 _ => unreachable!("ring issuance only fails with RingExhausted"),
             })
     }

--- a/crates/postage-issuer/src/sharded.rs
+++ b/crates/postage-issuer/src/sharded.rs
@@ -51,6 +51,9 @@ impl BucketShard {
     }
 
     /// Returns the local index within this shard for a given global bucket.
+    // Shard routing invariant: callers only pass buckets owned by this shard, so
+    // `bucket >= base_bucket` and the subtraction cannot underflow.
+    #[allow(clippy::arithmetic_side_effects)]
     #[inline]
     const fn local_index(&self, bucket: u32) -> usize {
         (bucket - self.base_bucket) as usize
@@ -58,6 +61,9 @@ impl BucketShard {
 
     /// Allocates the next index for a bucket, returning the allocated index.
     /// Returns None if the bucket is full.
+    // Shard routing invariant: `local_index(bucket) < indices.len()` because this
+    // shard owns buckets `[base_bucket, base_bucket + indices.len())`.
+    #[allow(clippy::indexing_slicing)]
     #[inline]
     fn allocate(&self, bucket: u32, bucket_capacity: u32) -> Option<u32> {
         let local_idx = self.local_index(bucket);
@@ -72,6 +78,9 @@ impl BucketShard {
     }
 
     /// Gets the current utilization of a bucket.
+    // Shard routing invariant: `local_index(bucket) < indices.len()` because this
+    // shard owns buckets `[base_bucket, base_bucket + indices.len())`.
+    #[allow(clippy::indexing_slicing)]
     #[inline]
     fn utilization(&self, bucket: u32) -> u32 {
         let local_idx = self.local_index(bucket);
@@ -126,6 +135,13 @@ impl ShardedIssuer {
     /// # Panics
     ///
     /// Panics if `shard_count` is not a power of 2 or is greater than the bucket count.
+    // All arithmetic is on validated shard geometry: `shard_count` is a nonzero
+    // power of two clamped to `total_buckets = 2^bucket_depth`, so the division,
+    // the `shard_count - 1` mask, `bucket_depth - shard_bits`, and the
+    // `i * buckets_per_shard` shard bases (bounded by `total_buckets`) cannot
+    // divide by zero, underflow, or overflow; `depth >= bucket_depth` is the
+    // batch geometry invariant.
+    #[allow(clippy::arithmetic_side_effects)]
     pub fn with_shard_count(
         batch_id: BatchId,
         depth: u8,
@@ -205,7 +221,12 @@ impl ShardedIssuer {
             });
         }
         self.depth = new_depth;
-        self.bucket_capacity = 1u32 << (new_depth - self.bucket_depth);
+        // `new_depth >= self.depth >= self.bucket_depth` (checked above plus the
+        // batch geometry invariant), so the subtraction cannot underflow.
+        #[allow(clippy::arithmetic_side_effects)]
+        {
+            self.bucket_capacity = 1u32 << (new_depth - self.bucket_depth);
+        }
         Ok(())
     }
 
@@ -225,6 +246,9 @@ impl ShardedIssuer {
     ) -> Result<StampDigest, StampError> {
         let bucket = calculate_bucket(address, self.bucket_depth);
         let shard_idx = self.shard_index(bucket);
+        // `shard_index` masks with `shard_mask = shards.len() - 1`, so the index
+        // is always in range.
+        #[allow(clippy::indexing_slicing)]
         let shard = &self.shards[shard_idx];
 
         let position =
@@ -238,7 +262,10 @@ impl ShardedIssuer {
         // Update stats (relaxed ordering is fine for stats)
         self.stamps_issued.fetch_add(1, Ordering::Relaxed);
 
-        // Update max utilization (compare-and-swap loop)
+        // Update max utilization (compare-and-swap loop).
+        // `position < bucket_capacity <= u32::MAX` (allocate returned Some), so
+        // the increment cannot overflow.
+        #[allow(clippy::arithmetic_side_effects)]
         let new_util = position + 1;
         let mut current_max = self.max_utilization.load(Ordering::Relaxed);
         while new_util > current_max {
@@ -278,6 +305,9 @@ impl ShardedIssuer {
     }
 
     /// Current utilization of a specific bucket.
+    // `shard_index` masks with `shard_mask = shards.len() - 1`, so the index is
+    // always in range.
+    #[allow(clippy::indexing_slicing)]
     pub fn bucket_utilization(&self, bucket: u32) -> u32 {
         let shard_idx = self.shard_index(bucket);
         self.shards[shard_idx].utilization(bucket)

--- a/crates/postage-issuer/src/sharded_ring.rs
+++ b/crates/postage-issuer/src/sharded_ring.rs
@@ -62,6 +62,9 @@ impl<R: Reservation> RingShard<R> {
         }
     }
 
+    // Shard routing invariant: callers only pass buckets owned by this shard, so
+    // `bucket >= base_bucket` and the subtraction cannot underflow.
+    #[allow(clippy::arithmetic_side_effects)]
     #[inline]
     const fn local_index(&self, bucket: u32) -> usize {
         (bucket - self.base_bucket) as usize
@@ -72,8 +75,15 @@ impl<R: Reservation> RingShard<R> {
     ///
     /// Returns [`IssuerError::RingExhausted`] if every slot in the bucket is
     /// protected.
+    // Shard routing invariant: `local < cursors.len() == saturated.len()` because
+    // this shard owns that bucket range. The cursor is kept strictly below
+    // `bucket_capacity` (reset to 0 on wrap), so `position + 1` cannot overflow.
+    #[allow(clippy::indexing_slicing, clippy::arithmetic_side_effects)]
     fn next_slot(&self, bucket: u32, bucket_capacity: u32) -> Result<u32, IssuerError> {
         let local = self.local_index(bucket);
+        // Lock poisoning means another thread already panicked; propagating the
+        // panic is the intended behavior.
+        #[allow(clippy::expect_used)]
         let mut state = self.state.lock().expect("ring shard lock poisoned");
         for _ in 0..bucket_capacity {
             let position = state.cursors[local];
@@ -95,8 +105,14 @@ impl<R: Reservation> RingShard<R> {
 
     /// Returns the number of distinct slots written in a bucket, saturating at
     /// the bucket capacity.
+    // Shard routing invariant: `local < cursors.len() == saturated.len()` because
+    // this shard owns that bucket range.
+    #[allow(clippy::indexing_slicing)]
     fn utilization(&self, bucket: u32, bucket_capacity: u32) -> u32 {
         let local = self.local_index(bucket);
+        // Lock poisoning means another thread already panicked; propagating the
+        // panic is the intended behavior.
+        #[allow(clippy::expect_used)]
         let state = self.state.lock().expect("ring shard lock poisoned");
         if state.saturated[local] {
             bucket_capacity
@@ -205,6 +221,13 @@ impl<R: Reservation> ShardedRingIssuer<R> {
         ))
     }
 
+    // All arithmetic is on validated shard geometry: `shard_count` is a nonzero
+    // power of two clamped to `total_buckets = 2^bucket_depth`, so the division,
+    // the `shard_count - 1` mask, `bucket_depth - shard_bits`, and the
+    // `i * buckets_per_shard` shard bases (bounded by `total_buckets`) cannot
+    // divide by zero, underflow, or overflow; `depth >= bucket_depth` is the
+    // batch geometry invariant.
+    #[allow(clippy::arithmetic_side_effects)]
     fn with_shard_count(
         batch_id: BatchId,
         depth: u8,
@@ -268,6 +291,9 @@ impl<R: Reservation> ShardedRingIssuer<R> {
         timestamp: u64,
     ) -> Result<StampDigest, StampError> {
         let bucket = calculate_bucket(address, self.bucket_depth);
+        // `shard_index` masks with `shard_mask = shards.len() - 1`, so the index
+        // is always in range.
+        #[allow(clippy::indexing_slicing)]
         let shard = &self.shards[self.shard_index(bucket)];
 
         let position =
@@ -279,11 +305,22 @@ impl<R: Reservation> ShardedRingIssuer<R> {
                 })?;
 
         {
+            // Lock poisoning means another thread already panicked; propagating
+            // the panic is the intended behavior.
+            #[allow(clippy::expect_used)]
             let mut issued = self.stamps_issued.lock().expect("stamps lock poisoned");
-            *issued += 1;
+            // Monotone u64 issuance counter; one increment per stamp cannot
+            // realistically overflow 2^64.
+            #[allow(clippy::arithmetic_side_effects)]
+            {
+                *issued += 1;
+            }
         }
         let fill = shard.utilization(bucket, self.bucket_capacity);
         {
+            // Lock poisoning means another thread already panicked; propagating
+            // the panic is the intended behavior.
+            #[allow(clippy::expect_used)]
             let mut max = self
                 .max_utilization
                 .lock()
@@ -325,11 +362,17 @@ impl<R: Reservation> ShardedRingIssuer<R> {
     /// Returns the current utilization of a specific bucket, saturating at the
     /// bucket capacity once the ring has wrapped.
     pub fn bucket_utilization(&self, bucket: u32) -> u32 {
+        // `shard_index` masks with `shard_mask = shards.len() - 1`, so the index
+        // is always in range.
+        #[allow(clippy::indexing_slicing)]
         let shard = &self.shards[self.shard_index(bucket)];
         shard.utilization(bucket, self.bucket_capacity)
     }
 
     /// Returns the maximum bucket utilization observed across all buckets.
+    // Lock poisoning means another thread already panicked; propagating the
+    // panic is the intended behavior.
+    #[allow(clippy::expect_used)]
     pub fn max_bucket_utilization(&self) -> u32 {
         *self
             .max_utilization
@@ -338,6 +381,9 @@ impl<R: Reservation> ShardedRingIssuer<R> {
     }
 
     /// Returns the total number of stamps issued.
+    // Lock poisoning means another thread already panicked; propagating the
+    // panic is the intended behavior.
+    #[allow(clippy::expect_used)]
     pub fn stamps_issued(&self) -> u64 {
         *self.stamps_issued.lock().expect("stamps lock poisoned")
     }

--- a/crates/postage-usage/src/client.rs
+++ b/crates/postage-usage/src/client.rs
@@ -201,6 +201,9 @@ where
                 let root = RootInfo::parse(&root_bytes)?;
                 let mut leaves: Vec<Bytes> = Vec::with_capacity(root.leaf_count() as usize);
                 for leaf in 0..root.leaf_count() {
+                    // `leaf < leaf_count() <= u16::MAX`, so the increment
+                    // cannot overflow.
+                    #[allow(clippy::arithmetic_side_effects)]
                     let index = leaf + 1;
                     let leaf_addr = usage_chunk_address(&batch_id, &owner, index);
                     match source
@@ -287,6 +290,10 @@ where
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_secs())
             .unwrap_or(0);
+        // `previous` is a wall-clock seal timestamp in seconds, recorded by
+        // an earlier flush, so it sits far below u64::MAX and the increment
+        // cannot overflow.
+        #[allow(clippy::arithmetic_side_effects)]
         let timestamp = self
             .snapshot
             .last_seal_timestamp()

--- a/crates/postage-usage/src/codec.rs
+++ b/crates/postage-usage/src/codec.rs
@@ -61,6 +61,9 @@ pub struct RootInfo {
 }
 
 /// Returns the maximum delta representable in `width` bits.
+// In the else branch `width < 32`, so the u64 shift is in range and
+// `1 << width >= 1` makes the decrement safe.
+#[allow(clippy::arithmetic_side_effects)]
 const fn delta_limit(width: u8) -> u64 {
     if width >= 32 {
         u32::MAX as u64
@@ -70,11 +73,18 @@ const fn delta_limit(width: u8) -> u64 {
 }
 
 /// Returns the byte length of `buckets` deltas packed at `width` bits.
+// `buckets <= 2^16` (validated geometry) and `width <= 32`, so the product
+// is at most 2^21 and cannot overflow usize.
+#[allow(clippy::arithmetic_side_effects)]
 const fn packed_len(buckets: usize, width: u8) -> usize {
     (buckets * width as usize).div_ceil(8)
 }
 
 /// Returns the number of buckets per leaf for a given width (`width > 0`).
+// Callers uphold `width > 0` (leaves exist only for a nonzero delta width:
+// the encoder inlines width 0 and the parser rejects `leaves > 0` with
+// width 0), so the division cannot be by zero; the dividend is a constant.
+#[allow(clippy::arithmetic_side_effects)]
 const fn buckets_per_leaf(width: u8) -> usize {
     (MAX_PAYLOAD_SIZE * 8) / width as usize
 }
@@ -89,6 +99,10 @@ const fn leaf_count(buckets: usize, width: u8) -> usize {
 }
 
 /// Writes the low `width` bits of `value` at `bit_offset`, MSB first.
+// Callers size `buf` to `packed_len(..)` with `bit_offset + width` within
+// its bit length, and `i < width` keeps the shift exponent in range, so the
+// offset math and byte indexing cannot overflow or go out of bounds.
+#[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)]
 fn write_bits(buf: &mut [u8], bit_offset: usize, width: u8, value: u64) {
     for i in 0..width as usize {
         let bit = (value >> (width as usize - 1 - i)) & 1;
@@ -100,6 +114,10 @@ fn write_bits(buf: &mut [u8], bit_offset: usize, width: u8, value: u64) {
 }
 
 /// Reads `width` bits at `bit_offset`, MSB first.
+// Callers validate `buf` to `packed_len(..)` bytes with `bit_offset + width`
+// within its bit length before reading, and `width <= 32` keeps the value
+// accumulation within u64, so the offset math and indexing cannot fail.
+#[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)]
 fn read_bits(buf: &[u8], bit_offset: usize, width: u8) -> u64 {
     let mut value = 0u64;
     for i in 0..width as usize {
@@ -114,6 +132,11 @@ fn read_bits(buf: &[u8], bit_offset: usize, width: u8) -> u64 {
 ///
 /// Exception buckets are filled with all one bits; `exceptions` must be
 /// sorted ascending by bucket.
+// `start <= end <= counts.len()` (callers pass leaf ranges clamped to the
+// bucket count), every bucket index is below `end`, and `base` is the
+// minimum count, so `count - base` cannot underflow; `i * width` is bounded
+// by the buffer sized from `packed_len`.
+#[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)]
 fn pack_range(
     counts: &[u32],
     base: u32,
@@ -142,6 +165,10 @@ fn pack_range(
 }
 
 /// Checks that all bits past `bit_len` in `buf` are zero.
+// Callers validate `buf.len() == packed_len(..) == ceil(bit_len / 8)`
+// before the call, so when `bit_len` is not byte-aligned the final byte
+// `buf[bit_len / 8]` exists.
+#[allow(clippy::indexing_slicing)]
 const fn padding_is_zero(buf: &[u8], bit_len: usize) -> bool {
     if !bit_len.is_multiple_of(8) {
         let last = buf[bit_len / 8];
@@ -157,6 +184,13 @@ const fn padding_is_zero(buf: &[u8], bit_len: usize) -> bool {
 /// plus 8 bytes per exception, plus 32 bytes per leaf digest when the table
 /// does not inline. Ties break toward the smaller width. Returns `None` when
 /// no width fits, which cannot happen within the supported geometry.
+// `base` is the minimum count so `count - base` cannot underflow;
+// `leading_zeros() <= 32` keeps the histogram index within its 33 entries
+// and `width <= MAX_WIDTH = 32` keeps the tail slice in bounds; the size
+// arithmetic is over values bounded by the geometry (buckets <= 2^16,
+// exceptions <= buckets, allocated <= the snapshot's chunk count), all far
+// below usize overflow.
+#[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)]
 fn select_width(counts: &[u32], base: u32, buckets: usize, allocated: usize) -> Option<u8> {
     // histogram[n] counts deltas whose minimal representation is n bits, so
     // the exception count at width w is the histogram tail above w.
@@ -190,6 +224,11 @@ fn select_width(counts: &[u32], base: u32, buckets: usize, allocated: usize) -> 
 }
 
 /// Encodes a snapshot into its root and leaf payloads.
+// All arithmetic here is over values bounded by the validated table
+// geometry: `buckets <= 2^16`, `width <= 32`, counter deltas fit the
+// selected width (`base` is the minimum count), and byte sizes are within
+// a few multiples of MAX_PAYLOAD_SIZE, so none of it can overflow.
+#[allow(clippy::arithmetic_side_effects)]
 #[must_use = "the encoded payloads are the snapshot to publish; dropping them discards the encode"]
 pub(crate) fn encode(table: &UsageTable, sequence: u64, slots: &[u32]) -> Result<Encoded> {
     if slots.is_empty() {
@@ -275,20 +314,48 @@ pub(crate) fn encode(table: &UsageTable, sequence: u64, slots: &[u32]) -> Result
     }
 }
 
+// The fixed-size reads below are called only with offsets that were bounds
+// checked against the payload length (`parse` verifies the exact payload
+// size before reading), so the slicing and offset math cannot go out of
+// bounds, and `try_into` on an exactly-sized subslice is infallible.
+#[allow(
+    clippy::arithmetic_side_effects,
+    clippy::indexing_slicing,
+    clippy::unwrap_used
+)]
 fn read_u16(buf: &[u8], offset: usize) -> u16 {
     u16::from_be_bytes(buf[offset..offset + 2].try_into().unwrap())
 }
 
+#[allow(
+    clippy::arithmetic_side_effects,
+    clippy::indexing_slicing,
+    clippy::unwrap_used
+)]
 fn read_u32(buf: &[u8], offset: usize) -> u32 {
     u32::from_be_bytes(buf[offset..offset + 4].try_into().unwrap())
 }
 
+#[allow(
+    clippy::arithmetic_side_effects,
+    clippy::indexing_slicing,
+    clippy::unwrap_used
+)]
 fn read_u64(buf: &[u8], offset: usize) -> u64 {
     u64::from_be_bytes(buf[offset..offset + 8].try_into().unwrap())
 }
 
 impl RootInfo {
     /// Parses and structurally validates a root payload.
+    // Untrusted input is handled length-first: the header reads are guarded
+    // by the `payload.len() >= ROOT_HEADER_SIZE` check at the top, and every
+    // read past the header happens after `payload.len() == expected` is
+    // verified, where `expected` is the exact sum of all section sizes read
+    // below it. The size arithmetic itself is over u16-derived counts
+    // (allocated, leaves, exceptions <= 2^16) and validated geometry
+    // (`bucket_depth in 1..=16`, `depth - bucket_depth <= 31`), so it cannot
+    // overflow.
+    #[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)]
     pub fn parse(payload: &[u8]) -> Result<Self> {
         if payload.len() < ROOT_HEADER_SIZE {
             return Err(UsageError::PayloadLength {
@@ -469,6 +536,11 @@ impl RootInfo {
 
     /// Returns the expected byte length of the zero-based `leaf`, or `None`
     /// if the index is out of range.
+    // `leaf < leaf_count <= 2^16` and `per_leaf <= MAX_PAYLOAD_SIZE * 8`,
+    // so `leaf * per_leaf` stays far below usize overflow, and
+    // `end = min(start + per_leaf, buckets) >= start` keeps `end - start`
+    // from underflowing.
+    #[allow(clippy::arithmetic_side_effects)]
     pub fn expected_leaf_len(&self, leaf: u16) -> Option<usize> {
         if (leaf as usize) >= self.leaf_count() as usize {
             return None;
@@ -485,6 +557,14 @@ impl RootInfo {
     ///
     /// `leaves` must contain exactly [`leaf_count`](Self::leaf_count)
     /// payloads in chunk-index order.
+    // `parse` already validated the geometry (`depth - bucket_depth <= 31`),
+    // the exception buckets (`bucket < buckets`, indexed into a `counts`
+    // vector of exactly `buckets` entries), and the inline packed length;
+    // each untrusted leaf payload is length checked against `packed_len`
+    // before it is unpacked. The remaining index math (`i * per_leaf`,
+    // `start + per_leaf`, `end - start` with `end >= start`) is bounded by
+    // `buckets <= 2^16` and `width <= 32`.
+    #[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)]
     #[must_use = "the reassembled snapshot is the recovered state; dropping it discards the assemble"]
     pub fn assemble<L: AsRef<[u8]>>(self, leaves: &[L]) -> Result<Snapshot> {
         let buckets = 1usize << self.bucket_depth;

--- a/crates/postage-usage/src/lib.rs
+++ b/crates/postage-usage/src/lib.rs
@@ -95,6 +95,20 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::get_unwrap,
+        clippy::indexing_slicing,
+        clippy::string_slice,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::panic_in_result_fn
+    )
+)]
 
 extern crate alloc;
 

--- a/crates/postage-usage/src/snapshot.rs
+++ b/crates/postage-usage/src/snapshot.rs
@@ -770,6 +770,10 @@ impl Validated<'_> {
         self.snapshot.issued_at_persist = Some(self.snapshot.table.total_issued());
 
         let slots = &self.snapshot.slots;
+        // The leaf count is bounded by the chunk geometry (at most
+        // MAX_PAYLOAD_SIZE / 32 digests fit the root), so `1 + len` cannot
+        // overflow.
+        #[allow(clippy::arithmetic_side_effects)]
         let mut chunks = Vec::with_capacity(1 + encoded.leaves.len());
         let payloads = core::iter::once(&encoded.root).chain(encoded.leaves.iter());
         for (index, payload) in payloads.enumerate() {
@@ -777,6 +781,10 @@ impl Validated<'_> {
             let id = usage_chunk_id(&batch_id, index);
             let address = usage_chunk_address(&batch_id, owner, index);
             let bucket = calculate_bucket(&address, bucket_depth);
+            // The allocation loop above breaks only once
+            // `slots.len() > encoded.leaves.len()`, so every payload index
+            // (root plus one per leaf) has an allocated slot.
+            #[allow(clippy::indexing_slicing)]
             chunks.push(PlannedChunk {
                 index,
                 id,
@@ -956,6 +964,9 @@ mod arbitrary_impls {
             let allocated = u.int_in_range(0..=4usize)?;
             let mut slots = Vec::with_capacity(allocated);
             for _ in 0..allocated {
+                // `bucket_capacity()` is `1 << counter_bits >= 1`, so the
+                // decrement cannot underflow.
+                #[allow(clippy::arithmetic_side_effects)]
                 slots.push(u.int_in_range(0..=capacity - 1)?);
             }
             // Cannot fail for the values generated above; map defensively

--- a/crates/postage-usage/src/table.rs
+++ b/crates/postage-usage/src/table.rs
@@ -41,6 +41,9 @@ pub(crate) const fn map_counter_error(err: CounterError) -> UsageError {
 /// meaningless, and `nectar_postage::calculate_bucket` shifts a `u32` right by
 /// `32 - bucket_depth`, so `bucket_depth == 0` would overflow the shift on the
 /// persist and issue paths.
+// `depth - bucket_depth` is short-circuit guarded by the preceding
+// `depth < bucket_depth` disjunct, so it cannot underflow.
+#[allow(clippy::arithmetic_side_effects)]
 pub(crate) const fn validate_geometry(depth: u8, bucket_depth: u8) -> Result<()> {
     if bucket_depth == 0
         || bucket_depth > MAX_BUCKET_DEPTH
@@ -464,6 +467,9 @@ mod arbitrary_impls {
             // exactly the format invariant, not a generator restriction.
             let bucket_depth = u.int_in_range(1..=MAX_BUCKET_DEPTH)?;
             let counter_bits = u.int_in_range(0..=MAX_COUNTER_BITS)?;
+            // `bucket_depth <= 16` and `counter_bits <= 31`, so the u8 sum
+            // is at most 47.
+            #[allow(clippy::arithmetic_side_effects)]
             let depth = bucket_depth + counter_bits;
             let capacity = 1u32 << counter_bits;
             let mutability = Mutability::arbitrary(u)?;
@@ -474,7 +480,12 @@ mod arbitrary_impls {
             let outliers = u.int_in_range(0..=buckets.min(16))?;
             for _ in 0..outliers {
                 let bucket = u.choose_index(buckets)?;
-                counts[bucket] = u.int_in_range(0..=capacity)?;
+                // `choose_index(buckets)` returns an index below `buckets`,
+                // the length of `counts`.
+                #[allow(clippy::indexing_slicing)]
+                {
+                    counts[bucket] = u.int_in_range(0..=capacity)?;
+                }
             }
 
             // Cannot fail for the geometry and counters generated above; map

--- a/crates/postage/src/batch.rs
+++ b/crates/postage/src/batch.rs
@@ -153,6 +153,7 @@ impl Batch {
     ///
     /// This is equal to 2^(depth - bucket_depth).
     #[inline]
+    #[allow(clippy::arithmetic_side_effects)] // batch geometry invariant: depth >= bucket_depth (capacity is 2^(depth - bucket_depth) chunks per bucket)
     pub const fn bucket_upper_bound(&self) -> u32 {
         1u32 << (self.depth - self.bucket_depth)
     }

--- a/crates/postage/src/lib.rs
+++ b/crates/postage/src/lib.rs
@@ -36,6 +36,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::get_unwrap, clippy::indexing_slicing, clippy::string_slice, clippy::arithmetic_side_effects, clippy::panic, clippy::unreachable, clippy::panic_in_result_fn))]
 
 // k256 is a dependency only to enable the precomputed-tables feature for faster ECDSA
 #[cfg(not(test))]

--- a/crates/postage/src/stamped.rs
+++ b/crates/postage/src/stamped.rs
@@ -87,6 +87,7 @@ impl<const BODY_SIZE: usize> StampedChunk<BODY_SIZE> {
     pub fn to_typed_bytes(&self) -> Vec<u8> {
         let stamp = self.stamp.to_bytes();
         let chunk = self.chunk.to_typed_bytes();
+        #[allow(clippy::arithmetic_side_effects)] // capacity hint: sum of two in-memory buffer lengths cannot overflow usize
         let mut out = Vec::with_capacity(stamp.len() + chunk.len());
         out.extend_from_slice(&stamp);
         out.extend_from_slice(&chunk);

--- a/crates/postage/src/util.rs
+++ b/crates/postage/src/util.rs
@@ -60,6 +60,8 @@ pub const fn current_timestamp() -> u64 {
 /// assert_eq!(bucket, 0xCBE5);
 /// ```
 #[inline]
+#[allow(clippy::indexing_slicing, clippy::unwrap_used)] // SwarmAddress is a fixed 32-byte array: `[0..4]` and the 4-byte `try_into` are infallible
+#[allow(clippy::arithmetic_side_effects)] // `32 - bucket_depth` underflow is the documented `# Panics` contract (`bucket_depth` in 1..=32)
 pub fn calculate_bucket(address: &SwarmAddress, bucket_depth: u8) -> u32 {
     // Take the first 4 bytes as a big-endian u32
     let leading = u32::from_be_bytes(address.as_bytes()[0..4].try_into().unwrap());

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -34,7 +34,6 @@ derive_more.workspace = true
 # Core dependencies
 bytes.workspace = true
 thiserror.workspace = true
-once_cell.workspace = true
 serde = { workspace = true, optional = true }
 
 # key material protection

--- a/crates/primitives/examples/wasm-demo/Cargo.toml
+++ b/crates/primitives/examples/wasm-demo/Cargo.toml
@@ -20,7 +20,6 @@ default = ["console_error_panic_hook"]
 [dependencies]
 bytes.workspace = true
 nectar-primitives.workspace = true
-digest.workspace = true
 wasm-bindgen.workspace = true
 js-sys.workspace = true
 console_error_panic_hook = { version = "0.1.7", optional = true }

--- a/crates/primitives/src/address.rs
+++ b/crates/primitives/src/address.rs
@@ -131,6 +131,7 @@ impl SwarmAddress {
     }
 
     /// Calculate the distance between Self and address `y` in big-endian
+    #[allow(clippy::indexing_slicing)] // i < 32 from enumerating a 32-byte address, matching result's length
     #[inline(always)]
     #[must_use]
     pub fn distance(&self, y: &Self) -> U256 {
@@ -176,6 +177,7 @@ impl SwarmAddress {
     /// is closer (smaller distance), because `min_by` selects the element for
     /// which the comparator returns `Less` - and we want to select the one
     /// that is NOT closer (i.e., has a larger distance), leaving the closest.
+    #[allow(clippy::indexing_slicing)] // ab, xb and yb are all 32-byte addresses and i < ab.len()
     #[inline(always)]
     #[must_use]
     pub fn distance_cmp(&self, x: &Self, y: &Self) -> Ordering {
@@ -242,6 +244,7 @@ impl SwarmAddress {
     /// XOR distance - bitwise XOR of the two 32-byte addresses as a new
     /// [`SwarmAddress`]. Useful when callers want the raw distance bytes
     /// (e.g. for content-routing bias) rather than the proximity-order metric.
+    #[allow(clippy::indexing_slicing)] // i < 32 from enumerating a 32-byte address, matching out's length
     #[inline(always)]
     #[must_use]
     pub fn xor(&self, other: &Self) -> Self {
@@ -262,6 +265,8 @@ impl SwarmAddress {
     }
 
     /// Helper function to calculate proximity with a maximum
+    #[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)]
+    // max is MAX_PO (31) or EXTENDED_PO (36), so i <= max_bytes = 4 < 32 and i * 8 + leading_zeros <= 40 fits u8
     #[inline(always)]
     fn proximity_helper(&self, other: &Self, max: usize) -> u8 {
         let max_bytes = max / 8;

--- a/crates/primitives/src/bmt/constants.rs
+++ b/crates/primitives/src/bmt/constants.rs
@@ -25,6 +25,7 @@ pub const SPAN_SIZE: usize = std::mem::size_of::<u64>();
 pub(crate) const PROOF_LENGTH: usize = 7;
 
 /// Compute number of zero tree levels for a given body size.
+#[allow(clippy::arithmetic_side_effects)] // trailing_zeros() <= 64, so + 1 cannot overflow usize
 #[inline]
 pub(crate) const fn zero_tree_levels(body_size: usize) -> usize {
     (body_size / SEGMENT_PAIR_LENGTH).trailing_zeros() as usize + 1

--- a/crates/primitives/src/bmt/hasher.rs
+++ b/crates/primitives/src/bmt/hasher.rs
@@ -16,6 +16,7 @@ use super::constants::*;
 const ZERO_TREE_LEVELS: usize = zero_tree_levels(DEFAULT_BODY_SIZE);
 
 /// Pre-computed zero hashes for the default body size tree.
+#[allow(clippy::indexing_slicing)] // indices 0, i and i-1 with 1 <= i < ZERO_TREE_LEVELS, the array length
 static ZERO_HASHES: LazyLock<[B256; ZERO_TREE_LEVELS]> = LazyLock::new(|| {
     let mut hashes = [B256::ZERO; ZERO_TREE_LEVELS];
 
@@ -40,6 +41,7 @@ static ZERO_HASHES: LazyLock<[B256; ZERO_TREE_LEVELS]> = LazyLock::new(|| {
 ///
 /// `pairs` is the flat byte view of the level (`out.len()` pairs of two
 /// 32-byte nodes); each output is `keccak(prefix || left || right)`.
+#[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)] // entry = prefix len + 64 and entry * out.len() size the scratch Vec that is then sliced by the same bounds; each `slot` is exactly `entry` bytes long
 pub(super) fn hash_pairs(prefix: Option<&[u8]>, pairs: &[u8], out: &mut [[u8; 32]]) {
     debug_assert_eq!(pairs.len(), out.len() * SEGMENT_PAIR_LENGTH);
 
@@ -164,6 +166,8 @@ impl<const BODY_SIZE: usize> Hasher<BODY_SIZE> {
     }
 
     /// Update the hasher with more data (non-destructive)
+    #[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)]
+    // cursor <= BODY_SIZE invariant: bytes_to_copy = min(data.len(), BODY_SIZE - cursor), so the subtraction, the cursor bump and the buffer slice all stay within BODY_SIZE
     #[inline]
     pub fn update(&mut self, data: &[u8]) {
         if data.is_empty() {
@@ -214,6 +218,8 @@ impl<const BODY_SIZE: usize> Hasher<BODY_SIZE> {
     /// 1. Finds the smallest power-of-2 subtree containing all data
     /// 2. Hashes only that subtree
     /// 3. Iteratively combines with pre-computed zero hashes to reach the root
+    #[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)]
+    // cursor <= BODY_SIZE, effective_size is clamped to [64, BODY_SIZE], zero-hash indices are < ZERO_TREE_LEVELS by construction, and current_size *= 2 stops at BODY_SIZE
     #[inline(always)]
     fn hash_internal(&self) -> B256 {
         let prefix = self.prefix.as_deref();
@@ -268,6 +274,7 @@ impl<const BODY_SIZE: usize> Hasher<BODY_SIZE> {
     /// `keccak(prefix || left || right)` (the level-0 entry being
     /// `keccak(prefix || 64 zero bytes)`), matching bee's per-prefix
     /// `zerohashes`.
+    #[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)] // indices 0, i and i-1 with 1 <= i < ZERO_TREE_LEVELS, the array length
     #[inline(always)]
     fn zero_hashes(&self, prefix: Option<&[u8]>) -> [B256; ZERO_TREE_LEVELS] {
         let Some(p) = prefix else {
@@ -296,6 +303,7 @@ impl<const BODY_SIZE: usize> Hasher<BODY_SIZE> {
     /// Only pairs that overlap live data (the cursor) cost a Keccak; everything
     /// past them is an all-zero subtree taken from `zero_hashes`, which the
     /// caller has already made prefix-aware.
+    #[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)] // data.len() is a power of two >= 64, live <= pairs = data.len()/64 (so live*64 <= data.len() and level/next slices hold), depth < ZERO_TREE_LEVELS as count halves from pairs, and count > 1 guarantees level[0] exists
     fn hash_subtree(&self, data: &[u8], zero_hashes: &[B256; ZERO_TREE_LEVELS]) -> B256 {
         debug_assert!(data.len().is_power_of_two());
         debug_assert!(data.len() >= SEGMENT_PAIR_LENGTH);
@@ -342,6 +350,7 @@ impl<const BODY_SIZE: usize> Hasher<BODY_SIZE> {
 
     /// Calculate the zero-tree level for a given subtree length.
     /// Length must be a power of 2 between 64 and 4096.
+    #[allow(clippy::arithmetic_side_effects)] // length >= 64 (per contract above), so trailing_zeros() >= 6 and the subtraction cannot underflow
     #[inline(always)]
     const fn zero_tree_level(length: usize) -> usize {
         // length = 64 * 2^level, so level = log2(length) - log2(64) = log2(length) - 6
@@ -412,6 +421,8 @@ impl<const BODY_SIZE: usize> Hasher<BODY_SIZE> {
     }
 
     /// Compute the hash for a single segment at given index
+    #[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)]
+    // start < data.len() is checked before slicing, end is clamped to data.len(), and segment_data.len() < SEGMENT_SIZE guards the zero-padding subtraction
     #[inline(always)]
     fn compute_segment_hash(&self, data: &[u8], i: usize) -> B256 {
         let start = i << SEGMENT_SIZE_LOG2; // Equivalent to i * SEGMENT_SIZE
@@ -438,6 +449,8 @@ impl<const BODY_SIZE: usize> Hasher<BODY_SIZE> {
 }
 
 impl<const BODY_SIZE: usize> Write for Hasher<BODY_SIZE> {
+    #[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)]
+    // cursor <= BODY_SIZE invariant: to_write = min(buf.len(), BODY_SIZE - cursor), so the subtraction, the cursor bump and the buffer slice all stay within BODY_SIZE
     #[inline]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let available = BODY_SIZE - self.cursor;

--- a/crates/primitives/src/bmt/proof.rs
+++ b/crates/primitives/src/bmt/proof.rs
@@ -121,6 +121,7 @@ pub trait Prover {
 }
 
 impl Prover for Hasher {
+    #[allow(clippy::indexing_slicing)] // n = min(data.len(), ..) bounds data[..n], chunk.len() <= SEGMENT_SIZE bounds leaf[..], segment_index < BRANCHES is checked above, and index halves in lockstep with each level's width so level[index ^ 1] is in range
     fn generate_proof(&self, data: &[u8], segment_index: usize) -> Result<Proof> {
         if segment_index >= BRANCHES {
             return Err(self::BmtError::invalid_input_size(format!(

--- a/crates/primitives/src/chunk/any_chunk.rs
+++ b/crates/primitives/src/chunk/any_chunk.rs
@@ -238,6 +238,7 @@ impl<const BODY_SIZE: usize> AnyChunk<BODY_SIZE> {
     /// let decoded: AnyChunk = AnyChunk::from_typed_bytes(&address, &encoded).unwrap();
     /// assert_eq!(decoded.address(), any.address());
     /// ```
+    #[allow(clippy::arithmetic_side_effects)] // 1 + a chunk wire length bounded by the chunk format is a capacity hint far below usize::MAX
     pub fn to_typed_bytes(&self) -> Vec<u8> {
         let tag = self.type_id().as_u8();
         // Clone is required because `into_bytes` consumes the chunk; chunk

--- a/crates/primitives/src/chunk/bmt_body.rs
+++ b/crates/primitives/src/chunk/bmt_body.rs
@@ -45,6 +45,7 @@ impl<const BODY_SIZE: usize> BmtBody<BODY_SIZE> {
     }
 
     /// Get the size of this body in bytes
+    #[allow(clippy::arithmetic_side_effects)] // SPAN_SIZE (8) + a body bounded by BODY_SIZE cannot overflow usize
     pub const fn size(&self) -> usize {
         SPAN_SIZE + self.data.len()
     }
@@ -104,6 +105,7 @@ impl<const BODY_SIZE: usize> From<BmtBody<BODY_SIZE>> for Bytes {
 impl<const BODY_SIZE: usize> TryFrom<Bytes> for BmtBody<BODY_SIZE> {
     type Error = PrimitivesError;
 
+    #[allow(clippy::unwrap_used)] // infallible: split_to(SPAN_SIZE) yields exactly 8 bytes (length checked above)
     fn try_from(mut buf: Bytes) -> Result<Self> {
         if buf.len() < SPAN_SIZE {
             return Err(ChunkError::invalid_size(
@@ -191,6 +193,7 @@ impl<const BODY_SIZE: usize> BmtBodyBuilder<BODY_SIZE, Initial> {
 }
 
 impl<const BODY_SIZE: usize> BmtBodyBuilder<BODY_SIZE, WithSpan> {
+    #[allow(clippy::unwrap_used)] // the WithSpan typestate guarantees span is Some
     pub(crate) fn with_data(
         mut self,
         data: impl Into<Bytes>,
@@ -218,6 +221,7 @@ impl<const BODY_SIZE: usize> BmtBodyBuilder<BODY_SIZE, WithSpan> {
 }
 
 impl<const BODY_SIZE: usize> BmtBodyBuilder<BODY_SIZE, ReadyToBuild> {
+    #[allow(clippy::unwrap_used)] // the ReadyToBuild typestate guarantees span and data are Some
     pub(crate) fn build(self) -> Result<BmtBody<BODY_SIZE>> {
         Ok(BmtBody::new_unchecked(
             self.span.unwrap(),
@@ -228,6 +232,7 @@ impl<const BODY_SIZE: usize> BmtBodyBuilder<BODY_SIZE, ReadyToBuild> {
 
 #[cfg(any(test, feature = "arbitrary"))]
 impl<'a, const BODY_SIZE: usize> arbitrary::Arbitrary<'a> for BmtBody<BODY_SIZE> {
+    #[allow(clippy::arithmetic_side_effects, clippy::unwrap_used)] // test-input generator: BODY_SIZE + 1 sums small constants, and the builder cannot fail on the generated span/data combination
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         // Decide whether to generate a leaf chunk (span == data_len) or an
         // intermediate chunk (span > BODY_SIZE, full body).

--- a/crates/primitives/src/chunk/content.rs
+++ b/crates/primitives/src/chunk/content.rs
@@ -191,6 +191,7 @@ impl<const BODY_SIZE: usize> EncryptedContentChunk<BODY_SIZE> {
     }
 
     /// Decrypt back to a plaintext `ContentChunk`.
+    #[allow(clippy::indexing_slicing)] // a ContentChunk's wire bytes always start with an 8-byte span, so [..SPAN_SIZE] holds
     pub fn decrypt(&self) -> Result<ContentChunk<BODY_SIZE>> {
         use super::encryption::transcrypt;
         use crate::bmt::SPAN_SIZE;
@@ -258,6 +259,7 @@ impl<const BODY_SIZE: usize> Chunk for ContentChunk<BODY_SIZE> {
         self.body.data()
     }
 
+    #[allow(clippy::arithmetic_side_effects)] // header (0 bytes) plus a body bounded by BODY_SIZE cannot overflow usize
     fn size(&self) -> usize {
         self.header().bytes().len() + self.body.size()
     }
@@ -300,6 +302,7 @@ impl<const BODY_SIZE: usize> TryFrom<&[u8]> for ContentChunk<BODY_SIZE> {
 }
 
 impl<const BODY_SIZE: usize> fmt::Display for ContentChunk<BODY_SIZE> {
+    #[allow(clippy::indexing_slicing)] // the address is a fixed 32-byte value, so [..8] holds
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -381,6 +384,7 @@ impl<const BODY_SIZE: usize> ContentChunkBuilderImpl<BODY_SIZE, ReadyToBuild> {
     }
 
     /// Build the final ContentChunk
+    #[allow(clippy::unwrap_used)] // the ReadyToBuild typestate guarantees body is Some
     fn build(self) -> ContentChunk<BODY_SIZE> {
         // This is safe as we have already checked that the body is set
         let body = self.body.unwrap();

--- a/crates/primitives/src/chunk/encryption/chunk.rs
+++ b/crates/primitives/src/chunk/encryption/chunk.rs
@@ -10,6 +10,7 @@ use super::error::EncryptionError;
 use super::key::EncryptionKey;
 
 /// Span encryption counter: `BODY_SIZE / EncryptionKey::SIZE` (128 for default 4096).
+#[allow(clippy::arithmetic_side_effects)] // EncryptionKey::SIZE is the nonzero constant 32
 const fn span_ctr(body_size: usize) -> u32 {
     (body_size / EncryptionKey::SIZE) as u32
 }
@@ -22,6 +23,7 @@ const fn span_ctr(body_size: usize) -> u32 {
 ///
 /// `chunk_data` must be `SPAN_SIZE..=SPAN_SIZE + BODY_SIZE` bytes.
 #[cfg(feature = "encryption")]
+#[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)] // SPAN_SIZE + BODY_SIZE and SPAN_SIZE + data.len() sum small constants; the length checks above bound chunk_data, and output is allocated SPAN_SIZE + BODY_SIZE bytes
 pub(crate) fn encrypt_chunk<const BODY_SIZE: usize>(
     chunk_data: &[u8],
     key: &EncryptionKey,
@@ -64,6 +66,7 @@ pub(crate) fn encrypt_chunk<const BODY_SIZE: usize>(
 ///
 /// `encrypted_data` must be exactly `SPAN_SIZE + BODY_SIZE` bytes.
 /// `data_length` specifies the actual data length (excluding padding).
+#[allow(clippy::arithmetic_side_effects)] // SPAN_SIZE (8) + data_length (<= BODY_SIZE, checked in decrypt_chunk_into) cannot overflow usize
 pub(crate) fn decrypt_chunk_data<const BODY_SIZE: usize>(
     encrypted_data: &[u8],
     key: &EncryptionKey,
@@ -78,6 +81,7 @@ pub(crate) fn decrypt_chunk_data<const BODY_SIZE: usize>(
 ///
 /// `output` must be at least `SPAN_SIZE + data_length` bytes.
 /// `encrypted_data` must be exactly `SPAN_SIZE + BODY_SIZE` bytes.
+#[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)] // the three length checks above guarantee data_length <= BODY_SIZE, encrypted_data.len() == SPAN_SIZE + BODY_SIZE and output.len() >= SPAN_SIZE + data_length, bounding every sum and slice
 pub(crate) fn decrypt_chunk_into<const BODY_SIZE: usize>(
     encrypted_data: &[u8],
     key: &EncryptionKey,

--- a/crates/primitives/src/chunk/encryption/cipher.rs
+++ b/crates/primitives/src/chunk/encryption/cipher.rs
@@ -31,6 +31,7 @@ fn derive_segment_key(key_state: &Keccak256, counter: u32) -> [u8; 32] {
 }
 
 /// XOR `data` with the Keccak-256 CTR keystream in place.
+#[allow(clippy::indexing_slicing)] // j < chunk.len() <= EncryptionKey::SIZE = seg.len() (32)
 #[inline]
 fn apply_keystream(key: &EncryptionKey, init_ctr: u32, data: &mut [u8]) {
     let ks = key_state(key);
@@ -49,6 +50,7 @@ fn apply_keystream(key: &EncryptionKey, init_ctr: u32, data: &mut [u8]) {
 ///
 /// `output` must be at least as long as `input`. Bytes in `output` beyond
 /// `input.len()` are left untouched.
+#[allow(clippy::indexing_slicing)] // output.len() >= input.len() is checked above with an error return
 #[inline]
 pub fn transcrypt(
     key: &EncryptionKey,

--- a/crates/primitives/src/chunk/encryption/reference.rs
+++ b/crates/primitives/src/chunk/encryption/reference.rs
@@ -42,6 +42,7 @@ impl EncryptedChunkRef {
     }
 
     /// Write the reference into `buf`. Panics if `buf` is too small.
+    #[allow(clippy::indexing_slicing)] // documented contract: panics if buf.len() < Self::SIZE; both callers pass fixed [u8; Self::SIZE] buffers
     pub fn write_to(&self, buf: &mut [u8]) {
         buf[..size_of::<ChunkAddress>()].copy_from_slice(self.address.as_bytes());
         buf[size_of::<ChunkAddress>()..Self::SIZE].copy_from_slice(self.key.as_bytes());
@@ -74,6 +75,7 @@ impl From<&EncryptedChunkRef> for Vec<u8> {
 impl TryFrom<&[u8]> for EncryptedChunkRef {
     type Error = EncryptionError;
 
+    #[allow(clippy::indexing_slicing)] // slice.len() == Self::SIZE (64) is checked above with an error return, covering both the 32-byte address and 32-byte key slices
     fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
         if slice.len() != Self::SIZE {
             return Err(EncryptionError::InvalidReferenceLength { len: slice.len() });

--- a/crates/primitives/src/chunk/single_owner.rs
+++ b/crates/primitives/src/chunk/single_owner.rs
@@ -280,6 +280,7 @@ impl<const BODY_SIZE: usize> SingleOwnerChunk<BODY_SIZE> {
     }
 
     // Checks if the chunk is a valid dispersed replica
+    #[allow(clippy::indexing_slicing)] // both id and body hash are fixed 32-byte values, so [1..] holds
     fn is_valid_replica(&self) -> bool {
         self.id()[1..] == self.body.hash().as_slice()[1..]
     }
@@ -339,6 +340,7 @@ impl<const BODY_SIZE: usize> Chunk for SingleOwnerChunk<BODY_SIZE> {
         self.body.data()
     }
 
+    #[allow(clippy::arithmetic_side_effects)] // header (97 bytes) plus a body bounded by BODY_SIZE cannot overflow usize
     fn size(&self) -> usize {
         self.header().bytes().len() + self.body.size()
     }
@@ -427,6 +429,7 @@ impl<const BODY_SIZE: usize> TryFrom<&[u8]> for SingleOwnerChunk<BODY_SIZE> {
 }
 
 impl<const BODY_SIZE: usize> fmt::Display for SingleOwnerChunk<BODY_SIZE> {
+    #[allow(clippy::indexing_slicing)] // id is a fixed 32-byte value, so [..8] holds
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let owner_str = self.owner().map_or_else(
             |_| "invalid".to_string(),
@@ -550,6 +553,7 @@ impl<const BODY_SIZE: usize> SingleOwnerChunkBuilderImpl<BODY_SIZE, WithData> {
     }
 
     /// Creates a new dispersed replica chunk with the given first byte and transitions to ReadyToBuild
+    #[allow(clippy::unwrap_used, clippy::indexing_slicing)] // the WithData typestate guarantees body is Some; id and body_hash are fixed 32-byte values; DISPERSED_REPLICA_OWNER_PK is a known-valid constant key
     fn dispersed_replica(
         self,
         first_byte: u8,
@@ -567,6 +571,7 @@ impl<const BODY_SIZE: usize> SingleOwnerChunkBuilderImpl<BODY_SIZE, WithData> {
 
 impl<const BODY_SIZE: usize> SingleOwnerChunkBuilderImpl<BODY_SIZE, WithId> {
     /// Sign the chunk with the given signer
+    #[allow(clippy::unwrap_used)] // the WithId typestate guarantees body and id are Some
     fn with_signer(
         self,
         signer: &impl SignerSync,
@@ -604,6 +609,7 @@ impl<const BODY_SIZE: usize> SingleOwnerChunkBuilderImpl<BODY_SIZE, WithId> {
 
 impl<const BODY_SIZE: usize> SingleOwnerChunkBuilderImpl<BODY_SIZE, ReadyToBuild> {
     /// Build the final SingleOwnerChunk
+    #[allow(clippy::unwrap_used)] // the ReadyToBuild typestate guarantees body, id and signature are Some
     fn build(self) -> Result<SingleOwnerChunk<BODY_SIZE>> {
         let body = self.body.unwrap();
         let id = self.id.unwrap();

--- a/crates/primitives/src/chunk/traits.rs
+++ b/crates/primitives/src/chunk/traits.rs
@@ -59,6 +59,7 @@ pub trait Chunk: Send + Sync + 'static {
     fn data(&self) -> &Bytes;
 
     /// Get the total size of this chunk in bytes
+    #[allow(clippy::arithmetic_side_effects)] // header and payload are both bounded by the chunk wire size, far below usize::MAX
     fn size(&self) -> usize {
         self.header().bytes().len() + self.data().len()
     }
@@ -83,6 +84,7 @@ pub trait ChunkSerialization {
 }
 
 impl<T: Chunk> ChunkSerialization for T {
+    #[allow(clippy::arithmetic_side_effects)] // 2 + a chunk size bounded by the wire format is a capacity hint far below usize::MAX
     fn serialize_with_prefix(&self) -> Bytes {
         let mut bytes = BytesMut::with_capacity(2 + self.size());
         bytes.extend(self.header().bytes());

--- a/crates/primitives/src/file/constants.rs
+++ b/crates/primitives/src/file/constants.rs
@@ -5,6 +5,7 @@ use crate::bmt::{BRANCHES, DEFAULT_BODY_SIZE, HASH_SIZE};
 /// Derive the maximum tree depth from branching factor and body size.
 /// The limit is the number of levels needed to address all storable data:
 /// `branches^(limit-1) * body_size` must exceed any practical file size.
+#[allow(clippy::arithmetic_side_effects)] // compile-time constants: body_bits <= 12 < 64 and branch_bits >= 1 for the power-of-two inputs used
 const fn compute_level_limit(branches: usize, body_size: usize) -> usize {
     // bits needed = ceil(log2(u64::MAX / body_size)) / log2(branches)
     // For branches=128 (7 bits), body_size=4096 (12 bits): (64-12)/7 + 1 = 8.4 → 9
@@ -26,6 +27,7 @@ const REFS_PER_CHUNK: usize = BRANCHES;
 
 /// Compute span multipliers for a given branching factor.
 /// `spans[i] = branches^i`, representing how many level-0 refs each level-i ref covers.
+#[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)] // i < LEVEL_LIMIT is the loop condition and the array length; i += 1 stops at LEVEL_LIMIT
 const fn compute_spans(branches: usize) -> [u64; LEVEL_LIMIT] {
     let mut spans = [0u64; LEVEL_LIMIT];
     let mut span = 1u64;
@@ -58,6 +60,7 @@ pub(crate) const fn assert_valid_body_size<const BODY_SIZE: usize>() {
 }
 
 /// Calculate tree depth for a given file size using integer arithmetic.
+#[allow(clippy::arithmetic_side_effects)] // chunk_size and ref_size are nonzero constants with ref_size <= chunk_size, so branches >= 1; depth increments at most log_branches(data_chunks) times
 pub(crate) const fn tree_depth(length: u64, chunk_size: usize, ref_size: usize) -> usize {
     if length == 0 {
         return 0;
@@ -82,7 +85,7 @@ pub(crate) const fn tree_depth(length: u64, chunk_size: usize, ref_size: usize) 
 
 /// Calculate subspan size for children of a node with given span, using the
 /// provided span multiplier table.
-#[inline]
+#[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)] // indices i, i - 1 (i > 0 checked) and LEVEL_LIMIT - 2 are all < LEVEL_LIMIT = spans.len(); every span produced by the splitters returns before the last level's product, and a span beyond the deepest level falls through to the same deepest-level subspan
 pub(crate) fn subspan_for_spans<const BODY_SIZE: usize>(
     span: u64,
     spans: &[u64; LEVEL_LIMIT],

--- a/crates/primitives/src/file/entry_ref.rs
+++ b/crates/primitives/src/file/entry_ref.rs
@@ -24,6 +24,8 @@ impl EntryRef {
     pub fn try_from_bytes(bytes: &[u8]) -> Result<Self, FileError> {
         match bytes.len() {
             32 => {
+                #[allow(clippy::expect_used)]
+                // infallible: this match arm guarantees bytes.len() == 32
                 let addr_bytes: [u8; 32] = bytes.try_into().expect("length checked");
                 Ok(Self::Plain(ChunkAddress::from(addr_bytes)))
             }

--- a/crates/primitives/src/file/frontier.rs
+++ b/crates/primitives/src/file/frontier.rs
@@ -30,6 +30,8 @@ impl<M: JoinMode> Clone for SubtreeNode<M> {
 }
 
 /// Parse children of an intermediate node that overlap a byte range.
+#[allow(clippy::arithmetic_side_effects)]
+// REF_SIZE is a nonzero constant; i < num_children <= BS / REF_SIZE bounds i * REF_SIZE within body.len(); child byte offsets and chunk-range bounds stay within the u64 file span for any tree the splitters can produce
 #[inline]
 pub(crate) fn overlapping_children<M, const BS: usize>(
     body: &[u8],
@@ -93,6 +95,7 @@ struct BfsExpander<M: JoinMode, const BS: usize> {
 
 impl<M: JoinMode, const BS: usize> BfsExpander<M, BS> {
     /// Returns `None` if `span` fits in a single chunk (no expansion possible).
+    #[allow(clippy::arithmetic_side_effects)] // both callers pass a nonzero target_subtrees (DEFAULT_ASYNC_CONCURRENCY * 2)
     fn new(
         root: &ChunkAddress,
         context: &M::JoinerContext,
@@ -123,6 +126,7 @@ impl<M: JoinMode, const BS: usize> BfsExpander<M, BS> {
 
     /// Apply pre-read bodies for expanded nodes, produce next frontier layer.
     /// Returns `false` if nothing was expanded (converged).
+    #[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)] // body_idx < expand_indices.len() is checked before both indexings, and the caller supplies exactly one body per expand index
     fn advance(&mut self, expand_indices: &[usize], bodies: &[Bytes]) -> Result<bool> {
         if expand_indices.is_empty() {
             return Ok(false);
@@ -188,6 +192,8 @@ where
         let futs: Vec<_> = indices
             .iter()
             .map(|&i| {
+                #[allow(clippy::indexing_slicing)]
+                // indices come from enumerating this same frontier
                 let n = &bfs.frontier[i];
                 super::mode::read_chunk_body::<M, G, BS>(getter, &n.addr, &n.context, n.span)
             })

--- a/crates/primitives/src/file/helpers.rs
+++ b/crates/primitives/src/file/helpers.rs
@@ -13,6 +13,7 @@ pub(crate) enum ReadRangeCheck {
 }
 
 /// Validate a read range against span and body size, returning the action to take.
+#[allow(clippy::arithmetic_side_effects)] // span - offset is guarded by the offset >= span early return
 #[inline]
 pub(crate) fn validate_read_range<const BODY_SIZE: usize>(
     offset: u64,
@@ -36,6 +37,7 @@ pub(crate) fn validate_read_range<const BODY_SIZE: usize>(
 }
 
 /// Build an intermediate chunk payload: span (LE u64) prepended to reference data.
+#[allow(clippy::arithmetic_side_effects)] // SPAN_SIZE (8) + ref_data.len() (<= BODY_SIZE) is a capacity hint far below usize::MAX
 #[inline]
 pub(crate) fn build_intermediate_payload(span: u64, ref_data: &[u8]) -> Vec<u8> {
     let mut payload = Vec::with_capacity(SPAN_SIZE + ref_data.len());

--- a/crates/primitives/src/file/joiner.rs
+++ b/crates/primitives/src/file/joiner.rs
@@ -254,6 +254,7 @@ where
         clippy::too_many_arguments,
         reason = "internal helper threading already-decomposed reader state from two call sites"
     )]
+    #[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)] // validate_read_range clamps offset + actual_len within the single chunk body; chunk indices and subtree byte offsets are bounded by the file span, so the u64 products/sums cannot overflow
     async fn read_range_with(
         getter: &Arc<G>,
         subtrees: &[SubtreeNode<M>],
@@ -366,6 +367,7 @@ where
     /// single contiguous result, so peak memory is bounded by the in-flight
     /// width, not the file size. Set the width with
     /// [`with_concurrency`](Self::with_concurrency).
+    #[allow(clippy::arithmetic_side_effects)] // base + leaf_index * BODY_SIZE addresses a leaf inside the file, so it is bounded by the file span (u64)
     pub fn into_offset_stream(self) -> impl Stream<Item = Result<(u64, Bytes)>> {
         let getter = self.getter;
         let concurrency = self.concurrency;
@@ -449,6 +451,7 @@ where
     /// file size. Set the width with [`with_concurrency`](Self::with_concurrency).
     /// Reassembling the pairs by offset reproduces the file, byte-for-byte equal
     /// to [`read_all`](Self::read_all).
+    #[allow(clippy::arithmetic_side_effects, clippy::expect_used)] // retries - 1 is guarded by retries > 0; intermediate_in_flight moves in lockstep with admissions (bounded by MAX_INTERMEDIATE_IN_FLIGHT) so +1/-1 cannot wrap; the pop_front().expect is guarded by the !is_empty() admission check just above
     pub fn into_offset_stream_chunked(self) -> impl Stream<Item = Result<(u64, Bytes)>>
     where
         G: 'static,
@@ -675,6 +678,7 @@ where
 /// children overlapping `[start, start + len)`, clips boundary leaves to the
 /// range, and keeps absolute offsets, so the returned stream is identical to the
 /// inherent method.
+#[allow(clippy::arithmetic_side_effects, clippy::expect_used)] // range_end >= range_start by the min/saturating clamps above; retries - 1 is guarded by retries > 0; in-flight counters move in lockstep with admissions; leaf/chunk offsets are bounded by the file span; range_end - leaf_start is guarded by the leaf_start >= range_end continue; the pop_front().expect is guarded by the !is_empty() admission check just above
 pub(crate) fn chunked_range_stream_from<G, M, const BODY_SIZE: usize>(
     getter: Arc<G>,
     subtrees: Vec<SubtreeNode<M>>,
@@ -928,6 +932,11 @@ where
     G: ChunkGet<BODY_SIZE> + 'static,
     M: JoinMode + Send + Sync + 'static,
 {
+    #[allow(
+        clippy::arithmetic_side_effects,
+        clippy::indexing_slicing,
+        clippy::unwrap_used
+    )] // to_copy = min(len, remaining) bounds both slices; span - position is guarded by the EOF return above; position advances by read lengths bounded by the file span; the unwrap follows the is_none() branch that just set the future
     fn poll_read(
         self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,

--- a/crates/primitives/src/file/mod.rs
+++ b/crates/primitives/src/file/mod.rs
@@ -136,10 +136,17 @@ pub(crate) fn resolve_seek_position(
 ) -> std::io::Result<u64> {
     use std::io::{Error, ErrorKind::InvalidInput, SeekFrom};
     let to_i64 = |v: u64, msg: &str| i64::try_from(v).map_err(|_| Error::new(InvalidInput, msg));
+    // Match std's seek semantics: a relative offset that overflows i64 is an
+    // invalid-input error, never a wrap or panic.
+    let overflow = || Error::new(InvalidInput, "seek position overflows i64");
     let new_pos = match pos {
         SeekFrom::Start(off) => to_i64(off, "seek offset exceeds i64::MAX")?,
-        SeekFrom::End(off) => to_i64(span, "file span exceeds i64::MAX")? + off,
-        SeekFrom::Current(off) => to_i64(current, "current position exceeds i64::MAX")? + off,
+        SeekFrom::End(off) => to_i64(span, "file span exceeds i64::MAX")?
+            .checked_add(off)
+            .ok_or_else(overflow)?,
+        SeekFrom::Current(off) => to_i64(current, "current position exceeds i64::MAX")?
+            .checked_add(off)
+            .ok_or_else(overflow)?,
     };
     if new_pos < 0 {
         return Err(Error::new(InvalidInput, "seek to negative position"));

--- a/crates/primitives/src/file/mode.rs
+++ b/crates/primitives/src/file/mode.rs
@@ -38,6 +38,7 @@ pub trait JoinMode: Sized + 'static {
     type JoinerContext: Clone + Debug + Send + Sync;
 
     /// Number of child references per intermediate chunk.
+    #[allow(clippy::arithmetic_side_effects)] // REF_SIZE is the nonzero constant 32 or 64
     #[inline]
     fn refs_per_chunk(body_size: usize) -> usize {
         body_size / Self::REF_SIZE
@@ -50,6 +51,7 @@ pub trait JoinMode: Sized + 'static {
     }
 
     /// Subspan size for a given parent span.
+    #[allow(clippy::arithmetic_side_effects)] // REF_SIZE is the nonzero constant 32 or 64
     #[inline]
     fn subspan_size<const BS: usize>(span: u64) -> u64 {
         let spans = compute_spans_inline(BS / Self::REF_SIZE);
@@ -57,6 +59,8 @@ pub trait JoinMode: Sized + 'static {
     }
 
     /// Compute the span covered by a child at `child_index` within a parent of `parent_span`.
+    #[allow(clippy::arithmetic_side_effects)]
+    // branches = BS / REF_SIZE >= 1 for the asserted BS >= 64, so branches - 1 cannot underflow; child_index * subspan addresses a child inside the parent span for any tree the splitters can produce
     #[inline]
     fn child_span<const BS: usize>(parent_span: u64, subspan: u64, child_index: usize) -> u64 {
         let branches = Self::refs_per_chunk(BS);
@@ -177,10 +181,12 @@ impl JoinMode for PlainMode {
 
     #[inline]
     fn parse_child_ref(body: &[u8], ref_start: usize) -> Result<(ChunkAddress, ())> {
-        let ref_end = ref_start + REF_SIZE;
-        let child_addr_bytes: [u8; 32] = body[ref_start..ref_end]
-            .try_into()
-            .map_err(|_| FileError::InvalidReference { level: 0 })?;
+        // Bounds-check the untrusted body instead of panicking on a short slice.
+        let child_addr_bytes: [u8; 32] = ref_start
+            .checked_add(REF_SIZE)
+            .and_then(|ref_end| body.get(ref_start..ref_end))
+            .and_then(|slice| slice.try_into().ok())
+            .ok_or(FileError::InvalidReference { level: 0 })?;
         Ok((ChunkAddress::from(child_addr_bytes), ()))
     }
 }
@@ -221,6 +227,7 @@ pub struct EncryptedMode;
 
 impl EncryptedMode {
     /// Calculate data length for decryption of a chunk with given span.
+    #[allow(clippy::arithmetic_side_effects)] // sub = subspan_size(..) >= BS > 0 for the div_ceil; num_children <= branches (sub covers at least span / branches), so the product is bounded by BS
     fn decrypt_data_length<const BS: usize>(span: u64) -> usize {
         if span <= BS as u64 {
             span as usize
@@ -268,11 +275,16 @@ impl JoinMode for EncryptedMode {
     }
 
     fn parse_child_ref(body: &[u8], ref_start: usize) -> Result<(ChunkAddress, EncryptionKey)> {
-        let ref_end = ref_start + ENCRYPTED_REF_SIZE;
-        let child_addr_bytes: [u8; 32] = body[ref_start..ref_start + 32]
+        // Bounds-check the untrusted body instead of panicking on a short slice.
+        let ref_bytes = ref_start
+            .checked_add(ENCRYPTED_REF_SIZE)
+            .and_then(|ref_end| body.get(ref_start..ref_end))
+            .ok_or(FileError::InvalidReference { level: 0 })?;
+        let (addr_bytes, key_bytes) = ref_bytes.split_at(32);
+        let child_addr_bytes: [u8; 32] = addr_bytes
             .try_into()
             .map_err(|_| FileError::InvalidReference { level: 0 })?;
-        let child_key = EncryptionKey::try_from(&body[ref_start + 32..ref_end])?;
+        let child_key = EncryptionKey::try_from(key_bytes)?;
         Ok((ChunkAddress::from(child_addr_bytes), child_key))
     }
 }
@@ -317,6 +329,7 @@ impl SplitMode for EncryptedMode {
 }
 
 /// Decrypt just the span (first 8 bytes) from encrypted chunk data.
+#[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)] // SPAN_SIZE + BODY_SIZE sums small compile-time constants; the exact-length check above guarantees encrypted_data has at least SPAN_SIZE bytes; EncryptionKey::SIZE is a nonzero constant
 fn decrypt_span<const BODY_SIZE: usize>(
     encrypted_data: &[u8],
     key: &EncryptionKey,

--- a/crates/primitives/src/file/read_at.rs
+++ b/crates/primitives/src/file/read_at.rs
@@ -21,6 +21,7 @@ pub trait ReadAt {
 }
 
 impl ReadAt for [u8] {
+    #[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)] // offset < self.len() is checked above, and to_read = min(buf.len(), self.len() - offset) bounds both slices
     fn read_at(&self, offset: u64, buf: &mut [u8]) -> io::Result<usize> {
         let offset = offset as usize;
         if offset >= self.len() {

--- a/crates/primitives/src/file/splitter.rs
+++ b/crates/primitives/src/file/splitter.rs
@@ -54,6 +54,7 @@ where
     M: SplitMode,
 {
     /// Create a splitter for data of known size.
+    #[allow(clippy::arithmetic_side_effects)] // BODY_SIZE * 2 multiplies small compile-time constants
     pub fn new(span_length: u64) -> Self {
         const { super::constants::assert_valid_body_size::<BODY_SIZE>() };
 
@@ -106,6 +107,7 @@ impl<M, const BODY_SIZE: usize> Write for GenericSplitter<M, BODY_SIZE>
 where
     M: SplitMode,
 {
+    #[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)] // span_length + 1 only renders the error message (span_length < u64::MAX in any reachable state); to_write <= buf.len() bounds the slice
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let remaining = self.span_length.saturating_sub(self.buffer.len() as u64) as usize;
         let to_write = buf.len().min(remaining);

--- a/crates/primitives/src/file/splitter_parallel.rs
+++ b/crates/primitives/src/file/splitter_parallel.rs
@@ -51,6 +51,7 @@ where
     ///
     /// `sink` is called from rayon worker threads, so it must be `Fn + Sync`.
     /// Returns the root reference.
+    #[allow(clippy::arithmetic_side_effects)] // M::REF_SIZE is the nonzero constant 32 or 64
     pub fn split_into<R, F>(source: &R, sink: F) -> Result<M::RootRef>
     where
         R: ReadAt + Sync,
@@ -79,6 +80,7 @@ where
     ///
     /// Chunk order is irrelevant; callers key by address. Returns the root
     /// reference and the produced chunks.
+    #[allow(clippy::unwrap_used)] // Mutex poisoning requires a sink panic, which itself already aborts the rayon join; both unwraps are on that same local mutex
     pub fn split_to_vec<R: ReadAt + Sync>(
         source: &R,
     ) -> Result<(M::RootRef, Vec<AnyChunk<BODY_SIZE>>)> {
@@ -87,6 +89,7 @@ where
         Ok((root, chunks.into_inner().unwrap()))
     }
 
+    #[allow(clippy::arithmetic_side_effects)] // i < data_chunks = ceil(size / BODY_SIZE), so offset = i * BODY_SIZE < size and size - offset cannot underflow
     fn create_data_chunks<R, F>(
         source: &R,
         tree: &TreeParams<BODY_SIZE>,
@@ -127,6 +130,7 @@ where
         results.into_iter().collect()
     }
 
+    #[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)] // refs starts non-empty (size > 0 produces >= 1 data chunk) and each level keeps >= 1 ref, so refs[0] exists; level increments at most log_branches(refs) < LEVEL_LIMIT times
     fn build_intermediate_levels<F>(
         mut refs: Vec<M::RefBytes>,
         total_size: u64,
@@ -147,6 +151,7 @@ where
         M::extract_root(refs[0].as_ref())
     }
 
+    #[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)] // refs_per_chunk >= 1; level < LEVEL_LIMIT = spans.len() for any in-memory ref count; start = i * refs_per_chunk < refs.len() and end is clamped to refs.len(), so the slice holds and child_refs is non-empty
     fn build_level<F>(
         refs: &[M::RefBytes],
         level: usize,

--- a/crates/primitives/src/file/tree.rs
+++ b/crates/primitives/src/file/tree.rs
@@ -23,6 +23,7 @@ impl<const BODY_SIZE: usize> TreeParams<BODY_SIZE> {
     }
 
     /// Create tree parameters with a custom reference size (e.g. 64 for encrypted mode).
+    #[allow(clippy::arithmetic_side_effects)] // ref_size is the constant 32 (plain) or 64 (encrypted), never zero
     pub fn with_ref_size(size: u64, ref_size: usize) -> Self {
         let branches = BODY_SIZE / ref_size;
         let (depth, data_chunks) = if size == 0 {
@@ -57,6 +58,7 @@ impl<const BODY_SIZE: usize> TreeParams<BODY_SIZE> {
     }
 
     /// Total chunks across all levels.
+    #[allow(clippy::arithmetic_side_effects)] // branches >= 1 (BODY_SIZE / 64 minimum) and the geometric level sum is < 2 * data_chunks, far below u64::MAX
     pub const fn total_chunks(&self) -> u64 {
         let mut total = self.data_chunks;
         let mut chunks_at_level = self.data_chunks;
@@ -70,6 +72,7 @@ impl<const BODY_SIZE: usize> TreeParams<BODY_SIZE> {
     }
 
     /// Chunks at a specific level.
+    #[allow(clippy::arithmetic_side_effects)] // branches >= 1, so the div_ceil divisor is never zero
     pub fn chunks_at_level(&self, level: usize) -> u64 {
         if level >= self.depth {
             return 0;
@@ -86,6 +89,7 @@ impl<const BODY_SIZE: usize> TreeParams<BODY_SIZE> {
     }
 
     /// Span for a chunk at given level and index.
+    #[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)] // level < depth <= LEVEL_LIMIT = spans.len(); index < chunks_at_level and per-chunk spans partition the file size, so the products/sums stay within the u64 file span
     pub fn span_at(&self, level: usize, index: u64) -> u64 {
         let spans = super::constants::compute_spans_inline(self.branches);
         let max_span = spans[level] * BODY_SIZE as u64;
@@ -107,11 +111,13 @@ impl<const BODY_SIZE: usize> TreeParams<BODY_SIZE> {
     }
 
     /// Byte offset for start of chunk at level 0.
+    #[allow(clippy::arithmetic_side_effects)] // chunk_index < data_chunks, so the byte offset is bounded by the u64 file size
     pub const fn chunk_offset(&self, chunk_index: u64) -> u64 {
         chunk_index * BODY_SIZE as u64
     }
 
     /// Byte range covered by a data chunk.
+    #[allow(clippy::arithmetic_side_effects)] // start is bounded by the file size, so start + BODY_SIZE cannot overflow u64
     pub fn chunk_range(&self, chunk_index: u64) -> (u64, u64) {
         let start = self.chunk_offset(chunk_index);
         let end = (start + BODY_SIZE as u64).min(self.size);
@@ -119,6 +125,7 @@ impl<const BODY_SIZE: usize> TreeParams<BODY_SIZE> {
     }
 
     /// Calculate required data chunks for a byte range.
+    #[allow(clippy::arithmetic_side_effects)] // offset < size (early return above) and len is a read length within the file, so offset + len stays within u64; BODY_SIZE divisor is a nonzero constant
     pub fn chunks_for_range(&self, offset: u64, len: u64) -> ChunkRange {
         if len == 0 || offset >= self.size {
             return ChunkRange { start: 0, end: 0 };
@@ -134,6 +141,7 @@ impl<const BODY_SIZE: usize> TreeParams<BODY_SIZE> {
         }
     }
 
+    #[allow(clippy::arithmetic_side_effects)] // branches >= 1 for the div_ceil; depth increments at most log_branches(data_chunks) times
     fn calculate_depth_with(data_chunks: u64, branches: usize) -> usize {
         if data_chunks <= 1 {
             return 1;
@@ -180,6 +188,7 @@ impl ChunkRange {
 /// Given a set of chunk bodies corresponding to `chunk_range`, copies the
 /// relevant byte slices into a single output buffer accounting for partial
 /// reads at the start/end of the range.
+#[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)] // the caller supplies one body per chunk in chunk_range; read_start/read_end are derived from the chunk's intersection with [offset, offset + actual_len) so read_start <= read_end <= body.len() and the copied total is exactly actual_len
 pub(crate) fn assemble_range<const BODY_SIZE: usize>(
     tree: &TreeParams<BODY_SIZE>,
     offset: u64,

--- a/crates/primitives/src/file/windowed.rs
+++ b/crates/primitives/src/file/windowed.rs
@@ -183,6 +183,7 @@ fn is_leaf<M: JoinMode, const BS: usize>(node: &SubtreeNode<M>) -> bool {
 
 /// Fetch one node: a leaf yields its body, an intermediate yields its children.
 /// A leaf error consumes one retry, then re-queues or fails.
+#[allow(clippy::arithmetic_side_effects)] // retries - 1 is guarded by retries > 0
 async fn fetch_one<G, M, const BS: usize>(
     getter: &G,
     chunk_range: &ChunkRange,
@@ -252,6 +253,7 @@ fn insert_by_offset<M: JoinMode>(queue: &mut VecDeque<Pending<M>>, pending: Pend
 /// intermediate always exposes the head's region next. The count gate keeps
 /// in-flight plus buffered leaves at `window`, so peak memory is `window` leaf
 /// bodies regardless of resolve order, leaf span, tree depth, or file size.
+#[allow(clippy::arithmetic_side_effects, clippy::expect_used)] // span - range_start is guarded by range_start = start.min(span); leaf/chunk offsets are bounded by the file span; the in-flight and pending-intermediate counters move in lockstep with admissions/retirements so +=/-= cannot wrap; each expect follows the emptiness/head check observed just above it
 fn windowed_walk<G, M, const BODY_SIZE: usize>(
     getter: Arc<G>,
     subtrees: Vec<SubtreeNode<M>>,
@@ -516,6 +518,11 @@ where
     G: ChunkGet<BODY_SIZE> + 'static,
     M: JoinMode + Send + Sync + 'static,
 {
+    #[allow(
+        clippy::arithmetic_side_effects,
+        clippy::indexing_slicing,
+        clippy::expect_used
+    )] // to_copy = min(len, remaining) bounds both slices; position advances by leaf lengths bounded by the file span; the expect follows the is_none() branch that just set the stream
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,

--- a/crates/primitives/src/file/write_at.rs
+++ b/crates/primitives/src/file/write_at.rs
@@ -85,6 +85,7 @@ impl WriteAt for std::fs::File {
 impl WriteAt for Mutex<Vec<u8>> {
     type Error = io::Error;
 
+    #[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)] // offset + buf.len() is a leaf position within the file size the sink was set to; the resize above guarantees vec.len() >= end
     async fn write_at(&self, offset: u64, buf: &[u8]) -> io::Result<()> {
         let mut vec = self
             .lock()
@@ -145,6 +146,7 @@ where
 
     /// As [`download_into`](Self::download_into), invoking
     /// `on_progress(written, total)` after each leaf lands.
+    #[allow(clippy::arithmetic_side_effects)] // written sums leaf body lengths, bounded by the u64 file size
     pub async fn download_into_with_progress<S: WriteAt, F: FnMut(u64, u64)>(
         self,
         sink: S,

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -30,6 +30,21 @@
 //! let owner_chunk = DefaultSingleOwnerChunk::new(id, b"Signed data".as_slice(), &wallet).unwrap();
 //! ```
 
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::get_unwrap,
+        clippy::indexing_slicing,
+        clippy::string_slice,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::panic_in_result_fn
+    )
+)]
+
 // Re-export dependencies that are part of our public API
 pub use bytes;
 

--- a/crates/primitives/src/neighborhood_depth.rs
+++ b/crates/primitives/src/neighborhood_depth.rs
@@ -45,6 +45,7 @@ use crate::Bin;
 /// let depth = recompute_neighborhood_depth(&counts, 8, 2);
 /// assert!(depth.get() <= 8);
 /// ```
+#[allow(clippy::indexing_slicing)] // connected_per_bin[i] with i from the reversed 0..len() range
 #[must_use]
 pub fn recompute_neighborhood_depth(
     connected_per_bin: &[u8; 32],

--- a/crates/primitives/src/signing.rs
+++ b/crates/primitives/src/signing.rs
@@ -49,6 +49,7 @@ pub const SIGN_DATA_PREFIX: &[u8] = b"bee-handshake-";
 /// behaviour (so `None` and `Some(Address::ZERO)` produce byte-identical
 /// sign-data - verified by the test suite).
 #[must_use]
+#[allow(clippy::arithmetic_side_effects)] // capacity hint summing an underlay address plus ~100 bytes of fixed-size fields, far below usize::MAX
 pub fn sign_data(
     underlay_bytes: &[u8],
     overlay: &SwarmAddress,

--- a/crates/primitives/src/spec.rs
+++ b/crates/primitives/src/spec.rs
@@ -66,6 +66,7 @@ pub trait SwarmSpec {
     }
 
     /// Convenience: the routing-table bin count (`max_proximity_order() + 1`).
+    #[allow(clippy::arithmetic_side_effects)] // max_proximity_order() <= MAX_PO (31), so + 1 cannot overflow usize
     fn bin_count(&self) -> usize {
         usize::from(self.max_proximity_order().get()) + 1
     }

--- a/crates/primitives/src/store/retry.rs
+++ b/crates/primitives/src/store/retry.rs
@@ -123,6 +123,7 @@ impl<G, S> RetryingChunkGet<G, S> {
 impl<const BS: usize, G: ChunkGet<BS>, S: Sleeper> ChunkGet<BS> for RetryingChunkGet<G, S> {
     type Error = G::Error;
 
+    #[allow(clippy::arithmetic_side_effects)] // attempt only increments while < max_attempts (u32), so + 1 cannot overflow
     async fn get(&self, address: &ChunkAddress) -> Result<AnyChunk<BS>, Self::Error> {
         let mut attempt = 1;
         loop {

--- a/crates/primitives/src/timestamp.rs
+++ b/crates/primitives/src/timestamp.rs
@@ -62,6 +62,7 @@ impl Timestamp {
     /// Panics only if the system clock is set before the unix epoch, which
     /// would already break far more than this primitive. Pre-1970 callers
     /// can construct via [`Self::from_seconds`] manually.
+    #[allow(clippy::expect_used)] // documented invariants: panics only on a pre-1970 or absurdly far-future system clock
     pub fn now() -> Self {
         use web_time::{SystemTime, UNIX_EPOCH};
         let secs = SystemTime::now()

--- a/crates/swarms/src/lib.rs
+++ b/crates/swarms/src/lib.rs
@@ -12,6 +12,22 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+// Test code may freely unwrap/index/panic; the runtime-safety restriction
+// lints target production code paths.
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::get_unwrap,
+        clippy::indexing_slicing,
+        clippy::string_slice,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::panic_in_result_fn
+    )
+)]
 
 mod named;
 mod swarm;


### PR DESCRIPTION
## Summary

Enables a deny-level clippy restriction lint set across the whole workspace: `unwrap_used`, `expect_used`, `get_unwrap`, `indexing_slicing`, `string_slice`, `arithmetic_side_effects`, `panic`, `unreachable`, `todo`, `unimplemented`, and `panic_in_result_fn`. It also backs the set with a new CI lint job and fixes every resulting production-code violation in `nectar-postage`, `nectar-postage-issuer`, `nectar-postage-usage`, `nectar-mantaray`, and `nectar-primitives`. `clippy::as_conversions` and `clippy::missing_panics_doc` stay at `warn` for now and are deferred to the maximal follow-up PR that lands the lossy-cast pass.

Stacked on `fuzz/4-encrypted-ref-coverage`.

## What changed

**Lint configuration** (`Cargo.toml`)
- `[workspace.lints.clippy]`: the eleven restriction lints above set to `deny`; `as_conversions` and `missing_panics_doc` set to `warn` with an inline comment noting they will be denied in the follow-up PR.
- Each crate touched gets a `#![cfg_attr(test, allow(...))]` crate-root exemption so test code is not forced through the same restriction set as production code.

**CI** (`.github/workflows/lint.yml`, new)
- `clippy` job: `cargo clippy --workspace --locked` (default features, default targets); fails the build on any deny-level restriction-lint hit in lib/bin code.
- `unused-deps` job: `cargo machete` via `taiki-e/install-action`.
- Per-library `unused_crate_dependencies` enforcement via `cargo rustc -p <crate> --lib -- -D unused_crate_dependencies` in a loop, scoping the flag to each crate's own lib target only (never benches, examples, tests, or third-party crates), so there are zero false positives and it is a hard deny.
- Pinned actions by SHA, mold linker, `Swatinem/rust-cache`.

**Per-crate violation fixes**
- `nectar-postage`: 5 deny violations, all resolved with narrow justified `#[allow]`s on provably-safe internal sites (batch-geometry invariants, fixed-size array conversions).
- `nectar-postage-issuer`: 55 violations, all justified `#[allow]`s (bounds-checked indexing, shard-routing invariants, monotone counters, intentional lock-poisoning propagation).
- `nectar-postage-usage`: 78 violations, all justified `#[allow]`s, with the untrusted-input paths (`codec.rs` length-prefixed wire parsing, `RootInfo::assemble`) called out explicitly as already bounds-checked before the flagged operation.
- `nectar-mantaray`: 26 justified `#[allow]`s plus 4 real fixes on untrusted-input paths. `parse_fork_header` slice indexing is replaced with `.get(..).ok_or(DataTooShort)?`, and `ManifestIter::next` is rewritten from a `last().is_some_and` plus `pop().unwrap()` pattern to `Vec::pop_if`.
- `nectar-primitives`: 233 violations, 88 justified `#[allow]`s plus 3 real fixes on untrusted-input paths. `PlainMode`/`EncryptedMode::parse_child_ref` now return `FileError::InvalidReference` instead of panicking on a short intermediate body, and `resolve_seek_position` uses `checked_add` for `SeekFrom::End`/`Current` offsets instead of raw arithmetic that could wrap (release) or panic (debug).

**Unused dependencies removed**
- `once_cell` (direct dep of `nectar-primitives`, dropped from the crate and the workspace `[workspace.dependencies]` table; still present transitively via `alloy`).
- `serde` (optional feature dep of `nectar-postage-issuer` and `nectar-mantaray`, unused by any downstream crate or the fuzz workspace).
- `digest` (unused example dep in `crates/primitives/examples/wasm-demo`).

## Why

Clippy was not run in CI at all, so panicking and overflowing operations could reach production code paths unchecked. This adds the restriction gate plus unused-dependency checks and clears the existing backlog of violations. The lint set stays `deny` so new code must comply.

Closes #149

## Adoption strategy

Deny-by-default, with two escape hatches, both audited:

1. **Test code is exempted per crate** via `#![cfg_attr(test, allow(...))]`; test assertions and fixtures may `unwrap`, index, and panic freely, since this lint set targets production and library code paths, not test ergonomics.
2. **Provably-safe internal sites get a narrow, justified `#[allow]`**, scoped to the smallest span possible (statement, then line, then fn), each with an inline comment stating the invariant that makes the flagged operation infallible (for example "SwarmAddress is a fixed 32-byte array", "depth >= bucket_depth is this type's construction invariant", "index is bounds-checked on the line above"). There are no behaviour changes at these sites; release-mode output is byte-identical before and after.
3. **Untrusted and fallible paths get real fixes** instead of allows. Parsing of wire-format and user-supplied data (`parse_fork_header`, `parse_child_ref`, seek-offset arithmetic) now returns a typed error instead of panicking or silently wrapping.

`as_conversions` (199 remaining warnings) and `missing_panics_doc` (6 remaining) are intentionally left at `warn`; they are a large, mostly-mechanical cast-narrowing pass that is out of scope here and lands in the maximal follow-up PR.

## Testing

Run from the workspace root:

```bash
cargo clippy --workspace --locked   # exits 0; only as_conversions/missing_panics_doc warnings remain
cargo machete                       # reports no unused dependencies
cargo test --workspace              # 487 passed, 0 failed, 18 ignored
```

The full-workspace clippy run exits 0 with only the two deferred warning categories remaining. `cargo machete` reports no unused dependencies. All 7 libs pass the `-D unused_crate_dependencies` lib check.

Per-crate spot checks (useful while `nectar-primitives` and downstream crates land in dependency order, since clippy also lints workspace deps, so a crate can show clean with `--no-deps` before the full workspace command is green):

```bash
cargo clippy -p nectar-postage --no-deps
cargo clippy -p nectar-postage-issuer --no-deps
cargo clippy -p nectar-postage-usage --no-deps
cargo clippy -p nectar-mantaray --no-deps
cargo clippy -p nectar-primitives
```

## Known limitations

- **Lint scope is default-features, lib and bin targets only**, matching what CI's `cargo clippy --workspace --locked` actually runs. Feature-gated code (for example `nectar-mantaray`'s `arbitrary`/`encryption` modules beyond what is exercised by default) still compiles but has not been swept for these lints.
- **Benches and doctests are not covered** by the deny gate (only the `#![cfg_attr(test, ...)]` unit and integration test exemption is wired up); a stray panic-family call in a bench harness will not be caught by CI today.
- **`nectar-swarms`** was not part of this PR's per-crate fix scope and still carries `as_conversions`/`missing_panics_doc` warnings (deferred with the rest; no deny-level violations there currently). `nectar-swarms` and `nectar-contracts` carry the `#![cfg_attr(test, allow(clippy::...))]` test exemption for consistency, and keep their pre-existing `#![cfg_attr(not(test), warn(unused_crate_dependencies))]` line.
- **`as_conversions` is not yet enforced**; 199 lossy-cast warnings remain across the workspace, tracked for the follow-up maximal PR that promotes it to `deny`.

Stacked on #143 (`fuzz/4-encrypted-ref-coverage`). GPG-signed; red-team confirmed no behaviour changes across all 5 crates.

AI Assistance: Claude (Anthropic) used for the lint configuration, the per-crate violation fixes, and this PR description.
