### PR TITLE
chore: add zepter feature-propagation gate and resolve RUSTSEC-2026-0204

### DIFF
--- a/.github/workflows/zepter.yml
+++ b/.github/workflows/zepter.yml
@@ -1,0 +1,31 @@
+# Feature-propagation hygiene: enabling `std` / `serde` / `arbitrary` /
+# `encryption` / `parallel` on a crate must also enable it on that crate's
+# dependencies. Configured in zepter.yaml; run `zepter run` locally to auto-fix.
+name: zepter
+
+on:
+    pull_request:
+        paths: ['**/Cargo.toml', 'zepter.yaml']
+    merge_group:
+    push:
+        branches: [main]
+        paths: ['**/Cargo.toml', 'zepter.yaml']
+
+env:
+    CARGO_TERM_COLOR: always
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: true
+
+jobs:
+    zepter:
+        name: feature propagation
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+            - uses: taiki-e/install-action@1b57bc699ba2af96a06eb2a2a0d32b43a7d8e8b8  # install-action
+              with:
+                  tool: zepter@1.88.1
+            - name: zepter run check
+              run: zepter run check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,9 +1180,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/mantaray/Cargo.toml
+++ b/crates/mantaray/Cargo.toml
@@ -40,7 +40,11 @@ harness = false
 [features]
 default = ["std"]
 std = ["alloy-primitives/std", "thiserror/std", "serde_json/std", "rand", "nectar-primitives/std"]
-serde = ["dep:serde", "alloy-primitives/serde"]
+serde = [
+	"dep:serde",
+	"alloy-primitives/serde",
+	"nectar-primitives/serde"
+]
 encryption = ["nectar-primitives/encryption"]
 
 [package.metadata.docs.rs]

--- a/crates/mantaray/src/codec.rs
+++ b/crates/mantaray/src/codec.rs
@@ -243,6 +243,12 @@ fn decode_v01<E: NodeEntry>(data: &[u8]) -> Result<Node<E>> {
         });
     }
 
+    // Guard the entry slot and the 32-byte forks index that follows it; the
+    // header check in `try_from` only guarantees `NodeHeader::SIZE` bytes.
+    if data.len() < NodeHeader::SIZE + ref_bytes_size + 32 {
+        return Err(MantarayError::DataTooShort);
+    }
+
     let entry_bytes = &data[NodeHeader::SIZE..NodeHeader::SIZE + ref_bytes_size];
     let entry = if entry_bytes.iter().all(|&b| b == 0) {
         None
@@ -291,6 +297,12 @@ fn decode_v02<E: NodeEntry>(data: &[u8]) -> Result<Node<E>> {
             expected: E::SIZE,
             actual: ref_bytes_size,
         });
+    }
+
+    // Guard the entry slot and the 32-byte forks index that follows it; the
+    // header check in `try_from` only guarantees `NodeHeader::SIZE` bytes.
+    if data.len() < NodeHeader::SIZE + ref_bytes_size + 32 {
+        return Err(MantarayError::DataTooShort);
     }
 
     let entry_bytes = &data[NodeHeader::SIZE..NodeHeader::SIZE + ref_bytes_size];
@@ -756,6 +768,91 @@ mod tests {
             <ChunkAddress as NodeEntry>::SIZE,
             "encoder must emit ref_size = E::SIZE, not 0; spec requires uniform reference width"
         );
