### PR TITLE
refactor(mantaray)!: type the entry seam and remove byte round-trips

### DIFF
--- a/crates/mantaray/src/entry.rs
+++ b/crates/mantaray/src/entry.rs
@@ -5,8 +5,8 @@ use std::collections::BTreeMap;
 use nectar_primitives::chunk::{ChunkAddress, Reference};
 use nectar_primitives::file::EntryRef;
 
+use crate::metadata;
 use crate::node::Node;
-use crate::{MantarayError, Result, metadata};
 
 /// A manifest entry: a path, typed reference, and optional metadata.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -87,31 +87,20 @@ impl Entry {
 
     /// Reconstruct an `Entry` from a trie node and its accumulated path.
     ///
-    /// Converts the typed `Option<&R>` entry to an `Option<EntryRef>` via
-    /// serialization, keeping `Entry` non-generic for the public API.
-    pub(crate) fn from_node<R: Reference>(path: &[u8], node: &Node<R>) -> Result<Self> {
-        let reference = match node.entry() {
-            Some(e) => {
-                let bytes = e.to_bytes();
-                Some(EntryRef::try_from_bytes(&bytes).map_err(|_| {
-                    MantarayError::EntrySizeMismatch {
-                        expected: R::SIZE,
-                        actual: bytes.len(),
-                    }
-                })?)
-            }
-            None => None,
-        };
+    /// Flows the node's typed reference straight into an [`EntryRef`], keeping
+    /// `Entry` non-generic for the public API without a wire round-trip.
+    pub(crate) fn from_node<R: Reference>(path: &[u8], node: &Node<R>) -> Self {
+        let reference = node.entry().cloned().map(Reference::into_entry_ref);
         let metadata = if node.metadata().is_empty() {
             BTreeMap::new()
         } else {
             node.metadata().clone()
         };
-        Ok(Self {
+        Self {
             path: path.to_vec(),
             reference,
             metadata,
-        })
+        }
     }
 }
 

--- a/crates/mantaray/src/error.rs
+++ b/crates/mantaray/src/error.rs
@@ -90,6 +90,9 @@ pub enum MantarayError {
         /// Actual size.
         actual: usize,
     },
+    /// Entry reference kind does not match the manifest's reference type.
+    #[error(transparent)]
+    WrongRefKind(#[from] nectar_primitives::chunk::WrongRefKind),
     /// Path cannot be empty for this operation.
     #[error("empty path")]
     EmptyPath,

--- a/crates/mantaray/src/manifest.rs
+++ b/crates/mantaray/src/manifest.rs
@@ -115,18 +115,7 @@ impl<S: ChunkGet<BS>, R: Reference + MaybeSend, const BS: usize> Manifest<S, R, 
 
     /// Add a path with a pre-built [`Entry`] (metadata + reference).
     pub async fn add_entry(&mut self, path: &str, entry: Entry) -> Result<()> {
-        let e = match entry.reference {
-            Some(r) => {
-                let bytes = Vec::from(&r);
-                let reference =
-                    R::from_wire_bytes(&bytes).ok_or(MantarayError::EntrySizeMismatch {
-                        expected: R::SIZE,
-                        actual: bytes.len(),
-                    })?;
-                Some(reference)
-            }
-            None => None,
-        };
+        let e = entry.reference.map(R::from_entry_ref).transpose()?;
         self.trie
             .add::<S, BS>(path.as_bytes(), e, entry.metadata, &self.store)
             .await
@@ -150,7 +139,7 @@ impl<S: ChunkGet<BS>, R: Reference + MaybeSend, const BS: usize> Manifest<S, R, 
             return Err(MantarayError::NotValueType);
         }
 
-        Entry::from_node(path.as_bytes(), node)
+        Ok(Entry::from_node(path.as_bytes(), node))
     }
 
     /// Test whether the manifest contains a prefix.
