### PR TITLE
chore(lint): deny clippy::as_conversions and make all casts explicit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,9 @@ unreachable = "deny"
 todo = "deny"
 unimplemented = "deny"
 panic_in_result_fn = "deny"
-# Lossy/`as` casts: warn now; denied in the maximal follow-up PR.
-as_conversions = "warn"
+# Lossy/`as` casts: all casts must be explicit (`from`/`try_into`) or a
+# justified `#[allow]` where truncation is intended and provably in range.
+as_conversions = "deny"
 missing_panics_doc = "warn"
 
 [workspace.metadata.docs.rs]

--- a/crates/mantaray/src/codec.rs
+++ b/crates/mantaray/src/codec.rs
@@ -123,7 +123,9 @@ fn encode_node<E: NodeEntry>(node: &Node<E>) -> Result<Vec<u8>> {
     data[NodeHeader::VERSION_HASH_OFFSET..NodeHeader::VERSION_HASH_OFFSET + VersionHash::SIZE]
         .copy_from_slice(VersionHash::V02.as_bytes());
 
-    data[NodeHeader::REF_SIZE_OFFSET] = ref_size as u8;
+    #[allow(clippy::as_conversions)] // ref_size = E::SIZE (32 or 64), always fits u8
+    let ref_size_byte = ref_size as u8;
+    data[NodeHeader::REF_SIZE_OFFSET] = ref_size_byte;
 
     // append entry (or E::SIZE zero bytes if empty)
     match &node.entry {
@@ -134,7 +136,7 @@ fn encode_node<E: NodeEntry>(node: &Node<E>) -> Result<Vec<u8>> {
     // build the 256-bit index of which fork bytes are present
     let mut index = U256::ZERO;
     for &fork_byte in node.forks.keys() {
-        index.set_bit(fork_byte as usize, true);
+        index.set_bit(usize::from(fork_byte), true);
     }
     data.extend_from_slice(&index.to_le_bytes::<32>());
 
@@ -241,7 +243,7 @@ fn decode_empty_terminal_node<E: NodeEntry>(data: &[u8]) -> Result<Node<E>> {
 // (<= 64) that cannot overflow usize.
 #[allow(clippy::indexing_slicing, clippy::arithmetic_side_effects)]
 fn decode_v01<E: NodeEntry>(data: &[u8]) -> Result<Node<E>> {
-    let ref_bytes_size = data[NodeHeader::REF_SIZE_OFFSET] as usize;
+    let ref_bytes_size = usize::from(data[NodeHeader::REF_SIZE_OFFSET]);
     // BEE-WORKAROUND(bee#5483): see HAZMAT block above `decode_empty_terminal_node`.
     if ref_bytes_size == 0 {
         return decode_empty_terminal_node::<E>(data);
@@ -272,13 +274,13 @@ fn decode_v01<E: NodeEntry>(data: &[u8]) -> Result<Node<E>> {
 
     let mut forks = BTreeMap::new();
     for b in 0..=u8::MAX {
-        if index.bit(b as usize) {
+        if index.bit(usize::from(b)) {
             let end = offset + ForkHeader::PRE_REFERENCE_SIZE + ref_bytes_size;
             if data.len() < end {
                 return Err(MantarayError::InsufficientForkBytes {
                     expected: end,
                     actual: data.len(),
-                    byte_index: b as usize,
+                    byte_index: usize::from(b),
                 });
             }
 
@@ -303,7 +305,7 @@ fn decode_v01<E: NodeEntry>(data: &[u8]) -> Result<Node<E>> {
 // and a metadata size (<= u16::MAX) that cannot overflow usize.
 #[allow(clippy::indexing_slicing, clippy::arithmetic_side_effects)]
 fn decode_v02<E: NodeEntry>(data: &[u8]) -> Result<Node<E>> {
-    let ref_bytes_size = data[NodeHeader::REF_SIZE_OFFSET] as usize;
+    let ref_bytes_size = usize::from(data[NodeHeader::REF_SIZE_OFFSET]);
     // BEE-WORKAROUND(bee#5483): see HAZMAT block above `decode_empty_terminal_node`.
     if ref_bytes_size == 0 {
         return decode_empty_terminal_node::<E>(data);
@@ -341,14 +343,14 @@ fn decode_v02<E: NodeEntry>(data: &[u8]) -> Result<Node<E>> {
 
     let mut forks = BTreeMap::new();
     for b in 0..=u8::MAX {
-        if index.bit(b as usize) {
+        if index.bit(usize::from(b)) {
             let mut fork = Fork::default();
 
             if data.len() < offset + 1 {
                 return Err(MantarayError::InsufficientForkBytes {
                     expected: offset + 1,
                     actual: data.len(),
-                    byte_index: b as usize,
+                    byte_index: usize::from(b),
                 });
             }
 
@@ -368,16 +370,16 @@ fn decode_v02<E: NodeEntry>(data: &[u8]) -> Result<Node<E>> {
                             + ref_bytes_size
                             + ForkHeader::METADATA_LEN_SIZE,
                         actual: data.len(),
-                        byte_index: b as usize,
+                        byte_index: usize::from(b),
                     });
                 }
 
-                let metadata_bytes_size = u16::from_be_bytes(
+                let metadata_bytes_size = usize::from(u16::from_be_bytes(
                     data[offset + node_fork_size
                         ..offset + node_fork_size + ForkHeader::METADATA_LEN_SIZE]
                         .try_into()
                         .map_err(|_| MantarayError::DataTooShort)?,
-                ) as usize;
+                ));
 
                 node_fork_size += ForkHeader::METADATA_LEN_SIZE;
                 node_fork_size += metadata_bytes_size;
@@ -386,7 +388,7 @@ fn decode_v02<E: NodeEntry>(data: &[u8]) -> Result<Node<E>> {
                     return Err(MantarayError::InsufficientForkBytes {
                         expected: offset + node_fork_size,
                         actual: data.len(),
-                        byte_index: b as usize,
+                        byte_index: usize::from(b),
                     });
                 }
 
@@ -400,7 +402,7 @@ fn decode_v02<E: NodeEntry>(data: &[u8]) -> Result<Node<E>> {
                     return Err(MantarayError::InsufficientForkBytes {
                         expected: offset + ForkHeader::PRE_REFERENCE_SIZE + ref_bytes_size,
                         actual: data.len(),
-                        byte_index: b as usize,
+                        byte_index: usize::from(b),
                     });
                 }
 
@@ -456,7 +458,9 @@ impl<E: NodeEntry> Fork<E> {
     #[allow(clippy::arithmetic_side_effects)] // in-memory buffer length arithmetic; padding math is guarded (`SIZE - x` only when `x < SIZE`, `SIZE - rem` only when `rem != 0`) and `% ObfuscationKey::SIZE` has a nonzero constant divisor
     fn encode_into(&self, data: &mut Vec<u8>) -> Result<()> {
         data.push(self.node.node_type.bits());
-        data.push(self.prefix.len() as u8);
+        #[allow(clippy::as_conversions)] // Prefix invariant: len <= Prefix::MAX_LEN (30), fits u8
+        let prefix_len_byte = self.prefix.len() as u8;
+        data.push(prefix_len_byte);
 
         // write prefix padded to Prefix::MAX_LEN; Prefix is already zero-padded
         data.extend_from_slice(self.prefix.padded_bytes());
@@ -495,14 +499,13 @@ impl<E: NodeEntry> Fork<E> {
             metadata_json.resize(metadata_json.len() + padding, 0x0a);
 
             let metadata_size = metadata_json.len();
-            if metadata_size > u16::MAX as usize {
-                return Err(MantarayError::MetadataTooLarge {
-                    max: u16::MAX as usize,
+            let metadata_size_u16 =
+                u16::try_from(metadata_size).map_err(|_| MantarayError::MetadataTooLarge {
+                    max: usize::from(u16::MAX),
                     actual: metadata_size,
-                });
-            }
+                })?;
 
-            data.extend_from_slice(&(metadata_size as u16).to_be_bytes());
+            data.extend_from_slice(&metadata_size_u16.to_be_bytes());
             data.extend_from_slice(&metadata_json);
         }
 
@@ -792,7 +795,7 @@ mod tests {
         xor_in_place(&mut decoded[ObfuscationKey::SIZE..], &key);
 
         assert_eq!(
-            decoded[NodeHeader::REF_SIZE_OFFSET] as usize,
+            usize::from(decoded[NodeHeader::REF_SIZE_OFFSET]),
             <ChunkAddress as NodeEntry>::SIZE,
             "encoder must emit ref_size = E::SIZE, not 0; spec requires uniform reference width"
         );
@@ -989,6 +992,7 @@ mod tests {
         use arbitrary::{Arbitrary, Unstructured};
 
         // Deterministic pseudo-random bytes (Knuth multiplicative hash).
+        #[allow(clippy::as_conversions)] // u32 >> 24 is always <= 0xFF, fits u8
         let raw: Vec<u8> = (0u32..8192)
             .map(|i| (i.wrapping_mul(2654435761) >> 24) as u8)
             .collect();
@@ -1030,7 +1034,9 @@ mod tests {
         // assign deterministic references to forks so encoding works
         for (counter, fork) in n.forks.values_mut().enumerate() {
             let mut addr = [0u8; 32];
-            addr[31] = counter as u8;
+            #[allow(clippy::as_conversions)] // forks are keyed by u8, so counter <= 255
+            let counter_byte = counter as u8;
+            addr[31] = counter_byte;
             fork.node.reference = Some(nectar_primitives::chunk::ChunkAddress::from(addr));
         }
 

--- a/crates/mantaray/src/manifest.rs
+++ b/crates/mantaray/src/manifest.rs
@@ -455,7 +455,7 @@ impl<'a, S: ChunkGet<BS>, E: NodeEntry, const BS: usize> ManifestIter<'a, S, E, 
                 };
 
                 self.stack.push(IterFrame {
-                    node: self.trie as *mut Node<E>,
+                    node: std::ptr::from_mut(self.trie),
                     path_len_before: 0,
                     keys,
                     key_idx: 0,
@@ -494,7 +494,7 @@ impl<'a, S: ChunkGet<BS>, E: NodeEntry, const BS: usize> ManifestIter<'a, S, E, 
                 }
             };
 
-            let child = &mut fork.node as *mut Node<E>;
+            let child = std::ptr::from_mut(&mut fork.node);
 
             // SAFETY: child is a descendant of the exclusively borrowed trie.
             let child_ref = unsafe { &mut *child };

--- a/crates/mantaray/src/node.rs
+++ b/crates/mantaray/src/node.rs
@@ -68,14 +68,14 @@ impl Prefix {
         let mut data = [0u8; PREFIX_MAX_LEN];
         #[allow(clippy::indexing_slicing)] // src.len() <= PREFIX_MAX_LEN asserted above (documented # Panics contract)
         data[..src.len()].copy_from_slice(src);
-        Self {
-            len: src.len() as u8,
-            data,
-        }
+        #[allow(clippy::as_conversions)] // src.len() <= PREFIX_MAX_LEN (30) asserted above, fits u8
+        let len = src.len() as u8;
+        Self { len, data }
     }
 
     /// Returns the prefix length in bytes.
     #[inline]
+    #[allow(clippy::as_conversions)] // u8 -> usize widening, infallible; `usize::from` is not const-callable
     pub const fn len(&self) -> usize {
         self.len as usize
     }
@@ -99,7 +99,7 @@ impl std::ops::Deref for Prefix {
     #[inline]
     #[allow(clippy::indexing_slicing)] // invariant: self.len <= PREFIX_MAX_LEN, the backing array length
     fn deref(&self) -> &[u8] {
-        &self.data[..self.len as usize]
+        &self.data[..usize::from(self.len)]
     }
 }
 
@@ -624,7 +624,7 @@ impl<E: NodeEntry> Node<E> {
         }
 
         let mut stack: Vec<SaveFrame<E>> = vec![SaveFrame {
-            node: self as *mut Self,
+            node: std::ptr::from_mut(self),
             keys: self.forks.keys().copied().collect(),
             key_idx: 0,
         }];
@@ -642,7 +642,7 @@ impl<E: NodeEntry> Node<E> {
                 #[allow(clippy::expect_used)] // key was collected from this node's fork map, which is not mutated while the frame is live
                 let child = node.forks.get_mut(&key).expect("key from this node");
                 if child.node.reference.is_none() {
-                    let child_ptr = &mut child.node as *mut Self;
+                    let child_ptr = std::ptr::from_mut(&mut child.node);
                     let child_keys = child.node.forks.keys().copied().collect();
                     stack.push(SaveFrame {
                         node: child_ptr,
@@ -733,7 +733,7 @@ where
     f(path_buf, node)?;
 
     let mut stack: Vec<WalkFrame> = vec![WalkFrame {
-        node: (node as *mut Node<E>).cast::<()>(),
+        node: std::ptr::from_mut(node).cast::<()>(),
         path_len_before: path_buf.len(),
         keys: node.forks.keys().copied().collect(),
         key_idx: 0,
@@ -767,7 +767,7 @@ where
         child.ensure_loaded(store).await?;
         f(path_buf, child)?;
 
-        let child_ptr = (child as *mut Node<E>).cast::<()>();
+        let child_ptr = std::ptr::from_mut(child).cast::<()>();
         let child_keys = child.forks.keys().copied().collect();
         stack.push(WalkFrame {
             node: child_ptr,
@@ -810,10 +810,9 @@ mod arbitrary_impls {
             let len = u.int_in_range(1..=PREFIX_MAX_LEN)?;
             let mut data = [0u8; PREFIX_MAX_LEN];
             u.fill_buffer(&mut data[..len])?;
-            Ok(Self {
-                len: len as u8,
-                data,
-            })
+            #[allow(clippy::as_conversions)] // len ∈ 1..=PREFIX_MAX_LEN (30), fits u8
+            let len = len as u8;
+            Ok(Self { len, data })
         }
     }
 

--- a/crates/postage-issuer/src/counter.rs
+++ b/crates/postage-issuer/src/counter.rs
@@ -166,6 +166,10 @@ impl CounterTable {
         let mut issued = 0u64;
         for (bucket, &count) in counts.iter().enumerate() {
             if count > capacity {
+                // `bucket` indexes a vector whose length was validated above to
+                // be `2^bucket_depth`; a table wider than `u32` is geometrically
+                // impossible (the bucket space is addressed by `u32` throughout).
+                #[allow(clippy::as_conversions)]
                 return Err(CounterError::CounterOverflow {
                     bucket: bucket as u32,
                     count,
@@ -225,6 +229,8 @@ impl CounterTable {
     }
 
     /// Returns the counter of a bucket.
+    // `u32` always fits `usize` on the >=32-bit targets this crate supports.
+    #[allow(clippy::as_conversions)]
     pub fn count(&self, bucket: u32) -> Result<u32, CounterError> {
         self.counts
             .get(bucket as usize)
@@ -271,7 +277,10 @@ impl CounterTable {
         bucket: u32,
         is_protected: impl Fn(u32) -> bool,
     ) -> Result<u32, CounterError> {
-        if bucket as usize >= self.counts.len() {
+        // `u32` always fits `usize` on the >=32-bit targets this crate supports.
+        #[allow(clippy::as_conversions)]
+        let bucket_idx = bucket as usize;
+        if bucket_idx >= self.counts.len() {
             return Err(CounterError::InvalidBucket { bucket });
         }
         let capacity = self.bucket_capacity();
@@ -279,7 +288,7 @@ impl CounterTable {
         if matches!(self.mode, CounterMode::Fill) {
             // Indexing guarded by the bucket range check at the top of `record`.
             #[allow(clippy::indexing_slicing)]
-            let count = &mut self.counts[bucket as usize];
+            let count = &mut self.counts[bucket_idx];
             if *count >= capacity {
                 return Err(CounterError::BucketFull { bucket, capacity });
             }
@@ -296,7 +305,7 @@ impl CounterTable {
 
         // Indexing guarded by the bucket range check at the top of `record`.
         #[allow(clippy::indexing_slicing)]
-        let old_cursor = self.counts[bucket as usize];
+        let old_cursor = self.counts[bucket_idx];
         // Start at the cursor; a cursor equal to capacity means "wrap on the next
         // write", resetting to 0 when the bucket bound is reached.
         let mut candidate = if old_cursor >= capacity {
@@ -328,7 +337,7 @@ impl CounterTable {
         // Indexing guarded by the bucket range check at the top of `record`.
         #[allow(clippy::indexing_slicing)]
         {
-            self.counts[bucket as usize] = new_cursor;
+            self.counts[bucket_idx] = new_cursor;
         }
         // Keep issued == sum(counts): fold in the signed delta (it decreases on
         // wrap, when new_cursor < old_cursor). `issued == sum(counts) >=

--- a/crates/postage-issuer/src/issuer.rs
+++ b/crates/postage-issuer/src/issuer.rs
@@ -126,8 +126,8 @@ pub trait StampIssuer {
     /// Returns `true` if the most utilized bucket has reached the
     /// specified percentage of capacity (0.0 to 1.0).
     fn is_near_capacity(&self, threshold: f64) -> bool {
-        let max_util = self.max_bucket_utilization() as f64;
-        let capacity = self.bucket_capacity() as f64;
+        let max_util = f64::from(self.max_bucket_utilization());
+        let capacity = f64::from(self.bucket_capacity());
         max_util / capacity >= threshold
     }
 }
@@ -265,8 +265,13 @@ mod tests {
 
     fn test_address(leading: u16) -> SwarmAddress {
         let mut bytes = [0u8; 32];
-        bytes[0] = (leading >> 8) as u8;
-        bytes[1] = leading as u8;
+        // Big-endian split of a u16: `leading >> 8` is <= 0xFF and the low-byte
+        // truncation is the intended extraction; both casts are lossless.
+        #[allow(clippy::as_conversions)]
+        {
+            bytes[0] = (leading >> 8) as u8;
+            bytes[1] = leading as u8;
+        }
         SwarmAddress::new(bytes)
     }
 

--- a/crates/postage-issuer/src/ring.rs
+++ b/crates/postage-issuer/src/ring.rs
@@ -262,8 +262,9 @@ impl<R: Reservation> RingIssuer<R> {
         // fresh slot, so the bucket is saturated from here on.
         if self.counters.count(bucket).unwrap_or(0) == self.counters.bucket_capacity() {
             // `record` above succeeded, so `bucket` is within the bucket count and
-            // `saturated` has that same length by construction.
-            #[allow(clippy::indexing_slicing)]
+            // `saturated` has that same length by construction; `u32` always fits
+            // `usize` on the >=32-bit targets this crate supports.
+            #[allow(clippy::indexing_slicing, clippy::as_conversions)]
             {
                 self.saturated[bucket as usize] = true;
             }
@@ -296,6 +297,8 @@ impl<R: Reservation> RingIssuer<R> {
             self.stamps_issued += 1;
         }
 
+        // `u32` always fits `usize` on the >=32-bit targets this crate supports.
+        #[allow(clippy::as_conversions)]
         let fill = self.bucket_fill(bucket as usize);
         if fill > self.max_utilization {
             self.max_utilization = fill;
@@ -357,6 +360,8 @@ impl<R: Reservation> StampIssuer for RingIssuer<R> {
     }
 
     fn bucket_utilization(&self, bucket: u32) -> u32 {
+        // `u32` always fits `usize` on the >=32-bit targets this crate supports.
+        #[allow(clippy::as_conversions)]
         let bucket_idx = bucket as usize;
         if bucket_idx >= self.counters.counts().len() {
             return 0;
@@ -365,6 +370,8 @@ impl<R: Reservation> StampIssuer for RingIssuer<R> {
     }
 
     fn bucket_has_capacity(&self, bucket: u32) -> bool {
+        // `u32` always fits `usize` on the >=32-bit targets this crate supports.
+        #[allow(clippy::as_conversions)]
         let bucket_idx = bucket as usize;
         if bucket_idx >= self.counters.counts().len() {
             return false;
@@ -389,8 +396,13 @@ mod tests {
 
     fn test_address(leading: u16) -> SwarmAddress {
         let mut bytes = [0u8; 32];
-        bytes[0] = (leading >> 8) as u8;
-        bytes[1] = leading as u8;
+        // Big-endian split of a u16: `leading >> 8` is <= 0xFF and the low-byte
+        // truncation is the intended extraction; both casts are lossless.
+        #[allow(clippy::as_conversions)]
+        {
+            bytes[0] = (leading >> 8) as u8;
+            bytes[1] = leading as u8;
+        }
         SwarmAddress::new(bytes)
     }
 

--- a/crates/postage-issuer/src/sharded.rs
+++ b/crates/postage-issuer/src/sharded.rs
@@ -52,8 +52,10 @@ impl BucketShard {
 
     /// Returns the local index within this shard for a given global bucket.
     // Shard routing invariant: callers only pass buckets owned by this shard, so
-    // `bucket >= base_bucket` and the subtraction cannot underflow.
-    #[allow(clippy::arithmetic_side_effects)]
+    // `bucket >= base_bucket` and the subtraction cannot underflow. The offset
+    // always fits `usize` on the >=32-bit targets this crate supports (const fn,
+    // so `usize::try_from` is unavailable).
+    #[allow(clippy::arithmetic_side_effects, clippy::as_conversions)]
     #[inline]
     const fn local_index(&self, bucket: u32) -> usize {
         (bucket - self.base_bucket) as usize
@@ -154,18 +156,29 @@ impl ShardedIssuer {
         );
 
         let total_buckets = 1u32 << bucket_depth;
+        // `u32` always fits `usize` on the >=32-bit targets this crate supports.
+        #[allow(clippy::as_conversions)]
         let shard_count = shard_count.min(total_buckets as usize);
-        let buckets_per_shard = total_buckets / shard_count as u32;
+        // `shard_count <= total_buckets <= u32::MAX` after the clamp above, so
+        // the narrowing is lossless.
+        #[allow(clippy::as_conversions)]
+        let shard_count_u32 = shard_count as u32;
+        let buckets_per_shard = total_buckets / shard_count_u32;
         let bucket_capacity = 1u32 << (depth - bucket_depth);
 
         // Calculate shard_shift: how many bits to shift bucket to get shard index
         // For bucket_depth=16 and shard_count=16, we take top 4 bits: shift = 16 - 4 = 12
-        let shard_bits = (shard_count as u32).trailing_zeros();
-        let shard_shift = bucket_depth as u32 - shard_bits;
-        let shard_mask = (shard_count - 1) as u32;
+        let shard_bits = shard_count_u32.trailing_zeros();
+        let shard_shift = u32::from(bucket_depth) - shard_bits;
+        let shard_mask = shard_count_u32 - 1;
 
         let shards: Vec<_> = (0..shard_count)
-            .map(|i| BucketShard::new(i as u32 * buckets_per_shard, buckets_per_shard))
+            .map(|i| {
+                // `i < shard_count <= u32::MAX`, so the narrowing is lossless.
+                #[allow(clippy::as_conversions)]
+                let base = i as u32 * buckets_per_shard;
+                BucketShard::new(base, buckets_per_shard)
+            })
             .collect();
 
         Self {
@@ -231,6 +244,9 @@ impl ShardedIssuer {
     }
 
     /// Maps a bucket to its shard index.
+    // The masked value always fits `usize` on the >=32-bit targets this crate
+    // supports (const fn, so `usize::try_from` is unavailable).
+    #[allow(clippy::as_conversions)]
     #[inline]
     const fn shard_index(&self, bucket: u32) -> usize {
         ((bucket >> self.shard_shift) & self.shard_mask) as usize
@@ -525,10 +541,10 @@ mod tests {
             handle.join().unwrap();
         }
 
-        assert_eq!(
-            issuer.stamps_issued(),
-            (num_threads * stamps_per_thread) as u64
-        );
+        // `8 * 1000` is positive and fits `u64`; the cast is lossless.
+        #[allow(clippy::as_conversions)]
+        let expected = (num_threads * stamps_per_thread) as u64;
+        assert_eq!(issuer.stamps_issued(), expected);
     }
 
     #[cfg(feature = "parallel")]

--- a/crates/postage-issuer/src/sharded_ring.rs
+++ b/crates/postage-issuer/src/sharded_ring.rs
@@ -51,6 +51,8 @@ struct RingShardState {
 
 impl<R: Reservation> RingShard<R> {
     fn new(base_bucket: u32, buckets_per_shard: u32, reservation: R) -> Self {
+        // `u32` always fits `usize` on the >=32-bit targets this crate supports.
+        #[allow(clippy::as_conversions)]
         let count = buckets_per_shard as usize;
         Self {
             base_bucket,
@@ -63,8 +65,10 @@ impl<R: Reservation> RingShard<R> {
     }
 
     // Shard routing invariant: callers only pass buckets owned by this shard, so
-    // `bucket >= base_bucket` and the subtraction cannot underflow.
-    #[allow(clippy::arithmetic_side_effects)]
+    // `bucket >= base_bucket` and the subtraction cannot underflow. The offset
+    // always fits `usize` on the >=32-bit targets this crate supports (const fn,
+    // so `usize::try_from` is unavailable).
+    #[allow(clippy::arithmetic_side_effects, clippy::as_conversions)]
     #[inline]
     const fn local_index(&self, bucket: u32) -> usize {
         (bucket - self.base_bucket) as usize
@@ -241,16 +245,24 @@ impl<R: Reservation> ShardedRingIssuer<R> {
         );
 
         let total_buckets = 1u32 << bucket_depth;
+        // `u32` always fits `usize` on the >=32-bit targets this crate supports.
+        #[allow(clippy::as_conversions)]
         let shard_count = shard_count.min(total_buckets as usize);
-        let buckets_per_shard = total_buckets / shard_count as u32;
+        // `shard_count <= total_buckets <= u32::MAX` after the clamp above, so
+        // the narrowing is lossless.
+        #[allow(clippy::as_conversions)]
+        let shard_count_u32 = shard_count as u32;
+        let buckets_per_shard = total_buckets / shard_count_u32;
         let bucket_capacity = 1u32 << (depth - bucket_depth);
 
-        let shard_bits = (shard_count as u32).trailing_zeros();
-        let shard_shift = bucket_depth as u32 - shard_bits;
-        let shard_mask = (shard_count - 1) as u32;
+        let shard_bits = shard_count_u32.trailing_zeros();
+        let shard_shift = u32::from(bucket_depth) - shard_bits;
+        let shard_mask = shard_count_u32 - 1;
 
         let shards: Vec<_> = (0..shard_count)
             .map(|i| {
+                // `i < shard_count <= u32::MAX`, so the narrowing is lossless.
+                #[allow(clippy::as_conversions)]
                 let base = i as u32 * buckets_per_shard;
                 let end = base + buckets_per_shard;
                 RingShard::new(base, buckets_per_shard, make_reservation(base, end, i))
@@ -270,6 +282,9 @@ impl<R: Reservation> ShardedRingIssuer<R> {
         }
     }
 
+    // The masked value always fits `usize` on the >=32-bit targets this crate
+    // supports (const fn, so `usize::try_from` is unavailable).
+    #[allow(clippy::as_conversions)]
     #[inline]
     const fn shard_index(&self, bucket: u32) -> usize {
         ((bucket >> self.shard_shift) & self.shard_mask) as usize
@@ -285,6 +300,11 @@ impl<R: Reservation> ShardedRingIssuer<R> {
     /// Returns [`StampError::BucketFull`] only when every slot in the target
     /// bucket is protected, which is geometrically impossible at real batch
     /// depths.
+    ///
+    /// # Panics
+    ///
+    /// Panics if an internal lock is poisoned, i.e. another stamping thread
+    /// already panicked; propagating the panic is the intended behavior.
     pub fn prepare_stamp(
         &self,
         address: &SwarmAddress,
@@ -370,8 +390,11 @@ impl<R: Reservation> ShardedRingIssuer<R> {
     }
 
     /// Returns the maximum bucket utilization observed across all buckets.
-    // Lock poisoning means another thread already panicked; propagating the
-    // panic is the intended behavior.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the utilization lock is poisoned, i.e. another stamping thread
+    /// already panicked; propagating the panic is the intended behavior.
     #[allow(clippy::expect_used)]
     pub fn max_bucket_utilization(&self) -> u32 {
         *self
@@ -381,8 +404,11 @@ impl<R: Reservation> ShardedRingIssuer<R> {
     }
 
     /// Returns the total number of stamps issued.
-    // Lock poisoning means another thread already panicked; propagating the
-    // panic is the intended behavior.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the issuance counter lock is poisoned, i.e. another stamping
+    /// thread already panicked; propagating the panic is the intended behavior.
     #[allow(clippy::expect_used)]
     pub fn stamps_issued(&self) -> u64 {
         *self.stamps_issued.lock().expect("stamps lock poisoned")
@@ -396,8 +422,13 @@ mod tests {
 
     fn test_address(leading: u16) -> SwarmAddress {
         let mut bytes = [0u8; 32];
-        bytes[0] = (leading >> 8) as u8;
-        bytes[1] = leading as u8;
+        // Big-endian split of a u16: `leading >> 8` is <= 0xFF and the low-byte
+        // truncation is the intended extraction; both casts are lossless.
+        #[allow(clippy::as_conversions)]
+        {
+            bytes[0] = (leading >> 8) as u8;
+            bytes[1] = leading as u8;
+        }
         SwarmAddress::new(bytes)
     }
 
@@ -470,7 +501,9 @@ mod tests {
         let bucket_hi = 0xF001u32;
         let issuer = ShardedRingIssuer::reserved(&batch, [(bucket_lo, 0), (bucket_hi, 1)]).unwrap();
 
+        #[allow(clippy::as_conversions)] // 0x0001 fits u16, lossless
         let addr_lo = test_address(bucket_lo as u16);
+        #[allow(clippy::as_conversions)] // 0xF001 fits u16, lossless
         let addr_hi = test_address(bucket_hi as u16);
 
         // bucket_lo protects slot 0, so it may only emit slot 1.

--- a/crates/postage-issuer/src/stamper.rs
+++ b/crates/postage-issuer/src/stamper.rs
@@ -326,7 +326,7 @@ mod tests {
         let mut sig_bytes = [0u8; 65];
         sig_bytes[..32].copy_from_slice(&signature.r().to_be_bytes::<32>());
         sig_bytes[32..64].copy_from_slice(&signature.s().to_be_bytes::<32>());
-        sig_bytes[64] = signature.v() as u8 + 27;
+        sig_bytes[64] = u8::from(signature.v()) + 27;
 
         assert_eq!(
             sig_bytes.as_slice(),

--- a/crates/postage-usage/src/client.rs
+++ b/crates/postage-usage/src/client.rs
@@ -199,7 +199,7 @@ where
                 // committed leaf must be present; a missing leaf is corruption,
                 // not a reason to start over.
                 let root = RootInfo::parse(&root_bytes)?;
-                let mut leaves: Vec<Bytes> = Vec::with_capacity(root.leaf_count() as usize);
+                let mut leaves: Vec<Bytes> = Vec::with_capacity(usize::from(root.leaf_count()));
                 for leaf in 0..root.leaf_count() {
                     // `leaf < leaf_count() <= u16::MAX`, so the increment
                     // cannot overflow.

--- a/crates/postage-usage/src/codec.rs
+++ b/crates/postage-usage/src/codec.rs
@@ -62,8 +62,9 @@ pub struct RootInfo {
 
 /// Returns the maximum delta representable in `width` bits.
 // In the else branch `width < 32`, so the u64 shift is in range and
-// `1 << width >= 1` makes the decrement safe.
-#[allow(clippy::arithmetic_side_effects)]
+// `1 << width >= 1` makes the decrement safe. The `u32::MAX -> u64`
+// widening is infallible; `u64::from` is not const-callable.
+#[allow(clippy::arithmetic_side_effects, clippy::as_conversions)]
 const fn delta_limit(width: u8) -> u64 {
     if width >= 32 {
         u32::MAX as u64
@@ -74,8 +75,9 @@ const fn delta_limit(width: u8) -> u64 {
 
 /// Returns the byte length of `buckets` deltas packed at `width` bits.
 // `buckets <= 2^16` (validated geometry) and `width <= 32`, so the product
-// is at most 2^21 and cannot overflow usize.
-#[allow(clippy::arithmetic_side_effects)]
+// is at most 2^21 and cannot overflow usize. The `u8 -> usize` widening is
+// infallible; `usize::from` is not const-callable.
+#[allow(clippy::arithmetic_side_effects, clippy::as_conversions)]
 const fn packed_len(buckets: usize, width: u8) -> usize {
     (buckets * width as usize).div_ceil(8)
 }
@@ -84,7 +86,9 @@ const fn packed_len(buckets: usize, width: u8) -> usize {
 // Callers uphold `width > 0` (leaves exist only for a nonzero delta width:
 // the encoder inlines width 0 and the parser rejects `leaves > 0` with
 // width 0), so the division cannot be by zero; the dividend is a constant.
-#[allow(clippy::arithmetic_side_effects)]
+// The `u8 -> usize` widening is infallible; `usize::from` is not
+// const-callable.
+#[allow(clippy::arithmetic_side_effects, clippy::as_conversions)]
 const fn buckets_per_leaf(width: u8) -> usize {
     (MAX_PAYLOAD_SIZE * 8) / width as usize
 }
@@ -104,8 +108,8 @@ const fn leaf_count(buckets: usize, width: u8) -> usize {
 // offset math and byte indexing cannot overflow or go out of bounds.
 #[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)]
 fn write_bits(buf: &mut [u8], bit_offset: usize, width: u8, value: u64) {
-    for i in 0..width as usize {
-        let bit = (value >> (width as usize - 1 - i)) & 1;
+    for i in 0..usize::from(width) {
+        let bit = (value >> (usize::from(width) - 1 - i)) & 1;
         if bit != 0 {
             let pos = bit_offset + i;
             buf[pos / 8] |= 1 << (7 - pos % 8);
@@ -120,12 +124,20 @@ fn write_bits(buf: &mut [u8], bit_offset: usize, width: u8, value: u64) {
 #[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)]
 fn read_bits(buf: &[u8], bit_offset: usize, width: u8) -> u64 {
     let mut value = 0u64;
-    for i in 0..width as usize {
+    for i in 0..usize::from(width) {
         let pos = bit_offset + i;
         let bit = (buf[pos / 8] >> (7 - pos % 8)) & 1;
         value = (value << 1) | u64::from(bit);
     }
     value
+}
+
+/// Returns `bucket` as a table index.
+// `u32` always fits `usize` on the >=32-bit targets this crate supports;
+// `usize::from` takes at most `u16`.
+#[allow(clippy::as_conversions)]
+const fn bucket_index(bucket: u32) -> usize {
+    bucket as usize
 }
 
 /// Packs the deltas of buckets `range` into a fresh zero-padded buffer.
@@ -149,7 +161,7 @@ fn pack_range(
     let mut out = vec![0u8; packed_len(end - start, width)];
     let mut except = exceptions
         .iter()
-        .map(|&(bucket, _)| bucket as usize)
+        .map(|&(bucket, _)| bucket_index(bucket))
         .skip_while(|&b| b < start)
         .peekable();
     for (i, bucket) in (start..end).enumerate() {
@@ -159,7 +171,7 @@ fn pack_range(
         } else {
             u64::from(counts[bucket] - base)
         };
-        write_bits(&mut out, i * width as usize, width, delta);
+        write_bits(&mut out, i * usize::from(width), width, delta);
     }
     out
 }
@@ -197,12 +209,15 @@ fn select_width(counts: &[u32], base: u32, buckets: usize, allocated: usize) -> 
     let mut histogram = [0usize; 33];
     for &count in counts {
         let delta = count - base;
-        histogram[(32 - delta.leading_zeros()) as usize] += 1;
+        // `leading_zeros() <= 32`, so the histogram index fits usize.
+        #[allow(clippy::as_conversions)]
+        let bits = (32 - delta.leading_zeros()) as usize;
+        histogram[bits] += 1;
     }
 
     let mut best: Option<(u8, usize)> = None;
     for width in 0..=MAX_WIDTH {
-        let exceptions: usize = histogram[width as usize + 1..].iter().sum();
+        let exceptions: usize = histogram[usize::from(width) + 1..].iter().sum();
         if exceptions > MAX_EXCEPTIONS {
             continue;
         }
@@ -234,6 +249,9 @@ pub(crate) fn encode(table: &UsageTable, sequence: u64, slots: &[u32]) -> Result
     if slots.is_empty() {
         return Err(UsageError::Malformed("root slot not allocated"));
     }
+    // The u32 bucket count always fits usize on the >=32-bit targets this
+    // crate supports.
+    #[allow(clippy::as_conversions)]
     let buckets = table.bucket_count() as usize;
     let counts = table.counts();
     let base = table.min_count();
@@ -250,7 +268,12 @@ pub(crate) fn encode(table: &UsageTable, sequence: u64, slots: &[u32]) -> Result
             .iter()
             .enumerate()
             .filter(|&(_, &count)| u64::from(count - base) > limit)
-            .map(|(bucket, &count)| (bucket as u32, count))
+            .map(|(bucket, &count)| {
+                // `bucket < buckets <= 2^16`, so it fits u32.
+                #[allow(clippy::as_conversions)]
+                let bucket = bucket as u32;
+                (bucket, count)
+            })
             .collect();
 
         let fixed = ROOT_HEADER_SIZE + 8 * exceptions.len() + 4 * allocated;
@@ -289,8 +312,16 @@ pub(crate) fn encode(table: &UsageTable, sequence: u64, slots: &[u32]) -> Result
         root.extend_from_slice(&sequence.to_be_bytes());
         root.extend_from_slice(&table.total_issued().to_be_bytes());
         root.extend_from_slice(&base.to_be_bytes());
+        // The section counts are bounded by the validated geometry:
+        // `allocated <= u16::MAX` (checked by `validate_parts`), `leaves`
+        // is at most the digests that fit a root chunk, and
+        // `exceptions.len() <= MAX_EXCEPTIONS` (guaranteed by
+        // `select_width`), so each fits u16.
+        #[allow(clippy::as_conversions)]
         root.extend_from_slice(&(allocated as u16).to_be_bytes());
+        #[allow(clippy::as_conversions)]
         root.extend_from_slice(&(leaves as u16).to_be_bytes());
+        #[allow(clippy::as_conversions)]
         root.extend_from_slice(&(exceptions.len() as u16).to_be_bytes());
         for &(bucket, count) in &exceptions {
             root.extend_from_slice(&bucket.to_be_bytes());
@@ -384,9 +415,9 @@ impl RootInfo {
         let sequence = read_u64(payload, 40);
         let total_issued = read_u64(payload, 48);
         let base = read_u32(payload, 56);
-        let allocated = read_u16(payload, 60) as usize;
-        let leaves = read_u16(payload, 62) as usize;
-        let exception_count = read_u16(payload, 64) as usize;
+        let allocated = usize::from(read_u16(payload, 60));
+        let leaves = usize::from(read_u16(payload, 62));
+        let exception_count = usize::from(read_u16(payload, 64));
 
         let buckets = 1usize << bucket_depth;
         let capacity = 1u32 << (depth - bucket_depth);
@@ -432,7 +463,7 @@ impl RootInfo {
             let bucket = read_u32(payload, offset);
             let count = read_u32(payload, offset + 4);
             offset += 8;
-            if bucket as usize >= buckets {
+            if bucket_index(bucket) >= buckets {
                 return Err(UsageError::CorruptBucket { bucket });
             }
             if previous.is_some_and(|p| p >= bucket) {
@@ -468,7 +499,7 @@ impl RootInfo {
             LeafSection::Digests(digests)
         } else {
             let packed = payload[offset..].to_vec();
-            if !padding_is_zero(&packed, buckets * width as usize) {
+            if !padding_is_zero(&packed, buckets * usize::from(width)) {
                 return Err(UsageError::Malformed("nonzero padding"));
             }
             LeafSection::Inline(packed)
@@ -527,6 +558,10 @@ impl RootInfo {
 
     /// Returns the number of leaf chunks that must be fetched to assemble
     /// this snapshot.
+    // The digest list length round-trips a `leaves` header field parsed
+    // from a u16, so it always fits back into u16; `u16::try_from` is not
+    // const-callable.
+    #[allow(clippy::as_conversions)]
     pub const fn leaf_count(&self) -> u16 {
         match &self.leaves {
             LeafSection::Inline(_) => 0,
@@ -542,12 +577,12 @@ impl RootInfo {
     // from underflowing.
     #[allow(clippy::arithmetic_side_effects)]
     pub fn expected_leaf_len(&self, leaf: u16) -> Option<usize> {
-        if (leaf as usize) >= self.leaf_count() as usize {
+        if usize::from(leaf) >= usize::from(self.leaf_count()) {
             return None;
         }
         let buckets = 1usize << self.bucket_depth;
         let per_leaf = buckets_per_leaf(self.width);
-        let start = leaf as usize * per_leaf;
+        let start = usize::from(leaf) * per_leaf;
         let end = (start + per_leaf).min(buckets);
         Some(packed_len(end - start, self.width))
     }
@@ -576,13 +611,13 @@ impl RootInfo {
         // a meaningless filler value; they are skipped here and overlaid with
         // their absolute counts afterwards.
         let unpack_range = |counts: &mut [u32], packed: &[u8], start: usize, end: usize| {
-            if !padding_is_zero(packed, (end - start) * width as usize) {
+            if !padding_is_zero(packed, (end - start) * usize::from(width)) {
                 return Err(UsageError::Malformed("nonzero padding"));
             }
             let mut except = self
                 .exceptions
                 .iter()
-                .map(|&(bucket, _)| bucket as usize)
+                .map(|&(bucket, _)| bucket_index(bucket))
                 .skip_while(|&b| b < start)
                 .peekable();
             for (i, count) in counts[start..end].iter_mut().enumerate() {
@@ -591,15 +626,24 @@ impl RootInfo {
                     except.next();
                     continue;
                 }
-                let value = u64::from(self.base) + read_bits(packed, i * width as usize, width);
+                let value = u64::from(self.base) + read_bits(packed, i * usize::from(width), width);
                 if value > u64::from(capacity) {
+                    // `bucket < buckets <= 2^16` fits u32, and the reported
+                    // count is min-clamped to u32::MAX before the cast.
+                    #[allow(clippy::as_conversions)]
+                    let bucket = bucket as u32;
+                    #[allow(clippy::as_conversions)]
+                    let count = value.min(u64::from(u32::MAX)) as u32;
                     return Err(UsageError::CorruptCounter {
-                        bucket: bucket as u32,
-                        count: value.min(u64::from(u32::MAX)) as u32,
+                        bucket,
+                        count,
                         capacity,
                     });
                 }
-                *count = value as u32;
+                // `value <= capacity` (checked above) keeps it within u32.
+                #[allow(clippy::as_conversions)]
+                let value = value as u32;
+                *count = value;
             }
             Ok(())
         };
@@ -623,19 +667,23 @@ impl RootInfo {
                 }
                 let per_leaf = buckets_per_leaf(width);
                 for (i, (payload, digest)) in leaves.iter().zip(digests.iter()).enumerate() {
+                    // `i < digests.len() <= u16::MAX` (the digest list length
+                    // round-trips a u16 header field).
+                    #[allow(clippy::as_conversions)]
+                    let index = i as u16;
                     let payload = payload.as_ref();
                     let start = i * per_leaf;
                     let end = (start + per_leaf).min(buckets);
                     let expected = packed_len(end - start, width);
                     if payload.len() != expected {
                         return Err(UsageError::LeafLength {
-                            index: i as u16,
+                            index,
                             expected,
                             got: payload.len(),
                         });
                     }
                     if keccak256(payload) != *digest {
-                        return Err(UsageError::LeafDigestMismatch { index: i as u16 });
+                        return Err(UsageError::LeafDigestMismatch { index });
                     }
                     unpack_range(&mut counts, payload, start, end)?;
                 }
@@ -643,7 +691,7 @@ impl RootInfo {
         }
 
         for &(bucket, count) in &self.exceptions {
-            counts[bucket as usize] = count;
+            counts[bucket_index(bucket)] = count;
         }
 
         let sum: u64 = counts.iter().map(|&c| u64::from(c)).sum();
@@ -701,11 +749,11 @@ mod tests {
             let values = [0, 1, limit / 2, limit.saturating_sub(1), limit];
             let mut buf = vec![0u8; packed_len(values.len(), width)];
             for (i, &v) in values.iter().enumerate() {
-                write_bits(&mut buf, i * width as usize, width, v);
+                write_bits(&mut buf, i * usize::from(width), width, v);
             }
             for (i, &v) in values.iter().enumerate() {
                 assert_eq!(
-                    read_bits(&buf, i * width as usize, width),
+                    read_bits(&buf, i * usize::from(width), width),
                     v,
                     "width {width}"
                 );
@@ -922,7 +970,7 @@ mod tests {
         corrupt[packed_start] |= 0b1111_1000;
 
         let info = RootInfo::parse(&corrupt).unwrap();
-        let err = info.assemble(&[] as &[&[u8]]).unwrap_err();
+        let err = info.assemble::<&[u8]>(&[]).unwrap_err();
         assert_eq!(
             err,
             UsageError::CorruptCounter {
@@ -1022,7 +1070,8 @@ mod tests {
 
         // Deterministic pseudo-random bytes (Knuth multiplicative hash).
         let raw: Vec<u8> = (0u32..8192)
-            .map(|i| (i.wrapping_mul(2654435761) >> 24) as u8)
+            // The high byte of the mixed u32 (`x >> 24`) always fits u8.
+            .map(|i| i.wrapping_mul(2654435761).to_be_bytes()[0])
             .collect();
         let mut u = Unstructured::new(&raw);
         let owner = Address::repeat_byte(0x11);

--- a/crates/postage-usage/src/snapshot.rs
+++ b/crates/postage-usage/src/snapshot.rs
@@ -225,7 +225,7 @@ impl Snapshot {
     /// the codec's recovery path.
     pub(crate) fn validate_parts(table: &UsageTable, slots: &[u32]) -> Result<()> {
         let capacity = table.bucket_capacity();
-        if slots.len() > u16::MAX as usize {
+        if slots.len() > usize::from(u16::MAX) {
             return Err(UsageError::Malformed("too many allocated chunks"));
         }
         if let Some(&slot) = slots.iter().find(|&&slot| slot >= capacity) {
@@ -477,7 +477,11 @@ impl Snapshot {
             .iter()
             .enumerate()
             .map(|(index, &slot)| {
-                let address = usage_chunk_address(&batch_id, owner, index as u16);
+                // `validate_parts` caps the slot list at u16::MAX entries,
+                // so every index fits u16.
+                #[allow(clippy::as_conversions)]
+                let index = index as u16;
+                let address = usage_chunk_address(&batch_id, owner, index);
                 StampIndex::new(calculate_bucket(&address, bucket_depth), slot)
             })
             .collect()
@@ -734,6 +738,10 @@ impl Validated<'_> {
             work.sequence = sequence;
 
             let allocate = |work: &mut Snapshot| -> Result<()> {
+                // The allocation loop stops once the slots outnumber the
+                // leaves (at most the digests that fit a root chunk), far
+                // below u16::MAX.
+                #[allow(clippy::as_conversions)]
                 let index = work.slots.len() as u16;
                 let address = usage_chunk_address(&batch_id, owner, index);
                 let bucket = calculate_bucket(&address, bucket_depth);
@@ -777,6 +785,9 @@ impl Validated<'_> {
         let mut chunks = Vec::with_capacity(1 + encoded.leaves.len());
         let payloads = core::iter::once(&encoded.root).chain(encoded.leaves.iter());
         for (index, payload) in payloads.enumerate() {
+            // Chunk indices count the root plus the leaves, bounded by the
+            // allocated slot list (`validate_parts` caps it at u16::MAX).
+            #[allow(clippy::as_conversions)]
             let index = index as u16;
             let id = usage_chunk_id(&batch_id, index);
             let address = usage_chunk_address(&batch_id, owner, index);
@@ -789,9 +800,9 @@ impl Validated<'_> {
                 index,
                 id,
                 address,
-                stamp_index: StampIndex::new(bucket, slots[index as usize]),
+                stamp_index: StampIndex::new(bucket, slots[usize::from(index)]),
                 payload: payload.clone(),
-                newly_allocated: (index as usize) >= previously_allocated,
+                newly_allocated: usize::from(index) >= previously_allocated,
             });
         }
 

--- a/crates/postage-usage/tests/issuer.rs
+++ b/crates/postage-usage/tests/issuer.rs
@@ -19,8 +19,11 @@ const fn owner() -> Address {
 /// `salt` mixed into lower bytes so distinct calls stay in the same bucket.
 fn content_address(bucket: u32, salt: u8) -> SwarmAddress {
     let mut bytes = [0u8; 32];
-    bytes[0] = (bucket >> 8) as u8;
-    bytes[1] = bucket as u8;
+    // Take the low two big-endian bytes of the u32 (identical to the former
+    // `>> 8` / truncating casts).
+    let [_, _, hi, lo] = bucket.to_be_bytes();
+    bytes[0] = hi;
+    bytes[1] = lo;
     bytes[31] = salt;
     SwarmAddress::new(bytes)
 }
@@ -176,7 +179,7 @@ fn sole_issuance_path_cannot_evict_snapshot_slots() {
         // Churn well past several wraps of the ring.
         for salt in 0..120u8 {
             let addr = content_address(bucket, salt);
-            let digest = issuer.prepare_stamp(&addr, salt as u64).unwrap();
+            let digest = issuer.prepare_stamp(&addr, u64::from(salt)).unwrap();
             assert!(
                 !reserved_here.contains(&digest.index),
                 "the sole issuance path evicted a reserved snapshot slot"

--- a/crates/postage-usage/tests/snapshot.rs
+++ b/crates/postage-usage/tests/snapshot.rs
@@ -26,7 +26,10 @@ fn synthetic_counts(buckets: usize, base: u32, spread: u32) -> Vec<u32> {
             state = state
                 .wrapping_mul(6364136223846793005)
                 .wrapping_add(1442695040888963407);
-            base + ((state >> 33) as u32) % (spread + 1)
+            // `state >> 33` keeps 31 bits, which always fit u32.
+            #[allow(clippy::as_conversions)]
+            let mixed = (state >> 33) as u32;
+            base + mixed % (spread + 1)
         })
         .collect()
 }
@@ -34,7 +37,7 @@ fn synthetic_counts(buckets: usize, base: u32, spread: u32) -> Vec<u32> {
 fn roundtrip(plan: &PersistPlan) -> Snapshot {
     let root = RootInfo::parse(&plan.chunks[0].payload).unwrap();
     let leaves: Vec<_> = plan.chunks[1..].iter().map(|c| &c.payload).collect();
-    assert_eq!(root.leaf_count() as usize, leaves.len());
+    assert_eq!(usize::from(root.leaf_count()), leaves.len());
     root.assemble(&leaves).unwrap()
 }
 
@@ -187,6 +190,9 @@ fn snapshot_accounts_for_its_own_chunks() {
         .plan_persist(&owner())
         .unwrap();
 
+    // A plan holds at most root + leaves chunks; usize fits u64 on
+    // supported targets.
+    #[allow(clippy::as_conversions)]
     let allocated = plan.chunks.len() as u64;
     assert_eq!(snapshot.table().total_issued(), issued_before + allocated);
     for chunk in &plan.chunks {
@@ -605,11 +611,15 @@ fn table_view_exposes_counts_and_geometry_without_yielding_an_owned_table() {
     let recovered = roundtrip(&plan);
     let view = recovered.table();
 
+    // Test geometry: `buckets = 2^BUCKET_DEPTH` fits u32.
+    #[allow(clippy::as_conversions)]
+    let buckets_u32 = buckets as u32;
+
     // Geometry getters.
     assert_eq!(view.batch_id(), batch_id());
     assert_eq!(view.depth(), 24);
     assert_eq!(view.bucket_depth(), BUCKET_DEPTH);
-    assert_eq!(view.bucket_count(), buckets as u32);
+    assert_eq!(view.bucket_count(), buckets_u32);
     assert_eq!(view.bucket_capacity(), 1u32 << (24 - BUCKET_DEPTH));
     assert_eq!(view.total_capacity(), 1u64 << 24);
     assert!(!view.is_mutable());
@@ -625,7 +635,7 @@ fn table_view_exposes_counts_and_geometry_without_yielding_an_owned_table() {
         recovered.table().counts().iter().copied().min().unwrap()
     );
     assert!(
-        view.count(buckets as u32).is_err(),
+        view.count(buckets_u32).is_err(),
         "out-of-range bucket errors"
     );
     assert!(view.has_capacity(7).unwrap());
@@ -851,9 +861,12 @@ fn failed_allocation_rolls_back_the_snapshot() {
 /// Returns a chunk address whose top `BUCKET_DEPTH` bits select `bucket`.
 fn address_in_bucket(bucket: u32) -> nectar_primitives::SwarmAddress {
     let mut bytes = [0u8; 32];
-    // bucket occupies the most-significant BUCKET_DEPTH (=16) bits.
-    bytes[0] = (bucket >> 8) as u8;
-    bytes[1] = bucket as u8;
+    // bucket occupies the most-significant BUCKET_DEPTH (=16) bits: take the
+    // low two big-endian bytes of the u32 (identical to the former `>> 8` /
+    // truncating casts).
+    let [_, _, hi, lo] = bucket.to_be_bytes();
+    bytes[0] = hi;
+    bytes[1] = lo;
     nectar_primitives::SwarmAddress::new(bytes)
 }
 

--- a/crates/postage-usage/tests/vector.rs
+++ b/crates/postage-usage/tests/vector.rs
@@ -56,7 +56,7 @@ fn readme_worked_example_vector() {
 
     // And the vector decodes back to the same snapshot.
     let root = RootInfo::parse(&hex::decode(ROOT_PAYLOAD_HEX).unwrap()).unwrap();
-    let recovered = root.assemble(&[] as &[&[u8]]).unwrap();
+    let recovered = root.assemble::<&[u8]>(&[]).unwrap();
     assert_eq!(recovered, snapshot);
 }
 
@@ -150,7 +150,7 @@ fn mutable_vector_flags_byte_and_round_trip() {
     // It decodes back as mutable to the same snapshot.
     let root = RootInfo::parse(&hex::decode(MUTABLE_ROOT_PAYLOAD_HEX).unwrap()).unwrap();
     assert!(root.is_mutable());
-    let recovered = root.assemble(&[] as &[&[u8]]).unwrap();
+    let recovered = root.assemble::<&[u8]>(&[]).unwrap();
     assert!(recovered.table().is_mutable());
     assert_eq!(recovered, snapshot);
 }

--- a/crates/postage/src/stamp.rs
+++ b/crates/postage/src/stamp.rs
@@ -77,6 +77,7 @@ impl StampIndex {
     /// bucket and index values; the exact wire format for the combined index
     /// used in signature computation is left to implementations.
     #[inline]
+    #[allow(clippy::as_conversions)] // widening u32 -> u64, infallible; `u64::from` is not const-callable
     pub const fn encode(&self) -> u64 {
         ((self.bucket as u64) << 32) | (self.index as u64)
     }
@@ -85,6 +86,7 @@ impl StampIndex {
     ///
     /// See [`encode`](Self::encode) for the encoding format.
     #[inline]
+    #[allow(clippy::as_conversions)] // `encoded >> 32` fits in u32; low-word cast is the intended 32-bit extraction; `try_from` is not const-callable
     pub const fn decode(encoded: u64) -> Self {
         Self {
             bucket: (encoded >> 32) as u32,
@@ -850,7 +852,12 @@ mod tests {
 
         // Deterministic pseudo-random bytes (Knuth multiplicative hash).
         let raw: alloc::vec::Vec<u8> = (0u32..8192)
-            .map(|i| (i.wrapping_mul(2654435761) >> 24) as u8)
+            .map(|i| {
+                #[allow(clippy::as_conversions)] // `u32 >> 24` is always <= 0xFF, cast is lossless
+                {
+                    (i.wrapping_mul(2654435761) >> 24) as u8
+                }
+            })
             .collect();
         let mut u = Unstructured::new(&raw);
 

--- a/crates/postage/src/util.rs
+++ b/crates/postage/src/util.rs
@@ -13,7 +13,14 @@ pub fn current_timestamp() -> u64 {
     use web_time::{SystemTime, UNIX_EPOCH};
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_nanos() as u64)
+        // Nanoseconds since the Unix epoch fit in a `u64` until the year
+        // ~2554; truncation is unreachable in practice.
+        .map(|d| {
+            #[allow(clippy::as_conversions)]
+            {
+                d.as_nanos() as u64
+            }
+        })
         .unwrap_or(0)
 }
 

--- a/crates/primitives/src/address.rs
+++ b/crates/primitives/src/address.rs
@@ -265,8 +265,12 @@ impl SwarmAddress {
     }
 
     /// Helper function to calculate proximity with a maximum
-    #[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)]
-    // max is MAX_PO (31) or EXTENDED_PO (36), so i <= max_bytes = 4 < 32 and i * 8 + leading_zeros <= 40 fits u8
+    #[allow(
+        clippy::arithmetic_side_effects,
+        clippy::indexing_slicing,
+        clippy::as_conversions
+    )]
+    // max is MAX_PO (31) or EXTENDED_PO (36), so i <= max_bytes = 4 < 32 and i * 8 + leading_zeros <= 40 fits u8; the casts to u8 (max, i, and the u8 xor's leading_zeros <= 8) are all within those bounds
     #[inline(always)]
     fn proximity_helper(&self, other: &Self, max: usize) -> u8 {
         let max_bytes = max / 8;

--- a/crates/primitives/src/bin.rs
+++ b/crates/primitives/src/bin.rs
@@ -42,6 +42,9 @@ impl Bin {
     pub const MAX: Self = Self(MAX_PO);
 
     /// The number of bins in the routing table (`MAX_PO + 1` = 32).
+    // `u8 -> usize` widening is infallible; `usize::from` is not
+    // const-callable.
+    #[allow(clippy::as_conversions)]
     pub const COUNT: usize = MAX_PO as usize + 1;
 
     /// Construct without bounds checking. Caller must ensure `raw <= MAX_PO`.
@@ -68,6 +71,9 @@ impl Bin {
     }
 
     /// Index into a `[T; Bin::COUNT]` array.
+    // `u8 -> usize` widening is infallible; `usize::from` is not
+    // const-callable.
+    #[allow(clippy::as_conversions)]
     #[inline]
     pub const fn as_index(self) -> usize {
         self.0 as usize

--- a/crates/primitives/src/bmt/constants.rs
+++ b/crates/primitives/src/bmt/constants.rs
@@ -25,7 +25,8 @@ pub const SPAN_SIZE: usize = std::mem::size_of::<u64>();
 pub(crate) const PROOF_LENGTH: usize = 7;
 
 /// Compute number of zero tree levels for a given body size.
-#[allow(clippy::arithmetic_side_effects)] // trailing_zeros() <= 64, so + 1 cannot overflow usize
+#[allow(clippy::arithmetic_side_effects, clippy::as_conversions)]
+// trailing_zeros() <= 64, so + 1 cannot overflow usize and the u32 -> usize widening is infallible (usize::from is not const-callable)
 #[inline]
 pub(crate) const fn zero_tree_levels(body_size: usize) -> usize {
     (body_size / SEGMENT_PAIR_LENGTH).trailing_zeros() as usize + 1

--- a/crates/primitives/src/bmt/hasher.rs
+++ b/crates/primitives/src/bmt/hasher.rs
@@ -350,7 +350,8 @@ impl<const BODY_SIZE: usize> Hasher<BODY_SIZE> {
 
     /// Calculate the zero-tree level for a given subtree length.
     /// Length must be a power of 2 between 64 and 4096.
-    #[allow(clippy::arithmetic_side_effects)] // length >= 64 (per contract above), so trailing_zeros() >= 6 and the subtraction cannot underflow
+    #[allow(clippy::arithmetic_side_effects, clippy::as_conversions)]
+    // length >= 64 (per contract above), so trailing_zeros() >= 6 and the subtraction cannot underflow; the u32 -> usize widening is infallible (usize::from is not const-callable)
     #[inline(always)]
     const fn zero_tree_level(length: usize) -> usize {
         // length = 64 * 2^level, so level = log2(length) - log2(64) = log2(length) - 6

--- a/crates/primitives/src/cast.rs
+++ b/crates/primitives/src/cast.rs
@@ -1,0 +1,26 @@
+//! Crate-internal explicit-cast helpers.
+//!
+//! Single justified home for the `usize`/`u64` conversions the chunk-tree
+//! math needs, replacing scattered silent `as` casts
+//! (`clippy::as_conversions` is denied workspace-wide).
+
+/// Returns `n` as `u64`.
+// `usize` is at most 64 bits wide on every Rust target, so this widening
+// never loses information; `u64: From<usize>` does not exist in std, and
+// `try_from` is not const-callable.
+#[allow(clippy::as_conversions)]
+pub(crate) const fn u64_from_usize(n: usize) -> u64 {
+    n as u64
+}
+
+/// Returns `n` as `usize`, with the same semantics as the `as` cast it
+/// replaces: lossless on 64-bit targets, truncating on 32-bit targets
+/// (wasm32).
+// Callers pass in-memory byte counts and offsets that are bounded by an
+// existing allocation or by the chunk body size, or values whose pre-existing
+// truncation-on-32-bit behavior must be preserved verbatim. Do NOT use this
+// for values that must be range-checked: use `usize::try_from` there.
+#[allow(clippy::as_conversions)]
+pub(crate) const fn usize_from_u64(n: u64) -> usize {
+    n as usize
+}

--- a/crates/primitives/src/chunk/bmt_body.rs
+++ b/crates/primitives/src/chunk/bmt_body.rs
@@ -182,7 +182,7 @@ impl<const BODY_SIZE: usize> BmtBodyBuilder<BODY_SIZE, Initial> {
         let data = validate_data::<BODY_SIZE>(data)?;
         let len = data.len();
         self.data = Some(data);
-        self.span = Some(len as u64);
+        self.span = Some(crate::cast::u64_from_usize(len));
 
         Ok(BmtBodyBuilder {
             span: self.span,
@@ -203,13 +203,17 @@ impl<const BODY_SIZE: usize> BmtBodyBuilder<BODY_SIZE, WithSpan> {
         self.data = Some(data);
 
         let span = self.span.unwrap();
-        if span <= BODY_SIZE as u64 && data_len != span as usize {
-            return Err(ChunkError::invalid_size(
-                "span does not match data size",
-                span as usize,
-                data_len,
-            )
-            .into());
+        if span <= crate::cast::u64_from_usize(BODY_SIZE) {
+            // span <= BODY_SIZE here, so it fits usize on all supported targets.
+            let span_len = crate::cast::usize_from_u64(span);
+            if data_len != span_len {
+                return Err(ChunkError::invalid_size(
+                    "span does not match data size",
+                    span_len,
+                    data_len,
+                )
+                .into());
+            }
         }
 
         Ok(BmtBodyBuilder {
@@ -240,10 +244,10 @@ impl<'a, const BODY_SIZE: usize> arbitrary::Arbitrary<'a> for BmtBody<BODY_SIZE>
 
         let (span, data_len) = if is_leaf {
             let data_len: usize = u.int_in_range(0..=BODY_SIZE)?;
-            (data_len as u64, data_len)
+            (crate::cast::u64_from_usize(data_len), data_len)
         } else {
             // Intermediate node: span exceeds BODY_SIZE, body is always full.
-            let span = u.int_in_range(BODY_SIZE as u64 + 1..=u64::MAX)?;
+            let span = u.int_in_range(crate::cast::u64_from_usize(BODY_SIZE) + 1..=u64::MAX)?;
             (span, BODY_SIZE)
         };
 

--- a/crates/primitives/src/chunk/content.rs
+++ b/crates/primitives/src/chunk/content.rs
@@ -200,10 +200,13 @@ impl<const BODY_SIZE: usize> EncryptedContentChunk<BODY_SIZE> {
         let key = self.encrypted_ref.key();
 
         // Decrypt the span to learn the original data length
+        // BODY_SIZE / 32 is 128 for the default 4096-byte body and stays far
+        // below u32::MAX for any chunk-sized body.
+        #[allow(clippy::as_conversions)]
         let span_ctr = (BODY_SIZE / super::encryption::EncryptionKey::SIZE) as u32;
         let mut span_buf = [0u8; SPAN_SIZE];
         transcrypt(key, span_ctr, &encrypted_data[..SPAN_SIZE], &mut span_buf)?;
-        let data_length = u64::from_le_bytes(span_buf) as usize;
+        let data_length = crate::cast::usize_from_u64(u64::from_le_bytes(span_buf));
 
         let decrypted =
             super::encryption::decrypt_chunk_data::<BODY_SIZE>(&encrypted_data, key, data_length)?;

--- a/crates/primitives/src/chunk/encryption/chunk.rs
+++ b/crates/primitives/src/chunk/encryption/chunk.rs
@@ -10,7 +10,7 @@ use super::error::EncryptionError;
 use super::key::EncryptionKey;
 
 /// Span encryption counter: `BODY_SIZE / EncryptionKey::SIZE` (128 for default 4096).
-#[allow(clippy::arithmetic_side_effects)] // EncryptionKey::SIZE is the nonzero constant 32
+#[allow(clippy::arithmetic_side_effects, clippy::as_conversions)] // EncryptionKey::SIZE is the nonzero constant 32; body_size / 32 is 128 for the default 4096-byte body and stays far below u32::MAX for any chunk-sized body (u32::try_from is not const-callable)
 const fn span_ctr(body_size: usize) -> u32 {
     (body_size / EncryptionKey::SIZE) as u32
 }

--- a/crates/primitives/src/chunk/encryption/cipher.rs
+++ b/crates/primitives/src/chunk/encryption/cipher.rs
@@ -31,7 +31,8 @@ fn derive_segment_key(key_state: &Keccak256, counter: u32) -> [u8; 32] {
 }
 
 /// XOR `data` with the Keccak-256 CTR keystream in place.
-#[allow(clippy::indexing_slicing)] // j < chunk.len() <= EncryptionKey::SIZE = seg.len() (32)
+#[allow(clippy::indexing_slicing, clippy::as_conversions)]
+// j < chunk.len() <= EncryptionKey::SIZE = seg.len() (32); i < data.len() / 32 <= a few hundred for any chunk-sized buffer, so it fits u32
 #[inline]
 fn apply_keystream(key: &EncryptionKey, init_ctr: u32, data: &mut [u8]) {
     let ks = key_state(key);

--- a/crates/primitives/src/file/constants.rs
+++ b/crates/primitives/src/file/constants.rs
@@ -5,7 +5,7 @@ use crate::bmt::{BRANCHES, DEFAULT_BODY_SIZE, HASH_SIZE};
 /// Derive the maximum tree depth from branching factor and body size.
 /// The limit is the number of levels needed to address all storable data:
 /// `branches^(limit-1) * body_size` must exceed any practical file size.
-#[allow(clippy::arithmetic_side_effects)] // compile-time constants: body_bits <= 12 < 64 and branch_bits >= 1 for the power-of-two inputs used
+#[allow(clippy::arithmetic_side_effects, clippy::as_conversions)] // compile-time constants: body_bits <= 12 < 64 and branch_bits >= 1 for the power-of-two inputs used; the trailing_zeros u32 -> usize widenings are infallible (usize::from is not const-callable)
 const fn compute_level_limit(branches: usize, body_size: usize) -> usize {
     // bits needed = ceil(log2(u64::MAX / body_size)) / log2(branches)
     // For branches=128 (7 bits), body_size=4096 (12 bits): (64-12)/7 + 1 = 8.4 → 9
@@ -34,7 +34,7 @@ const fn compute_spans(branches: usize) -> [u64; LEVEL_LIMIT] {
     let mut i = 0;
     while i < LEVEL_LIMIT {
         spans[i] = span;
-        span = span.saturating_mul(branches as u64);
+        span = span.saturating_mul(crate::cast::u64_from_usize(branches));
         i += 1;
     }
     spans
@@ -66,10 +66,10 @@ pub(crate) const fn tree_depth(length: u64, chunk_size: usize, ref_size: usize) 
         return 0;
     }
 
-    let branches = (chunk_size / ref_size) as u64;
+    let branches = crate::cast::u64_from_usize(chunk_size / ref_size);
 
     // div_ceil(length, chunk_size)
-    let data_chunks = length.div_ceil(chunk_size as u64);
+    let data_chunks = length.div_ceil(crate::cast::u64_from_usize(chunk_size));
     if data_chunks <= 1 {
         return 1;
     }
@@ -90,17 +90,18 @@ pub(crate) fn subspan_for_spans<const BODY_SIZE: usize>(
     span: u64,
     spans: &[u64; LEVEL_LIMIT],
 ) -> u64 {
+    let body_size = crate::cast::u64_from_usize(BODY_SIZE);
     for i in 0..LEVEL_LIMIT {
-        let level_span = spans[i] * BODY_SIZE as u64;
+        let level_span = spans[i] * body_size;
         if span <= level_span {
             return if i == 0 {
-                BODY_SIZE as u64
+                body_size
             } else {
-                spans[i - 1] * BODY_SIZE as u64
+                spans[i - 1] * body_size
             };
         }
     }
-    spans[LEVEL_LIMIT - 2] * BODY_SIZE as u64
+    spans[LEVEL_LIMIT - 2] * body_size
 }
 
 #[cfg(test)]

--- a/crates/primitives/src/file/entry_ref.rs
+++ b/crates/primitives/src/file/entry_ref.rs
@@ -21,6 +21,7 @@ impl EntryRef {
     ///
     /// - 32 bytes → `Plain`
     /// - 64 bytes → `Encrypted` (requires `encryption` feature)
+    #[allow(clippy::missing_panics_doc)] // the expect below is unreachable: the match arm guarantees the length, so there is no panic to document
     pub fn try_from_bytes(bytes: &[u8]) -> Result<Self, FileError> {
         match bytes.len() {
             32 => {

--- a/crates/primitives/src/file/frontier.rs
+++ b/crates/primitives/src/file/frontier.rs
@@ -43,12 +43,12 @@ where
 {
     let subspan = M::subspan_size::<BS>(parent.span);
     let num_children = body.len() / M::REF_SIZE;
-    let range_start = chunk_range.start * BS as u64;
-    let range_end = chunk_range.end * BS as u64;
+    let range_start = chunk_range.start * crate::cast::u64_from_usize(BS);
+    let range_end = chunk_range.end * crate::cast::u64_from_usize(BS);
 
     let mut children = Vec::with_capacity(num_children);
     for i in 0..num_children {
-        let byte_offset = parent.byte_offset + i as u64 * subspan;
+        let byte_offset = parent.byte_offset + crate::cast::u64_from_usize(i) * subspan;
         let span = M::child_span::<BS>(parent.span, subspan, i);
 
         if byte_offset >= range_end || byte_offset + span <= range_start {
@@ -103,13 +103,13 @@ impl<M: JoinMode, const BS: usize> BfsExpander<M, BS> {
         chunk_range: &ChunkRange,
         target_subtrees: usize,
     ) -> Option<Self> {
-        if span <= BS as u64 {
+        if span <= crate::cast::u64_from_usize(BS) {
             return None;
         }
         Some(Self {
             frontier: vec![frontier_seed::<M>(root, context, span)],
             next: Vec::new(),
-            ideal_span: span / target_subtrees as u64,
+            ideal_span: span / crate::cast::u64_from_usize(target_subtrees),
             chunk_range: *chunk_range,
         })
     }
@@ -119,7 +119,7 @@ impl<M: JoinMode, const BS: usize> BfsExpander<M, BS> {
         self.frontier
             .iter()
             .enumerate()
-            .filter(|(_, n)| n.span > self.ideal_span && n.span > BS as u64)
+            .filter(|(_, n)| n.span > self.ideal_span && n.span > crate::cast::u64_from_usize(BS))
             .map(|(i, _)| i)
             .collect()
     }
@@ -233,7 +233,7 @@ where
             current.span,
         )
         .await?;
-        if current.span <= BS as u64 {
+        if current.span <= crate::cast::u64_from_usize(BS) {
             out.push(body);
         } else {
             let children = overlapping_children::<M, BS>(&body, &current, chunk_range)?;

--- a/crates/primitives/src/file/helpers.rs
+++ b/crates/primitives/src/file/helpers.rs
@@ -24,12 +24,12 @@ pub(crate) fn validate_read_range<const BODY_SIZE: usize>(
         return ReadRangeCheck::Empty;
     }
 
-    let actual_len = len.min((span - offset) as usize);
+    let actual_len = len.min(crate::cast::usize_from_u64(span - offset));
     if actual_len == 0 {
         return ReadRangeCheck::Empty;
     }
 
-    if span <= BODY_SIZE as u64 {
+    if span <= crate::cast::u64_from_usize(BODY_SIZE) {
         return ReadRangeCheck::SingleChunk { offset, actual_len };
     }
 

--- a/crates/primitives/src/file/joiner.rs
+++ b/crates/primitives/src/file/joiner.rs
@@ -246,7 +246,8 @@ where
 
     /// Read entire file into memory.
     pub async fn read_all(&self) -> Result<Vec<u8>> {
-        self.read_range(0, self.span as usize).await
+        self.read_range(0, crate::cast::usize_from_u64(self.span))
+            .await
     }
 
     /// Shared read-range implementation used by both `read_range` and `poll_read`.
@@ -276,16 +277,17 @@ where
                     type_name: "non-content",
                 })?;
                 let body = M::decode_body::<BODY_SIZE>(chunk, context, span)?;
-                let start = offset as usize;
+                // offset < span <= BODY_SIZE in the single-chunk case.
+                let start = crate::cast::usize_from_u64(offset);
                 let end = start + actual_len;
                 return Ok(body[start..end].to_vec());
             }
             ReadRangeCheck::MultiChunk { offset, actual_len } => (offset, actual_len),
         };
 
-        let chunk_range = tree.chunks_for_range(offset, actual_len as u64);
-        let range_start_byte = chunk_range.start * BODY_SIZE as u64;
-        let range_end_byte = chunk_range.end * BODY_SIZE as u64;
+        let chunk_range = tree.chunks_for_range(offset, crate::cast::u64_from_usize(actual_len));
+        let range_start_byte = chunk_range.start * crate::cast::u64_from_usize(BODY_SIZE);
+        let range_end_byte = chunk_range.end * crate::cast::u64_from_usize(BODY_SIZE);
 
         let relevant: Vec<_> = subtrees
             .iter()
@@ -408,7 +410,9 @@ where
                 // Drain leaves already in hand, offsetting each leaf from its
                 // subtree base by a whole body per preceding leaf.
                 if let Some(body) = state.pending.next() {
-                    let offset = state.base + state.leaf_index as u64 * BODY_SIZE as u64;
+                    let offset = state.base
+                        + crate::cast::u64_from_usize(state.leaf_index)
+                            * crate::cast::u64_from_usize(BODY_SIZE);
                     state.leaf_index += 1;
                     return Some((Ok((offset, body)), state));
                 }
@@ -451,7 +455,11 @@ where
     /// file size. Set the width with [`with_concurrency`](Self::with_concurrency).
     /// Reassembling the pairs by offset reproduces the file, byte-for-byte equal
     /// to [`read_all`](Self::read_all).
-    #[allow(clippy::arithmetic_side_effects, clippy::expect_used)] // retries - 1 is guarded by retries > 0; intermediate_in_flight moves in lockstep with admissions (bounded by MAX_INTERMEDIATE_IN_FLIGHT) so +1/-1 cannot wrap; the pop_front().expect is guarded by the !is_empty() admission check just above
+    #[allow(
+        clippy::arithmetic_side_effects,
+        clippy::expect_used,
+        clippy::missing_panics_doc
+    )] // retries - 1 is guarded by retries > 0; intermediate_in_flight moves in lockstep with admissions (bounded by MAX_INTERMEDIATE_IN_FLIGHT) so +1/-1 cannot wrap; the pop_front().expect is guarded by the !is_empty() admission check just above, so no panic is reachable to document
     pub fn into_offset_stream_chunked(self) -> impl Stream<Item = Result<(u64, Bytes)>>
     where
         G: 'static,
@@ -508,7 +516,7 @@ where
             {
                 Ok(body) => body,
                 Err(e) => {
-                    if node.span <= BS as u64 && pending.retries > 0 {
+                    if node.span <= crate::cast::u64_from_usize(BS) && pending.retries > 0 {
                         return Resolved::Retry(Pending {
                             node: pending.node,
                             retries: pending.retries - 1,
@@ -518,7 +526,7 @@ where
                 }
             };
 
-            if node.span <= BS as u64 {
+            if node.span <= crate::cast::u64_from_usize(BS) {
                 return Resolved::Leaf(node.byte_offset, body);
             }
             match overlapping_children::<M, BS>(&body, node, chunk_range) {
@@ -549,7 +557,7 @@ where
                 node: st,
                 retries: DEFAULT_LEAF_RETRIES,
             };
-            if pending.node.span <= BODY_SIZE as u64 {
+            if pending.node.span <= crate::cast::u64_from_usize(BODY_SIZE) {
                 leaf_queue.push_back(pending);
             } else {
                 node_queue.push_back(pending);
@@ -593,9 +601,10 @@ where
 
                     let getter = Arc::clone(&state.getter);
                     let range = state.chunk_range;
-                    state.in_flight.push(Box::pin(async move {
+                    let fut: BoxResolvedFuture<M> = Box::pin(async move {
                         fetch_one::<G, M, BODY_SIZE>(&*getter, &range, pending).await
-                    }) as BoxResolvedFuture<M>);
+                    });
+                    state.in_flight.push(fut);
                 }
 
                 // Nothing in flight and nothing queued: the tree is drained.
@@ -611,7 +620,7 @@ where
                                 node: child,
                                 retries: DEFAULT_LEAF_RETRIES,
                             };
-                            if pending.node.span <= BODY_SIZE as u64 {
+                            if pending.node.span <= crate::cast::u64_from_usize(BODY_SIZE) {
                                 state.leaf_queue.push_back(pending);
                             } else {
                                 state.node_queue.push_back(pending);
@@ -749,7 +758,7 @@ where
         {
             Ok(body) => body,
             Err(e) => {
-                if node.span <= BS as u64 && pending.retries > 0 {
+                if node.span <= crate::cast::u64_from_usize(BS) && pending.retries > 0 {
                     return Resolved::Retry(Pending {
                         node: pending.node,
                         retries: pending.retries - 1,
@@ -759,7 +768,7 @@ where
             }
         };
 
-        if node.span <= BS as u64 {
+        if node.span <= crate::cast::u64_from_usize(BS) {
             return Resolved::Leaf(node.byte_offset, body);
         }
         match overlapping_children::<M, BS>(&body, node, chunk_range) {
@@ -790,15 +799,15 @@ where
     let mut node_queue = std::collections::VecDeque::new();
     let mut leaf_queue = std::collections::VecDeque::new();
     if range_end > range_start {
-        let range_start_byte = chunk_range.start * BODY_SIZE as u64;
-        let range_end_byte = chunk_range.end * BODY_SIZE as u64;
+        let range_start_byte = chunk_range.start * crate::cast::u64_from_usize(BODY_SIZE);
+        let range_end_byte = chunk_range.end * crate::cast::u64_from_usize(BODY_SIZE);
         for st in subtrees {
             if st.byte_offset < range_end_byte && st.byte_offset + st.span > range_start_byte {
                 let pending = Pending {
                     node: st,
                     retries: DEFAULT_LEAF_RETRIES,
                 };
-                if pending.node.span <= BODY_SIZE as u64 {
+                if pending.node.span <= crate::cast::u64_from_usize(BODY_SIZE) {
                     leaf_queue.push_back(pending);
                 } else {
                     node_queue.push_back(pending);
@@ -842,9 +851,10 @@ where
 
                 let getter = Arc::clone(&state.getter);
                 let range = state.chunk_range;
-                state.in_flight.push(Box::pin(async move {
+                let fut: BoxResolvedFuture<M> = Box::pin(async move {
                     fetch_one::<G, M, BODY_SIZE>(&*getter, &range, pending).await
-                }) as BoxResolvedFuture<M>);
+                });
+                state.in_flight.push(fut);
             }
 
             // Nothing in flight and nothing queued: the range is drained.
@@ -855,12 +865,16 @@ where
                     // boundary leaf emits only its in-range slice, and the
                     // emitted offset is the later of the leaf start and the
                     // range start.
-                    let leaf_end = leaf_start + body.len() as u64;
+                    let leaf_end = leaf_start + crate::cast::u64_from_usize(body.len());
                     if leaf_end <= state.range_start || leaf_start >= state.range_end {
                         continue;
                     }
-                    let clip_lo = state.range_start.saturating_sub(leaf_start) as usize;
-                    let clip_hi = (state.range_end - leaf_start).min(body.len() as u64) as usize;
+                    // Both clip bounds are <= body.len(), so they fit usize.
+                    let clip_lo =
+                        crate::cast::usize_from_u64(state.range_start.saturating_sub(leaf_start));
+                    let clip_hi = crate::cast::usize_from_u64(
+                        (state.range_end - leaf_start).min(crate::cast::u64_from_usize(body.len())),
+                    );
                     let offset = leaf_start.max(state.range_start);
                     return Some((Ok((offset, body.slice(clip_lo..clip_hi))), state));
                 }
@@ -871,7 +885,7 @@ where
                             node: child,
                             retries: DEFAULT_LEAF_RETRIES,
                         };
-                        if pending.node.span <= BODY_SIZE as u64 {
+                        if pending.node.span <= crate::cast::u64_from_usize(BODY_SIZE) {
                             state.leaf_queue.push_back(pending);
                         } else {
                             state.node_queue.push_back(pending);
@@ -962,7 +976,7 @@ where
         // Create a future for the next read if we don't have one
         if this.future.is_none() {
             let position = this.joiner.position;
-            let remaining = (this.joiner.span - position) as usize;
+            let remaining = crate::cast::usize_from_u64(this.joiner.span - position);
             let read_len = remaining.min(BODY_SIZE);
             let getter = Arc::clone(&this.joiner.getter);
             let root = this.joiner.root;
@@ -995,7 +1009,7 @@ where
             Poll::Ready(Ok(data)) => {
                 this.future = None;
                 let bytes = Bytes::from(data);
-                this.joiner.position += bytes.len() as u64;
+                this.joiner.position += crate::cast::u64_from_usize(bytes.len());
                 let to_copy = bytes.len().min(buf.remaining());
                 buf.put_slice(&bytes[..to_copy]);
                 if to_copy < bytes.len() {

--- a/crates/primitives/src/file/mod.rs
+++ b/crates/primitives/src/file/mod.rs
@@ -151,7 +151,10 @@ pub(crate) fn resolve_seek_position(
     if new_pos < 0 {
         return Err(Error::new(InvalidInput, "seek to negative position"));
     }
-    Ok(new_pos as u64)
+    // new_pos >= 0 was just checked, so the i64 -> u64 conversion is lossless.
+    #[allow(clippy::as_conversions)]
+    let new_pos = new_pos as u64;
+    Ok(new_pos)
 }
 
 // ---- Primary async API ----

--- a/crates/primitives/src/file/mode.rs
+++ b/crates/primitives/src/file/mode.rs
@@ -64,11 +64,12 @@ pub trait JoinMode: Sized + 'static {
     #[inline]
     fn child_span<const BS: usize>(parent_span: u64, subspan: u64, child_index: usize) -> u64 {
         let branches = Self::refs_per_chunk(BS);
-        if child_index == branches - 1 {
-            let preceding = child_index as u64 * subspan;
+        let child_index = crate::cast::u64_from_usize(child_index);
+        if child_index == crate::cast::u64_from_usize(branches - 1) {
+            let preceding = child_index * subspan;
             parent_span.saturating_sub(preceding)
         } else {
-            subspan.min(parent_span.saturating_sub(child_index as u64 * subspan))
+            subspan.min(parent_span.saturating_sub(child_index * subspan))
         }
     }
 
@@ -229,11 +230,13 @@ impl EncryptedMode {
     /// Calculate data length for decryption of a chunk with given span.
     #[allow(clippy::arithmetic_side_effects)] // sub = subspan_size(..) >= BS > 0 for the div_ceil; num_children <= branches (sub covers at least span / branches), so the product is bounded by BS
     fn decrypt_data_length<const BS: usize>(span: u64) -> usize {
-        if span <= BS as u64 {
-            span as usize
+        if span <= crate::cast::u64_from_usize(BS) {
+            // span <= BS here, so it fits usize on all supported targets.
+            crate::cast::usize_from_u64(span)
         } else {
             let sub = Self::subspan_size::<BS>(span);
-            let num_children = span.div_ceil(sub) as usize;
+            // num_children <= branches (sub covers at least span / branches).
+            let num_children = crate::cast::usize_from_u64(span.div_ceil(sub));
             let raw = num_children * ENCRYPTED_REF_SIZE;
             raw.min(BS)
         }
@@ -346,6 +349,9 @@ fn decrypt_span<const BODY_SIZE: usize>(
         ));
     }
 
+    // BODY_SIZE / 32 is 128 for the default 4096-byte body and stays far
+    // below u32::MAX for any chunk-sized body.
+    #[allow(clippy::as_conversions)]
     let span_ctr = (BODY_SIZE / EncryptionKey::SIZE) as u32;
     let mut span_buf = [0u8; SPAN_SIZE];
     transcrypt(key, span_ctr, &encrypted_data[..SPAN_SIZE], &mut span_buf)

--- a/crates/primitives/src/file/read_at.rs
+++ b/crates/primitives/src/file/read_at.rs
@@ -23,7 +23,7 @@ pub trait ReadAt {
 impl ReadAt for [u8] {
     #[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)] // offset < self.len() is checked above, and to_read = min(buf.len(), self.len() - offset) bounds both slices
     fn read_at(&self, offset: u64, buf: &mut [u8]) -> io::Result<usize> {
-        let offset = offset as usize;
+        let offset = crate::cast::usize_from_u64(offset);
         if offset >= self.len() {
             return Ok(0);
         }
@@ -34,7 +34,7 @@ impl ReadAt for [u8] {
     }
 
     fn len(&self) -> u64 {
-        <[u8]>::len(self) as u64
+        crate::cast::u64_from_usize(<[u8]>::len(self))
     }
 }
 
@@ -44,7 +44,7 @@ impl ReadAt for Vec<u8> {
     }
 
     fn len(&self) -> u64 {
-        Self::len(self) as u64
+        crate::cast::u64_from_usize(Self::len(self))
     }
 }
 
@@ -54,7 +54,7 @@ impl ReadAt for Bytes {
     }
 
     fn len(&self) -> u64 {
-        Self::len(self) as u64
+        crate::cast::u64_from_usize(Self::len(self))
     }
 }
 

--- a/crates/primitives/src/file/splitter.rs
+++ b/crates/primitives/src/file/splitter.rs
@@ -60,14 +60,17 @@ where
 
         Self {
             span_length,
-            buffer: Vec::with_capacity(span_length.min(BODY_SIZE as u64 * 2) as usize),
+            // The capacity hint is clamped to 2 * BODY_SIZE, so it fits usize.
+            buffer: Vec::with_capacity(crate::cast::usize_from_u64(
+                span_length.min(crate::cast::u64_from_usize(BODY_SIZE) * 2),
+            )),
             _mode: PhantomData,
         }
     }
 
     /// Bytes written so far.
     pub const fn len(&self) -> u64 {
-        self.buffer.len() as u64
+        crate::cast::u64_from_usize(self.buffer.len())
     }
 
     /// Whether any data has been written.
@@ -87,10 +90,10 @@ where
 {
     /// Finalize, returning the root reference and the produced chunks.
     pub fn finish(self) -> Result<(M::RootRef, Vec<AnyChunk<BODY_SIZE>>)> {
-        if self.buffer.len() as u64 != self.span_length {
+        if crate::cast::u64_from_usize(self.buffer.len()) != self.span_length {
             return Err(FileError::SpanMismatch {
                 expected: self.span_length,
-                actual: self.buffer.len() as u64,
+                actual: crate::cast::u64_from_usize(self.buffer.len()),
             });
         }
 
@@ -109,7 +112,10 @@ where
 {
     #[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)] // span_length + 1 only renders the error message (span_length < u64::MAX in any reachable state); to_write <= buf.len() bounds the slice
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let remaining = self.span_length.saturating_sub(self.buffer.len() as u64) as usize;
+        let remaining = crate::cast::usize_from_u64(
+            self.span_length
+                .saturating_sub(crate::cast::u64_from_usize(self.buffer.len())),
+        );
         let to_write = buf.len().min(remaining);
         if to_write == 0 && !buf.is_empty() {
             return Err(io::Error::other(

--- a/crates/primitives/src/file/splitter_parallel.rs
+++ b/crates/primitives/src/file/splitter_parallel.rs
@@ -105,8 +105,9 @@ where
         let results: Vec<Result<M::RefBytes>> = (0..data_chunks)
             .into_par_iter()
             .map(|i| {
-                let offset = i * BODY_SIZE as u64;
-                let chunk_size = ((size - offset) as usize).min(BODY_SIZE);
+                let offset = i * crate::cast::u64_from_usize(BODY_SIZE);
+                // The min against BODY_SIZE bounds the chunk size.
+                let chunk_size = crate::cast::usize_from_u64(size - offset).min(BODY_SIZE);
 
                 let mut buf = vec![0u8; chunk_size];
                 source
@@ -116,7 +117,7 @@ where
                 let span = if i + 1 == data_chunks {
                     size - offset
                 } else {
-                    BODY_SIZE as u64
+                    crate::cast::u64_from_usize(BODY_SIZE)
                 };
 
                 let chunk_bytes = super::helpers::build_intermediate_payload(span, &buf);
@@ -164,7 +165,7 @@ where
     {
         let refs_per_chunk = M::refs_per_chunk(BODY_SIZE);
         let chunks_at_level = refs.len().div_ceil(refs_per_chunk);
-        let max_span = spans[level] * BODY_SIZE as u64;
+        let max_span = spans[level] * crate::cast::u64_from_usize(BODY_SIZE);
 
         let results: Vec<Result<M::RefBytes>> = (0..chunks_at_level)
             .into_par_iter()
@@ -179,7 +180,7 @@ where
                 }
 
                 let span = if i + 1 == chunks_at_level {
-                    total_size.saturating_sub(i as u64 * max_span)
+                    total_size.saturating_sub(crate::cast::u64_from_usize(i) * max_span)
                 } else {
                     max_span
                 };

--- a/crates/primitives/src/file/tree.rs
+++ b/crates/primitives/src/file/tree.rs
@@ -29,7 +29,7 @@ impl<const BODY_SIZE: usize> TreeParams<BODY_SIZE> {
         let (depth, data_chunks) = if size == 0 {
             (1, 1) // Empty file still produces one chunk
         } else {
-            let data_chunks = size.div_ceil(BODY_SIZE as u64);
+            let data_chunks = size.div_ceil(crate::cast::u64_from_usize(BODY_SIZE));
             let depth = Self::calculate_depth_with(data_chunks, branches);
             (depth, data_chunks)
         };
@@ -64,7 +64,7 @@ impl<const BODY_SIZE: usize> TreeParams<BODY_SIZE> {
         let mut chunks_at_level = self.data_chunks;
 
         while chunks_at_level > 1 {
-            chunks_at_level = chunks_at_level.div_ceil(self.branches as u64);
+            chunks_at_level = chunks_at_level.div_ceil(crate::cast::u64_from_usize(self.branches));
             total += chunks_at_level;
         }
 
@@ -83,7 +83,7 @@ impl<const BODY_SIZE: usize> TreeParams<BODY_SIZE> {
 
         let mut chunks = self.data_chunks;
         for _ in 0..level {
-            chunks = chunks.div_ceil(self.branches as u64);
+            chunks = chunks.div_ceil(crate::cast::u64_from_usize(self.branches));
         }
         chunks
     }
@@ -92,7 +92,7 @@ impl<const BODY_SIZE: usize> TreeParams<BODY_SIZE> {
     #[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)] // level < depth <= LEVEL_LIMIT = spans.len(); index < chunks_at_level and per-chunk spans partition the file size, so the products/sums stay within the u64 file span
     pub fn span_at(&self, level: usize, index: u64) -> u64 {
         let spans = super::constants::compute_spans_inline(self.branches);
-        let max_span = spans[level] * BODY_SIZE as u64;
+        let max_span = spans[level] * crate::cast::u64_from_usize(BODY_SIZE);
         let chunks_at_level = self.chunks_at_level(level);
 
         if index + 1 == chunks_at_level {
@@ -113,14 +113,14 @@ impl<const BODY_SIZE: usize> TreeParams<BODY_SIZE> {
     /// Byte offset for start of chunk at level 0.
     #[allow(clippy::arithmetic_side_effects)] // chunk_index < data_chunks, so the byte offset is bounded by the u64 file size
     pub const fn chunk_offset(&self, chunk_index: u64) -> u64 {
-        chunk_index * BODY_SIZE as u64
+        chunk_index * crate::cast::u64_from_usize(BODY_SIZE)
     }
 
     /// Byte range covered by a data chunk.
     #[allow(clippy::arithmetic_side_effects)] // start is bounded by the file size, so start + BODY_SIZE cannot overflow u64
     pub fn chunk_range(&self, chunk_index: u64) -> (u64, u64) {
         let start = self.chunk_offset(chunk_index);
-        let end = (start + BODY_SIZE as u64).min(self.size);
+        let end = (start + crate::cast::u64_from_usize(BODY_SIZE)).min(self.size);
         (start, end)
     }
 
@@ -132,8 +132,8 @@ impl<const BODY_SIZE: usize> TreeParams<BODY_SIZE> {
         }
 
         let end_offset = (offset + len).min(self.size);
-        let start_chunk = offset / BODY_SIZE as u64;
-        let end_chunk = end_offset.div_ceil(BODY_SIZE as u64);
+        let start_chunk = offset / crate::cast::u64_from_usize(BODY_SIZE);
+        let end_chunk = end_offset.div_ceil(crate::cast::u64_from_usize(BODY_SIZE));
 
         ChunkRange {
             start: start_chunk,
@@ -150,7 +150,7 @@ impl<const BODY_SIZE: usize> TreeParams<BODY_SIZE> {
         let mut depth = 1;
         let mut chunks = data_chunks;
         while chunks > 1 {
-            chunks = chunks.div_ceil(branches as u64);
+            chunks = chunks.div_ceil(crate::cast::u64_from_usize(branches));
             depth += 1;
         }
         depth.min(LEVEL_LIMIT)
@@ -201,16 +201,18 @@ pub(crate) fn assemble_range<const BODY_SIZE: usize>(
 
     for (i, chunk_idx) in chunk_range.iter().enumerate() {
         let (chunk_start, chunk_end) = tree.chunk_range(chunk_idx);
-        let chunk_data_len = (chunk_end - chunk_start) as usize;
+        // Per-chunk byte quantities: all bounded by BODY_SIZE, so they fit usize.
+        let chunk_data_len = crate::cast::usize_from_u64(chunk_end - chunk_start);
 
         let read_start = if chunk_start < offset {
-            (offset - chunk_start) as usize
+            crate::cast::usize_from_u64(offset - chunk_start)
         } else {
             0
         };
 
-        let read_end = if chunk_end > offset + actual_len as u64 {
-            chunk_data_len - ((chunk_end - offset - actual_len as u64) as usize)
+        let actual_len_u64 = crate::cast::u64_from_usize(actual_len);
+        let read_end = if chunk_end > offset + actual_len_u64 {
+            chunk_data_len - crate::cast::usize_from_u64(chunk_end - offset - actual_len_u64)
         } else {
             chunk_data_len
         };

--- a/crates/primitives/src/file/windowed.rs
+++ b/crates/primitives/src/file/windowed.rs
@@ -178,7 +178,7 @@ enum Resolved<M: JoinMode> {
 /// Is this node a leaf?
 #[inline]
 fn is_leaf<M: JoinMode, const BS: usize>(node: &SubtreeNode<M>) -> bool {
-    node.span <= BS as u64
+    node.span <= crate::cast::u64_from_usize(BS)
 }
 
 /// Fetch one node: a leaf yields its body, an intermediate yields its children.
@@ -304,8 +304,8 @@ where
     let mut leaf_queue = VecDeque::new();
     let mut node_queue = VecDeque::new();
     let mut pending_intermediate_offsets: BTreeMap<u64, usize> = BTreeMap::new();
-    let range_start_byte = chunk_range.start * BODY_SIZE as u64;
-    let range_end_byte = chunk_range.end * BODY_SIZE as u64;
+    let range_start_byte = chunk_range.start * crate::cast::u64_from_usize(BODY_SIZE);
+    let range_end_byte = chunk_range.end * crate::cast::u64_from_usize(BODY_SIZE);
     for st in subtrees {
         if st.byte_offset >= range_end_byte || st.byte_offset + st.span <= range_start_byte {
             continue;
@@ -351,7 +351,7 @@ where
                 .is_some_and(|(&k, _)| k == state.next_emit_offset);
             if head_ready {
                 let (_, body) = state.buffered.pop_first().expect("head just observed");
-                state.next_emit_offset += body.len() as u64;
+                state.next_emit_offset += crate::cast::u64_from_usize(body.len());
                 return Some((Ok(body), state));
             }
 
@@ -391,9 +391,10 @@ where
 
                 let getter = Arc::clone(&state.getter);
                 let range = state.chunk_range;
-                state.in_flight.push(Box::pin(async move {
+                let fut: BoxResolvedFuture<M> = Box::pin(async move {
                     fetch_one::<G, M, BODY_SIZE>(&*getter, &range, pending).await
-                }) as BoxResolvedFuture<M>);
+                });
+                state.in_flight.push(fut);
             }
 
             // In-flight leaf fetches plus buffered leaves never exceed `window`.
@@ -416,11 +417,13 @@ where
                     // Clip the first partial leaf at the read position; offsets
                     // stay absolute, so a boundary leaf buffers only its in-range
                     // tail keyed at the read position.
-                    let leaf_end = leaf_start + body.len() as u64;
+                    let leaf_end = leaf_start + crate::cast::u64_from_usize(body.len());
                     if leaf_end <= state.range_start {
                         continue;
                     }
-                    let clip_lo = state.range_start.saturating_sub(leaf_start) as usize;
+                    // clip_lo < body.len() (leaf_end > range_start above).
+                    let clip_lo =
+                        crate::cast::usize_from_u64(state.range_start.saturating_sub(leaf_start));
                     let offset = leaf_start.max(state.range_start);
                     state.buffered.insert(offset, body.slice(clip_lo..));
                 }
@@ -561,7 +564,7 @@ where
             Poll::Ready(Some(Ok(body))) => {
                 let to_copy = body.len().min(buf.remaining());
                 buf.put_slice(&body[..to_copy]);
-                this.reader.position += body.len() as u64;
+                this.reader.position += crate::cast::u64_from_usize(body.len());
                 if to_copy < body.len() {
                     this.residual = body.slice(to_copy..);
                 }

--- a/crates/primitives/src/file/write_at.rs
+++ b/crates/primitives/src/file/write_at.rs
@@ -63,7 +63,10 @@ impl WriteAt for std::fs::File {
         use std::os::windows::fs::FileExt;
         let mut written = 0;
         while written < buf.len() {
-            let n = self.seek_write(&buf[written..], offset + written as u64)?;
+            let n = self.seek_write(
+                &buf[written..],
+                offset + crate::cast::u64_from_usize(written),
+            )?;
             if n == 0 {
                 return Err(io::Error::from(io::ErrorKind::WriteZero));
             }
@@ -90,11 +93,13 @@ impl WriteAt for Mutex<Vec<u8>> {
         let mut vec = self
             .lock()
             .map_err(|_| io::Error::other("sink lock poisoned"))?;
-        let end = offset as usize + buf.len();
+        // In-memory sink: offsets are bounded by the Vec the sink grows.
+        let offset = crate::cast::usize_from_u64(offset);
+        let end = offset + buf.len();
         if vec.len() < end {
             vec.resize(end, 0);
         }
-        vec[offset as usize..end].copy_from_slice(buf);
+        vec[offset..end].copy_from_slice(buf);
         Ok(())
     }
 
@@ -102,7 +107,7 @@ impl WriteAt for Mutex<Vec<u8>> {
         let mut vec = self
             .lock()
             .map_err(|_| io::Error::other("sink lock poisoned"))?;
-        vec.resize(len as usize, 0);
+        vec.resize(crate::cast::usize_from_u64(len), 0);
         Ok(())
     }
 }
@@ -161,7 +166,7 @@ where
             sink.write_at(offset, &body)
                 .await
                 .map_err(FileError::sink)?;
-            written += body.len() as u64;
+            written += crate::cast::u64_from_usize(body.len());
             on_progress(written, total);
         }
         sink.flush().await.map_err(FileError::sink)?;

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -41,7 +41,8 @@
         clippy::arithmetic_side_effects,
         clippy::panic,
         clippy::unreachable,
-        clippy::panic_in_result_fn
+        clippy::panic_in_result_fn,
+        clippy::as_conversions
     )
 )]
 
@@ -52,6 +53,7 @@ pub mod address;
 pub mod bin;
 pub mod bmt;
 mod cache;
+mod cast;
 pub mod chunk;
 pub mod error;
 pub mod file;

--- a/crates/primitives/src/neighborhood_depth.rs
+++ b/crates/primitives/src/neighborhood_depth.rs
@@ -45,7 +45,8 @@ use crate::Bin;
 /// let depth = recompute_neighborhood_depth(&counts, 8, 2);
 /// assert!(depth.get() <= 8);
 /// ```
-#[allow(clippy::indexing_slicing)] // connected_per_bin[i] with i from the reversed 0..len() range
+#[allow(clippy::indexing_slicing, clippy::as_conversions)]
+// connected_per_bin[i] with i from the reversed 0..len() range; i < 32, so the bin-index casts to u8 are in range
 #[must_use]
 pub fn recompute_neighborhood_depth(
     connected_per_bin: &[u8; 32],

--- a/crates/primitives/src/timestamp.rs
+++ b/crates/primitives/src/timestamp.rs
@@ -59,9 +59,12 @@ impl Timestamp {
     /// and the browser clock on `wasm32`, so this runs on every supported
     /// target instead of panicking through the std unsupported-platform stub.
     ///
-    /// Panics only if the system clock is set before the unix epoch, which
-    /// would already break far more than this primitive. Pre-1970 callers
-    /// can construct via [`Self::from_seconds`] manually.
+    /// # Panics
+    ///
+    /// Only if the system clock is set before the unix epoch (or past
+    /// `i64::MAX` unix-seconds), which would already break far more than this
+    /// primitive. Pre-1970 callers can construct via [`Self::from_seconds`]
+    /// manually.
     #[allow(clippy::expect_used)] // documented invariants: panics only on a pre-1970 or absurdly far-future system clock
     pub fn now() -> Self {
         use web_time::{SystemTime, UNIX_EPOCH};

--- a/crates/swarms/src/named.rs
+++ b/crates/swarms/src/named.rs
@@ -52,6 +52,7 @@ macro_rules! impl_into_numeric {
     ($($t:ty)+) => {$(
         impl From<NamedSwarm> for $t {
             #[inline]
+            #[allow(clippy::as_conversions)] // repr(u64) discriminant {1, 10, 1337} fits all target types losslessly
             fn from(swarm: NamedSwarm) -> Self {
                 swarm as $t
             }
@@ -71,6 +72,28 @@ macro_rules! impl_try_from_numeric {
 
                 #[inline]
                 fn try_from(value: $native) -> Result<Self, Self::Error> {
+                    u64::from(value).try_into()
+                }
+            }
+        )+
+    };
+}
+
+impl_try_from_numeric!(u8 u16 u32);
+
+// Signed and pointer-sized inputs have no lossless `u64::from`. The `as u64`
+// cast sign-extends negative values (and zero-extends `usize`), so any value
+// outside the valid discriminant set {1, 10, 1337} keeps failing the
+// `try_into` discriminant check exactly as before.
+macro_rules! impl_try_from_numeric_lossy {
+    ($($native:ty)+) => {
+        $(
+            impl TryFrom<$native> for NamedSwarm {
+                type Error = TryFromPrimitiveError<Self>;
+
+                #[inline]
+                #[allow(clippy::as_conversions)] // extension to u64 cannot alias a valid discriminant
+                fn try_from(value: $native) -> Result<Self, Self::Error> {
                     (value as u64).try_into()
                 }
             }
@@ -78,7 +101,7 @@ macro_rules! impl_try_from_numeric {
     };
 }
 
-impl_try_from_numeric!(u8 i8 u16 i16 u32 i32 usize isize);
+impl_try_from_numeric_lossy!(i8 i16 i32 usize isize);
 
 impl fmt::Display for NamedSwarm {
     #[inline]
@@ -97,14 +120,14 @@ impl AsRef<str> for NamedSwarm {
 impl PartialEq<u64> for NamedSwarm {
     #[inline]
     fn eq(&self, other: &u64) -> bool {
-        (*self as u64) == *other
+        u64::from(*self) == *other
     }
 }
 
 impl PartialOrd<u64> for NamedSwarm {
     #[inline]
     fn partial_cmp(&self, other: &u64) -> Option<Ordering> {
-        (*self as u64).partial_cmp(other)
+        u64::from(*self).partial_cmp(other)
     }
 }
 
@@ -147,6 +170,7 @@ impl NamedSwarm {
 
     /// Returns the network ID for this swarm.
     #[inline]
+    #[allow(clippy::as_conversions)] // repr(u64) discriminant read; `u64::from` is not const-callable
     pub const fn id(&self) -> u64 {
         *self as u64
     }

--- a/crates/swarms/src/swarm.rs
+++ b/crates/swarms/src/swarm.rs
@@ -122,14 +122,10 @@ impl<'de> serde::Deserialize<'de> for Swarm {
             }
 
             fn visit_i64<E: serde::de::Error>(self, v: i64) -> Result<Self::Value, E> {
-                if v.is_negative() {
-                    Err(serde::de::Error::invalid_value(
-                        serde::de::Unexpected::Signed(v),
-                        &self,
-                    ))
-                } else {
-                    Ok(Swarm::from_id(v as u64))
-                }
+                // `u64::try_from(i64)` fails exactly when `v` is negative.
+                u64::try_from(v).map(Swarm::from_id).map_err(|_| {
+                    serde::de::Error::invalid_value(serde::de::Unexpected::Signed(v), &self)
+                })
             }
 
             fn visit_u64<E: serde::de::Error>(self, value: u64) -> Result<Self::Value, E> {
@@ -177,7 +173,7 @@ impl Swarm {
     #[inline]
     pub const fn id(self) -> u64 {
         match *self.kind() {
-            SwarmKind::Named(named) => named as u64,
+            SwarmKind::Named(named) => named.id(),
             SwarmKind::Id(id) => id,
         }
     }


### PR DESCRIPTION
## What

Flip `clippy::as_conversions` from allow to `deny` workspace-wide and resolve every resulting site (roughly 150) across `nectar-primitives`, `nectar-postage`, `nectar-swarms`, `nectar-mantaray`, `nectar-postage-issuer`, and `nectar-postage-usage`.

Behaviour-preserving: no public signatures, error types, or wire/encoding formats changed.

The config flip adds `clippy::as_conversions = "deny"` to the workspace lint table. The remaining commits fix casts one crate at a time.

### Per-crate cast fixes (from-widenings / try_from-narrowings / justified-allows)

| crate | from | try_from | allow | tests |
|---|---|---|---|---|
| nectar-primitives | 67 | 0 | 16 | 202 lib + 16 doctest (287+17 all-features) |
| nectar-postage | 0 | 0 | 4 | 47 unit + 1 doctest |
| nectar-swarms | 3 | 1 | 3 | 20 |
| nectar-mantaray | 14 | 1 | 7 | 72 unit + 4 integration + 3 doctest |
| nectar-postage-issuer | 5 | 0 | 24 | 52 unit + 1 doctest |
| nectar-postage-usage | 22 | 0 | 21 | 27 unit + 29 snapshot + 3 vector + 7 doctest |

### Strategy (behaviour-preserving)

1. Pure widening (`u8/u16/u32/usize` to `u64/usize`, provably lossless on every target): replaced with `T::from(x)`. No behaviour change, no new error path.
2. Narrowing on untrusted/attacker-controlled input where a rejection path made sense: replaced with `T::try_from(x)` mapped to the pre-existing error type, verified to preserve the exact accept/reject boundary and error payload. For example, `nectar-swarms` serde `visit_i64` now uses `u64::try_from(v).map_err(...)`, which accepts/rejects identically to the old `v.is_negative()` check; `nectar-mantaray` `Fork::encode_into` metadata-length guard now uses `u16::try_from` into the existing `MetadataTooLarge` error.
3. Provably-safe truncation (value bounded by prior validation, `const fn` where `T::from`/`try_from` is not const-callable, or truncation is the intended semantic such as extracting low bits): narrow, comment-justified `#[allow(clippy::as_conversions)]` at the expression or function level, never crate-wide.
4. Where the original cast already had no lossless equivalent and no sensible rejection path (for example `nectar-primitives::cast::usize_from_u64`, used on decode-path spans with no pre-existing error branch), the exact original truncation semantics, including pre-existing wasm32 truncation behaviour, were preserved verbatim via a documented crate-internal helper rather than introducing a new fallible path. Introducing one would have been a behaviour change, not a hardening.
5. A handful of `&mut T as *mut T` trait-object/pointer coercions were replaced with `std::ptr::from_mut` or explicit turbofish typing (byte-identical, not lossy casts, done for lint-cleanliness only).

No production `as` casts on untrusted decode paths were left un-justified; the two `try_from` red-team sites above were specifically flagged for adversarial review and came back clean (see Testing).

## Why

Closes #151.

Stacked on #150 (`fuzz/5-clippy-hardening`). Denying `as_conversions` forces every integer cast to be explicit and checked, removing a class of silent lossy-truncation bugs on decode and encode paths.

## Testing

Full-workspace gate:

```bash
cargo clippy --workspace --locked   # exit 0, zero warnings/errors, as_conversions deny holds
cargo test --workspace              # exit 0, all suites + doctests green
git status --porcelain              # empty, working tree clean
```

Per-crate spot checks used during implementation:

```bash
cargo clippy -p nectar-<crate> [--no-deps] [--all-features] [--all-targets]
cargo test -p nectar-<crate> [--all-features]
```

Observed: `cargo clippy --workspace --locked` exits 0 with the `deny` in place, and `cargo test --workspace` passes all listed unit, integration, doctest, snapshot, and vector suites.

## Known limits

- `benches/` and `tests/` targets are outside the enforced lint surface (CI runs `cargo clippy --workspace --locked` against lib targets only); some pre-existing `unwrap_used`/`indexing_slicing` diagnostics remain there under `--all-targets`, unrelated to this change and out of scope.
- `nectar-swarms/src/lib.rs` is missing the `#![cfg_attr(test, allow(...))]` exemption block present in postage/mantaray. Pre-existing, not introduced or fixed here, does not gate CI.
- One unrelated pre-existing `fmt` drift in `chunk_type_set.rs` was intentionally left untouched (reverted from an incidental fix) to keep the primitives change focused.
- Each crate was individually verified as clippy-clean and green before the dependent-crate compile issue (primitives blocking downstream `cargo clippy` without `--no-deps`) was resolved by the final `nectar-primitives` change; the workspace `cargo clippy --workspace --locked` run above confirms the full stack is clean end to end.

AI Assistance: Claude (Anthropic) used for the implementation, tests, and this PR description.

---
Supersedes #152, which was auto-closed and locked by GitHub after a botched force-push briefly zeroed its diff during a stack rebase; branch content is identical and tree-verified.
