### PR TITLE
refactor(mantaray)!: split DecodeError from ManifestError with chunk provenance

### DIFF
--- a/crates/mantaray/src/codec.rs
+++ b/crates/mantaray/src/codec.rs
@@ -259,7 +259,7 @@ fn decode_node<R: Reference>(data: &[u8]) -> DecodeResult<Node<R>> {
 /// width.
 ///
 /// The version hash is validated only after the ref_size byte is confirmed
-/// present, so a header truncated at that byte reports `DataTooShort` rather
+/// present, so a header truncated at that byte reports `TooShort` rather
 /// than an invalid-version error.
 fn parse_header(cur: &mut Cursor<'_>) -> DecodeResult<(VersionHash, RefSize)> {
     // The obfuscation key was already consumed by the caller for decryption.
@@ -318,7 +318,7 @@ fn insufficient_fork(underrun: Underrun, total: usize, byte_index: u8) -> Decode
 /// Decode the node body: entry slot, forks bitfield, then each present fork.
 ///
 /// The entry slot and index are both read before the entry is validated, so a
-/// truncated index reports `DataTooShort` rather than an entry-shaped error.
+/// truncated index reports `TooShort` rather than an entry-shaped error.
 /// v0.2 derives the root EDGE flag from a non-empty index; v0.1 leaves it unset.
 fn decode_body<R: Reference>(
     cur: &mut Cursor<'_>,
@@ -867,7 +867,7 @@ mod tests {
             let result = Node::<ChunkRef>::try_from(data.as_slice());
             assert!(
                 matches!(result, Err(DecodeError::TooShort)),
-                "length {len} must yield DataTooShort"
+                "length {len} must yield TooShort"
             );
         }
     }
@@ -881,7 +881,7 @@ mod tests {
             let result = Node::<ChunkRef>::try_from(data.as_slice());
             assert!(
                 matches!(result, Err(DecodeError::TooShort)),
-                "length {len} must yield DataTooShort"
+                "length {len} must yield TooShort"
             );
         }
     }
@@ -940,7 +940,7 @@ mod tests {
                 let result = Node::<EncryptedChunkRef>::try_from(data.as_slice());
                 assert!(
                     matches!(result, Err(DecodeError::TooShort)),
-                    "encref {label} length {len} must yield DataTooShort"
+                    "encref {label} length {len} must yield TooShort"
                 );
             }
         }

