### PR TITLE
refactor(mantaray)!: restrict the raw node encode surface

### DIFF
--- a/crates/mantaray/Cargo.toml
+++ b/crates/mantaray/Cargo.toml
@@ -35,9 +35,12 @@ nectar-primitives = { workspace = true, features = ["arbitrary"] }
 rand.workspace = true
 serde_json.workspace = true
 
+# The encode/decode benches drive the raw node codec, so the bench target
+# needs the hazmat surface: `cargo bench --features hazmat`.
 [[bench]]
 name = "mantaray_bench"
 harness = false
+required-features = ["hazmat"]
 
 [features]
 default = [ "std" ]
@@ -58,6 +61,8 @@ arbitrary = [
 	"std",
 ]
 encryption = [ "nectar-primitives/encryption" ]
+# Raw node internals (the `hazmat` module) for fuzz harnesses and benches.
+hazmat = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/mantaray/benches/mantaray_bench.rs
+++ b/crates/mantaray/benches/mantaray_bench.rs
@@ -13,7 +13,7 @@
 )]
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use futures::executor::block_on;
-use nectar_mantaray::hazmat::Node;
+use nectar_mantaray::hazmat;
 use nectar_mantaray::{MemoryStore, PlainManifest};
 use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::ChunkAddress;
@@ -187,7 +187,7 @@ fn bench_encode(c: &mut Criterion) {
     let (n, _) = m2.into_parts();
 
     group.bench_function("spa_trie", |b| {
-        b.iter(|| Vec::<u8>::try_from(&n).unwrap());
+        b.iter(|| hazmat::encode(&n).unwrap());
     });
 
     group.finish();
@@ -203,10 +203,10 @@ fn bench_decode(c: &mut Criterion) {
     let mut m2 = PlainManifest::open(root_ref, store);
     block_on(m2.walk(&mut |_, _| Ok(()))).unwrap();
     let (n, _) = m2.into_parts();
-    let data = Vec::<u8>::try_from(&n).unwrap();
+    let data = hazmat::encode(&n).unwrap();
 
     group.bench_function("spa_trie", |b| {
-        b.iter(|| Node::<nectar_primitives::chunk::ChunkRef>::try_from(data.as_slice()).unwrap());
+        b.iter(|| hazmat::decode::<nectar_primitives::chunk::ChunkRef>(data.as_slice()).unwrap());
     });
 
     group.finish();

--- a/crates/mantaray/benches/mantaray_bench.rs
+++ b/crates/mantaray/benches/mantaray_bench.rs
@@ -13,7 +13,7 @@
 )]
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use futures::executor::block_on;
-use nectar_mantaray::node::Node;
+use nectar_mantaray::hazmat::Node;
 use nectar_mantaray::{MemoryStore, PlainManifest};
 use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::ChunkAddress;

--- a/crates/mantaray/src/codec.rs
+++ b/crates/mantaray/src/codec.rs
@@ -137,12 +137,35 @@ fn xor_in_place(data: &mut [u8], key: &[u8]) {
     }
 }
 
