### PR TITLE
chore(mantaray): use core and alloc imports for no_std readiness

### DIFF
--- a/crates/mantaray/src/builder.rs
+++ b/crates/mantaray/src/builder.rs
@@ -36,7 +36,7 @@
 //! # });
 //! ```
 
-use std::collections::BTreeMap;
+use alloc::collections::BTreeMap;
 
 use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{ChunkAddress, ChunkRef, Reference};

--- a/crates/mantaray/src/codec.rs
+++ b/crates/mantaray/src/codec.rs
@@ -1,6 +1,6 @@
 //! Binary encoding for mantaray nodes (v0.1 and v0.2).
 
-use std::collections::BTreeMap;
+use alloc::collections::BTreeMap;
 
 use crate::error::{DecodeError, DecodeResult, MantarayError, Result};
 use crate::node::{Fork, Node, NodeType, Prefix};

--- a/crates/mantaray/src/entry.rs
+++ b/crates/mantaray/src/entry.rs
@@ -1,6 +1,6 @@
 //! Manifest entry type: path, reference, and metadata.
 
-use std::collections::BTreeMap;
+use alloc::collections::BTreeMap;
 
 use nectar_primitives::chunk::{ChunkAddress, Reference};
 use nectar_primitives::file::EntryRef;
@@ -77,7 +77,7 @@ impl Entry {
 
     /// Path as a UTF-8 string. Returns `None` if the path is not valid UTF-8.
     pub fn path_str(&self) -> Option<&str> {
-        std::str::from_utf8(&self.path).ok()
+        core::str::from_utf8(&self.path).ok()
     }
 
     /// Chunk address from the reference.

--- a/crates/mantaray/src/error.rs
+++ b/crates/mantaray/src/error.rs
@@ -1,15 +1,15 @@
 //! Error types for mantaray operations.
 
-use std::sync::Arc;
+use alloc::sync::Arc;
 
 use nectar_primitives::chunk::ChunkAddress;
 use nectar_primitives::error::PrimitivesError;
 
 /// Result type alias for mantaray operations.
-pub type Result<T> = std::result::Result<T, MantarayError>;
+pub type Result<T> = core::result::Result<T, MantarayError>;
 
 /// Result type alias for node wire decoding.
-pub type DecodeResult<T> = std::result::Result<T, DecodeError>;
+pub type DecodeResult<T> = core::result::Result<T, DecodeError>;
 
 /// Wire decode failures for a mantaray node chunk.
 ///
@@ -148,13 +148,13 @@ pub enum MantarayError {
     #[error("store get error: {source}")]
     StoreGet {
         /// Original store error, preserved for downcasting.
-        source: Arc<dyn std::error::Error + Send + Sync>,
+        source: Arc<dyn core::error::Error + Send + Sync>,
     },
     /// Error from the typed chunk store during put operations.
     #[error("store put error: {source}")]
     StorePut {
         /// Original store error, preserved for downcasting.
-        source: Arc<dyn std::error::Error + Send + Sync>,
+        source: Arc<dyn core::error::Error + Send + Sync>,
     },
 }
 

--- a/crates/mantaray/src/lib.rs
+++ b/crates/mantaray/src/lib.rs
@@ -106,6 +106,10 @@
     )
 )]
 
+// `alloc` backs the fork maps (`BTreeMap`) and shared error sources (`Arc`).
+// `nectar-primitives`, a hard dependency, already requires an allocator.
+extern crate alloc;
+
 use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::ChunkRef;
 

--- a/crates/mantaray/src/manifest.rs
+++ b/crates/mantaray/src/manifest.rs
@@ -1,6 +1,6 @@
 //! High-level mantaray manifest and lazy iterator.
 
-use std::collections::BTreeMap;
+use alloc::collections::BTreeMap;
 
 use futures::{Stream, StreamExt, TryStreamExt, stream};
 use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
@@ -455,8 +455,8 @@ pub struct ManifestIter<'a, S, R: Reference = ChunkRef, const BS: usize = DEFAUL
     root_visited: bool,
 }
 
-impl<S, R: Reference, const BS: usize> std::fmt::Debug for ManifestIter<'_, S, R, BS> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<S, R: Reference, const BS: usize> core::fmt::Debug for ManifestIter<'_, S, R, BS> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("ManifestIter")
             .field("stack_depth", &self.stack.len())
             .field("root_visited", &self.root_visited)
@@ -514,7 +514,7 @@ impl<'a, S: ChunkGet<BS>, R: Reference, const BS: usize> ManifestIter<'a, S, R, 
                 };
 
                 self.stack.push(IterFrame {
-                    node: std::ptr::from_mut(self.trie),
+                    node: core::ptr::from_mut(self.trie),
                     path_len_before: 0,
                     keys,
                     key_idx: 0,
@@ -554,7 +554,7 @@ impl<'a, S: ChunkGet<BS>, R: Reference, const BS: usize> ManifestIter<'a, S, R, 
                 }
             };
 
