### PR TITLE
refactor(primitives)!: key JoinMode and SplitMode off Reference

### DIFF
--- a/crates/primitives/src/file/constants.rs
+++ b/crates/primitives/src/file/constants.rs
@@ -19,6 +19,7 @@ pub(crate) const LEVEL_LIMIT: usize = compute_level_limit(BRANCHES, DEFAULT_BODY
 const _: () = assert!(LEVEL_LIMIT == 9);
 
 /// Size of a chunk reference. Derived from the reference type.
+#[cfg(test)]
 pub(crate) const REF_SIZE: usize = crate::chunk::ChunkRef::SIZE;
 
 /// Number of references per intermediate chunk (plain mode). Same as bmt::BRANCHES.
@@ -39,9 +40,6 @@ const fn compute_spans(branches: usize) -> [u64; LEVEL_LIMIT] {
     }
     spans
 }
-
-/// Size of an encrypted chunk reference (address + decryption key).
-pub(crate) const ENCRYPTED_REF_SIZE: usize = crate::chunk::encryption::EncryptedChunkRef::SIZE;
 
 /// Compute span multipliers for an arbitrary branching factor.
 /// Used by `TreeParams` which derives its branching factor from const generics,

--- a/crates/primitives/src/file/frontier.rs
+++ b/crates/primitives/src/file/frontier.rs
@@ -57,7 +57,7 @@ where
         // mode's trailing context. The Cursor is the only fallible read and
         // cannot underrun while i < num_children.
         let addr_bytes = cursor
-            .take_array::<{ ChunkRef::SIZE }>()
+            .take::<[u8; ChunkRef::SIZE]>()
             .map_err(|_| FileError::InvalidReference { level: 0 })?;
         let context = M::context_from_wire(&mut cursor)?;
 
