### PR TITLE
style(cargo): canonical zepter feature-list formatting

### DIFF
--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -29,9 +29,9 @@ serde = { workspace = true, optional = true }
 proptest = { workspace = true }
 
 [features]
-default = ["std"]
-std = ["alloy-primitives/std", "alloy-sol-types/std", "serde?/std"]
-serde = ["dep:serde", "alloy-primitives/serde"]
+default = [ "std" ]
+std = [ "alloy-primitives/std", "alloy-sol-types/std", "serde?/std" ]
+serde = [ "alloy-primitives/serde", "dep:serde" ]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/mantaray/Cargo.toml
+++ b/crates/mantaray/Cargo.toml
@@ -40,18 +40,24 @@ name = "mantaray_bench"
 harness = false
 
 [features]
-default = ["std"]
-std = ["alloy-primitives/std", "thiserror/std", "serde_json/std", "rand", "nectar-primitives/std"]
+default = [ "std" ]
+std = [
+	"alloy-primitives/std",
+	"nectar-primitives/std",
+	"rand",
+	"serde_json/std",
+	"thiserror/std",
+]
 # Valid-by-construction `arbitrary::Arbitrary` impls for `Node`, `Fork`,
 # `Prefix`, `NodeType`, and `ObfuscationKey`, for structured (round-trip)
 # fuzz targets.
 arbitrary = [
-	"std",
+	"alloy-primitives/arbitrary",
 	"dep:arbitrary",
 	"nectar-primitives/arbitrary",
-	"alloy-primitives/arbitrary",
+	"std",
 ]
-encryption = ["nectar-primitives/encryption"]
+encryption = [ "nectar-primitives/encryption" ]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/postage-issuer/Cargo.toml
+++ b/crates/postage-issuer/Cargo.toml
@@ -48,24 +48,24 @@ harness = false
 required-features = ["parallel"]
 
 [features]
-default = ["std"]
+default = [ "std" ]
 
 # Standard library support
-std = ["nectar-postage/std"]
+std = [ "nectar-postage/std" ]
 
 # Local key signing for testing and development
-local-signer = ["dep:alloy-signer-local", "std"]
+local-signer = [ "dep:alloy-signer-local", "std" ]
 
 # Parallel signing operations using rayon
 parallel = [
 	"dep:rayon",
-	"std",
 	"nectar-postage/parallel",
-	"nectar-primitives/parallel"
+	"nectar-primitives/parallel",
+	"std",
 ]
 
 # Arbitrary trait implementations for property-based testing
-arbitrary = ["nectar-postage/arbitrary", "nectar-primitives/arbitrary"]
+arbitrary = [ "nectar-postage/arbitrary", "nectar-primitives/arbitrary" ]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/postage-usage/Cargo.toml
+++ b/crates/postage-usage/Cargo.toml
@@ -38,35 +38,40 @@ alloy-signer-local = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }
 
 [features]
-default = ["std"]
+default = [ "std" ]
 
 # Standard library support.
-std = ["nectar-postage/std", "nectar-postage-issuer/std", "alloy-primitives/std", "thiserror/std"]
+std = [
+	"alloy-primitives/std",
+	"nectar-postage-issuer/std",
+	"nectar-postage/std",
+	"thiserror/std",
+]
 
 # Valid-by-construction `arbitrary::Arbitrary` impls for `UsageTable`,
 # `Mutability`, and `Snapshot`, for structured (round-trip) fuzz targets.
 arbitrary = [
-	"std",
 	"dep:arbitrary",
-	"nectar-postage/arbitrary",
 	"nectar-postage-issuer/arbitrary",
-	"nectar-primitives/arbitrary"
+	"nectar-postage/arbitrary",
+	"nectar-primitives/arbitrary",
+	"std",
 ]
 
 # Implements `nectar_postage_issuer::StampIssuer` for `SnapshotIssuer` so a
 # snapshot can back a `BatchStamper` directly. The shared counter table that
 # backs every usage table already comes from the issuer crate; this feature adds
 # the `StampIssuer` adapter on top.
-issuer = ["std"]
+issuer = [ "std" ]
 
 # Turns persist plans into signed single-owner chunks and stamps.
-seal = ["dep:alloy-signer", "std"]
+seal = [ "dep:alloy-signer", "std" ]
 
 # High-level async facade (`BatchStamper`) that collapses the open / stamp /
 # flush cross-machine roam into three calls. The consumer supplies the network
 # through the `SnapshotSource` and `SnapshotSink` traits. Implies `seal` (it seals
 # every persist) and `std` (it reads the wall clock for the seal timestamp).
-client = ["std", "seal", "dep:auto_impl", "dep:web-time"]
+client = [ "dep:auto_impl", "dep:web-time", "seal", "std" ]
 
 [[example]]
 name = "roam_between_machines"

--- a/crates/postage/Cargo.toml
+++ b/crates/postage/Cargo.toml
@@ -51,24 +51,30 @@ harness = false
 required-features = ["parallel"]
 
 [features]
-default = ["std"]
+default = [ "std" ]
 
 # Standard library support. Enables BatchStore, BatchFactory, and timestamp functions.
-std = ["dep:web-time", "nectar-primitives/std", "alloy-primitives/std", "thiserror/std", "serde?/std"]
+std = [
+	"alloy-primitives/std",
+	"dep:web-time",
+	"nectar-primitives/std",
+	"serde?/std",
+	"thiserror/std",
+]
 
 # Serialization support with serde.
