### PR TITLE
feat(primitives): length-carrying errors on fallible byte constructors

### DIFF
--- a/crates/postage-usage/src/lib.rs
+++ b/crates/postage-usage/src/lib.rs
@@ -199,7 +199,6 @@ pub fn usage_chunk_address(batch_id: &BatchId, owner: &Address, index: u16) -> S
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::B256;
 
     #[test]
     fn chunk_ids_are_domain_separated_and_indexed() {

--- a/crates/primitives/src/address.rs
+++ b/crates/primitives/src/address.rs
@@ -73,7 +73,7 @@ use alloy_primitives::{B256, U256};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::error::Result;
+use crate::error::{Result, WrongLength};
 use crate::{Bin, ProximityOrder};
 
 /// Maximum proximity order for standard routing operations.
@@ -117,10 +117,11 @@ impl SwarmAddress {
         self.0.as_slice()
     }
 
-    /// Creates a new address from a slice, checking the length
+    /// Creates a new address from a slice, checking the length.
+    ///
+    /// The error carries expected and actual lengths via [`WrongLength`].
     pub fn from_slice(slice: &[u8]) -> Result<Self> {
-        let address = B256::try_from(slice)?;
-        Ok(Self(address))
+        Ok(Self::try_from(slice)?)
     }
 
     /// Checks if this address is zeros
@@ -352,6 +353,18 @@ impl AsRef<[u8]> for SwarmAddress {
     }
 }
 
