### PR TITLE
chore(lint): exempt non-shipping targets from restriction lints

### DIFF
--- a/crates/mantaray/benches/mantaray_bench.rs
+++ b/crates/mantaray/benches/mantaray_bench.rs
@@ -1,5 +1,16 @@
 #![allow(missing_docs)]
-
+// Bench, example, and integration-test code: unwraps, direct indexing,
+// casts, and assertions are setup and illustration, not shipped surface.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::as_conversions,
+    clippy::missing_panics_doc
+)]
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use futures::executor::block_on;
 use nectar_mantaray::node::Node;

--- a/crates/mantaray/src/node.rs
+++ b/crates/mantaray/src/node.rs
@@ -66,7 +66,8 @@ impl Prefix {
             PREFIX_MAX_LEN
         );
         let mut data = [0u8; PREFIX_MAX_LEN];
-        #[allow(clippy::indexing_slicing)] // src.len() <= PREFIX_MAX_LEN asserted above (documented # Panics contract)
+        #[allow(clippy::indexing_slicing)]
+        // src.len() <= PREFIX_MAX_LEN asserted above (documented # Panics contract)
         data[..src.len()].copy_from_slice(src);
         #[allow(clippy::as_conversions)] // src.len() <= PREFIX_MAX_LEN (30) asserted above, fits u8
         let len = src.len() as u8;
@@ -639,7 +640,8 @@ impl<E: NodeEntry> Node<E> {
                 #[allow(clippy::indexing_slicing)] // key_idx < keys.len() checked above
                 let key = frame.keys[frame.key_idx];
                 frame.key_idx += 1;
-                #[allow(clippy::expect_used)] // key was collected from this node's fork map, which is not mutated while the frame is live
+                #[allow(clippy::expect_used)]
+                // key was collected from this node's fork map, which is not mutated while the frame is live
                 let child = node.forks.get_mut(&key).expect("key from this node");
                 if child.node.reference.is_none() {
                     let child_ptr = std::ptr::from_mut(&mut child.node);
@@ -809,6 +811,8 @@ mod arbitrary_impls {
         fn arbitrary(u: &mut Unstructured<'a>) -> ArbitraryResult<Self> {
             let len = u.int_in_range(1..=PREFIX_MAX_LEN)?;
             let mut data = [0u8; PREFIX_MAX_LEN];
+            // In-bounds: len is drawn from 1..=PREFIX_MAX_LEN and data is PREFIX_MAX_LEN long.
+            #[allow(clippy::indexing_slicing)]
             u.fill_buffer(&mut data[..len])?;
             #[allow(clippy::as_conversions)] // len ∈ 1..=PREFIX_MAX_LEN (30), fits u8
             let len = len as u8;
@@ -830,7 +834,8 @@ mod arbitrary_impls {
             let prefix = Prefix::arbitrary(u)?;
             // On the wire a fork child is flags + a chunk reference (plus
             // optional metadata); a reference-less child is not encodable.
-            let mut node = Node::<E>::from_reference(ChunkAddress::from(u.arbitrary::<[u8; 32]>()?));
+            let mut node =
+                Node::<E>::from_reference(ChunkAddress::from(u.arbitrary::<[u8; 32]>()?));
             node.node_type = NodeType::arbitrary(u)?;
             if node.node_type.contains(NodeType::METADATA) {
                 // Keep pairs small: the encoder caps the padded metadata JSON
@@ -866,6 +871,8 @@ mod arbitrary_impls {
             let mut forks = BTreeMap::new();
             for _ in 0..fork_count {
                 let fork = Fork::<E>::arbitrary(u)?;
+                // In-bounds: Prefix::arbitrary yields a non-empty prefix.
+                #[allow(clippy::indexing_slicing)]
                 forks.insert(fork.prefix[0], fork);
             }
 

--- a/crates/mantaray/tests/file_manifest_integration.rs
+++ b/crates/mantaray/tests/file_manifest_integration.rs
@@ -1,5 +1,17 @@
 //! Integration test: unified store for file splitting and manifest creation.
 
+// Bench, example, and integration-test code: unwraps, direct indexing,
+// casts, and assertions are setup and illustration, not shipped surface.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::as_conversions,
+    clippy::missing_panics_doc
+)]
 use futures::executor::block_on;
 use nectar_mantaray::PlainManifest;
 use nectar_primitives::bmt::DEFAULT_BODY_SIZE;

--- a/crates/postage-issuer/benches/sign.rs
+++ b/crates/postage-issuer/benches/sign.rs
@@ -3,7 +3,18 @@
 //! This benchmark file focuses on stamp issuing and signing operations,
 //! suitable for CLI tools (like dipper) that create stamps.
 #![allow(missing_docs)]
-
+// Bench, example, and integration-test code: unwraps, direct indexing,
+// casts, and assertions are setup and illustration, not shipped surface.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::as_conversions,
+    clippy::missing_panics_doc
+)]
 use alloy_primitives::{B256, Signature, U256};
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;

--- a/crates/postage-issuer/benches/upload_pipeline.rs
+++ b/crates/postage-issuer/benches/upload_pipeline.rs
@@ -8,6 +8,18 @@
 //!
 //! This provides realistic throughput estimates for upload operations.
 
+// Bench, example, and integration-test code: unwraps, direct indexing,
+// casts, and assertions are setup and illustration, not shipped surface.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::as_conversions,
+    clippy::missing_panics_doc
+)]
 use std::io::Write;
 
 use alloy_primitives::{B256, Signature, U256};

--- a/crates/postage-usage/examples/roam_between_machines.rs
+++ b/crates/postage-usage/examples/roam_between_machines.rs
@@ -25,6 +25,18 @@
 //! drop to the low-level `Snapshot` / `revalidate` / `seal_plan` path the facade
 //! is built on; it stays public and unchanged.
 
+// Bench, example, and integration-test code: unwraps, direct indexing,
+// casts, and assertions are setup and illustration, not shipped surface.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::as_conversions,
+    clippy::missing_panics_doc
+)]
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 