-impl<R: Reference> TryFrom<&Node<R>> for Vec<u8> {
-    type Error = MantarayError;
-
+impl<R: Reference> Node<R> {
+    /// Encode this node into its wire image.
+    ///
+    /// Crate-internal: the only public path to node bytes is
+    /// [`Manifest::save`](crate::Manifest::save), so callers cannot
+    /// serialise nodes directly.
     #[inline]
-    fn try_from(node: &Node<R>) -> Result<Self> {
-        encode_node(node)
+    pub(crate) fn encode(&self) -> Result<Vec<u8>> {
+        encode_node(self)
+    }
+
+    /// Decode a wire image into a node.
+    ///
+    /// Crate-internal: nodes are decoded on load from a chunk store.
+    /// The obfuscation key is the header's first field and is stored in the
+    /// clear; every later byte is XOR-encrypted under it.
+    pub(crate) fn decode(value: &[u8]) -> DecodeResult<Self> {
+        let mut data = value.to_vec();
+
+        let (key, body) = data
+            .split_first_chunk_mut::<{ ObfuscationKey::SIZE }>()
+            .ok_or(DecodeError::TooShort)?;
+        let obfuscation_key = ObfuscationKey::from(*key);
+        xor_in_place(body, obfuscation_key.as_bytes());
+
+        let mut node = decode_node::<R>(&data)?;
+        node.obfuscation_key = obfuscation_key;
+        node.loaded = true;
+        Ok(node)
     }
 }
 
@@ -192,27 +215,6 @@ fn encode_node<R: Reference>(node: &Node<R>) -> Result<Vec<u8>> {
     xor_in_place(body, obfuscation_key);
 
     Ok(data)
-}
-
-impl<R: Reference> TryFrom<&[u8]> for Node<R> {
-    type Error = DecodeError;
-
-    fn try_from(value: &[u8]) -> DecodeResult<Self> {
-        let mut data = value.to_vec();
-
-        // The obfuscation key is the header's first field and is stored in the
-        // clear; every later byte is XOR-encrypted under it.
-        let (key, body) = data
-            .split_first_chunk_mut::<{ ObfuscationKey::SIZE }>()
-            .ok_or(DecodeError::TooShort)?;
-        let obfuscation_key = ObfuscationKey::from(*key);
-        xor_in_place(body, obfuscation_key.as_bytes());
-
-        let mut node = decode_node::<R>(&data)?;
-        node.obfuscation_key = obfuscation_key;
-        node.loaded = true;
-        Ok(node)
-    }
 }
 
 // ┌─────────────────────────── HAZMAT ───────────────────────────┐
@@ -610,7 +612,7 @@ mod tests {
     #[test]
     fn decode_v01() {
         let data = hex::decode(ENCODED_V01).unwrap();
-        let n = Node::<ChunkRef>::try_from(data.as_slice()).unwrap();
+        let n = Node::<ChunkRef>::decode(data.as_slice()).unwrap();
 
         let mut expect_bytes = hex::decode(&ENCODED_V01[128..192]).unwrap();
         xor_in_place(&mut expect_bytes, n.obfuscation_key().as_bytes());
@@ -633,7 +635,7 @@ mod tests {
     #[test]
     fn decode_v02() {
         let data = hex::decode(ENCODED_V02).unwrap();
-        let n = Node::<ChunkRef>::try_from(data.as_slice()).unwrap();
+        let n = Node::<ChunkRef>::decode(data.as_slice()).unwrap();
 
         let mut expect_bytes = hex::decode(&ENCODED_V02[128..192]).unwrap();
         xor_in_place(&mut expect_bytes, n.obfuscation_key().as_bytes());
@@ -692,21 +694,21 @@ mod tests {
 
     #[test]
     fn decode_nil_input() {
-        let result = Node::<ChunkRef>::try_from([].as_slice());
+        let result = Node::<ChunkRef>::decode([].as_slice());
         assert!(matches!(result, Err(DecodeError::TooShort)));
     }
 
     #[test]
     fn decode_too_short_for_header() {
         let data = vec![0u8; NodeHeader::SIZE - 1];
-        let result = Node::<ChunkRef>::try_from(data.as_slice());
+        let result = Node::<ChunkRef>::decode(data.as_slice());
         assert!(matches!(result, Err(DecodeError::TooShort)));
     }
 
     #[test]
     fn decode_invalid_version_hash() {
         let data = vec![0u8; NodeHeader::SIZE];
-        let result = Node::<ChunkRef>::try_from(data.as_slice());
+        let result = Node::<ChunkRef>::decode(data.as_slice());
         assert!(matches!(result, Err(DecodeError::InvalidVersionHash)));
     }
 
@@ -718,7 +720,7 @@ mod tests {
         let data = hex::decode(
             "00000000000000000000000000000000000000000000000000000000000000005768b3b6a7db56d21d1abff40d41cebfc83448fed8d7e9b06ec0d3b073f28f200000000000000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000016012f0000000000000000000000000000000000000000000000000000000000e87f95c3d081c4fede769b6c69e27b435e525cbd25c6715c607e7c531e329639005d7b22776562736974652d696e6465782d646f63756d656e74223a2233356561656538316262363338303436393965633637316265323736326465626665346662643330636461646139303232393239646131613965366134366436227d0a"
         ).unwrap();
-        assert!(Node::<ChunkRef>::try_from(data.as_slice()).is_ok());
+        assert!(Node::<ChunkRef>::decode(data.as_slice()).is_ok());
     }
 
     /// Test vector: metadata size field says 89 but actual content needs 93.
@@ -728,7 +730,7 @@ mod tests {
         let data = hex::decode(
             "00000000000000000000000000000000000000000000000000000000000000005768b3b6a7db56d21d1abff40d41cebfc83448fed8d7e9b06ec0d3b073f28f200000000000000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000016012f0000000000000000000000000000000000000000000000000000000000e87f95c3d081c4fede769b6c69e27b435e525cbd25c6715c607e7c531e32963900597b22776562736974652d696e6465782d646f63756d656e74223a2233356561656538316262363338303436393965633637316265323736326465626665346662643330636461646139303232393239646131613965366134366436227d0a"
         ).unwrap();
-        assert!(Node::<ChunkRef>::try_from(data.as_slice()).is_err());
+        assert!(Node::<ChunkRef>::decode(data.as_slice()).is_err());
     }
 
     /// Test vector: metadata size field says 95 but actual content is 93.
@@ -738,7 +740,7 @@ mod tests {
         let data = hex::decode(
             "00000000000000000000000000000000000000000000000000000000000000005768b3b6a7db56d21d1abff40d41cebfc83448fed8d7e9b06ec0d3b073f28f200000000000000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000016012f0000000000000000000000000000000000000000000000000000000000e87f95c3d081c4fede769b6c69e27b435e525cbd25c6715c607e7c531e329639005f7b22776562736974652d696e6465782d646f63756d656e74223a2233356561656538316262363338303436393965633637316265323736326465626665346662643330636461646139303232393239646131613965366134366436227d0a"
         ).unwrap();
-        assert!(Node::<ChunkRef>::try_from(data.as_slice()).is_err());
+        assert!(Node::<ChunkRef>::decode(data.as_slice()).is_err());
     }
 
     /// Test vector: metadata size field says 96 but actual content is 93.
@@ -748,7 +750,7 @@ mod tests {
         let data = hex::decode(
             "00000000000000000000000000000000000000000000000000000000000000005768b3b6a7db56d21d1abff40d41cebfc83448fed8d7e9b06ec0d3b073f28f200000000000000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000016012f0000000000000000000000000000000000000000000000000000000000e87f95c3d081c4fede769b6c69e27b435e525cbd25c6715c607e7c531e32963900607b22776562736974652d696e6465782d646f63756d656e74223a2233356561656538316262363338303436393965633637316265323736326465626665346662643330636461646139303232393239646131613965366134366436227d0a"
         ).unwrap();
-        assert!(Node::<ChunkRef>::try_from(data.as_slice()).is_err());
+        assert!(Node::<ChunkRef>::decode(data.as_slice()).is_err());
     }
 
     /// BEE-WORKAROUND(bee#5483): bee occasionally emits nodes with
@@ -764,7 +766,7 @@ mod tests {
             .copy_from_slice(VersionHash::V02.as_bytes());
         // ref_size at offset 63 is left as 0; index (offset 64..96) is all zero.
 
-        let n = Node::<ChunkRef>::try_from(data.as_slice())
+        let n = Node::<ChunkRef>::decode(data.as_slice())
             .expect("ref_size=0 with empty forks should decode as terminal node");
         assert!(n.entry().is_none());
         assert!(n.forks().is_empty());
@@ -782,7 +784,7 @@ mod tests {
         // ref_size = 0 (offset 63 already zero), but flip one bit in the index.
         data[NodeHeader::SIZE] = 0x01;
 
-        let result = Node::<ChunkRef>::try_from(data.as_slice());
+        let result = Node::<ChunkRef>::decode(data.as_slice());
         assert!(matches!(
             result,
             Err(DecodeError::RefSizeMismatch {
@@ -800,7 +802,7 @@ mod tests {
         data[ObfuscationKey::SIZE..ObfuscationKey::SIZE + VersionHash::SIZE]
             .copy_from_slice(VersionHash::V01.as_bytes());
 
-        let n = Node::<ChunkRef>::try_from(data.as_slice())
+        let n = Node::<ChunkRef>::decode(data.as_slice())
             .expect("v0.1 ref_size=0 with empty forks should decode as terminal node");
         assert!(n.entry().is_none());
         assert!(n.forks().is_empty());
@@ -813,7 +815,7 @@ mod tests {
     #[test]
     fn encoder_never_emits_ref_size_zero_for_entryless_node() {
         let n = Node::<ChunkRef>::new_unencrypted();
-        let encoded = Vec::<u8>::try_from(&n).unwrap();
+        let encoded = n.encode().unwrap();
 
         // Decrypt (obfuscation key is all-zero for `new_unencrypted`, so XOR
         // is a no-op, but go through the motions for clarity).
@@ -846,7 +848,7 @@ mod tests {
     #[test]
     fn decode_v01_header_only_64_bytes_returns_err() {
         let data = truncated_node_bytes(&VersionHash::V01, NodeHeader::SIZE);
-        let result = Node::<ChunkRef>::try_from(data.as_slice());
+        let result = Node::<ChunkRef>::decode(data.as_slice());
         assert!(matches!(result, Err(DecodeError::TooShort)));
     }
 
@@ -854,7 +856,7 @@ mod tests {
     #[test]
     fn decode_v02_header_only_64_bytes_returns_err() {
         let data = truncated_node_bytes(&VersionHash::V02, NodeHeader::SIZE);
-        let result = Node::<ChunkRef>::try_from(data.as_slice());
+        let result = Node::<ChunkRef>::decode(data.as_slice());
         assert!(matches!(result, Err(DecodeError::TooShort)));
     }
 
@@ -865,7 +867,7 @@ mod tests {
     fn decode_v01_truncated_lengths_return_err() {
         for len in NodeHeader::SIZE..NodeHeader::SIZE + 32 + 32 {
             let data = truncated_node_bytes(&VersionHash::V01, len);
-            let result = Node::<ChunkRef>::try_from(data.as_slice());
+            let result = Node::<ChunkRef>::decode(data.as_slice());
             assert!(
                 matches!(result, Err(DecodeError::TooShort)),
                 "length {len} must yield TooShort"
@@ -879,7 +881,7 @@ mod tests {
     fn decode_v02_truncated_lengths_return_err() {
         for len in NodeHeader::SIZE..NodeHeader::SIZE + 32 + 32 {
             let data = truncated_node_bytes(&VersionHash::V02, len);
-            let result = Node::<ChunkRef>::try_from(data.as_slice());
+            let result = Node::<ChunkRef>::decode(data.as_slice());
             assert!(
                 matches!(result, Err(DecodeError::TooShort)),
                 "length {len} must yield TooShort"
@@ -894,7 +896,7 @@ mod tests {
         let mut data = truncated_node_bytes(&VersionHash::V01, NodeHeader::SIZE + 32 + 32);
         // Set bit 0 of the forks index (LE bitfield at offset 96).
         data[NodeHeader::SIZE + 32] = 0x01;
-        let result = Node::<ChunkRef>::try_from(data.as_slice());
+        let result = Node::<ChunkRef>::decode(data.as_slice());
         assert!(matches!(
             result,
             Err(DecodeError::InsufficientForkBytes { .. })
@@ -906,7 +908,7 @@ mod tests {
     fn decode_v02_index_demands_missing_fork_returns_err() {
         let mut data = truncated_node_bytes(&VersionHash::V02, NodeHeader::SIZE + 32 + 32);
         data[NodeHeader::SIZE + 32] = 0x01;
-        let result = Node::<ChunkRef>::try_from(data.as_slice());
+        let result = Node::<ChunkRef>::decode(data.as_slice());
         assert!(matches!(
             result,
             Err(DecodeError::InsufficientForkBytes { .. })
@@ -938,7 +940,7 @@ mod tests {
         for (label, version) in [("v01", VersionHash::V01), ("v02", VersionHash::V02)] {
             for len in NodeHeader::SIZE..NodeHeader::SIZE + 64 + 32 {
                 let data = truncated_encref_node_bytes(&version, len);
-                let result = Node::<EncryptedChunkRef>::try_from(data.as_slice());
+                let result = Node::<EncryptedChunkRef>::decode(data.as_slice());
                 assert!(
                     matches!(result, Err(DecodeError::TooShort)),
                     "encref {label} length {len} must yield TooShort"
@@ -957,7 +959,7 @@ mod tests {
             let mut data = truncated_encref_node_bytes(&version, NodeHeader::SIZE + 64 + 32);
             // Set bit 0 of the forks index (LE bitfield at offset 128).
             data[NodeHeader::SIZE + 64] = 0x01;
-            let result = Node::<EncryptedChunkRef>::try_from(data.as_slice());
+            let result = Node::<EncryptedChunkRef>::decode(data.as_slice());
             assert!(
                 matches!(result, Err(DecodeError::InsufficientForkBytes { .. })),
                 "encref {label} missing fork body must yield InsufficientForkBytes"
@@ -991,9 +993,9 @@ mod tests {
             // The fuzz oracle: must not panic. Drive both entry widths the
             // fuzz target drives; the 64-byte `EncryptedChunkRef` path only
             // exists under the `encryption` feature.
-            let result = Node::<ChunkRef>::try_from(data.as_slice());
+            let result = Node::<ChunkRef>::decode(data.as_slice());
             #[cfg(feature = "encryption")]
-            let _ = Node::<nectar_primitives::EncryptedChunkRef>::try_from(data.as_slice());
+            let _ = Node::<nectar_primitives::EncryptedChunkRef>::decode(data.as_slice());
 
             if name.starts_with("crash-") {
                 assert!(result.is_err(), "seed {name} must remain an Err reproducer");
@@ -1015,19 +1017,21 @@ mod tests {
     /// Returns whether the width decoded, so callers can assert the corpus
     /// actually exercises the width it claims.
     fn record_round_trip<R: Reference>(data: &[u8]) -> bool {
-        let Ok(node) = Node::<R>::try_from(data) else {
+        let Ok(node) = Node::<R>::decode(data) else {
             return false;
         };
-        let encoded = Vec::<u8>::try_from(&node).expect("a decoded node must re-encode");
+        let encoded = node.encode().expect("a decoded node must re-encode");
         let redecoded =
-            Node::<R>::try_from(encoded.as_slice()).expect("the canonical image must decode");
-        let reencoded = Vec::<u8>::try_from(&redecoded).expect("a re-decoded node must re-encode");
+            Node::<R>::decode(encoded.as_slice()).expect("the canonical image must decode");
+        let reencoded = redecoded
+            .encode()
+            .expect("a re-decoded node must re-encode");
         assert_eq!(
             reencoded, encoded,
             "encode/decode must reach a byte-canonical fixed point"
         );
         let redecoded_again =
-            Node::<R>::try_from(reencoded.as_slice()).expect("the canonical image must re-decode");
+            Node::<R>::decode(reencoded.as_slice()).expect("the canonical image must re-decode");
         assert_eq!(
             redecoded_again, redecoded,
             "decode(encode(node)) must be structurally stable"
@@ -1102,8 +1106,8 @@ mod tests {
         let mut checked = 0usize;
         while !u.is_empty() && checked < 16 {
             let node = Node::<ChunkRef>::arbitrary(&mut u).unwrap();
-            let encoded = Vec::<u8>::try_from(&node).unwrap();
-            let decoded = Node::<ChunkRef>::try_from(encoded.as_slice()).unwrap();
+            let encoded = node.encode().unwrap();
+            let decoded = Node::<ChunkRef>::decode(encoded.as_slice()).unwrap();
             assert_eq!(
                 decoded, node,
                 "decode(encode(node)) must reproduce the node"
@@ -1137,7 +1141,7 @@ mod tests {
         .unwrap();
 
         // The fork's child node has no reference assigned (never persisted).
-        let result = Vec::<u8>::try_from(&n);
+        let result = n.encode();
         assert!(matches!(result, Err(MantarayError::MissingReference)));
     }
 
@@ -1220,8 +1224,8 @@ mod tests {
             fork.node.reference = Some(nectar_primitives::chunk::ChunkAddress::from(addr));
         }
 
-        let encoded = Vec::<u8>::try_from(&n).unwrap();
-        let n2 = Node::<ChunkRef>::try_from(encoded.as_slice()).unwrap();
+        let encoded = n.encode().unwrap();
+        let n2 = Node::<ChunkRef>::decode(encoded.as_slice()).unwrap();
 
         // Root has no entry; encoding writes zero bytes, decoding reads them back as None
         assert!(n2.entry().is_none());

--- a/crates/mantaray/src/codec.rs
+++ b/crates/mantaray/src/codec.rs
@@ -1104,10 +1104,16 @@ mod tests {
             let node = Node::<ChunkRef>::arbitrary(&mut u).unwrap();
             let encoded = Vec::<u8>::try_from(&node).unwrap();
             let decoded = Node::<ChunkRef>::try_from(encoded.as_slice()).unwrap();
-            assert_eq!(decoded, node, "decode(encode(node)) must reproduce the node");
+            assert_eq!(
+                decoded, node,
+                "decode(encode(node)) must reproduce the node"
+            );
             checked += 1;
         }
-        assert!(checked >= 8, "expected at least 8 arbitrary nodes, got {checked}");
+        assert!(
+            checked >= 8,
+            "expected at least 8 arbitrary nodes, got {checked}"
+        );
     }
 
     /// Encoding a fork whose child has no saved reference must error rather

--- a/crates/mantaray/src/lib.rs
+++ b/crates/mantaray/src/lib.rs
@@ -56,6 +56,32 @@
 //! assert_eq!(metadata::CONTENT_TYPE, "Content-Type");
 //! ```
 //!
+//! # Raw encode containment
+//!
+//! Node bytes are produced only inside [`Manifest::save`] and consumed only
+//! on load; a node handed out by [`Manifest::root`], [`Manifest::walk`], or
+//! [`Manifest::into_parts`] carries no public encode:
+//!
+//! ```compile_fail
+//! use nectar_mantaray::{DefaultMemoryStore, PlainManifest};
+//!
+//! let manifest: PlainManifest<_> = PlainManifest::new(DefaultMemoryStore::new());
+//! let bytes: Vec<u8> = Vec::try_from(manifest.root()).unwrap();
+//! ```
+//!
+//! The raw node internals exist only under the `hazmat` feature, for fuzz
+//! harnesses and benches; without it the module does not resolve:
+//!
+#![cfg_attr(not(feature = "hazmat"), doc = "```compile_fail")]
+#![cfg_attr(feature = "hazmat", doc = "```")]
+//! use nectar_mantaray::hazmat::{self, Node};
+//!
+//! let node: Node = Node::new_unencrypted();
+//! let bytes = hazmat::encode(&node).unwrap();
+//! let decoded: Node = hazmat::decode(&bytes).unwrap();
+//! assert!(decoded.entry().is_none());
+//! ```
+//!
 //! # Upstream-bug workarounds
 //!
 //! Code that exists solely to tolerate a defect in an upstream reference
@@ -104,13 +130,27 @@ pub use manifest_ref::ManifestRef;
 pub use node::NodeType;
 pub use obfuscation::ObfuscationKey;
 
-/// Raw node internals for fuzz harnesses only.
+/// Raw node internals for fuzz harnesses and benches only.
 ///
-/// Not part of the public API and exempt from semver guarantees; the encode
-/// path here (`Vec::<u8>::try_from(&Node)`) has no other sanctioned spelling.
+/// Not part of the public API and exempt from semver guarantees. Compiled
+/// only under the `hazmat` feature; normal builds carry no raw node types
+/// and no raw encode or decode surface.
+#[cfg(feature = "hazmat")]
 #[doc(hidden)]
 pub mod hazmat {
-    pub use crate::node::{Fork, Node, Prefix};
+    use nectar_primitives::chunk::Reference;
+
+    pub use crate::node::{Fork, Node};
+
+    /// Encode a raw node into its wire image.
+    pub fn encode<R: Reference>(node: &Node<R>) -> crate::Result<Vec<u8>> {
+        node.encode()
+    }
+
+    /// Decode a wire image into a raw node.
+    pub fn decode<R: Reference>(bytes: &[u8]) -> crate::DecodeResult<Node<R>> {
+        Node::decode(bytes)
+    }
 }
 
 // Re-export typed storage traits from primitives.

--- a/crates/mantaray/src/lib.rs
+++ b/crates/mantaray/src/lib.rs
@@ -76,7 +76,7 @@ pub mod entry;
 pub mod error;
 pub mod manifest;
 pub mod manifest_ref;
-pub mod node;
+mod node;
 pub mod obfuscation;
 
 // Re-export constants.
@@ -88,8 +88,17 @@ pub use entry::Entry;
 pub use error::{DecodeError, DecodeResult, MantarayError, Result};
 pub use manifest::{Manifest, ManifestIter};
 pub use manifest_ref::ManifestRef;
-pub use node::{Fork, Node, NodeType, Prefix};
+pub use node::NodeType;
 pub use obfuscation::ObfuscationKey;
+
+/// Raw node internals for fuzz harnesses only.
+///
+/// Not part of the public API and exempt from semver guarantees; the encode
+/// path here (`Vec::<u8>::try_from(&Node)`) has no other sanctioned spelling.
+#[doc(hidden)]
+pub mod hazmat {
+    pub use crate::node::{Fork, Node, Prefix};
+}
 
 // Re-export typed storage traits from primitives.
 pub use nectar_primitives::DefaultMemoryStore;

--- a/crates/mantaray/src/lib.rs
+++ b/crates/mantaray/src/lib.rs
@@ -65,7 +65,20 @@
 //! number should be removed. Run `git grep -n BEE-WORKAROUND` to enumerate
 //! them.
 
-#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::get_unwrap, clippy::indexing_slicing, clippy::string_slice, clippy::arithmetic_side_effects, clippy::panic, clippy::unreachable, clippy::panic_in_result_fn))]
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::get_unwrap,
+        clippy::indexing_slicing,
+        clippy::string_slice,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::panic_in_result_fn
+    )
+)]
 
 use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::ChunkRef;

--- a/crates/mantaray/src/manifest.rs
+++ b/crates/mantaray/src/manifest.rs
@@ -76,7 +76,8 @@ impl<S, R: Reference, const BS: usize> Manifest<S, R, BS> {
     }
 
     /// Mutable access to the root trie node.
-    pub const fn root_mut(&mut self) -> &mut Node<R> {
+    #[allow(dead_code)] // crate-internal mutation seam retained for the node-state follow-up
+    pub(crate) const fn root_mut(&mut self) -> &mut Node<R> {
         &mut self.trie
     }
 

--- a/crates/mantaray/src/manifest.rs
+++ b/crates/mantaray/src/manifest.rs
@@ -466,7 +466,8 @@ impl<'a, S: ChunkGet<BS>, R: Reference, const BS: usize> ManifestIter<'a, S, R, 
             // Advance: get the next fork key and parent pointer from the top frame.
             let (key, parent_node) = {
                 let frame = self.stack.last_mut()?;
-                #[allow(clippy::indexing_slicing)] // the pop_if loop above removed every frame with key_idx >= keys.len()
+                #[allow(clippy::indexing_slicing)]
+                // the pop_if loop above removed every frame with key_idx >= keys.len()
                 let key = frame.keys[frame.key_idx];
                 frame.key_idx += 1;
                 (key, frame.node)

--- a/crates/mantaray/src/node.rs
+++ b/crates/mantaray/src/node.rs
@@ -25,7 +25,7 @@ type RecurseFuture<'a> = Pin<Box<dyn Future<Output = Result<()>> + 'a>>;
 /// Always stores data inline; no heap allocation, no branching.
 /// 31 bytes total (1 len + 30 data).
 #[derive(Clone, PartialEq, Eq)]
-pub struct Prefix {
+pub(crate) struct Prefix {
     len: u8,
     data: [u8; PREFIX_MAX_LEN],
 }
@@ -39,11 +39,11 @@ impl Default for Prefix {
 
 impl Prefix {
     /// Maximum prefix length in bytes (constrained by the fork pre-reference region).
-    pub const MAX_LEN: usize = PREFIX_MAX_LEN;
+    pub(crate) const MAX_LEN: usize = PREFIX_MAX_LEN;
 
     /// Create an empty prefix.
     #[inline]
-    pub const fn new() -> Self {
+    pub(crate) const fn new() -> Self {
         Self {
             len: 0,
             data: [0u8; PREFIX_MAX_LEN],
@@ -60,7 +60,7 @@ impl Prefix {
     ///
     /// Panics if `src.len() > 30`.
     #[inline]
-    pub fn from_slice(src: &[u8]) -> Self {
+    pub(crate) fn from_slice(src: &[u8]) -> Self {
         assert!(
             src.len() <= PREFIX_MAX_LEN,
             "prefix length {} exceeds maximum {}",
@@ -83,7 +83,7 @@ impl Prefix {
     /// relies on a caller-side guard. Bytes past `len` are re-zeroed to keep
     /// the padding canonical for equality and re-encoding.
     #[inline]
-    pub fn from_wire(padded: &[u8; PREFIX_MAX_LEN], len: u8) -> DecodeResult<Self> {
+    pub(crate) fn from_wire(padded: &[u8; PREFIX_MAX_LEN], len: u8) -> DecodeResult<Self> {
         let len_usize = usize::from(len);
         if len == 0 || len_usize > PREFIX_MAX_LEN {
             return Err(DecodeError::InvalidPrefixLength {
@@ -100,19 +100,19 @@ impl Prefix {
     /// Returns the prefix length in bytes.
     #[inline]
     #[allow(clippy::as_conversions)] // u8 -> usize widening, infallible; `usize::from` is not const-callable
-    pub const fn len(&self) -> usize {
+    pub(crate) const fn len(&self) -> usize {
         self.len as usize
     }
 
     /// Returns true if the prefix is empty.
     #[inline]
-    pub const fn is_empty(&self) -> bool {
+    pub(crate) const fn is_empty(&self) -> bool {
         self.len == 0
     }
 
     /// Returns the full 30-byte backing array (zero-padded beyond `len`).
     #[inline]
-    pub const fn padded_bytes(&self) -> &[u8; PREFIX_MAX_LEN] {
+    pub(crate) const fn padded_bytes(&self) -> &[u8; PREFIX_MAX_LEN] {
         &self.data
     }
 }
@@ -136,7 +136,7 @@ impl FromCursor for Prefix {
 impl ToWriter for Prefix {
     fn put_into(&self, w: &mut Writer<'_>) {
         w.put(&self.len);
-        w.put(&self.data);
+        w.put(self.padded_bytes());
     }
 }
 
@@ -365,7 +365,7 @@ impl<R: Reference> Node<R> {
             .map_err(|e| MantarayError::StoreGet {
                 source: std::sync::Arc::new(e),
             })?;
-        let mut loaded = Self::try_from(chunk.data().as_ref())
+        let mut loaded = Self::decode(chunk.data().as_ref())
             .map_err(|source| MantarayError::Corrupt { address, source })?;
         loaded.reference = Some(address);
         // Preserve fields that live in the parent's fork data, not in this node's chunk:
@@ -703,7 +703,7 @@ impl<R: Reference> Node<R> {
             }
 
             // All children saved; encode and put this node, then pop.
-            let data = Vec::<u8>::try_from(&*node)?;
+            let data = node.encode()?;
             let chunk = ContentChunk::<BS>::new(Bytes::from(data))?;
             let address = *chunk.address();
             store

--- a/crates/postage-usage/src/codec.rs
+++ b/crates/postage-usage/src/codec.rs
@@ -1032,12 +1032,12 @@ mod tests {
         // the depth - bucket_depth = 32 shift-overflow shape.
         for (depth, bucket_depth, width) in [
             (0u8, 0u8, 0u8),
-            (15, 16, 0),   // depth < bucket_depth
-            (16, 17, 0),   // bucket_depth over MAX_BUCKET_DEPTH
-            (47, 16, 0),   // depth - bucket_depth = 31 (max counter bits)
-            (48, 16, 0),   // depth - bucket_depth = 32 (must be rejected)
-            (20, 16, 32),  // width at MAX_WIDTH
-            (20, 16, 33),  // width over MAX_WIDTH
+            (15, 16, 0),  // depth < bucket_depth
+            (16, 17, 0),  // bucket_depth over MAX_BUCKET_DEPTH
+            (47, 16, 0),  // depth - bucket_depth = 31 (max counter bits)
+            (48, 16, 0),  // depth - bucket_depth = 32 (must be rejected)
+            (20, 16, 32), // width at MAX_WIDTH
+            (20, 16, 33), // width over MAX_WIDTH
             (255, 255, 255),
         ] {
             let mut header = vec![0u8; ROOT_HEADER_SIZE];
@@ -1089,8 +1089,13 @@ mod tests {
                 Err(_) => continue,
             };
             let root = RootInfo::parse(&plan.chunks[0].payload).expect("planned root must parse");
-            let leaves: Vec<_> = plan.chunks[1..].iter().map(|c| c.payload.as_ref()).collect();
-            let recovered = root.assemble(&leaves).expect("planned leaves must assemble");
+            let leaves: Vec<_> = plan.chunks[1..]
+                .iter()
+                .map(|c| c.payload.as_ref())
+                .collect();
+            let recovered = root
+                .assemble(&leaves)
+                .expect("planned leaves must assemble");
             assert_eq!(
                 recovered, snapshot,
                 "parse+assemble must recover the persisted snapshot"

--- a/crates/postage/src/lib.rs
+++ b/crates/postage/src/lib.rs
@@ -36,7 +36,20 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::get_unwrap, clippy::indexing_slicing, clippy::string_slice, clippy::arithmetic_side_effects, clippy::panic, clippy::unreachable, clippy::panic_in_result_fn))]
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::get_unwrap,
+        clippy::indexing_slicing,
+        clippy::string_slice,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::panic_in_result_fn
+    )
+)]
 
 // k256 is a dependency only to enable the precomputed-tables feature for faster ECDSA
 #[cfg(not(test))]

--- a/crates/postage/src/stamp.rs
+++ b/crates/postage/src/stamp.rs
@@ -813,8 +813,8 @@ mod tests {
     /// without running the fuzzer itself.
     #[test]
     fn seed_replay_stamp_decode() {
-        let seed_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("../../fuzz/seeds/stamp_decode");
+        let seed_dir =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../fuzz/seeds/stamp_decode");
         let mut replayed = 0usize;
         for entry in std::fs::read_dir(&seed_dir)
             .unwrap_or_else(|e| panic!("seed dir {} must exist: {e}", seed_dir.display()))

--- a/crates/postage/src/stamped.rs
+++ b/crates/postage/src/stamped.rs
@@ -87,7 +87,8 @@ impl<const BODY_SIZE: usize> StampedChunk<BODY_SIZE> {
     pub fn to_typed_bytes(&self) -> Vec<u8> {
         let stamp = self.stamp.to_bytes();
         let chunk = self.chunk.to_typed_bytes();
-        #[allow(clippy::arithmetic_side_effects)] // capacity hint: sum of two in-memory buffer lengths cannot overflow usize
+        #[allow(clippy::arithmetic_side_effects)]
+        // capacity hint: sum of two in-memory buffer lengths cannot overflow usize
         let mut out = Vec::with_capacity(stamp.len() + chunk.len());
         out.extend_from_slice(&stamp);
         out.extend_from_slice(&chunk);

--- a/crates/primitives/src/chunk/chunk_type_set.rs
+++ b/crates/primitives/src/chunk/chunk_type_set.rs
@@ -303,15 +303,15 @@ mod tests {
         let edge_inputs: Vec<Vec<u8>> = alloc::vec![
             Vec::new(),
             alloc::vec![0x00],
-            alloc::vec![0xff; 7],                              // one short of a CAC span
-            alloc::vec![0x00; 8],                              // zero span, empty payload
-            alloc::vec![0xff; 8],                              // max span, empty payload
-            alloc::vec![0xff; 96],                             // one short of the SOC header
-            alloc::vec![0xff; 97],                             // SOC header, no body
-            alloc::vec![0xff; 105],                            // SOC header + span, empty payload
-            alloc::vec![0xff; 8 + DEFAULT_BODY_SIZE],          // max CAC encoding
-            alloc::vec![0xff; 8 + DEFAULT_BODY_SIZE + 1],      // one past max CAC
-            alloc::vec![0x00; 97 + 8 + DEFAULT_BODY_SIZE],     // max SOC encoding
+            alloc::vec![0xff; 7],                     // one short of a CAC span
+            alloc::vec![0x00; 8],                     // zero span, empty payload
+            alloc::vec![0xff; 8],                     // max span, empty payload
+            alloc::vec![0xff; 96],                    // one short of the SOC header
+            alloc::vec![0xff; 97],                    // SOC header, no body
+            alloc::vec![0xff; 105],                   // SOC header + span, empty payload
+            alloc::vec![0xff; 8 + DEFAULT_BODY_SIZE], // max CAC encoding
+            alloc::vec![0xff; 8 + DEFAULT_BODY_SIZE + 1], // one past max CAC
+            alloc::vec![0x00; 97 + 8 + DEFAULT_BODY_SIZE], // max SOC encoding
             alloc::vec![0xff; 97 + 8 + DEFAULT_BODY_SIZE + 1], // one past max SOC
         ];
         for data in &edge_inputs {
@@ -326,8 +326,8 @@ mod tests {
     /// seeds meaningful on stable without running the fuzzer itself.
     #[test]
     fn seed_replay_chunk_decode() {
-        let seed_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("../../fuzz/seeds/chunk_decode");
+        let seed_dir =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../fuzz/seeds/chunk_decode");
         let mut replayed = 0usize;
         for entry in std::fs::read_dir(&seed_dir)
             .unwrap_or_else(|e| panic!("seed dir {} must exist: {e}", seed_dir.display()))

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,10 +15,12 @@ arbitrary = { version = "1", features = ["derive"] }
 alloy-signer-local = { version = "2.0", default-features = false }
 libfuzzer-sys = "0.4"
 # `encryption` gates the `Reference for EncryptedChunkRef` impl that
-# `mantaray_node_decode` uses to drive the 64-byte entry path.
+# `mantaray_node_decode` uses to drive the 64-byte entry path; `hazmat`
+# exposes the raw node types and codec the mantaray targets exercise.
 nectar-mantaray = { path = "../crates/mantaray", features = [
 	"arbitrary",
 	"encryption",
+	"hazmat",
 ] }
 nectar-postage = { path = "../crates/postage", features = ["arbitrary"] }
 nectar-postage-usage = { path = "../crates/postage-usage", features = [

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -38,7 +38,7 @@ OOM, no hang*:
 
 | Target | Entry point | Invariant |
 |---|---|---|
-| `mantaray_node_decode` | `Node::<ChunkAddress>::try_from(&[u8])` | manifest decoding never panics |
+| `mantaray_node_decode` | `hazmat::decode` over raw bytes | manifest decoding never panics |
 | `chunk_decode` | `StandardChunkSet::deserialize` + direct CAC/SOC `TryFrom` | chunk decoding, BMT address forcing, and SOC owner recovery never panic |
 | `stamp_decode` | `Stamp::try_from_slice` (+ `recover_signer` over a stamp‖address split) | stamp decoding and EIP-191 signer recovery never panic |
 | `usage_snapshot_decode` | `RootInfo::parse` | SBU1 root parsing (geometry/packed-length arithmetic) never panics |

--- a/fuzz/fuzz_targets/mantaray_node_decode.rs
+++ b/fuzz/fuzz_targets/mantaray_node_decode.rs
@@ -1,7 +1,8 @@
 //! Fuzz the mantaray node wire decoder with raw attacker-controlled bytes.
 //!
-//! `Node::<R>::try_from(&[u8])` is the entry point through which untrusted
-//! manifest chunks from the network are parsed. Both entry widths are
+//! The node wire decoder (reached here through `hazmat::decode`) is the
+//! entry point through which untrusted manifest chunks from the network are
+//! parsed. Both entry widths are
 //! exercised on every input: `ChunkRef` (plain manifests, 32-byte
 //! entries) and `EncryptedChunkRef` (encrypted manifests, 64-byte entries),
 //! each of which drives its own reference-width cursor reads through the
@@ -16,11 +17,11 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use nectar_mantaray::hazmat::Node;
+use nectar_mantaray::hazmat;
 use nectar_primitives::EncryptedChunkRef;
 use nectar_primitives::chunk::ChunkRef;
 
 fuzz_target!(|data: &[u8]| {
-    let _ = Node::<ChunkRef>::try_from(data);
-    let _ = Node::<EncryptedChunkRef>::try_from(data);
+    let _ = hazmat::decode::<ChunkRef>(data);
+    let _ = hazmat::decode::<EncryptedChunkRef>(data);
 });

--- a/fuzz/fuzz_targets/mantaray_node_decode.rs
+++ b/fuzz/fuzz_targets/mantaray_node_decode.rs
@@ -16,7 +16,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use nectar_mantaray::Node;
+use nectar_mantaray::hazmat::Node;
 use nectar_primitives::EncryptedChunkRef;
 use nectar_primitives::chunk::ChunkRef;
 

--- a/fuzz/fuzz_targets/mantaray_node_roundtrip.rs
+++ b/fuzz/fuzz_targets/mantaray_node_roundtrip.rs
@@ -14,7 +14,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use nectar_mantaray::Node;
+use nectar_mantaray::hazmat::Node;
 use nectar_primitives::chunk::ChunkRef;
 
 fuzz_target!(|node: Node<ChunkRef>| {

--- a/fuzz/fuzz_targets/mantaray_node_roundtrip.rs
+++ b/fuzz/fuzz_targets/mantaray_node_roundtrip.rs
@@ -3,8 +3,8 @@
 //! The valid-by-construction `Arbitrary` impl for `Node<ChunkRef>`
 //! (crates/mantaray/src/node.rs) generates only encodable, round-trip-stable
 //! nodes, so the oracle is stronger than "no panic": every generated node
-//! must encode (`TryFrom<&Node> for Vec<u8>`), the encoding must decode
-//! (`TryFrom<&[u8]> for Node`), the decoded node must equal the original,
+//! must encode (`hazmat::encode`), the encoding must decode
+//! (`hazmat::decode`), the decoded node must equal the original,
 //! and re-encoding the decoded node must reproduce the same bytes (canonical
 //! form). Any failure is a codec bug.
 //!
@@ -14,16 +14,16 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use nectar_mantaray::hazmat::Node;
+use nectar_mantaray::hazmat::{self, Node};
 use nectar_primitives::chunk::ChunkRef;
 
 fuzz_target!(|node: Node<ChunkRef>| {
-    let encoded = Vec::<u8>::try_from(&node).expect("arbitrary nodes must encode");
+    let encoded = hazmat::encode(&node).expect("arbitrary nodes must encode");
     let decoded =
-        Node::<ChunkRef>::try_from(encoded.as_slice()).expect("encoded nodes must decode");
+        hazmat::decode::<ChunkRef>(encoded.as_slice()).expect("encoded nodes must decode");
     assert_eq!(decoded, node, "decode(encode(node)) must reproduce the node");
 
     // Canonical form: re-encoding the decoded node must be byte-identical.
-    let reencoded = Vec::<u8>::try_from(&decoded).expect("decoded nodes must re-encode");
+    let reencoded = hazmat::encode(&decoded).expect("decoded nodes must re-encode");
     assert_eq!(reencoded, encoded, "encoding must be canonical");
 });

--- a/fuzz/fuzz_targets/mantaray_record_roundtrip.rs
+++ b/fuzz/fuzz_targets/mantaray_record_roundtrip.rs
@@ -24,7 +24,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use nectar_mantaray::hazmat::Node;
+use nectar_mantaray::hazmat;
 use nectar_primitives::EncryptedChunkRef;
 use nectar_primitives::chunk::{ChunkRef, Reference};
 
@@ -32,21 +32,21 @@ use nectar_primitives::chunk::{ChunkRef, Reference};
 /// declare decodes to `Err` and is skipped; every decoded node must reach a
 /// byte- and structure-canonical fixed point under encode/decode.
 fn round_trip<R: Reference>(data: &[u8]) {
-    let Ok(node) = Node::<R>::try_from(data) else {
+    let Ok(node) = hazmat::decode::<R>(data) else {
         return;
     };
 
     // A decoded node carries a saved reference on every fork child, so it is
     // always encodable; this first re-encode is the canonical v0.2 image.
-    let encoded = Vec::<u8>::try_from(&node).expect("a decoded node must re-encode");
+    let encoded = hazmat::encode(&node).expect("a decoded node must re-encode");
     let redecoded =
-        Node::<R>::try_from(encoded.as_slice()).expect("the canonical image must decode");
+        hazmat::decode::<R>(encoded.as_slice()).expect("the canonical image must decode");
 
-    let reencoded = Vec::<u8>::try_from(&redecoded).expect("a re-decoded node must re-encode");
+    let reencoded = hazmat::encode(&redecoded).expect("a re-decoded node must re-encode");
     assert_eq!(reencoded, encoded, "encode/decode must reach a byte-canonical fixed point");
 
     let redecoded_again =
-        Node::<R>::try_from(reencoded.as_slice()).expect("the canonical image must re-decode");
+        hazmat::decode::<R>(reencoded.as_slice()).expect("the canonical image must re-decode");
     assert_eq!(
         redecoded_again, redecoded,
         "decode(encode(node)) must be structurally stable"

--- a/fuzz/fuzz_targets/mantaray_record_roundtrip.rs
+++ b/fuzz/fuzz_targets/mantaray_record_roundtrip.rs
@@ -24,7 +24,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use nectar_mantaray::Node;
+use nectar_mantaray::hazmat::Node;
 use nectar_primitives::EncryptedChunkRef;
 use nectar_primitives::chunk::{ChunkRef, Reference};
 


### PR DESCRIPTION
## What

Restricts the raw node encode surface: the Writer/WireFork path is the only sanctioned encoding; raw byte-level encode entry points are crate-private (`root_mut` retained as `pub(crate)` for the node-state follow-up). Carries one rider commit normalizing rustfmt layout across the fuzz and lint stack files that had drifted.

Closes #170

## Why

A single sanctioned encode path is what makes the unsaved-child error and the width invariants total; a public raw byte surface would let callers bypass both.

## Testing

Independently gated: fmt and clippy clean on the diff; full workspace test suite green; the public encode surface verified post-change (only the sanctioned path exported). The gate's mechanical follow-ups (a saturating_sub in the postage generator and two provably in-bounds allows in the mantaray arbitrary impl) landed in the `fuzz/8` lint car this branch stacks on.

## AI Assistance

Implemented and red-teamed with Claude Opus; assembled and filed by Claude Fable under maintainer direction.