+impl TryFrom<&[u8]> for SwarmAddress {
+    type Error = WrongLength;
+
+    fn try_from(slice: &[u8]) -> std::result::Result<Self, Self::Error> {
+        let bytes: [u8; 32] = slice.try_into().map_err(|_| WrongLength {
+            expected: 32,
+            got: slice.len(),
+        })?;
+        Ok(Self::new(bytes))
+    }
+}
+
 impl From<SwarmAddress> for [u8; 32] {
     fn from(addr: SwarmAddress) -> Self {
         addr.0.into()
@@ -362,5 +375,45 @@ impl From<SwarmAddress> for [u8; 32] {
 impl<'a> arbitrary::Arbitrary<'a> for SwarmAddress {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self(B256::arbitrary(u)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::PrimitivesError;
+
+    #[test]
+    fn try_from_slice_valid() {
+        let bytes = [0x5au8; 32];
+        assert_eq!(
+            SwarmAddress::try_from(bytes.as_slice()).unwrap(),
+            SwarmAddress::new(bytes)
+        );
+    }
+
+    #[test]
+    fn try_from_slice_wrong_length() {
+        let short = [0u8; 31];
+        assert_eq!(
+            SwarmAddress::try_from(short.as_slice()).unwrap_err(),
+            WrongLength {
+                expected: 32,
+                got: 31
+            }
+        );
+    }
+
+    #[test]
+    fn from_slice_carries_lengths() {
+        let long = [0u8; 33];
+        let err = SwarmAddress::from_slice(&long).unwrap_err();
+        assert!(matches!(
+            err,
+            PrimitivesError::WrongLength(WrongLength {
+                expected: 32,
+                got: 33
+            })
+        ));
     }
 }

--- a/crates/primitives/src/chunk/encryption/error.rs
+++ b/crates/primitives/src/chunk/encryption/error.rs
@@ -24,20 +24,6 @@ pub enum EncryptionError {
         max: usize,
     },
 
-    /// Reference byte slice is not 32 or 64 bytes.
-    #[error("invalid reference length: {len} bytes (expected 32 or 64)")]
-    InvalidReferenceLength {
-        /// Actual length.
-        len: usize,
-    },
-
-    /// Key byte slice is not 32 bytes.
-    #[error("invalid key length: {len} bytes (expected 32)")]
-    InvalidKeyLength {
-        /// Actual length.
-        len: usize,
-    },
-
     /// Output buffer is too small for decryption.
     #[error("output buffer too small: {len} bytes, need {required}")]
     OutputBufferTooSmall {

--- a/crates/primitives/src/chunk/encryption/key.rs
+++ b/crates/primitives/src/chunk/encryption/key.rs
@@ -6,7 +6,7 @@ use alloy_primitives::B256;
 use subtle::ConstantTimeEq;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
-use super::error::EncryptionError;
+use crate::error::WrongLength;
 
 /// 32-byte encryption key for chunk encryption.
 ///
@@ -72,14 +72,13 @@ impl AsRef<[u8]> for EncryptionKey {
 }
 
 impl TryFrom<&[u8]> for EncryptionKey {
-    type Error = EncryptionError;
+    type Error = WrongLength;
 
     fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
-        if slice.len() != Self::SIZE {
-            return Err(EncryptionError::InvalidKeyLength { len: slice.len() });
-        }
-        let mut bytes = [0u8; Self::SIZE];
-        bytes.copy_from_slice(slice);
+        let bytes: [u8; Self::SIZE] = slice.try_into().map_err(|_| WrongLength {
+            expected: Self::SIZE,
+            got: slice.len(),
+        })?;
         Ok(Self(bytes))
     }
 }
@@ -130,7 +129,13 @@ mod tests {
     fn try_from_slice_invalid() {
         let short = [0u8; 16];
         let err = EncryptionKey::try_from(short.as_slice()).unwrap_err();
-        assert!(matches!(err, EncryptionError::InvalidKeyLength { len: 16 }));
+        assert_eq!(
+            err,
+            WrongLength {
+                expected: EncryptionKey::SIZE,
+                got: 16
+            }
+        );
     }
 
     #[test]

--- a/crates/primitives/src/chunk/encryption/key.rs
+++ b/crates/primitives/src/chunk/encryption/key.rs
@@ -136,6 +136,16 @@ mod tests {
                 got: 16
             }
         );
+
+        let long = [0u8; 64];
+        let err = EncryptionKey::try_from(long.as_slice()).unwrap_err();
+        assert_eq!(
+            err,
+            WrongLength {
+                expected: EncryptionKey::SIZE,
+                got: 64
+            }
+        );
     }
 
     #[test]

--- a/crates/primitives/src/chunk/encryption/reference.rs
+++ b/crates/primitives/src/chunk/encryption/reference.rs
@@ -195,6 +195,16 @@ mod tests {
                 got: 48
             }
         );
+
+        let long = [0u8; 80];
+        let err = EncryptedChunkRef::try_from(long.as_slice()).unwrap_err();
+        assert_eq!(
+            err,
+            WrongLength {
+                expected: EncryptedChunkRef::SIZE,
+                got: 80
+            }
+        );
     }
 
     #[test]

--- a/crates/primitives/src/chunk/encryption/reference.rs
+++ b/crates/primitives/src/chunk/encryption/reference.rs
@@ -2,10 +2,10 @@
 
 use crate::chunk::reference::{RefKind, Reference, WrongRefKind, sealed};
 use crate::chunk::{ChunkAddress, ChunkRef};
+use crate::error::WrongLength;
 use crate::file::EntryRef;
 use crate::wire::{Cursor, Underrun};
 
-use super::error::EncryptionError;
 use super::key::EncryptionKey;
 
 /// An encrypted chunk reference: a plain reference plus the decryption key.
@@ -148,17 +148,14 @@ impl From<&EncryptedChunkRef> for Vec<u8> {
 }
 
 impl TryFrom<&[u8]> for EncryptedChunkRef {
-    type Error = EncryptionError;
+    type Error = WrongLength;
 
-    #[allow(clippy::indexing_slicing)] // slice.len() == Self::SIZE (64) is checked above with an error return, covering both the 32-byte address and 32-byte key slices
     fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
-        if slice.len() != Self::SIZE {
-            return Err(EncryptionError::InvalidReferenceLength { len: slice.len() });
-        }
-        let addr = ChunkAddress::from_slice(&slice[..ChunkRef::SIZE])
-            .map_err(|_| EncryptionError::InvalidReferenceLength { len: slice.len() })?;
-        let key = EncryptionKey::try_from(&slice[ChunkRef::SIZE..])?;
-        Ok(Self::new(addr, key))
+        let bytes: &[u8; Self::SIZE] = slice.try_into().map_err(|_| WrongLength {
+            expected: Self::SIZE,
+            got: slice.len(),
+        })?;
+        Ok(Self::from_bytes(bytes))
     }
 }
 
