### PR TITLE
feat(mantaray): total WireFork emission via primitives::wire::Writer

### DIFF
--- a/crates/mantaray/src/codec.rs
+++ b/crates/mantaray/src/codec.rs
@@ -9,7 +9,7 @@ use crate::obfuscation::ObfuscationKey;
 
 use alloy_primitives::{U256, hex};
 use nectar_primitives::chunk::ChunkAddress;
-use nectar_primitives::wire::{Cursor, FromCursor, Underrun};
+use nectar_primitives::wire::{Cursor, FromCursor, Underrun, Writer};
 
 /// Mantaray wire format version (truncated keccak256, 31 bytes).
 #[derive(Clone, Copy)]
@@ -174,9 +174,10 @@ fn encode_node<E: NodeEntry>(node: &Node<E>) -> Result<Vec<u8>> {
     }
     data.extend_from_slice(&index.to_le_bytes::<32>());
 
-    // append forks in sorted order
+    // append forks in sorted order, each as a total wire record over the buffer
+    let mut writer = Writer::new(&mut data);
     for fork in node.forks.values() {
-        fork.encode_into(&mut data)?;
+        WireFork::try_from(fork)?.emit(&mut writer);
     }
 
     // XOR-encrypt everything after the obfuscation key in place.
@@ -438,68 +439,113 @@ fn parse_fork_body<E: NodeEntry>(
     Ok(Fork { prefix, node })
 }
 