@@ -225,7 +214,7 @@ impl<S: ChunkGet<BS>, R: Reference + MaybeSend, const BS: usize> Manifest<S, R, 
             let mut pending: Vec<(Vec<u8>, Node<R>)> = Vec::new();
             for (path, node) in &frontier {
                 if node.is_value() {
-                    out.push(Entry::from_node(path, node)?);
+                    out.push(Entry::from_node(path, node));
                 }
                 for fork in node.forks.values() {
                     let mut child_path = path.clone();
@@ -450,10 +439,7 @@ impl<'a, S: ChunkGet<BS>, R: Reference, const BS: usize> ManifestIter<'a, S, R, 
 
                 let keys: Vec<u8> = self.trie.forks.keys().copied().collect();
                 let entry = if self.trie.is_value() {
-                    match Entry::from_node(&[], self.trie) {
-                        Ok(e) => Some(e),
-                        Err(e) => return Some(Err(e)),
-                    }
+                    Some(Entry::from_node(&[], self.trie))
                 } else {
                     None
                 };
@@ -523,10 +509,7 @@ impl<'a, S: ChunkGet<BS>, R: Reference, const BS: usize> ManifestIter<'a, S, R, 
             });
 
             if is_value {
-                match Entry::from_node(&self.path_buf, child_ref) {
-                    Ok(e) => return Some(Ok(e)),
-                    Err(e) => return Some(Err(e)),
-                }
+                return Some(Ok(Entry::from_node(&self.path_buf, child_ref)));
             }
         }
     }

--- a/crates/primitives/src/chunk/encryption/reference.rs
+++ b/crates/primitives/src/chunk/encryption/reference.rs
@@ -1,7 +1,8 @@
 //! Chunk reference types for encrypted chunks.
 
-use crate::chunk::reference::{RefKind, Reference, sealed};
+use crate::chunk::reference::{RefKind, Reference, WrongRefKind, sealed};
 use crate::chunk::{ChunkAddress, ChunkRef};
+use crate::file::EntryRef;
 use crate::wire::{Cursor, Underrun};
 
 use super::error::EncryptionError;
