### PR TITLE
feat(mantaray): add save-consuming ManifestBuilder

### DIFF
--- a/crates/mantaray/src/builder.rs
+++ b/crates/mantaray/src/builder.rs
@@ -1,0 +1,279 @@
+//! Save-consuming builder for the mantaray write path.
+//!
+//! [`ManifestBuilder`] owns the only sanctioned route to wire bytes: entries
+//! are staged in memory, then [`save`](ManifestBuilder::save) consumes the
+//! builder, persists children before parents, and hands back the typed root
+//! alongside a read handle over the same store. Because `save` takes `self`,
+//! an unsaved builder holds no address and a saved one cannot be saved again.
+//!
+//! A root node carrying its own metadata is unrepresentable on the wire (only
+//! fork children serialize metadata), so `save` rejects it rather than drop it
+//! silently.
+//!
+//! ```
+//! # use nectar_mantaray::{ManifestBuilder, DefaultMemoryStore};
+//! # use nectar_primitives::chunk::ChunkAddress;
+//! # futures::executor::block_on(async {
+//! let mut builder = ManifestBuilder::new(DefaultMemoryStore::new());
+//! builder
+//!     .add("index.html", ChunkAddress::from([1u8; 32]))
+//!     .await
+//!     .unwrap();
+//! let (_root, mut manifest) = builder.save().await.unwrap();
+//! let entry = manifest.lookup("index.html").await.unwrap();
+//! assert_eq!(entry.address(), Some(&ChunkAddress::from([1u8; 32])));
+//! # });
+//! ```
+//!
+//! `save` consumes the builder, so a second save cannot compile:
+//!
+//! ```compile_fail
+//! # use nectar_mantaray::{ManifestBuilder, DefaultMemoryStore};
+//! # futures::executor::block_on(async {
+//! let builder = ManifestBuilder::new(DefaultMemoryStore::new());
+//! let _ = builder.save().await;
+//! let _ = builder.save().await;
+//! # });
+//! ```
+
+use std::collections::BTreeMap;
+
+use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
+use nectar_primitives::chunk::{ChunkAddress, ChunkRef, Reference};
+use nectar_primitives::store::{ChunkGet, ChunkPut, MaybeSend};
+
+use crate::entry::Entry;
+use crate::manifest::Manifest;
+use crate::{MantarayError, Result};
+
+/// Staging buffer for a mantaray manifest whose `save` consumes the builder.
+///
+/// The reference type parameter `R` fixes what `add` accepts and what `save`
+/// returns (a plain [`ChunkAddress`] or an encrypted
+/// [`ManifestRef`](crate::ManifestRef)), mirroring [`Manifest`].
+#[derive(Debug)]
+pub struct ManifestBuilder<S, R: Reference = ChunkRef, const BS: usize = DEFAULT_BODY_SIZE> {
+    manifest: Manifest<S, R, BS>,
+}
+
+impl<S, const BS: usize> ManifestBuilder<S, ChunkRef, BS> {
+    /// Create a new plain builder (no obfuscation, 32-byte refs).
+    pub fn new(store: S) -> Self {
+        Self {
+            manifest: Manifest::new(store),
+        }
+    }
+}
+
+#[cfg(feature = "encryption")]
+impl<S, const BS: usize> ManifestBuilder<S, nectar_primitives::EncryptedChunkRef, BS> {
+    /// Create a new encrypted builder (random obfuscation key, 64-byte refs).
+    pub fn new_encrypted(store: S) -> Self {
+        Self {
+            manifest: Manifest::new_encrypted(store),
+        }
+    }
+}
+
+impl<S, R: Reference, const BS: usize> ManifestBuilder<S, R, BS> {
+    /// Access the underlying chunk store.
+    pub const fn store(&self) -> &S {
+        self.manifest.store()
+    }
+
+    /// Reject a root that carries its own metadata: the wire format serializes
+    /// metadata only on fork children, so a root's would be dropped on encode.
+    fn ensure_root_serializable(&self) -> Result<()> {
+        if self.manifest.root().metadata().is_empty() {
+            Ok(())
+        } else {
+            Err(MantarayError::RootMetadata)
+        }
+    }
+}
+
+impl<S: ChunkGet<BS>, R: Reference + MaybeSend, const BS: usize> ManifestBuilder<S, R, BS> {
+    /// Stage a path with a typed reference.
+    pub async fn add(&mut self, path: &str, reference: impl Into<R>) -> Result<()> {
+        self.manifest.add(path, reference).await
+    }
+
+    /// Stage a path with a typed reference and metadata.
+    pub async fn add_with_metadata(
+        &mut self,
+        path: &str,
+        reference: impl Into<R>,
+        metadata: BTreeMap<String, String>,
+    ) -> Result<()> {
+        self.manifest
+            .add_with_metadata(path, reference, metadata)
+            .await
+    }
+
+    /// Stage a path with a pre-built [`Entry`] (metadata + reference).
+    pub async fn add_entry(&mut self, path: &str, entry: Entry) -> Result<()> {
+        self.manifest.add_entry(path, entry).await
+    }
+
+    /// Remove a staged path.
+    pub async fn remove(&mut self, path: &str) -> Result<()> {
+        self.manifest.remove(path).await
+    }
+
+    /// Set the website index document on the root path metadata.
+    ///
+    /// The value lands on the `/` fork child, not the root node, so it stays
+    /// serializable.
+    pub async fn set_index_document(&mut self, filename: &str) -> Result<()> {
+        self.manifest.set_index_document(filename).await
+    }
+
+    /// Set the website error document on the root path metadata.
+    pub async fn set_error_document(&mut self, path: &str) -> Result<()> {
+        self.manifest.set_error_document(path).await
+    }
+}
+
+impl<S: ChunkGet<BS> + ChunkPut<BS>, const BS: usize> ManifestBuilder<S, ChunkRef, BS> {
+    /// Persist the plain manifest, consuming the builder.
+    ///
+    /// Returns the root chunk address and a read handle over the same store.
+    pub async fn save(mut self) -> Result<(ChunkAddress, Manifest<S, ChunkRef, BS>)> {
+        self.ensure_root_serializable()?;
+        let root = self.manifest.save().await?;
+        Ok((root, self.manifest))
+    }
+}
+
+#[cfg(feature = "encryption")]
+impl<S: ChunkGet<BS> + ChunkPut<BS>, const BS: usize>
+    ManifestBuilder<S, nectar_primitives::EncryptedChunkRef, BS>
+{
+    /// Persist the encrypted manifest, consuming the builder.
+    ///
+    /// Returns a [`ManifestRef`](crate::ManifestRef) and a read handle over the
+    /// same store.
+    pub async fn save(
+        mut self,
+    ) -> Result<(
+        crate::ManifestRef,
+        Manifest<S, nectar_primitives::EncryptedChunkRef, BS>,
+    )> {
+        self.ensure_root_serializable()?;
+        let root = self.manifest.save().await?;
+        Ok((root, self.manifest))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::executor::block_on;
+    use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
+    use nectar_primitives::chunk::ChunkAddress;
+    use nectar_primitives::store::MemoryStore;
+
+    use super::*;
+    use crate::metadata;
+
+    type Store = MemoryStore<DEFAULT_BODY_SIZE>;
+
+    fn make_addr(s: &str) -> ChunkAddress {
+        let bytes = s.as_bytes();
+        let mut buf = [0u8; 32];
+        let len = bytes.len().min(32);
+        buf[..len].copy_from_slice(&bytes[..len]);
+        ChunkAddress::from(buf)
+    }
+
+    #[test]
+    fn save_returns_root_and_read_handle() {
+        let mut builder: ManifestBuilder<Store> = ManifestBuilder::new(Store::new());
+        let paths = &["index.html", "img/1.png", "img/2.png", "robots.txt"];
+        for &path in paths {
+            block_on(builder.add(path, make_addr(path))).unwrap();
+        }
+
+        let (root, mut manifest) = block_on(builder.save()).unwrap();
+        assert_eq!(manifest.reference(), Some(&root));
+
+        for &path in paths {
+            let entry = block_on(manifest.lookup(path)).unwrap();
+            assert_eq!(entry.address(), Some(&make_addr(path)));
+        }
+    }
+
+    #[test]
+    fn empty_builder_saves_to_a_root() {
+        let builder: ManifestBuilder<Store> = ManifestBuilder::new(Store::new());
+        let (_root, mut manifest) = block_on(builder.save()).unwrap();
+        assert!(block_on(manifest.entries()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn root_metadata_is_rejected_at_save() {
+        let mut builder: ManifestBuilder<Store> = ManifestBuilder::new(Store::new());
+        // The empty path targets the root node itself; attaching metadata there
+        // produces the unserializable shape the guard must catch.
+        let mut meta = BTreeMap::new();
+        meta.insert("k".to_string(), "v".to_string());
+        block_on(builder.add_with_metadata("", make_addr("root"), meta)).unwrap();
+
+        let err = block_on(builder.save()).unwrap_err();
+        assert!(matches!(err, MantarayError::RootMetadata));
+    }
+
+    #[test]
+    fn root_entry_without_metadata_saves() {
+        // A root value with no metadata is serializable (the entry slot lives
+        // in the node header); only root metadata is rejected.
+        let mut builder: ManifestBuilder<Store> = ManifestBuilder::new(Store::new());
+        block_on(builder.add("", make_addr("root"))).unwrap();
+        assert!(block_on(builder.save()).is_ok());
+    }
+
+    #[test]
+    fn oversized_metadata_is_rejected_at_save() {
+        let mut builder: ManifestBuilder<Store> = ManifestBuilder::new(Store::new());
+        let mut meta = BTreeMap::new();
+        meta.insert("k".to_string(), "a".repeat(usize::from(u16::MAX) + 16));
+        block_on(builder.add_with_metadata("file", make_addr("file"), meta)).unwrap();
+
+        let err = block_on(builder.save()).unwrap_err();
+        assert!(matches!(err, MantarayError::MetadataTooLarge { .. }));
+    }
+
+    #[test]
+    fn website_documents_round_trip_through_the_handle() {
+        let mut builder: ManifestBuilder<Store> = ManifestBuilder::new(Store::new());
+        block_on(builder.add("index.html", make_addr("index.html"))).unwrap();
+        block_on(builder.set_index_document("index.html")).unwrap();
+        block_on(builder.set_error_document("404.html")).unwrap();
+
+        let (_root, mut manifest) = block_on(builder.save()).unwrap();
+        let index = block_on(manifest.lookup(metadata::ROOT_PATH)).unwrap();
+        assert_eq!(
+            index.metadata().get(metadata::WEBSITE_INDEX_DOCUMENT),
+            Some(&"index.html".to_string())
+        );
+        assert_eq!(
+            index.metadata().get(metadata::WEBSITE_ERROR_DOCUMENT),
+            Some(&"404.html".to_string())
+        );
+    }
+
+    #[test]
+    fn remove_before_save_drops_the_path() {
+        let mut builder: ManifestBuilder<Store> = ManifestBuilder::new(Store::new());
+        block_on(builder.add("a.txt", make_addr("a"))).unwrap();
+        block_on(builder.add("b.txt", make_addr("b"))).unwrap();
+        block_on(builder.remove("a.txt")).unwrap();
+
+        let (_root, mut manifest) = block_on(builder.save()).unwrap();
+        let paths: Vec<_> = block_on(manifest.entries())
+            .unwrap()
+            .into_iter()
+            .map(|e| e.path().to_vec())
+            .collect();
+        assert_eq!(paths, vec![b"b.txt".to_vec()]);
+    }
+}

--- a/crates/mantaray/src/builder.rs
+++ b/crates/mantaray/src/builder.rs
@@ -261,6 +261,46 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "encryption")]
+    #[test]
+    fn encrypted_builder_round_trips_the_reference() {
+        use nectar_primitives::file::EntryRef;
+        use nectar_primitives::{EncryptedChunkRef, EncryptionKey};
+
+        let mut builder = ManifestBuilder::<Store, EncryptedChunkRef>::new_encrypted(Store::new());
+        let eref = EncryptedChunkRef::new(
+            make_addr("index.html"),
+            EncryptionKey::from([7u8; EncryptionKey::SIZE]),
+        );
+        block_on(builder.add("index.html", eref.clone())).unwrap();
+
+        let (root, mut manifest) = block_on(builder.save()).unwrap();
+        // The returned reference addresses the saved root.
+        assert_eq!(manifest.reference(), Some(root.address()));
+
+        // Address and decryption key both survive encode and decode.
+        let entry = block_on(manifest.lookup("index.html")).unwrap();
+        assert_eq!(entry.reference(), Some(&EntryRef::Encrypted(eref)));
+    }
+
+    #[cfg(feature = "encryption")]
+    #[test]
+    fn encrypted_builder_rejects_root_metadata() {
+        use nectar_primitives::{EncryptedChunkRef, EncryptionKey};
+
+        let mut builder = ManifestBuilder::<Store, EncryptedChunkRef>::new_encrypted(Store::new());
+        let eref = EncryptedChunkRef::new(
+            make_addr("root"),
+            EncryptionKey::from([9u8; EncryptionKey::SIZE]),
+        );
+        let mut meta = BTreeMap::new();
+        meta.insert("k".to_string(), "v".to_string());
+        block_on(builder.add_with_metadata("", eref, meta)).unwrap();
+
+        let err = block_on(builder.save()).unwrap_err();
+        assert!(matches!(err, MantarayError::RootMetadata));
+    }
+
     #[test]
     fn remove_before_save_drops_the_path() {
         let mut builder: ManifestBuilder<Store> = ManifestBuilder::new(Store::new());

--- a/crates/mantaray/src/builder.rs
+++ b/crates/mantaray/src/builder.rs
@@ -193,11 +193,11 @@ mod tests {
             block_on(builder.add(path, make_addr(path))).unwrap();
         }
 
-        let (root, mut manifest) = block_on(builder.save()).unwrap();
+        let (root, manifest) = block_on(builder.save()).unwrap();
         assert_eq!(manifest.reference(), Some(&root));
 
         for &path in paths {
-            let entry = block_on(manifest.lookup(path)).unwrap();
+            let entry = block_on(manifest.get(path)).unwrap().unwrap();
             assert_eq!(entry.address(), Some(&make_addr(path)));
         }
     }
@@ -205,7 +205,7 @@ mod tests {
     #[test]
     fn empty_builder_saves_to_a_root() {
         let builder: ManifestBuilder<Store> = ManifestBuilder::new(Store::new());
-        let (_root, mut manifest) = block_on(builder.save()).unwrap();
+        let (_root, manifest) = block_on(builder.save()).unwrap();
         assert!(block_on(manifest.entries()).unwrap().is_empty());
     }
 
@@ -249,8 +249,8 @@ mod tests {
         block_on(builder.set_index_document("index.html")).unwrap();
         block_on(builder.set_error_document("404.html")).unwrap();
 
-        let (_root, mut manifest) = block_on(builder.save()).unwrap();
-        let index = block_on(manifest.lookup(metadata::ROOT_PATH)).unwrap();
+        let (_root, manifest) = block_on(builder.save()).unwrap();
+        let index = block_on(manifest.get(metadata::ROOT_PATH)).unwrap().unwrap();
         assert_eq!(
             index.metadata().get(metadata::WEBSITE_INDEX_DOCUMENT),
             Some(&"index.html".to_string())
@@ -274,12 +274,12 @@ mod tests {
         );
         block_on(builder.add("index.html", eref.clone())).unwrap();
 
-        let (root, mut manifest) = block_on(builder.save()).unwrap();
+        let (root, manifest) = block_on(builder.save()).unwrap();
         // The returned reference addresses the saved root.
         assert_eq!(manifest.reference(), Some(root.address()));
 
         // Address and decryption key both survive encode and decode.
-        let entry = block_on(manifest.lookup("index.html")).unwrap();
+        let entry = block_on(manifest.get("index.html")).unwrap().unwrap();
         assert_eq!(entry.reference(), Some(&EntryRef::Encrypted(eref)));
     }
 
@@ -308,7 +308,7 @@ mod tests {
         block_on(builder.add("b.txt", make_addr("b"))).unwrap();
         block_on(builder.remove("a.txt")).unwrap();
 
-        let (_root, mut manifest) = block_on(builder.save()).unwrap();
+        let (_root, manifest) = block_on(builder.save()).unwrap();
         let paths: Vec<_> = block_on(manifest.entries())
             .unwrap()
             .into_iter()

--- a/crates/mantaray/src/error.rs
+++ b/crates/mantaray/src/error.rs
@@ -132,6 +132,12 @@ pub enum MantarayError {
     /// Node has not been saved yet (reference is empty).
     #[error("missing reference")]
     MissingReference,
+    /// Root node carries its own metadata, which the wire format cannot hold.
+    ///
+    /// Only fork children serialize metadata; a root's would be silently
+    /// dropped, so the builder rejects it at save.
+    #[error("root node metadata is not serializable")]
+    RootMetadata,
     /// Error from primitives (chunk creation, BMT, etc.).
     #[error(transparent)]
     Primitives(#[from] PrimitivesError),

--- a/crates/mantaray/src/lib.rs
+++ b/crates/mantaray/src/lib.rs
@@ -109,6 +109,7 @@
 use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::ChunkRef;
 
+pub mod builder;
 pub mod codec;
 mod constants;
 pub mod entry;
@@ -123,6 +124,7 @@ pub use constants::metadata;
 pub(crate) use constants::*;
 
 // Re-export public types.
+pub use builder::ManifestBuilder;
 pub use entry::Entry;
 pub use error::{DecodeError, DecodeResult, MantarayError, Result};
 pub use manifest::{Manifest, ManifestIter};


### PR DESCRIPTION
## What

Adds `ManifestBuilder<S, R, BS>` in a new `crates/mantaray/src/builder.rs` module: a save-consuming builder for the mantaray write path, with plain and (behind the `encryption` feature) encrypted variants.

- Entries are staged in memory via `add`, `add_with_metadata`, `add_entry`, `remove`, `set_index_document`, `set_error_document`, delegating to the underlying `Manifest`.
- `save(self)` consumes the builder, persists the manifest (children before parents, via the existing `Manifest::save`), and returns the typed root (`ChunkAddress` for plain, `ManifestRef` for encrypted) alongside a read handle: the reopened `Manifest` over the same store.
- Because `save` takes `self` by value, an unsaved builder holds no address, and a saved builder cannot be saved a second time; this is pinned by a `compile_fail` doctest in the module docs.
- A new `ensure_root_serializable` guard runs before every save and rejects a root node that carries its own metadata, since the wire format only serializes metadata on fork children and a root's metadata would otherwise be silently dropped on encode. This is surfaced as a new `MantarayError::RootMetadata` variant added to `crates/mantaray/src/error.rs`.
- `builder` is wired up as a public module and `ManifestBuilder` is re-exported from `crates/mantaray/src/lib.rs`.

The diff is purely additive: three files touched (`builder.rs`, `error.rs`, `lib.rs`), 327 insertions, no deletions, no changes to the codec or wire format.

Closes #174

## Why

Nothing outside `mantaray` should hand-assemble wire bytes. `ManifestBuilder` is the single sanctioned route from staged entries to a persisted manifest, and the type-state-by-consumption (`save(self)`) makes "saved twice" and "used before saving" compile errors rather than runtime bugs. The root-metadata guard closes a real footgun in the wire format: without it, a root with its own metadata would encode successfully but silently drop that metadata, which is far worse than a loud rejection at save time.

## Testing

Verified independently on a fresh clone, 2 commits atop `s157/54-node-state`, detached at `376b5b7`, changed files limited to `crates/mantaray/src/{builder.rs,error.rs,lib.rs}`:

- `cargo fmt --all -- --check`: pass.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: pass, zero warnings.
- `cargo nextest run --workspace --all-features`: 607 tests run, 607 passed, 1 skipped, including all 9 `builder::tests` (`save_returns_root_and_read_handle`, `empty_builder_saves_to_a_root`, `root_metadata_is_rejected_at_save`, `root_entry_without_metadata_saves`, `oversized_metadata_is_rejected_at_save`, `website_documents_round_trip_through_the_handle`, `encrypted_builder_round_trips_the_reference`, `encrypted_builder_rejects_root_metadata`, `remove_before_save_drops_the_path`).

This is a stacked PR targeting `s157/60-shared-read-option`, not `main`; no CI beyond CLA will run until it is retargeted.

## AI Assistance

Claude (Anthropic) was used for implementation, adversarial red-team review, and independent test verification of this change, per the org AI assistance disclosure policy.

