### PR TITLE
refactor(primitives)!: store BMT proof segments as a fixed array

### DIFF
--- a/crates/primitives/benches/bmt_bench.rs
+++ b/crates/primitives/benches/bmt_bench.rs
@@ -107,7 +107,7 @@ fn bench_bmt_proof(c: &mut Criterion) {
 
     // Benchmark proof verification
     group.bench_function("verify", |b| {
-        b.iter(|| DefaultHasher::verify_proof(&proof, root_hash.as_slice()).unwrap());
+        b.iter(|| DefaultHasher::verify_proof(&proof, &root_hash).unwrap());
     });
 
     group.finish();

--- a/crates/primitives/benches/proofs.rs
+++ b/crates/primitives/benches/proofs.rs
@@ -67,12 +67,11 @@ pub fn proofs(c: &mut Criterion) {
         let index = indexes[i];
         // Verify proof is valid before benchmarking
         assert!(
-            DefaultHasher::verify_proof(proof, root_hash.as_slice())
-                .expect("Failed to verify proof"),
+            DefaultHasher::verify_proof(proof, &root_hash).expect("Failed to verify proof"),
             "Verification failed for index {index}"
         );
         group.bench_with_input(BenchmarkId::new("verify_proof", index), &index, |b, _| {
-            b.iter(|| black_box(DefaultHasher::verify_proof(proof, root_hash.as_slice())));
+            b.iter(|| black_box(DefaultHasher::verify_proof(proof, &root_hash)));
         });
     }
 
@@ -83,7 +82,7 @@ pub fn proofs(c: &mut Criterion) {
             let proof = hasher
                 .generate_proof(&data, index)
                 .expect("Failed to generate proof");
-            black_box(DefaultHasher::verify_proof(&proof, root_hash.as_slice()))
+            black_box(DefaultHasher::verify_proof(&proof, &root_hash))
         });
     });
 
@@ -105,7 +104,7 @@ pub fn proofs(c: &mut Criterion) {
                     let proof = h
                         .generate_proof(partial_data, idx)
                         .expect("Failed to generate proof");
-                    black_box(DefaultHasher::verify_proof(&proof, partial_root.as_slice()))
+                    black_box(DefaultHasher::verify_proof(&proof, &partial_root))
                 });
             },
         );

