### PR TITLE
feat(primitives)!: add SocId newtype for single-owner chunk identifiers

### DIFF
--- a/crates/postage-usage/src/lib.rs
+++ b/crates/postage-usage/src/lib.rs
@@ -140,14 +140,14 @@ pub use seal::{SealError, SealedChunk, seal_plan};
 #[cfg(feature = "client")]
 pub use client::{BatchStamper, ClientError, SnapshotSink, SnapshotSource};
 
-pub use nectar_primitives::SwarmAddress;
+pub use nectar_primitives::{SocId, SwarmAddress};
 
 /// Postage types re-exported so a downstream caller naming
 /// [`PlannedChunk::stamp_index`] or calling [`UsageTable::from_batch`] does not
 /// need a direct `nectar-postage` dependency.
 pub use nectar_postage::{Batch, BatchId, StampIndex};
 
-use alloy_primitives::{Address, B256, Keccak256};
+use alloy_primitives::{Address, Keccak256};
 
 /// Result alias for this crate.
 pub type Result<T> = core::result::Result<T, UsageError>;
@@ -179,12 +179,12 @@ pub(crate) const MAX_WIDTH: u8 = 32;
 
 /// Returns the single-owner chunk id of snapshot chunk `index` (0 is the
 /// root, `n >= 1` is leaf `n - 1`).
