### PR TITLE
feat(mantaray): fuse put_file/read across the file/manifest seam

### DIFF
--- a/crates/mantaray/src/builder.rs
+++ b/crates/mantaray/src/builder.rs
@@ -40,6 +40,7 @@ use std::collections::BTreeMap;
 
 use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{ChunkAddress, ChunkRef, Reference};
+use nectar_primitives::file::{ChunkPutExt, ReadAt};
 use nectar_primitives::store::{ChunkGet, ChunkPut, MaybeSend};
 
 use crate::entry::Entry;
@@ -135,6 +136,15 @@ impl<S: ChunkGet<BS>, R: Reference + MaybeSend, const BS: usize> ManifestBuilder
 }
 
 impl<S: ChunkGet<BS> + ChunkPut<BS>, const BS: usize> ManifestBuilder<S, ChunkRef, BS> {
+    /// Split `data`, store its chunks, and stage the resulting root at `path`.
+    ///
+    /// One mode end to end: a plain builder splits in plain mode and stages a
+    /// plain reference, so a plain-encrypted pairing cannot be expressed.
+    pub async fn put_file<D: ReadAt + Sync>(&mut self, path: &str, data: D) -> Result<()> {
+        let root = self.store().write_file(data).await?;
+        self.add(path, root).await
+    }
+
     /// Persist the plain manifest, consuming the builder.
     ///
     /// Returns the root chunk address and a read handle over the same store.
@@ -149,6 +159,21 @@ impl<S: ChunkGet<BS> + ChunkPut<BS>, const BS: usize> ManifestBuilder<S, ChunkRe
 impl<S: ChunkGet<BS> + ChunkPut<BS>, const BS: usize>
     ManifestBuilder<S, nectar_primitives::EncryptedChunkRef, BS>
 {
+    /// Split `data` in encrypted mode, store its chunks, and stage the root at `path`.
+    ///
+    /// One mode end to end: an encrypted builder splits in encrypted mode and
+    /// stages an encrypted reference, so a plain-encrypted pairing cannot be
+    /// expressed. Drives the splitter directly rather than the deprecated
+    /// `write_encrypted_file` ergonomic wrapper it supersedes.
+    pub async fn put_file<D: ReadAt + Sync>(&mut self, path: &str, data: D) -> Result<()> {
+        use nectar_primitives::file::{EncryptedParallelSplitter, FileError};
+        let (root, chunks) = EncryptedParallelSplitter::<BS>::split_to_vec(&data)?;
+        for chunk in chunks {
+            self.store().put(chunk).await.map_err(FileError::store)?;
+        }
+        self.add(path, root).await
+    }
+
     /// Persist the encrypted manifest, consuming the builder.
     ///
     /// Returns a [`ManifestRef`](crate::ManifestRef) and a read handle over the
@@ -299,6 +324,57 @@ mod tests {
 
         let err = block_on(builder.save()).unwrap_err();
         assert!(matches!(err, MantarayError::RootMetadata));
+    }
+
+    #[test]
+    fn put_file_round_trips_through_read() {
+        let mut builder: ManifestBuilder<Store> = ManifestBuilder::new(Store::new());
+        // A multi-chunk payload exercises the splitter and joiner, not just a
+        // single content chunk.
+        let big = vec![0xabu8; DEFAULT_BODY_SIZE * 3 + 17];
+        block_on(builder.put_file("a.txt", b"file A contents".to_vec())).unwrap();
+        block_on(builder.put_file("dir/big.bin", big.clone())).unwrap();
+
+        let (root, manifest) = block_on(builder.save()).unwrap();
+
+        assert_eq!(
+            block_on(manifest.read("a.txt")).unwrap().unwrap(),
+            b"file A contents"
+        );
+        assert_eq!(
+            block_on(manifest.read("dir/big.bin")).unwrap().unwrap(),
+            big
+        );
+        // Absent path reads as None, not an error.
+        assert!(block_on(manifest.read("missing.txt")).unwrap().is_none());
+
+        // Reopen from storage: read drives the lazy-load path.
+        let (_, store) = manifest.into_parts();
+        let reopened = super::Manifest::<Store, ChunkRef>::open(root, store);
+        assert_eq!(
+            block_on(reopened.read("dir/big.bin")).unwrap().unwrap(),
+            big
+        );
+    }
+
+    #[cfg(feature = "encryption")]
+    #[test]
+    fn encrypted_put_file_round_trips_through_read() {
+        use nectar_primitives::EncryptedChunkRef;
+
+        let mut builder = ManifestBuilder::<Store, EncryptedChunkRef>::new_encrypted(Store::new());
+        let big = vec![0x5cu8; DEFAULT_BODY_SIZE * 2 + 5];
+        block_on(builder.put_file("secret.txt", b"secret data".to_vec())).unwrap();
+        block_on(builder.put_file("blob.bin", big.clone())).unwrap();
+
+        let (_root, manifest) = block_on(builder.save()).unwrap();
+
+        assert_eq!(
+            block_on(manifest.read("secret.txt")).unwrap().unwrap(),
+            b"secret data"
+        );
+        assert_eq!(block_on(manifest.read("blob.bin")).unwrap().unwrap(), big);
+        assert!(block_on(manifest.read("absent")).unwrap().is_none());
     }
 
     #[test]

--- a/crates/mantaray/src/builder.rs
+++ b/crates/mantaray/src/builder.rs
@@ -165,9 +165,13 @@ impl<S: ChunkGet<BS> + ChunkPut<BS>, const BS: usize>
     /// stages an encrypted reference, so a plain-encrypted pairing cannot be
     /// expressed. Drives the splitter directly rather than the deprecated
     /// `write_encrypted_file` ergonomic wrapper it supersedes.
+    ///
+    /// `data` is dropped before the first store await, mirroring `write_file`,
+    /// so the returned future never holds the source across a suspension point.
     pub async fn put_file<D: ReadAt + Sync>(&mut self, path: &str, data: D) -> Result<()> {
         use nectar_primitives::file::{EncryptedParallelSplitter, FileError};
         let (root, chunks) = EncryptedParallelSplitter::<BS>::split_to_vec(&data)?;
+        drop(data);
         for chunk in chunks {
             self.store().put(chunk).await.map_err(FileError::store)?;
         }

--- a/crates/mantaray/src/builder.rs
+++ b/crates/mantaray/src/builder.rs
@@ -19,8 +19,8 @@
 //!     .add("index.html", ChunkAddress::from([1u8; 32]))
 //!     .await
 //!     .unwrap();
-//! let (_root, mut manifest) = builder.save().await.unwrap();
-//! let entry = manifest.lookup("index.html").await.unwrap();
+//! let (_root, manifest) = builder.save().await.unwrap();
+//! let entry = manifest.get("index.html").await.unwrap().unwrap();
 //! assert_eq!(entry.address(), Some(&ChunkAddress::from([1u8; 32])));
 //! # });
 //! ```
@@ -279,7 +279,9 @@ mod tests {
         block_on(builder.set_error_document("404.html")).unwrap();
 
         let (_root, manifest) = block_on(builder.save()).unwrap();
-        let index = block_on(manifest.get(metadata::ROOT_PATH)).unwrap().unwrap();
+        let index = block_on(manifest.get(metadata::ROOT_PATH))
+            .unwrap()
+            .unwrap();
         assert_eq!(
             index.metadata().get(metadata::WEBSITE_INDEX_DOCUMENT),
             Some(&"index.html".to_string())

--- a/crates/mantaray/src/error.rs
+++ b/crates/mantaray/src/error.rs
@@ -141,6 +141,9 @@ pub enum MantarayError {
     /// Error from primitives (chunk creation, BMT, etc.).
     #[error(transparent)]
     Primitives(#[from] PrimitivesError),
+    /// Error from the file splitter or joiner across the file/manifest seam.
+    #[error(transparent)]
+    File(#[from] nectar_primitives::file::FileError),
     /// Error from the typed chunk store during get operations.
     #[error("store get error: {source}")]
     StoreGet {

--- a/crates/mantaray/src/manifest.rs
+++ b/crates/mantaray/src/manifest.rs
@@ -5,6 +5,7 @@ use std::collections::BTreeMap;
 use futures::{Stream, StreamExt, TryStreamExt, stream};
 use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{ChunkAddress, ChunkRef, Reference};
+use nectar_primitives::file::join;
 use nectar_primitives::store::{ChunkGet, ChunkPut, MaybeSend};
 
 use crate::entry::Entry;
@@ -368,6 +369,26 @@ impl<S: ChunkGet<BS>, R: Reference + MaybeSend, const BS: usize> Manifest<S, R, 
     }
 }
 
+impl<S: ChunkGet<BS>, const BS: usize> Manifest<S, ChunkRef, BS> {
+    /// Look up `path` and join the file it references into memory.
+    ///
+    /// Shared-read (`&self`); `None` when the path is absent or is not a value.
+    /// One mode end to end: a plain manifest joins a plain reference, so a
+    /// plain-encrypted pairing surfaces as [`WrongRefKind`](MantarayError::WrongRefKind)
+    /// rather than a silent byte-width mismatch.
+    pub async fn read(&self, path: &str) -> Result<Option<Vec<u8>>> {
+        let Some(entry) = self.get(path).await? else {
+            return Ok(None);
+        };
+        let Some(entry_ref) = entry.reference else {
+            return Ok(None);
+        };
+        let reference = ChunkRef::from_entry_ref(entry_ref)?;
+        let data = join::<_, _, BS>(&self.store, reference.into_address()).await?;
+        Ok(Some(data))
+    }
+}
+
 impl<S: ChunkGet<BS> + ChunkPut<BS>, const BS: usize> Manifest<S, ChunkRef, BS> {
     /// Persist the plain manifest trie to storage, returning the root chunk address.
     pub async fn save(&mut self) -> Result<ChunkAddress> {
@@ -376,6 +397,28 @@ impl<S: ChunkGet<BS> + ChunkPut<BS>, const BS: usize> Manifest<S, ChunkRef, BS> 
             .trie
             .reference()
             .ok_or(MantarayError::MissingReference)?)
+    }
+}
+
+#[cfg(feature = "encryption")]
+impl<S: ChunkGet<BS>, const BS: usize> Manifest<S, nectar_primitives::EncryptedChunkRef, BS> {
+    /// Look up `path` and join the encrypted file it references into memory.
+    ///
+    /// Shared-read (`&self`); `None` when the path is absent or is not a value.
+    /// One mode end to end: an encrypted manifest joins an encrypted reference,
+    /// so a plain-encrypted pairing surfaces as
+    /// [`WrongRefKind`](MantarayError::WrongRefKind) rather than a silent
+    /// byte-width mismatch.
+    pub async fn read(&self, path: &str) -> Result<Option<Vec<u8>>> {
+        let Some(entry) = self.get(path).await? else {
+            return Ok(None);
+        };
+        let Some(entry_ref) = entry.reference else {
+            return Ok(None);
+        };
+        let reference = nectar_primitives::EncryptedChunkRef::from_entry_ref(entry_ref)?;
+        let data = join::<_, _, BS>(&self.store, reference).await?;
+        Ok(Some(data))
     }
 }
 

--- a/crates/mantaray/tests/file_manifest_integration.rs
+++ b/crates/mantaray/tests/file_manifest_integration.rs
@@ -215,6 +215,39 @@ fn ergonomic_api_workflow() {
     }
 }
 
+/// Fused seam: `ManifestBuilder::put_file` splits, stores, and stages in one
+/// mode; `Manifest::read` looks up and joins, collapsing the manual
+/// write_file + add and get + join dance the earlier tests spell out.
+#[test]
+fn fused_put_file_read_workflow() {
+    use nectar_mantaray::ManifestBuilder;
+
+    let mut builder: ManifestBuilder<Store> = ManifestBuilder::new(Store::new());
+    block_on(builder.put_file("a.txt", b"file A contents".to_vec())).unwrap();
+    block_on(builder.put_file("nested/b.txt", b"file B contents".to_vec())).unwrap();
+
+    let (root, manifest) = block_on(builder.save()).unwrap();
+
+    // Read back through the handle the save returned.
+    assert_eq!(
+        block_on(manifest.read("a.txt")).unwrap().unwrap(),
+        b"file A contents"
+    );
+    assert_eq!(
+        block_on(manifest.read("nested/b.txt")).unwrap().unwrap(),
+        b"file B contents"
+    );
+    assert!(block_on(manifest.read("missing")).unwrap().is_none());
+
+    // Reopen from storage and read again, exercising the lazy-load path.
+    let (_, store) = manifest.into_parts();
+    let reopened = PlainManifest::open(root, store);
+    assert_eq!(
+        block_on(reopened.read("nested/b.txt")).unwrap().unwrap(),
+        b"file B contents"
+    );
+}
+
 /// Create a ChunkAddress from a string, right-padded with zeroes.
 fn make_addr(s: &str) -> ChunkAddress {
     let bytes = s.as_bytes();

--- a/crates/primitives/src/file/mod.rs
+++ b/crates/primitives/src/file/mod.rs
@@ -273,6 +273,9 @@ pub trait ChunkPutExt<const BODY_SIZE: usize>: ChunkPut<BODY_SIZE> {
 
     /// Split `data` into encrypted chunks and store them, returning the root reference.
     #[cfg(feature = "encryption")]
+    #[deprecated(
+        note = "select encrypted mode through the reference type: an encrypted `ManifestBuilder::put_file`, or the `EncryptedParallelSplitter`/`split_encrypted` primitives directly"
+    )]
     fn write_encrypted_file<D: ReadAt + Sync>(
         &self,
         data: D,

--- a/crates/primitives/src/file/tests.rs
+++ b/crates/primitives/src/file/tests.rs
@@ -266,6 +266,7 @@ mod write_file_ext {
         use futures::executor::block_on;
 
         #[test]
+        #[allow(deprecated)] // pins the deprecated ergonomic wrapper's behaviour until removal
         fn write_encrypted_file_roundtrip() {
             let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
             let enc_ref = block_on(store.write_encrypted_file(b"secret data".to_vec())).unwrap();


### PR DESCRIPTION
## What

Fuses the file/manifest write and read paths so the split/join seam is typed end to end, with no byte round-trips.

- Adds `ManifestBuilder::put_file(path, data)` in both the plain and encrypted impl blocks. Plain drives `write_file`; encrypted drives `EncryptedParallelSplitter::split_to_vec` directly and stores the resulting chunks, dropping the source before the first store await. In each case the builder's reference type parameter selects the split mode, so a plain-encrypted pairing cannot be expressed.
- Adds `Manifest::read(path)`, also in both plain and encrypted impl blocks, as a shared-read `&self` method. It looks up the entry via the base `get` `Option` API, recovers the typed reference through `Reference::from_entry_ref` (so a width mismatch surfaces as `WrongRefKind` rather than a silent byte-count error), and joins the file via `nectar_primitives::file::join`. Returns `Ok(None)` for absent or non-value paths.
- Threads a new additive `MantarayError::File(#[from] FileError)` variant through so file errors compose with the existing manifest error type.
- Deprecates `ChunkPutExt::write_encrypted_file`, superseded by the encrypted `put_file`/`EncryptedParallelSplitter` path.
- Updates existing builder tests from the old `lookup` API to `get`/`Option`, and adds round-trip tests for `put_file`/`read` in both plain and encrypted modes, including a reopen-from-storage case that exercises the lazy-load path and an absent-path `None` case.

Diff: +163/-10 across `crates/mantaray/src/builder.rs`, `crates/mantaray/src/error.rs`, `crates/mantaray/src/manifest.rs`, `crates/mantaray/tests/file_manifest_integration.rs`, `crates/primitives/src/file/mod.rs`, `crates/primitives/src/file/tests.rs`.

Closes #175

## Why

Previously the write and read paths for files stored inside a manifest were split across separate ergonomic wrappers with no shared typed seam, so callers could mismatch plain and encrypted modes only at the byte level. Fusing them onto the builder's and manifest's own reference type parameter makes a plain-encrypted pairing a compile error on the write side and a typed `WrongRefKind` error rather than a silent misread on the read side.

## Testing

Reviewed as a detached `FETCH_HEAD` atop `origin/s157/62-manifest-builder`, all commands run via `nix develop --command`.

- `cargo fmt --all -- --check`: clean.
- Round-trip tests added for `put_file`/`read` in plain and encrypted modes, including a multi-chunk payload (exercising the splitter and joiner, not just a single content chunk), a reopen-from-storage case, and an absent-path `None` case.
- A minor defect was found and fixed during review: the encrypted `put_file` held the source across store awaits, imposing a stricter `Send` bound than the plain twin and a peak-memory regression versus the superseded `write_encrypted_file` wrapper. Fixed by dropping the source after split, mirroring `write_file`'s documented invariant.

This is a stacked branch targeting `s157/62-manifest-builder`; no CI beyond CLA runs until it is retargeted at `main`.

## AI Assistance

AI Assistance: Claude (Anthropic) used for implementation, red-teaming, and independent verification of this change, per the nxm-rs org AI assistance disclosure policy.

