### PR TITLE
feat(mantaray): add shared-read (&self) manifest API

### DIFF
--- a/crates/mantaray/benches/mantaray_bench.rs
+++ b/crates/mantaray/benches/mantaray_bench.rs
@@ -11,6 +11,8 @@
     clippy::as_conversions,
     clippy::missing_panics_doc
 )]
+// The lookup benches deliberately measure the mutating `&mut self` lookup path.
+#![allow(deprecated)]
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use futures::executor::block_on;
 use nectar_mantaray::hazmat;
@@ -357,7 +359,7 @@ fn bench_iter(c: &mut Criterion) {
 
     // Compare with entries() (walk-based collection)
     group.bench_function("entries_spa_trie", |b| {
-        let mut m = build_spa_manifest();
+        let m = build_spa_manifest();
 
         b.iter(|| {
             let entries = block_on(m.entries()).unwrap();

--- a/crates/mantaray/src/manifest.rs
+++ b/crates/mantaray/src/manifest.rs
@@ -129,7 +129,23 @@ impl<S: ChunkGet<BS>, R: Reference + MaybeSend, const BS: usize> Manifest<S, R, 
             .await
     }
 
+    /// Look up a path, returning `None` when it is absent or not a value.
+    ///
+    /// Shared-read (`&self`) accessor: descends over owned clones, so a
+    /// persisted manifest is read without mutating or caching into the trie.
+    pub async fn get(&self, path: &str) -> Result<Option<Entry>> {
+        let path = path.as_bytes();
+        let Some(node) = self.trie.get_node::<S, BS>(path, &self.store).await? else {
+            return Ok(None);
+        };
+        if !node.is_value() {
+            return Ok(None);
+        }
+        Ok(Some(Entry::from_node(path, &node)))
+    }
+
     /// Look up a path in the manifest.
+    #[deprecated(note = "use `get`, which returns `Ok(None)` for absent paths instead of erroring")]
     pub async fn lookup(&mut self, path: &str) -> Result<Entry> {
         let node = self
             .trie
@@ -170,9 +186,10 @@ impl<S: ChunkGet<BS>, R: Reference + MaybeSend, const BS: usize> Manifest<S, R, 
 
     /// Collect all value entries from the manifest.
     ///
-    /// Convenience wrapper around the [`stream`](Self::stream) accessor.
-    pub async fn entries(&mut self) -> Result<Vec<Entry>> {
-        let mut iter = self.iter();
+    /// Shared-read (`&self`) accessor: depth-first over owned clones, leaving
+    /// the trie untouched. Convenience wrapper around [`stream`](Self::stream).
+    pub async fn entries(&self) -> Result<Vec<Entry>> {
+        let mut iter = self.shared_iter();
         let mut out = Vec::new();
         while let Some(item) = iter.next().await {
             out.push(item?);
@@ -252,13 +269,17 @@ impl<S: ChunkGet<BS>, R: Reference + MaybeSend, const BS: usize> Manifest<S, R, 
     }
 
     /// Get the website index document from root path metadata.
-    pub async fn index_document(&mut self) -> Result<Option<String>> {
+    ///
+    /// Shared-read (`&self`) accessor; `None` when unset.
+    pub async fn index_document(&self) -> Result<Option<String>> {
         self.get_root_metadata(metadata::WEBSITE_INDEX_DOCUMENT)
             .await
     }
 
     /// Get the website error document from root path metadata.
-    pub async fn error_document(&mut self) -> Result<Option<String>> {
+    ///
+    /// Shared-read (`&self`) accessor; `None` when unset.
+    pub async fn error_document(&self) -> Result<Option<String>> {
         self.get_root_metadata(metadata::WEBSITE_ERROR_DOCUMENT)
             .await
     }
@@ -298,10 +319,18 @@ impl<S: ChunkGet<BS>, R: Reference + MaybeSend, const BS: usize> Manifest<S, R, 
     }
 
     /// Lazy depth-first stream over all entries in the manifest.
-    pub fn stream(&mut self) -> impl Stream<Item = Result<Entry>> + '_ {
-        futures::stream::unfold(self.iter(), |mut iter| async move {
+    ///
+    /// Shared-read (`&self`) accessor: traverses owned clones on demand,
+    /// leaving the trie untouched.
+    pub fn stream(&self) -> impl Stream<Item = Result<Entry>> + '_ {
+        futures::stream::unfold(self.shared_iter(), |mut iter| async move {
             iter.next().await.map(|item| (item, iter))
         })
+    }
+
+    /// Seed a shared-read depth-first traversal from a clone of the root.
+    fn shared_iter(&self) -> SharedIter<'_, S, R, BS> {
+        SharedIter::new(self.trie.clone(), &self.store)
     }
 
     async fn set_root_metadata(&mut self, key: &str, value: &str) -> Result<()> {
@@ -330,16 +359,12 @@ impl<S: ChunkGet<BS>, R: Reference + MaybeSend, const BS: usize> Manifest<S, R, 
         }
     }
 
-    async fn get_root_metadata(&mut self, key: &str) -> Result<Option<String>> {
-        match self
+    async fn get_root_metadata(&self, key: &str) -> Result<Option<String>> {
+        let node = self
             .trie
-            .lookup_node::<S, BS>(metadata::ROOT_PATH.as_bytes(), &self.store)
-            .await
-        {
-            Ok(node) => Ok(node.metadata().get(key).cloned()),
-            Err(MantarayError::NoForkFound { .. }) => Ok(None),
-            Err(e) => Err(e),
-        }
+            .get_node::<S, BS>(metadata::ROOT_PATH.as_bytes(), &self.store)
+            .await?;
+        Ok(node.and_then(|n| n.metadata().get(key).cloned()))
     }
 }
 
@@ -517,6 +542,119 @@ impl<'a, S: ChunkGet<BS>, R: Reference, const BS: usize> ManifestIter<'a, S, R, 
     }
 }
 
+/// Shared-read depth-first iterator over owned node clones.
+///
+/// Shared-read (`&self`) counterpart to [`ManifestIter`]: each descent step
+/// clones the child fork, so a persisted manifest is streamed without mutating
+/// or caching into the trie. Nodes load from storage on demand.
+struct SharedIter<'a, S, R: Reference = ChunkRef, const BS: usize = DEFAULT_BODY_SIZE> {
+    store: &'a S,
+    /// Cloned root, taken and visited on the first advance.
+    root: Option<Node<R>>,
+    stack: Vec<SharedFrame<R>>,
+    /// Running path buffer; extended when pushing frames, truncated when popping.
+    path_buf: Vec<u8>,
+}
+
+struct SharedFrame<R: Reference> {
+    /// Owned clone of the node at this stack level.
+    node: Node<R>,
+    /// Length of `path_buf` before this frame's prefix was appended.
+    path_len_before: usize,
+    /// This node's sorted fork keys.
+    keys: Vec<u8>,
+    /// Index into `keys` for the next fork to visit.
+    key_idx: usize,
+}
+
+impl<'a, S: ChunkGet<BS>, R: Reference, const BS: usize> SharedIter<'a, S, R, BS> {
+    const fn new(root: Node<R>, store: &'a S) -> Self {
+        Self {
+            store,
+            root: Some(root),
+            stack: Vec::new(),
+            path_buf: Vec::new(),
+        }
+    }
+
+    /// Advance the traversal, returning the next entry (or `None` when done).
+    #[allow(clippy::arithmetic_side_effects)] // the only arithmetic is the fork-cursor `key_idx += 1`, bounded by keys.len() <= 256
+    async fn next(&mut self) -> Option<Result<Entry>> {
+        loop {
+            if let Some(mut root) = self.root.take() {
+                if !root.is_loaded()
+                    && let Err(e) = root.load::<S, BS>(self.store).await
+                {
+                    return Some(Err(e));
+                }
+
+                let keys: Vec<u8> = root.forks.keys().copied().collect();
+                let entry = root.is_value().then(|| Entry::from_node(&[], &root));
+
+                self.stack.push(SharedFrame {
+                    node: root,
+                    path_len_before: 0,
+                    keys,
+                    key_idx: 0,
+                });
+
+                if let Some(entry) = entry {
+                    return Some(Ok(entry));
+                }
+                continue;
+            }
+
+            // Pop exhausted frames, truncating path_buf as we go.
+            while let Some(frame) = self.stack.pop_if(|f| f.key_idx >= f.keys.len()) {
+                self.path_buf.truncate(frame.path_len_before);
+            }
+
+            // Clone the next child out of the top frame, releasing its borrow
+            // before touching path_buf.
+            let (mut child, prefix) = {
+                let frame = self.stack.last_mut()?;
+                #[allow(clippy::indexing_slicing)]
+                // the pop_if loop above removed every frame with key_idx >= keys.len()
+                let key = frame.keys[frame.key_idx];
+                frame.key_idx += 1;
+                match frame.node.forks.get(&key) {
+                    Some(fork) => (fork.node.clone(), fork.prefix.clone()),
+                    None => {
+                        return Some(Err(MantarayError::NoForkFound {
+                            reference: frame.node.reference().copied(),
+                        }));
+                    }
+                }
+            };
+
+            let path_len_before = self.path_buf.len();
+            self.path_buf.extend_from_slice(&prefix);
+
+            if !child.is_loaded()
+                && let Err(e) = child.load::<S, BS>(self.store).await
+            {
+                return Some(Err(e));
+            }
+
+            let keys: Vec<u8> = child.forks.keys().copied().collect();
+            let entry = child
+                .is_value()
+                .then(|| Entry::from_node(&self.path_buf, &child));
+
+            self.stack.push(SharedFrame {
+                node: child,
+                path_len_before,
+                keys,
+                key_idx: 0,
+            });
+
+            if let Some(entry) = entry {
+                return Some(Ok(entry));
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use futures::executor::block_on;
@@ -577,7 +715,7 @@ mod tests {
         block_on(m.save()).unwrap();
 
         for &path in paths {
-            let entry = block_on(m.lookup(path)).unwrap();
+            let entry = block_on(m.get(path)).unwrap().unwrap();
             let expected = make_addr(path);
             assert_eq!(entry.address(), Some(&expected));
         }
@@ -647,7 +785,7 @@ mod tests {
     #[test]
     fn website_document_helpers_none_when_missing() {
         let store = Store::new();
-        let mut m = PlainManifest::new(store);
+        let m = PlainManifest::new(store);
 
         assert_eq!(block_on(m.index_document()).unwrap(), None);
         assert_eq!(block_on(m.error_document()).unwrap(), None);
@@ -706,12 +844,12 @@ mod tests {
 
         assert_ne!(root_ref_1, root_ref_2);
 
-        let entry = block_on(m.lookup("dir0/file0.txt")).unwrap();
+        let entry = block_on(m.get("dir0/file0.txt")).unwrap().unwrap();
         assert_eq!(entry.address(), Some(&updated_addr));
 
         for i in 1..100u32 {
             let path = format!("dir{}/file{}.txt", i / 10, i);
-            let entry = block_on(m.lookup(&path)).unwrap();
+            let entry = block_on(m.get(&path)).unwrap().unwrap();
             let expected = make_addr_u32(i);
             assert_eq!(
                 entry.address(),
@@ -1125,5 +1263,83 @@ mod tests {
                 "path {path} missing after partial lazy iteration"
             );
         }
+    }
+
+    #[test]
+    fn get_returns_some_for_present_path() {
+        let store = Store::new();
+        let mut m = PlainManifest::new(store);
+        let addr = make_addr("only");
+        block_on(m.add("only.txt", addr)).unwrap();
+
+        let entry = block_on(m.get("only.txt")).unwrap().unwrap();
+        assert_eq!(entry.address(), Some(&addr));
+    }
+
+    #[test]
+    fn get_returns_none_for_absent_path() {
+        let store = Store::new();
+        let mut m = PlainManifest::new(store);
+        block_on(m.add("present.txt", make_addr("present"))).unwrap();
+
+        assert!(block_on(m.get("absent.txt")).unwrap().is_none());
+        // A pure prefix of an existing path is an edge, not a value.
+        assert!(block_on(m.get("present")).unwrap().is_none());
+    }
+
+    #[test]
+    fn get_resolves_after_save_reload() {
+        let store = Store::new();
+        let mut m = PlainManifest::new(store);
+        let paths = &["index.html", "img/1.png", "img/2.png"];
+        for &path in paths {
+            block_on(m.add(path, make_addr(path))).unwrap();
+        }
+        let root_ref = block_on(m.save()).unwrap();
+        let (_, store) = m.into_parts();
+        let m2 = PlainManifest::open(root_ref, store);
+
+        // Shared reference: several reads share `&m2` without exclusive borrow.
+        let read = |p: &str| block_on(m2.get(p)).unwrap();
+        assert_eq!(
+            read("img/1.png").unwrap().address(),
+            Some(&make_addr("img/1.png"))
+        );
+        assert!(read("img/3.png").is_none());
+        assert_eq!(
+            read("index.html").unwrap().address(),
+            Some(&make_addr("index.html"))
+        );
+    }
+
+    #[test]
+    fn shared_reads_take_shared_reference() {
+        let store = Store::new();
+        let mut m = PlainManifest::new(store);
+        block_on(m.add("/", ChunkAddress::from([0u8; 32]))).unwrap();
+        block_on(m.set_index_document("index.html")).unwrap();
+        block_on(m.add("a.txt", make_addr("a"))).unwrap();
+
+        // All read accessors are callable through a shared borrow.
+        fn read_all<S: ChunkGet<DEFAULT_BODY_SIZE>>(m: &PlainManifest<S>) {
+            assert!(block_on(m.get("a.txt")).unwrap().is_some());
+            assert_eq!(block_on(m.entries()).unwrap().len(), 2);
+            assert_eq!(
+                block_on(m.index_document()).unwrap(),
+                Some("index.html".to_string())
+            );
+        }
+        read_all(&m);
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn deprecated_lookup_still_errors_on_miss() {
+        let store = Store::new();
+        let mut m = PlainManifest::new(store);
+        block_on(m.add("present.txt", make_addr("present"))).unwrap();
+
+        assert!(block_on(m.lookup("present.txt")).is_ok());
+        assert!(block_on(m.lookup("absent.txt")).is_err());
     }
 }

--- a/crates/mantaray/src/manifest.rs
+++ b/crates/mantaray/src/manifest.rs
@@ -627,14 +627,17 @@ impl<'a, S: ChunkGet<BS>, R: Reference, const BS: usize> SharedIter<'a, S, R, BS
                 }
             };
 
-            let path_len_before = self.path_buf.len();
-            self.path_buf.extend_from_slice(&prefix);
-
+            // Load before extending path_buf: an early return on load error
+            // must leave path_buf unchanged so a resumed traversal keeps its
+            // path prefix intact.
             if !child.is_loaded()
                 && let Err(e) = child.load::<S, BS>(self.store).await
             {
                 return Some(Err(e));
             }
+
+            let path_len_before = self.path_buf.len();
+            self.path_buf.extend_from_slice(&prefix);
 
             let keys: Vec<u8> = child.forks.keys().copied().collect();
             let entry = child
@@ -1341,5 +1344,70 @@ mod tests {
 
         assert!(block_on(m.lookup("present.txt")).is_ok());
         assert!(block_on(m.lookup("absent.txt")).is_err());
+    }
+
+    #[test]
+    fn stream_load_error_does_not_corrupt_sibling_paths() {
+        use futures::StreamExt;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        // Store injecting a single load failure on the `fail_on`-th get,
+        // delegating every other get to the inner store.
+        struct FailOnceStore {
+            inner: Store,
+            fail_on: usize,
+            count: AtomicUsize,
+        }
+
+        impl ChunkGet<DEFAULT_BODY_SIZE> for FailOnceStore {
+            type Error = nectar_primitives::store::ChunkStoreError;
+
+            async fn get(
+                &self,
+                address: &ChunkAddress,
+            ) -> std::result::Result<
+                nectar_primitives::chunk::AnyChunk<DEFAULT_BODY_SIZE>,
+                Self::Error,
+            > {
+                let n = self.count.fetch_add(1, Ordering::SeqCst) + 1;
+                if n == self.fail_on {
+                    // Force a miss to surface a load error mid-traversal.
+                    return ChunkGet::get(&self.inner, &ChunkAddress::from([0xffu8; 32])).await;
+                }
+                ChunkGet::get(&self.inner, address).await
+            }
+        }
+
+        // Two top-level leaves; 'a' sorts before 'b', so the depth-first
+        // traversal descends the 'a' fork first.
+        let store = Store::new();
+        let mut m = PlainManifest::new(store);
+        block_on(m.add("a.txt", make_addr("a.txt"))).unwrap();
+        block_on(m.add("b.txt", make_addr("b.txt"))).unwrap();
+        let root_ref = block_on(m.save()).unwrap();
+        let (_, store) = m.into_parts();
+
+        // get #1 loads the root; get #2 is the 'a' leaf and is failed; get #3
+        // is the sibling 'b' leaf and succeeds. A resumed traversal must not
+        // carry the failed fork's prefix into the sibling's path.
+        let failing = FailOnceStore {
+            inner: store,
+            fail_on: 2,
+            count: AtomicUsize::new(0),
+        };
+        let m2 = PlainManifest::open(root_ref, failing);
+
+        let items: Vec<Result<Entry>> = block_on(m2.stream().collect::<Vec<_>>());
+
+        assert_eq!(items.len(), 2);
+        assert!(
+            items[0].is_err(),
+            "first descent should surface the injected load error"
+        );
+        assert_eq!(
+            items[1].as_ref().unwrap().path(),
+            b"b.txt",
+            "sibling path must not be prefixed by the failed fork"
+        );
     }
 }

--- a/crates/mantaray/src/node.rs
+++ b/crates/mantaray/src/node.rs
@@ -436,6 +436,42 @@ impl<R: Reference> Node<R> {
         }
     }
 
+    /// Resolve the node at `path` over owned clones, loading on demand.
+    ///
+    /// Shared-read counterpart to [`lookup_node`](Self::lookup_node): borrows
+    /// `&self` and clones each descended fork, so reading a persisted manifest
+    /// leaves the trie untouched. Returns `None` for an absent path.
+    #[allow(clippy::indexing_slicing)] // `rest` is checked non-empty before `rest[0]`; `c <= rest.len()` from common_prefix_len
+    pub(crate) async fn get_node<S: ChunkGet<BS>, const BS: usize>(
+        &self,
+        path: &[u8],
+        store: &S,
+    ) -> Result<Option<Self>> {
+        let mut current = self.clone();
+        let mut rest = path;
+        loop {
+            current.ensure_loaded(store).await?;
+
+            if rest.is_empty() {
+                return Ok(Some(current));
+            }
+
+            let first = rest[0];
+            let Some(fork) = current.forks.get(&first) else {
+                return Ok(None);
+            };
+
+            let c = common_prefix_len(&fork.prefix, rest);
+            if c != fork.prefix.len() {
+                return Ok(None);
+            }
+
+            let child = fork.node.clone();
+            rest = &rest[c..];
+            current = child;
+        }
+    }
+
     /// Look up the entry at the given path, loading from storage as needed.
     #[cfg(test)]
     pub(crate) async fn lookup<S: ChunkGet<BS>, const BS: usize>(

--- a/crates/mantaray/tests/file_manifest_integration.rs
+++ b/crates/mantaray/tests/file_manifest_integration.rs
@@ -56,14 +56,14 @@ fn unified_store_workflow() {
     assert!(store.len() > files_chunk_count);
 
     // Reload manifest from the store
-    let mut manifest2 = PlainManifest::open(root_ref, store.clone());
+    let manifest2 = PlainManifest::open(root_ref, store.clone());
 
     // Verify lookup
-    let entry_a = block_on(manifest2.lookup("a.txt")).unwrap();
+    let entry_a = block_on(manifest2.get("a.txt")).unwrap().unwrap();
     assert_eq!(entry_a.address(), Some(&root_a));
     assert_eq!(entry_a.content_type(), Some("text/plain"));
 
-    let entry_b = block_on(manifest2.lookup("b.txt")).unwrap();
+    let entry_b = block_on(manifest2.get("b.txt")).unwrap().unwrap();
     assert_eq!(entry_b.address(), Some(&root_b));
 
     // Verify file data round-trip through the same store
@@ -101,7 +101,7 @@ fn entries_round_trip() {
     let root_ref = block_on(manifest.save()).unwrap();
 
     let (_, store) = manifest.into_parts();
-    let mut manifest2 = PlainManifest::open(root_ref, store);
+    let manifest2 = PlainManifest::open(root_ref, store);
 
     let entries = block_on(manifest2.entries()).unwrap();
     assert_eq!(entries.len(), paths.len());


### PR DESCRIPTION
## What

Adds a shared-read (`&self`) manifest API, layered over the typed-entry seam and `NodeState` on the base branch.

`node.rs`:
- `Node::get_node(&self, path, store) -> Result<Option<Self>>`, the shared-read counterpart to `lookup_node`. It descends over owned clones (like `entries_concurrent`), loading on demand, and returns `Ok(None)` for an absent path. Reuses the existing private `common_prefix_len`, with the same indexing-slicing justification as `lookup_node`.

`manifest.rs`:
- `get(&self, path) -> Result<Option<Entry>>`: `Ok(None)` for absent or non-value paths, `Ok(Some(entry))` otherwise.
- `entries`, `stream`, `index_document`, `error_document` (and the private `get_root_metadata`) reshaped from `&mut self` to `&self`, source-compatible and non-breaking.
- A new private `SharedIter` owned-clone depth-first iterator backs the reshaped accessors.
- `lookup` is deprecated in favour of `get`.

Closes #173

## Why

Reading a persisted manifest currently requires `&mut self` even though nothing is mutated, which forces unnecessary exclusive borrows on read-only call sites. This adds a shared-read path so callers can query manifests concurrently without locking for exclusive access, without breaking the existing `&mut self` API surface.

## Testing

Full battery run via `nix develop` on a fresh clone at HEAD `ad0f674` (two commits atop `s157/54-node-state`):

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean, including benches; the added `#![allow(deprecated)]` and the `&self` `entries()` reshape compile.
- `cargo nextest run --workspace --all-features` (nextest supplied ephemerally via `nix shell nixpkgs#cargo-nextest`): 604 passed, 1 skipped, 0 failed.
- `cargo test --doc --workspace`: all doctests pass.
- Wasm and fuzz checks not applicable: only the 4 mantaray files changed, `postage-usage` and `fuzz/` untouched.

New shared-read API behaviour is covered by branch tests, including `get_returns_some_for_present_path` and `get_returns_none_for_absent_path`.

During red-teaming, a correctness divergence was found in `SharedIter::next`: `path_buf` was extended before the child load, so on a load error (reachable via truncated or corrupt chunks) the non-terminating shared-read stream prepended the failed fork's stale prefix to all subsequent sibling paths, diverging from the mutable `ManifestIter`. This was fixed by reordering to load-before-extend (commit `ad0f674`), with a fault-injecting-store regression test that was confirmed to fail on the pre-fix ordering. The rest of the diff was verified sound: `get_node` is bounds-safe, and the `Option` semantics are equivalent to the old error-based path.

This is a stacked PR targeting `s157/54-node-state`, not `main`; no CI beyond CLA runs until retarget.

AI Assistance: Claude (Anthropic) used for implementation, red-teaming, and independent verification of this change.
