### PR TITLE
feat(primitives): derive reference-width constants from a sealed Reference trait

### DIFF
--- a/crates/primitives/src/address.rs
+++ b/crates/primitives/src/address.rs
@@ -95,6 +95,9 @@ pub const EXTENDED_PO: u8 = MAX_PO + 5;
 pub struct SwarmAddress(pub B256);
 
 impl SwarmAddress {
+    /// Width in bytes of an address.
+    pub const SIZE: usize = size_of::<B256>();
+
     /// Creates an address with only the first byte set, rest zeros.
     ///
     /// The first byte controls proximity order (leading bits determine PO).

--- a/crates/primitives/src/bmt/constants.rs
+++ b/crates/primitives/src/bmt/constants.rs
@@ -1,7 +1,7 @@
 //! Constants used in the Binary Merkle Tree implementation
 
-/// Hash size in bytes (keccak256).
-pub const HASH_SIZE: usize = 32;
+/// Hash size in bytes (keccak256), equal to a plain chunk reference width.
+pub const HASH_SIZE: usize = crate::chunk::ChunkRef::SIZE;
 
 /// Size of a segment in the BMT (same as hash size).
 pub(crate) const SEGMENT_SIZE: usize = HASH_SIZE;

--- a/crates/primitives/src/chunk/encryption/reference.rs
+++ b/crates/primitives/src/chunk/encryption/reference.rs
@@ -1,34 +1,42 @@
 //! Chunk reference types for encrypted chunks.
 
-use std::mem::size_of;
-
-use crate::chunk::ChunkAddress;
+use crate::chunk::reference::{RefKind, Reference, sealed};
+use crate::chunk::{ChunkAddress, ChunkRef};
 
 use super::error::EncryptionError;
 use super::key::EncryptionKey;
 
-/// An encrypted chunk reference: 32-byte address + 32-byte decryption key.
+/// An encrypted chunk reference: a plain reference plus the decryption key.
 ///
-/// This type statically guarantees the reference is encrypted,
-/// eliminating runtime variant checks.
+/// This type statically guarantees the reference is encrypted, eliminating
+/// runtime variant checks. It composes [`ChunkRef`] rather than restating the
+/// address field.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EncryptedChunkRef {
-    address: ChunkAddress,
+    reference: ChunkRef,
     key: EncryptionKey,
 }
 
 impl EncryptedChunkRef {
-    /// Serialized size: address + decryption key.
-    pub const SIZE: usize = size_of::<ChunkAddress>() + EncryptionKey::SIZE;
+    /// Serialized size: reference + decryption key.
+    pub const SIZE: usize = ChunkRef::SIZE + EncryptionKey::SIZE;
 
     /// Create a new encrypted chunk reference.
     pub const fn new(address: ChunkAddress, key: EncryptionKey) -> Self {
-        Self { address, key }
+        Self {
+            reference: ChunkRef::new(address),
+            key,
+        }
+    }
+
+    /// The plain reference this encrypted reference extends.
+    pub const fn reference(&self) -> &ChunkRef {
+        &self.reference
     }
 
     /// Chunk address (BMT hash of ciphertext).
     pub const fn address(&self) -> &ChunkAddress {
-        &self.address
+        self.reference.address()
     }
 
     /// Decryption key.
@@ -38,15 +46,21 @@ impl EncryptedChunkRef {
 
     /// Consume and return (address, key).
     pub fn into_parts(self) -> (ChunkAddress, EncryptionKey) {
-        (self.address, self.key)
+        (self.reference.into_address(), self.key)
     }
 
     /// Write the reference into `buf`. Panics if `buf` is too small.
     #[allow(clippy::indexing_slicing)] // documented contract: panics if buf.len() < Self::SIZE; both callers pass fixed [u8; Self::SIZE] buffers
     pub fn write_to(&self, buf: &mut [u8]) {
-        buf[..size_of::<ChunkAddress>()].copy_from_slice(self.address.as_bytes());
-        buf[size_of::<ChunkAddress>()..Self::SIZE].copy_from_slice(self.key.as_bytes());
+        buf[..ChunkRef::SIZE].copy_from_slice(self.address().as_bytes());
+        buf[ChunkRef::SIZE..Self::SIZE].copy_from_slice(self.key.as_bytes());
     }
+}
+
+impl sealed::Sealed for EncryptedChunkRef {}
+
+impl Reference for EncryptedChunkRef {
+    const KIND: RefKind = RefKind::Encrypted;
 }
 
 impl From<&EncryptedChunkRef> for [u8; EncryptedChunkRef::SIZE] {
@@ -66,7 +80,7 @@ impl From<EncryptedChunkRef> for [u8; EncryptedChunkRef::SIZE] {
 impl From<&EncryptedChunkRef> for Vec<u8> {
     fn from(r: &EncryptedChunkRef) -> Self {
         let mut v = Self::with_capacity(EncryptedChunkRef::SIZE);
-        v.extend_from_slice(r.address.as_bytes());
+        v.extend_from_slice(r.address().as_bytes());
         v.extend_from_slice(r.key.as_bytes());
         v
     }
@@ -80,10 +94,10 @@ impl TryFrom<&[u8]> for EncryptedChunkRef {
         if slice.len() != Self::SIZE {
             return Err(EncryptionError::InvalidReferenceLength { len: slice.len() });
         }
-        let addr = ChunkAddress::from_slice(&slice[..size_of::<ChunkAddress>()])
+        let addr = ChunkAddress::from_slice(&slice[..ChunkRef::SIZE])
             .map_err(|_| EncryptionError::InvalidReferenceLength { len: slice.len() })?;
-        let key = EncryptionKey::try_from(&slice[size_of::<ChunkAddress>()..])?;
-        Ok(Self { address: addr, key })
+        let key = EncryptionKey::try_from(&slice[ChunkRef::SIZE..])?;
+        Ok(Self::new(addr, key))
     }
 }
 

--- a/crates/primitives/src/chunk/encryption/reference.rs
+++ b/crates/primitives/src/chunk/encryption/reference.rs
@@ -113,6 +113,7 @@ mod tests {
         let enc_ref = EncryptedChunkRef::new(addr, key.clone());
 
         assert_eq!(enc_ref.address(), &addr);
+        assert_eq!(enc_ref.reference().address(), &addr);
         assert_eq!(enc_ref.key(), &key);
 
         let bytes: [u8; 64] = (&enc_ref).into();

--- a/crates/primitives/src/chunk/encryption/reference.rs
+++ b/crates/primitives/src/chunk/encryption/reference.rs
@@ -2,6 +2,7 @@
 
 use crate::chunk::reference::{RefKind, Reference, sealed};
 use crate::chunk::{ChunkAddress, ChunkRef};
+use crate::wire::{Cursor, Underrun};
 
 use super::error::EncryptionError;
 use super::key::EncryptionKey;
@@ -61,6 +62,21 @@ impl sealed::Sealed for EncryptedChunkRef {}
 
 impl Reference for EncryptedChunkRef {
     const KIND: RefKind = RefKind::Encrypted;
+
+    fn read_optional(cursor: &mut Cursor<'_>) -> Result<Option<Self>, Underrun> {
+        // The sentinel is the whole slot as written on the wire: address and
+        // key both all-zero.
+        let addr = cursor.take::<[u8; ChunkAddress::SIZE]>()?;
+        let key = cursor.take::<[u8; EncryptionKey::SIZE]>()?;
+        if addr.iter().all(|&b| b == 0) && key.iter().all(|&b| b == 0) {
+            Ok(None)
+        } else {
+            Ok(Some(Self::new(
+                ChunkAddress::new(addr),
+                EncryptionKey::from(key),
+            )))
+        }
+    }
 }
 
 impl From<&EncryptedChunkRef> for [u8; EncryptedChunkRef::SIZE] {
@@ -143,5 +159,30 @@ mod tests {
         enc_ref.write_to(&mut buf);
         assert_eq!(&buf[..32], &[0x22; 32]);
         assert_eq!(&buf[32..], &[0x33; 32]);
+    }
+
+    #[test]
+    fn read_optional_sentinel_is_the_whole_slot() {
+        let zeros = [0u8; EncryptedChunkRef::SIZE];
+        let mut cur = Cursor::new(&zeros);
+        assert_eq!(EncryptedChunkRef::read_optional(&mut cur).unwrap(), None);
+        assert!(cur.is_empty());
+
+        // A zero address under a nonzero key is a reference, not the sentinel.
+        let mut slot = [0u8; EncryptedChunkRef::SIZE];
+        slot[32..].copy_from_slice(&[0x33; 32]);
+        let mut cur = Cursor::new(&slot);
+        assert_eq!(
+            EncryptedChunkRef::read_optional(&mut cur).unwrap(),
+            Some(EncryptedChunkRef::new(
+                ChunkAddress::new([0u8; 32]),
+                EncryptionKey::from([0x33; 32])
+            ))
+        );
+
+        // Underrun inside the slot is an error, not a sentinel.
+        let short = [0u8; EncryptedChunkRef::SIZE - 1];
+        let mut cur = Cursor::new(&short);
+        assert!(EncryptedChunkRef::read_optional(&mut cur).is_err());
     }
 }

--- a/crates/primitives/src/chunk/mod.rs
+++ b/crates/primitives/src/chunk/mod.rs
@@ -23,6 +23,7 @@ mod chunk_type_set;
 mod content;
 pub mod encryption;
 pub(crate) mod error;
+mod reference;
 mod single_owner;
 mod traits;
 mod type_id;
@@ -32,6 +33,9 @@ pub mod wasm;
 
 // Re-export the core traits
 pub use traits::{BmtChunk, Chunk, ChunkAddress, ChunkHeader, ChunkMetadata, ChunkSerialization};
+
+// Re-export the reference types
+pub use reference::{ChunkRef, RefKind, Reference};
 
 // Re-export the type system
 pub use any_chunk::AnyChunk;

--- a/crates/primitives/src/chunk/reference.rs
+++ b/crates/primitives/src/chunk/reference.rs
@@ -1,0 +1,119 @@
+//! Typed chunk references.
+//!
+//! A reference names a chunk by its 32-byte address; the width is a fact of the
+//! reference type, not a runtime byte count. [`RefKind`] names the two widths
+//! and [`Reference`] carries them at the type level, so every wire-width
+//! constant in the crate derives from this single statement of the fact.
+
+use std::mem::size_of;
+
+use crate::chunk::ChunkAddress;
+
+pub(crate) mod sealed {
+    pub trait Sealed {}
+}
+
+/// The two reference widths: a plain address, or an address plus a key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RefKind {
+    /// A plain reference ([`ChunkRef`]): a 32-byte address.
+    Unencrypted,
+    /// An encrypted reference
+    /// ([`EncryptedChunkRef`](crate::chunk::encryption::EncryptedChunkRef)):
+    /// the same address plus the chunk's decryption key.
+    Encrypted,
+}
+
+impl RefKind {
+    /// Wire width in bytes of a reference of this kind.
+    pub const fn size(self) -> usize {
+        match self {
+            Self::Unencrypted => ChunkRef::SIZE,
+            Self::Encrypted => crate::chunk::encryption::EncryptedChunkRef::SIZE,
+        }
+    }
+}
+
+/// A chunk reference whose width is a compile-time fact.
+///
+/// Sealed: the only references are [`ChunkRef`] and
+/// [`EncryptedChunkRef`](crate::chunk::encryption::EncryptedChunkRef).
+pub trait Reference: sealed::Sealed {
+    /// Which width this reference carries.
+    const KIND: RefKind;
+
+    /// Wire width in bytes; the width fact, derived from [`Self::KIND`].
+    const SIZE: usize = Self::KIND.size();
+}
+
+/// A 32-byte reference to a chunk.
+///
+/// The chunk may be content-addressed or single-owner; a reference is identical
+/// either way, and which kind it is is resolved on fetch and validation, never
+/// from the reference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ChunkRef(ChunkAddress);
+
+impl ChunkRef {
+    /// Wire width in bytes.
+    pub const SIZE: usize = size_of::<ChunkAddress>();
+
+    /// Wrap an address as a reference.
+    pub const fn new(address: ChunkAddress) -> Self {
+        Self(address)
+    }
+
+    /// The referenced chunk address.
+    pub const fn address(&self) -> &ChunkAddress {
+        &self.0
+    }
+
+    /// Consume the reference, returning its address.
+    pub const fn into_address(self) -> ChunkAddress {
+        self.0
+    }
+}
+
+impl From<ChunkAddress> for ChunkRef {
+    fn from(address: ChunkAddress) -> Self {
+        Self(address)
+    }
+}
+
+impl sealed::Sealed for ChunkRef {}
+
+impl Reference for ChunkRef {
+    const KIND: RefKind = RefKind::Unencrypted;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chunk::encryption::EncryptedChunkRef;
+    use alloy_primitives::B256;
+
+    #[test]
+    fn chunk_ref_is_address_width() {
+        assert_eq!(ChunkRef::SIZE, 32);
+        assert_eq!(<ChunkRef as Reference>::SIZE, ChunkRef::SIZE);
+        assert_eq!(ChunkRef::KIND, RefKind::Unencrypted);
+        assert_eq!(RefKind::Unencrypted.size(), ChunkRef::SIZE);
+    }
+
+    #[test]
+    fn encrypted_ref_is_address_plus_key() {
+        assert_eq!(EncryptedChunkRef::SIZE, 64);
+        assert_eq!(<EncryptedChunkRef as Reference>::SIZE, EncryptedChunkRef::SIZE);
+        assert_eq!(EncryptedChunkRef::KIND, RefKind::Encrypted);
+        assert_eq!(RefKind::Encrypted.size(), EncryptedChunkRef::SIZE);
+    }
+
+    #[test]
+    fn round_trips_through_address() {
+        let addr = ChunkAddress::from(B256::repeat_byte(0x7f));
+        let reference = ChunkRef::new(addr);
+        assert_eq!(reference.address(), &addr);
+        assert_eq!(reference.into_address(), addr);
+        assert_eq!(ChunkRef::from(addr), reference);
+    }
+}

--- a/crates/primitives/src/chunk/reference.rs
+++ b/crates/primitives/src/chunk/reference.rs
@@ -103,7 +103,10 @@ mod tests {
     #[test]
     fn encrypted_ref_is_address_plus_key() {
         assert_eq!(EncryptedChunkRef::SIZE, 64);
-        assert_eq!(<EncryptedChunkRef as Reference>::SIZE, EncryptedChunkRef::SIZE);
+        assert_eq!(
+            <EncryptedChunkRef as Reference>::SIZE,
+            EncryptedChunkRef::SIZE
+        );
         assert_eq!(EncryptedChunkRef::KIND, RefKind::Encrypted);
         assert_eq!(RefKind::Encrypted.size(), EncryptedChunkRef::SIZE);
     }

--- a/crates/primitives/src/chunk/reference.rs
+++ b/crates/primitives/src/chunk/reference.rs
@@ -8,6 +8,7 @@
 use std::mem::size_of;
 
 use crate::chunk::ChunkAddress;
+use crate::wire::{Cursor, Underrun};
 
 pub(crate) mod sealed {
     pub trait Sealed {}
@@ -38,12 +39,17 @@ impl RefKind {
 ///
 /// Sealed: the only references are [`ChunkRef`] and
 /// [`EncryptedChunkRef`](crate::chunk::encryption::EncryptedChunkRef).
-pub trait Reference: sealed::Sealed {
+pub trait Reference: sealed::Sealed + Sized {
     /// Which width this reference carries.
     const KIND: RefKind;
 
     /// Wire width in bytes; the width fact, derived from [`Self::KIND`].
     const SIZE: usize = Self::KIND.size();
+
+    /// Read a reference from `cursor`, or `None` when the slot is the all-zero
+    /// sentinel. Each impl reads its own typed fields; the cursor is the sole
+    /// fallible read.
+    fn read_optional(cursor: &mut Cursor<'_>) -> Result<Option<Self>, Underrun>;
 }
 
 /// A 32-byte reference to a chunk.
@@ -84,6 +90,15 @@ impl sealed::Sealed for ChunkRef {}
 
 impl Reference for ChunkRef {
     const KIND: RefKind = RefKind::Unencrypted;
+
+    fn read_optional(cursor: &mut Cursor<'_>) -> Result<Option<Self>, Underrun> {
+        let addr = cursor.take::<[u8; ChunkAddress::SIZE]>()?;
+        if addr.iter().all(|&b| b == 0) {
+            Ok(None)
+        } else {
+            Ok(Some(Self(ChunkAddress::new(addr))))
+        }
+    }
 }
 
 #[cfg(test)]
@@ -118,5 +133,25 @@ mod tests {
         assert_eq!(reference.address(), &addr);
         assert_eq!(reference.into_address(), addr);
         assert_eq!(ChunkRef::from(addr), reference);
+    }
+
+    #[test]
+    fn read_optional_maps_the_zero_slot_to_none() {
+        let zeros = [0u8; ChunkRef::SIZE];
+        let mut cur = Cursor::new(&zeros);
+        assert_eq!(ChunkRef::read_optional(&mut cur).unwrap(), None);
+        assert!(cur.is_empty());
+
+        let bytes = [0x7fu8; ChunkRef::SIZE];
+        let mut cur = Cursor::new(&bytes);
+        assert_eq!(
+            ChunkRef::read_optional(&mut cur).unwrap(),
+            Some(ChunkRef::new(ChunkAddress::new(bytes)))
+        );
+        assert!(cur.is_empty());
+
+        let short = [0x7fu8; ChunkRef::SIZE - 1];
+        let mut cur = Cursor::new(&short);
+        assert!(ChunkRef::read_optional(&mut cur).is_err());
     }
 }

--- a/crates/primitives/src/file/constants.rs
+++ b/crates/primitives/src/file/constants.rs
@@ -1,6 +1,6 @@
 //! Constants for file splitting and joining.
 
-use crate::bmt::{BRANCHES, DEFAULT_BODY_SIZE, HASH_SIZE};
+use crate::bmt::{BRANCHES, DEFAULT_BODY_SIZE};
 
 /// Derive the maximum tree depth from branching factor and body size.
 /// The limit is the number of levels needed to address all storable data:
@@ -18,8 +18,8 @@ const fn compute_level_limit(branches: usize, body_size: usize) -> usize {
 pub(crate) const LEVEL_LIMIT: usize = compute_level_limit(BRANCHES, DEFAULT_BODY_SIZE);
 const _: () = assert!(LEVEL_LIMIT == 9);
 
-/// Size of a chunk reference (hash). Same as bmt::HASH_SIZE.
-pub(crate) const REF_SIZE: usize = HASH_SIZE;
+/// Size of a chunk reference. Derived from the reference type.
+pub(crate) const REF_SIZE: usize = crate::chunk::ChunkRef::SIZE;
 
 /// Number of references per intermediate chunk (plain mode). Same as bmt::BRANCHES.
 #[cfg(test)]

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -109,8 +109,11 @@ pub use chunk::{
     ChunkTypeId,
     ChunkTypeSet,
     // Concrete chunk types
+    ChunkRef,
     ContentChunk,
     ContentOnlyChunkSet,
+    RefKind,
+    Reference,
     SingleOwnerChunk,
     StandardChunkSet,
 };

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -104,12 +104,12 @@ pub use chunk::{
     BmtChunk,
     Chunk,
     ChunkAddress,
+    // Concrete chunk types
+    ChunkRef,
     ChunkSerialization,
     ChunkType,
     ChunkTypeId,
     ChunkTypeSet,
-    // Concrete chunk types
-    ChunkRef,
     ContentChunk,
     ContentOnlyChunkSet,
     RefKind,


### PR DESCRIPTION
## What

Introduces a sealed `Reference` trait in `nectar-primitives` carrying `const KIND: RefKind` (`Unencrypted`/`Encrypted`) with a derived `const SIZE = Self::KIND.size()`, making a reference's wire width a compile-time fact of its type rather than a restated constant.

Adds a new module `crates/primitives/src/chunk/reference.rs` defining `RefKind`, the sealed `Reference` trait, and `ChunkRef(ChunkAddress)` — a 32-byte plain reference with `new`/`address`/`into_address` accessors and a `From<ChunkAddress>` impl.

Reworks `EncryptedChunkRef` to compose `ChunkRef` internally (`{ reference: ChunkRef, key: EncryptionKey }`) instead of restating an address field, adding a `reference()` accessor. All existing byte APIs (`SIZE`, `new`, `address`, `key`, `into_parts`, `write_to`, `From`/`TryFrom` for byte arrays and `Vec`) are preserved unchanged.

`HASH_SIZE` (`bmt/constants.rs`) is now derived as `ChunkRef::SIZE`, with `SEGMENT_SIZE` following transitively, and `REF_SIZE` (`file/constants.rs`) is now derived as `crate::chunk::ChunkRef::SIZE` instead of restating `bmt::HASH_SIZE`. `ChunkRef`, `RefKind`, and `Reference` are re-exported from `chunk::mod` and the crate root.

## Why

Closes #164

Before this change the 32-byte and 64-byte reference widths were independently declared as `usize` constants in several places (`bmt::HASH_SIZE`, `file::REF_SIZE`, `EncryptedChunkRef::SIZE`), so nothing enforced that they stayed in step. Stating the width once, as an associated constant on the type that owns it, and deriving every other constant from that single fact removes the duplication and makes drift between the constants a compile error rather than a runtime risk.

## Testing

New unit tests in `chunk/reference.rs` cover `ChunkRef` and `EncryptedChunkRef` width derivation and the `ChunkRef` round trip through `ChunkAddress`: `chunk_ref_is_address_width`, `encrypted_ref_is_address_plus_key`, `round_trips_through_address`. The existing `EncryptedChunkRef` tests were extended to assert `reference().address()` matches `address()`.

This is a stacked PR targeting `s157/20-single-decoder`; no CI beyond CLA will run until it is retargeted onto `main`.

## AI Assistance

Implemented with Claude Sonnet 5 (Anthropic), per the org contract in nxm-rs/.github CONTRIBUTING.md.