@@ -191,10 +188,13 @@ mod tests {
     fn invalid_length() {
         let bad = [0u8; 48];
         let err = EncryptedChunkRef::try_from(bad.as_slice()).unwrap_err();
-        assert!(matches!(
+        assert_eq!(
             err,
-            EncryptionError::InvalidReferenceLength { len: 48 }
-        ));
+            WrongLength {
+                expected: EncryptedChunkRef::SIZE,
+                got: 48
+            }
+        );
     }
 
     #[test]

--- a/crates/primitives/src/chunk/reference.rs
+++ b/crates/primitives/src/chunk/reference.rs
@@ -8,6 +8,7 @@
 use std::mem::size_of;
 
 use crate::chunk::ChunkAddress;
+use crate::error::WrongLength;
 use crate::file::EntryRef;
 use crate::wire::{Cursor, Underrun};
 
@@ -127,6 +128,18 @@ impl From<ChunkAddress> for ChunkRef {
     }
 }
 
+impl TryFrom<&[u8]> for ChunkRef {
+    type Error = WrongLength;
+
+    fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
+        let bytes: [u8; Self::SIZE] = slice.try_into().map_err(|_| WrongLength {
+            expected: Self::SIZE,
+            got: slice.len(),
+        })?;
+        Ok(Self::new(ChunkAddress::from(bytes)))
+    }
+}
+
 impl sealed::Sealed for ChunkRef {}
 
 impl Reference for ChunkRef {
@@ -238,6 +251,25 @@ mod tests {
             WrongRefKind {
                 expected: RefKind::Plain,
                 got: RefKind::Encrypted,
+            }
+        );
+    }
+
+    #[test]
+    fn try_from_slice_round_trips() {
+        let addr = ChunkAddress::from(B256::repeat_byte(0x66));
+        let reference = ChunkRef::new(addr);
+        assert_eq!(ChunkRef::try_from(addr.as_bytes()).unwrap(), reference);
+    }
+
+    #[test]
+    fn try_from_slice_wrong_length() {
+        let short = [0u8; 31];
+        assert_eq!(
+            ChunkRef::try_from(short.as_slice()).unwrap_err(),
+            WrongLength {
+                expected: ChunkRef::SIZE,
+                got: 31
             }
         );
     }

--- a/crates/primitives/src/chunk/reference.rs
+++ b/crates/primitives/src/chunk/reference.rs
@@ -272,6 +272,15 @@ mod tests {
                 got: 31
             }
         );
+
+        let long = [0u8; 64];
+        assert_eq!(
+            ChunkRef::try_from(long.as_slice()).unwrap_err(),
+            WrongLength {
+                expected: ChunkRef::SIZE,
+                got: 64
+            }
+        );
     }
 
     #[test]

--- a/crates/primitives/src/error.rs
+++ b/crates/primitives/src/error.rs
@@ -41,6 +41,19 @@ use thiserror::Error;
 /// Result type for operations in the primitives crate
 pub type Result<T> = std::result::Result<T, PrimitivesError>;
 
+/// A byte slice did not carry the width its target type requires.
+///
+/// Returned by the fallible byte constructors on the fixed-width types so
+/// wire codecs can propagate the observed length instead of pre-checking it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+#[error("wrong length: expected {expected} bytes, got {got}")]
+pub struct WrongLength {
+    /// The byte width the target type requires.
+    pub expected: usize,
+    /// The byte width the slice actually carried.
+    pub got: usize,
+}
+
 /// Main error type for the primitives crate
 ///
 /// This enum represents all the possible errors that can occur when using