-pub fn usage_chunk_id(batch_id: &BatchId, index: u16) -> B256 {
+pub fn usage_chunk_id(batch_id: &BatchId, index: u16) -> SocId {
     let mut hasher = Keccak256::new();
     hasher.update(USAGE_DOMAIN);
     hasher.update(batch_id);
     hasher.update(index.to_be_bytes());
-    hasher.finalize()
+    SocId::from(hasher.finalize())
 }
 
 /// Returns the address of snapshot chunk `index` for a batch owned by
@@ -199,6 +199,7 @@ pub fn usage_chunk_address(batch_id: &BatchId, owner: &Address, index: u16) -> S
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_primitives::B256;
 
     #[test]
     fn chunk_ids_are_domain_separated_and_indexed() {

--- a/crates/postage-usage/src/snapshot.rs
+++ b/crates/postage-usage/src/snapshot.rs
@@ -3,10 +3,10 @@
 use alloc::collections::BTreeSet;
 use alloc::vec::Vec;
 
-use alloy_primitives::{Address, B256};
+use alloy_primitives::Address;
 use bytes::Bytes;
 use nectar_postage::{Batch, BatchId, StampIndex, calculate_bucket};
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::{SocId, SwarmAddress};
 
 use crate::codec::{self, Encoded, RootInfo};
 use crate::table::{TableView, UsageTable};
@@ -84,7 +84,7 @@ pub struct PlannedChunk {
     /// The snapshot chunk index (0 is the root).
     pub index: u16,
     /// The single-owner chunk id.
-    pub id: B256,
+    pub id: SocId,
     /// The single-owner chunk address.
     pub address: SwarmAddress,
     /// The stamp index to use. Constant across persists for a given chunk;

--- a/crates/postage/src/stamped.rs
+++ b/crates/postage/src/stamped.rs
@@ -176,7 +176,7 @@ impl<'a, const BODY_SIZE: usize> arbitrary::Arbitrary<'a> for StampedChunk<BODY_
 mod tests {
     use alloy_primitives::{B256, Signature};
     use alloy_signer_local::PrivateKeySigner;
-    use nectar_primitives::{Chunk, ContentChunk, SingleOwnerChunk, bytes::Bytes};
+    use nectar_primitives::{Chunk, ContentChunk, SingleOwnerChunk, SocId, bytes::Bytes};
 
     use super::*;
 
@@ -193,8 +193,12 @@ mod tests {
 
     fn single_owner_chunk() -> SingleOwnerChunk<DEFAULT_BODY_SIZE> {
         let signer = PrivateKeySigner::from_bytes(&B256::repeat_byte(0x11)).expect("valid signer");
-        SingleOwnerChunk::new(B256::repeat_byte(0x22), &b"soc payload"[..], &signer)
-            .expect("valid soc")
+        SingleOwnerChunk::new(
+            SocId::from(B256::repeat_byte(0x22)),
+            &b"soc payload"[..],
+            &signer,
+        )
+        .expect("valid soc")
     }
 
     #[test]

--- a/crates/primitives/benches/bmt_bench.rs
+++ b/crates/primitives/benches/bmt_bench.rs
@@ -19,7 +19,7 @@ use rand::{Rng, rng};
 
 use nectar_primitives::bmt::Prover;
 use nectar_primitives::{
-    DEFAULT_BODY_SIZE, DefaultContentChunk, DefaultHasher, DefaultSingleOwnerChunk,
+    DEFAULT_BODY_SIZE, DefaultContentChunk, DefaultHasher, DefaultSingleOwnerChunk, SocId,
 };
 
 fn bench_bmt_hash(c: &mut Criterion) {
@@ -166,7 +166,7 @@ fn bench_single_owner_chunk_creation(c: &mut Criterion) {
         // Generate random data and ID
         let mut data = vec![0u8; *size];
         rng().fill_bytes(&mut data);
-        let id = B256::random();
+        let id = SocId::random();
 
         group.bench_with_input(BenchmarkId::from_parameter(size), &data, |b, data| {
             b.iter(|| DefaultSingleOwnerChunk::new(id, data.clone(), &signer).unwrap());
@@ -199,7 +199,7 @@ fn bench_chunk_deserialization(c: &mut Criterion) {
         );
 
         // Create single-owner chunk and serialize
-        let id = B256::random();
+        let id = SocId::random();
         let soc = DefaultSingleOwnerChunk::new(id, data.clone(), &signer).unwrap();
         let soc_bytes: Bytes = soc.into();
 

--- a/crates/primitives/examples/basic_usage.rs
+++ b/crates/primitives/examples/basic_usage.rs
@@ -15,14 +15,13 @@
     clippy::as_conversions,
     clippy::missing_panics_doc
 )]
-use alloy_primitives::B256;
 use alloy_signer::SignerSync;
 use alloy_signer_local::LocalSigner;
 use bytes::Bytes;
 
 use nectar_primitives::bmt::Prover;
 use nectar_primitives::chunk::{BmtChunk, Chunk};
-use nectar_primitives::{DefaultContentChunk, DefaultHasher, DefaultSingleOwnerChunk};
+use nectar_primitives::{DefaultContentChunk, DefaultHasher, DefaultSingleOwnerChunk, SocId};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Nectar Primitives Example");
@@ -98,10 +97,10 @@ fn content_chunk_example() -> Result<(), Box<dyn std::error::Error>> {
 
 fn single_owner_chunk_example(wallet: &impl SignerSync) -> Result<(), Box<dyn std::error::Error>> {
     // Create a unique ID for the chunk
-    let id = B256::random();
+    let id = SocId::random();
     println!(
         "Generated random chunk ID: {}",
-        alloy_primitives::hex::encode(&id[..8])
+        alloy_primitives::hex::encode(&id.as_slice()[..8])
     );
 
     // Create a single-owner chunk
@@ -161,7 +160,7 @@ fn deserialization_example() -> Result<(), Box<dyn std::error::Error>> {
     let content_chunk = DefaultContentChunk::new(data1)?;
 
     let wallet = LocalSigner::random();
-    let id = B256::random();
+    let id = SocId::random();
     let data2 = b"Example owner chunk".to_vec();
     let single_owner_chunk = DefaultSingleOwnerChunk::new(id, data2, &wallet)?;
 

--- a/crates/primitives/examples/builder_patterns.rs
+++ b/crates/primitives/examples/builder_patterns.rs
@@ -15,12 +15,11 @@
     clippy::as_conversions,
     clippy::missing_panics_doc
 )]
-use alloy_primitives::B256;
 use alloy_signer::SignerSync;
 use alloy_signer_local::LocalSigner;
 
 use nectar_primitives::chunk::{BmtChunk, Chunk};
-use nectar_primitives::{DefaultContentChunk, DefaultSingleOwnerChunk};
+use nectar_primitives::{DefaultContentChunk, DefaultSingleOwnerChunk, SocId};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Nectar Primitives - Creation Pattern Examples");
@@ -74,13 +73,16 @@ fn single_owner_creation_methods(
 
     // Basic creation
     println!("\n1. Basic creation with signer");
-    let id = B256::random();
+    let id = SocId::random();
     let data = b"Single owner chunk".to_vec();
 
     let chunk = DefaultSingleOwnerChunk::new(id, data, wallet)?;
 
     println!("  - Created chunk with address: {}", chunk.address());
-    println!("  - ID: {}", alloy_primitives::hex::encode(&id[..8]));
+    println!(
+        "  - ID: {}",
+        alloy_primitives::hex::encode(&id.as_slice()[..8])
+    );
     println!(
         "  - Owner: {}",
         alloy_primitives::hex::encode(chunk.owner()?.as_slice())
@@ -109,7 +111,7 @@ fn special_use_cases(wallet: &impl SignerSync) -> Result<(), Box<dyn std::error:
     println!("\n1. Reconstructing chunks from storage");
 
     // Simulate stored chunk data
-    let original_id = B256::random();
+    let original_id = SocId::random();
     let original_data = b"Original chunk data".to_vec();
     let original_chunk = DefaultSingleOwnerChunk::new(original_id, original_data, wallet)?;
     let stored_data = original_chunk.data().clone();
@@ -158,7 +160,7 @@ fn special_use_cases(wallet: &impl SignerSync) -> Result<(), Box<dyn std::error:
 
     // Verify a single-owner chunk's signature - verify against its own address
     let owner_chunk =
-        DefaultSingleOwnerChunk::new(B256::random(), b"Signed data".to_vec(), wallet)?;
+        DefaultSingleOwnerChunk::new(SocId::random(), b"Signed data".to_vec(), wallet)?;
     println!("  - Verifying signature on single-owner chunk");
     owner_chunk.verify(owner_chunk.address())?;
     println!("  - Signature verification successful ✅");

--- a/crates/primitives/examples/wasm-demo/src/lib.rs
+++ b/crates/primitives/examples/wasm-demo/src/lib.rs
@@ -8,7 +8,7 @@ use alloy_primitives::{hex, Address, B256};
 use alloy_signer_local::PrivateKeySigner;
 use bytes::Bytes;
 use nectar_primitives::{
-    Chunk, ChunkAddress, DefaultContentChunk, DefaultHasher, DefaultSingleOwnerChunk,
+    Chunk, ChunkAddress, DefaultContentChunk, DefaultHasher, DefaultSingleOwnerChunk, SocId,
 };
 use wasm_bindgen::prelude::*;
 
@@ -835,7 +835,7 @@ pub fn create_single_owner_chunk(
     };
 
     // Create the single owner chunk
-    let chunk = match DefaultSingleOwnerChunk::new(chunk_id, data.to_vec(), &signer) {
+    let chunk = match DefaultSingleOwnerChunk::new(SocId::from(chunk_id), data.to_vec(), &signer) {
         Ok(chunk) => chunk,
         Err(e) => {
             return Err(JsValue::from_str(&format!(
@@ -920,7 +920,7 @@ pub fn analyze_chunk(
                 chunk_type: ChunkType::SingleOwner,
                 address: *single_owner_chunk.address().deref(),
                 data: single_owner_chunk.data().to_vec(),
-                id: Some(single_owner_chunk.id()),
+                id: Some(single_owner_chunk.id().into()),
                 owner: single_owner_chunk.owner().ok(),
                 signature: Some(single_owner_chunk.signature().as_bytes().to_vec()),
                 error_message: None,
@@ -946,7 +946,7 @@ pub fn analyze_chunk(
             chunk_type: ChunkType::SingleOwner,
             address: *single_owner_chunk.address().deref(),
             data: single_owner_chunk.data().to_vec(),
-            id: Some(single_owner_chunk.id()),
+            id: Some(single_owner_chunk.id().into()),
             owner: single_owner_chunk.owner().ok(),
             signature: Some(single_owner_chunk.signature().as_bytes().to_vec()),
             error_message: Some(format!(

--- a/crates/primitives/src/chunk/any_chunk.rs
+++ b/crates/primitives/src/chunk/any_chunk.rs
@@ -427,7 +427,7 @@ mod tests {
     }
 
     fn sample_single_owner() -> DefaultSingleOwnerChunk {
-        let id = alloy_primitives::B256::ZERO;
+        let id = crate::SocId::ZERO;
         DefaultSingleOwnerChunk::new(id, b"single owner payload".to_vec(), &test_signer()).unwrap()
     }
 

--- a/crates/primitives/src/chunk/mod.rs
+++ b/crates/primitives/src/chunk/mod.rs
@@ -25,6 +25,7 @@ pub mod encryption;
 pub(crate) mod error;
 mod reference;
 mod single_owner;
+mod soc_id;
 mod traits;
 mod type_id;
 
@@ -50,3 +51,4 @@ pub use content::EncryptedContentChunk;
 #[cfg(feature = "encryption")]
 pub use encryption::ChunkEncrypt;
 pub use single_owner::SingleOwnerChunk;
+pub use soc_id::SocId;

--- a/crates/primitives/src/chunk/single_owner.rs
+++ b/crates/primitives/src/chunk/single_owner.rs
@@ -3,7 +3,7 @@
 //! This module provides the implementation of single-owner chunks,
 //! which are chunks that include an owner identifier and signature.
 
-use alloy_primitives::{Address, B256, FixedBytes, Keccak256, Signature, address, b256, hex};
+use alloy_primitives::{Address, B256, Keccak256, Signature, address, b256, hex};
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use bytes::{Bytes, BytesMut};
@@ -18,6 +18,7 @@ use crate::error::Result;
 
 use super::bmt_body::BmtBody;
 use super::content::ContentChunk;
+use super::soc_id::SocId;
 use super::traits::{BmtChunk, Chunk, ChunkAddress, ChunkHeader, ChunkMetadata};
 
 // Constants for field sizes
@@ -51,19 +52,19 @@ pub struct SingleOwnerChunk<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> {
 #[derive(Debug, Clone)]
 pub struct SingleOwnerChunkMetadata {
     /// Unique identifier for this chunk
-    id: B256,
+    id: SocId,
     /// Digital signature of the chunk's ID and body hash
     signature: Signature,
 }
 
 impl SingleOwnerChunkMetadata {
     /// Create a new metadata instance with the given ID and signature
-    pub const fn new(id: B256, signature: Signature) -> Self {
+    pub const fn new(id: SocId, signature: Signature) -> Self {
         Self { id, signature }
     }
 
     /// Get the unique ID of this chunk
-    pub const fn id(&self) -> B256 {
+    pub const fn id(&self) -> SocId {
         self.id
     }
 
@@ -131,7 +132,7 @@ impl<const BODY_SIZE: usize> SingleOwnerChunk<BODY_SIZE> {
     ///
     /// A Result containing the new SingleOwnerChunk, or an error if creation fails.
     #[must_use = "this returns a new chunk without modifying the input"]
-    pub fn new(id: B256, data: impl Into<Bytes>, signer: &impl SignerSync) -> Result<Self> {
+    pub fn new(id: SocId, data: impl Into<Bytes>, signer: &impl SignerSync) -> Result<Self> {
         SingleOwnerChunkBuilderImpl::<BODY_SIZE, Initial>::default()
             .auto_from_data(data)?
             .with_id(id)
@@ -154,7 +155,7 @@ impl<const BODY_SIZE: usize> SingleOwnerChunk<BODY_SIZE> {
     ///
     /// A Result containing the new SingleOwnerChunk, or an error if creation fails.
     #[must_use = "this returns a new chunk without modifying the input"]
-    pub fn with_signature(id: B256, signature: Signature, data: impl Into<Bytes>) -> Result<Self> {
+    pub fn with_signature(id: SocId, signature: Signature, data: impl Into<Bytes>) -> Result<Self> {
         SingleOwnerChunkBuilderImpl::<BODY_SIZE, Initial>::default()
             .auto_from_data(data)?
             .with_id(id)
@@ -186,7 +187,7 @@ impl<const BODY_SIZE: usize> SingleOwnerChunk<BODY_SIZE> {
     /// * `signature` - The digital signature.
     /// * `body` - The BMT body containing the data.
     #[must_use]
-    pub const fn from_parts(id: B256, signature: Signature, body: BmtBody<BODY_SIZE>) -> Self {
+    pub const fn from_parts(id: SocId, signature: Signature, body: BmtBody<BODY_SIZE>) -> Self {
         let metadata = SingleOwnerChunkMetadata::new(id, signature);
         let header = SingleOwnerChunkHeader::new(metadata);
 
@@ -204,7 +205,7 @@ impl<const BODY_SIZE: usize> SingleOwnerChunk<BODY_SIZE> {
     /// the chunk address and owner address.
     #[must_use]
     pub fn from_parts_with_caches(
-        id: B256,
+        id: SocId,
         signature: Signature,
         body: BmtBody<BODY_SIZE>,
         address: ChunkAddress,
@@ -272,7 +273,7 @@ impl<const BODY_SIZE: usize> SingleOwnerChunk<BODY_SIZE> {
     /// # Returns
     ///
     /// A 32-byte hash representing the data to sign.
-    fn to_sign(id: &B256, body: &BmtBody<BODY_SIZE>) -> B256 {
+    fn to_sign(id: &SocId, body: &BmtBody<BODY_SIZE>) -> B256 {
         let mut hasher = Keccak256::new();
         hasher.update(id);
         hasher.update(body.hash());
@@ -282,11 +283,11 @@ impl<const BODY_SIZE: usize> SingleOwnerChunk<BODY_SIZE> {
     // Checks if the chunk is a valid dispersed replica
     #[allow(clippy::indexing_slicing)] // both id and body hash are fixed 32-byte values, so [1..] holds
     fn is_valid_replica(&self) -> bool {
-        self.id()[1..] == self.body.hash().as_slice()[1..]
+        self.id().as_slice()[1..] == self.body.hash().as_slice()[1..]
     }
 
     /// Get the ID of this chunk.
-    pub const fn id(&self) -> B256 {
+    pub const fn id(&self) -> SocId {
         self.header.metadata.id
     }
 
@@ -396,8 +397,9 @@ impl<const BODY_SIZE: usize> TryFrom<Bytes> for SingleOwnerChunk<BODY_SIZE> {
 
         // Extract ID
         let id_slice = &bytes.slice(0..ID_SIZE);
-        let mut id = FixedBytes::<32>::default();
+        let mut id = B256::default();
         id.copy_from_slice(id_slice);
+        let id = SocId::from(id);
 
         // Extract signature
         let sig_slice = &bytes.slice(ID_SIZE..ID_SIZE + SIGNATURE_SIZE);
@@ -438,7 +440,7 @@ impl<const BODY_SIZE: usize> fmt::Display for SingleOwnerChunk<BODY_SIZE> {
         write!(
             f,
             "SingleOwnerChunk[id={}, owner={}]",
-            hex::encode(&self.id()[..8]),
+            hex::encode(&self.id().as_slice()[..8]),
             owner_str
         )
     }
@@ -486,7 +488,7 @@ struct SingleOwnerChunkBuilderImpl<const BODY_SIZE: usize, S: BuilderState = Ini
     /// The body to use for the chunk
     body: Option<BmtBody<BODY_SIZE>>,
     /// The ID to use for the chunk
-    id: Option<B256>,
+    id: Option<SocId>,
     /// The signature to use for the chunk
     signature: Option<Signature>,
     /// Marker for the builder state
@@ -541,7 +543,7 @@ impl<const BODY_SIZE: usize> SingleOwnerChunkBuilderImpl<BODY_SIZE, Initial> {
 
 impl<const BODY_SIZE: usize> SingleOwnerChunkBuilderImpl<BODY_SIZE, WithData> {
     /// Set the ID for this chunk
-    fn with_id(mut self, id: B256) -> SingleOwnerChunkBuilderImpl<BODY_SIZE, WithId> {
+    fn with_id(mut self, id: SocId) -> SingleOwnerChunkBuilderImpl<BODY_SIZE, WithId> {
         self.id = Some(id);
 
         SingleOwnerChunkBuilderImpl {
@@ -565,7 +567,7 @@ impl<const BODY_SIZE: usize> SingleOwnerChunkBuilderImpl<BODY_SIZE, WithData> {
 
         let signer = PrivateKeySigner::from_slice(DISPERSED_REPLICA_OWNER_PK.as_slice()).unwrap();
 
-        self.with_id(id).with_signer(&signer)
+        self.with_id(SocId::from(id)).with_signer(&signer)
     }
 }
 
@@ -632,7 +634,7 @@ impl<const BODY_SIZE: usize> SingleOwnerChunk<BODY_SIZE> {
     ) -> arbitrary::Result<Self> {
         use arbitrary::Arbitrary;
 
-        let id = B256::arbitrary(u)?;
+        let id = SocId::arbitrary(u)?;
         let body = BmtBody::<BODY_SIZE>::arbitrary(u)?;
 
         SingleOwnerChunkBuilderImpl::<BODY_SIZE, Initial>::default()
@@ -651,7 +653,7 @@ impl<'a, const BODY_SIZE: usize> arbitrary::Arbitrary<'a> for SingleOwnerChunk<B
         // not a signature over the id and body, so ownership recovery and
         // address verification may fail. Use [`Self::arbitrary_signed`] or
         // `crate::generators` for a valid-by-construction chunk.
-        let id = B256::arbitrary(u)?;
+        let id = SocId::arbitrary(u)?;
         let signature = Signature::arbitrary(u)?;
         let body = BmtBody::<BODY_SIZE>::arbitrary(u)?;
         Ok(Self::from_parts(id, signature, body))
@@ -724,7 +726,7 @@ mod tests {
 
             // Verify it's recognised as a dispersed replica
             prop_assert!(chunk.is_valid_replica());
-            prop_assert_eq!(chunk.id()[0], first_byte);
+            prop_assert_eq!(chunk.id().as_slice()[0], first_byte);
             prop_assert_eq!(chunk.owner().unwrap(), DISPERSED_REPLICA_OWNER);
 
             // Verify chunk address
@@ -732,7 +734,7 @@ mod tests {
         }
 
         #[test]
-        fn test_chunk_creation(id in arb::<B256>(), data in proptest::collection::vec(any::<u8>(), 1..DEFAULT_BODY_SIZE)) {
+        fn test_chunk_creation(id in arb::<SocId>(), data in proptest::collection::vec(any::<u8>(), 1..DEFAULT_BODY_SIZE)) {
             let wallet = get_test_wallet();
 
             // Test creation through builder
@@ -779,7 +781,7 @@ mod tests {
         }
 
         #[test]
-        fn test_chunk_invalid_signature(id in arb::<B256>(), data in proptest::collection::vec(any::<u8>(), 1..DEFAULT_BODY_SIZE)) {
+        fn test_chunk_invalid_signature(id in arb::<SocId>(), data in proptest::collection::vec(any::<u8>(), 1..DEFAULT_BODY_SIZE)) {
             let wallet = get_test_wallet();
 
             // Test creation through builder
@@ -810,7 +812,7 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let id = B256::ZERO;
+        let id = SocId::ZERO;
         let data = b"foo".to_vec();
         let wallet = get_test_wallet();
 
@@ -822,7 +824,7 @@ mod tests {
 
     #[test]
     fn test_new_signed() {
-        let id = B256::ZERO;
+        let id = SocId::ZERO;
         let data = b"foo".to_vec();
 
         // Known good signature from Go tests
@@ -886,7 +888,7 @@ mod tests {
                     .auto_from_data(test_data)?
                     .build()?,
             )
-            .with_id(B256::ZERO)
+            .with_id(SocId::ZERO)
             .with_signer(&dispersed_replica_wallet)?
             .build()?;
         let replica_address = chunk.address();

--- a/crates/primitives/src/chunk/soc_id.rs
+++ b/crates/primitives/src/chunk/soc_id.rs
@@ -1,0 +1,86 @@
+//! Typed identifier for single-owner chunks.
+//!
+//! A [`SocId`] is the 32-byte identifier a single-owner chunk is signed
+//! under; the SOC address is `keccak256(id || owner)`. See
+//! [`SingleOwnerChunk`](super::single_owner::SingleOwnerChunk) and bee
+//! `pkg/soc/soc.go` for the reference semantics.
+
+use alloy_primitives::B256;
+use derive_more::{AsRef, Display, From, Into};
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// 32-byte single-owner chunk identifier.
+///
+/// Transparent over the same 32 wire bytes as the raw field it types: a SOC
+/// still serializes as `id || signature || body`. Dispersed replicas
+/// constrain `id[1..]` to the wrapped body hash, leaving only the first byte
+/// mined.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Display, From, Into, AsRef)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+#[display("{_0}")]
+#[from(B256, [u8; 32])]
+#[into(B256, [u8; 32])]
+#[as_ref([u8])]
+pub struct SocId(B256);
+
+impl SocId {
+    /// Zero id, useful for tests and deterministic vectors.
+    pub const ZERO: Self = Self(B256::ZERO);
+
+    /// Construct from raw 32 bytes. `const` for static contexts; for runtime
+    /// conversions prefer the `From` impls.
+    #[inline]
+    pub const fn new(bytes: [u8; 32]) -> Self {
+        Self(B256::new(bytes))
+    }
+
+    /// Borrow the underlying 32 bytes.
+    #[inline]
+    pub const fn as_slice(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+
+    /// Sample a cryptographically random id via `alloy_primitives::B256::random`.
+    pub fn random() -> Self {
+        Self(B256::random())
+    }
+}
+
+#[cfg(any(test, feature = "arbitrary"))]
+impl<'a> arbitrary::Arbitrary<'a> for SocId {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self::new(u.arbitrary()?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_is_all_zero_bytes() {
+        assert_eq!(SocId::ZERO.as_slice(), &[0u8; 32]);
+    }
+
+    #[test]
+    fn roundtrips_via_from_impls() {
+        let bytes = [7u8; 32];
+        let id = SocId::new(bytes);
+        assert_eq!(B256::from(id), B256::new(bytes));
+        assert_eq!(SocId::from(B256::new(bytes)), id);
+        assert_eq!(<[u8; 32]>::from(id), bytes);
+        assert_eq!(SocId::from(bytes), id);
+    }
+
+    #[test]
+    fn display_matches_b256_lowercase_hex() {
+        let id = SocId::new([0xab; 32]);
+        let rendered = format!("{id}");
+        assert!(rendered.starts_with("0x"));
+        assert_eq!(rendered.len(), 66);
+        assert!(rendered.chars().skip(2).all(|c| c.is_ascii_hexdigit()));
+    }
+}

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -12,9 +12,8 @@
 //! ## Usage Examples
 //!
 //! ```
-//! use nectar_primitives::{Chunk, DefaultContentChunk, DefaultSingleOwnerChunk};
+//! use nectar_primitives::{Chunk, DefaultContentChunk, DefaultSingleOwnerChunk, SocId};
 //! use alloy_signer_local::LocalSigner;
-//! use alloy_primitives::FixedBytes;
 //!
 //! // Creating content chunks
 //! let chunk = DefaultContentChunk::new(b"Hello, world!".as_slice()).unwrap();
@@ -26,7 +25,7 @@
 //!
 //! // Creating signed chunks
 //! let wallet = LocalSigner::random();
-//! let id = FixedBytes::random();
+//! let id = SocId::random();
 //! let owner_chunk = DefaultSingleOwnerChunk::new(id, b"Signed data".as_slice(), &wallet).unwrap();
 //! ```
 
@@ -115,6 +114,7 @@ pub use chunk::{
     RefKind,
     Reference,
     SingleOwnerChunk,
+    SocId,
     StandardChunkSet,
     WrongRefKind,
 };


### PR DESCRIPTION
## What

Introduces a `SocId` newtype (`crates/primitives/src/chunk/soc_id.rs`) for the 32-byte single-owner-chunk identifier, following the existing `Nonce` `derive_more` pattern: `Display`/`From`/`Into`/`AsRef<[u8]>` over `B256`, `serde(transparent)`, plus `ZERO`, `const new`, `as_slice`, `random`, and an `Arbitrary` impl.

`SocId` is then threaded through `SingleOwnerChunk` (`SingleOwnerChunkMetadata::id`, `new`, `with_signature`, `from_parts`, `from_parts_with_caches`, the builder's `with_id`, `to_sign`, `id()`) and through `nectar-postage-usage` (`usage_chunk_id` returns `SocId`, `PlannedChunk::id: SocId`), where `SocId` is now re-exported alongside `SwarmAddress`.

Natural-surface compile fixes follow from the type change: the `primitives` crate-level doc example, `examples/basic_usage.rs`, `examples/builder_patterns.rs`, `benches/bmt_bench.rs`, `examples/wasm-demo/src/lib.rs`, and a test helper in `postage/src/stamped.rs`.

## Why

Closes #179

`B256` was doing double duty as both a generic 32-byte value and the semantically distinct SOC identifier, which made call sites easy to mix up with other 32-byte fields (body hash, chunk address, batch id). A dedicated type gives the compiler that distinction for free without changing any on-wire or consensus behaviour.

## Testing

- Wire format is unchanged: `SingleOwnerChunk` encode still writes `id.as_ref()` as 32 bytes, `to_sign` hashes `id` via its `AsRef<[u8]>` impl, `address()` hashes `self.id()` the same way, and `TryFrom<Bytes>` decodes 32 bytes into a `B256` and wraps it with `SocId::from` — byte-for-byte identical to the prior `B256` path.
- Consensus invariants preserved: `address = keccak(id || owner)`, the dispersed-replica `id[1..]` constraint (now expressed via `id().as_slice()[1..]`), and the `id || signature || body` wire layout.
- `SingleOwnerChunk::arbitrary_signed` and the raw `Arbitrary` impl draw `SocId` (via its own `Arbitrary`) with identical byte consumption to the previous direct `B256::arbitrary` draw, so existing corpora/seeds stay valid.
- Bee parity vectors (`test_chunk_address`, `test_new_signed`, the README worked example vector) pass unchanged.

## AI Assistance

This PR was implemented with Claude (Sonnet 4.5) via Claude Code, and independently red-teamed and re-verified with Claude (Sonnet 4.5) in a separate session, per the org's AI-assistance disclosure policy (nxm-rs/.github `CONTRIBUTING.md`).