--- a/crates/primitives/examples/basic_usage.rs
+++ b/crates/primitives/examples/basic_usage.rs
@@ -212,7 +212,7 @@ fn bmt_proof_example() -> Result<(), Box<dyn std::error::Error>> {
     println!("  - Proof length: {} segments", proof.proof_segments.len());
 
     // Verify the proof
-    let is_valid = DefaultHasher::verify_proof(&proof, hash.as_slice())?;
+    let is_valid = DefaultHasher::verify_proof(&proof, &hash)?;
     println!(
         "  - Proof verification: {}",
         if is_valid {

--- a/crates/primitives/src/bmt/mod.rs
+++ b/crates/primitives/src/bmt/mod.rs
@@ -27,7 +27,7 @@
 //! let proof = hasher.generate_proof(data, 0).unwrap();
 //!
 //! // Verify the proof
-//! assert!(Hasher::verify_proof(&proof, hash.as_slice()).unwrap());
+//! assert!(Hasher::verify_proof(&proof, &hash).unwrap());
 //! ```
 
 mod constants;

--- a/crates/primitives/src/bmt/proof.rs
+++ b/crates/primitives/src/bmt/proof.rs
@@ -29,8 +29,11 @@ pub struct Proof {
     pub segment_index: usize,
     /// The segment data being proven
     pub segment: B256,
-    /// The proof segments (sibling hashes in the path to the root)
-    pub proof_segments: Vec<B256>,
+    /// The sibling hashes on the path to the root, one per tree level.
+    ///
+    /// The length is fixed by the tree geometry, so an ill-sized path is
+    /// unrepresentable rather than checked at verification time.
+    pub proof_segments: [B256; PROOF_LENGTH],
     /// The span of the data
     pub span: u64,
     /// Optional prefix (used during verification)
@@ -42,7 +45,7 @@ impl Proof {
     pub const fn new(
         segment_index: usize,
         segment: B256,
-        proof_segments: Vec<B256>,
+        proof_segments: [B256; PROOF_LENGTH],
         span: u64,
         prefix: Option<Vec<u8>>,
     ) -> Self {
@@ -55,14 +58,11 @@ impl Proof {
         }
     }
 
-    /// Verify this proof against a root hash
-    pub fn verify(&self, root_hash: &[u8]) -> Result<bool> {
-        if self.proof_segments.len() != PROOF_LENGTH {
-            return Err(
-                BmtError::invalid_proof_length(PROOF_LENGTH, self.proof_segments.len()).into(),
-            );
-        }
-
+    /// Verify this proof against a root hash.
+    ///
+    /// The root is a typed 32-byte hash, so a mis-sized root cannot silently
+    /// verify as a mismatch.
+    pub fn verify(&self, root_hash: &B256) -> Result<bool> {
         // Start with the segment being proven
         let mut current_hash = self.segment;
         let mut current_index = self.segment_index;
@@ -107,7 +107,7 @@ impl Proof {
         let computed_root = B256::from_slice(hasher.finalize().as_slice());
 
         // Compare with provided root hash
-        Ok(computed_root.as_slice() == root_hash)
+        Ok(computed_root == *root_hash)
     }
 }
 
@@ -117,11 +117,11 @@ pub trait Prover {
     fn generate_proof(&self, data: &[u8], segment_index: usize) -> Result<Proof>;
 
     /// Verify a proof against a root hash
-    fn verify_proof(proof: &Proof, root_hash: &[u8]) -> Result<bool>;
+    fn verify_proof(proof: &Proof, root_hash: &B256) -> Result<bool>;
 }
 
 impl Prover for Hasher {
-    #[allow(clippy::indexing_slicing)] // n = min(data.len(), ..) bounds data[..n], chunk.len() <= SEGMENT_SIZE bounds leaf[..], segment_index < BRANCHES is checked above, and index halves in lockstep with each level's width so level[index ^ 1] is in range
+    #[allow(clippy::indexing_slicing)] // n = min(data.len(), ..) bounds data[..n], chunk.len() <= SEGMENT_SIZE bounds leaf[..], segment_index < BRANCHES is checked above, from_fn yields exactly PROOF_LENGTH levels so levels[level] is in range, and index halves in lockstep with each level's width so levels[level][index ^ 1] is in range
     fn generate_proof(&self, data: &[u8], segment_index: usize) -> Result<Proof> {
         if segment_index >= BRANCHES {
             return Err(self::BmtError::invalid_input_size(format!(
@@ -160,13 +160,14 @@ impl Prover for Hasher {
             current = next;
         }
 
-        // The proof is the sibling of the proven node at every level.
-        let mut proof_segments = Vec::with_capacity(PROOF_LENGTH);
+        // The proof is the sibling of the proven node at every level. One
+        // sibling per level, so the level count fixes the array length.
         let mut index = segment_index;
-        for level in &levels {
-            proof_segments.push(B256::from(level[index ^ 1]));
+        let proof_segments = core::array::from_fn(|level| {
+            let sibling = B256::from(levels[level][index ^ 1]);
             index /= 2;
-        }
+            sibling
+        });
 
         Ok(Proof::new(
             segment_index,
@@ -177,7 +178,7 @@ impl Prover for Hasher {
         ))
     }
 
-    fn verify_proof(proof: &Proof, root_hash: &[u8]) -> Result<bool> {
+    fn verify_proof(proof: &Proof, root_hash: &B256) -> Result<bool> {
         proof.verify(root_hash)
     }
 }

--- a/crates/primitives/src/bmt/tests.rs
+++ b/crates/primitives/src/bmt/tests.rs
@@ -270,7 +270,7 @@ fn test_prefix_proof_roundtrip() {
         let proof = hasher.generate_proof(&payload, seg).unwrap();
         assert_eq!(proof.prefix.as_deref(), Some(ANCHOR));
         assert!(
-            DefaultHasher::verify_proof(&proof, root.as_slice()).unwrap(),
+            DefaultHasher::verify_proof(&proof, &root).unwrap(),
             "prefixed proof for segment {seg} must verify against the prefixed root"
         );
 
@@ -280,7 +280,7 @@ fn test_prefix_proof_roundtrip() {
         plain.update(&payload);
         let plain_root = plain.sum();
         assert!(
-            !DefaultHasher::verify_proof(&proof, plain_root.as_slice()).unwrap(),
+            !DefaultHasher::verify_proof(&proof, &plain_root).unwrap(),
             "prefixed proof must not verify against the plain root"
         );
     }
@@ -318,8 +318,7 @@ fn test_proof_generation_and_verification() {
         .expect("Failed to generate proof");
 
     // Verify the proof
-    let is_valid =
-        DefaultHasher::verify_proof(&proof, root_hash.as_slice()).expect("Failed to verify proof");
+    let is_valid = DefaultHasher::verify_proof(&proof, &root_hash).expect("Failed to verify proof");
 
     assert!(is_valid, "Proof verification should succeed");
 }
@@ -383,8 +382,7 @@ fn test_proof_correctness() {
     verify_segments(&expected_segments, &proof.proof_segments);
 
     // Test proof verification
-    let is_valid =
-        DefaultHasher::verify_proof(&proof, root_hash.as_slice()).expect("Failed to verify proof");
+    let is_valid = DefaultHasher::verify_proof(&proof, &root_hash).expect("Failed to verify proof");
 
     assert!(is_valid, "Proof verification should succeed");
 
@@ -408,7 +406,7 @@ fn test_proof_correctness() {
         &rightmost_proof.proof_segments,
     );
 
-    let is_valid = DefaultHasher::verify_proof(&rightmost_proof, root_hash.as_slice())
+    let is_valid = DefaultHasher::verify_proof(&rightmost_proof, &root_hash)
         .expect("Failed to verify rightmost proof");
     assert!(is_valid, "Rightmost proof verification should succeed");
 
@@ -429,7 +427,7 @@ fn test_proof_correctness() {
 
     verify_segments(&expected_middle_segments, &middle_proof.proof_segments);
 
-    let is_valid = DefaultHasher::verify_proof(&middle_proof, root_hash.as_slice())
+    let is_valid = DefaultHasher::verify_proof(&middle_proof, &root_hash)
         .expect("Failed to verify middle proof");
     assert!(is_valid, "Middle proof verification should succeed");
 }
@@ -476,8 +474,8 @@ fn test_root_hash_calculation() {
         .expect("Failed to generate proof");
 
     // Verify the proof against the root hash
-    let is_valid = DefaultHasher::verify_proof(&proof, expected_root_hash.as_slice())
-        .expect("Failed to verify proof");
+    let is_valid =
+        DefaultHasher::verify_proof(&proof, &expected_root_hash).expect("Failed to verify proof");
     assert!(is_valid, "Proof verification should succeed");
 }
 
@@ -501,8 +499,8 @@ fn test_proof() {
             .expect("Failed to generate proof");
 
         // Verify the proof
-        let is_valid = DefaultHasher::verify_proof(&proof, root_hash.as_slice())
-            .expect("Failed to verify proof");
+        let is_valid =
+            DefaultHasher::verify_proof(&proof, &root_hash).expect("Failed to verify proof");
 
         assert!(
             is_valid,

--- a/crates/primitives/src/bmt/wasm.rs
+++ b/crates/primitives/src/bmt/wasm.rs
@@ -65,7 +65,9 @@ impl WasmHasher {
     /// Verify a proof against a root hash
     #[wasm_bindgen(js_name = verifyProof, static_method_of = Hasher)]
     pub fn verify_proof(proof: &WasmProof, root_hash: &Uint8Array) -> Result<bool, JsValue> {
-        match Hasher::verify_proof(&proof.0, &root_hash.to_vec()) {
+        let root = B256::try_from(root_hash.to_vec().as_slice())
+            .map_err(|e| JsValue::from_str(&e.to_string()))?;
+        match Hasher::verify_proof(&proof.0, &root) {
             Ok(result) => Ok(result),
             Err(e) => Err(JsValue::from_str(&e.to_string())),
         }
@@ -113,7 +115,9 @@ impl WasmProof {
     /// Verify this proof against a root hash
     #[wasm_bindgen]
     pub fn verify(&self, root_hash: &Uint8Array) -> Result<bool, JsValue> {
-        match self.0.verify(&root_hash.to_vec()) {
+        let root = B256::try_from(root_hash.to_vec().as_slice())
+            .map_err(|e| JsValue::from_str(&e.to_string()))?;
+        match self.0.verify(&root) {
             Ok(result) => Ok(result),
             Err(e) => Err(JsValue::from_str(&e.to_string())),
         }


### PR DESCRIPTION
Closes #169

## What

Changes `Proof::proof_segments` in `crates/primitives/src/bmt/proof.rs` from `Vec<B256>` to a fixed-size array `[B256; PROOF_LENGTH]`. The length is fixed by the tree geometry (a proof always has exactly `PROOF_LENGTH` sibling hashes, one per tree level), so `Proof::new` now takes the array directly and `generate_proof` builds it allocation-free with `core::array::from_fn` over the tree levels, instead of pushing into a `Vec`. `verify` no longer needs a runtime length check on `proof_segments` since the array length is enforced at the type level.

As an amendment in scope with the same issue, `Proof::verify` and `Prover::verify_proof` now take a typed `&B256` root instead of `&[u8]`. Previously a wrong-length root would silently fail the length check and return `Ok(false)` rather than surfacing the caller's mistake; comparison is now a direct `B256` equality check.

Updated all in-scope call sites: the bmt doc example in `mod.rs`, the bmt tests, `examples/basic_usage.rs`, `benches/bmt_bench.rs` and `benches/proofs.rs`. The WASM wrappers in `wasm.rs` now normalize the incoming `Uint8Array` into a `B256` via `try_from`, surfacing a length error through `JsValue` rather than accepting an arbitrary-length byte slice.

## Why

`proof_segments` was never actually variable-length in practice: the BMT tree geometry (`BRANCHES = 128 = 2^7` leaves) always produces exactly `PROOF_LENGTH = 7` levels, so a `Vec<B256>` allowed representing invalid states (wrong-length proofs) that had to be caught with a runtime check. Encoding the invariant in the type removes the check, the allocation, and the possibility of a truncated or malformed proof reaching `verify`. Switching the root hash from `&[u8]` to `&B256` closes a related correctness gap where a mis-sized root would compare unequal and return `Ok(false)` instead of signalling a type/length error to the caller.

## Testing

`cargo clippy --workspace --locked` (the command CI's `lint.yml` runs) passes clean on the branch's source files, with no warnings.

This is a stacked PR targeting `s157/14-prefix-from-wire`; no CI beyond CLA runs until it is retargeted onto that base.

## AI Assistance

This PR was implemented, red-teamed, and independently tested with Claude (Anthropic), per the process described in [nxm-rs/.github CONTRIBUTING.md](https://github.com/nxm-rs/.github/blob/main/CONTRIBUTING.md).