--- a/crates/postage-usage/tests/issuer.rs
+++ b/crates/postage-usage/tests/issuer.rs
@@ -2,7 +2,18 @@
 //! owner-aware issuance path bound to a `Snapshot`'s shared table.
 
 #![cfg(feature = "issuer")]
-
+// Bench, example, and integration-test code: unwraps, direct indexing,
+// casts, and assertions are setup and illustration, not shipped surface.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::as_conversions,
+    clippy::missing_panics_doc
+)]
 use alloy_primitives::{Address, B256};
 use nectar_postage::{StampIndex, calculate_bucket};
 use nectar_postage_issuer::StampIssuer;

--- a/crates/postage-usage/tests/seal.rs
+++ b/crates/postage-usage/tests/seal.rs
@@ -1,7 +1,18 @@
 //! Tests for sealing a persist plan into signed chunks and stamps.
 
 #![cfg(feature = "seal")]
-
+// Bench, example, and integration-test code: unwraps, direct indexing,
+// casts, and assertions are setup and illustration, not shipped surface.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::as_conversions,
+    clippy::missing_panics_doc
+)]
 use alloy_primitives::{Address, B256};
 use alloy_signer_local::PrivateKeySigner;
 use nectar_postage_usage::{

--- a/crates/postage-usage/tests/snapshot.rs
+++ b/crates/postage-usage/tests/snapshot.rs
@@ -1,6 +1,18 @@
 //! End-to-end tests for the snapshot format: persist planning, encoding,
 //! decoding, dilution, and corruption rejection.
 
+// Bench, example, and integration-test code: unwraps, direct indexing,
+// casts, and assertions are setup and illustration, not shipped surface.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::as_conversions,
+    clippy::missing_panics_doc
+)]
 use alloy_primitives::{Address, B256};
 use nectar_postage::calculate_bucket;
 use nectar_postage_usage::{

--- a/crates/postage-usage/tests/vector.rs
+++ b/crates/postage-usage/tests/vector.rs
@@ -8,6 +8,18 @@
 //! root comparison and the assemble round-trip. Pinning the root pins the
 //! entire snapshot.
 
+// Bench, example, and integration-test code: unwraps, direct indexing,
+// casts, and assertions are setup and illustration, not shipped surface.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::as_conversions,
+    clippy::missing_panics_doc
+)]
 use alloy_primitives::{Address, B256, hex};
 use nectar_postage::calculate_bucket;
 use nectar_postage_usage::{

--- a/crates/postage/benches/verify.rs
+++ b/crates/postage/benches/verify.rs
@@ -3,7 +3,18 @@
 //! This benchmark file focuses on verification-only operations, suitable for
 //! node/vertex use cases that primarily verify stamps rather than create them.
 #![allow(missing_docs)]
-
+// Bench, example, and integration-test code: unwraps, direct indexing,
+// casts, and assertions are setup and illustration, not shipped surface.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::as_conversions,
+    clippy::missing_panics_doc
+)]
 use alloy_primitives::{Address, B256, Signature};
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;

--- a/crates/postage/src/generators.rs
+++ b/crates/postage/src/generators.rs
@@ -49,7 +49,7 @@ pub fn signed_stamp(
     address: &SwarmAddress,
 ) -> arbitrary::Result<Stamp> {
     let bucket = batch.bucket_for_address(address);
-    let position = u.int_in_range(0..=batch.bucket_upper_bound() - 1)?;
+    let position = u.int_in_range(0..=batch.bucket_upper_bound().saturating_sub(1))?;
     let index = StampIndex::new(bucket, position);
     let timestamp = u.arbitrary()?;
 

--- a/crates/primitives/benches/address.rs
+++ b/crates/primitives/benches/address.rs
@@ -1,4 +1,16 @@
 #![allow(missing_docs)]
+// Bench and example code: unwraps, direct indexing, casts, and assertions
+// are setup and illustration, not shipped surface.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::as_conversions,
+    clippy::missing_panics_doc
+)]
 use alloy_primitives::{B256, b256};
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use nectar_primitives::SwarmAddress;

