### PR TITLE
refactor(postage)!: promote BatchId from a B256 alias to a newtype

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,6 +2084,7 @@ dependencies = [
  "arbitrary",
  "byteorder",
  "codspeed-criterion-compat",
+ "derive_more",
  "k256",
  "nectar-primitives",
  "proptest",

--- a/crates/postage-issuer/benches/sign.rs
+++ b/crates/postage-issuer/benches/sign.rs
@@ -20,7 +20,7 @@ use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
 use nectar_postage_issuer::{
-    BatchStamper, MemoryIssuer, ShardedIssuer, SigningError, Stamper, sign_stamps_parallel,
+    BatchId, BatchStamper, MemoryIssuer, ShardedIssuer, SigningError, Stamper, sign_stamps_parallel,
 };
 use nectar_primitives::SwarmAddress;
 use rand::RngExt;
@@ -57,7 +57,7 @@ fn bench_stamper_mock(c: &mut Criterion) {
 
     group.bench_function("single", |b| {
         b.iter(|| {
-            let issuer = MemoryIssuer::new(B256::ZERO, 24, 16);
+            let issuer = MemoryIssuer::new(BatchId::ZERO, 24, 16);
             let mut stamper = BatchStamper::new(issuer, MockSigner);
             let address = random_address();
             black_box(stamper.stamp(black_box(&address)))
@@ -69,7 +69,7 @@ fn bench_stamper_mock(c: &mut Criterion) {
 
     group.bench_function("throughput_1000", |b| {
         b.iter(|| {
-            let issuer = MemoryIssuer::new(B256::ZERO, 32, 16);
+            let issuer = MemoryIssuer::new(BatchId::ZERO, 32, 16);
             let mut stamper = BatchStamper::new(issuer, MockSigner);
             for addr in &addresses {
                 black_box(stamper.stamp(addr).unwrap());
@@ -90,7 +90,7 @@ fn bench_ecdsa_sign_sequential(c: &mut Criterion) {
 
     group.bench_function("single", |b| {
         b.iter(|| {
-            let issuer = MemoryIssuer::new(B256::ZERO, 24, 16);
+            let issuer = MemoryIssuer::new(BatchId::ZERO, 24, 16);
             let mut stamper = BatchStamper::new(issuer, &signer);
             let address = random_address();
             black_box(stamper.stamp(black_box(&address)))
@@ -101,7 +101,7 @@ fn bench_ecdsa_sign_sequential(c: &mut Criterion) {
 
     group.bench_function("throughput_100", |b| {
         b.iter(|| {
-            let issuer = MemoryIssuer::new(B256::ZERO, 32, 16);
+            let issuer = MemoryIssuer::new(BatchId::ZERO, 32, 16);
             let mut stamper = BatchStamper::new(issuer, &signer);
             for addr in &addresses {
                 black_box(stamper.stamp(addr).unwrap());
@@ -131,7 +131,7 @@ fn bench_ecdsa_sign_parallel(c: &mut Criterion) {
     group.throughput(Throughput::Elements(100));
     group.bench_function("throughput_100", |b| {
         b.iter(|| {
-            let issuer = ShardedIssuer::new(B256::ZERO, 32, 16);
+            let issuer = ShardedIssuer::new(BatchId::ZERO, 32, 16);
             black_box(sign_stamps_parallel(&issuer, &sign_fn, &addresses_100))
         })
     });
@@ -139,7 +139,7 @@ fn bench_ecdsa_sign_parallel(c: &mut Criterion) {
     group.throughput(Throughput::Elements(1000));
     group.bench_function("throughput_1000", |b| {
         b.iter(|| {
-            let issuer = ShardedIssuer::new(B256::ZERO, 32, 16);
+            let issuer = ShardedIssuer::new(BatchId::ZERO, 32, 16);
             black_box(sign_stamps_parallel(&issuer, &sign_fn, &addresses_1000))
         })
     });
@@ -166,7 +166,7 @@ fn bench_sign_comparison(c: &mut Criterion) {
     // Sequential
     group.bench_function("sequential", |b| {
         b.iter(|| {
-            let issuer = MemoryIssuer::new(B256::ZERO, 32, 16);
+            let issuer = MemoryIssuer::new(BatchId::ZERO, 32, 16);
             let mut stamper = BatchStamper::new(issuer, &signer);
             for addr in &addresses {
                 black_box(stamper.stamp(addr).unwrap());
@@ -177,7 +177,7 @@ fn bench_sign_comparison(c: &mut Criterion) {
     // Parallel
     group.bench_function("parallel", |b| {
         b.iter(|| {
-            let issuer = ShardedIssuer::new(B256::ZERO, 32, 16);
+            let issuer = ShardedIssuer::new(BatchId::ZERO, 32, 16);
             black_box(sign_stamps_parallel(&issuer, &sign_fn, &addresses))
         })
     });

--- a/crates/postage-issuer/benches/upload_pipeline.rs
+++ b/crates/postage-issuer/benches/upload_pipeline.rs
@@ -29,7 +29,7 @@ use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, 
 use rand::{Rng, rng};
 
 use nectar_postage_issuer::{
-    BatchStamper, MemoryIssuer, ShardedIssuer, SigningError, Stamper, sign_stamps_parallel,
+    BatchId, BatchStamper, MemoryIssuer, ShardedIssuer, SigningError, Stamper, sign_stamps_parallel,
 };
 use nectar_primitives::DEFAULT_BODY_SIZE;
 use nectar_primitives::file::{ParallelSplitter, Splitter};
@@ -81,7 +81,7 @@ fn bench_pipeline_mock_sequential(c: &mut Criterion) {
                 let store = MemoryStore::from_chunks(chunks);
 
                 // Stamp each chunk
-                let issuer = MemoryIssuer::new(B256::ZERO, 32, 16);
+                let issuer = MemoryIssuer::new(BatchId::ZERO, 32, 16);
                 let mut stamper = BatchStamper::new(issuer, MockSigner);
 
                 let chunks = store.into_chunks();
@@ -115,7 +115,7 @@ fn bench_pipeline_mock_parallel_split(c: &mut Criterion) {
                 let store = MemoryStore::from_chunks(chunks);
 
                 // Stamp each chunk (sequential)
-                let issuer = MemoryIssuer::new(B256::ZERO, 32, 16);
+                let issuer = MemoryIssuer::new(BatchId::ZERO, 32, 16);
                 let mut stamper = BatchStamper::new(issuer, MockSigner);
 
                 let chunks = store.into_chunks();
@@ -154,7 +154,7 @@ fn bench_pipeline_ecdsa_sequential(c: &mut Criterion) {
                 let store = MemoryStore::from_chunks(chunks);
 
                 // Stamp each chunk with real signatures
-                let issuer = MemoryIssuer::new(B256::ZERO, 32, 16);
+                let issuer = MemoryIssuer::new(BatchId::ZERO, 32, 16);
                 let mut stamper = BatchStamper::new(issuer, &signer);
 
                 let chunks = store.into_chunks();
@@ -202,7 +202,7 @@ fn bench_pipeline_fully_parallel(c: &mut Criterion) {
                 let addresses: Vec<_> = chunks.keys().copied().collect();
 
                 // Parallel stamp signing
-                let issuer = ShardedIssuer::new(B256::ZERO, 32, 16);
+                let issuer = ShardedIssuer::new(BatchId::ZERO, 32, 16);
                 let stamps = sign_stamps_parallel(&issuer, &sign_fn, &addresses);
 
                 black_box((root, stamps))
@@ -238,7 +238,7 @@ fn bench_pipeline_comparison(c: &mut Criterion) {
             let (root, chunks) = splitter.finish().unwrap();
             let store = MemoryStore::from_chunks(chunks);
 
-            let issuer = MemoryIssuer::new(B256::ZERO, 32, 16);
+            let issuer = MemoryIssuer::new(BatchId::ZERO, 32, 16);
             let mut stamper = BatchStamper::new(issuer, &signer);
 
             let chunks = store.into_chunks();
@@ -258,7 +258,7 @@ fn bench_pipeline_comparison(c: &mut Criterion) {
                 ParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(&data).unwrap();
             let store = MemoryStore::from_chunks(chunks);
 
-            let issuer = MemoryIssuer::new(B256::ZERO, 32, 16);
+            let issuer = MemoryIssuer::new(BatchId::ZERO, 32, 16);
             let mut stamper = BatchStamper::new(issuer, &signer);
 
             let chunks = store.into_chunks();
@@ -281,7 +281,7 @@ fn bench_pipeline_comparison(c: &mut Criterion) {
             let chunks = store.into_chunks();
             let addresses: Vec<_> = chunks.keys().copied().collect();
 
-            let issuer = ShardedIssuer::new(B256::ZERO, 32, 16);
+            let issuer = ShardedIssuer::new(BatchId::ZERO, 32, 16);
             let stamps = sign_stamps_parallel(&issuer, &sign_fn, &addresses);
 
             black_box((root, stamps))
@@ -330,7 +330,7 @@ fn bench_pipeline_stages(c: &mut Criterion) {
     // Stage 2: Stamp only (sequential)
     group.bench_function("2_stamp_sequential", |b| {
         b.iter(|| {
-            let issuer = MemoryIssuer::new(B256::ZERO, 32, 16);
+            let issuer = MemoryIssuer::new(BatchId::ZERO, 32, 16);
             let mut stamper = BatchStamper::new(issuer, &signer);
             let stamps: Vec<_> = addresses
                 .iter()
@@ -349,7 +349,7 @@ fn bench_pipeline_stages(c: &mut Criterion) {
 
     group.bench_function("2_stamp_parallel", |b| {
         b.iter(|| {
-            let issuer = ShardedIssuer::new(B256::ZERO, 32, 16);
+            let issuer = ShardedIssuer::new(BatchId::ZERO, 32, 16);
             black_box(sign_stamps_parallel(&issuer, &sign_fn, &addresses))
         });
     });

--- a/crates/postage-issuer/src/dilute_handler.rs
+++ b/crates/postage-issuer/src/dilute_handler.rs
@@ -170,10 +170,9 @@ impl BatchEventHandler for IssuerRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::B256;
 
     fn batch_id(byte: u8) -> BatchId {
-        B256::repeat_byte(byte)
+        BatchId::new([byte; 32])
     }
 
     #[test]

--- a/crates/postage-issuer/src/factory.rs
+++ b/crates/postage-issuer/src/factory.rs
@@ -95,14 +95,12 @@ impl MemoryBatchFactory {
     }
 
     fn generate_batch_id(&self) -> BatchId {
-        use alloy_primitives::B256;
-
         let id = self
             .next_id
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         let mut bytes = [0u8; 32];
         bytes[24..32].copy_from_slice(&id.to_be_bytes());
-        B256::from(bytes)
+        BatchId::new(bytes)
     }
 }
 

--- a/crates/postage-issuer/src/issuer.rs
+++ b/crates/postage-issuer/src/issuer.rs
@@ -261,7 +261,6 @@ impl StampIssuer for MemoryIssuer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::B256;
 
     fn test_address(leading: u16) -> SwarmAddress {
         let mut bytes = [0u8; 32];
@@ -277,7 +276,7 @@ mod tests {
 
     #[test]
     fn test_memory_issuer_basic() {
-        let batch_id = B256::ZERO;
+        let batch_id = BatchId::ZERO;
         let issuer = MemoryIssuer::new(batch_id, 20, 16);
 
         assert_eq!(issuer.batch_id(), batch_id);
@@ -291,12 +290,12 @@ mod tests {
 
     #[test]
     fn test_memory_issuer_prepare_stamp() {
-        let mut issuer = MemoryIssuer::new(B256::ZERO, 20, 16);
+        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 20, 16);
 
         let address = test_address(0xCBE5);
         let digest = issuer.prepare_stamp(&address, 12345).unwrap();
 
-        assert_eq!(digest.batch_id, B256::ZERO);
+        assert_eq!(digest.batch_id, BatchId::ZERO);
         assert_eq!(digest.index.bucket(), 0xCBE5);
         assert_eq!(digest.index.index(), 0);
         assert_eq!(digest.timestamp, 12345);
@@ -306,7 +305,7 @@ mod tests {
 
     #[test]
     fn test_memory_issuer_increments_index() {
-        let mut issuer = MemoryIssuer::new(B256::ZERO, 20, 16);
+        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 20, 16);
 
         let address = test_address(0xCBE5);
 
@@ -323,7 +322,7 @@ mod tests {
     #[test]
     fn test_memory_issuer_bucket_full() {
         // depth=17, bucket_depth=16 gives 2 slots per bucket
-        let mut issuer = MemoryIssuer::new(B256::ZERO, 17, 16);
+        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 17, 16);
 
         let address = test_address(0xABCD);
 
@@ -344,7 +343,7 @@ mod tests {
 
     #[test]
     fn test_memory_issuer_bucket_utilization() {
-        let mut issuer = MemoryIssuer::new(B256::ZERO, 20, 16);
+        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 20, 16);
 
         let addr1 = test_address(0x1234);
         let addr2 = test_address(0x5678);
@@ -361,7 +360,7 @@ mod tests {
     #[test]
     fn test_memory_issuer_capacity_check() {
         // depth=17, bucket_depth=16 gives 2 slots per bucket
-        let mut issuer = MemoryIssuer::new(B256::ZERO, 17, 16);
+        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 17, 16);
 
         let address = test_address(0x0001);
 
@@ -377,7 +376,7 @@ mod tests {
     #[test]
     fn test_memory_issuer_near_capacity() {
         // depth=18, bucket_depth=16 gives 4 slots per bucket
-        let mut issuer = MemoryIssuer::new(B256::ZERO, 18, 16);
+        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 18, 16);
 
         let address = test_address(0x0001);
 
@@ -403,7 +402,7 @@ mod tests {
         // A mutable batch must never yield an issuer: the obvious constructor
         // refuses it instead of handing back a reserved-blind ring that would
         // silently overwrite a self-hosted snapshot's own chunks.
-        let mutable = Batch::new(B256::ZERO, 0, 0, Default::default(), 20, 16, false);
+        let mutable = Batch::new(BatchId::ZERO, 0, 0, Default::default(), 20, 16, false);
 
         assert!(matches!(
             MemoryIssuer::from_batch(&mutable),
@@ -417,7 +416,7 @@ mod tests {
 
         // An immutable batch yields a fill-only issuer byte-for-byte identical
         // to `new` for the same geometry: same indices and the same digest.
-        let batch_id = B256::from([0x11u8; 32]);
+        let batch_id = BatchId::new([0x11u8; 32]);
         let immutable = Batch::new(batch_id, 0, 0, Default::default(), 17, 16, true);
 
         let mut from_batch = MemoryIssuer::from_batch(&immutable).unwrap();
@@ -444,7 +443,7 @@ mod tests {
     #[test]
     fn test_memory_issuer_dilute_grows_capacity_only() {
         // depth=17, bucket_depth=16 gives 2 slots per bucket.
-        let mut issuer = MemoryIssuer::new(B256::ZERO, 17, 16);
+        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 17, 16);
         let address = test_address(0xABCD);
 
         // Fill the bucket, then a dilution to depth 18 (4 slots) reopens it

--- a/crates/postage-issuer/src/lib.rs
+++ b/crates/postage-issuer/src/lib.rs
@@ -33,12 +33,11 @@
 //!
 //! ```compile_fail
 //! use nectar_postage_issuer::{RingIssuer, Reserved, Unreserved};
-//! use nectar_postage::Batch;
-//! use alloy_primitives::B256;
+//! use nectar_postage::{Batch, BatchId};
 //!
 //! fn self_hosting_sink(_ring: RingIssuer<Reserved>) {}
 //!
-//! let batch = Batch::new(B256::ZERO, 0, 0, Default::default(), 20, 16, false);
+//! let batch = Batch::new(BatchId::ZERO, 0, 0, Default::default(), 20, 16, false);
 //! let unreserved: RingIssuer<Unreserved> = RingIssuer::external(&batch).unwrap();
 //! // A reserved-blind ring is not a Reserved ring, and there is no conversion.
 //! self_hosting_sink(unreserved);
@@ -53,13 +52,12 @@
 //! # Example
 //!
 //! ```ignore
-//! use nectar_postage_issuer::{BatchStamper, MemoryIssuer, Stamper};
+//! use nectar_postage_issuer::{BatchId, BatchStamper, MemoryIssuer, Stamper};
 //! use nectar_primitives::SwarmAddress;
-//! use alloy_primitives::B256;
 //! use alloy_signer_local::PrivateKeySigner;
 //!
 //! // Create an issuer for a batch
-//! let issuer = MemoryIssuer::new(B256::ZERO, 20, 16);
+//! let issuer = MemoryIssuer::new(BatchId::ZERO, 20, 16);
 //!
 //! // Combine with any SignerSync implementation to create a stamper
 //! let signer = PrivateKeySigner::random();

--- a/crates/postage-issuer/src/ring.rs
+++ b/crates/postage-issuer/src/ring.rs
@@ -392,7 +392,6 @@ impl<R: Reservation> StampIssuer for RingIssuer<R> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::B256;
 
     fn test_address(leading: u16) -> SwarmAddress {
         let mut bytes = [0u8; 32];
@@ -408,7 +407,7 @@ mod tests {
 
     fn mutable_batch(depth: u8, bucket_depth: u8) -> Batch {
         Batch::new(
-            B256::ZERO,
+            BatchId::ZERO,
             0,
             0,
             Default::default(),
@@ -420,7 +419,7 @@ mod tests {
 
     fn immutable_batch(depth: u8, bucket_depth: u8) -> Batch {
         Batch::new(
-            B256::ZERO,
+            BatchId::ZERO,
             0,
             0,
             Default::default(),

--- a/crates/postage-issuer/src/sharded.rs
+++ b/crates/postage-issuer/src/sharded.rs
@@ -98,10 +98,9 @@ impl BucketShard {
 /// # Example
 ///
 /// ```ignore
-/// use nectar_postage_issuer::ShardedIssuer;
-/// use alloy_primitives::B256;
+/// use nectar_postage_issuer::{BatchId, ShardedIssuer};
 ///
-/// let issuer = ShardedIssuer::new(B256::ZERO, 20, 16);
+/// let issuer = ShardedIssuer::new(BatchId::ZERO, 20, 16);
 /// // Now safe to use from multiple threads via sign_stamps_parallel
 /// ```
 #[derive(Debug)]
@@ -379,11 +378,11 @@ pub struct StampResult {
 /// # Example
 ///
 /// ```ignore
-/// use nectar_postage_issuer::{sign_stamps_parallel, ShardedIssuer};
+/// use nectar_postage_issuer::{BatchId, ShardedIssuer, sign_stamps_parallel};
 /// use alloy_primitives::B256;
 /// use alloy_signer::SignerSync;
 ///
-/// let issuer = ShardedIssuer::new(B256::ZERO, 20, 16);
+/// let issuer = ShardedIssuer::new(BatchId::ZERO, 20, 16);
 /// let addresses: Vec<SwarmAddress> = /* ... */;
 /// // Use sign_message_sync for EIP-191 compatibility
 /// let signer_fn = |prehash: &B256| signer.sign_message_sync(prehash.as_slice());
@@ -450,7 +449,7 @@ mod tests {
         // The parallel constructor refuses a mutable batch for the same reason
         // as MemoryIssuer: a reserved-blind ring would silently overwrite a
         // self-hosted snapshot's own chunks.
-        let mutable = Batch::new(B256::ZERO, 0, 0, Default::default(), 20, 16, false);
+        let mutable = Batch::new(BatchId::ZERO, 0, 0, Default::default(), 20, 16, false);
         assert!(matches!(
             ShardedIssuer::from_batch(&mutable),
             Err(IssuerError::MutableNotSupported)
@@ -461,15 +460,15 @@ mod tests {
     fn test_sharded_issuer_from_batch_immutable_ok() {
         use nectar_postage::Batch;
 
-        let immutable = Batch::new(B256::ZERO, 0, 0, Default::default(), 20, 16, true);
+        let immutable = Batch::new(BatchId::ZERO, 0, 0, Default::default(), 20, 16, true);
         assert!(ShardedIssuer::from_batch(&immutable).is_ok());
     }
 
     #[test]
     fn test_sharded_issuer_basic() {
-        let issuer = ShardedIssuer::new(B256::ZERO, 20, 16);
+        let issuer = ShardedIssuer::new(BatchId::ZERO, 20, 16);
 
-        assert_eq!(issuer.batch_id(), B256::ZERO);
+        assert_eq!(issuer.batch_id(), BatchId::ZERO);
         assert_eq!(issuer.batch_depth(), 20);
         assert_eq!(issuer.bucket_depth(), 16);
         assert_eq!(issuer.bucket_capacity(), 16); // 2^(20-16) = 16
@@ -478,12 +477,12 @@ mod tests {
 
     #[test]
     fn test_sharded_issuer_prepare_stamp() {
-        let issuer = ShardedIssuer::new(B256::ZERO, 20, 16);
+        let issuer = ShardedIssuer::new(BatchId::ZERO, 20, 16);
         let address = SwarmAddress::from(B256::random());
 
         let digest = issuer.prepare_stamp(&address, 12345).unwrap();
 
-        assert_eq!(digest.batch_id, B256::ZERO);
+        assert_eq!(digest.batch_id, BatchId::ZERO);
         assert_eq!(digest.timestamp, 12345);
         assert_eq!(issuer.stamps_issued(), 1);
     }
@@ -491,7 +490,7 @@ mod tests {
     #[test]
     fn test_sharded_issuer_dilute_grows_capacity_only() {
         // depth=17, bucket_depth=16 gives 2 slots per bucket.
-        let mut issuer = ShardedIssuer::new(B256::ZERO, 17, 16);
+        let mut issuer = ShardedIssuer::new(BatchId::ZERO, 17, 16);
         let address = SwarmAddress::from(B256::repeat_byte(0xAB));
         let bucket = calculate_bucket(&address, 16);
 
@@ -521,7 +520,7 @@ mod tests {
         use std::sync::Arc;
         use std::thread;
 
-        let issuer = Arc::new(ShardedIssuer::new(B256::ZERO, 24, 16));
+        let issuer = Arc::new(ShardedIssuer::new(BatchId::ZERO, 24, 16));
         let num_threads = 8;
         let stamps_per_thread = 1000;
 
@@ -554,7 +553,7 @@ mod tests {
         use alloy_signer::SignerSync;
         use alloy_signer_local::PrivateKeySigner;
 
-        let issuer = ShardedIssuer::new(B256::ZERO, 24, 16);
+        let issuer = ShardedIssuer::new(BatchId::ZERO, 24, 16);
         let signer = PrivateKeySigner::random();
 
         let addresses: Vec<_> = (0..100)

--- a/crates/postage-issuer/src/sharded_ring.rs
+++ b/crates/postage-issuer/src/sharded_ring.rs
@@ -418,7 +418,6 @@ impl<R: Reservation> ShardedRingIssuer<R> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::B256;
 
     fn test_address(leading: u16) -> SwarmAddress {
         let mut bytes = [0u8; 32];
@@ -434,7 +433,7 @@ mod tests {
 
     fn mutable_batch(depth: u8, bucket_depth: u8) -> Batch {
         Batch::new(
-            B256::ZERO,
+            BatchId::ZERO,
             0,
             0,
             Default::default(),
@@ -446,7 +445,7 @@ mod tests {
 
     fn immutable_batch(depth: u8, bucket_depth: u8) -> Batch {
         Batch::new(
-            B256::ZERO,
+            BatchId::ZERO,
             0,
             0,
             Default::default(),

--- a/crates/postage-issuer/src/stamper.rs
+++ b/crates/postage-issuer/src/stamper.rs
@@ -218,20 +218,20 @@ mod tests {
 
     #[test]
     fn test_batch_stamper_basic() {
-        let issuer = MemoryIssuer::new(B256::ZERO, 20, 16);
+        let issuer = MemoryIssuer::new(BatchId::ZERO, 20, 16);
         let mut stamper = BatchStamper::new(issuer, MockSigner);
 
         let address = SwarmAddress::new([0xAB; 32]);
         let stamp = stamper.stamp(&address).unwrap();
 
-        assert_eq!(stamp.batch(), B256::ZERO);
+        assert_eq!(stamp.batch(), BatchId::ZERO);
         // First stamp in bucket should have index 0
         assert_eq!(stamp.index(), 0);
     }
 
     #[test]
     fn test_batch_stamper_increments_index() {
-        let issuer = MemoryIssuer::new(B256::ZERO, 20, 16);
+        let issuer = MemoryIssuer::new(BatchId::ZERO, 20, 16);
         let mut stamper = BatchStamper::new(issuer, MockSigner);
 
         // Use same address to hit same bucket
@@ -256,7 +256,7 @@ mod tests {
 
         // Create an issuer with very small bucket capacity: depth=17, bucket_depth=16
         // This gives 2^(17-16) = 2 slots per bucket
-        let issuer = MemoryIssuer::new(B256::ZERO, 17, 16);
+        let issuer = MemoryIssuer::new(BatchId::ZERO, 17, 16);
         let mut stamper = BatchStamper::new(issuer, MockSigner);
 
         let address = SwarmAddress::new([0xAB; 32]);
@@ -275,7 +275,7 @@ mod tests {
 
     #[test]
     fn test_batch_stamper_max_utilization() {
-        let issuer = MemoryIssuer::new(B256::ZERO, 20, 16);
+        let issuer = MemoryIssuer::new(BatchId::ZERO, 20, 16);
         let mut stamper = BatchStamper::new(issuer, MockSigner);
 
         assert_eq!(stamper.max_bucket_utilization(), 0);
@@ -291,7 +291,7 @@ mod tests {
     #[test]
     fn test_stamp_digest_prehash() {
         let address = SwarmAddress::new([0xAB; 32]);
-        let batch_id = B256::ZERO;
+        let batch_id = BatchId::ZERO;
         let index = StampIndex::new(100, 5);
         let timestamp = 1234567890u64;
 

--- a/crates/postage-usage/examples/roam_between_machines.rs
+++ b/crates/postage-usage/examples/roam_between_machines.rs
@@ -43,7 +43,7 @@ use std::sync::{Arc, Mutex};
 use alloy_primitives::{Address, B256, hex};
 use alloy_signer_local::PrivateKeySigner;
 use bytes::Bytes;
-use nectar_postage::Batch;
+use nectar_postage::{Batch, BatchId};
 use nectar_postage_usage::{
     BatchStamper, Mutability, PublishedSequence, SealedChunk, Snapshot, SnapshotSink,
     SnapshotSource, SwarmAddress, UsageError, UsageTable,
@@ -93,7 +93,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // address, so machine B can find the state without any local store.
     let signer = PrivateKeySigner::random();
     let owner: Address = signer.address();
-    let batch_id = B256::repeat_byte(0x42);
+    let batch_id = BatchId::new([0x42; 32]);
     let batch = Batch::new(batch_id, 0, 0, owner, DEPTH, BUCKET_DEPTH, true);
 
     println!("Postage batch usage: roaming between machines");
@@ -208,7 +208,7 @@ async fn machine_b(
 /// flush.
 fn stale_persist_is_rejected(
     owner: Address,
-    batch_id: B256,
+    batch_id: BatchId,
 ) -> Result<(), Box<dyn std::error::Error>> {
     println!("Stale persist: rejected by the published floor");
     println!("----------------------------------------------");

--- a/crates/postage-usage/src/client.rs
+++ b/crates/postage-usage/src/client.rs
@@ -437,7 +437,7 @@ mod tests {
 
     fn test_batch(signer: &PrivateKeySigner, immutable: bool) -> Batch {
         Batch::new(
-            B256::repeat_byte(0x42),
+            BatchId::new([0x42; 32]),
             0,
             0,
             signer.address(),

--- a/crates/postage-usage/src/codec.rs
+++ b/crates/postage-usage/src/codec.rs
@@ -397,7 +397,7 @@ impl RootInfo {
         if payload[0..4] != MAGIC {
             return Err(UsageError::BadMagic);
         }
-        let batch_id = B256::from_slice(&payload[4..36]);
+        let batch_id = BatchId::from_slice(&payload[4..36]);
         let depth = payload[36];
         let bucket_depth = payload[37];
         validate_geometry(depth, bucket_depth).map_err(UsageError::into_corruption)?;
@@ -785,7 +785,7 @@ mod tests {
         // codec refuses it. The public path reaches encoding only through
         // `plan_persist`, which always allocates the root first.
         let table =
-            UsageTable::new(B256::repeat_byte(0x42), 20, 16, Mutability::Immutable).unwrap();
+            UsageTable::new(BatchId::new([0x42; 32]), 20, 16, Mutability::Immutable).unwrap();
         assert_eq!(
             encode(&table, 0, &[]),
             Err(UsageError::Malformed("root slot not allocated")),
@@ -794,10 +794,8 @@ mod tests {
 
     #[test]
     fn flags_bit0_is_mutable_other_bits_rejected() {
-        use alloy_primitives::B256;
-
         // Build a minimal valid mutable root: width 0, one slot, no exceptions.
-        let table = UsageTable::new(B256::repeat_byte(0x42), 20, 16, Mutability::Mutable).unwrap();
+        let table = UsageTable::new(BatchId::new([0x42; 32]), 20, 16, Mutability::Mutable).unwrap();
         let encoded = encode(&table, 1, &[0]).unwrap();
         let mut root = encoded.root.to_vec();
         assert_eq!(root[38], 0x01, "mutable flag must be set");
@@ -831,7 +829,7 @@ mod tests {
         // base so the encoder packs nothing inline.
         counts[5] = 16;
         let table = UsageTable::from_counts(
-            B256::repeat_byte(0x42),
+            BatchId::new([0x42; 32]),
             12,
             8,
             counts,
@@ -949,7 +947,7 @@ mod tests {
         // exceptions): every count is within the capacity of 16.
         let counts: Vec<u32> = (0..256u32).map(|b| b % 17).collect();
         let table = UsageTable::from_counts(
-            B256::repeat_byte(0x42),
+            BatchId::new([0x42; 32]),
             12,
             8,
             counts,
@@ -991,7 +989,7 @@ mod tests {
         let mut counts = vec![0u32; 256];
         counts[5] = 17; // capacity is 16
         let err = UsageTable::from_counts(
-            B256::repeat_byte(0x42),
+            BatchId::new([0x42; 32]),
             12,
             8,
             counts,

--- a/crates/postage-usage/src/lib.rs
+++ b/crates/postage-usage/src/lib.rs
@@ -27,10 +27,10 @@
 //! ```
 //! use alloy_primitives::{Address, B256};
 //! use nectar_postage_usage::{
-//!     Mutability, PublishedSequence, RootInfo, Snapshot, SwarmAddress, UsageTable,
+//!     BatchId, Mutability, PublishedSequence, RootInfo, Snapshot, SwarmAddress, UsageTable,
 //! };
 //!
-//! let batch_id = B256::repeat_byte(0x42);
+//! let batch_id = BatchId::new([0x42; 32]);
 //! let owner = Address::repeat_byte(0x11);
 //!
 //! // Issue a stamp for an uploaded chunk through the snapshot's issuing handle,
@@ -202,8 +202,8 @@ mod tests {
 
     #[test]
     fn chunk_ids_are_domain_separated_and_indexed() {
-        let a = B256::repeat_byte(1);
-        let b = B256::repeat_byte(2);
+        let a = BatchId::new([0x01; 32]);
+        let b = BatchId::new([0x02; 32]);
         assert_ne!(usage_chunk_id(&a, 0), usage_chunk_id(&b, 0));
         assert_ne!(usage_chunk_id(&a, 0), usage_chunk_id(&a, 1));
         // Deterministic.
@@ -212,7 +212,7 @@ mod tests {
 
     #[test]
     fn chunk_address_binds_owner() {
-        let batch = B256::repeat_byte(1);
+        let batch = BatchId::new([0x01; 32]);
         let alice = Address::repeat_byte(0xaa);
         let bob = Address::repeat_byte(0xbb);
         assert_ne!(

--- a/crates/postage-usage/src/table.rs
+++ b/crates/postage-usage/src/table.rs
@@ -129,19 +129,18 @@ impl Mutability {
 /// runtime check.
 ///
 /// ```compile_fail
-/// use alloy_primitives::B256;
-/// use nectar_postage_usage::{Mutability, UsageTable};
+/// use nectar_postage_usage::{BatchId, Mutability, UsageTable};
 ///
-/// let mut table = UsageTable::new(B256::repeat_byte(0x42), 18, 16, Mutability::Mutable).unwrap();
+/// let mut table = UsageTable::new(BatchId::new([0x42; 32]), 18, 16, Mutability::Mutable).unwrap();
 /// // `record` no longer exists on the inert table.
 /// table.record(7).unwrap();
 /// ```
 ///
 /// ```compile_fail
 /// use alloy_primitives::B256;
-/// use nectar_postage_usage::{Mutability, SwarmAddress, UsageTable};
+/// use nectar_postage_usage::{BatchId, Mutability, SwarmAddress, UsageTable};
 ///
-/// let mut table = UsageTable::new(B256::repeat_byte(0x42), 18, 16, Mutability::Mutable).unwrap();
+/// let mut table = UsageTable::new(BatchId::new([0x42; 32]), 18, 16, Mutability::Mutable).unwrap();
 /// // `record_address` no longer exists on the inert table.
 /// table.record_address(&SwarmAddress::from(B256::repeat_byte(0x99))).unwrap();
 /// ```
@@ -441,8 +440,8 @@ impl<'a> TableView<'a> {
 #[cfg(any(test, feature = "arbitrary"))]
 mod arbitrary_impls {
     use alloc::vec;
-    use alloy_primitives::B256;
     use arbitrary::{Arbitrary, Result as ArbitraryResult, Unstructured};
+    use nectar_postage::BatchId;
 
     use super::{Mutability, UsageTable};
     use crate::{MAX_BUCKET_DEPTH, MAX_COUNTER_BITS};
@@ -459,7 +458,7 @@ mod arbitrary_impls {
 
     impl<'a> Arbitrary<'a> for UsageTable {
         fn arbitrary(u: &mut Unstructured<'a>) -> ArbitraryResult<Self> {
-            let batch_id = B256::from(u.arbitrary::<[u8; 32]>()?);
+            let batch_id = BatchId::new(u.arbitrary::<[u8; 32]>()?);
             // `bucket_depth == 0` (a zero-width bucket) is invalid geometry:
             // `validate_geometry` rejects it because `nectar_postage::
             // calculate_bucket` shifts a u32 right by `32 - bucket_depth`, so
@@ -504,7 +503,9 @@ mod tests {
     use super::*;
 
     fn batch_id() -> BatchId {
-        b256!("0x1122334455667788112233445566778811223344556677881122334455667788")
+        BatchId::from(b256!(
+            "0x1122334455667788112233445566778811223344556677881122334455667788"
+        ))
     }
 
     fn immutable_counts() -> Vec<u32> {

--- a/crates/postage-usage/tests/issuer.rs
+++ b/crates/postage-usage/tests/issuer.rs
@@ -14,8 +14,8 @@
     clippy::as_conversions,
     clippy::missing_panics_doc
 )]
-use alloy_primitives::{Address, B256};
-use nectar_postage::{StampIndex, calculate_bucket};
+use alloy_primitives::Address;
+use nectar_postage::{BatchId, StampIndex, calculate_bucket};
 use nectar_postage_issuer::StampIssuer;
 use nectar_postage_usage::{Mutability, PublishedSequence, Snapshot, SnapshotIssuer, UsageTable};
 use nectar_primitives::SwarmAddress;
@@ -41,7 +41,7 @@ fn content_address(bucket: u32, salt: u8) -> SwarmAddress {
 
 #[test]
 fn snapshot_issuer_issues_sequential_indices() {
-    let batch_id = B256::repeat_byte(0x42);
+    let batch_id = BatchId::new([0x42; 32]);
     let table = UsageTable::new(batch_id, 18, BUCKET_DEPTH, Mutability::Immutable).unwrap();
     // A fresh, never-persisted snapshot reserves no slots, so issuance fills the
     // bucket from index zero just as a bare table once did.
@@ -75,7 +75,7 @@ fn snapshot_issuer_issues_sequential_indices() {
 
 #[test]
 fn shared_table_immutable_never_collides_with_reserved_slots() {
-    let batch_id = B256::repeat_byte(0x42);
+    let batch_id = BatchId::new([0x42; 32]);
     let counts = vec![5u32; 1usize << BUCKET_DEPTH];
     let table =
         UsageTable::from_counts(batch_id, 24, BUCKET_DEPTH, counts, Mutability::Immutable).unwrap();
@@ -105,7 +105,7 @@ fn shared_table_immutable_never_collides_with_reserved_slots() {
 
 #[test]
 fn shared_table_mutable_skips_reserved_across_wraps() {
-    let batch_id = B256::repeat_byte(0x42);
+    let batch_id = BatchId::new([0x42; 32]);
     // Capacity 4 per bucket; fill near-full so the ring wraps almost at once.
     let counts = vec![2u32; 1usize << BUCKET_DEPTH];
     let table =
@@ -156,7 +156,7 @@ fn shared_table_mutable_skips_reserved_across_wraps() {
 /// not hold.
 #[test]
 fn sole_issuance_path_cannot_evict_snapshot_slots() {
-    let batch_id = B256::repeat_byte(0x42);
+    let batch_id = BatchId::new([0x42; 32]);
     // A mutable bucket at capacity 4, pre-filled to 3 so the very next stamp
     // wraps the ring and would land on the reserved slot under a naive issuer.
     let counts = vec![3u32; 1usize << BUCKET_DEPTH];
@@ -215,7 +215,7 @@ fn sole_issuance_path_cannot_evict_snapshot_slots() {
 fn shared_counter_table_backs_both_crates_identically() {
     use nectar_postage_issuer::MemoryIssuer;
 
-    let batch_id = B256::repeat_byte(0x42);
+    let batch_id = BatchId::new([0x42; 32]);
     // A fresh, never-persisted snapshot reserves no slots, so its fill watermark
     // advances exactly like a bare MemoryIssuer.
     let table = UsageTable::new(batch_id, 20, BUCKET_DEPTH, Mutability::Immutable).unwrap();
@@ -248,7 +248,7 @@ fn snapshot_issuer_adapter_drives_a_batch_stamper_path() {
 
     let signer = PrivateKeySigner::random();
     let owner = signer.address();
-    let batch_id = B256::repeat_byte(0x77);
+    let batch_id = BatchId::new([0x77; 32]);
 
     let table = UsageTable::new(batch_id, 20, BUCKET_DEPTH, Mutability::Mutable).unwrap();
     let mut snapshot = Snapshot::new(table);

--- a/crates/postage-usage/tests/seal.rs
+++ b/crates/postage-usage/tests/seal.rs
@@ -13,16 +13,17 @@
     clippy::as_conversions,
     clippy::missing_panics_doc
 )]
-use alloy_primitives::{Address, B256};
+use alloy_primitives::Address;
 use alloy_signer_local::PrivateKeySigner;
 use nectar_postage_usage::{
-    Mutability, PublishedSequence, SealError, Snapshot, UsageTable, seal_plan, usage_chunk_address,
+    BatchId, Mutability, PublishedSequence, SealError, Snapshot, UsageTable, seal_plan,
+    usage_chunk_address,
 };
 use nectar_primitives::Chunk;
 
 const BUCKET_DEPTH: u8 = 16;
 
-fn seeded_snapshot(owner: Address, batch_id: B256) -> Snapshot {
+fn seeded_snapshot(owner: Address, batch_id: BatchId) -> Snapshot {
     // Seed one stamp in bucket 123 via the inert constructor; the table itself
     // has no record path.
     let mut counts = vec![0u32; 1usize << BUCKET_DEPTH];
@@ -42,7 +43,7 @@ fn seeded_snapshot(owner: Address, batch_id: B256) -> Snapshot {
 fn sealed_chunks_and_stamps_verify() {
     let signer = PrivateKeySigner::random();
     let owner = signer.address();
-    let batch_id = B256::repeat_byte(0x42);
+    let batch_id = BatchId::new([0x42; 32]);
 
     let mut snapshot = seeded_snapshot(owner, batch_id);
     let plan = snapshot
@@ -98,7 +99,7 @@ fn sealed_chunks_and_stamps_verify() {
 fn non_increasing_seal_timestamp_is_rejected() {
     let signer = PrivateKeySigner::random();
     let owner = signer.address();
-    let batch_id = B256::repeat_byte(0x42);
+    let batch_id = BatchId::new([0x42; 32]);
 
     let mut snapshot = seeded_snapshot(owner, batch_id);
 

--- a/crates/postage-usage/tests/snapshot.rs
+++ b/crates/postage-usage/tests/snapshot.rs
@@ -13,17 +13,17 @@
     clippy::as_conversions,
     clippy::missing_panics_doc
 )]
-use alloy_primitives::{Address, B256};
+use alloy_primitives::Address;
 use nectar_postage::calculate_bucket;
 use nectar_postage_usage::{
-    Batch, MAGIC, Mutability, PersistPlan, PublishedSequence, RootInfo, Snapshot, UsageError,
-    UsageTable, usage_chunk_address, usage_chunk_id,
+    Batch, BatchId, MAGIC, Mutability, PersistPlan, PublishedSequence, RootInfo, Snapshot,
+    UsageError, UsageTable, usage_chunk_address, usage_chunk_id,
 };
 
 const BUCKET_DEPTH: u8 = 16;
 
-const fn batch_id() -> B256 {
-    B256::repeat_byte(0x42)
+const fn batch_id() -> BatchId {
+    BatchId::new([0x42; 32])
 }
 
 const fn owner() -> Address {

--- a/crates/postage-usage/tests/vector.rs
+++ b/crates/postage-usage/tests/vector.rs
@@ -20,10 +20,10 @@
     clippy::as_conversions,
     clippy::missing_panics_doc
 )]
-use alloy_primitives::{Address, B256, hex};
+use alloy_primitives::{Address, hex};
 use nectar_postage::calculate_bucket;
 use nectar_postage_usage::{
-    Mutability, PublishedSequence, RootInfo, Snapshot, UsageTable, usage_chunk_address,
+    BatchId, Mutability, PublishedSequence, RootInfo, Snapshot, UsageTable, usage_chunk_address,
     usage_chunk_id,
 };
 
@@ -37,7 +37,7 @@ const ROOT_ADDRESS_HEX: &str = "296daebd0b1cd7b78b83016fc9bc9cc62d378c2ff21fb934
 
 #[test]
 fn readme_worked_example_vector() {
-    let batch_id = B256::repeat_byte(0x42);
+    let batch_id = BatchId::new([0x42; 32]);
     let owner = Address::repeat_byte(0x11);
     let mut counts: Vec<u32> = (0..256u32).map(|b| 3 + (b & 3)).collect();
     counts[200] = 16;
@@ -82,7 +82,7 @@ const LARGE_ROOT_PAYLOAD_HEX: &str = "534255314242424242424242424242424242424242
 
 #[test]
 fn readme_large_batch_multi_leaf_vector() {
-    let batch_id = B256::repeat_byte(0x42);
+    let batch_id = BatchId::new([0x42; 32]);
     let owner = Address::repeat_byte(0x11);
     let mut counts: Vec<u32> = (0..65536u32).map(|b| 100 + (b % 50)).collect();
     counts[0x1234] = 5000;
@@ -137,7 +137,7 @@ const MUTABLE_ROOT_PAYLOAD_HEX: &str = "5342553142424242424242424242424242424242
 
 #[test]
 fn mutable_vector_flags_byte_and_round_trip() {
-    let batch_id = B256::repeat_byte(0x42);
+    let batch_id = BatchId::new([0x42; 32]);
     let owner = Address::repeat_byte(0x11);
     let mut counts: Vec<u32> = (0..256u32).map(|b| 3 + (b & 3)).collect();
     counts[200] = 16;

--- a/crates/postage/Cargo.toml
+++ b/crates/postage/Cargo.toml
@@ -22,6 +22,7 @@ nectar-primitives = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy-signer = { workspace = true }
 byteorder = { workspace = true }
+derive_more = { workspace = true }
 thiserror = { workspace = true }
 
 # k256 with precomputed tables for faster ECDSA verification

--- a/crates/postage/benches/verify.rs
+++ b/crates/postage/benches/verify.rs
@@ -15,12 +15,12 @@
     clippy::as_conversions,
     clippy::missing_panics_doc
 )]
-use alloy_primitives::{Address, B256, Signature};
+use alloy_primitives::{Address, Signature};
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
 use nectar_postage::{
-    Batch, Stamp, StampBytes, StampDigest, StampIndex,
+    Batch, BatchId, Stamp, StampBytes, StampDigest, StampIndex,
     parallel::{verify_stamps_parallel, verify_stamps_parallel_with_pubkey},
 };
 use nectar_primitives::SwarmAddress;
@@ -31,7 +31,7 @@ fn random_stamp() -> Stamp {
     let mut rng = rand::rng();
     let mut batch_bytes = [0u8; 32];
     rng.fill(&mut batch_bytes);
-    let batch = B256::from(batch_bytes);
+    let batch = BatchId::new(batch_bytes);
 
     let bucket: u32 = rng.random();
     let index: u32 = rng.random();
@@ -55,7 +55,7 @@ fn random_address() -> SwarmAddress {
 fn create_signed_stamp(
     signer: &PrivateKeySigner,
     chunk_address: &SwarmAddress,
-    batch_id: B256,
+    batch_id: BatchId,
 ) -> Stamp {
     let index = StampIndex::new(0, 0);
     let timestamp = 12345u64;
@@ -123,7 +123,7 @@ fn bench_stamp_index_roundtrip(c: &mut Criterion) {
 // Validation Benchmarks
 
 fn bench_validate_index(c: &mut Criterion) {
-    let batch = Batch::new(B256::ZERO, 0, 0, Address::ZERO, 20, 16, false);
+    let batch = Batch::new(BatchId::ZERO, 0, 0, Address::ZERO, 20, 16, false);
     let valid_index = StampIndex::new(1000, 10);
     let invalid_bucket = StampIndex::new(70000, 0);
 
@@ -147,7 +147,7 @@ fn bench_stamp_digest_prehash(c: &mut Criterion) {
     let mut rng = rand::rng();
     let mut batch_bytes = [0u8; 32];
     rng.fill(&mut batch_bytes);
-    let batch_id = B256::from(batch_bytes);
+    let batch_id = BatchId::new(batch_bytes);
     let index = StampIndex::new(1000, 5);
     let timestamp = 1234567890u64;
     let digest = StampDigest::new(address, batch_id, index, timestamp);
@@ -182,7 +182,7 @@ fn recover_stamp_signer(
 fn bench_ecdsa_verify_sequential(c: &mut Criterion) {
     let signer = PrivateKeySigner::random();
     let expected_address = signer.address();
-    let batch_id = B256::ZERO;
+    let batch_id = BatchId::ZERO;
 
     let single_addr = random_address();
     let single_stamp = create_signed_stamp(&signer, &single_addr, batch_id);
@@ -223,7 +223,7 @@ fn bench_ecdsa_verify_sequential(c: &mut Criterion) {
 
 fn bench_ecdsa_verify_with_pubkey(c: &mut Criterion) {
     let signer = PrivateKeySigner::random();
-    let batch_id = B256::ZERO;
+    let batch_id = BatchId::ZERO;
 
     // Create stamps
     let addresses: Vec<SwarmAddress> = (0..100).map(|_| random_address()).collect();
@@ -262,7 +262,7 @@ fn bench_ecdsa_verify_with_pubkey(c: &mut Criterion) {
 
 fn bench_ecdsa_verify_parallel(c: &mut Criterion) {
     let signer = PrivateKeySigner::random();
-    let batch_id = B256::ZERO;
+    let batch_id = BatchId::ZERO;
 
     // Pre-generate 100 stamps for verification
     let addresses_100: Vec<SwarmAddress> = (0..100).map(|_| random_address()).collect();
@@ -303,7 +303,7 @@ fn bench_ecdsa_verify_parallel(c: &mut Criterion) {
 
 fn bench_ecdsa_verify_parallel_with_pubkey(c: &mut Criterion) {
     let signer = PrivateKeySigner::random();
-    let batch_id = B256::ZERO;
+    let batch_id = BatchId::ZERO;
 
     // Pre-generate 100 stamps for verification
     let addresses_100: Vec<SwarmAddress> = (0..100).map(|_| random_address()).collect();
@@ -357,7 +357,7 @@ fn bench_ecdsa_verify_parallel_with_pubkey(c: &mut Criterion) {
 
 fn bench_verify_comparison(c: &mut Criterion) {
     let signer = PrivateKeySigner::random();
-    let batch_id = B256::ZERO;
+    let batch_id = BatchId::ZERO;
 
     // Pre-generate 1000 stamps
     let addresses: Vec<SwarmAddress> = (0..1000).map(|_| random_address()).collect();

--- a/crates/postage/src/batch.rs
+++ b/crates/postage/src/batch.rs
@@ -1,12 +1,60 @@
 //! Postage batch types.
 
 use alloy_primitives::{Address, B256};
+use derive_more::{AsRef, Display, From, Into};
 use nectar_primitives::SwarmAddress;
 
 use crate::{StampError, StampIndex, calculate_bucket};
 
 /// A 32-byte batch identifier.
-pub type BatchId = B256;
+///
+/// Nominal wrapper over [`B256`]: other 32-byte values (chunk addresses,
+/// hashes) do not type-check as batch ids. The `From`/`Into` conversions
+/// cover the contracts `bytes32` boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Display, From, Into, AsRef)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+#[display("{_0}")]
+#[from(B256, [u8; 32])]
+#[into(B256, [u8; 32])]
+#[as_ref([u8])]
+#[repr(transparent)]
+pub struct BatchId(B256);
+
+impl BatchId {
+    /// Zero id, useful for tests and deterministic vectors.
+    pub const ZERO: Self = Self(B256::ZERO);
+
+    /// Construct from raw 32 bytes. `const` for static contexts; for runtime
+    /// conversions prefer the `From` impls.
+    #[inline]
+    pub const fn new(bytes: [u8; 32]) -> Self {
+        Self(B256::new(bytes))
+    }
+
+    /// Borrow the underlying 32 bytes.
+    #[inline]
+    pub const fn as_slice(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+
+    /// Copy an id out of a 32-byte slice.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `slice` is not exactly 32 bytes.
+    #[inline]
+    pub fn from_slice(slice: &[u8]) -> Self {
+        Self(B256::from_slice(slice))
+    }
+}
+
+#[cfg(any(test, feature = "arbitrary"))]
+impl<'a> arbitrary::Arbitrary<'a> for BatchId {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self::new(u.arbitrary()?))
+    }
+}
 
 /// Parameters for creating a new batch.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -271,7 +319,7 @@ impl<'a> arbitrary::Arbitrary<'a> for Batch {
         let bucket_depth: u8 = u.int_in_range(1..=depth)?;
 
         Ok(Self::new(
-            B256::arbitrary(u)?,
+            BatchId::arbitrary(u)?,
             u.arbitrary()?,
             u.arbitrary()?,
             Address::arbitrary(u)?,
@@ -287,8 +335,18 @@ mod tests {
     use super::*;
 
     #[test]
+    fn batch_id_roundtrips_via_from_impls() {
+        let bytes = [7u8; 32];
+        let id = BatchId::new(bytes);
+        assert_eq!(B256::from(id), B256::new(bytes));
+        assert_eq!(BatchId::from(B256::new(bytes)), id);
+        assert_eq!(<[u8; 32]>::from(id), bytes);
+        assert_eq!(BatchId::from(bytes), id);
+    }
+
+    #[test]
     fn test_batch_creation() {
-        let id = B256::ZERO;
+        let id = BatchId::ZERO;
         let batch = Batch::new(id, 1000, 100, Address::ZERO, 18, 16, false);
 
         assert_eq!(batch.id(), id);
@@ -302,7 +360,7 @@ mod tests {
 
     #[test]
     fn test_bucket_calculations() {
-        let batch = Batch::new(B256::ZERO, 0, 0, Address::ZERO, 18, 16, false);
+        let batch = Batch::new(BatchId::ZERO, 0, 0, Address::ZERO, 18, 16, false);
 
         // 2^(18-16) = 2^2 = 4 chunks per bucket
         assert_eq!(batch.bucket_upper_bound(), 4);
@@ -312,7 +370,7 @@ mod tests {
 
     #[test]
     fn test_batch_expiry() {
-        let batch = Batch::new(B256::ZERO, 1000, 0, Address::ZERO, 18, 16, false);
+        let batch = Batch::new(BatchId::ZERO, 1000, 0, Address::ZERO, 18, 16, false);
 
         assert!(!batch.is_expired(999));
         assert!(batch.is_expired(1000));
@@ -321,7 +379,7 @@ mod tests {
 
     #[test]
     fn test_batch_usability() {
-        let batch = Batch::new(B256::ZERO, 1000, 100, Address::ZERO, 18, 16, false);
+        let batch = Batch::new(BatchId::ZERO, 1000, 100, Address::ZERO, 18, 16, false);
 
         assert!(!batch.is_usable(100, 10)); // Same block
         assert!(!batch.is_usable(109, 10)); // Not enough confirmations

--- a/crates/postage/src/events.rs
+++ b/crates/postage/src/events.rs
@@ -82,12 +82,12 @@ pub trait BatchEventHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::{Address, B256};
+    use alloy_primitives::Address;
 
     #[test]
     fn test_batch_event_batch_id() {
         let batch = Batch::new(
-            B256::repeat_byte(1),
+            BatchId::new([0x01; 32]),
             1000,
             100,
             Address::ZERO,

--- a/crates/postage/src/parallel.rs
+++ b/crates/postage/src/parallel.rs
@@ -191,13 +191,13 @@ mod tests {
     use alloy_signer::SignerSync;
     use alloy_signer_local::PrivateKeySigner;
 
-    use crate::{Stamp, StampIndex, current_timestamp};
+    use crate::{BatchId, Stamp, StampIndex, current_timestamp};
 
     /// Creates a stamp for testing verification.
     fn create_test_stamp(
         signer: &PrivateKeySigner,
         chunk_address: &SwarmAddress,
-        batch_id: B256,
+        batch_id: BatchId,
     ) -> Stamp {
         let index = StampIndex::new(0, 0);
         let timestamp = current_timestamp();
@@ -213,7 +213,7 @@ mod tests {
     fn test_parallel_verification() {
         let signer = PrivateKeySigner::random();
         let expected_owner = signer.address();
-        let batch_id = B256::ZERO;
+        let batch_id = BatchId::ZERO;
 
         // Create stamps
         let addresses: Vec<_> = (0..50)
@@ -239,7 +239,7 @@ mod tests {
     fn test_verify_wrong_signer() {
         let signer = PrivateKeySigner::random();
         let wrong_owner = Address::repeat_byte(0xFF);
-        let batch_id = B256::ZERO;
+        let batch_id = BatchId::ZERO;
 
         let address = SwarmAddress::from(B256::random());
         let stamp = create_test_stamp(&signer, &address, batch_id);
@@ -258,7 +258,7 @@ mod tests {
     fn test_verify_stamps_parallel_basic() {
         let signer = PrivateKeySigner::random();
         let expected_owner = signer.address();
-        let batch_id = B256::ZERO;
+        let batch_id = BatchId::ZERO;
 
         let address = SwarmAddress::from(B256::random());
         let stamp = create_test_stamp(&signer, &address, batch_id);
@@ -274,7 +274,7 @@ mod tests {
     fn test_verify_stamps_parallel_with_pubkey() {
         let signer = PrivateKeySigner::random();
         let expected_owner = signer.address();
-        let batch_id = B256::ZERO;
+        let batch_id = BatchId::ZERO;
 
         // Create stamps
         let addresses: Vec<_> = (0..50)

--- a/crates/postage/src/snapshot_store.rs
+++ b/crates/postage/src/snapshot_store.rs
@@ -84,7 +84,6 @@ pub trait SnapshotStore<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::B256;
     use std::collections::HashMap;
     use std::convert::Infallible;
     use std::sync::Mutex;
@@ -133,7 +132,7 @@ mod tests {
     }
 
     fn id(byte: u8) -> BatchId {
-        B256::repeat_byte(byte)
+        BatchId::new([byte; 32])
     }
 
     #[test]

--- a/crates/postage/src/stamp.rs
+++ b/crates/postage/src/stamp.rs
@@ -232,7 +232,7 @@ impl Stamp {
     /// Returns an error if the signature bytes are invalid.
     #[inline]
     pub fn from_bytes(bytes: &StampBytes) -> Result<Self, StampError> {
-        let batch = B256::from_slice(&bytes[..32]);
+        let batch = BatchId::from_slice(&bytes[..32]);
         let bucket = BigEndian::read_u32(&bytes[32..36]);
         let index = BigEndian::read_u32(&bytes[36..40]);
         let timestamp = BigEndian::read_u64(&bytes[40..48]);
@@ -435,6 +435,16 @@ impl Stamp {
 /// The digest that must be signed to create a valid stamp.
 ///
 /// The digest is computed as: `keccak256(chunk_address || batch_id || index || timestamp)`
+///
+/// The address and batch id are nominal types, so a swapped construction is
+/// rejected at compile time:
+///
+/// ```compile_fail
+/// use nectar_postage::{BatchId, StampDigest, StampIndex};
+/// use nectar_primitives::SwarmAddress;
+///
+/// let _ = StampDigest::new(BatchId::ZERO, SwarmAddress::zero(), StampIndex::new(0, 0), 0);
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StampDigest {
     /// The chunk address being stamped.
@@ -510,7 +520,7 @@ impl<'a> arbitrary::Arbitrary<'a> for Stamp {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         use alloy_primitives::U256;
 
-        let batch: B256 = u.arbitrary()?;
+        let batch: BatchId = u.arbitrary()?;
         let index = StampIndex::arbitrary(u)?;
         let timestamp: u64 = u.arbitrary()?;
 
@@ -561,7 +571,7 @@ mod tests {
 
     #[test]
     fn test_stamp_roundtrip() {
-        let batch = B256::ZERO;
+        let batch = BatchId::ZERO;
         let sig = Signature::test_signature();
         let stamp = Stamp::new(batch, 100, 50, 1234567890, sig);
 
@@ -576,7 +586,7 @@ mod tests {
         let bytes = hex::decode(TEST_STAMP).unwrap();
         let stamp = Stamp::try_from_slice(&bytes).unwrap();
 
-        let expected_batch = B256::from_slice(&hex::decode(TEST_BATCH_ID).unwrap());
+        let expected_batch = BatchId::from_slice(&hex::decode(TEST_BATCH_ID).unwrap());
         assert_eq!(stamp.batch(), expected_batch);
         assert_eq!(stamp.bucket(), 52197); // 0x0000cbe5
         assert_eq!(stamp.index(), 0);
@@ -585,7 +595,7 @@ mod tests {
 
     #[test]
     fn test_stamp_with_index() {
-        let batch = B256::ZERO;
+        let batch = BatchId::ZERO;
         let idx = StampIndex::new(100, 50);
         let sig = Signature::test_signature();
         let stamp = Stamp::with_index(batch, idx, 1234567890, sig);
@@ -610,7 +620,7 @@ mod tests {
     #[test]
     fn test_from_conversions() {
         let sig = Signature::test_signature();
-        let stamp = Stamp::new(B256::ZERO, 1, 2, 3, sig);
+        let stamp = Stamp::new(BatchId::ZERO, 1, 2, 3, sig);
 
         // From<Stamp> for StampBytes
         let bytes: StampBytes = stamp.clone().into();
@@ -722,7 +732,7 @@ mod tests {
         // Create a stamp with one signer
         let signer = PrivateKeySigner::random();
         let chunk_address = SwarmAddress::new([0xAB; 32]);
-        let batch_id = B256::ZERO;
+        let batch_id = BatchId::ZERO;
         let index = StampIndex::new(0, 0);
         let timestamp = 12345u64;
 

--- a/crates/postage/src/stamped.rs
+++ b/crates/postage/src/stamped.rs
@@ -184,7 +184,7 @@ mod tests {
 
     fn test_stamp() -> Stamp {
         let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
-        Stamp::new(B256::repeat_byte(0xaa), 3, 7, 42, sig)
+        Stamp::new(BatchId::new([0xaa; 32]), 3, 7, 42, sig)
     }
 
     fn content_chunk() -> ContentChunk<DEFAULT_BODY_SIZE> {

--- a/crates/postage/src/validation.rs
+++ b/crates/postage/src/validation.rs
@@ -7,7 +7,7 @@ use nectar_primitives::SwarmAddress;
 use crate::Batch;
 
 #[cfg(test)]
-use crate::StampIndex;
+use crate::{BatchId, StampIndex};
 
 #[cfg(feature = "std")]
 use crate::{BatchStore, BatchStoreExt};
@@ -225,11 +225,11 @@ impl<S: BatchStore> StoreValidator<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::{Address, B256};
+    use alloy_primitives::Address;
 
     #[test]
     fn test_validate_index_valid() {
-        let batch = Batch::new(B256::ZERO, 0, 0, Address::ZERO, 18, 16, false);
+        let batch = Batch::new(BatchId::ZERO, 0, 0, Address::ZERO, 18, 16, false);
 
         // Valid: bucket < 2^16, index < 2^(18-16) = 4
         let index = StampIndex::new(1000, 3);
@@ -238,7 +238,7 @@ mod tests {
 
     #[test]
     fn test_validate_index_bucket_out_of_range() {
-        let batch = Batch::new(B256::ZERO, 0, 0, Address::ZERO, 18, 16, false);
+        let batch = Batch::new(BatchId::ZERO, 0, 0, Address::ZERO, 18, 16, false);
 
         // Invalid: bucket >= 2^16 = 65536
         let index = StampIndex::new(70000, 0);
@@ -250,7 +250,7 @@ mod tests {
 
     #[test]
     fn test_validate_index_position_out_of_range() {
-        let batch = Batch::new(B256::ZERO, 0, 0, Address::ZERO, 18, 16, false);
+        let batch = Batch::new(BatchId::ZERO, 0, 0, Address::ZERO, 18, 16, false);
 
         // Invalid: index >= 2^(18-16) = 4
         let index = StampIndex::new(1000, 5);
@@ -262,7 +262,7 @@ mod tests {
 
     #[test]
     fn test_bucket_for_address() {
-        let batch = Batch::new(B256::ZERO, 0, 0, Address::ZERO, 18, 16, false);
+        let batch = Batch::new(BatchId::ZERO, 0, 0, Address::ZERO, 18, 16, false);
 
         let address = SwarmAddress::new([
             0xCB, 0xE5, 0x00, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -274,7 +274,7 @@ mod tests {
 
     #[test]
     fn test_validate_bucket_match() {
-        let batch = Batch::new(B256::ZERO, 0, 0, Address::ZERO, 18, 16, false);
+        let batch = Batch::new(BatchId::ZERO, 0, 0, Address::ZERO, 18, 16, false);
 
         let address = SwarmAddress::new([
             0xCB, 0xE5, 0x00, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -287,7 +287,7 @@ mod tests {
 
     #[test]
     fn test_validate_bucket_mismatch() {
-        let batch = Batch::new(B256::ZERO, 0, 0, Address::ZERO, 18, 16, false);
+        let batch = Batch::new(BatchId::ZERO, 0, 0, Address::ZERO, 18, 16, false);
 
         let address = SwarmAddress::new([
             0xCB, 0xE5, 0x00, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1949,6 +1949,7 @@ dependencies = [
  "alloy-signer",
  "arbitrary",
  "byteorder",
+ "derive_more",
  "k256",
  "nectar-primitives",
  "serde",


### PR DESCRIPTION
Closes #178

## What

Promotes `BatchId` from a `pub type BatchId = B256` alias to a `repr(transparent)` newtype over `B256`, in `crates/postage/src/batch.rs`, following the existing `Nonce` `derive_more` pattern: `Display`/`From`/`Into`/`AsRef` derives, `serde(transparent)` gated behind the `serde` feature, and `Arbitrary` gated behind `cfg(test, feature = "arbitrary")`.

`BatchId` gains inherent `ZERO`, `new`, `as_slice`, and `from_slice`. `From<B256>`/`Into<B256>` and `From<[u8; 32]>`/`Into<[u8; 32]>` conversions cover the contracts `bytes32` boundary, with a unit test pinning the round-trips.

The stamp wire decode (`Stamp::from_bytes`) and the issuer factory's raw-byte id construction (`MemoryBatchFactory::generate_batch_id`) now build a `BatchId` directly instead of a bare `B256`. `StampDigest`'s address/batch fields are now nominally distinct types, so a swapped positional construction is rejected at compile time; this is proven with a `compile_fail` doctest on `StampDigest`.

The change is threaded through `postage`, `postage-issuer`, and `postage-usage` call sites (benches, tests, examples) that previously passed `B256` where a `BatchId` is now required.

## Why

`BatchId` and other 32-byte values (chunk addresses, hashes) previously all type-checked as interchangeable `B256`, so a caller could accidentally swap a batch id and an address (or any other 32-byte value) without the compiler noticing. Making `BatchId` a nominal newtype closes that hole while keeping the wire format byte-for-byte identical, since `as_slice`/`AsRef<[u8]>`/`from_slice` all delegate to the inner `B256`.

## Testing

All commands run via `nix develop --command`, reviewed detached at the single commit `5c9b6f1` (`refactor(postage)!: promote BatchId from a B256 alias to a newtype`) on top of base `s157/80-sweep-fixes`.

- `cargo fmt --all -- --check`: pass.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: pass, 0 warnings.
- `cargo test --workspace --all-features`: all suites `test result: ok`, 0 failed across the workspace (postage lib 105 ok, plus the postage-issuer/postage-usage suites, all ok). `cargo nextest` is not provided by this repo's devShell, so the plain `cargo test` runner was used instead.
- `cargo test --doc --workspace --all-features`: pass, including the new `StampDigest` `compile_fail` doctest (verified it fails with the two expected positional type-mismatch errors when the batch id and address are swapped, and compiles in the correct order).

This is a stacked branch targeting `s157/80-sweep-fixes`, not `main`.

## AI assistance

Implementation, review, and verification on this branch were carried out by Claude (Anthropic), per the AI assistance disclosure required by github.com/nxm-rs/.github CONTRIBUTING.md.

