### PR TITLE
refactor(primitives)!: array byte APIs for EncryptedChunkRef and ManifestRef

### DIFF
--- a/crates/mantaray/src/manifest_ref.rs
+++ b/crates/mantaray/src/manifest_ref.rs
@@ -2,6 +2,7 @@
 
 use nectar_primitives::chunk::ChunkAddress;
 
+use crate::error::MantarayError;
 use crate::obfuscation::ObfuscationKey;
 
 /// Root reference for an encrypted manifest: chunk address + obfuscation key.
@@ -12,6 +13,9 @@ pub struct ManifestRef {
 }
 
 impl ManifestRef {
+    /// Wire width: root address followed by obfuscation key.
+    pub const SIZE: usize = size_of::<ChunkAddress>() + ObfuscationKey::SIZE;
+
     /// Create a new manifest reference.
     pub const fn new(address: ChunkAddress, obfuscation_key: ObfuscationKey) -> Self {
         Self {
@@ -33,5 +37,118 @@ impl ManifestRef {
     /// Consume into (address, obfuscation_key).
     pub const fn into_parts(self) -> (ChunkAddress, ObfuscationKey) {
         (self.address, self.obfuscation_key)
+    }
+
+    /// Serialise to the fixed wire form: address followed by obfuscation key.
+    pub const fn to_bytes(&self) -> [u8; Self::SIZE] {
+        let mut buf = [0u8; Self::SIZE];
+        let (address, key) = buf.split_at_mut(size_of::<ChunkAddress>());
+        address.copy_from_slice(self.address.as_bytes());
+        key.copy_from_slice(self.obfuscation_key.as_bytes());
+        buf
+    }
+
+    /// Reconstruct from the fixed wire form: any 64 bytes are a valid reference.
+    pub fn from_bytes(bytes: &[u8; Self::SIZE]) -> Self {
+        let mut address = [0u8; size_of::<ChunkAddress>()];
+        let mut key = [0u8; ObfuscationKey::SIZE];
+        let (a, k) = bytes.split_at(size_of::<ChunkAddress>());
+        address.copy_from_slice(a);
+        key.copy_from_slice(k);
+        Self::new(ChunkAddress::from(address), ObfuscationKey::from(key))
+    }
+}
+
+impl From<&ManifestRef> for [u8; ManifestRef::SIZE] {
+    fn from(r: &ManifestRef) -> Self {
+        r.to_bytes()
+    }
+}
+
+impl From<ManifestRef> for [u8; ManifestRef::SIZE] {
+    fn from(r: ManifestRef) -> Self {
+        r.to_bytes()
+    }
+}
+
+impl From<[u8; Self::SIZE]> for ManifestRef {
+    fn from(bytes: [u8; Self::SIZE]) -> Self {
+        Self::from_bytes(&bytes)
+    }
+}
+
+impl From<&ManifestRef> for Vec<u8> {
+    fn from(r: &ManifestRef) -> Self {
+        r.to_bytes().to_vec()
+    }
+}
+
+impl TryFrom<&[u8]> for ManifestRef {
+    type Error = MantarayError;
+
+    fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
+        let bytes: &[u8; Self::SIZE] =
+            slice
+                .try_into()
+                .map_err(|_| MantarayError::EntrySizeMismatch {
+                    expected: Self::SIZE,
+                    actual: slice.len(),
+                })?;
+        Ok(Self::from_bytes(bytes))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nectar_primitives::chunk::ChunkAddress;
+
+    fn sample() -> ManifestRef {
+        let address = ChunkAddress::from([0xcd; 32]);
+        let obfuscation_key = ObfuscationKey::from([0xef; 32]);
+        ManifestRef::new(address, obfuscation_key)
+    }
+
+    #[test]
+    fn size_is_address_plus_key() {
+        assert_eq!(ManifestRef::SIZE, 64);
+    }
+
+    #[test]
+    fn to_bytes_layout() {
+        let bytes = sample().to_bytes();
+        assert_eq!(&bytes[..32], &[0xcd; 32]);
+        assert_eq!(&bytes[32..], &[0xef; 32]);
+    }
+
+    #[test]
+    fn fixed_array_roundtrip() {
+        let reference = sample();
+        let bytes: [u8; 64] = (&reference).into();
+
+        assert_eq!(ManifestRef::from_bytes(&bytes), reference);
+        assert_eq!(ManifestRef::from(bytes), reference);
+        assert_eq!(<[u8; 64]>::from(reference), bytes);
+    }
+
+    #[test]
+    fn slice_roundtrip() {
+        let reference = sample();
+        let bytes = Vec::from(&reference);
+        assert_eq!(bytes.len(), 64);
+        assert_eq!(ManifestRef::try_from(bytes.as_slice()).unwrap(), reference);
+    }
+
+    #[test]
+    fn invalid_length() {
+        let bad = [0u8; 48];
+        let err = ManifestRef::try_from(bad.as_slice()).unwrap_err();
+        assert!(matches!(
+            err,
+            MantarayError::EntrySizeMismatch {
+                expected: 64,
+                actual: 48
+            }
+        ));
     }
 }

--- a/crates/primitives/src/chunk/encryption/reference.rs
+++ b/crates/primitives/src/chunk/encryption/reference.rs
@@ -50,11 +50,23 @@ impl EncryptedChunkRef {
         (self.reference.into_address(), self.key)
     }
 
-    /// Write the reference into `buf`. Panics if `buf` is too small.
-    #[allow(clippy::indexing_slicing)] // documented contract: panics if buf.len() < Self::SIZE; both callers pass fixed [u8; Self::SIZE] buffers
-    pub fn write_to(&self, buf: &mut [u8]) {
-        buf[..ChunkRef::SIZE].copy_from_slice(self.address().as_bytes());
-        buf[ChunkRef::SIZE..Self::SIZE].copy_from_slice(self.key.as_bytes());
+    /// Serialise to the fixed wire form: address followed by decryption key.
+    pub const fn to_bytes(&self) -> [u8; Self::SIZE] {
+        let mut buf = [0u8; Self::SIZE];
+        let (address, key) = buf.split_at_mut(ChunkRef::SIZE);
+        address.copy_from_slice(self.address().as_bytes());
+        key.copy_from_slice(self.key.as_bytes());
+        buf
+    }
+
+    /// Reconstruct from the fixed wire form: any 64 bytes are a valid reference.
+    pub fn from_bytes(bytes: &[u8; Self::SIZE]) -> Self {
+        let mut address = [0u8; ChunkRef::SIZE];
+        let mut key = [0u8; EncryptionKey::SIZE];
+        let (a, k) = bytes.split_at(ChunkRef::SIZE);
+        address.copy_from_slice(a);
+        key.copy_from_slice(k);
+        Self::new(ChunkAddress::from(address), EncryptionKey::from(key))
     }
 }
 
@@ -81,15 +93,19 @@ impl Reference for EncryptedChunkRef {
 
 impl From<&EncryptedChunkRef> for [u8; EncryptedChunkRef::SIZE] {
     fn from(r: &EncryptedChunkRef) -> Self {
-        let mut buf = [0u8; EncryptedChunkRef::SIZE];
-        r.write_to(&mut buf);
-        buf
+        r.to_bytes()
     }
 }
 
 impl From<EncryptedChunkRef> for [u8; EncryptedChunkRef::SIZE] {
     fn from(r: EncryptedChunkRef) -> Self {
-        (&r).into()
+        r.to_bytes()
+    }
+}
+
+impl From<[u8; Self::SIZE]> for EncryptedChunkRef {
+    fn from(bytes: [u8; Self::SIZE]) -> Self {
+        Self::from_bytes(&bytes)
     }
 }
 
@@ -137,6 +153,9 @@ mod tests {
 
         let recovered = EncryptedChunkRef::try_from(bytes.as_slice()).unwrap();
         assert_eq!(recovered, enc_ref);
+
+        assert_eq!(EncryptedChunkRef::from(bytes), enc_ref);
+        assert_eq!(EncryptedChunkRef::from_bytes(&bytes), enc_ref);
     }
 
     #[test]
@@ -150,13 +169,12 @@ mod tests {
     }
 
     #[test]
-    fn write_to_buffer() {
+    fn to_bytes_layout() {
         let addr = ChunkAddress::from(B256::repeat_byte(0x22));
         let key = EncryptionKey::from([0x33; 32]);
         let enc_ref = EncryptedChunkRef::new(addr, key);
 
-        let mut buf = [0u8; 64];
-        enc_ref.write_to(&mut buf);
+        let buf = enc_ref.to_bytes();
         assert_eq!(&buf[..32], &[0x22; 32]);
         assert_eq!(&buf[32..], &[0x33; 32]);
     }


### PR DESCRIPTION
## What

Gives `EncryptedChunkRef` and mantaray's `ManifestRef` symmetric fixed-array byte codecs: `From` conversions to and from `[u8; 64]`, fallible `TryFrom<&[u8]>`, and a total replacement for the previously panicking `EncryptedChunkRef::write_to`.

`ManifestRef` previously had no byte codec at all despite being the same 64-byte address-plus-key shape; it now mirrors the `EncryptedChunkRef` surface.

Closes #168

## Why

The two types are byte-identical 64-byte shapes with divergent APIs, and the panicking `write_to` was the last infallible-looking byte sink that could abort on a short buffer; the epic requires the only fallible byte access to be the wire cursor.

## Testing

Full workspace battery on the branch: `cargo fmt` clean on the diff, `cargo clippy --workspace --all-targets --all-features -D warnings` clean on the diff, `cargo test --workspace --all-features` green, verified independently by the gate reviewer. One reviewer note retained as-is: wrong-length `TryFrom` input reuses the existing `EntrySizeMismatch` variant, matching the established pattern in mode.rs and codec.rs.

## AI Assistance

Implemented and red-teamed with Claude Opus; assembled and filed by Claude Fable under maintainer direction.