@@ -77,6 +78,20 @@ impl Reference for EncryptedChunkRef {
 
     fn address(&self) -> &ChunkAddress {
         self.reference.address()
+    }
+
+    fn into_entry_ref(self) -> EntryRef {
+        EntryRef::Encrypted(self)
+    }
+
+    fn from_entry_ref(entry: EntryRef) -> Result<Self, WrongRefKind> {
+        match entry {
+            EntryRef::Encrypted(enc) => Ok(enc),
+            EntryRef::Plain(_) => Err(WrongRefKind {
+                expected: Self::KIND,
+                got: RefKind::Unencrypted,
+            }),
+        }
     }
 
     fn write_to(&self, out: &mut Vec<u8>) {

--- a/crates/primitives/src/chunk/mod.rs
+++ b/crates/primitives/src/chunk/mod.rs
@@ -35,7 +35,7 @@ pub mod wasm;
 pub use traits::{BmtChunk, Chunk, ChunkAddress, ChunkHeader, ChunkMetadata, ChunkSerialization};
 
 // Re-export the reference types
-pub use reference::{ChunkRef, RefKind, Reference};
+pub use reference::{ChunkRef, RefKind, Reference, WrongRefKind};
 
 // Re-export the type system
 pub use any_chunk::AnyChunk;

--- a/crates/primitives/src/chunk/reference.rs
+++ b/crates/primitives/src/chunk/reference.rs
@@ -8,10 +8,24 @@
 use std::mem::size_of;
 
 use crate::chunk::ChunkAddress;
+use crate::file::EntryRef;
 use crate::wire::{Cursor, Underrun};
 
 pub(crate) mod sealed {
     pub trait Sealed {}
+}
+
+/// An [`EntryRef`] did not carry the width its target reference type requires.
+///
+/// Raised where a manifest keyed by one [`RefKind`] is handed an entry of the
+/// other; the typed replacement for a laundered byte-length mismatch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("wrong reference kind: expected {expected:?}, got {got:?}")]
+pub struct WrongRefKind {
+    /// The reference kind the target type requires.
+    pub expected: RefKind,
+    /// The reference kind the entry actually carried.
+    pub got: RefKind,
 }
 
 /// The two reference widths: a plain address, or an address plus a key.
@@ -50,6 +64,14 @@ pub trait Reference: sealed::Sealed + Sized + Clone + Eq + core::fmt::Debug + 's
 
     /// The chunk address this reference names.
     fn address(&self) -> &ChunkAddress;
+
+    /// This reference as a width-typed [`EntryRef`], carrying its address (and
+    /// key) without a wire round-trip.
+    fn into_entry_ref(self) -> EntryRef;
+
+    /// Recover a typed reference from an [`EntryRef`], or report the kind found
+    /// when it is not [`KIND`](Self::KIND).
+    fn from_entry_ref(entry: EntryRef) -> Result<Self, WrongRefKind>;
 
     /// Append this reference's [`SIZE`](Self::SIZE) wire bytes to `out`.
     fn write_to(&self, out: &mut Vec<u8>);
@@ -114,6 +136,20 @@ impl Reference for ChunkRef {
         &self.0
     }
 
+    fn into_entry_ref(self) -> EntryRef {
+        EntryRef::Plain(self.into_address())
+    }
+
+    fn from_entry_ref(entry: EntryRef) -> Result<Self, WrongRefKind> {
+        match entry {
+            EntryRef::Plain(address) => Ok(Self::new(address)),
+            EntryRef::Encrypted(_) => Err(WrongRefKind {
+                expected: Self::KIND,
+                got: RefKind::Encrypted,
+            }),
+        }
+    }
+
     fn write_to(&self, out: &mut Vec<u8>) {
         out.extend_from_slice(self.0.as_bytes());
     }
@@ -143,7 +179,7 @@ impl<'a> arbitrary::Arbitrary<'a> for ChunkRef {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::chunk::encryption::EncryptedChunkRef;
+    use crate::chunk::encryption::{EncryptedChunkRef, EncryptionKey};
     use alloy_primitives::B256;
 
     #[test]
@@ -163,6 +199,47 @@ mod tests {
         );
         assert_eq!(EncryptedChunkRef::KIND, RefKind::Encrypted);
         assert_eq!(RefKind::Encrypted.size(), EncryptedChunkRef::SIZE);
+    }
+
+    #[test]
+    fn entry_ref_round_trips_plain() {
+        let addr = ChunkAddress::from(B256::repeat_byte(0x11));
+        let reference = ChunkRef::new(addr);
+        let entry = reference.into_entry_ref();
+        assert_eq!(entry, EntryRef::Plain(addr));
+        assert_eq!(ChunkRef::from_entry_ref(entry).unwrap(), reference);
+    }
+
+    #[test]
+    fn entry_ref_round_trips_encrypted() {
+        let addr = ChunkAddress::from(B256::repeat_byte(0x22));
+        let reference = EncryptedChunkRef::new(addr, EncryptionKey::from([0x33; 32]));
+        let entry = reference.clone().into_entry_ref();
+        assert_eq!(entry, EntryRef::Encrypted(reference.clone()));
+        assert_eq!(EncryptedChunkRef::from_entry_ref(entry).unwrap(), reference);
+    }
+
+    #[test]
+    fn from_entry_ref_rejects_wrong_kind() {
+        let addr = ChunkAddress::from(B256::repeat_byte(0x44));
+        let plain = ChunkRef::new(addr).into_entry_ref();
+        let encrypted =
+            EncryptedChunkRef::new(addr, EncryptionKey::from([0x55; 32])).into_entry_ref();
+
+        assert_eq!(
+            EncryptedChunkRef::from_entry_ref(plain).unwrap_err(),
+            WrongRefKind {
+                expected: RefKind::Encrypted,
+                got: RefKind::Unencrypted,
+            }
+        );
+        assert_eq!(
+            ChunkRef::from_entry_ref(encrypted).unwrap_err(),
+            WrongRefKind {
+                expected: RefKind::Unencrypted,
+                got: RefKind::Encrypted,
+            }
+        );
     }
 
     #[test]

--- a/crates/primitives/src/file/entry_ref.rs
+++ b/crates/primitives/src/file/entry_ref.rs
@@ -1,7 +1,6 @@
 //! Unified file entry reference type.
 
 use crate::chunk::ChunkAddress;
-#[cfg(feature = "encryption")]
 use crate::chunk::encryption::EncryptedChunkRef;
 
 use super::error::FileError;
@@ -12,7 +11,6 @@ pub enum EntryRef {
     /// Plain 32-byte chunk address.
     Plain(ChunkAddress),
     /// Encrypted 64-byte reference (address + decryption key).
-    #[cfg(feature = "encryption")]
     Encrypted(EncryptedChunkRef),
 }
 
@@ -30,7 +28,6 @@ impl EntryRef {
                 let addr_bytes: [u8; 32] = bytes.try_into().expect("length checked");
                 Ok(Self::Plain(ChunkAddress::from(addr_bytes)))
             }
-            #[cfg(feature = "encryption")]
             64 => {
                 let enc_ref = EncryptedChunkRef::try_from(bytes)
                     .map_err(|_| FileError::InvalidEntryRef { len: bytes.len() })?;
@@ -44,7 +41,6 @@ impl EntryRef {
     pub const fn address(&self) -> &ChunkAddress {
         match self {
             Self::Plain(addr) => addr,
-            #[cfg(feature = "encryption")]
             Self::Encrypted(enc) => enc.address(),
         }
     }
@@ -56,7 +52,6 @@ impl From<ChunkAddress> for EntryRef {
     }
 }
 
-#[cfg(feature = "encryption")]
 impl From<EncryptedChunkRef> for EntryRef {
     fn from(enc: EncryptedChunkRef) -> Self {
         Self::Encrypted(enc)
@@ -67,7 +62,6 @@ impl From<&EntryRef> for Vec<u8> {
     fn from(entry_ref: &EntryRef) -> Self {
         match entry_ref {
             EntryRef::Plain(addr) => addr.as_bytes().to_vec(),
-            #[cfg(feature = "encryption")]
             EntryRef::Encrypted(enc) => Self::from(enc),
         }
     }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -116,6 +116,7 @@ pub use chunk::{
     Reference,
     SingleOwnerChunk,
     StandardChunkSet,
+    WrongRefKind,
 };
 
 /// Default BMT hasher.


### PR DESCRIPTION
## What

Types the mantaray entry seam end to end: `Entry::from_node` no longer round-trips through bytes (typed value to `to_bytes()` to `EntryRef::try_from_bytes`); the `Reference` types (`ChunkRef`/`EncryptedChunkRef`) flow directly, and entry-kind mismatches surface as `WrongRefKind` through the decode error path with provenance intact.

Closes #167

## Why

The byte round-trip inside one function was the last place the entry seam erased its own types; the epic requires the width and kind facts to live in the type, not in re-parsed bytes.

## Testing

Independently gated: fmt and clippy clean on the diff; full workspace test suite green on the branch; the gate additionally verified by grep that no `to_bytes`/`try_from_bytes` round-trip remains on the entry path and that wire behaviour is byte-identical. The gate's earlier hard fail was the train-wide bench/example lint debt, since resolved by the `fuzz/8` lint-exemption car this branch now stacks on.

## AI Assistance

Implemented and red-teamed with Claude Opus; assembled and filed by Claude Fable under maintainer direction.