@@ -69,7 +69,7 @@ where
         }
 
         children.push(SubtreeNode {
-            addr: ChunkAddress::from(*addr_bytes),
+            addr: ChunkAddress::from(addr_bytes),
             context,
             span,
             byte_offset,

--- a/crates/primitives/src/file/frontier.rs
+++ b/crates/primitives/src/file/frontier.rs
@@ -2,9 +2,10 @@
 
 use bytes::Bytes;
 
-use crate::chunk::ChunkAddress;
+use crate::chunk::{ChunkAddress, ChunkRef};
+use crate::wire::Cursor;
 
-use super::error::Result;
+use super::error::{FileError, Result};
 use super::mode::JoinMode;
 use super::tree::ChunkRange;
 use crate::store::MaybeSend;
@@ -31,7 +32,7 @@ impl<M: JoinMode> Clone for SubtreeNode<M> {
 
 /// Parse children of an intermediate node that overlap a byte range.
 #[allow(clippy::arithmetic_side_effects)]
-// REF_SIZE is a nonzero constant; i < num_children <= BS / REF_SIZE bounds i * REF_SIZE within body.len(); child byte offsets and chunk-range bounds stay within the u64 file span for any tree the splitters can produce
+// REF_SIZE is a nonzero constant; child byte offsets and chunk-range bounds stay within the u64 file span for any tree the splitters can produce
 #[inline]
 pub(crate) fn overlapping_children<M, const BS: usize>(
     body: &[u8],
@@ -42,12 +43,24 @@ where
     M: JoinMode,
 {
     let subspan = M::subspan_size::<BS>(parent.span);
+    // An intermediate body packs whole references back to back. A trailing run
+    // shorter than one reference (body.len() % REF_SIZE bytes) is not a child:
+    // the splitter never emits one, so it is tolerated and left unread.
     let num_children = body.len() / M::REF_SIZE;
     let range_start = chunk_range.start * crate::cast::u64_from_usize(BS);
     let range_end = chunk_range.end * crate::cast::u64_from_usize(BS);
 
+    let mut cursor = Cursor::new(body);
     let mut children = Vec::with_capacity(num_children);
     for i in 0..num_children {
+        // Each turn consumes exactly one reference: the address, then this
+        // mode's trailing context. The Cursor is the only fallible read and
+        // cannot underrun while i < num_children.
+        let addr_bytes = cursor
+            .take_array::<{ ChunkRef::SIZE }>()
+            .map_err(|_| FileError::InvalidReference { level: 0 })?;
+        let context = M::context_from_wire(&mut cursor)?;
+
         let byte_offset = parent.byte_offset + crate::cast::u64_from_usize(i) * subspan;
         let span = M::child_span::<BS>(parent.span, subspan, i);
 
@@ -55,10 +68,8 @@ where
             continue;
         }
 
-        let ref_start = i * M::REF_SIZE;
-        let (addr, context) = M::parse_child_ref(body, ref_start)?;
         children.push(SubtreeNode {
-            addr,
+            addr: ChunkAddress::from(*addr_bytes),
             context,
             span,
             byte_offset,

--- a/crates/primitives/src/file/mode.rs
+++ b/crates/primitives/src/file/mode.rs
@@ -6,10 +6,11 @@ use bytes::Bytes;
 
 use crate::bmt::SPAN_SIZE;
 use crate::chunk::encryption::{EncryptedChunkRef, EncryptionKey, decrypt_chunk_data};
-use crate::chunk::{BmtChunk, Chunk, ChunkAddress, ContentChunk};
+use crate::chunk::{BmtChunk, Chunk, ChunkAddress, ChunkRef, ContentChunk, Reference};
 use crate::store::MaybeSend;
+use crate::wire::Cursor;
 
-use super::constants::{ENCRYPTED_REF_SIZE, REF_SIZE, compute_spans_inline, subspan_for_spans};
+use super::constants::{compute_spans_inline, subspan_for_spans};
 use super::error::{FileError, Result};
 
 /// Convert a `PrimitivesError` from chunk creation into a `FileError`.
@@ -28,8 +29,12 @@ fn create_chunk<const BS: usize>(data: Bytes) -> Result<ContentChunk<BS>> {
 
 /// Joiner-side chunk mode operations.
 pub trait JoinMode: Sized + 'static {
-    /// Size of a single reference in bytes (32 plain, 64 encrypted).
-    const REF_SIZE: usize;
+    /// The reference type this mode reads; its width is a fact of the type.
+    type Ref: Reference + Clone + Debug + Send + Sync;
+
+    /// Wire width of one reference, derived from [`Self::Ref`] so no mode
+    /// restates 32 or 64.
+    const REF_SIZE: usize = <Self::Ref as Reference>::SIZE;
 
     /// Root reference type: `ChunkAddress` (plain) or `EncryptedChunkRef` (encrypted).
     type RootRef: Clone + Debug + Send + Sync;
@@ -89,11 +94,10 @@ pub trait JoinMode: Sized + 'static {
         span: u64,
     ) -> Result<Bytes>;
 
-    /// Parse a child reference from body bytes at offset. Returns (address, child_context).
-    fn parse_child_ref(
-        body: &[u8],
-        ref_start: usize,
-    ) -> Result<(ChunkAddress, Self::JoinerContext)>;
+    /// Read this mode's per-child context, the bytes that trail the address in
+    /// a child reference: plain carries none, encrypted reads its key. The
+    /// [`Cursor`] is the sole fallible read.
+    fn context_from_wire(cursor: &mut Cursor<'_>) -> Result<Self::JoinerContext>;
 }
 
 /// Initialize joiner: fetch root chunk, extract span and context.
@@ -135,18 +139,19 @@ pub(crate) async fn read_chunk_body<
 
 /// Splitter-side chunk mode operations (extends JoinMode).
 pub trait SplitMode: JoinMode {
-    /// Fixed-size byte array for a reference: `[u8; 32]` or `[u8; 64]`.
-    type RefBytes: AsRef<[u8]> + AsMut<[u8]> + Clone + Debug + Send + Sync;
-
-    /// Prepare chunk data (span + body), returning chunk and reference bytes.
-    /// Takes ownership of the payload to avoid an extra allocation.
-    fn prepare_chunk<const BS: usize>(data: Vec<u8>) -> Result<(ContentChunk<BS>, Self::RefBytes)>;
+    /// Prepare chunk data (span + body), returning the chunk and the reference
+    /// that names it. Takes ownership of the payload to avoid an extra
+    /// allocation.
+    fn prepare_chunk<const BS: usize>(data: Vec<u8>) -> Result<(ContentChunk<BS>, Self::Ref)>;
 
     /// Produce the chunk for an empty file, returning it and the root ref.
     fn empty_chunk<const BS: usize>() -> Result<(ContentChunk<BS>, Self::RootRef)>;
 
-    /// Extract root reference from top of buffer.
-    fn extract_root(buffer: &[u8]) -> Result<Self::RootRef>;
+    /// Append a reference's `REF_SIZE` wire bytes to `out`.
+    fn extend_ref_bytes(reference: &Self::Ref, out: &mut Vec<u8>);
+
+    /// The root reference of a finished tree from its sole top reference.
+    fn root_ref(reference: Self::Ref) -> Self::RootRef;
 }
 
 /// Plain (unencrypted) chunk mode.
@@ -154,7 +159,7 @@ pub trait SplitMode: JoinMode {
 pub struct PlainMode;
 
 impl JoinMode for PlainMode {
-    const REF_SIZE: usize = REF_SIZE;
+    type Ref = ChunkRef;
     type RootRef = ChunkAddress;
     type JoinerContext = ();
 
@@ -181,25 +186,18 @@ impl JoinMode for PlainMode {
     }
 
     #[inline]
-    fn parse_child_ref(body: &[u8], ref_start: usize) -> Result<(ChunkAddress, ())> {
-        // Bounds-check the untrusted body instead of panicking on a short slice.
-        let child_addr_bytes: [u8; 32] = ref_start
-            .checked_add(REF_SIZE)
-            .and_then(|ref_end| body.get(ref_start..ref_end))
-            .and_then(|slice| slice.try_into().ok())
-            .ok_or(FileError::InvalidReference { level: 0 })?;
-        Ok((ChunkAddress::from(child_addr_bytes), ()))
+    fn context_from_wire(_cursor: &mut Cursor<'_>) -> Result<()> {
+        // A plain reference is the address alone; it carries no trailing context.
+        Ok(())
     }
 }
 
 impl SplitMode for PlainMode {
-    type RefBytes = [u8; REF_SIZE];
-
     #[inline]
-    fn prepare_chunk<const BS: usize>(data: Vec<u8>) -> Result<(ContentChunk<BS>, [u8; REF_SIZE])> {
+    fn prepare_chunk<const BS: usize>(data: Vec<u8>) -> Result<(ContentChunk<BS>, ChunkRef)> {
         let chunk = create_chunk::<BS>(Bytes::from(data))?;
-        let ref_bytes = (*chunk.address()).into();
-        Ok((chunk, ref_bytes))
+        let reference = ChunkRef::new(*chunk.address());
+        Ok((chunk, reference))
     }
 
     fn empty_chunk<const BS: usize>() -> Result<(ContentChunk<BS>, ChunkAddress)> {
@@ -210,12 +208,14 @@ impl SplitMode for PlainMode {
         Ok((chunk, address))
     }
 
-    fn extract_root(buffer: &[u8]) -> Result<ChunkAddress> {
-        let root_bytes: [u8; 32] = buffer
-            .get(..REF_SIZE)
-            .and_then(|s| s.try_into().ok())
-            .ok_or(FileError::InvalidReference { level: 0 })?;
-        Ok(ChunkAddress::from(root_bytes))
+    #[inline]
+    fn extend_ref_bytes(reference: &ChunkRef, out: &mut Vec<u8>) {
+        out.extend_from_slice(reference.address().as_bytes());
+    }
+
+    #[inline]
+    fn root_ref(reference: ChunkRef) -> ChunkAddress {
+        reference.into_address()
     }
 }
 
@@ -237,14 +237,14 @@ impl EncryptedMode {
             let sub = Self::subspan_size::<BS>(span);
             // num_children <= branches (sub covers at least span / branches).
             let num_children = crate::cast::usize_from_u64(span.div_ceil(sub));
-            let raw = num_children * ENCRYPTED_REF_SIZE;
+            let raw = num_children * EncryptedChunkRef::SIZE;
             raw.min(BS)
         }
     }
 }
 
 impl JoinMode for EncryptedMode {
-    const REF_SIZE: usize = ENCRYPTED_REF_SIZE;
+    type Ref = EncryptedChunkRef;
     type RootRef = EncryptedChunkRef;
     type JoinerContext = EncryptionKey;
 
@@ -277,38 +277,27 @@ impl JoinMode for EncryptedMode {
         Ok(Bytes::from(decrypted).slice(SPAN_SIZE..))
     }
 
-    fn parse_child_ref(body: &[u8], ref_start: usize) -> Result<(ChunkAddress, EncryptionKey)> {
-        // Bounds-check the untrusted body instead of panicking on a short slice.
-        let ref_bytes = ref_start
-            .checked_add(ENCRYPTED_REF_SIZE)
-            .and_then(|ref_end| body.get(ref_start..ref_end))
-            .ok_or(FileError::InvalidReference { level: 0 })?;
-        let (addr_bytes, key_bytes) = ref_bytes.split_at(32);
-        let child_addr_bytes: [u8; 32] = addr_bytes
-            .try_into()
+    fn context_from_wire(cursor: &mut Cursor<'_>) -> Result<EncryptionKey> {
+        // An encrypted reference trails its address with the decryption key.
+        let key_bytes = cursor
+            .take(EncryptionKey::SIZE)
             .map_err(|_| FileError::InvalidReference { level: 0 })?;
-        let child_key = EncryptionKey::try_from(key_bytes)?;
-        Ok((ChunkAddress::from(child_addr_bytes), child_key))
+        Ok(EncryptionKey::try_from(key_bytes)?)
     }
 }
 
 #[cfg(feature = "encryption")]
 impl SplitMode for EncryptedMode {
-    type RefBytes = [u8; ENCRYPTED_REF_SIZE];
-
     fn prepare_chunk<const BS: usize>(
         data: Vec<u8>,
-    ) -> Result<(ContentChunk<BS>, [u8; ENCRYPTED_REF_SIZE])> {
+    ) -> Result<(ContentChunk<BS>, EncryptedChunkRef)> {
         use crate::chunk::encryption::encrypt_chunk;
 
         let key = EncryptionKey::generate();
         let ciphertext = encrypt_chunk::<BS>(&data, &key)?;
         let chunk = create_chunk::<BS>(Bytes::from(ciphertext))?;
-
-        let mut ref_bytes = [0u8; ENCRYPTED_REF_SIZE];
-        ref_bytes[..32].copy_from_slice(chunk.address().as_bytes());
-        ref_bytes[32..].copy_from_slice(key.as_bytes());
-        Ok((chunk, ref_bytes))
+        let reference = EncryptedChunkRef::new(*chunk.address(), key);
+        Ok((chunk, reference))
     }
 
     fn empty_chunk<const BS: usize>() -> Result<(ContentChunk<BS>, EncryptedChunkRef)> {
@@ -322,12 +311,12 @@ impl SplitMode for EncryptedMode {
         Ok((chunk, EncryptedChunkRef::new(address, key)))
     }
 
-    fn extract_root(buffer: &[u8]) -> Result<EncryptedChunkRef> {
-        let root_ref_bytes = buffer
-            .get(..ENCRYPTED_REF_SIZE)
-            .ok_or(FileError::InvalidReference { level: 0 })?;
-        EncryptedChunkRef::try_from(root_ref_bytes)
-            .map_err(|_| FileError::InvalidReference { level: 0 })
+    fn extend_ref_bytes(reference: &EncryptedChunkRef, out: &mut Vec<u8>) {
+        out.extend_from_slice(&<[u8; EncryptedChunkRef::SIZE]>::from(reference));
+    }
+
+    fn root_ref(reference: EncryptedChunkRef) -> EncryptedChunkRef {
+        reference
     }
 }
 

--- a/crates/primitives/src/file/mode.rs
+++ b/crates/primitives/src/file/mode.rs
@@ -280,7 +280,7 @@ impl JoinMode for EncryptedMode {
     fn context_from_wire(cursor: &mut Cursor<'_>) -> Result<EncryptionKey> {
         // An encrypted reference trails its address with the decryption key.
         let key_bytes = cursor
-            .take(EncryptionKey::SIZE)
+            .take_slice(EncryptionKey::SIZE)
             .map_err(|_| FileError::InvalidReference { level: 0 })?;
         Ok(EncryptionKey::try_from(key_bytes)?)
     }

--- a/crates/primitives/src/file/splitter_parallel.rs
+++ b/crates/primitives/src/file/splitter_parallel.rs
@@ -94,7 +94,7 @@ where
         source: &R,
         tree: &TreeParams<BODY_SIZE>,
         sink: &F,
-    ) -> Result<Vec<M::RefBytes>>
+    ) -> Result<Vec<M::Ref>>
     where
         R: ReadAt + Sync,
         F: Fn(AnyChunk<BODY_SIZE>) + Sync,
@@ -102,7 +102,7 @@ where
         let data_chunks = tree.data_chunks();
         let size = tree.size();
 
-        let results: Vec<Result<M::RefBytes>> = (0..data_chunks)
+        let results: Vec<Result<M::Ref>> = (0..data_chunks)
             .into_par_iter()
             .map(|i| {
                 let offset = i * crate::cast::u64_from_usize(BODY_SIZE);
@@ -122,9 +122,9 @@ where
 
                 let chunk_bytes = super::helpers::build_intermediate_payload(span, &buf);
 
-                let (chunk, ref_bytes) = M::prepare_chunk::<BODY_SIZE>(chunk_bytes)?;
+                let (chunk, reference) = M::prepare_chunk::<BODY_SIZE>(chunk_bytes)?;
                 sink(chunk.into());
-                Ok(ref_bytes)
+                Ok(reference)
             })
             .collect();
 
@@ -133,7 +133,7 @@ where
 
     #[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)] // refs starts non-empty (size > 0 produces >= 1 data chunk) and each level keeps >= 1 ref, so refs[0] exists; level increments at most log_branches(refs) < LEVEL_LIMIT times
     fn build_intermediate_levels<F>(
-        mut refs: Vec<M::RefBytes>,
+        mut refs: Vec<M::Ref>,
         total_size: u64,
         spans: &[u64; LEVEL_LIMIT],
         sink: &F,
@@ -148,18 +148,18 @@ where
             level += 1;
         }
 
-        // Extract root reference from the single remaining ref.
-        M::extract_root(refs[0].as_ref())
+        // The single remaining reference is the tree root.
+        Ok(M::root_ref(refs[0].clone()))
     }
 
     #[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)] // refs_per_chunk >= 1; level < LEVEL_LIMIT = spans.len() for any in-memory ref count; start = i * refs_per_chunk < refs.len() and end is clamped to refs.len(), so the slice holds and child_refs is non-empty
     fn build_level<F>(
-        refs: &[M::RefBytes],
+        refs: &[M::Ref],
         level: usize,
         total_size: u64,
         spans: &[u64; LEVEL_LIMIT],
         sink: &F,
-    ) -> Result<Vec<M::RefBytes>>
+    ) -> Result<Vec<M::Ref>>
     where
         F: Fn(AnyChunk<BODY_SIZE>) + Sync,
     {
@@ -167,7 +167,7 @@ where
         let chunks_at_level = refs.len().div_ceil(refs_per_chunk);
         let max_span = spans[level] * crate::cast::u64_from_usize(BODY_SIZE);
 
-        let results: Vec<Result<M::RefBytes>> = (0..chunks_at_level)
+        let results: Vec<Result<M::Ref>> = (0..chunks_at_level)
             .into_par_iter()
             .map(|i| {
                 let start = i * refs_per_chunk;
@@ -185,16 +185,15 @@ where
                     max_span
                 };
 
-                let ref_data: Vec<u8> = child_refs
-                    .iter()
-                    .flat_map(|r| r.as_ref())
-                    .copied()
-                    .collect();
+                let mut ref_data = Vec::with_capacity(child_refs.len() * M::REF_SIZE);
+                for reference in child_refs {
+                    M::extend_ref_bytes(reference, &mut ref_data);
+                }
                 let chunk_bytes = super::helpers::build_intermediate_payload(span, &ref_data);
 
-                let (chunk, ref_bytes) = M::prepare_chunk::<BODY_SIZE>(chunk_bytes)?;
+                let (chunk, reference) = M::prepare_chunk::<BODY_SIZE>(chunk_bytes)?;
                 sink(chunk.into());
-                Ok(ref_bytes)
+                Ok(reference)
             })
             .collect();
 

--- a/crates/primitives/src/file/tree.rs
+++ b/crates/primitives/src/file/tree.rs
@@ -1,13 +1,14 @@
 //! Tree structure calculations for parallel file operations.
 
-use super::constants::{LEVEL_LIMIT, REF_SIZE};
+use super::constants::LEVEL_LIMIT;
 use crate::bmt::DEFAULT_BODY_SIZE;
+use crate::chunk::{ChunkRef, Reference};
 
 /// Tree structure for a file of known size.
 ///
 /// Pre-computes chunk counts and spans for efficient parallel operations.
 /// The branching factor defaults to `BODY_SIZE / 32` (plain mode, 128 branches).
-/// Use [`with_ref_size`](Self::with_ref_size) for encrypted mode (`BODY_SIZE / 64` = 64 branches).
+/// Use [`with_ref`](Self::with_ref) for encrypted mode (`BODY_SIZE / 64` = 64 branches).
 #[derive(Debug, Clone, Copy)]
 pub struct TreeParams<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> {
     size: u64,
@@ -19,13 +20,14 @@ pub struct TreeParams<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> {
 impl<const BODY_SIZE: usize> TreeParams<BODY_SIZE> {
     /// Create tree parameters for a file of given size (plain mode, `REF_SIZE = 32`).
     pub fn new(size: u64) -> Self {
-        Self::with_ref_size(size, REF_SIZE)
+        Self::with_ref::<ChunkRef>(size)
     }
 
-    /// Create tree parameters with a custom reference size (e.g. 64 for encrypted mode).
-    #[allow(clippy::arithmetic_side_effects)] // ref_size is the constant 32 (plain) or 64 (encrypted), never zero
-    pub fn with_ref_size(size: u64, ref_size: usize) -> Self {
-        let branches = BODY_SIZE / ref_size;
+    /// Create tree parameters whose branching derives from reference type `R`;
+    /// the width is [`Reference::SIZE`], never a passed-in byte count.
+    #[allow(clippy::arithmetic_side_effects)] // R::SIZE is the constant 32 (plain) or 64 (encrypted), never zero
+    pub fn with_ref<R: Reference>(size: u64) -> Self {
+        let branches = BODY_SIZE / R::SIZE;
         let (depth, data_chunks) = if size == 0 {
             (1, 1) // Empty file still produces one chunk
         } else {
@@ -231,7 +233,7 @@ pub(crate) fn assemble_range<const BODY_SIZE: usize>(
 /// Calculate subspan size for children of a node with given span (plain mode).
 #[cfg(test)]
 fn subspan_size<const BODY_SIZE: usize>(span: u64) -> u64 {
-    let spans = super::constants::compute_spans_inline(BODY_SIZE / super::constants::REF_SIZE);
+    let spans = super::constants::compute_spans_inline(BODY_SIZE / ChunkRef::SIZE);
     super::constants::subspan_for_spans::<BODY_SIZE>(span, &spans)
 }
 
@@ -357,11 +359,11 @@ mod tests {
 
     #[test]
     fn test_encrypted_tree_params() {
-        use super::super::constants::ENCRYPTED_REF_SIZE;
+        use crate::chunk::encryption::EncryptedChunkRef;
 
         // 64 data chunks fills one encrypted intermediate exactly
         let size = DEFAULT_BODY_SIZE as u64 * 64;
-        let tree = TreeParams::<DEFAULT_BODY_SIZE>::with_ref_size(size, ENCRYPTED_REF_SIZE);
+        let tree = TreeParams::<DEFAULT_BODY_SIZE>::with_ref::<EncryptedChunkRef>(size);
         assert_eq!(tree.depth(), 2); // 64 chunks / 64 branches = 1 intermediate
         assert_eq!(tree.data_chunks(), 64);
         assert_eq!(tree.chunks_at_level(0), 64);
@@ -370,7 +372,7 @@ mod tests {
 
         // 65 data chunks needs a third level
         let size2 = DEFAULT_BODY_SIZE as u64 * 65;
-        let tree2 = TreeParams::<DEFAULT_BODY_SIZE>::with_ref_size(size2, ENCRYPTED_REF_SIZE);
+        let tree2 = TreeParams::<DEFAULT_BODY_SIZE>::with_ref::<EncryptedChunkRef>(size2);
         assert_eq!(tree2.depth(), 3);
         assert_eq!(tree2.chunks_at_level(0), 65);
         assert_eq!(tree2.chunks_at_level(1), 2);


### PR DESCRIPTION
## What

Re-keys the file join/split modes off the `Reference` trait.

`JoinMode` now carries `type Ref: Reference` (`ChunkRef` for `PlainMode`, `EncryptedChunkRef` for `EncryptedMode`), with `const REF_SIZE = <Self::Ref as Reference>::SIZE` derived, so no mode restates 32/64.

Both `parse_child_ref` bodies are deleted: the frontier loop (`overlapping_children`) now runs over a `wire::Cursor`, taking `ChunkRef::SIZE` for the address then delegating the trailing per-child context to a new `JoinMode::context_from_wire` (plain: none; encrypted: the key). The trailing-byte tolerance (`body.len() % REF_SIZE`) is documented as deliberately ignored.

`SplitMode` drops the `RefBytes` associated type and `extract_root`. `prepare_chunk` now returns the typed `Self::Ref`, which flows through the parallel splitter, serialized to wire bytes via a new `extend_ref_bytes`, and resolved to the root via a new `root_ref` (typed `Ref` -> `RootRef`).

`TreeParams::with_ref_size(size, bytes)` becomes `with_ref::<R: Reference>(size)`.

Changed files: `crates/primitives/src/file/{constants,frontier,mode,splitter_parallel,tree}.rs`.

Closes #166

## Why

The previous mode traits carried a raw `REF_SIZE` constant and a `RefBytes` byte-array associated type in parallel with the actual reference types, so the wire width and the reference shape could drift out of sync and every mode had to restate its own 32/64 byte constant. Keying both traits off `Reference` makes the wire width a derived fact of the type instead of a duplicated literal, and removes the manual bounds-checked byte-slicing in `parse_child_ref` in favour of a shared `Cursor`-driven decode path.

## Testing

- `cargo nextest run --workspace --all-features`: 580 passed, 1 skipped, 0 failed.
- Wire-format audit confirmed the encoder is byte-for-byte identical to the previous one (plain = 32-byte address; encrypted = 32 addr || 32 key via `write_to`; root ref extraction unchanged), so the new `Cursor`-driven decoder and the `Reference`-typed encoder round-trip the old bytes both ways, validated by `test_go_vectors` and `encrypted_roundtrip_all_sizes`.
- Truncation/adversarial safety verified: the frontier's only fallible reads go through `Cursor` (`take`/`take_array` -> `Underrun` -> `FileError`).

This PR targets `s157/30-writer-wirefork` as part of the `s157` stack; it will not build/pass CI standalone against `main` until retargeted.

## AI Assistance

Implemented and red-teamed with Claude (Anthropic), per the org contract in [nxm-rs/.github CONTRIBUTING.md](https://github.com/nxm-rs/.github/blob/main/CONTRIBUTING.md).