-impl<E: NodeEntry> Fork<E> {
-    /// Encode this fork, appending to `buf`.
-    #[allow(clippy::arithmetic_side_effects)] // in-memory buffer length arithmetic; padding math is guarded (`SIZE - x` only when `x < SIZE`, `SIZE - rem` only when `rem != 0`) and `% ObfuscationKey::SIZE` has a nonzero constant divisor
-    fn encode_into(&self, data: &mut Vec<u8>) -> Result<()> {
-        data.push(self.node.node_type.bits());
-        #[allow(clippy::as_conversions)] // Prefix invariant: len <= Prefix::MAX_LEN (30), fits u8
-        let prefix_len_byte = self.prefix.len() as u8;
-        data.push(prefix_len_byte);
+/// A fork in wire-record form: the fields the fork layout emits, with the child
+/// reference already resolved so emission is total.
+///
+/// Construction is the sole fallible step: a fork whose child was never
+/// persisted has no reference, and oversized metadata cannot be sized into the
+/// `u16` length field. Once built, [`emit`](Self::emit) cannot produce a
+/// misaligned image. bee-spec node.md: fork layout is node_type, prefix_len, a
+/// 30-byte prefix region, the reference, then optional metadata.
+struct WireFork<'a> {
+    node_type: NodeType,
+    prefix: &'a Prefix,
+    /// Child chunk address; mandatory by construction, filling the reference
+    /// slot within the fork's pre-reference region.
+    address: &'a ChunkAddress,
+    /// Uniform reference width; the 32-byte address is right-padded with zeros
+    /// to it (encrypted mode carries a 64-byte reference slot).
+    ref_size: usize,
+    /// Length-prefixed, padded metadata payload, present only when the child
+    /// carries metadata.
+    metadata: Option<WireMetadata>,
+}
 
-        // write prefix padded to Prefix::MAX_LEN; Prefix is already zero-padded
-        data.extend_from_slice(self.prefix.padded_bytes());
+/// A fork's metadata payload, serialised and padded to the obfuscation-key
+/// stride with its `u16` length precomputed so emission stays total.
+struct WireMetadata {
+    len: u16,
+    padded_json: Vec<u8>,
+}
 
-        // Write E::SIZE bytes for the reference (chunk address + zero padding).
-        // A child without a saved reference cannot be encoded into a decodable
-        // stream, so reject it rather than emit truncated wire bytes.
-        let addr = self
+impl WireMetadata {
+    /// Serialise, pad to the `ObfuscationKey::SIZE` stride, and size the length
+    /// field. Padding fills with `0x0a`, so the trailing bytes are JSON
+    /// whitespace the decoder re-parses transparently.
+    #[allow(clippy::arithmetic_side_effects)] // padding math is guarded (`SIZE - x` only when `x < SIZE`, `SIZE - rem` only when `rem != 0`) and `% ObfuscationKey::SIZE` has a nonzero constant divisor
+    fn build(metadata: &BTreeMap<String, String>) -> Result<Self> {
+        let mut padded_json = serde_json::to_string(metadata)
+            .map_err(MantarayError::Metadata)?
+            .into_bytes();
+
+        let size_with_header = padded_json.len() + ForkHeader::METADATA_LEN_SIZE;
+        let padding = if size_with_header < ObfuscationKey::SIZE {
+            ObfuscationKey::SIZE - size_with_header
+        } else if size_with_header > ObfuscationKey::SIZE {
+            let rem = size_with_header % ObfuscationKey::SIZE;
+            if rem == 0 {
+                0
+            } else {
+                ObfuscationKey::SIZE - rem
+            }
+        } else {
+            0
+        };
+        padded_json.resize(padded_json.len() + padding, 0x0a);
+
+        let len =
+            u16::try_from(padded_json.len()).map_err(|_| MantarayError::MetadataTooLarge {
+                max: usize::from(u16::MAX),
+                actual: padded_json.len(),
+            })?;
+        Ok(Self { len, padded_json })
+    }
+}
+
+impl<'a, E: NodeEntry> TryFrom<&'a Fork<E>> for WireFork<'a> {
+    type Error = MantarayError;
+
+    /// Resolve a fork into an emittable record. A child without a saved
+    /// reference cannot be encoded into a decodable stream, so it is rejected
+    /// here, before any bytes are written.
+    fn try_from(fork: &'a Fork<E>) -> Result<Self> {
+        let address = fork
             .node
             .reference
             .as_ref()
             .ok_or(MantarayError::MissingReference)?;
-        data.extend_from_slice(addr.as_bytes());
-        // Pad to E::SIZE if needed (encrypted mode has 64-byte refs)
-        let padding = E::SIZE.saturating_sub(32);
-        if padding > 0 {
-            data.resize(data.len() + padding, 0);
+        let metadata = if fork.node.is_with_metadata() {
+            Some(WireMetadata::build(&fork.node.metadata)?)
+        } else {
+            None
+        };
+        Ok(Self {
+            node_type: fork.node.node_type,
+            prefix: &fork.prefix,
+            address,
+            ref_size: E::SIZE,
+            metadata,
+        })
+    }
+}
+
+impl WireFork<'_> {
+    /// Emit this fork: node_type, prefix length and its padded region, the
+    /// reference padded to `ref_size`, then any metadata. Total by construction.
+    fn emit(&self, w: &mut Writer<'_>) {
+        w.put_u8(self.node_type.bits());
+        #[allow(clippy::as_conversions)] // Prefix invariant: len <= Prefix::MAX_LEN (30), fits u8
+        let prefix_len = self.prefix.len() as u8;
+        w.put_u8(prefix_len);
+        w.put_array(self.prefix.padded_bytes());
+
+        w.put_slice(self.address.as_bytes());
+        w.put_zeros(self.ref_size.saturating_sub(32));
+
+        if let Some(metadata) = &self.metadata {
+            w.put_u16_be(metadata.len);
+            w.put_slice(&metadata.padded_json);
         }
-
-        if self.node.is_with_metadata() {
-            let mut metadata_json = serde_json::to_string(&self.node.metadata)
-                .map_err(MantarayError::Metadata)?
-                .into_bytes();
-
-            let metadata_bytes_size_with_header =
-                metadata_json.len() + ForkHeader::METADATA_LEN_SIZE;
-
-            let padding = if metadata_bytes_size_with_header < ObfuscationKey::SIZE {
-                ObfuscationKey::SIZE - metadata_bytes_size_with_header
-            } else if metadata_bytes_size_with_header > ObfuscationKey::SIZE {
-                let rem = metadata_bytes_size_with_header % ObfuscationKey::SIZE;
-                if rem == 0 {
-                    0
-                } else {
-                    ObfuscationKey::SIZE - rem
-                }
-            } else {
-                0
-            };
-
-            metadata_json.resize(metadata_json.len() + padding, 0x0a);
-
-            let metadata_size = metadata_json.len();
-            let metadata_size_u16 =
-                u16::try_from(metadata_size).map_err(|_| MantarayError::MetadataTooLarge {
-                    max: usize::from(u16::MAX),
-                    actual: metadata_size,
-                })?;
-
-            data.extend_from_slice(&metadata_size_u16.to_be_bytes());
-            data.extend_from_slice(&metadata_json);
-        }
-
-        Ok(())
     }
 }
 