@@ -76,4 +89,8 @@ pub enum PrimitivesError {
     /// Array conversion errors
     #[error("Array conversion error: {0}")]
     ArrayConversion(#[from] std::array::TryFromSliceError),
+
+    /// A byte slice had the wrong width for a fixed-width type
+    #[error(transparent)]
+    WrongLength(#[from] WrongLength),
 }

--- a/crates/primitives/src/file/error.rs
+++ b/crates/primitives/src/file/error.rs
@@ -67,6 +67,10 @@ pub enum FileError {
     #[error("encryption error: {0}")]
     Encryption(#[from] crate::chunk::encryption::EncryptionError),
 
+    /// A byte slice had the wrong width for a fixed-width type.
+    #[error(transparent)]
+    WrongLength(#[from] crate::error::WrongLength),
+
     /// Invalid entry reference length (expected 32 or 64 bytes).
     #[error("invalid entry reference length: {len} (expected 32 or 64)")]
     InvalidEntryRef {

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -83,7 +83,7 @@ pub use chunk::{ChunkEncrypt, EncryptedContentChunk};
 // Re-export core types
 pub use address::{EXTENDED_PO, MAX_PO, SwarmAddress};
 pub use bin::{Bin, BinError};
-pub use error::{PrimitivesError, Result};
+pub use error::{PrimitivesError, Result, WrongLength};
 pub use neighborhood_depth::recompute_neighborhood_depth;
 pub use network_id::NetworkId;
 pub use nonce::Nonce;

--- a/crates/primitives/src/nonce.rs
+++ b/crates/primitives/src/nonce.rs
@@ -107,6 +107,15 @@ mod tests {
                 got: 16
             }
         );
+
+        let long = [0u8; 48];
+        assert_eq!(
+            Nonce::try_from(long.as_slice()).unwrap_err(),
+            WrongLength {
+                expected: 32,
+                got: 48
+            }
+        );
     }
 
     #[test]

--- a/crates/primitives/src/nonce.rs
+++ b/crates/primitives/src/nonce.rs
@@ -8,6 +8,8 @@
 use alloy_primitives::B256;
 use derive_more::{AsRef, Display, From, Into};
 
+use crate::error::WrongLength;
+
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -48,6 +50,18 @@ impl Nonce {
     }
 }
 
+impl TryFrom<&[u8]> for Nonce {
+    type Error = WrongLength;
+
+    fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
+        let bytes: [u8; 32] = slice.try_into().map_err(|_| WrongLength {
+            expected: 32,
+            got: slice.len(),
+        })?;
+        Ok(Self::new(bytes))
+    }
+}
+
 #[cfg(any(test, feature = "arbitrary"))]
 impl<'a> arbitrary::Arbitrary<'a> for Nonce {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
@@ -72,6 +86,27 @@ mod tests {
         assert_eq!(Nonce::from(B256::new(bytes)), n);
         assert_eq!(<[u8; 32]>::from(n), bytes);
         assert_eq!(Nonce::from(bytes), n);
+    }
+
+    #[test]
+    fn try_from_slice_valid() {
+        let bytes = [9u8; 32];
+        assert_eq!(
+            Nonce::try_from(bytes.as_slice()).unwrap(),
+            Nonce::new(bytes)
+        );
+    }
+
+    #[test]
+    fn try_from_slice_wrong_length() {
+        let short = [0u8; 16];
+        assert_eq!(
+            Nonce::try_from(short.as_slice()).unwrap_err(),
+            WrongLength {
+                expected: 32,
+                got: 16
+            }
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

The fallible byte constructors on the 32-byte types (`SwarmAddress::from_slice`, `Nonce`, `EncryptionKey`, `EncryptedChunkRef`, and the `ChunkRef` reference types) now return errors carrying the expected and actual lengths, so wire codecs can call `try_from` once and propagate instead of pre-checking `len()` at every boundary.

Closes #184

## Why

Every downstream protocol codec currently re-implements the same length pre-check with its own error variant because the constructor errors do not say what length was expected or received.

## Testing

Independently gated: per-constructor tests assert expected/actual are populated on both short and long input; full workspace battery green on the branch; wire behaviour identical (only the reject-path error payload changes).

## AI Assistance

Implemented with Claude Fable, red-teamed with Claude Opus, filed by Claude Fable under maintainer direction.