--- a/crates/mantaray/src/codec.rs
+++ b/crates/mantaray/src/codec.rs
@@ -269,8 +269,7 @@ fn parse_header(cur: &mut Cursor<'_>) -> DecodeResult<(VersionHash, RefSize)> {
         .take::<[u8; VersionHash::SIZE]>()
         .map_err(|_| DecodeError::TooShort)?;
     let ref_size = cur.take::<u8>().map_err(|_| DecodeError::TooShort)?;
-    let version =
-        VersionHash::from_bytes(&version_bytes).ok_or(DecodeError::InvalidVersionHash)?;
+    let version = VersionHash::from_bytes(&version_bytes).ok_or(DecodeError::InvalidVersionHash)?;
     let ref_size = if ref_size == 0 {
         RefSize::EmptyTerminal
     } else {
@@ -418,7 +417,9 @@ fn parse_fork_body<R: Reference>(
     let mut cur = Cursor::new(body);
     let ForkHeader { node_type, prefix } = cur.take::<ForkHeader>()?;
 
-    let ref_region = cur.take_slice(ref_size).map_err(|_| DecodeError::TooShort)?;
+    let ref_region = cur
+        .take_slice(ref_size)
+        .map_err(|_| DecodeError::TooShort)?;
     let mut ref_cur = Cursor::new(ref_region);
     let addr = ref_cur
         .take::<[u8; 32]>()

--- a/crates/mantaray/src/codec.rs
+++ b/crates/mantaray/src/codec.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 
-use crate::error::{MantarayError, Result};
+use crate::error::{DecodeError, DecodeResult, MantarayError, Result};
 use crate::node::{Fork, Node, NodeType, Prefix};
 use crate::obfuscation::ObfuscationKey;
 
@@ -67,7 +67,7 @@ impl ForkHeader {
 }
 
 impl FromCursor for ForkHeader {
-    type Error = MantarayError;
+    type Error = DecodeError;
 
     fn take_from(cur: &mut Cursor<'_>) -> core::result::Result<Self, Self::Error> {
         let node_type = NodeType::from_bits_truncate(cur.take::<u8>()?);
@@ -195,16 +195,16 @@ fn encode_node<R: Reference>(node: &Node<R>) -> Result<Vec<u8>> {
 }
 
 impl<R: Reference> TryFrom<&[u8]> for Node<R> {
-    type Error = MantarayError;
+    type Error = DecodeError;
 
-    fn try_from(value: &[u8]) -> Result<Self> {
+    fn try_from(value: &[u8]) -> DecodeResult<Self> {
         let mut data = value.to_vec();
 
         // The obfuscation key is the header's first field and is stored in the
         // clear; every later byte is XOR-encrypted under it.
         let (key, body) = data
             .split_first_chunk_mut::<{ ObfuscationKey::SIZE }>()
-            .ok_or(MantarayError::DataTooShort)?;
+            .ok_or(DecodeError::TooShort)?;
         let obfuscation_key = ObfuscationKey::from(*key);
         xor_in_place(body, obfuscation_key.as_bytes());
 
@@ -245,7 +245,7 @@ enum RefSize {
 }
 
 /// Decode a decrypted node buffer: header, then the version-specific body.
-fn decode_node<R: Reference>(data: &[u8]) -> Result<Node<R>> {
+fn decode_node<R: Reference>(data: &[u8]) -> DecodeResult<Node<R>> {
     let total = data.len();
     let mut cur = Cursor::new(data);
     let (version, ref_size) = parse_header(&mut cur)?;
@@ -261,16 +261,16 @@ fn decode_node<R: Reference>(data: &[u8]) -> Result<Node<R>> {
 /// The version hash is validated only after the ref_size byte is confirmed
 /// present, so a header truncated at that byte reports `DataTooShort` rather
 /// than an invalid-version error.
-fn parse_header(cur: &mut Cursor<'_>) -> Result<(VersionHash, RefSize)> {
+fn parse_header(cur: &mut Cursor<'_>) -> DecodeResult<(VersionHash, RefSize)> {
     // The obfuscation key was already consumed by the caller for decryption.
     cur.take::<[u8; ObfuscationKey::SIZE]>()
-        .map_err(|_| MantarayError::DataTooShort)?;
+        .map_err(|_| DecodeError::TooShort)?;
     let version_bytes = cur
         .take::<[u8; VersionHash::SIZE]>()
-        .map_err(|_| MantarayError::DataTooShort)?;
-    let ref_size = cur.take::<u8>().map_err(|_| MantarayError::DataTooShort)?;
+        .map_err(|_| DecodeError::TooShort)?;
+    let ref_size = cur.take::<u8>().map_err(|_| DecodeError::TooShort)?;
     let version =
-        VersionHash::from_bytes(&version_bytes).ok_or(MantarayError::InvalidVersionHash)?;
+        VersionHash::from_bytes(&version_bytes).ok_or(DecodeError::InvalidVersionHash)?;
     let ref_size = if ref_size == 0 {
         RefSize::EmptyTerminal
     } else {
@@ -286,12 +286,12 @@ fn parse_header(cur: &mut Cursor<'_>) -> Result<(VersionHash, RefSize)> {
 /// have zero width), so it is rejected as malformed rather than silently
 /// dropping forks the way bee's v0.2 decoder does
 /// (`bee/pkg/manifest/mantaray/marshal.go:285-287`). See the HAZMAT block.
-fn decode_empty_terminal<R: Reference>(cur: &mut Cursor<'_>) -> Result<Node<R>> {
+fn decode_empty_terminal<R: Reference>(cur: &mut Cursor<'_>) -> DecodeResult<Node<R>> {
     let index = cur
         .take::<[u8; FORK_INDEX_SIZE]>()
-        .map_err(|_| MantarayError::DataTooShort)?;
+        .map_err(|_| DecodeError::TooShort)?;
     if index.iter().any(|&b| b != 0) {
-        return Err(MantarayError::EntrySizeMismatch {
+        return Err(DecodeError::RefSizeMismatch {
             expected: R::SIZE,
             actual: 0,
         });
@@ -305,8 +305,8 @@ fn decode_empty_terminal<R: Reference>(cur: &mut Cursor<'_>) -> Result<Node<R>> 
 
 /// Restate a fork-region [`Underrun`] as an `InsufficientForkBytes` diagnostic
 /// carrying absolute byte offsets into the node buffer.
-fn insufficient_fork(underrun: Underrun, total: usize, byte_index: u8) -> MantarayError {
-    MantarayError::InsufficientForkBytes {
+fn insufficient_fork(underrun: Underrun, total: usize, byte_index: u8) -> DecodeError {
+    DecodeError::InsufficientForkBytes {
         expected: total
             .saturating_sub(underrun.available)
             .saturating_add(underrun.expected),
@@ -325,9 +325,9 @@ fn decode_body<R: Reference>(
     version: VersionHash,
     ref_size: usize,
     total: usize,
-) -> Result<Node<R>> {
+) -> DecodeResult<Node<R>> {
     if ref_size != R::SIZE {
-        return Err(MantarayError::EntrySizeMismatch {
+        return Err(DecodeError::RefSizeMismatch {
             expected: R::SIZE,
             actual: ref_size,
         });
@@ -336,10 +336,10 @@ fn decode_body<R: Reference>(
     // The entry slot is a zero-sentinel `Option<R>`: `read_optional` maps the
     // all-zero width to `None`. The index is read next so a truncated index
     // reports `DataTooShort` rather than an entry-shaped error.
-    let entry = R::read_optional(cur).map_err(|_| MantarayError::DataTooShort)?;
+    let entry = R::read_optional(cur).map_err(|_| DecodeError::TooShort)?;
     let index_bytes = cur
         .take::<[u8; FORK_INDEX_SIZE]>()
-        .map_err(|_| MantarayError::DataTooShort)?;
+        .map_err(|_| DecodeError::TooShort)?;
 
     let mut node_type = NodeType::empty();
     if matches!(version, VersionHash::V02) && index_bytes.iter().any(|&b| b != 0) {
@@ -375,7 +375,7 @@ fn parse_fork<R: Reference>(
     ref_size: usize,
     byte_index: u8,
     total: usize,
-) -> Result<Fork<R>> {
+) -> DecodeResult<Fork<R>> {
     let mut peek = cur.clone();
     let node_type = NodeType::from_bits_truncate(
         peek.take::<u8>()
@@ -414,17 +414,15 @@ fn parse_fork_body<R: Reference>(
     body: &[u8],
     ref_size: usize,
     has_metadata: bool,
-) -> Result<Fork<R>> {
+) -> DecodeResult<Fork<R>> {
     let mut cur = Cursor::new(body);
     let ForkHeader { node_type, prefix } = cur.take::<ForkHeader>()?;
 
-    let ref_region = cur
-        .take_slice(ref_size)
-        .map_err(|_| MantarayError::DataTooShort)?;
+    let ref_region = cur.take_slice(ref_size).map_err(|_| DecodeError::TooShort)?;
     let mut ref_cur = Cursor::new(ref_region);
     let addr = ref_cur
         .take::<[u8; 32]>()
-        .map_err(|_| MantarayError::DataTooShort)?;
+        .map_err(|_| DecodeError::TooShort)?;
 
     let mut node = Node::from_reference(ChunkAddress::from(addr));
     node.node_type = node_type;
@@ -432,7 +430,7 @@ fn parse_fork_body<R: Reference>(
     if has_metadata {
         let metadata_len = cur
             .take::<MetadataLen>()
-            .map_err(|_| MantarayError::DataTooShort)?;
+            .map_err(|_| DecodeError::TooShort)?;
         if metadata_len.get() > 0 {
             node.metadata = serde_json::from_slice(cur.finish())?;
         }
@@ -671,12 +669,12 @@ mod tests {
     }
 
     #[test]
-    fn fork_header_take_underrun_is_data_too_short() {
+    fn fork_header_take_underrun_is_too_short() {
         let wire = [NodeType::VALUE.bits()];
         let mut cur = Cursor::new(&wire);
         assert!(matches!(
             cur.take::<ForkHeader>(),
-            Err(MantarayError::DataTooShort)
+            Err(DecodeError::TooShort)
         ));
     }
 
@@ -694,21 +692,21 @@ mod tests {
     #[test]
     fn decode_nil_input() {
         let result = Node::<ChunkRef>::try_from([].as_slice());
-        assert!(matches!(result, Err(MantarayError::DataTooShort)));
+        assert!(matches!(result, Err(DecodeError::TooShort)));
     }
 
     #[test]
     fn decode_too_short_for_header() {
         let data = vec![0u8; NodeHeader::SIZE - 1];
         let result = Node::<ChunkRef>::try_from(data.as_slice());
-        assert!(matches!(result, Err(MantarayError::DataTooShort)));
+        assert!(matches!(result, Err(DecodeError::TooShort)));
     }
 
     #[test]
     fn decode_invalid_version_hash() {
         let data = vec![0u8; NodeHeader::SIZE];
         let result = Node::<ChunkRef>::try_from(data.as_slice());
-        assert!(matches!(result, Err(MantarayError::InvalidVersionHash)));
+        assert!(matches!(result, Err(DecodeError::InvalidVersionHash)));
     }
 
     /// Test vector: valid manifest with correct metadata size (93 bytes).
@@ -786,7 +784,7 @@ mod tests {
         let result = Node::<ChunkRef>::try_from(data.as_slice());
         assert!(matches!(
             result,
-            Err(MantarayError::EntrySizeMismatch {
+            Err(DecodeError::RefSizeMismatch {
                 expected: 32,
                 actual: 0
             })
@@ -848,7 +846,7 @@ mod tests {
     fn decode_v01_header_only_64_bytes_returns_err() {
         let data = truncated_node_bytes(&VersionHash::V01, NodeHeader::SIZE);
         let result = Node::<ChunkRef>::try_from(data.as_slice());
-        assert!(matches!(result, Err(MantarayError::DataTooShort)));
+        assert!(matches!(result, Err(DecodeError::TooShort)));
     }
 
     /// Regression: same minimal 64-byte crash case for the v0.2 decoder.
@@ -856,7 +854,7 @@ mod tests {
     fn decode_v02_header_only_64_bytes_returns_err() {
         let data = truncated_node_bytes(&VersionHash::V02, NodeHeader::SIZE);
         let result = Node::<ChunkRef>::try_from(data.as_slice());
-        assert!(matches!(result, Err(MantarayError::DataTooShort)));
+        assert!(matches!(result, Err(DecodeError::TooShort)));
     }
 
     /// Regression: every length in 64..128 used to panic in `decode_v01`,
@@ -868,7 +866,7 @@ mod tests {
             let data = truncated_node_bytes(&VersionHash::V01, len);
             let result = Node::<ChunkRef>::try_from(data.as_slice());
             assert!(
-                matches!(result, Err(MantarayError::DataTooShort)),
+                matches!(result, Err(DecodeError::TooShort)),
                 "length {len} must yield DataTooShort"
             );
         }
@@ -882,7 +880,7 @@ mod tests {
             let data = truncated_node_bytes(&VersionHash::V02, len);
             let result = Node::<ChunkRef>::try_from(data.as_slice());
             assert!(
-                matches!(result, Err(MantarayError::DataTooShort)),
+                matches!(result, Err(DecodeError::TooShort)),
                 "length {len} must yield DataTooShort"
             );
         }
@@ -898,7 +896,7 @@ mod tests {
         let result = Node::<ChunkRef>::try_from(data.as_slice());
         assert!(matches!(
             result,
-            Err(MantarayError::InsufficientForkBytes { .. })
+            Err(DecodeError::InsufficientForkBytes { .. })
         ));
     }
 
@@ -910,7 +908,7 @@ mod tests {
         let result = Node::<ChunkRef>::try_from(data.as_slice());
         assert!(matches!(
             result,
-            Err(MantarayError::InsufficientForkBytes { .. })
+            Err(DecodeError::InsufficientForkBytes { .. })
         ));
     }
 
@@ -941,7 +939,7 @@ mod tests {
                 let data = truncated_encref_node_bytes(&version, len);
                 let result = Node::<EncryptedChunkRef>::try_from(data.as_slice());
                 assert!(
-                    matches!(result, Err(MantarayError::DataTooShort)),
+                    matches!(result, Err(DecodeError::TooShort)),
                     "encref {label} length {len} must yield DataTooShort"
                 );
             }
@@ -960,7 +958,7 @@ mod tests {
             data[NodeHeader::SIZE + 64] = 0x01;
             let result = Node::<EncryptedChunkRef>::try_from(data.as_slice());
             assert!(
-                matches!(result, Err(MantarayError::InsufficientForkBytes { .. })),
+                matches!(result, Err(DecodeError::InsufficientForkBytes { .. })),
                 "encref {label} missing fork body must yield InsufficientForkBytes"
             );
         }

--- a/crates/mantaray/src/error.rs
+++ b/crates/mantaray/src/error.rs
@@ -8,6 +8,61 @@ use nectar_primitives::error::PrimitivesError;
 /// Result type alias for mantaray operations.
 pub type Result<T> = std::result::Result<T, MantarayError>;
 
+/// Result type alias for node wire decoding.
+pub type DecodeResult<T> = std::result::Result<T, DecodeError>;
+
+/// Wire decode failures for a mantaray node chunk.
+///
+/// Reported to callers through [`MantarayError::Corrupt`], which pairs the
+/// failure with the address of the chunk the malformed bytes came from so a
+/// deep-load failure names the offending chunk. bee-spec node.md governs the
+/// layout these variants reject.
+#[non_exhaustive]
+#[derive(thiserror::Error, Debug)]
+pub enum DecodeError {
+    /// Data is too short to contain a header or a declared field.
+    #[error("data too short")]
+    TooShort,
+    /// Version hash does not match any known version.
+    #[error("invalid version hash")]
+    InvalidVersionHash,
+    /// Header-declared reference width does not match the entry type width.
+    #[error("reference size mismatch: expected {expected}, got {actual}")]
+    RefSizeMismatch {
+        /// Entry-type reference width in bytes.
+        expected: usize,
+        /// Width declared by the node header.
+        actual: usize,
+    },
+    /// Fork data has insufficient bytes.
+    #[error("insufficient fork bytes: expected {expected}, got {actual} at byte {byte_index}")]
+    InsufficientForkBytes {
+        /// Expected number of bytes.
+        expected: usize,
+        /// Actual number of bytes.
+        actual: usize,
+        /// Byte index of the fork.
+        byte_index: usize,
+    },
+    /// Prefix length is outside the 1..=30 wire range.
+    #[error("invalid prefix length: max {max}, got {actual}")]
+    InvalidPrefixLength {
+        /// Maximum allowed length.
+        max: usize,
+        /// Actual length.
+        actual: usize,
+    },
+    /// Entry bytes are not a valid reference of the expected width.
+    #[error("malformed entry of {size} bytes")]
+    Entry {
+        /// Entry reference width in bytes.
+        size: usize,
+    },
+    /// Fork metadata is not valid JSON.
+    #[error("invalid metadata")]
+    Metadata(#[from] serde_json::Error),
+}
+
 /// Errors that can occur during mantaray trie operations.
 #[non_exhaustive]
 #[derive(thiserror::Error, Debug)]
@@ -44,21 +99,13 @@ pub enum MantarayError {
         /// The prefix that was not found.
         prefix: String,
     },
-    /// Data is too short to contain a valid header.
-    #[error("data too short for header")]
-    DataTooShort,
-    /// Version hash does not match any known version.
-    #[error("invalid version hash")]
-    InvalidVersionHash,
-    /// Fork data has insufficient bytes.
-    #[error("insufficient fork bytes: expected {expected}, got {actual} at byte {byte_index}")]
-    InsufficientForkBytes {
-        /// Expected number of bytes.
-        expected: usize,
-        /// Actual number of bytes.
-        actual: usize,
-        /// Byte index of the fork.
-        byte_index: usize,
+    /// A chunk's bytes could not be decoded into a node.
+    #[error("corrupt chunk {address}: {source}")]
+    Corrupt {
+        /// Address of the chunk whose bytes failed to decode.
+        address: ChunkAddress,
+        /// The underlying wire decode failure.
+        source: DecodeError,
     },
     /// Reference is too long.
     #[error("reference too long: max {max}, got {actual}")]
@@ -74,14 +121,6 @@ pub enum MantarayError {
         /// Maximum allowed size.
         max: usize,
         /// Actual size.
-        actual: usize,
-    },
-    /// Prefix length is invalid.
-    #[error("invalid prefix length: max {max}, got {actual}")]
-    InvalidPrefixLength {
-        /// Maximum allowed length.
-        max: usize,
-        /// Actual length.
         actual: usize,
     },
     /// Metadata could not be parsed.
@@ -108,8 +147,8 @@ pub enum MantarayError {
 }
 
 /// A wire-level short read is a truncated node buffer.
-impl From<nectar_primitives::wire::Underrun> for MantarayError {
+impl From<nectar_primitives::wire::Underrun> for DecodeError {
     fn from(_: nectar_primitives::wire::Underrun) -> Self {
-        Self::DataTooShort
+        Self::TooShort
     }
 }

--- a/crates/mantaray/src/lib.rs
+++ b/crates/mantaray/src/lib.rs
@@ -85,7 +85,7 @@ pub(crate) use constants::*;
 
 // Re-export public types.
 pub use entry::Entry;
-pub use error::{MantarayError, Result};
+pub use error::{DecodeError, DecodeResult, MantarayError, Result};
 pub use manifest::{Manifest, ManifestIter};
 pub use manifest_ref::ManifestRef;
 pub use node::{Fork, Node, NodeType, Prefix};

--- a/crates/mantaray/src/node.rs
+++ b/crates/mantaray/src/node.rs
@@ -1351,6 +1351,31 @@ mod tests {
         }
     }
 
+    /// A chunk whose bytes fail to decode surfaces as `Corrupt`, naming the
+    /// address the malformed bytes came from so a deep-load failure is
+    /// diagnosable rather than an anonymous wire error.
+    #[test]
+    fn load_corrupt_chunk_reports_address() {
+        // Fewer bytes than the obfuscation-key header cannot decode: the
+        // wire failure is `TooShort`, wrapped with the chunk's address.
+        let chunk = ContentChunk::<{ DEFAULT_BODY_SIZE }>::new(Bytes::from(vec![1u8; 8])).unwrap();
+        let address = *chunk.address();
+
+        let store = MemoryStore::<{ DEFAULT_BODY_SIZE }>::new();
+        block_on(store.put(chunk.into())).unwrap();
+
+        let mut node: Node = Node::from_reference(address);
+        let err = block_on(node.load(&store)).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                MantarayError::Corrupt { address: a, source: DecodeError::TooShort }
+                    if a == address
+            ),
+            "expected Corrupt naming the chunk address, got {err:?}"
+        );
+    }
+
     #[test]
     fn add_and_lookup_with_load_save_a() {
         run_add_and_lookup_with_load_save(&test_case_data()[0].items);

--- a/crates/mantaray/src/node.rs
+++ b/crates/mantaray/src/node.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::error::{MantarayError, Result};
+use crate::error::{DecodeError, DecodeResult, MantarayError, Result};
 use crate::obfuscation::ObfuscationKey;
 use crate::{PATH_SEPARATOR, PREFIX_MAX_LEN};
 use bytes::Bytes;
@@ -83,10 +83,10 @@ impl Prefix {
     /// relies on a caller-side guard. Bytes past `len` are re-zeroed to keep
     /// the padding canonical for equality and re-encoding.
     #[inline]
-    pub fn from_wire(padded: &[u8; PREFIX_MAX_LEN], len: u8) -> Result<Self> {
+    pub fn from_wire(padded: &[u8; PREFIX_MAX_LEN], len: u8) -> DecodeResult<Self> {
         let len_usize = usize::from(len);
         if len == 0 || len_usize > PREFIX_MAX_LEN {
-            return Err(MantarayError::InvalidPrefixLength {
+            return Err(DecodeError::InvalidPrefixLength {
                 max: PREFIX_MAX_LEN,
                 actual: len_usize,
             });
@@ -121,7 +121,7 @@ impl Prefix {
 /// block. The length byte never leaves this impl; callers take a validated
 /// `Prefix` in one step.
 impl FromCursor for Prefix {
-    type Error = MantarayError;
+    type Error = DecodeError;
 
     fn take_from(cur: &mut Cursor<'_>) -> std::result::Result<Self, Self::Error> {
         let len = cur.take::<u8>()?;
@@ -365,7 +365,8 @@ impl<R: Reference> Node<R> {
             .map_err(|e| MantarayError::StoreGet {
                 source: std::sync::Arc::new(e),
             })?;
-        let mut loaded = Self::try_from(chunk.data().as_ref())?;
+        let mut loaded = Self::try_from(chunk.data().as_ref())
+            .map_err(|source| MantarayError::Corrupt { address, source })?;
         loaded.reference = Some(address);
         // Preserve fields that live in the parent's fork data, not in this node's chunk:
         // node_type flags and metadata key-value pairs.
@@ -1199,7 +1200,7 @@ mod tests {
         let err = Prefix::from_wire(&padded, 0).unwrap_err();
         assert!(matches!(
             err,
-            MantarayError::InvalidPrefixLength { max, actual } if max == PREFIX_MAX_LEN && actual == 0
+            DecodeError::InvalidPrefixLength { max, actual } if max == PREFIX_MAX_LEN && actual == 0
         ));
     }
 
@@ -1211,7 +1212,7 @@ mod tests {
         let err = Prefix::from_wire(&padded, over).unwrap_err();
         assert!(matches!(
             err,
-            MantarayError::InvalidPrefixLength { max, actual }
+            DecodeError::InvalidPrefixLength { max, actual }
                 if max == PREFIX_MAX_LEN && actual == usize::from(over)
         ));
     }
@@ -1255,17 +1256,17 @@ mod tests {
         let mut cur = Cursor::new(&wire);
         assert!(matches!(
             cur.take::<Prefix>().unwrap_err(),
-            MantarayError::InvalidPrefixLength { actual: 0, .. }
+            DecodeError::InvalidPrefixLength { actual: 0, .. }
         ));
     }
 
     #[test]
-    fn prefix_take_underrun_is_data_too_short() {
+    fn prefix_take_underrun_is_too_short() {
         let wire = [3u8, b'a'];
         let mut cur = Cursor::new(&wire);
         assert!(matches!(
             cur.take::<Prefix>().unwrap_err(),
-            MantarayError::DataTooShort
+            DecodeError::TooShort
         ));
     }
 


### PR DESCRIPTION
## What

Splits the node wire-decode failure modes out of `MantarayError` into a dedicated `DecodeError`, and adds `MantarayError::Corrupt { address, source: DecodeError }` so a deep-load failure names the offending chunk.

`DecodeError` (`#[non_exhaustive]`) carries `TooShort`, `InvalidVersionHash`, `RefSizeMismatch`, `InsufficientForkBytes`, `InvalidPrefixLength`, `Entry`, and `Metadata`. The node decoder (`TryFrom<&[u8]> for Node`, plus `decode_node`/`parse_header`/`decode_body`/`parse_fork`/`parse_fork_body`/`decode_empty_terminal`/`insufficient_fork`) and `Prefix::from_wire` now return `DecodeError`/`DecodeResult` instead of `MantarayError`/`Result`.

The provenance is attached at the sole non-test decode seam, `Node::load` in `node.rs`, which maps the `try_from` error into `MantarayError::Corrupt` with the known chunk address. `MantarayError` keeps its store, metadata, path and entry-seam variants (the former `DataTooShort`, `InvalidVersionHash`, `InsufficientForkBytes` and `InvalidPrefixLength` variants moved into `DecodeError`).

`DecodeError`/`DecodeResult` are exported from `lib.rs`. Codec and `Prefix::from_wire` decode tests were updated to match against `DecodeError` variants, and a new test covers `Corrupt` address provenance on deep-load.

Files: `crates/mantaray/src/{error.rs,codec.rs,node.rs,lib.rs}`.

Closes #171

## Why

Before this change, a caller of `Node::load` who hit a malformed chunk got a bare wire-parse error with no indication of which chunk failed. Folding the node wire-decode variants into a dedicated `DecodeError` and wrapping it with the chunk address at the `Node::load` seam means a deep-load failure is diagnosable rather than anonymous, while `MantarayError` stays focused on the store/metadata/path/entry seams it actually owns.

## Testing

- `cargo test --workspace --all-features`: all crates green, including `nectar_mantaray` (covering every decode-error-variant test and the new `load_corrupt_chunk_reports_address` provenance test).
- `cargo test --doc --workspace --all-features`: all doctests pass.

This is a stacked PR targeting `s157/40-nodeentry-to-reference`, not `main`.

## AI Assistance

AI Assistance: Claude (Anthropic) used for implementation, review, and testing of this change, including the `DecodeError` split, the `Node::load` provenance wrapping, and the associated test coverage.