-            let child = std::ptr::from_mut(&mut fork.node);
+            let child = core::ptr::from_mut(&mut fork.node);
 
             // SAFETY: child is a descendant of the exclusively borrowed trie.
             let child_ref = unsafe { &mut *child };
@@ -1052,34 +1052,34 @@ mod tests {
     /// stays bounded by the chosen width.
     struct TrackingStore {
         inner: Store,
-        inflight: std::sync::atomic::AtomicUsize,
-        max_inflight: std::sync::atomic::AtomicUsize,
-        gets: std::sync::atomic::AtomicUsize,
+        inflight: core::sync::atomic::AtomicUsize,
+        max_inflight: core::sync::atomic::AtomicUsize,
+        gets: core::sync::atomic::AtomicUsize,
     }
 
     impl TrackingStore {
         fn new(inner: Store) -> Self {
             Self {
                 inner,
-                inflight: std::sync::atomic::AtomicUsize::new(0),
-                max_inflight: std::sync::atomic::AtomicUsize::new(0),
-                gets: std::sync::atomic::AtomicUsize::new(0),
+                inflight: core::sync::atomic::AtomicUsize::new(0),
+                max_inflight: core::sync::atomic::AtomicUsize::new(0),
+                gets: core::sync::atomic::AtomicUsize::new(0),
             }
         }
 
         fn max_inflight(&self) -> usize {
-            self.max_inflight.load(std::sync::atomic::Ordering::SeqCst)
+            self.max_inflight.load(core::sync::atomic::Ordering::SeqCst)
         }
 
         fn gets(&self) -> usize {
-            self.gets.load(std::sync::atomic::Ordering::SeqCst)
+            self.gets.load(core::sync::atomic::Ordering::SeqCst)
         }
     }
 
     /// Yield once so sibling fetches in the same `buffer_unordered` batch can
     /// ramp their in-flight count before any single fetch resolves.
     async fn yield_once() {
-        use std::task::Poll;
+        use core::task::Poll;
         let mut yielded = false;
         futures::future::poll_fn(|cx| {
             if yielded {
@@ -1099,9 +1099,9 @@ mod tests {
         async fn get(
             &self,
             address: &ChunkAddress,
-        ) -> std::result::Result<nectar_primitives::chunk::AnyChunk<DEFAULT_BODY_SIZE>, Self::Error>
+        ) -> core::result::Result<nectar_primitives::chunk::AnyChunk<DEFAULT_BODY_SIZE>, Self::Error>
         {
-            use std::sync::atomic::Ordering::SeqCst;
+            use core::sync::atomic::Ordering::SeqCst;
             self.gets.fetch_add(1, SeqCst);
             let cur = self.inflight.fetch_add(1, SeqCst) + 1;
             self.max_inflight.fetch_max(cur, SeqCst);
@@ -1391,8 +1391,8 @@ mod tests {
 
     #[test]
     fn stream_load_error_does_not_corrupt_sibling_paths() {
+        use core::sync::atomic::{AtomicUsize, Ordering};
         use futures::StreamExt;
-        use std::sync::atomic::{AtomicUsize, Ordering};
 
         // Store injecting a single load failure on the `fail_on`-th get,
         // delegating every other get to the inner store.
@@ -1408,7 +1408,7 @@ mod tests {
             async fn get(
                 &self,
                 address: &ChunkAddress,
-            ) -> std::result::Result<
+            ) -> core::result::Result<
                 nectar_primitives::chunk::AnyChunk<DEFAULT_BODY_SIZE>,
                 Self::Error,
             > {

--- a/crates/mantaray/src/node.rs
+++ b/crates/mantaray/src/node.rs
@@ -1,8 +1,8 @@
 //! Node and Fork types for the mantaray trie.
 
-use std::collections::BTreeMap;
-use std::future::Future;
-use std::pin::Pin;
+use alloc::collections::BTreeMap;
+use core::future::Future;
+use core::pin::Pin;
 
 use crate::error::{DecodeError, DecodeResult, MantarayError, Result};
 use crate::obfuscation::ObfuscationKey;
@@ -123,7 +123,7 @@ impl Prefix {
 impl FromCursor for Prefix {
     type Error = DecodeError;
 
-    fn take_from(cur: &mut Cursor<'_>) -> std::result::Result<Self, Self::Error> {
+    fn take_from(cur: &mut Cursor<'_>) -> core::result::Result<Self, Self::Error> {
         let len = cur.take::<u8>()?;
         let padded = cur.take::<[u8; PREFIX_MAX_LEN]>()?;
         Self::from_wire(&padded, len)
@@ -140,7 +140,7 @@ impl ToWriter for Prefix {
     }
 }
 
-impl std::ops::Deref for Prefix {
+impl core::ops::Deref for Prefix {
     type Target = [u8];
 
     #[inline]
@@ -150,8 +150,8 @@ impl std::ops::Deref for Prefix {
     }
 }
 
-impl std::fmt::Debug for Prefix {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Prefix {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Prefix({:?})", &**self)
     }
 }
@@ -389,7 +389,7 @@ impl<R: Reference> Node<R> {
             .get(&address)
             .await
             .map_err(|e| MantarayError::StoreGet {
-                source: std::sync::Arc::new(e),
+                source: alloc::sync::Arc::new(e),
             })?;
         let mut loaded = Self::decode(chunk.data().as_ref())
             .map_err(|source| MantarayError::Corrupt { address, source })?;
@@ -734,7 +734,7 @@ impl<R: Reference> Node<R> {
         }
 
         let mut stack: Vec<SaveFrame<R>> = vec![SaveFrame {
-            node: std::ptr::from_mut(self),
+            node: core::ptr::from_mut(self),
             keys: self.forks.keys().copied().collect(),
             key_idx: 0,
         }];
@@ -753,7 +753,7 @@ impl<R: Reference> Node<R> {
                 // key was collected from this node's fork map, which is not mutated while the frame is live
                 let child = node.forks.get_mut(&key).expect("key from this node");
                 if child.node.reference().is_none() {
-                    let child_ptr = std::ptr::from_mut(&mut child.node);
+                    let child_ptr = core::ptr::from_mut(&mut child.node);
                     let child_keys = child.node.forks.keys().copied().collect();
                     stack.push(SaveFrame {
                         node: child_ptr,
@@ -772,7 +772,7 @@ impl<R: Reference> Node<R> {
                 .put(chunk.into())
                 .await
                 .map_err(|e| MantarayError::StorePut {
-                    source: std::sync::Arc::new(e),
+                    source: alloc::sync::Arc::new(e),
                 })?;
             // Persist the address and drop the now-redundant forks: the node
             // becomes a stub, reloaded on demand.
@@ -845,7 +845,7 @@ where
     f(path_buf, node)?;
 
     let mut stack: Vec<WalkFrame> = vec![WalkFrame {
-        node: std::ptr::from_mut(node).cast::<()>(),
+        node: core::ptr::from_mut(node).cast::<()>(),
         path_len_before: path_buf.len(),
         keys: node.forks.keys().copied().collect(),
         key_idx: 0,
@@ -879,7 +879,7 @@ where
         child.ensure_loaded(store).await?;
         f(path_buf, child)?;
 
-        let child_ptr = std::ptr::from_mut(child).cast::<()>();
+        let child_ptr = core::ptr::from_mut(child).cast::<()>();
         let child_keys = child.forks.keys().copied().collect();
         stack.push(WalkFrame {
             node: child_ptr,


### PR DESCRIPTION
Closes #176

## What

Mechanical `no_std`-readiness import sweep across `nectar-mantaray`, no behaviour or API change.

Swaps `std::` imports for their `core::`/`alloc::` equivalents across `error.rs`, `entry.rs`, `node.rs`, `codec.rs`, `builder.rs`, `manifest.rs`:

- `BTreeMap` -> `alloc::collections`
- `Arc` -> `alloc::sync` (`error.rs`)
- `Deref`, `Future`, `Pin`, `fmt` (`Debug`, `Formatter`, `Result`), `ptr::from_mut`, `sync::atomic` (`AtomicUsize`, `Ordering`), `task::Poll`, `str::from_utf8`, `result::Result` -> `core`
- the boxed `dyn` error source (`std::error::Error` -> `core::error::Error`) in `error.rs`'s `StoreGet`/`StorePut` variants

Adds `extern crate alloc;` to `lib.rs` with a terse rationale comment (`alloc` backs the fork `BTreeMap`s and `Arc`-shared error sources; `nectar-primitives` already requires an allocator), so the `alloc` paths resolve while the crate stays `std` by default.

Leaves the std-only test seed-file fixtures in `codec.rs` on `std::fs`/`std::path` — there is no `core`/`alloc` equivalent for filesystem access.

Also includes a second commit migrating the `builder.rs` doc/tests off the deprecated `Manifest::lookup`.

## Why

Prepares `nectar-mantaray` for eventual `no_std` support by removing unnecessary `std` coupling where a `core`/`alloc` path already exists, without changing behaviour, the public API, or the wire format.

## Testing

`core::error::Error` is a re-export of `std::error::Error` since Rust 1.81 (the pinned toolchain is 1.92), so this is a no-op on a `std` build: zero behaviour drift, zero API break.

`codec.rs` changed only its import; the existing seed-corpus round-trip decode tests confirm byte-for-byte wire compatibility is unaffected.

## AI Assistance

This PR was implemented with Claude (Anthropic), per the process described in [CONTRIBUTING.md](https://github.com/nxm-rs/.github/blob/main/CONTRIBUTING.md).

