### PR TITLE
refactor(primitives)!: apply the epic QA sweep fixes

### DIFF
--- a/crates/mantaray/src/codec.rs
+++ b/crates/mantaray/src/codec.rs
@@ -7,7 +7,7 @@ use crate::node::{Fork, Node, NodeType, Prefix};
 use crate::obfuscation::ObfuscationKey;
 
 use alloy_primitives::{U256, hex};
-use nectar_primitives::chunk::{ChunkAddress, Reference};
+use nectar_primitives::chunk::{ChunkAddress, ChunkRef, Reference};
 use nectar_primitives::wire::{Cursor, FromCursor, ToWriter, Underrun, Writer};
 
 /// Mantaray wire format version (truncated keccak256, 31 bytes).
@@ -202,7 +202,7 @@ fn encode_node<R: Reference>(node: &Node<R>) -> Result<Vec<u8>> {
     for &fork_byte in node.forks.keys() {
         index.set_bit(usize::from(fork_byte), true);
     }
-    data.extend_from_slice(&index.to_le_bytes::<32>());
+    data.extend_from_slice(&index.to_le_bytes::<FORK_INDEX_SIZE>());
 
     // append forks in sorted order, each as a total wire record over the buffer
     let mut writer = Writer::new(&mut data);
@@ -424,7 +424,7 @@ fn parse_fork_body<R: Reference>(
         .map_err(|_| DecodeError::TooShort)?;
     let mut ref_cur = Cursor::new(ref_region);
     let addr = ref_cur
-        .take::<[u8; 32]>()
+        .take::<[u8; ChunkRef::SIZE]>()
         .map_err(|_| DecodeError::TooShort)?;
 
     let mut node = Node::from_reference(ChunkAddress::from(addr));
@@ -542,7 +542,7 @@ impl WireFork<'_> {
         w.put(self.prefix);
 
         w.put(self.address.as_bytes());
-        w.put_zeros(self.ref_size.saturating_sub(32));
+        w.put_zeros(self.ref_size.saturating_sub(ChunkRef::SIZE));
 
         if let Some(metadata) = &self.metadata {
             w.put(&metadata.len);

--- a/crates/mantaray/src/codec.rs
+++ b/crates/mantaray/src/codec.rs
@@ -44,7 +44,7 @@ impl VersionHash {
     }
 }
 
-/// Wire layout descriptor for a serialised node header.
+/// Wire layout descriptor for a serialized node header.
 struct NodeHeader;
 
 impl NodeHeader {
@@ -285,8 +285,7 @@ fn parse_header(cur: &mut Cursor<'_>) -> DecodeResult<(VersionHash, RefSize)> {
 /// Accepts this wire shape only when the forks bitfield is also empty; a
 /// `ref_size = 0` node with non-empty forks is unrecoverable (fork refs would
 /// have zero width), so it is rejected as malformed rather than silently
-/// dropping forks the way bee's v0.2 decoder does
-/// (`bee/pkg/manifest/mantaray/marshal.go:285-287`). See the HAZMAT block.
+/// dropping forks. See the HAZMAT block.
 fn decode_empty_terminal<R: Reference>(cur: &mut Cursor<'_>) -> DecodeResult<Node<R>> {
     let index = cur
         .take::<[u8; FORK_INDEX_SIZE]>()
@@ -336,7 +335,7 @@ fn decode_body<R: Reference>(
 
     // The entry slot is a zero-sentinel `Option<R>`: `read_optional` maps the
     // all-zero width to `None`. The index is read next so a truncated index
-    // reports `DataTooShort` rather than an entry-shaped error.
+    // reports `TooShort` rather than an entry-shaped error.
     let entry = R::read_optional(cur).map_err(|_| DecodeError::TooShort)?;
     let index_bytes = cur
         .take::<[u8; FORK_INDEX_SIZE]>()
@@ -464,7 +463,7 @@ struct WireFork<'a> {
     metadata: Option<WireMetadata>,
 }
 
-/// A fork's metadata payload, serialised and padded to the obfuscation-key
+/// A fork's metadata payload, serialized and padded to the obfuscation-key
 /// stride with its `u16` length precomputed so emission stays total.
 struct WireMetadata {
     len: MetadataLen,
@@ -472,7 +471,7 @@ struct WireMetadata {
 }
 
 impl WireMetadata {
-    /// Serialise, pad to the `ObfuscationKey::SIZE` stride, and size the length
+    /// Serialize, pad to the `ObfuscationKey::SIZE` stride, and size the length
     /// field. Padding fills with `0x0a`, so the trailing bytes are JSON
     /// whitespace the decoder re-parses transparently.
     #[allow(clippy::arithmetic_side_effects)] // padding math is guarded (`SIZE - x` only when `x < SIZE`, `SIZE - rem` only when `rem != 0`) and `% ObfuscationKey::SIZE` has a nonzero constant divisor
@@ -774,7 +773,7 @@ mod tests {
     /// BEE-WORKAROUND(bee#5483): a `ref_size = 0` node with a non-empty forks
     /// bitfield is unrecoverable by any reference implementation (fork refs
     /// would have zero width). Reject as malformed rather than silently
-    /// dropping forks the way bee's v0.2 decoder does.
+    /// dropping forks.
     #[test]
     fn decode_bee_legacy_ref_size_zero_with_forks_is_rejected() {
         let mut data = vec![0u8; 96];

--- a/crates/mantaray/src/lib.rs
+++ b/crates/mantaray/src/lib.rs
@@ -5,13 +5,13 @@
 //!
 //! Mantaray is a trie-based manifest structure that maps human-readable paths
 //! (e.g. `index.html`, `img/logo.png`) to content-addressed chunk references.
-//! It supports XOR obfuscation, versioned binary serialisation (v0.1 and v0.2),
+//! It supports XOR obfuscation, versioned binary serialization (v0.1 and v0.2),
 //! and metadata per path.
 //!
 //! # Efficient Partial Updates
 //!
 //! The trie uses lazy loading and dirty-reference tracking so that updating a
-//! single path in a million-entry manifest only re-serialises O(depth) nodes:
+//! single path in a million-entry manifest only re-serializes O(depth) nodes:
 //!
 //! 1. [`Manifest::add`] lazily loads only the affected path branch.
 //! 2. Modified nodes have their reference cleared (dirty flag).

--- a/crates/mantaray/src/manifest.rs
+++ b/crates/mantaray/src/manifest.rs
@@ -188,7 +188,8 @@ impl<S: ChunkGet<BS>, R: Reference + MaybeSend, const BS: usize> Manifest<S, R, 
     /// Collect all value entries from the manifest.
     ///
     /// Shared-read (`&self`) accessor: depth-first over owned clones, leaving
-    /// the trie untouched. Convenience wrapper around [`stream`](Self::stream).
+    /// the trie untouched. Drives the same shared-read traversal as
+    /// [`stream`](Self::stream), collecting into a `Vec`.
     pub async fn entries(&self) -> Result<Vec<Entry>> {
         let mut iter = self.shared_iter();
         let mut out = Vec::new();

--- a/crates/mantaray/src/manifest_ref.rs
+++ b/crates/mantaray/src/manifest_ref.rs
@@ -39,7 +39,7 @@ impl ManifestRef {
         (self.address, self.obfuscation_key)
     }
 
-    /// Serialise to the fixed wire form: address followed by obfuscation key.
+    /// Serialize to the fixed wire form: address followed by obfuscation key.
     pub const fn to_bytes(&self) -> [u8; Self::SIZE] {
         let mut buf = [0u8; Self::SIZE];
         let (address, key) = buf.split_at_mut(size_of::<ChunkAddress>());

--- a/crates/mantaray/src/node.rs
+++ b/crates/mantaray/src/node.rs
@@ -192,7 +192,7 @@ pub(crate) enum NodeState {
 pub struct Node<R: Reference = ChunkRef> {
     /// Bitflags encoding the node kind (value, edge, path-separator, metadata).
     pub(crate) node_type: NodeType,
-    /// XOR obfuscation key for binary serialisation.
+    /// XOR obfuscation key for binary serialization.
     pub(crate) obfuscation_key: ObfuscationKey,
     /// The typed entry stored at this node (the chunk reference this path maps to).
     pub(crate) entry: Option<R>,
@@ -302,7 +302,7 @@ impl<R: Reference> Node<R> {
         &self.forks
     }
 
-    /// XOR obfuscation key for binary serialisation.
+    /// XOR obfuscation key for binary serialization.
     pub const fn obfuscation_key(&self) -> &ObfuscationKey {
         &self.obfuscation_key
     }

--- a/crates/mantaray/src/obfuscation.rs
+++ b/crates/mantaray/src/obfuscation.rs
@@ -1,4 +1,4 @@
-//! XOR obfuscation key for mantaray node serialisation.
+//! XOR obfuscation key for mantaray node serialization.
 
 /// 32-byte XOR obfuscation key.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/primitives/src/chunk/encryption/reference.rs
+++ b/crates/primitives/src/chunk/encryption/reference.rs
@@ -51,7 +51,7 @@ impl EncryptedChunkRef {
         (self.reference.into_address(), self.key)
     }
 
-    /// Serialise to the fixed wire form: address followed by decryption key.
+    /// Serialize to the fixed wire form: address followed by decryption key.
     pub const fn to_bytes(&self) -> [u8; Self::SIZE] {
         let mut buf = [0u8; Self::SIZE];
         let (address, key) = buf.split_at_mut(ChunkRef::SIZE);

--- a/crates/primitives/src/chunk/encryption/reference.rs
+++ b/crates/primitives/src/chunk/encryption/reference.rs
@@ -89,7 +89,7 @@ impl Reference for EncryptedChunkRef {
             EntryRef::Encrypted(enc) => Ok(enc),
             EntryRef::Plain(_) => Err(WrongRefKind {
                 expected: Self::KIND,
-                got: RefKind::Unencrypted,
+                got: RefKind::Plain,
             }),
         }
     }

--- a/crates/primitives/src/chunk/reference.rs
+++ b/crates/primitives/src/chunk/reference.rs
@@ -32,7 +32,7 @@ pub struct WrongRefKind {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RefKind {
     /// A plain reference ([`ChunkRef`]): a 32-byte address.
-    Unencrypted,
+    Plain,
     /// An encrypted reference
     /// ([`EncryptedChunkRef`](crate::chunk::encryption::EncryptedChunkRef)):
     /// the same address plus the chunk's decryption key.
@@ -43,7 +43,7 @@ impl RefKind {
     /// Wire width in bytes of a reference of this kind.
     pub const fn size(self) -> usize {
         match self {
-            Self::Unencrypted => ChunkRef::SIZE,
+            Self::Plain => ChunkRef::SIZE,
             Self::Encrypted => crate::chunk::encryption::EncryptedChunkRef::SIZE,
         }
     }
@@ -130,7 +130,7 @@ impl From<ChunkAddress> for ChunkRef {
 impl sealed::Sealed for ChunkRef {}
 
 impl Reference for ChunkRef {
-    const KIND: RefKind = RefKind::Unencrypted;
+    const KIND: RefKind = RefKind::Plain;
 
     fn address(&self) -> &ChunkAddress {
         &self.0
@@ -186,8 +186,8 @@ mod tests {
     fn chunk_ref_is_address_width() {
         assert_eq!(ChunkRef::SIZE, 32);
         assert_eq!(<ChunkRef as Reference>::SIZE, ChunkRef::SIZE);
-        assert_eq!(ChunkRef::KIND, RefKind::Unencrypted);
-        assert_eq!(RefKind::Unencrypted.size(), ChunkRef::SIZE);
+        assert_eq!(ChunkRef::KIND, RefKind::Plain);
+        assert_eq!(RefKind::Plain.size(), ChunkRef::SIZE);
     }
 
     #[test]
@@ -230,13 +230,13 @@ mod tests {
             EncryptedChunkRef::from_entry_ref(plain).unwrap_err(),
             WrongRefKind {
                 expected: RefKind::Encrypted,
-                got: RefKind::Unencrypted,
+                got: RefKind::Plain,
             }
         );
         assert_eq!(
             ChunkRef::from_entry_ref(encrypted).unwrap_err(),
             WrongRefKind {
-                expected: RefKind::Unencrypted,
+                expected: RefKind::Plain,
                 got: RefKind::Encrypted,
             }
         );

--- a/crates/primitives/src/file/entry_ref.rs
+++ b/crates/primitives/src/file/entry_ref.rs
@@ -1,7 +1,7 @@
 //! Unified file entry reference type.
 
-use crate::chunk::ChunkAddress;
 use crate::chunk::encryption::EncryptedChunkRef;
+use crate::chunk::{ChunkAddress, ChunkRef};
 
 use super::error::FileError;
 
@@ -17,24 +17,18 @@ pub enum EntryRef {
 impl EntryRef {
     /// Parse an entry reference from raw bytes.
     ///
-    /// - 32 bytes → `Plain`
-    /// - 64 bytes → `Encrypted` (requires `encryption` feature)
-    #[allow(clippy::missing_panics_doc)] // the expect below is unreachable: the match arm guarantees the length, so there is no panic to document
+    /// - [`ChunkRef::SIZE`] bytes → `Plain`
+    /// - [`EncryptedChunkRef::SIZE`] bytes → `Encrypted`
     pub fn try_from_bytes(bytes: &[u8]) -> Result<Self, FileError> {
-        match bytes.len() {
-            32 => {
-                #[allow(clippy::expect_used)]
-                // infallible: this match arm guarantees bytes.len() == 32
-                let addr_bytes: [u8; 32] = bytes.try_into().expect("length checked");
-                Ok(Self::Plain(ChunkAddress::from(addr_bytes)))
-            }
-            64 => {
-                let enc_ref = EncryptedChunkRef::try_from(bytes)
-                    .map_err(|_| FileError::InvalidEntryRef { len: bytes.len() })?;
-                Ok(Self::Encrypted(enc_ref))
-            }
-            len => Err(FileError::InvalidEntryRef { len }),
+        if let Ok(addr_bytes) = <[u8; ChunkRef::SIZE]>::try_from(bytes) {
+            return Ok(Self::Plain(ChunkAddress::from(addr_bytes)));
         }
+        if bytes.len() == EncryptedChunkRef::SIZE {
+            let enc_ref = EncryptedChunkRef::try_from(bytes)
+                .map_err(|_| FileError::InvalidEntryRef { len: bytes.len() })?;
+            return Ok(Self::Encrypted(enc_ref));
+        }
+        Err(FileError::InvalidEntryRef { len: bytes.len() })
     }
 
     /// The chunk address (first 32 bytes of any reference).

--- a/crates/primitives/src/file/mode.rs
+++ b/crates/primitives/src/file/mode.rs
@@ -148,7 +148,10 @@ pub trait SplitMode: JoinMode {
     fn empty_chunk<const BS: usize>() -> Result<(ContentChunk<BS>, Self::RootRef)>;
 
     /// Append a reference's `REF_SIZE` wire bytes to `out`.
-    fn extend_ref_bytes(reference: &Self::Ref, out: &mut Vec<u8>);
+    #[inline]
+    fn extend_ref_bytes(reference: &Self::Ref, out: &mut Vec<u8>) {
+        reference.write_to(out);
+    }
 
     /// The root reference of a finished tree from its sole top reference.
     fn root_ref(reference: Self::Ref) -> Self::RootRef;
@@ -206,11 +209,6 @@ impl SplitMode for PlainMode {
         let chunk = ContentChunk::<BS>::new(Bytes::new()).map_err(chunk_creation_error)?;
         let address = *chunk.address();
         Ok((chunk, address))
-    }
-
-    #[inline]
-    fn extend_ref_bytes(reference: &ChunkRef, out: &mut Vec<u8>) {
-        out.extend_from_slice(reference.address().as_bytes());
     }
 
     #[inline]
@@ -309,10 +307,6 @@ impl SplitMode for EncryptedMode {
         let chunk = create_chunk::<BS>(Bytes::from(ciphertext))?;
         let address = *chunk.address();
         Ok((chunk, EncryptedChunkRef::new(address, key)))
-    }
-
-    fn extend_ref_bytes(reference: &EncryptedChunkRef, out: &mut Vec<u8>) {
-        out.extend_from_slice(&<[u8; EncryptedChunkRef::SIZE]>::from(reference));
     }
 
     fn root_ref(reference: EncryptedChunkRef) -> EncryptedChunkRef {

--- a/crates/primitives/src/wire.rs
+++ b/crates/primitives/src/wire.rs
@@ -121,20 +121,6 @@ impl<'a> Cursor<'a> {
         Self { bytes }
     }
 
-    /// Reads the next `N` bytes as a fixed-size array, advancing the cursor.
-    pub const fn take_array<const N: usize>(&mut self) -> Result<&'a [u8; N], Underrun> {
-        match self.bytes.split_first_chunk::<N>() {
-            Some((head, tail)) => {
-                self.bytes = tail;
-                Ok(head)
-            }
-            None => Err(Underrun {
-                expected: N,
-                available: self.bytes.len(),
-            }),
-        }
-    }
-
     /// Reads the next value as a whole via its [`FromCursor`] impl, advancing
     /// the cursor.
     pub fn take<T: FromCursor>(&mut self) -> Result<T, T::Error> {
@@ -153,17 +139,6 @@ impl<'a> Cursor<'a> {
                 available: self.bytes.len(),
             }),
         }
-    }
-
-    /// Reads a single byte, advancing the cursor.
-    pub fn take_u8(&mut self) -> Result<u8, Underrun> {
-        let &[byte] = self.take_array::<1>()?;
-        Ok(byte)
-    }
-
-    /// Reads a big-endian `u16`, advancing the cursor.
-    pub fn take_u16_be(&mut self) -> Result<u16, Underrun> {
-        self.take_array::<2>().map(|b| u16::from_be_bytes(*b))
     }
 
     /// The unread tail, without advancing.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1056,12 +1056,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2004,7 +1998,6 @@ dependencies = [
  "hybrid-array",
  "js-sys",
  "keccak-batch",
- "once_cell",
  "parking_lot",
  "rand 0.10.2",
  "rayon",
@@ -2079,10 +2072,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-dependencies = [
- "critical-section",
- "portable-atomic",
-]
 
 [[package]]
 name = "parity-scale-codec"
@@ -2166,12 +2155,6 @@ dependencies = [
  "der",
  "spki",
 ]
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "powerfmt"


### PR DESCRIPTION
## What

Whole-of-phase QA sweep fixes for the epic train: RefKind::Unencrypted renamed to RefKind::Plain to match the system vocabulary; EntryRef::try_from_bytes and the mantaray codec widths derived from ChunkRef::SIZE/EncryptedChunkRef::SIZE (last naked 32/64 literals gone); SplitMode::extend_ref_bytes gains a provided default over Reference::write_to (both hand-rolled mode impls deleted); a stale DataTooShort comment retitled; an external file:line citation trimmed from rustdoc; Manifest::entries doc corrected; -ize spelling normalized; fuzz/Cargo.lock regenerated so fuzz runs stop dirtying the tree.

Part of #157 - never closes it directly.

## Why

Three independent review lenses swept the assembled train (differential wire harness over ~4000 node images at both reference widths with zero byte divergence; 13M fuzz executions; per-car semver audit). No blockers or majors were found; these are the minors and high-value nits, applied while the train is still one coordinated stack.

## Testing

Central battery at the fixes tip: cargo fmt --check, clippy --workspace --all-targets --all-features -D warnings, cargo test --workspace --all-features (26/26 suites), doc tests, cargo fuzz build plus seed replay of the mantaray targets, and the wasm check - all green.

This is a stacked PR; merge bottom-up, full CI runs after retarget.

## AI Assistance

Lenses and fixes by Claude Fable, conducted by Claude Fable under maintainer direction.