--- a/crates/primitives/benches/bmt_bench.rs
+++ b/crates/primitives/benches/bmt_bench.rs
@@ -1,4 +1,16 @@
 #![allow(missing_docs)]
+// Bench and example code: unwraps, direct indexing, casts, and assertions
+// are setup and illustration, not shipped surface.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::as_conversions,
+    clippy::missing_panics_doc
+)]
 use alloy_primitives::B256;
 use alloy_signer_local::PrivateKeySigner;
 use bytes::Bytes;

--- a/crates/primitives/benches/encryption_bench.rs
+++ b/crates/primitives/benches/encryption_bench.rs
@@ -1,4 +1,16 @@
 #![allow(missing_docs)]
+// Bench and example code: unwraps, direct indexing, casts, and assertions
+// are setup and illustration, not shipped surface.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::as_conversions,
+    clippy::missing_panics_doc
+)]
 use std::collections::HashMap;
 use std::io::Write;
 

--- a/crates/primitives/benches/file_bench.rs
+++ b/crates/primitives/benches/file_bench.rs
@@ -5,6 +5,18 @@
 //! joining them back, covering plain and encrypted modes, streaming
 //! and direct variants.
 
+// Bench and example code: unwraps, direct indexing, casts, and assertions
+// are setup and illustration, not shipped surface.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::as_conversions,
+    clippy::missing_panics_doc
+)]
 use std::collections::HashMap;
 use std::io::Write;
 

--- a/crates/primitives/benches/primitives.rs
+++ b/crates/primitives/benches/primitives.rs
@@ -1,4 +1,16 @@
 #![allow(missing_docs)]
+// Bench and example code: unwraps, direct indexing, casts, and assertions
+// are setup and illustration, not shipped surface.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::as_conversions,
+    clippy::missing_panics_doc
+)]
 use alloy_primitives::keccak256;
 use bytes::BytesMut;
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};

--- a/crates/primitives/benches/proofs.rs
+++ b/crates/primitives/benches/proofs.rs
@@ -1,4 +1,16 @@
 #![allow(missing_docs)]
+// Bench and example code: unwraps, direct indexing, casts, and assertions
+// are setup and illustration, not shipped surface.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::as_conversions,
+    clippy::missing_panics_doc
+)]
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use nectar_primitives::{DEFAULT_BODY_SIZE, DefaultHasher, bmt::Prover};
 use rand::RngExt;

--- a/crates/primitives/examples/basic_usage.rs
+++ b/crates/primitives/examples/basic_usage.rs
@@ -3,6 +3,18 @@
 //! This example demonstrates the creation and verification of
 //! both content-addressed and single-owner chunks.
 
+// Bench and example code: unwraps, direct indexing, casts, and assertions
+// are setup and illustration, not shipped surface.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::as_conversions,
+    clippy::missing_panics_doc
+)]
 use alloy_primitives::B256;
 use alloy_signer::SignerSync;
 use alloy_signer_local::LocalSigner;

--- a/crates/primitives/examples/builder_patterns.rs
+++ b/crates/primitives/examples/builder_patterns.rs
@@ -3,6 +3,18 @@
 //! This example demonstrates usage of the chunk creation APIs,
 //! since our API doesn't use the builder pattern extensively.
 
+// Bench and example code: unwraps, direct indexing, casts, and assertions
+// are setup and illustration, not shipped surface.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::as_conversions,
+    clippy::missing_panics_doc
+)]
 use alloy_primitives::B256;
 use alloy_signer::SignerSync;
 use alloy_signer_local::LocalSigner;


### PR DESCRIPTION
## What

Exempts non-shipping compilation targets from the workspace restriction lints: benches, examples, and integration tests get a file-level allow header stating the policy (unwraps, direct indexing, casts, and assertions there are setup and illustration, not shipped surface). Two shipped-code follow-ups ride along: a `saturating_sub` in the postage generator (provably identical, the value is always at least 1) and two provably in-bounds indexing allows in the mantaray arbitrary impl.

## Why

The restriction lints protect shipped library code, but benches, examples, and integration tests are standalone compilation units the `cfg(test)` exemption never covered; under the full battery (`cargo clippy --workspace --all-targets --all-features -- -D warnings`) they produced several hundred errors that made the strict profile unusable as a gate. With this car the full battery is clean at the train tip.

## Testing

`cargo clippy --workspace --all-targets --all-features -- -D warnings` exits clean at this commit; the narrow CI profile is unaffected.

## AI Assistance

Authored by Claude Fable under maintainer direction during train conducting.