+    }
+
+    /// Build a header-only prefix of a node: zero obfuscation key (XOR is
+    /// identity), the given raw version hash, `ref_size = 32`, then zero
+    /// padding up to `len` bytes.
+    fn truncated_node_bytes(version: &VersionHash, len: usize) -> Vec<u8> {
+        assert!(len >= NodeHeader::SIZE);
+        let mut data = vec![0u8; len];
+        data[NodeHeader::VERSION_HASH_OFFSET..NodeHeader::VERSION_HASH_OFFSET + VersionHash::SIZE]
+            .copy_from_slice(version.as_bytes());
+        data[NodeHeader::REF_SIZE_OFFSET] = 32;
+        data
+    }
+
+    /// Regression: a 64-byte input (header only, `ref_size = 32`) used to
+    /// panic slicing the absent entry slot (`data[64..96]`). It must return
+    /// `Err`, never panic. Exact minimal crash case.
+    #[test]
+    fn decode_v01_header_only_64_bytes_returns_err() {
+        let data = truncated_node_bytes(&VersionHash::V01, NodeHeader::SIZE);
+        let result = Node::<ChunkAddress>::try_from(data.as_slice());
+        assert!(matches!(result, Err(MantarayError::DataTooShort)));
+    }
+
+    /// Regression: same minimal 64-byte crash case for the v0.2 decoder.
+    #[test]
+    fn decode_v02_header_only_64_bytes_returns_err() {
+        let data = truncated_node_bytes(&VersionHash::V02, NodeHeader::SIZE);
+        let result = Node::<ChunkAddress>::try_from(data.as_slice());
+        assert!(matches!(result, Err(MantarayError::DataTooShort)));
+    }
+
+    /// Regression: every length in 64..128 used to panic in `decode_v01`,
+    /// either slicing the entry slot (`data[64..96]`, lengths 64..96) or the
+    /// forks index (`data[96..128]`, lengths 96..128). All must return `Err`.
+    #[test]
+    fn decode_v01_truncated_lengths_return_err() {
+        for len in NodeHeader::SIZE..NodeHeader::SIZE + 32 + 32 {
+            let data = truncated_node_bytes(&VersionHash::V01, len);
+            let result = Node::<ChunkAddress>::try_from(data.as_slice());
+            assert!(
+                matches!(result, Err(MantarayError::DataTooShort)),
+                "length {len} must yield DataTooShort"
+            );
+        }
+    }
+
+    /// Regression: same truncated-length sweep for the v0.2 decoder, which
+    /// additionally read the forks index twice (edge-type deduction).
+    #[test]
+    fn decode_v02_truncated_lengths_return_err() {
+        for len in NodeHeader::SIZE..NodeHeader::SIZE + 32 + 32 {
+            let data = truncated_node_bytes(&VersionHash::V02, len);
+            let result = Node::<ChunkAddress>::try_from(data.as_slice());
+            assert!(
+                matches!(result, Err(MantarayError::DataTooShort)),
+                "length {len} must yield DataTooShort"
+            );
+        }
+    }
+
+    /// A 128-byte input (header + entry + index) whose index demands a fork
+    /// ref that is not present must hit the existing guarded error path.
+    #[test]
+    fn decode_v01_index_demands_missing_fork_returns_err() {
+        let mut data = truncated_node_bytes(&VersionHash::V01, NodeHeader::SIZE + 32 + 32);
+        // Set bit 0 of the forks index (LE bitfield at offset 96).
+        data[NodeHeader::SIZE + 32] = 0x01;
+        let result = Node::<ChunkAddress>::try_from(data.as_slice());
+        assert!(matches!(
+            result,
+            Err(MantarayError::InsufficientForkBytes { .. })
+        ));
+    }
+
+    /// Same as above for the v0.2 decoder.
+    #[test]
+    fn decode_v02_index_demands_missing_fork_returns_err() {
+        let mut data = truncated_node_bytes(&VersionHash::V02, NodeHeader::SIZE + 32 + 32);
+        data[NodeHeader::SIZE + 32] = 0x01;
+        let result = Node::<ChunkAddress>::try_from(data.as_slice());
+        assert!(matches!(
+            result,
+            Err(MantarayError::InsufficientForkBytes { .. })
+        ));
     }
 
     /// Encode-decode round-trip preserves entries and metadata.

--- a/crates/mantaray/src/node.rs
+++ b/crates/mantaray/src/node.rs
@@ -50,10 +50,21 @@ impl Prefix {
         }
     }
 