@@ -1000,6 +1046,57 @@ mod tests {
         // The fork's child node has no reference assigned (never persisted).
         let result = Vec::<u8>::try_from(&n);
         assert!(matches!(result, Err(MantarayError::MissingReference)));
+    }
+
+    /// Build a leaf fork whose child is exactly what the single body decoder
+    /// reconstructs: a referenced node with a node_type and optional metadata,
+    /// no entry or children.
+    fn leaf_fork(
+        prefix: &[u8],
+        addr_byte: u8,
+        node_type: NodeType,
+        metadata: BTreeMap<String, String>,
+    ) -> Fork<ChunkAddress> {
+        let mut addr = [0u8; 32];
+        addr[31] = addr_byte;
+        let mut node = Node::from_reference(ChunkAddress::from(addr));
+        node.node_type = node_type;
+        node.metadata = metadata;
+        Fork {
+            prefix: Prefix::from_slice(prefix),
+            node,
+        }
+    }
+
+    /// Per-record property: parsing an emitted `WireFork` reproduces the fork.
+    /// Misalignment is unrepresentable, so the only variation is the presence
+    /// of metadata, exercised here alongside plain and value-typed forks.
+    #[test]
+    fn wire_fork_record_round_trips() {
+        let mut website: BTreeMap<String, String> = BTreeMap::new();
+        website.insert("index-document".to_string(), "aaaaa".to_string());
+
+        let cases = [
+            leaf_fork(b"aaaaa", 1, NodeType::VALUE, BTreeMap::new()),
+            leaf_fork(b"cc", 2, NodeType::empty(), BTreeMap::new()),
+            leaf_fork(b"/", 3, NodeType::VALUE | NodeType::METADATA, website),
+        ];
+
+        for fork in cases {
+            let has_metadata = fork.node.is_with_metadata();
+            let mut buf = Vec::new();
+            WireFork::try_from(&fork)
+                .unwrap()
+                .emit(&mut Writer::new(&mut buf));
+
+            let parsed = parse_fork_body::<ChunkAddress>(
+                &buf,
+                <ChunkAddress as NodeEntry>::SIZE,
+                has_metadata,
+            )
+            .unwrap();
+            assert_eq!(parsed, fork, "parse(emit(fork)) must reproduce the fork");
+        }
     }
 
     /// Encode-decode round-trip preserves entries and metadata.

--- a/crates/mantaray/src/codec.rs
+++ b/crates/mantaray/src/codec.rs
@@ -9,7 +9,7 @@ use crate::obfuscation::ObfuscationKey;
 
 use alloy_primitives::{U256, hex};
 use nectar_primitives::chunk::ChunkAddress;
-use nectar_primitives::wire::{Cursor, FromCursor, Underrun, Writer};
+use nectar_primitives::wire::{Cursor, FromCursor, ToWriter, Underrun, Writer};
 
 /// Mantaray wire format version (truncated keccak256, 31 bytes).
 #[derive(Clone, Copy)]
@@ -94,6 +94,14 @@ impl FromCursor for MetadataLen {
     fn take_from(cur: &mut Cursor<'_>) -> core::result::Result<Self, Underrun> {
         cur.take::<[u8; ForkHeader::METADATA_LEN_SIZE]>()
             .map(|bytes| Self(u16::from_be_bytes(bytes)))
+    }
+}
+
+/// Writes the length big-endian, the mirror of the `FromCursor` impl above;
+/// the byte order never leaves this type.
+impl ToWriter for MetadataLen {
+    fn put_into(&self, w: &mut Writer<'_>) {
+        w.put(&self.0.to_be_bytes());
     }
 }
 
