### PR TITLE
fix(mantaray): error on encoding a fork with an unsaved child

### DIFF
--- a/crates/mantaray/src/codec.rs
+++ b/crates/mantaray/src/codec.rs
@@ -465,14 +465,19 @@ impl<E: NodeEntry> Fork<E> {
         // write prefix padded to Prefix::MAX_LEN; Prefix is already zero-padded
         data.extend_from_slice(self.prefix.padded_bytes());
 
-        // Write E::SIZE bytes for the reference (chunk address + zero padding)
-        if let Some(addr) = &self.node.reference {
-            data.extend_from_slice(addr.as_bytes());
-            // Pad to E::SIZE if needed (encrypted mode has 64-byte refs)
-            let padding = E::SIZE.saturating_sub(32);
-            if padding > 0 {
-                data.resize(data.len() + padding, 0);
-            }
+        // Write E::SIZE bytes for the reference (chunk address + zero padding).
+        // A child without a saved reference cannot be encoded into a decodable
+        // stream, so reject it rather than emit truncated wire bytes.
+        let addr = self
+            .node
+            .reference
+            .as_ref()
+            .ok_or(MantarayError::MissingReference)?;
+        data.extend_from_slice(addr.as_bytes());
+        // Pad to E::SIZE if needed (encrypted mode has 64-byte refs)
+        let padding = E::SIZE.saturating_sub(32);
+        if padding > 0 {
+            data.resize(data.len() + padding, 0);
         }
 
         if self.node.is_with_metadata() {
@@ -1007,6 +1012,31 @@ mod tests {
             checked += 1;
         }
         assert!(checked >= 8, "expected at least 8 arbitrary nodes, got {checked}");
+    }
+
+    /// Encoding a fork whose child has no saved reference must error rather
+    /// than emit a truncated, undecodable stream.
+    #[test]
+    fn encode_fork_with_unsaved_child_errors() {
+        let mut n = Node::<ChunkAddress>::new_unencrypted();
+
+        let path = b"aaaaa";
+        let e = {
+            let mut buf = [0u8; 32];
+            buf[32 - path.len()..].copy_from_slice(path);
+            ChunkAddress::from(buf)
+        };
+        futures::executor::block_on(n.add::<
+            nectar_primitives::store::NullLoader,
+            { nectar_primitives::bmt::DEFAULT_BODY_SIZE },
+        >(
+            path, Some(e), BTreeMap::new(), &nectar_primitives::store::NullLoader,
+        ))
+        .unwrap();
+
+        // The fork's child node has no reference assigned (never persisted).
+        let result = Vec::<u8>::try_from(&n);
+        assert!(matches!(result, Err(MantarayError::MissingReference)));
     }
 
     /// Encode-decode round-trip preserves entries and metadata.


### PR DESCRIPTION
Closes #159

## What

`Fork::<E>::encode_into` in `crates/mantaray/src/codec.rs` now returns `MantarayError::MissingReference` when a fork's child node has no saved reference, instead of silently emitting a truncated, undecodable stream.

The valid-input path is unchanged: when `node.reference` is `Some`, encoding still takes the same byte-identical write plus `E::SIZE` padding path as before, so wire compatibility of valid trees is preserved.
Only the `None` (invalid) path changed, from writing zero-padded garbage to returning an error.

## Why

Previously, if a fork's child had never been persisted (no saved reference), `encode_into` would proceed to write `E::SIZE` bytes of zero padding in place of a real address.
This produced a stream that looked encoded but could not be correctly decoded, silently corrupting the wire format instead of surfacing the programming error that caused it.

`MantarayError::MissingReference` already existed in `error.rs` and is used elsewhere (for example in `manifest.rs`), and `encode_into` already returned a `Result` with `encode_node` propagating errors via `?`, so no plumbing changes were required; this is a targeted fix confined to the reference-write branch.

## Testing

Added a scoped regression test, `encode_fork_with_unsaved_child_errors`, in `crates/mantaray/src/codec.rs`.
It builds a node with an unpersisted fork child (added via `Node::add` but never saved, so `reference` is `None`) and asserts that encoding returns `MantarayError::MissingReference`.

The diff is confined to `codec.rs` (38 insertions, 8 deletions): the encode branch and the new test.
The codec was not restructured; that is owned by a later PR in this stack.

---

AI Assistance: Claude (Anthropic) used for the implementation, the regression test, and this PR description.