-    /// Create a prefix from a byte slice. Panics if `src.len() > 30`.
+    /// Create a prefix from a byte slice.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `src.len() > 30`. Decode paths must validate the length
+    /// first (see `parse_fork_header`, which rejects oversized prefixes with
+    /// `MantarayError::InvalidPrefixLength` before calling this).
     #[inline]
     pub fn from_slice(src: &[u8]) -> Self {
-        debug_assert!(src.len() <= PREFIX_MAX_LEN);
+        assert!(
+            src.len() <= PREFIX_MAX_LEN,
+            "prefix length {} exceeds maximum {}",
+            src.len(),
+            PREFIX_MAX_LEN
+        );
         let mut data = [0u8; PREFIX_MAX_LEN];
         data[..src.len()].copy_from_slice(src);
         Self {

--- a/crates/postage-issuer/Cargo.toml
+++ b/crates/postage-issuer/Cargo.toml
@@ -55,13 +55,22 @@ default = ["std"]
 std = ["nectar-postage/std"]
 
 # Serialization support with serde
-serde = ["dep:serde", "nectar-postage/serde"]
+serde = [
+	"dep:serde",
+	"nectar-postage/serde",
+	"nectar-primitives/serde"
+]
 
 # Local key signing for testing and development
 local-signer = ["dep:alloy-signer-local", "std"]
 
 # Parallel signing operations using rayon
-parallel = ["dep:rayon", "std"]
+parallel = [
+	"dep:rayon",
+	"std",
+	"nectar-postage/parallel",
+	"nectar-primitives/parallel"
+]
 
 # Arbitrary trait implementations for property-based testing
 arbitrary = ["nectar-postage/arbitrary", "nectar-primitives/arbitrary"]

--- a/crates/postage/Cargo.toml
+++ b/crates/postage/Cargo.toml
@@ -60,7 +60,11 @@ std = ["dep:web-time", "nectar-primitives/std", "alloy-primitives/std", "thiserr
 serde = ["dep:serde", "nectar-primitives/serde", "alloy-primitives/serde"]
 
 # Parallel verification using rayon (sync, CPU-bound).
-parallel = ["dep:rayon", "std"]
+parallel = [
+	"dep:rayon",
+	"std",
+	"nectar-primitives/parallel"
+]
 
 # Arbitrary trait implementations and valid-by-construction generators for
 # property-based testing and fuzzing.

--- a/zepter.yaml
+++ b/zepter.yaml
@@ -1,0 +1,26 @@
+# Enforce that std/serde/arbitrary/encryption/parallel propagate to workspace
+# dependencies. Run `zepter` at the workspace root to auto-fix.
+version:
+  format: 1
+  binary: 1.88.1
+
+workflows:
+  check:
+    - [
+        "lint", "propagate-feature",
+        "--features=std,serde,arbitrary,encryption,parallel",
+        "--left-side-feature-missing=ignore",
+        "--left-side-outside-workspace=ignore",
+        "--dep-kinds=normal:check,dev:ignore",
+        "--workspace",
+        "--show-path",
+        "--quiet",
+      ]
+  default:
+    - [$check.0, "--fix"]
+
+help:
+  text: |
+    Feature propagation check failed. Run `zepter` at the workspace root to fix.
+  links:
+    - "https://github.com/ggwpez/zepter"


### PR DESCRIPTION
## What

Adds a zepter feature-propagation gate and fixes the gaps it surfaces, then resolves the RUSTSEC-2026-0204 advisory that is currently failing the audit CI. This is the base of the workspace-hygiene and fuzz/lint train.

- `zepter.yaml` and `.github/workflows/zepter.yml`: enforce that `std`, `serde`, `arbitrary`, `encryption`, and `parallel` propagate to dependencies. Workspace-scoped, dev-deps ignored via a per-lib `cargo rustc` model. Running `zepter run` locally auto-fixes.
- Propagation fixes: `nectar-postage` and `nectar-postage-issuer` `parallel` and `serde` now enable the matching feature on their `nectar-primitives` and `nectar-postage` deps; `nectar-mantaray` `serde` likewise.
- Security: bump `crossbeam-epoch` from 0.9.18 to 0.9.20 to resolve RUSTSEC-2026-0204 (invalid pointer deref in `fmt::Pointer`, transitive via rayon). Not reachable in nectar, but the audit gate denies it.

Feature-list formatting (`zepter format features`) is deferred to the top of the train so it reformats the final Cargo.toml state without rebase churn.

## Why

Feature-propagation gaps are the class of defect behind broken `--no-default-features` builds, and the RUSTSEC-2026-0204 advisory currently fails audit CI. Gating both keeps the rest of the train green.

Closes #153.

## Testing

    zepter run check
    cargo audit
    cargo build --workspace

Also built each no_std crate with `--no-default-features`. `zepter run check` reports no propagation gaps, `cargo audit` reports no advisories, and the workspace builds clean.

---

Base of the workspace-hygiene and fuzz/lint train, targeting `main`. GPG-signed.

AI Assistance: Claude (Anthropic) used for the configuration, propagation fixes, and this PR description.


Closes #136 (fixed by #140, squash-merged into this branch; its own closing keyword cannot fire from a non-default-base merge).