-serde = ["dep:serde", "nectar-primitives/serde", "alloy-primitives/serde"]
+serde = [ "alloy-primitives/serde", "dep:serde", "nectar-primitives/serde" ]
 
 # Parallel verification using rayon (sync, CPU-bound).
-parallel = [
-	"dep:rayon",
-	"std",
-	"nectar-primitives/parallel"
-]
+parallel = [ "dep:rayon", "nectar-primitives/parallel", "std" ]
 
 # Arbitrary trait implementations and valid-by-construction generators for
 # property-based testing and fuzzing.
-arbitrary = ["dep:arbitrary", "nectar-primitives/arbitrary", "alloy-primitives/arbitrary"]
+arbitrary = [
+	"alloy-primitives/arbitrary",
+	"dep:arbitrary",
+	"nectar-primitives/arbitrary",
+]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -88,7 +88,7 @@ proptest-arbitrary-interop.workspace = true
 rand.workspace = true
 
 [features]
-default = ["std"]
+default = [ "std" ]
 std = []
 # WASM thread pool via wasm-bindgen-rayon. OFF by default so the default wasm
 # build needs no SharedArrayBuffer / cross-origin isolation — letting it run on
@@ -97,7 +97,7 @@ std = []
 # requires shared memory). Must stay out of `default`: dependents pull this
 # crate with default features, so a default-on threads feature would be forced
 # on transitively and couldn't be opted out.
-wasm-threads = ["dep:wasm-bindgen-rayon"]
+wasm-threads = [ "dep:wasm-bindgen-rayon" ]
 # Plain-terminology umbrella for "run in parallel", matching the `parallel`
 # feature on nectar-postage and nectar-postage-issuer. Native builds already
 # parallelize through rayon, so this is a no-op there; on wasm32 it opts into the
@@ -105,16 +105,11 @@ wasm-threads = ["dep:wasm-bindgen-rayon"]
 # shared-memory / cross-origin-isolation requirement). Reach for `parallel` to
 # express intent; use `wasm-threads` directly only to toggle the wasm thread pool
 # on its own.
-parallel = ["wasm-threads"]
-serde = ["dep:serde"]
-arbitrary = [
-	"std",
-	"dep:rand",
-	"dep:arbitrary",
-	"alloy-primitives/arbitrary",
-]
-encryption = ["dep:rand"]
-tokio = ["dep:tokio"]
+parallel = [ "wasm-threads" ]
+serde = [ "dep:serde" ]
+arbitrary = [ "alloy-primitives/arbitrary", "dep:arbitrary", "dep:rand", "std" ]
+encryption = [ "dep:rand" ]
+tokio = [ "dep:tokio" ]
 
 [[bench]]
 name = "primitives"

--- a/crates/primitives/examples/wasm-demo/Cargo.toml
+++ b/crates/primitives/examples/wasm-demo/Cargo.toml
@@ -15,7 +15,7 @@ release = false
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["console_error_panic_hook"]
+default = [ "console_error_panic_hook" ]
 
 [dependencies]
 bytes.workspace = true

--- a/crates/swarms/Cargo.toml
+++ b/crates/swarms/Cargo.toml
@@ -30,10 +30,10 @@ proptest = { workspace = true }
 proptest-arbitrary-interop = { workspace = true }
 
 [features]
-default = ["std"]
-std = ["strum/std", "alloy-chains/std", "serde?/std"]
-serde = ["dep:serde", "alloy-chains/serde"]
-arbitrary = ["alloy-chains/arbitrary"]
+default = [ "std" ]
+std = [ "alloy-chains/std", "serde?/std", "strum/std" ]
+serde = [ "alloy-chains/serde", "dep:serde" ]
+arbitrary = [ "alloy-chains/arbitrary" ]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/zepter.yaml
+++ b/zepter.yaml
@@ -1,5 +1,5 @@
 # Enforce that std/serde/arbitrary/encryption/parallel propagate to workspace
-# dependencies. Run `zepter` at the workspace root to auto-fix.
+# dependencies, and keep feature lists formatted. Run `zepter` to auto-fix.
 version:
   format: 1
   binary: 1.88.1
@@ -16,8 +16,10 @@ workflows:
         "--show-path",
         "--quiet",
       ]
+    - ["format", "features"]
   default:
     - [$check.0, "--fix"]
+    - ["format", "features", "--fix"]
 
 help:
   text: |


### PR DESCRIPTION
## What

Runs `zepter format features` across every workspace `Cargo.toml`, producing sorted and normalized feature lists, and adds the `format features` step to the zepter gate so the formatting is enforced going forward.

This is purely cosmetic: no dependency changes and no feature-set changes. It sits at the top of the workspace-hygiene and fuzz/lint train rather than at the base, so it settles the final `Cargo.toml` shape without creating rebase conflicts against the feature edits in the units below (`arbitrary`, `serde`, propagation).

## Why

Closes #155.

Feature lists across the workspace were unsorted and inconsistently formatted. Enforcing a single canonical layout via the zepter gate keeps future diffs minimal and prevents drift.

## Testing

    zepter run check       # now runs propagation plus format
    cargo build --workspace

`zepter run check` passes with the `format features` step enabled, confirming the tree is already in canonical form. `cargo build --workspace` succeeds, confirming the reformatting introduced no dependency or feature-set changes.

---
Top of the train, stacked on #152 (`fuzz/6-maximal-casts`).

AI Assistance: Claude (Anthropic) used for the configuration, reformatting, and this PR description.

---
Supersedes #156 (same auto-close incident as #152); branch content identical and tree-verified.