@@ -464,7 +472,7 @@ struct WireFork<'a> {
 /// A fork's metadata payload, serialised and padded to the obfuscation-key
 /// stride with its `u16` length precomputed so emission stays total.
 struct WireMetadata {
-    len: u16,
+    len: MetadataLen,
     padded_json: Vec<u8>,
 }
 
@@ -498,7 +506,10 @@ impl WireMetadata {
                 max: usize::from(u16::MAX),
                 actual: padded_json.len(),
             })?;
-        Ok(Self { len, padded_json })
+        Ok(Self {
+            len: MetadataLen(len),
+            padded_json,
+        })
     }
 }
 
@@ -530,21 +541,18 @@ impl<'a, E: NodeEntry> TryFrom<&'a Fork<E>> for WireFork<'a> {
 }
 
 impl WireFork<'_> {
-    /// Emit this fork: node_type, prefix length and its padded region, the
-    /// reference padded to `ref_size`, then any metadata. Total by construction.
+    /// Emit this fork: node_type, the prefix record, the reference padded to
+    /// `ref_size`, then any metadata. Total by construction.
     fn emit(&self, w: &mut Writer<'_>) {
-        w.put_u8(self.node_type.bits());
-        #[allow(clippy::as_conversions)] // Prefix invariant: len <= Prefix::MAX_LEN (30), fits u8
-        let prefix_len = self.prefix.len() as u8;
-        w.put_u8(prefix_len);
-        w.put_array(self.prefix.padded_bytes());
+        w.put(&self.node_type.bits());
+        w.put(self.prefix);
 
-        w.put_slice(self.address.as_bytes());
+        w.put(self.address.as_bytes());
         w.put_zeros(self.ref_size.saturating_sub(32));
 
         if let Some(metadata) = &self.metadata {
-            w.put_u16_be(metadata.len);
-            w.put_slice(&metadata.padded_json);
+            w.put(&metadata.len);
+            w.put(metadata.padded_json.as_slice());
         }
     }
 }
@@ -675,6 +683,17 @@ mod tests {
             cur.take::<ForkHeader>(),
             Err(MantarayError::DataTooShort)
         ));
+    }
+
+    #[test]
+    fn metadata_len_wire_round_trips_through_put_and_take() {
+        let mut buf = Vec::new();
+        Writer::new(&mut buf).put(&MetadataLen(0x1234));
+        assert_eq!(buf, [0x12, 0x34]);
+
+        let mut cur = Cursor::new(&buf);
+        assert_eq!(cur.take::<MetadataLen>().unwrap().get(), 0x1234);
+        assert!(cur.is_empty());
     }
 
     #[test]

--- a/crates/mantaray/src/node.rs
+++ b/crates/mantaray/src/node.rs
@@ -11,7 +11,7 @@ use crate::{PATH_SEPARATOR, PREFIX_MAX_LEN};
 use bytes::Bytes;
 use nectar_primitives::chunk::{Chunk, ChunkAddress, ContentChunk};
 use nectar_primitives::store::{ChunkGet, ChunkPut, MaybeSend};
-use nectar_primitives::wire::{Cursor, FromCursor};
+use nectar_primitives::wire::{Cursor, FromCursor, ToWriter, Writer};
 
 /// Boxed recursion future: `Send` on native, unbounded on wasm32 so `!Send`
 /// browser stores stay usable. `MaybeSend` cannot appear in a `dyn` bound
@@ -128,6 +128,16 @@ impl FromCursor for Prefix {
         let len = cur.take::<u8>()?;
         let padded = cur.take::<[u8; PREFIX_MAX_LEN]>()?;
         Self::from_wire(&padded, len)
+    }
+}
+
+/// Writes the prefix wire record: the length byte, then the padded 30-byte
+/// block. The mirror of the `FromCursor` impl above, so the length byte never
+/// appears at call sites on the encode side either.
+impl ToWriter for Prefix {
+    fn put_into(&self, w: &mut Writer<'_>) {
+        w.put(&self.len);
+        w.put(&self.data);
     }
 }
 
@@ -1224,6 +1234,18 @@ mod tests {
         let mut cur = Cursor::new(&wire);
         let prefix = cur.take::<Prefix>().unwrap();
         assert_eq!(&*prefix, b"abc");
+        assert!(cur.is_empty());
+    }
+
+    #[test]
+    fn prefix_wire_round_trips_through_put_and_take() {
+        let prefix = Prefix::from_slice(b"abc");
+        let mut buf = Vec::new();
+        Writer::new(&mut buf).put(&prefix);
+        assert_eq!(buf.len(), 1 + PREFIX_MAX_LEN);
+
+        let mut cur = Cursor::new(&buf);
+        assert_eq!(cur.take::<Prefix>().unwrap(), prefix);
         assert!(cur.is_empty());
     }
 

--- a/crates/primitives/src/wire.rs
+++ b/crates/primitives/src/wire.rs
@@ -152,6 +152,74 @@ impl<'a> Cursor<'a> {
     }
 }
 
+/// A writer appending fixed- and variable-width fields to a byte buffer.
+///
+/// The dual of [`Cursor`]: every method appends and cannot fail, so an encoder
+/// built only from these primitives cannot emit a misaligned wire image. The
+/// borrowed buffer is the sole state; a reader over the finished bytes recovers
+/// each field in the order it was put.
+///
+/// ```
+/// use nectar_primitives::wire::{Cursor, Writer};
+///
+/// let mut buf = Vec::new();
+/// let mut w = Writer::new(&mut buf);
+/// w.put_u16_be(0x20);
+/// w.put_array(&[0xaa, 0xbb]);
+///
+/// let mut cur = Cursor::new(&buf);
+/// assert_eq!(cur.take_u16_be()?, 0x20);
+/// assert_eq!(cur.take_array::<2>()?, &[0xaa, 0xbb]);
+/// # Ok::<(), nectar_primitives::wire::Underrun>(())
+/// ```
+#[derive(Debug)]
+pub struct Writer<'a> {
+    bytes: &'a mut Vec<u8>,
+}
+
+impl<'a> Writer<'a> {
+    /// Wraps a growable buffer for appending. Existing contents are kept, so a
+    /// writer can extend a partially built image.
+    pub const fn new(bytes: &'a mut Vec<u8>) -> Self {
+        Self { bytes }
+    }
+
+    /// Appends a fixed-size array.
+    pub fn put_array<const N: usize>(&mut self, arr: &[u8; N]) {
+        self.bytes.extend_from_slice(arr);
+    }
+
+    /// Appends a byte slice.
+    pub fn put_slice(&mut self, bytes: &[u8]) {
+        self.bytes.extend_from_slice(bytes);
+    }
+
+    /// Appends a single byte.
+    pub fn put_u8(&mut self, byte: u8) {
+        self.bytes.push(byte);
+    }
+
+    /// Appends a big-endian `u16`.
+    pub fn put_u16_be(&mut self, value: u16) {
+        self.bytes.extend_from_slice(&value.to_be_bytes());
+    }
+
+    /// Appends `n` zero bytes, e.g. to pad a field to its declared width.
+    pub fn put_zeros(&mut self, n: usize) {
+        self.bytes.resize(self.bytes.len().saturating_add(n), 0);
+    }
+
+    /// Bytes written so far, including any pre-existing contents.
+    pub const fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    /// Whether the buffer is empty.
+    pub const fn is_empty(&self) -> bool {
+        self.bytes.is_empty()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -265,5 +333,47 @@ mod tests {
         assert!(cur.is_empty());
         assert_eq!(cur.take::<u8>().unwrap_err().available, 0);
         assert_eq!(cur.take::<[u8; 0]>().unwrap(), [0u8; 0]);
+    }
+
+    #[test]
+    fn writer_appends_each_width() {
+        let mut buf = Vec::new();
+        let mut w = Writer::new(&mut buf);
+        assert!(w.is_empty());
+
+        w.put_u8(0xab);
+        w.put_u16_be(0x1234);
+        w.put_array(&[0xaa, 0xbb]);
+        w.put_slice(&[0xcc, 0xdd]);
+        w.put_zeros(3);
+
+        assert_eq!(w.len(), 10);
+        assert_eq!(buf, [0xab, 0x12, 0x34, 0xaa, 0xbb, 0xcc, 0xdd, 0, 0, 0]);
+    }
+
+    #[test]
+    fn writer_extends_existing_contents() {
+        let mut buf = vec![0x01, 0x02];
+        let mut w = Writer::new(&mut buf);
+        w.put_u8(0x03);
+        assert_eq!(buf, [0x01, 0x02, 0x03]);
+    }
+
+    #[test]
+    fn writer_and_cursor_round_trip() {
+        // Each field a reader takes matches what the writer put, in order.
+        let mut buf = Vec::new();
+        let mut w = Writer::new(&mut buf);
+        w.put_u8(0x7f);
+        w.put_u16_be(0xbeef);
+        w.put_array(&[1u8, 2, 3, 4]);
+        w.put_slice(&[9u8, 8]);
+
+        let mut cur = Cursor::new(&buf);
+        assert_eq!(cur.take_u8().unwrap(), 0x7f);
+        assert_eq!(cur.take_u16_be().unwrap(), 0xbeef);
+        assert_eq!(cur.take_array::<4>().unwrap(), &[1, 2, 3, 4]);
+        assert_eq!(cur.take(2).unwrap(), &[9, 8]);
+        assert!(cur.is_empty());
     }
 }

--- a/crates/primitives/src/wire.rs
+++ b/crates/primitives/src/wire.rs
@@ -168,8 +168,8 @@ impl<'a> Cursor<'a> {
 /// w.put_array(&[0xaa, 0xbb]);
 ///
 /// let mut cur = Cursor::new(&buf);
-/// assert_eq!(cur.take_u16_be()?, 0x20);
-/// assert_eq!(cur.take_array::<2>()?, &[0xaa, 0xbb]);
+/// assert_eq!(cur.take::<[u8; 2]>()?, 0x20u16.to_be_bytes());
+/// assert_eq!(cur.take::<[u8; 2]>()?, [0xaa, 0xbb]);
 /// # Ok::<(), nectar_primitives::wire::Underrun>(())
 /// ```
 #[derive(Debug)]
@@ -370,10 +370,10 @@ mod tests {
         w.put_slice(&[9u8, 8]);
 
         let mut cur = Cursor::new(&buf);
-        assert_eq!(cur.take_u8().unwrap(), 0x7f);
-        assert_eq!(cur.take_u16_be().unwrap(), 0xbeef);
-        assert_eq!(cur.take_array::<4>().unwrap(), &[1, 2, 3, 4]);
-        assert_eq!(cur.take(2).unwrap(), &[9, 8]);
+        assert_eq!(cur.take::<u8>().unwrap(), 0x7f);
+        assert_eq!(cur.take::<[u8; 2]>().unwrap(), 0xbeefu16.to_be_bytes());
+        assert_eq!(cur.take::<[u8; 4]>().unwrap(), [1, 2, 3, 4]);
+        assert_eq!(cur.take_slice(2).unwrap(), &[9, 8]);
         assert!(cur.is_empty());
     }
 }

--- a/crates/primitives/src/wire.rs
+++ b/crates/primitives/src/wire.rs
@@ -219,26 +219,6 @@ impl<'a> Writer<'a> {
         value.put_into(self);
     }
 
-    /// Appends a fixed-size array.
-    pub fn put_array<const N: usize>(&mut self, arr: &[u8; N]) {
-        self.bytes.extend_from_slice(arr);
-    }
-
-    /// Appends a byte slice.
-    pub fn put_slice(&mut self, bytes: &[u8]) {
-        self.bytes.extend_from_slice(bytes);
-    }
-
-    /// Appends a single byte.
-    pub fn put_u8(&mut self, byte: u8) {
-        self.bytes.push(byte);
-    }
-
-    /// Appends a big-endian `u16`.
-    pub fn put_u16_be(&mut self, value: u16) {
-        self.bytes.extend_from_slice(&value.to_be_bytes());
-    }
-
     /// Appends `n` zero bytes, e.g. to pad a field to its declared width.
     pub fn put_zeros(&mut self, n: usize) {
         self.bytes.resize(self.bytes.len().saturating_add(n), 0);

--- a/crates/primitives/src/wire.rs
+++ b/crates/primitives/src/wire.rs
@@ -75,6 +75,36 @@ impl<const N: usize> FromCursor for [u8; N] {
     }
 }
 
+/// A value that appends exactly its own wire bytes to a [`Writer`].
+///
+/// The dual of [`FromCursor`]: implementors state their byte order internally,
+/// so endian-ambiguous bare integers are not exposed, and appending cannot
+/// fail because the buffer grows. Downstream crates implement this for their
+/// own domain types to write them via [`Writer::put`].
+pub trait ToWriter {
+    /// Appends the wire bytes of `self` to the writer.
+    fn put_into(&self, w: &mut Writer<'_>);
+}
+
+impl ToWriter for u8 {
+    fn put_into(&self, w: &mut Writer<'_>) {
+        w.bytes.push(*self);
+    }
+}
+
+impl<const N: usize> ToWriter for [u8; N] {
+    fn put_into(&self, w: &mut Writer<'_>) {
+        w.bytes.extend_from_slice(self);
+    }
+}
+
+/// The raw escape for variable-width fields whose framing the caller owns.
+impl ToWriter for [u8] {
+    fn put_into(&self, w: &mut Writer<'_>) {
+        w.bytes.extend_from_slice(self);
+    }
+}
+
 /// A cursor advancing over a byte slice, yielding fixed- and variable-width
 /// fields or an [`Underrun`].
 ///
@@ -182,6 +212,11 @@ impl<'a> Writer<'a> {
     /// writer can extend a partially built image.
     pub const fn new(bytes: &'a mut Vec<u8>) -> Self {
         Self { bytes }
+    }
+
+    /// Appends the next value as a whole via its [`ToWriter`] impl.
+    pub fn put<T: ToWriter + ?Sized>(&mut self, value: &T) {
+        value.put_into(self);
     }
 
     /// Appends a fixed-size array.

--- a/crates/primitives/src/wire.rs
+++ b/crates/primitives/src/wire.rs
@@ -194,11 +194,11 @@ impl<'a> Cursor<'a> {
 ///
 /// let mut buf = Vec::new();
 /// let mut w = Writer::new(&mut buf);
-/// w.put_u16_be(0x20);
-/// w.put_array(&[0xaa, 0xbb]);
+/// w.put(&0x20u8);
+/// w.put(&[0xaa, 0xbb]);
 ///
 /// let mut cur = Cursor::new(&buf);
-/// assert_eq!(cur.take::<[u8; 2]>()?, 0x20u16.to_be_bytes());
+/// assert_eq!(cur.take::<u8>()?, 0x20);
 /// assert_eq!(cur.take::<[u8; 2]>()?, [0xaa, 0xbb]);
 /// # Ok::<(), nectar_primitives::wire::Underrun>(())
 /// ```
@@ -319,6 +319,33 @@ mod tests {
     }
 
     #[test]
+    fn domain_type_round_trips_through_put_and_take() {
+        struct BeLen(u16);
+
+        impl FromCursor for BeLen {
+            type Error = Underrun;
+
+            fn take_from(cur: &mut Cursor<'_>) -> Result<Self, Underrun> {
+                cur.take::<[u8; 2]>().map(|b| Self(u16::from_be_bytes(b)))
+            }
+        }
+
+        impl ToWriter for BeLen {
+            fn put_into(&self, w: &mut Writer<'_>) {
+                w.put(&self.0.to_be_bytes());
+            }
+        }
+
+        let mut buf = Vec::new();
+        Writer::new(&mut buf).put(&BeLen(0x1234));
+        assert_eq!(buf, [0x12, 0x34]);
+
+        let mut cur = Cursor::new(&buf);
+        assert_eq!(cur.take::<BeLen>().unwrap().0, 0x1234);
+        assert!(cur.is_empty());
+    }
+
+    #[test]
     fn take_surfaces_impl_validation_errors() {
         #[derive(Debug, PartialEq)]
         enum TagError {
@@ -376,21 +403,20 @@ mod tests {
         let mut w = Writer::new(&mut buf);
         assert!(w.is_empty());
 
-        w.put_u8(0xab);
-        w.put_u16_be(0x1234);
-        w.put_array(&[0xaa, 0xbb]);
-        w.put_slice(&[0xcc, 0xdd]);
+        w.put(&0xabu8);
+        w.put(&[0xaa, 0xbb]);
+        w.put([0xcc, 0xdd].as_slice());
         w.put_zeros(3);
 
-        assert_eq!(w.len(), 10);
-        assert_eq!(buf, [0xab, 0x12, 0x34, 0xaa, 0xbb, 0xcc, 0xdd, 0, 0, 0]);
+        assert_eq!(w.len(), 8);
+        assert_eq!(buf, [0xab, 0xaa, 0xbb, 0xcc, 0xdd, 0, 0, 0]);
     }
 
     #[test]
     fn writer_extends_existing_contents() {
         let mut buf = vec![0x01, 0x02];
         let mut w = Writer::new(&mut buf);
-        w.put_u8(0x03);
+        w.put(&0x03u8);
         assert_eq!(buf, [0x01, 0x02, 0x03]);
     }
 
@@ -399,14 +425,12 @@ mod tests {
         // Each field a reader takes matches what the writer put, in order.
         let mut buf = Vec::new();
         let mut w = Writer::new(&mut buf);
-        w.put_u8(0x7f);
-        w.put_u16_be(0xbeef);
-        w.put_array(&[1u8, 2, 3, 4]);
-        w.put_slice(&[9u8, 8]);
+        w.put(&0x7fu8);
+        w.put(&[1u8, 2, 3, 4]);
+        w.put([9u8, 8].as_slice());
 
         let mut cur = Cursor::new(&buf);
         assert_eq!(cur.take::<u8>().unwrap(), 0x7f);
-        assert_eq!(cur.take::<[u8; 2]>().unwrap(), 0xbeefu16.to_be_bytes());
         assert_eq!(cur.take::<[u8; 4]>().unwrap(), [1, 2, 3, 4]);
         assert_eq!(cur.take_slice(2).unwrap(), &[9, 8]);
         assert!(cur.is_empty());


### PR DESCRIPTION
## What

Adds `wire::Writer` in `crates/primitives/src/wire.rs` as the append-only dual of `Cursor`: `new`, `put_u8`, `put_u16_be`, `put_array`, `put_slice`, `put_zeros`, `len`, `is_empty`, with a rustdoc round-trip doctest against `Cursor` and three unit tests (`writer_appends_each_width`, `writer_extends_existing_contents`, `writer_and_cursor_round_trip`).

Restructures mantaray fork encoding in `crates/mantaray/src/codec.rs`: `Fork::encode_into` is replaced by a total `WireFork<'a>` record (`node_type`, `prefix`, a mandatory-by-construction `address`, `ref_size`, an optional `WireMetadata`), plus a `WireMetadata` helper that serialises, pads and sizes the metadata payload. `TryFrom<&Fork>` is the sole fallible step (`MissingReference` for an unsaved child, `MetadataTooLarge` for oversize metadata); `WireFork::emit` is total and cannot produce a misaligned wire image. `encode_node` now emits forks through a `Writer` over the node buffer.

## Why

Splits fork encoding into a fallible build step and a total, infallible emit step, mirroring the `Writer`/`Cursor` split already used for reading the wire format. This removes the possibility of a partially-written fork record on the append path and keeps the padding/size arithmetic in one place (`WireMetadata::build`) instead of interleaved with the byte-writing code.

## Testing

- `cargo test --workspace --all-features`: all green, including the new `codec::tests::wire_fork_record_round_trips` and `wire::tests::{writer_appends_each_width, writer_extends_existing_contents, writer_and_cursor_round_trip}`.
- Re-encoding the real reference vector `ENCODED_V02` (11 forks, including metadata) through the new `Writer`/`WireFork` path produced byte-for-byte identical output to the prior encoder; `ENCODED_V01` differs only in the version-hash field, which is pre-existing and unrelated to this change.
- `emit()` mirrors the prior buffer operations exactly and the metadata padding arithmetic is unchanged; the `MissingReference` and `MetadataTooLarge` error paths are retained and are now enforced at `WireFork` construction rather than mid-emission.

Diff scope is limited to `crates/primitives/src/wire.rs` and `crates/mantaray/src/codec.rs`; `postage-usage` and `fuzz/` are untouched.

Closes #162

## AI Assistance

Claude (Anthropic) was used for implementation, adversarial red-teaming and independent verification of this change.
