### PR TITLE
refactor(primitives): make ChunkAddress a distinct type and share XOR ops

### DIFF
--- a/crates/postage-issuer/benches/sign.rs
+++ b/crates/postage-issuer/benches/sign.rs
@@ -22,15 +22,15 @@ use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_mai
 use nectar_postage_issuer::{
     BatchId, BatchStamper, MemoryIssuer, ShardedIssuer, SigningError, Stamper, sign_stamps_parallel,
 };
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::ChunkAddress;
 use rand::RngExt;
 
-/// Generate a random SwarmAddress for benchmarking.
-fn random_address() -> SwarmAddress {
+/// Generate a random ChunkAddress for benchmarking.
+fn random_address() -> ChunkAddress {
     let mut rng = rand::rng();
     let mut bytes = [0u8; 32];
     rng.fill(&mut bytes);
-    SwarmAddress::new(bytes)
+    ChunkAddress::new(bytes)
 }
 
 // Mock Signer (for measuring non-crypto overhead)
@@ -64,7 +64,7 @@ fn bench_stamper_mock(c: &mut Criterion) {
         })
     });
 
-    let addresses: Vec<SwarmAddress> = (0..1000).map(|_| random_address()).collect();
+    let addresses: Vec<ChunkAddress> = (0..1000).map(|_| random_address()).collect();
     group.throughput(Throughput::Elements(1000));
 
     group.bench_function("throughput_1000", |b| {
@@ -84,7 +84,7 @@ fn bench_stamper_mock(c: &mut Criterion) {
 
 fn bench_ecdsa_sign_sequential(c: &mut Criterion) {
     let signer = PrivateKeySigner::random();
-    let addresses: Vec<SwarmAddress> = (0..100).map(|_| random_address()).collect();
+    let addresses: Vec<ChunkAddress> = (0..100).map(|_| random_address()).collect();
 
     let mut group = c.benchmark_group("ecdsa_sign_sequential");
 
@@ -116,8 +116,8 @@ fn bench_ecdsa_sign_sequential(c: &mut Criterion) {
 
 fn bench_ecdsa_sign_parallel(c: &mut Criterion) {
     let signer = PrivateKeySigner::random();
-    let addresses_100: Vec<SwarmAddress> = (0..100).map(|_| random_address()).collect();
-    let addresses_1000: Vec<SwarmAddress> = (0..1000).map(|_| random_address()).collect();
+    let addresses_100: Vec<ChunkAddress> = (0..100).map(|_| random_address()).collect();
+    let addresses_1000: Vec<ChunkAddress> = (0..1000).map(|_| random_address()).collect();
 
     // Use sign_message_sync for EIP-191 compatibility
     let sign_fn = |prehash: &B256| -> Result<Signature, SigningError> {
@@ -151,7 +151,7 @@ fn bench_ecdsa_sign_parallel(c: &mut Criterion) {
 
 fn bench_sign_comparison(c: &mut Criterion) {
     let signer = PrivateKeySigner::random();
-    let addresses: Vec<SwarmAddress> = (0..1000).map(|_| random_address()).collect();
+    let addresses: Vec<ChunkAddress> = (0..1000).map(|_| random_address()).collect();
 
     // Use sign_message_sync for EIP-191 compatibility
     let sign_fn = |prehash: &B256| -> Result<Signature, SigningError> {

--- a/crates/postage-issuer/src/issuer.rs
+++ b/crates/postage-issuer/src/issuer.rs
@@ -3,7 +3,7 @@
 use crate::counter::{CounterMode, CounterTable};
 use crate::error::IssuerError;
 use nectar_postage::{Batch, BatchId, StampDigest, StampError, StampIndex, calculate_bucket};
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::ChunkAddress;
 
 /// A trait for managing stamp issuance within a batch.
 ///
@@ -21,12 +21,12 @@ use nectar_primitives::SwarmAddress;
 ///
 /// ```ignore
 /// use nectar_postage_issuer::{StampIssuer, StampDigest, StampError};
-/// use nectar_primitives::SwarmAddress;
+/// use nectar_primitives::ChunkAddress;
 ///
 /// struct MyIssuer { /* ... */ }
 ///
 /// impl StampIssuer for MyIssuer {
-///     fn prepare_stamp(&mut self, address: &SwarmAddress, timestamp: u64) -> Result<StampDigest, StampError> {
+///     fn prepare_stamp(&mut self, address: &ChunkAddress, timestamp: u64) -> Result<StampDigest, StampError> {
 ///         // Allocate index and return digest
 ///         todo!()
 ///     }
@@ -59,7 +59,7 @@ pub trait StampIssuer {
     /// Returns `StampError::BucketFull` if the bucket has no remaining capacity.
     fn prepare_stamp(
         &mut self,
-        address: &SwarmAddress,
+        address: &ChunkAddress,
         timestamp: u64,
     ) -> Result<StampDigest, StampError>;
 
@@ -204,7 +204,7 @@ impl MemoryIssuer {
 impl StampIssuer for MemoryIssuer {
     fn prepare_stamp(
         &mut self,
-        address: &SwarmAddress,
+        address: &ChunkAddress,
         timestamp: u64,
     ) -> Result<StampDigest, StampError> {
         let bucket = calculate_bucket(address, self.counters.bucket_depth());
@@ -262,7 +262,7 @@ impl StampIssuer for MemoryIssuer {
 mod tests {
     use super::*;
 
-    fn test_address(leading: u16) -> SwarmAddress {
+    fn test_address(leading: u16) -> ChunkAddress {
         let mut bytes = [0u8; 32];
         // Big-endian split of a u16: `leading >> 8` is <= 0xFF and the low-byte
         // truncation is the intended extraction; both casts are lossless.
@@ -271,7 +271,7 @@ mod tests {
             bytes[0] = (leading >> 8) as u8;
             bytes[1] = leading as u8;
         }
-        SwarmAddress::new(bytes)
+        ChunkAddress::new(bytes)
     }
 
     #[test]

--- a/crates/postage-issuer/src/lib.rs
+++ b/crates/postage-issuer/src/lib.rs
@@ -53,7 +53,7 @@
 //!
 //! ```ignore
 //! use nectar_postage_issuer::{BatchId, BatchStamper, MemoryIssuer, Stamper};
-//! use nectar_primitives::SwarmAddress;
+//! use nectar_primitives::ChunkAddress;
 //! use alloy_signer_local::PrivateKeySigner;
 //!
 //! // Create an issuer for a batch

--- a/crates/postage-issuer/src/ring.rs
+++ b/crates/postage-issuer/src/ring.rs
@@ -31,7 +31,7 @@ use alloc::collections::BTreeSet;
 use alloc::vec::Vec;
 
 use nectar_postage::{Batch, BatchId, StampDigest, StampError, StampIndex, calculate_bucket};
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::ChunkAddress;
 
 use crate::StampIssuer;
 use crate::counter::{CounterError, CounterMode, CounterTable};
@@ -284,7 +284,7 @@ impl<R: Reservation> RingIssuer<R> {
     /// impossible at real batch depths.
     fn prepare_ring_stamp(
         &mut self,
-        address: &SwarmAddress,
+        address: &ChunkAddress,
         timestamp: u64,
     ) -> Result<StampDigest, IssuerError> {
         let bucket = calculate_bucket(address, self.counters.bucket_depth());
@@ -322,7 +322,7 @@ impl<R: Reservation> RingIssuer<R> {
 impl<R: Reservation> StampIssuer for RingIssuer<R> {
     fn prepare_stamp(
         &mut self,
-        address: &SwarmAddress,
+        address: &ChunkAddress,
         timestamp: u64,
     ) -> Result<StampDigest, StampError> {
         // A ring never reports BucketFull; the only failure is a fully reserved
@@ -393,7 +393,7 @@ impl<R: Reservation> StampIssuer for RingIssuer<R> {
 mod tests {
     use super::*;
 
-    fn test_address(leading: u16) -> SwarmAddress {
+    fn test_address(leading: u16) -> ChunkAddress {
         let mut bytes = [0u8; 32];
         // Big-endian split of a u16: `leading >> 8` is <= 0xFF and the low-byte
         // truncation is the intended extraction; both casts are lossless.
@@ -402,7 +402,7 @@ mod tests {
             bytes[0] = (leading >> 8) as u8;
             bytes[1] = leading as u8;
         }
-        SwarmAddress::new(bytes)
+        ChunkAddress::new(bytes)
     }
 
     fn mutable_batch(depth: u8, bucket_depth: u8) -> Batch {

--- a/crates/postage-issuer/src/sharded.rs
+++ b/crates/postage-issuer/src/sharded.rs
@@ -17,7 +17,7 @@ use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 
 use crate::error::IssuerError;
 use nectar_postage::{Batch, BatchId, StampDigest, StampError, StampIndex, calculate_bucket};
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::ChunkAddress;
 
 #[cfg(feature = "parallel")]
 use {
@@ -256,7 +256,7 @@ impl ShardedIssuer {
     /// This is thread-safe and can be called concurrently from multiple threads.
     pub fn prepare_stamp(
         &self,
-        address: &SwarmAddress,
+        address: &ChunkAddress,
         timestamp: u64,
     ) -> Result<StampDigest, StampError> {
         let bucket = calculate_bucket(address, self.bucket_depth);
@@ -349,7 +349,7 @@ impl ShardedIssuer {
 #[derive(Debug)]
 pub struct StampResult {
     /// The chunk address that was stamped.
-    pub address: SwarmAddress,
+    pub address: ChunkAddress,
     /// The resulting stamp, or error message.
     pub result: Result<Stamp, SigningError>,
 }
@@ -383,7 +383,7 @@ pub struct StampResult {
 /// use alloy_signer::SignerSync;
 ///
 /// let issuer = ShardedIssuer::new(BatchId::ZERO, 20, 16);
-/// let addresses: Vec<SwarmAddress> = /* ... */;
+/// let addresses: Vec<ChunkAddress> = /* ... */;
 /// // Use sign_message_sync for EIP-191 compatibility
 /// let signer_fn = |prehash: &B256| signer.sign_message_sync(prehash.as_slice());
 /// let results = sign_stamps_parallel(&issuer, &signer_fn, &addresses);
@@ -392,7 +392,7 @@ pub struct StampResult {
 pub fn sign_stamps_parallel<S, E>(
     issuer: &ShardedIssuer,
     signer: &S,
-    addresses: &[SwarmAddress],
+    addresses: &[ChunkAddress],
 ) -> Vec<StampResult>
 where
     S: Fn(&B256) -> Result<Signature, E> + Sync,
@@ -416,7 +416,7 @@ where
 fn sign_stamp_internal<S, E>(
     issuer: &ShardedIssuer,
     signer: &S,
-    address: &SwarmAddress,
+    address: &ChunkAddress,
 ) -> Result<Stamp, SigningError>
 where
     S: Fn(&B256) -> Result<Signature, E>,
@@ -478,7 +478,7 @@ mod tests {
     #[test]
     fn test_sharded_issuer_prepare_stamp() {
         let issuer = ShardedIssuer::new(BatchId::ZERO, 20, 16);
-        let address = SwarmAddress::from(B256::random());
+        let address = ChunkAddress::from(B256::random());
 
         let digest = issuer.prepare_stamp(&address, 12345).unwrap();
 
@@ -491,7 +491,7 @@ mod tests {
     fn test_sharded_issuer_dilute_grows_capacity_only() {
         // depth=17, bucket_depth=16 gives 2 slots per bucket.
         let mut issuer = ShardedIssuer::new(BatchId::ZERO, 17, 16);
-        let address = SwarmAddress::from(B256::repeat_byte(0xAB));
+        let address = ChunkAddress::from(B256::repeat_byte(0xAB));
         let bucket = calculate_bucket(&address, 16);
 
         issuer.prepare_stamp(&address, 1).unwrap();
@@ -529,7 +529,7 @@ mod tests {
                 let issuer = Arc::clone(&issuer);
                 thread::spawn(move || {
                     for _ in 0..stamps_per_thread {
-                        let addr = SwarmAddress::from(B256::random());
+                        let addr = ChunkAddress::from(B256::random());
                         issuer.prepare_stamp(&addr, 0).unwrap();
                     }
                 })
@@ -557,7 +557,7 @@ mod tests {
         let signer = PrivateKeySigner::random();
 
         let addresses: Vec<_> = (0..100)
-            .map(|_| SwarmAddress::from(B256::random()))
+            .map(|_| ChunkAddress::from(B256::random()))
             .collect();
 
         let sign_fn = |prehash: &B256| -> Result<Signature, SigningError> {

--- a/crates/postage-issuer/src/sharded_ring.rs
+++ b/crates/postage-issuer/src/sharded_ring.rs
@@ -18,7 +18,7 @@
 use std::sync::Mutex;
 
 use nectar_postage::{Batch, BatchId, StampDigest, StampError, StampIndex, calculate_bucket};
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::ChunkAddress;
 
 use crate::error::IssuerError;
 use crate::ring::{Reservation, Reserved, Unreserved};
@@ -307,7 +307,7 @@ impl<R: Reservation> ShardedRingIssuer<R> {
     /// already panicked; propagating the panic is the intended behavior.
     pub fn prepare_stamp(
         &self,
-        address: &SwarmAddress,
+        address: &ChunkAddress,
         timestamp: u64,
     ) -> Result<StampDigest, StampError> {
         let bucket = calculate_bucket(address, self.bucket_depth);
@@ -419,7 +419,7 @@ impl<R: Reservation> ShardedRingIssuer<R> {
 mod tests {
     use super::*;
 
-    fn test_address(leading: u16) -> SwarmAddress {
+    fn test_address(leading: u16) -> ChunkAddress {
         let mut bytes = [0u8; 32];
         // Big-endian split of a u16: `leading >> 8` is <= 0xFF and the low-byte
         // truncation is the intended extraction; both casts are lossless.
@@ -428,7 +428,7 @@ mod tests {
             bytes[0] = (leading >> 8) as u8;
             bytes[1] = leading as u8;
         }
-        SwarmAddress::new(bytes)
+        ChunkAddress::new(bytes)
     }
 
     fn mutable_batch(depth: u8, bucket_depth: u8) -> Batch {

--- a/crates/postage-issuer/src/stamper.rs
+++ b/crates/postage-issuer/src/stamper.rs
@@ -15,7 +15,7 @@ use alloy_signer::SignerSync;
 use crate::StampIssuer;
 use crate::error::SigningError;
 use nectar_postage::{BatchId, Stamp, StampDigest, StampError, current_timestamp};
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::ChunkAddress;
 
 /// A trait for entities that can stamp chunks.
 ///
@@ -26,14 +26,14 @@ use nectar_primitives::SwarmAddress;
 ///
 /// ```ignore
 /// use nectar_postage_issuer::{Stamper, Stamp, StampError, BatchId};
-/// use nectar_primitives::SwarmAddress;
+/// use nectar_primitives::ChunkAddress;
 ///
 /// struct MyStamper { /* ... */ }
 ///
 /// impl Stamper for MyStamper {
 ///     type Error = StampError;
 ///
-///     fn stamp(&mut self, address: &SwarmAddress) -> Result<Stamp, Self::Error> {
+///     fn stamp(&mut self, address: &ChunkAddress) -> Result<Stamp, Self::Error> {
 ///         // Implementation details...
 ///     }
 ///
@@ -61,7 +61,7 @@ pub trait Stamper {
     /// - The bucket is full
     /// - Signature generation fails
     /// - Any other implementation-specific error occurs
-    fn stamp(&mut self, address: &SwarmAddress) -> Result<Stamp, Self::Error>;
+    fn stamp(&mut self, address: &ChunkAddress) -> Result<Stamp, Self::Error>;
 
     /// Returns the batch ID that stamps are issued for.
     fn batch_id(&self) -> BatchId;
@@ -155,7 +155,7 @@ where
     /// but does not sign it. Use this for async signing flows.
     pub fn prepare_stamp(
         &mut self,
-        address: &SwarmAddress,
+        address: &ChunkAddress,
         timestamp: u64,
     ) -> Result<StampDigest, StampError> {
         self.issuer.prepare_stamp(address, timestamp)
@@ -169,7 +169,7 @@ where
 {
     type Error = SigningError;
 
-    fn stamp(&mut self, address: &SwarmAddress) -> Result<Stamp, Self::Error> {
+    fn stamp(&mut self, address: &ChunkAddress) -> Result<Stamp, Self::Error> {
         let timestamp = current_timestamp();
         let digest = self.issuer.prepare_stamp(address, timestamp)?;
         let prehash = digest.to_prehash();
@@ -221,7 +221,7 @@ mod tests {
         let issuer = MemoryIssuer::new(BatchId::ZERO, 20, 16);
         let mut stamper = BatchStamper::new(issuer, MockSigner);
 
-        let address = SwarmAddress::new([0xAB; 32]);
+        let address = ChunkAddress::new([0xAB; 32]);
         let stamp = stamper.stamp(&address).unwrap();
 
         assert_eq!(stamp.batch(), BatchId::ZERO);
@@ -235,7 +235,7 @@ mod tests {
         let mut stamper = BatchStamper::new(issuer, MockSigner);
 
         // Use same address to hit same bucket
-        let address = SwarmAddress::new([0xAB; 32]);
+        let address = ChunkAddress::new([0xAB; 32]);
 
         let stamp1 = stamper.stamp(&address).unwrap();
         let stamp2 = stamper.stamp(&address).unwrap();
@@ -259,7 +259,7 @@ mod tests {
         let issuer = MemoryIssuer::new(BatchId::ZERO, 17, 16);
         let mut stamper = BatchStamper::new(issuer, MockSigner);
 
-        let address = SwarmAddress::new([0xAB; 32]);
+        let address = ChunkAddress::new([0xAB; 32]);
 
         // First two stamps should succeed
         assert!(stamper.stamp(&address).is_ok());
@@ -280,7 +280,7 @@ mod tests {
 
         assert_eq!(stamper.max_bucket_utilization(), 0);
 
-        let address = SwarmAddress::new([0xAB; 32]);
+        let address = ChunkAddress::new([0xAB; 32]);
         stamper.stamp(&address).unwrap();
         assert_eq!(stamper.max_bucket_utilization(), 1);
 
@@ -290,7 +290,7 @@ mod tests {
 
     #[test]
     fn test_stamp_digest_prehash() {
-        let address = SwarmAddress::new([0xAB; 32]);
+        let address = ChunkAddress::new([0xAB; 32]);
         let batch_id = BatchId::ZERO;
         let index = StampIndex::new(100, 5);
         let timestamp = 1234567890u64;
@@ -395,7 +395,7 @@ mod tests {
             "Go uses v=28 (0x1c) for odd y parity"
         );
 
-        let chunk_address = SwarmAddress::new(chunk_addr_bytes.try_into().unwrap());
+        let chunk_address = ChunkAddress::new(chunk_addr_bytes.try_into().unwrap());
         let digest = StampDigest::new(
             chunk_address,
             stamp.batch(),

--- a/crates/postage-usage/examples/roam_between_machines.rs
+++ b/crates/postage-usage/examples/roam_between_machines.rs
@@ -45,8 +45,8 @@ use alloy_signer_local::PrivateKeySigner;
 use bytes::Bytes;
 use nectar_postage::{Batch, BatchId};
 use nectar_postage_usage::{
-    BatchStamper, Mutability, PublishedSequence, SealedChunk, Snapshot, SnapshotSink,
-    SnapshotSource, SwarmAddress, UsageError, UsageTable,
+    BatchStamper, ChunkAddress, Mutability, PublishedSequence, SealedChunk, Snapshot, SnapshotSink,
+    SnapshotSource, UsageError, UsageTable,
 };
 use nectar_primitives::Chunk;
 
@@ -62,7 +62,7 @@ const BUCKET_DEPTH: u8 = 16;
 /// the bytes on the wire.
 #[derive(Clone, Default)]
 struct MemNet {
-    chunks: Arc<Mutex<HashMap<SwarmAddress, Bytes>>>,
+    chunks: Arc<Mutex<HashMap<ChunkAddress, Bytes>>>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -71,7 +71,7 @@ struct MemError;
 
 impl SnapshotSource for MemNet {
     type Error = MemError;
-    async fn fetch(&self, address: &SwarmAddress) -> Result<Option<Bytes>, Self::Error> {
+    async fn fetch(&self, address: &ChunkAddress) -> Result<Option<Bytes>, Self::Error> {
         Ok(self.chunks.lock().unwrap().get(address).cloned())
     }
 }
@@ -131,7 +131,7 @@ async fn machine_a(
 
     // Issue a content stamp. This is local: no network round trip, and the
     // reserved snapshot slots can never be assigned to content.
-    let content = SwarmAddress::from(B256::repeat_byte(0x99));
+    let content = ChunkAddress::from(B256::repeat_byte(0x99));
     let stamp_index = stamper.stamp(&content)?;
     println!(
         "issued a content stamp at bucket {}, slot {}",
@@ -175,7 +175,7 @@ async fn machine_b(
     // Resume issuing from the recovered state. A different content chunk lands in
     // a different bucket, advancing that counter without disturbing the
     // snapshot's own reserved slots.
-    let content = SwarmAddress::from(B256::repeat_byte(0xab));
+    let content = ChunkAddress::from(B256::repeat_byte(0xab));
     let stamp_index = stamper.stamp(&content)?;
     println!(
         "issued a content stamp at bucket {}, slot {}",

--- a/crates/postage-usage/src/client.rs
+++ b/crates/postage-usage/src/client.rs
@@ -34,7 +34,7 @@ use alloy_primitives::Address;
 use alloy_signer::SignerSync;
 use bytes::Bytes;
 use nectar_postage::{Batch, BatchId, StampIndex};
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::ChunkAddress;
 use thiserror::Error;
 
 use crate::codec::RootInfo;
@@ -68,7 +68,7 @@ pub trait SnapshotSource {
     /// browser transport with a `!Send` future can still implement this trait.
     fn fetch(
         &self,
-        address: &SwarmAddress,
+        address: &ChunkAddress,
     ) -> impl core::future::Future<Output = Result<Option<Bytes>, Self::Error>>;
 }
 
@@ -240,7 +240,7 @@ where
     /// chunks. Persist the resulting state with [`flush`](Self::flush).
     pub fn stamp(
         &mut self,
-        content: &SwarmAddress,
+        content: &ChunkAddress,
     ) -> Result<StampIndex, ClientError<Src::Error, Snk::Error>> {
         Ok(self.snapshot.issuer(self.owner).record_address(content)?)
     }
@@ -345,7 +345,7 @@ mod tests {
     /// [`SnapshotSink`], keyed by single-owner-chunk address.
     #[derive(Debug, Default, Clone)]
     struct MemNet {
-        chunks: std::sync::Arc<Mutex<BTreeMap<SwarmAddress, Bytes>>>,
+        chunks: std::sync::Arc<Mutex<BTreeMap<ChunkAddress, Bytes>>>,
     }
 
     #[derive(Debug, Error)]
@@ -354,7 +354,7 @@ mod tests {
 
     impl SnapshotSource for MemNet {
         type Error = MemError;
-        async fn fetch(&self, address: &SwarmAddress) -> Result<Option<Bytes>, Self::Error> {
+        async fn fetch(&self, address: &ChunkAddress) -> Result<Option<Bytes>, Self::Error> {
             Ok(self.chunks.lock().unwrap().get(address).cloned())
         }
     }
@@ -377,7 +377,7 @@ mod tests {
 
     impl SnapshotSource for FailingSource {
         type Error = MemError;
-        async fn fetch(&self, _address: &SwarmAddress) -> Result<Option<Bytes>, Self::Error> {
+        async fn fetch(&self, _address: &ChunkAddress) -> Result<Option<Bytes>, Self::Error> {
             Err(MemError)
         }
     }
@@ -398,7 +398,7 @@ mod tests {
         type Error = MemError;
         fn fetch(
             &self,
-            _address: &SwarmAddress,
+            _address: &ChunkAddress,
         ) -> impl core::future::Future<Output = Result<Option<Bytes>, Self::Error>> {
             let hold = self.0.clone();
             async move {
@@ -458,7 +458,7 @@ mod tests {
             .unwrap();
         assert_eq!(stamper.snapshot().sequence(), 0);
 
-        let content = SwarmAddress::from(B256::repeat_byte(0x99));
+        let content = ChunkAddress::from(B256::repeat_byte(0x99));
         stamper.stamp(&content).unwrap();
         assert!(stamper.is_dirty());
 
@@ -483,7 +483,7 @@ mod tests {
             let mut a = BatchStamper::open(signer.clone(), &batch, net.clone(), net.clone())
                 .await
                 .unwrap();
-            a.stamp(&SwarmAddress::from(B256::repeat_byte(0x99)))
+            a.stamp(&ChunkAddress::from(B256::repeat_byte(0x99)))
                 .unwrap();
             a.flush().await.unwrap();
         }
@@ -532,7 +532,7 @@ mod tests {
             persisted_this_session: false,
         };
         stamper
-            .stamp(&SwarmAddress::from(B256::repeat_byte(0x99)))
+            .stamp(&ChunkAddress::from(B256::repeat_byte(0x99)))
             .unwrap();
 
         let result = stamper.flush().await;
@@ -554,14 +554,14 @@ mod tests {
             .await
             .unwrap();
         stamper
-            .stamp(&SwarmAddress::from(B256::repeat_byte(0x99)))
+            .stamp(&ChunkAddress::from(B256::repeat_byte(0x99)))
             .unwrap();
         stamper.flush().await.unwrap();
         let slots_after_first = stamper.snapshot().allocated_slots().to_vec();
         assert_eq!(stamper.snapshot().sequence(), 1);
 
         stamper
-            .stamp(&SwarmAddress::from(B256::repeat_byte(0xab)))
+            .stamp(&ChunkAddress::from(B256::repeat_byte(0xab)))
             .unwrap();
         stamper.flush().await.unwrap();
         assert_eq!(stamper.snapshot().sequence(), 2, "sequence advanced");
@@ -584,10 +584,10 @@ mod tests {
             let mut a = BatchStamper::open(signer.clone(), &batch, net.clone(), net.clone())
                 .await
                 .unwrap();
-            a.stamp(&SwarmAddress::from(B256::repeat_byte(0x01)))
+            a.stamp(&ChunkAddress::from(B256::repeat_byte(0x01)))
                 .unwrap();
             a.flush().await.unwrap();
-            a.stamp(&SwarmAddress::from(B256::repeat_byte(0x02)))
+            a.stamp(&ChunkAddress::from(B256::repeat_byte(0x02)))
                 .unwrap();
             a.flush().await.unwrap();
             assert_eq!(a.snapshot().sequence(), 2);
@@ -614,7 +614,7 @@ mod tests {
             snapshot: stale,
             persisted_this_session: false,
         };
-        b.stamp(&SwarmAddress::from(B256::repeat_byte(0x03)))
+        b.stamp(&ChunkAddress::from(B256::repeat_byte(0x03)))
             .unwrap();
         let result = b.flush().await;
         assert!(

--- a/crates/postage-usage/src/issuer.rs
+++ b/crates/postage-usage/src/issuer.rs
@@ -4,7 +4,7 @@
 use alloy_primitives::Address;
 use nectar_postage::{BatchId, StampDigest, StampError};
 use nectar_postage_issuer::StampIssuer;
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::ChunkAddress;
 
 use crate::Snapshot;
 use crate::error::UsageError;
@@ -62,7 +62,7 @@ impl SnapshotIssuer {
 impl StampIssuer for SnapshotIssuer {
     fn prepare_stamp(
         &mut self,
-        address: &SwarmAddress,
+        address: &ChunkAddress,
         timestamp: u64,
     ) -> core::result::Result<StampDigest, StampError> {
         let index = self

--- a/crates/postage-usage/src/lib.rs
+++ b/crates/postage-usage/src/lib.rs
@@ -27,7 +27,7 @@
 //! ```
 //! use alloy_primitives::{Address, B256};
 //! use nectar_postage_usage::{
-//!     BatchId, Mutability, PublishedSequence, RootInfo, Snapshot, SwarmAddress, UsageTable,
+//!     BatchId, Mutability, PublishedSequence, RootInfo, Snapshot, ChunkAddress, UsageTable,
 //! };
 //!
 //! let batch_id = BatchId::new([0x42; 32]);
@@ -37,7 +37,7 @@
 //! // then plan a persist.
 //! let table = UsageTable::new(batch_id, 20, 16, Mutability::Immutable).unwrap();
 //! let mut snapshot = Snapshot::new(table);
-//! let address = SwarmAddress::from(B256::repeat_byte(0x99));
+//! let address = ChunkAddress::from(B256::repeat_byte(0x99));
 //! snapshot.issuer(owner).record_address(&address).unwrap();
 //! // This table is fresh and was never published, so the live network read
 //! // returns no root chunk and the floor is `NONE`.
@@ -140,7 +140,7 @@ pub use seal::{SealError, SealedChunk, seal_plan};
 #[cfg(feature = "client")]
 pub use client::{BatchStamper, ClientError, SnapshotSink, SnapshotSource};
 
-pub use nectar_primitives::{SocId, SwarmAddress};
+pub use nectar_primitives::{ChunkAddress, SocId};
 
 /// Postage types re-exported so a downstream caller naming
 /// [`PlannedChunk::stamp_index`] or calling [`UsageTable::from_batch`] does not
@@ -189,11 +189,11 @@ pub fn usage_chunk_id(batch_id: &BatchId, index: u16) -> SocId {
 
 /// Returns the address of snapshot chunk `index` for a batch owned by
 /// `owner`, i.e. the single-owner chunk address `keccak256(id || owner)`.
-pub fn usage_chunk_address(batch_id: &BatchId, owner: &Address, index: u16) -> SwarmAddress {
+pub fn usage_chunk_address(batch_id: &BatchId, owner: &Address, index: u16) -> ChunkAddress {
     let mut hasher = Keccak256::new();
     hasher.update(usage_chunk_id(batch_id, index));
     hasher.update(owner);
-    SwarmAddress::from(hasher.finalize())
+    ChunkAddress::from(hasher.finalize())
 }
 
 #[cfg(test)]

--- a/crates/postage-usage/src/snapshot.rs
+++ b/crates/postage-usage/src/snapshot.rs
@@ -6,7 +6,7 @@ use alloc::vec::Vec;
 use alloy_primitives::Address;
 use bytes::Bytes;
 use nectar_postage::{Batch, BatchId, StampIndex, calculate_bucket};
-use nectar_primitives::{SocId, SwarmAddress};
+use nectar_primitives::{ChunkAddress, SocId};
 
 use crate::codec::{self, Encoded, RootInfo};
 use crate::table::{TableView, UsageTable};
@@ -86,7 +86,7 @@ pub struct PlannedChunk {
     /// The single-owner chunk id.
     pub id: SocId,
     /// The single-owner chunk address.
-    pub address: SwarmAddress,
+    pub address: ChunkAddress,
     /// The stamp index to use. Constant across persists for a given chunk;
     /// reusing it with a newer timestamp overwrites the previous version in
     /// place instead of consuming another slot.
@@ -567,7 +567,7 @@ impl Snapshot {
     pub(crate) fn record_address(
         &mut self,
         owner: Address,
-        address: &SwarmAddress,
+        address: &ChunkAddress,
     ) -> Result<StampIndex> {
         self.issuer(owner).record_address(address)
     }
@@ -846,7 +846,7 @@ impl Issuer<'_> {
     /// The only content-issuance entry point. The reserved set was installed at
     /// construction, so a mutable ring never re-emits a slot held by the
     /// snapshot's own chunks.
-    pub fn record_address(&mut self, address: &SwarmAddress) -> Result<StampIndex> {
+    pub fn record_address(&mut self, address: &ChunkAddress) -> Result<StampIndex> {
         Ok(self.record_address_reporting_wrap(address)?.0)
     }
 
@@ -866,7 +866,7 @@ impl Issuer<'_> {
     /// `true`.
     pub fn record_address_reporting_wrap(
         &mut self,
-        address: &SwarmAddress,
+        address: &ChunkAddress,
     ) -> Result<(StampIndex, bool)> {
         let bucket = calculate_bucket(address, self.snapshot.table.bucket_depth());
         // Decide before the write: afterwards the cursor has already advanced.

--- a/crates/postage-usage/src/table.rs
+++ b/crates/postage-usage/src/table.rs
@@ -138,11 +138,11 @@ impl Mutability {
 ///
 /// ```compile_fail
 /// use alloy_primitives::B256;
-/// use nectar_postage_usage::{BatchId, Mutability, SwarmAddress, UsageTable};
+/// use nectar_postage_usage::{BatchId, Mutability, ChunkAddress, UsageTable};
 ///
 /// let mut table = UsageTable::new(BatchId::new([0x42; 32]), 18, 16, Mutability::Mutable).unwrap();
 /// // `record_address` no longer exists on the inert table.
-/// table.record_address(&SwarmAddress::from(B256::repeat_byte(0x99))).unwrap();
+/// table.record_address(&ChunkAddress::from(B256::repeat_byte(0x99))).unwrap();
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UsageTable {

--- a/crates/postage-usage/tests/issuer.rs
+++ b/crates/postage-usage/tests/issuer.rs
@@ -18,7 +18,7 @@ use alloy_primitives::Address;
 use nectar_postage::{BatchId, StampIndex, calculate_bucket};
 use nectar_postage_issuer::StampIssuer;
 use nectar_postage_usage::{Mutability, PublishedSequence, Snapshot, SnapshotIssuer, UsageTable};
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::ChunkAddress;
 
 const BUCKET_DEPTH: u8 = 16;
 
@@ -28,7 +28,7 @@ const fn owner() -> Address {
 
 /// Returns a content chunk address whose top 16 bits select `bucket`, with
 /// `salt` mixed into lower bytes so distinct calls stay in the same bucket.
-fn content_address(bucket: u32, salt: u8) -> SwarmAddress {
+const fn content_address(bucket: u32, salt: u8) -> ChunkAddress {
     let mut bytes = [0u8; 32];
     // Take the low two big-endian bytes of the u32 (identical to the former
     // `>> 8` / truncating casts).
@@ -36,7 +36,7 @@ fn content_address(bucket: u32, salt: u8) -> SwarmAddress {
     bytes[0] = hi;
     bytes[1] = lo;
     bytes[31] = salt;
-    SwarmAddress::new(bytes)
+    ChunkAddress::new(bytes)
 }
 
 #[test]
@@ -48,7 +48,7 @@ fn snapshot_issuer_issues_sequential_indices() {
     let snapshot = Snapshot::new(table);
     let mut issuer = SnapshotIssuer::new(snapshot, owner());
 
-    let address = SwarmAddress::new([0xCB; 32]);
+    let address = ChunkAddress::new([0xCB; 32]);
     let first = issuer.prepare_stamp(&address, 1).unwrap();
     let second = issuer.prepare_stamp(&address, 2).unwrap();
 

--- a/crates/postage-usage/tests/snapshot.rs
+++ b/crates/postage-usage/tests/snapshot.rs
@@ -871,7 +871,7 @@ fn failed_allocation_rolls_back_the_snapshot() {
 }
 
 /// Returns a chunk address whose top `BUCKET_DEPTH` bits select `bucket`.
-fn address_in_bucket(bucket: u32) -> nectar_primitives::SwarmAddress {
+const fn address_in_bucket(bucket: u32) -> nectar_primitives::ChunkAddress {
     let mut bytes = [0u8; 32];
     // bucket occupies the most-significant BUCKET_DEPTH (=16) bits: take the
     // low two big-endian bytes of the u32 (identical to the former `>> 8` /
@@ -879,7 +879,7 @@ fn address_in_bucket(bucket: u32) -> nectar_primitives::SwarmAddress {
     let [_, _, hi, lo] = bucket.to_be_bytes();
     bytes[0] = hi;
     bytes[1] = lo;
-    nectar_primitives::SwarmAddress::new(bytes)
+    nectar_primitives::ChunkAddress::new(bytes)
 }
 
 /// A fresh table for a batch already published at a higher sequence is the

--- a/crates/postage/benches/verify.rs
+++ b/crates/postage/benches/verify.rs
@@ -23,7 +23,7 @@ use nectar_postage::{
     Batch, BatchId, Stamp, StampBytes, StampDigest, StampIndex,
     parallel::{verify_stamps_parallel, verify_stamps_parallel_with_pubkey},
 };
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::ChunkAddress;
 use rand::RngExt;
 
 /// Generate a random stamp for benchmarking.
@@ -43,18 +43,18 @@ fn random_stamp() -> Stamp {
     Stamp::new(batch, bucket, index, timestamp, sig)
 }
 
-/// Generate a random SwarmAddress for benchmarking.
-fn random_address() -> SwarmAddress {
+/// Generate a random ChunkAddress for benchmarking.
+fn random_address() -> ChunkAddress {
     let mut rng = rand::rng();
     let mut bytes = [0u8; 32];
     rng.fill(&mut bytes);
-    SwarmAddress::new(bytes)
+    ChunkAddress::new(bytes)
 }
 
 /// Creates a valid stamp signed by the given signer.
 fn create_signed_stamp(
     signer: &PrivateKeySigner,
-    chunk_address: &SwarmAddress,
+    chunk_address: &ChunkAddress,
     batch_id: BatchId,
 ) -> Stamp {
     let index = StampIndex::new(0, 0);
@@ -163,7 +163,7 @@ fn bench_stamp_digest_prehash(c: &mut Criterion) {
 /// Uses EIP-191 message recovery for interoperability.
 fn recover_stamp_signer(
     stamp: &Stamp,
-    chunk_address: &SwarmAddress,
+    chunk_address: &ChunkAddress,
 ) -> Result<Address, alloy_primitives::SignatureError> {
     let digest = StampDigest::new(
         *chunk_address,
@@ -187,7 +187,7 @@ fn bench_ecdsa_verify_sequential(c: &mut Criterion) {
     let single_addr = random_address();
     let single_stamp = create_signed_stamp(&signer, &single_addr, batch_id);
 
-    let test_data: Vec<(SwarmAddress, Stamp)> = (0..100)
+    let test_data: Vec<(ChunkAddress, Stamp)> = (0..100)
         .map(|_| {
             let addr = random_address();
             let stamp = create_signed_stamp(&signer, &addr, batch_id);
@@ -226,7 +226,7 @@ fn bench_ecdsa_verify_with_pubkey(c: &mut Criterion) {
     let batch_id = BatchId::ZERO;
 
     // Create stamps
-    let addresses: Vec<SwarmAddress> = (0..100).map(|_| random_address()).collect();
+    let addresses: Vec<ChunkAddress> = (0..100).map(|_| random_address()).collect();
     let stamps: Vec<Stamp> = addresses
         .iter()
         .map(|addr| create_signed_stamp(&signer, addr, batch_id))
@@ -265,14 +265,14 @@ fn bench_ecdsa_verify_parallel(c: &mut Criterion) {
     let batch_id = BatchId::ZERO;
 
     // Pre-generate 100 stamps for verification
-    let addresses_100: Vec<SwarmAddress> = (0..100).map(|_| random_address()).collect();
+    let addresses_100: Vec<ChunkAddress> = (0..100).map(|_| random_address()).collect();
     let stamps_100: Vec<Stamp> = addresses_100
         .iter()
         .map(|addr| create_signed_stamp(&signer, addr, batch_id))
         .collect();
 
     // Pre-generate 1000 stamps for verification
-    let addresses_1000: Vec<SwarmAddress> = (0..1000).map(|_| random_address()).collect();
+    let addresses_1000: Vec<ChunkAddress> = (0..1000).map(|_| random_address()).collect();
     let stamps_1000: Vec<Stamp> = addresses_1000
         .iter()
         .map(|addr| create_signed_stamp(&signer, addr, batch_id))
@@ -306,14 +306,14 @@ fn bench_ecdsa_verify_parallel_with_pubkey(c: &mut Criterion) {
     let batch_id = BatchId::ZERO;
 
     // Pre-generate 100 stamps for verification
-    let addresses_100: Vec<SwarmAddress> = (0..100).map(|_| random_address()).collect();
+    let addresses_100: Vec<ChunkAddress> = (0..100).map(|_| random_address()).collect();
     let stamps_100: Vec<Stamp> = addresses_100
         .iter()
         .map(|addr| create_signed_stamp(&signer, addr, batch_id))
         .collect();
 
     // Pre-generate 1000 stamps for verification
-    let addresses_1000: Vec<SwarmAddress> = (0..1000).map(|_| random_address()).collect();
+    let addresses_1000: Vec<ChunkAddress> = (0..1000).map(|_| random_address()).collect();
     let stamps_1000: Vec<Stamp> = addresses_1000
         .iter()
         .map(|addr| create_signed_stamp(&signer, addr, batch_id))
@@ -360,7 +360,7 @@ fn bench_verify_comparison(c: &mut Criterion) {
     let batch_id = BatchId::ZERO;
 
     // Pre-generate 1000 stamps
-    let addresses: Vec<SwarmAddress> = (0..1000).map(|_| random_address()).collect();
+    let addresses: Vec<ChunkAddress> = (0..1000).map(|_| random_address()).collect();
     let stamps: Vec<Stamp> = addresses
         .iter()
         .map(|addr| create_signed_stamp(&signer, addr, batch_id))

--- a/crates/postage/src/batch.rs
+++ b/crates/postage/src/batch.rs
@@ -2,7 +2,7 @@
 
 use alloy_primitives::{Address, B256};
 use derive_more::{AsRef, Display, From, Into};
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::ChunkAddress;
 
 use crate::{StampError, StampIndex, calculate_bucket};
 
@@ -270,7 +270,7 @@ impl Batch {
     /// The bucket is determined by taking the first `bucket_depth` bits of the
     /// chunk address, interpreted as a big-endian unsigned integer.
     #[inline]
-    pub fn bucket_for_address(&self, address: &SwarmAddress) -> u32 {
+    pub fn bucket_for_address(&self, address: &ChunkAddress) -> u32 {
         calculate_bucket(address, self.bucket_depth)
     }
 
@@ -282,7 +282,7 @@ impl Batch {
     pub fn validate_bucket(
         &self,
         index: &StampIndex,
-        address: &SwarmAddress,
+        address: &ChunkAddress,
     ) -> Result<(), StampError> {
         let expected_bucket = self.bucket_for_address(address);
         if index.bucket() != expected_bucket {

--- a/crates/postage/src/generators.rs
+++ b/crates/postage/src/generators.rs
@@ -14,7 +14,7 @@
 use alloy_primitives::Address;
 use alloy_signer::SignerSync;
 use arbitrary::Unstructured;
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::ChunkAddress;
 
 use crate::{Batch, BatchId, Stamp, StampDigest, StampIndex, StampedChunk};
 
@@ -46,7 +46,7 @@ pub fn signed_stamp(
     u: &mut Unstructured<'_>,
     signer: &impl SignerSync,
     batch: &Batch,
-    address: &SwarmAddress,
+    address: &ChunkAddress,
 ) -> arbitrary::Result<Stamp> {
     let bucket = batch.bucket_for_address(address);
     let position = u.int_in_range(0..=batch.bucket_upper_bound().saturating_sub(1))?;

--- a/crates/postage/src/parallel.rs
+++ b/crates/postage/src/parallel.rs
@@ -18,7 +18,7 @@ use alloy_signer::utils::public_key_to_address;
 use rayon::prelude::*;
 
 use crate::{Stamp, StampDigest, StampError};
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::ChunkAddress;
 
 // Parallel Verification
 
@@ -50,7 +50,7 @@ pub struct VerifyResult {
 /// use nectar_postage::parallel::verify_stamps_parallel;
 ///
 /// let stamps: Vec<Stamp> = /* ... */;
-/// let addresses: Vec<SwarmAddress> = /* ... */;
+/// let addresses: Vec<ChunkAddress> = /* ... */;
 ///
 /// // Create tuples of references
 /// let items: Vec<_> = stamps.iter().zip(addresses.iter()).collect();
@@ -62,7 +62,7 @@ pub struct VerifyResult {
 ///     }
 /// }
 /// ```
-pub fn verify_stamps_parallel(stamps: &[(&Stamp, &SwarmAddress)]) -> Vec<VerifyResult> {
+pub fn verify_stamps_parallel(stamps: &[(&Stamp, &ChunkAddress)]) -> Vec<VerifyResult> {
     stamps
         .par_iter()
         .enumerate()
@@ -88,7 +88,7 @@ pub fn verify_stamps_parallel(stamps: &[(&Stamp, &SwarmAddress)]) -> Vec<VerifyR
 /// A vector of verification results. Each result contains either the recovered
 /// address if the stamp is valid and signed by the expected owner, or an error.
 pub fn verify_stamps_parallel_with_owner(
-    stamps: &[(&Stamp, &SwarmAddress)],
+    stamps: &[(&Stamp, &ChunkAddress)],
     expected_owner: Address,
 ) -> Vec<VerifyResult> {
     stamps
@@ -130,7 +130,7 @@ pub fn verify_stamps_parallel_with_owner(
 /// let results = verify_stamps_parallel_with_pubkey(&items, &pubkey);
 /// ```
 pub fn verify_stamps_parallel_with_pubkey(
-    stamps: &[(&Stamp, &SwarmAddress)],
+    stamps: &[(&Stamp, &ChunkAddress)],
     owner_pubkey: &VerifyingKey,
 ) -> Vec<VerifyResult> {
     let owner_address = public_key_to_address(owner_pubkey);
@@ -152,7 +152,7 @@ pub fn verify_stamps_parallel_with_pubkey(
 ///
 /// Uses EIP-191 message recovery for interoperability.
 /// The prehash (keccak256 of stamp data) is treated as the message.
-fn recover_stamp_signer(stamp: &Stamp, address: &SwarmAddress) -> Result<Address, StampError> {
+fn recover_stamp_signer(stamp: &Stamp, address: &ChunkAddress) -> Result<Address, StampError> {
     let digest = StampDigest::new(
         *address,
         stamp.batch(),
@@ -171,7 +171,7 @@ fn recover_stamp_signer(stamp: &Stamp, address: &SwarmAddress) -> Result<Address
 /// Verifies a stamp was signed by the expected owner.
 fn verify_stamp_owner(
     stamp: &Stamp,
-    address: &SwarmAddress,
+    address: &ChunkAddress,
     expected_owner: Address,
 ) -> Result<Address, StampError> {
     let recovered = recover_stamp_signer(stamp, address)?;
@@ -196,7 +196,7 @@ mod tests {
     /// Creates a stamp for testing verification.
     fn create_test_stamp(
         signer: &PrivateKeySigner,
-        chunk_address: &SwarmAddress,
+        chunk_address: &ChunkAddress,
         batch_id: BatchId,
     ) -> Stamp {
         let index = StampIndex::new(0, 0);
@@ -217,7 +217,7 @@ mod tests {
 
         // Create stamps
         let addresses: Vec<_> = (0..50)
-            .map(|_| SwarmAddress::from(B256::random()))
+            .map(|_| ChunkAddress::from(B256::random()))
             .collect();
         let stamps: Vec<_> = addresses
             .iter()
@@ -241,7 +241,7 @@ mod tests {
         let wrong_owner = Address::repeat_byte(0xFF);
         let batch_id = BatchId::ZERO;
 
-        let address = SwarmAddress::from(B256::random());
+        let address = ChunkAddress::from(B256::random());
         let stamp = create_test_stamp(&signer, &address, batch_id);
 
         // Use tuple syntax
@@ -260,7 +260,7 @@ mod tests {
         let expected_owner = signer.address();
         let batch_id = BatchId::ZERO;
 
-        let address = SwarmAddress::from(B256::random());
+        let address = ChunkAddress::from(B256::random());
         let stamp = create_test_stamp(&signer, &address, batch_id);
 
         let verify_input = [(&stamp, &address)];
@@ -278,7 +278,7 @@ mod tests {
 
         // Create stamps
         let addresses: Vec<_> = (0..50)
-            .map(|_| SwarmAddress::from(B256::random()))
+            .map(|_| ChunkAddress::from(B256::random()))
             .collect();
         let stamps: Vec<_> = addresses
             .iter()

--- a/crates/postage/src/stamp.rs
+++ b/crates/postage/src/stamp.rs
@@ -3,7 +3,7 @@
 use alloy_primitives::{Address, B256, Signature, eip191_hash_message};
 use alloy_signer::k256::ecdsa::VerifyingKey;
 use byteorder::{BigEndian, ByteOrder};
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::ChunkAddress;
 
 use crate::{BatchId, StampError};
 
@@ -283,7 +283,7 @@ impl Stamp {
     /// let signer = stamp.recover_signer(&chunk_address)?;
     /// println!("Stamp signed by: {}", signer);
     /// ```
-    pub fn recover_signer(&self, chunk_address: &SwarmAddress) -> Result<Address, StampError> {
+    pub fn recover_signer(&self, chunk_address: &ChunkAddress) -> Result<Address, StampError> {
         let digest = StampDigest::new(*chunk_address, self.batch, self.index, self.timestamp);
         let prehash = digest.to_prehash();
 
@@ -314,7 +314,7 @@ impl Stamp {
     /// let stamp = Stamp::try_from_slice(&bytes)?;
     /// stamp.verify(&chunk_address, batch.owner())?;
     /// ```
-    pub fn verify(&self, chunk_address: &SwarmAddress, owner: Address) -> Result<(), StampError> {
+    pub fn verify(&self, chunk_address: &ChunkAddress, owner: Address) -> Result<(), StampError> {
         let recovered = self.recover_signer(chunk_address)?;
         if recovered != owner {
             return Err(StampError::OwnerMismatch {
@@ -355,7 +355,7 @@ impl Stamp {
     ///     stamp.verify_with_pubkey(&addr, &pubkey)?;
     /// }
     /// ```
-    pub fn recover_pubkey(&self, chunk_address: &SwarmAddress) -> Result<VerifyingKey, StampError> {
+    pub fn recover_pubkey(&self, chunk_address: &ChunkAddress) -> Result<VerifyingKey, StampError> {
         let digest = StampDigest::new(*chunk_address, self.batch, self.index, self.timestamp);
         let prehash = digest.to_prehash();
 
@@ -408,7 +408,7 @@ impl Stamp {
     /// ```
     pub fn verify_with_pubkey(
         &self,
-        chunk_address: &SwarmAddress,
+        chunk_address: &ChunkAddress,
         pubkey: &VerifyingKey,
     ) -> Result<(), StampError> {
         use alloy_signer::k256::ecdsa::signature::hazmat::PrehashVerifier;
@@ -441,14 +441,14 @@ impl Stamp {
 ///
 /// ```compile_fail
 /// use nectar_postage::{BatchId, StampDigest, StampIndex};
-/// use nectar_primitives::SwarmAddress;
+/// use nectar_primitives::ChunkAddress;
 ///
-/// let _ = StampDigest::new(BatchId::ZERO, SwarmAddress::zero(), StampIndex::new(0, 0), 0);
+/// let _ = StampDigest::new(BatchId::ZERO, ChunkAddress::zero(), StampIndex::new(0, 0), 0);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StampDigest {
     /// The chunk address being stamped.
-    pub chunk_address: SwarmAddress,
+    pub chunk_address: ChunkAddress,
     /// The batch ID.
     pub batch_id: BatchId,
     /// The stamp index (bucket and position).
@@ -461,7 +461,7 @@ impl StampDigest {
     /// Creates a new stamp digest.
     #[inline]
     pub const fn new(
-        chunk_address: SwarmAddress,
+        chunk_address: ChunkAddress,
         batch_id: BatchId,
         index: StampIndex,
         timestamp: u64,
@@ -644,7 +644,7 @@ mod tests {
         ).unwrap();
         let expected_owner: Address = "8d3766440f0d7b949a5e32995d09619a7f86e632".parse().unwrap();
 
-        let chunk_address = SwarmAddress::new(chunk_addr_bytes.try_into().unwrap());
+        let chunk_address = ChunkAddress::new(chunk_addr_bytes.try_into().unwrap());
         let stamp = Stamp::try_from_slice(&full_stamp_bytes).unwrap();
 
         // Test recover_signer
@@ -665,7 +665,7 @@ mod tests {
         let expected_owner: Address = "8d3766440f0d7b949a5e32995d09619a7f86e632".parse().unwrap();
         let wrong_owner: Address = "0000000000000000000000000000000000000001".parse().unwrap();
 
-        let chunk_address = SwarmAddress::new(chunk_addr_bytes.try_into().unwrap());
+        let chunk_address = ChunkAddress::new(chunk_addr_bytes.try_into().unwrap());
         let stamp = Stamp::try_from_slice(&full_stamp_bytes).unwrap();
 
         // Verify with correct owner should succeed
@@ -690,7 +690,7 @@ mod tests {
         ).unwrap();
         let expected_owner: Address = "8d3766440f0d7b949a5e32995d09619a7f86e632".parse().unwrap();
 
-        let chunk_address = SwarmAddress::new(chunk_addr_bytes.try_into().unwrap());
+        let chunk_address = ChunkAddress::new(chunk_addr_bytes.try_into().unwrap());
         let stamp = Stamp::try_from_slice(&full_stamp_bytes).unwrap();
 
         // Test recover_pubkey
@@ -712,7 +712,7 @@ mod tests {
             "000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000003496cb9ac06221d39c3f6a7dd3b9c2301c1f923162b90d5443e42023f34ff908945b0da1c297190f111b7c6ebc828648ead8f7fce06c0364cb5a833410230c5c01c"
         ).unwrap();
 
-        let chunk_address = SwarmAddress::new(chunk_addr_bytes.try_into().unwrap());
+        let chunk_address = ChunkAddress::new(chunk_addr_bytes.try_into().unwrap());
         let stamp = Stamp::try_from_slice(&full_stamp_bytes).unwrap();
 
         // First recover the public key
@@ -731,7 +731,7 @@ mod tests {
 
         // Create a stamp with one signer
         let signer = PrivateKeySigner::random();
-        let chunk_address = SwarmAddress::new([0xAB; 32]);
+        let chunk_address = ChunkAddress::new([0xAB; 32]);
         let batch_id = BatchId::ZERO;
         let index = StampIndex::new(0, 0);
         let timestamp = 12345u64;
@@ -785,9 +785,9 @@ mod tests {
             // stamp is recovered against; ECDSA recovery over arbitrary
             // stamp fields must not panic.
             let address = if data.len() >= STAMP_SIZE + 32 {
-                SwarmAddress::from_slice(&data[STAMP_SIZE..STAMP_SIZE + 32]).unwrap()
+                ChunkAddress::from_slice(&data[STAMP_SIZE..STAMP_SIZE + 32]).unwrap()
             } else {
-                SwarmAddress::zero()
+                ChunkAddress::zero()
             };
             let _ = stamp.recover_signer(&address);
             let _ = stamp.verify(&address, Address::ZERO);

--- a/crates/postage/src/util.rs
+++ b/crates/postage/src/util.rs
@@ -1,6 +1,6 @@
 //! Utility functions for postage operations.
 
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::ChunkAddress;
 
 /// Returns the current timestamp in nanoseconds since the Unix epoch.
 ///
@@ -60,16 +60,16 @@ pub const fn current_timestamp() -> u64 {
 ///
 /// ```
 /// use nectar_postage::calculate_bucket;
-/// use nectar_primitives::SwarmAddress;
+/// use nectar_primitives::ChunkAddress;
 ///
-/// let address = SwarmAddress::new([0xCB, 0xE5, 0x00, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+/// let address = ChunkAddress::new([0xCB, 0xE5, 0x00, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
 /// let bucket = calculate_bucket(&address, 16);
 /// assert_eq!(bucket, 0xCBE5);
 /// ```
 #[inline]
-#[allow(clippy::indexing_slicing, clippy::unwrap_used)] // SwarmAddress is a fixed 32-byte array: `[0..4]` and the 4-byte `try_into` are infallible
+#[allow(clippy::indexing_slicing, clippy::unwrap_used)] // ChunkAddress is a fixed 32-byte array: `[0..4]` and the 4-byte `try_into` are infallible
 #[allow(clippy::arithmetic_side_effects)] // `32 - bucket_depth` underflow is the documented `# Panics` contract (`bucket_depth` in 1..=32)
-pub fn calculate_bucket(address: &SwarmAddress, bucket_depth: u8) -> u32 {
+pub fn calculate_bucket(address: &ChunkAddress, bucket_depth: u8) -> u32 {
     // Take the first 4 bytes as a big-endian u32
     let leading = u32::from_be_bytes(address.as_bytes()[0..4].try_into().unwrap());
     // Shift right to get only the top `bucket_depth` bits
@@ -135,7 +135,7 @@ mod tests {
     #[test]
     fn test_calculate_bucket() {
         // Address starting with 0xCBE5...
-        let address = SwarmAddress::new([
+        let address = ChunkAddress::new([
             0xCB, 0xE5, 0x00, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0,
         ]);

--- a/crates/postage/src/validation.rs
+++ b/crates/postage/src/validation.rs
@@ -1,7 +1,7 @@
 //! Stamp validation traits and utilities.
 
 use crate::{PostageContext, Stamp, StampError};
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::ChunkAddress;
 
 #[cfg(any(test, feature = "std"))]
 use crate::Batch;
@@ -26,14 +26,14 @@ use crate::{BatchStore, BatchStoreExt};
 ///
 /// ```ignore
 /// use nectar_postage::{StampValidator, Stamp, PostageContext};
-/// use nectar_primitives::SwarmAddress;
+/// use nectar_primitives::ChunkAddress;
 ///
 /// struct MyValidator { /* ... */ }
 ///
 /// impl StampValidator for MyValidator {
 ///     type Error = nectar_postage::StampError;
 ///
-///     fn validate(&self, stamp: &Stamp, address: &SwarmAddress, state: &PostageContext) -> Result<(), Self::Error> {
+///     fn validate(&self, stamp: &Stamp, address: &ChunkAddress, state: &PostageContext) -> Result<(), Self::Error> {
 ///         // Validation logic...
 ///         Ok(())
 ///     }
@@ -57,7 +57,7 @@ pub trait StampValidator {
     fn validate(
         &self,
         stamp: &Stamp,
-        address: &SwarmAddress,
+        address: &ChunkAddress,
         state: &PostageContext,
     ) -> Result<(), Self::Error>;
 
@@ -77,7 +77,7 @@ pub trait StampValidator {
     fn validate_structure(
         &self,
         stamp: &Stamp,
-        address: &SwarmAddress,
+        address: &ChunkAddress,
         state: &PostageContext,
     ) -> Result<(), Self::Error> {
         self.validate(stamp, address, state)
@@ -151,7 +151,7 @@ impl<S: BatchStore> StoreValidator<S> {
     /// # Returns
     ///
     /// `Ok(())` if the stamp is valid, or a [`StampError`] describing the failure.
-    pub fn validate(&self, stamp: &Stamp, address: &SwarmAddress) -> Result<(), StampError> {
+    pub fn validate(&self, stamp: &Stamp, address: &ChunkAddress) -> Result<(), StampError> {
         // Get the batch and verify it's usable
         let batch = self.get_batch_for_stamp(stamp)?;
 
@@ -171,7 +171,7 @@ impl<S: BatchStore> StoreValidator<S> {
     pub fn validate_structure(
         &self,
         stamp: &Stamp,
-        address: &SwarmAddress,
+        address: &ChunkAddress,
     ) -> Result<(), StampError> {
         let batch = self.get_batch_for_stamp(stamp)?;
         self.validate_structure_with_batch(stamp, address, &batch)
@@ -209,7 +209,7 @@ impl<S: BatchStore> StoreValidator<S> {
     fn validate_structure_with_batch(
         &self,
         stamp: &Stamp,
-        address: &SwarmAddress,
+        address: &ChunkAddress,
         batch: &Batch,
     ) -> Result<(), StampError> {
         // Validate index bounds
@@ -264,7 +264,7 @@ mod tests {
     fn test_bucket_for_address() {
         let batch = Batch::new(BatchId::ZERO, 0, 0, Address::ZERO, 18, 16, false);
 
-        let address = SwarmAddress::new([
+        let address = ChunkAddress::new([
             0xCB, 0xE5, 0x00, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0,
         ]);
@@ -276,7 +276,7 @@ mod tests {
     fn test_validate_bucket_match() {
         let batch = Batch::new(BatchId::ZERO, 0, 0, Address::ZERO, 18, 16, false);
 
-        let address = SwarmAddress::new([
+        let address = ChunkAddress::new([
             0xCB, 0xE5, 0x00, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0,
         ]);
@@ -289,7 +289,7 @@ mod tests {
     fn test_validate_bucket_mismatch() {
         let batch = Batch::new(BatchId::ZERO, 0, 0, Address::ZERO, 18, 16, false);
 
-        let address = SwarmAddress::new([
+        let address = ChunkAddress::new([
             0xCB, 0xE5, 0x00, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0,
         ]);

--- a/crates/primitives/benches/address.rs
+++ b/crates/primitives/benches/address.rs
@@ -13,7 +13,7 @@
 )]
 use alloy_primitives::{B256, b256};
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::{SwarmAddress, XorMetric};
 use rand::prelude::*;
 
 pub fn address_benchmarks(c: &mut Criterion) {

--- a/crates/primitives/examples/wasm-demo/src/lib.rs
+++ b/crates/primitives/examples/wasm-demo/src/lib.rs
@@ -2,8 +2,6 @@
 //!
 //! This module provides JavaScript-friendly wrappers around the BMT hasher.
 
-use std::ops::Deref;
-
 use alloy_primitives::{hex, Address, B256};
 use alloy_signer_local::PrivateKeySigner;
 use bytes::Bytes;
@@ -772,7 +770,7 @@ pub fn create_content_chunk(data: &[u8]) -> Result<ContentChunkResult, JsValue> 
 
     // Return the result
     Ok(ContentChunkResult {
-        address: *chunk.address().deref(),
+        address: B256::from(*chunk.address()),
         data: data.to_vec(),
         serialized,
     })
@@ -855,7 +853,7 @@ pub fn create_single_owner_chunk(
 
     // Return the result
     Ok(SingleOwnerChunkResult {
-        address: *chunk.address().deref(),
+        address: B256::from(*chunk.address()),
         id: chunk_id,
         owner,
         data: data.to_vec(),
@@ -907,7 +905,7 @@ pub fn analyze_chunk(
         (Ok(content_chunk), _) if content_chunk.address() == &expected => Ok(ChunkAnalysisResult {
             is_valid: true,
             chunk_type: ChunkType::Content,
-            address: *content_chunk.address().deref(),
+            address: B256::from(*content_chunk.address()),
             data: content_chunk.data().to_vec(),
             id: None,
             owner: None,
@@ -918,7 +916,7 @@ pub fn analyze_chunk(
             Ok(ChunkAnalysisResult {
                 is_valid: true,
                 chunk_type: ChunkType::SingleOwner,
-                address: *single_owner_chunk.address().deref(),
+                address: B256::from(*single_owner_chunk.address()),
                 data: single_owner_chunk.data().to_vec(),
                 id: Some(single_owner_chunk.id().into()),
                 owner: single_owner_chunk.owner().ok(),
@@ -930,7 +928,7 @@ pub fn analyze_chunk(
         (Ok(content_chunk), _) => Ok(ChunkAnalysisResult {
             is_valid: false,
             chunk_type: ChunkType::Content,
-            address: *content_chunk.address().deref(),
+            address: B256::from(*content_chunk.address()),
             data: content_chunk.data().to_vec(),
             id: None,
             owner: None,
@@ -944,7 +942,7 @@ pub fn analyze_chunk(
         (_, Ok(single_owner_chunk)) => Ok(ChunkAnalysisResult {
             is_valid: false,
             chunk_type: ChunkType::SingleOwner,
-            address: *single_owner_chunk.address().deref(),
+            address: B256::from(*single_owner_chunk.address()),
             data: single_owner_chunk.data().to_vec(),
             id: Some(single_owner_chunk.id().into()),
             owner: single_owner_chunk.owner().ok(),

--- a/crates/primitives/src/address.rs
+++ b/crates/primitives/src/address.rs
@@ -1,98 +1,25 @@
 //! Swarm address implementation
 //!
-//! This module provides the SwarmAddress type, which is a 32-byte identifier
-//! used for addressing chunks in the swarm network. It includes functionality
-//! for calculating distances between addresses and determining their proximity.
-//!
-//! ## Proximity Order (PO)
-//!
-//! Proximity order is a key concept in Kademlia-based routing. It measures
-//! how "close" two addresses are in the XOR metric space by counting the
-//! number of leading matching bits.
-//!
-//! ### Standard vs Extended Proximity
-//!
-//! - **Standard PO** (`MAX_PO = 31`): Used for most routing operations.
-//!   Returns a value 0-31, giving 32 Kademlia bins. The algorithm counts
-//!   leading matching bits up to 32 bits (4 bytes) and caps at 31.
-//!
-//! - **Extended PO** (`EXTENDED_PO = 36`): Used for Kademlia bin balancing.
-//!   When balancing bins, the algorithm needs finer granularity:
-//!   `po + BitSuffixLength + 1` where `BitSuffixLength = 4`.
-//!   For bin 31, this yields 31 + 4 + 1 = 36, hence `ExtendedPO = MaxPO + 5`.
-//!
-//! ### Compatibility
-//!
-//! This implementation matches the Swarm reference implementation exactly:
-//!
-//! - `MaxPO = 31` and `ExtendedPO = 36`
-//! - Counts leading matching BITS (not bytes)
-//! - Caps at the respective maximum values
-//!
-//! ### Distance vs Proximity
-//!
-//! - **Distance** (`distance()`): Returns the full 256-bit XOR distance as `U256`.
-//! - **Proximity** (`proximity()`): Returns a small integer (0-31) representing
-//!   the count of leading matching bits, capped at `MAX_PO`.
-//!
-//! Higher proximity = closer addresses = smaller XOR distance.
-//!
-//! ## Example Usage
-//!
-//! ```
-//! use nectar_primitives::SwarmAddress;
-//! use alloy_primitives::B256;
-//!
-//! // Create addresses
-//! let addr1 = SwarmAddress::from(B256::random());
-//! let addr2 = SwarmAddress::from(B256::random());
-//!
-//! // Calculate proximity
-//! let po = addr1.proximity(&addr2);
-//! println!("Proximity order: {}", po);
-//!
-//! // Calculate distance
-//! let distance = addr1.distance(&addr2);
-//! println!("Distance: {}", distance);
-//!
-//! // Compare distances
-//! let addr3 = SwarmAddress::from(B256::random());
-//! if addr1.closer(&addr2, &addr3) {
-//!     println!("addr1 is closer to addr2 than addr3");
-//! }
-//! ```
-//!
-//! [`extended_proximity()`]: SwarmAddress::extended_proximity
+//! This module provides the [`SwarmAddress`] type, a 32-byte identifier used
+//! for addressing nodes in the swarm network. The XOR-metric operations
+//! (distance, proximity) shared with the other address kinds live on the
+//! [`XorMetric`](crate::XorMetric) trait.
 
-use std::cmp::Ordering;
 use std::fmt;
-use std::ops::Deref;
 
-use alloy_primitives::{B256, U256};
+use alloy_primitives::B256;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::error::{Result, WrongLength};
-use crate::{Bin, ProximityOrder};
+use crate::xor_metric::XorMetric;
 
-/// Maximum proximity order for standard routing operations.
-///
-/// Value 31 gives 32 Kademlia bins (0-31).
-pub const MAX_PO: u8 = 31;
-
-/// Extended proximity order for Kademlia bin balancing.
-///
-/// Value 36 = MaxPO (31) + BitSuffixLength (4) + 1. Used when the Kademlia
-/// bin balancing algorithm needs to check proximity at finer granularity
-/// than standard routing.
-pub const EXTENDED_PO: u8 = MAX_PO + 5;
-
-/// A 256-bit address for a chunk in the Swarm network
+/// A 256-bit address in the Swarm network
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
-pub struct SwarmAddress(pub B256);
+pub struct SwarmAddress(B256);
 
 impl SwarmAddress {
     /// Width in bytes of an address.
@@ -133,179 +60,11 @@ impl SwarmAddress {
     pub const fn zero() -> Self {
         Self(B256::ZERO)
     }
+}
 
-    /// Calculate the distance between Self and address `y` in big-endian
-    #[allow(clippy::indexing_slicing)] // i < 32 from enumerating a 32-byte address, matching result's length
-    #[inline(always)]
-    #[must_use]
-    pub fn distance(&self, y: &Self) -> U256 {
-        let mut result = [0u8; 32];
-
-        for (i, (&a, &b)) in self
-            .0
-            .as_slice()
-            .iter()
-            .zip(y.0.as_slice().iter())
-            .enumerate()
-        {
-            result[i] = a ^ b;
-        }
-
-        U256::from_be_bytes(result)
-    }
-
-    /// Compares addresses `x` and `y` by their distance from `self`.
-    ///
-    /// Returns:
-    /// - `Ordering::Less` if `x` is farther from `self` than `y` (i.e., `y` is closer)
-    /// - `Ordering::Greater` if `x` is closer to `self` than `y`
-    /// - `Ordering::Equal` if `x` and `y` are equidistant from `self`
-    ///
-    /// # Usage with `min_by`
-    ///
-    /// This comparator is designed for use with `Iterator::min_by` to find
-    /// the address closest to `self`:
-    ///
-    /// ```
-    /// # use nectar_primitives::SwarmAddress;
-    /// # use alloy_primitives::B256;
-    /// let target = SwarmAddress::zero();
-    /// let addresses = vec![
-    ///     SwarmAddress::from(B256::repeat_byte(0x01)),
-    ///     SwarmAddress::from(B256::repeat_byte(0x02)),
-    /// ];
-    /// let closest = addresses.iter().min_by(|a, b| target.distance_cmp(a, b));
-    /// ```
-    ///
-    /// Note: The ordering may seem inverted from intuition. `Greater` means `x`
-    /// is closer (smaller distance), because `min_by` selects the element for
-    /// which the comparator returns `Less` - and we want to select the one
-    /// that is NOT closer (i.e., has a larger distance), leaving the closest.
-    #[allow(clippy::indexing_slicing)] // ab, xb and yb are all 32-byte addresses and i < ab.len()
-    #[inline(always)]
-    #[must_use]
-    pub fn distance_cmp(&self, x: &Self, y: &Self) -> Ordering {
-        let (ab, xb, yb) = (self.0.as_slice(), x.0.as_slice(), y.0.as_slice());
-
-        for i in 0..ab.len() {
-            let dx = xb[i] ^ ab[i];
-            let dy = yb[i] ^ ab[i];
-
-            if dx != dy {
-                return match dx < dy {
-                    true => Ordering::Greater,
-                    false => Ordering::Less,
-                };
-            }
-        }
-
-        Ordering::Equal
-    }
-
-    /// Determine if `self` is closer to `x` than to `y`.
-    ///
-    /// Returns `true` if `distance(self, x) < distance(self, y)`.
-    #[must_use]
-    pub fn closer(&self, x: &Self, y: &Self) -> bool {
-        // distance_cmp returns Greater when x is closer to self
-        self.distance_cmp(x, y) == Ordering::Greater
-    }
-
-    /// Check if this address is within the given proximity to another address
-    pub fn is_within_proximity(&self, other: &Self, min_proximity: ProximityOrder) -> bool {
-        self.proximity(other) >= min_proximity
-    }
-
-    /// Calculate the proximity order between self and another address.
-    ///
-    /// Returns the number of leading bits that match between the two addresses,
-    /// capped at `MAX_PO` (31). Use this for standard Kademlia routing operations.
-    ///
-    /// For operations requiring finer granularity (like reserve sampling),
-    /// use [`extended_proximity()`](Self::extended_proximity) instead.
-    #[inline(always)]
-    #[must_use]
-    pub fn proximity(&self, other: &Self) -> ProximityOrder {
-        // `proximity_helper` is bounded by MAX_PO, so the cast is sound.
-        ProximityOrder::new_unchecked(self.proximity_helper(other, MAX_PO.into()))
-    }
-
-    /// Calculate the extended proximity order between self and another address.
-    ///
-    /// Returns the number of leading bits that match between the two addresses,
-    /// capped at `EXTENDED_PO` (36). Use this for Kademlia bin balancing where
-    /// the algorithm checks `po + BitSuffixLength + 1` (up to 36 for bin 31).
-    ///
-    /// Returns a raw `u8` because the extended range exceeds `ProximityOrder`'s
-    /// invariant (`0..=MAX_PO`). For standard routing, use
-    /// [`proximity()`](Self::proximity) instead.
-    #[inline(always)]
-    #[must_use]
-    pub fn extended_proximity(&self, other: &Self) -> u8 {
-        self.proximity_helper(other, EXTENDED_PO.into())
-    }
-
-    /// XOR distance - bitwise XOR of the two 32-byte addresses as a new
-    /// [`SwarmAddress`]. Useful when callers want the raw distance bytes
-    /// (e.g. for content-routing bias) rather than the proximity-order metric.
-    #[allow(clippy::indexing_slicing)] // i < 32 from enumerating a 32-byte address, matching out's length
-    #[inline(always)]
-    #[must_use]
-    pub fn xor(&self, other: &Self) -> Self {
-        let mut out = [0u8; 32];
-        for (i, (a, b)) in self.0.as_slice().iter().zip(other.0.as_slice()).enumerate() {
-            out[i] = a ^ b;
-        }
-        Self(B256::from(out))
-    }
-
-    /// Kademlia bin index of `self` relative to `anchor` - semantic alias for
-    /// `Bin::from(self.proximity(anchor))`. The routing-table convention is
-    /// "the bin a peer occupies is its proximity order to our own overlay".
-    #[inline(always)]
-    #[must_use]
-    pub fn bin(&self, anchor: &Self) -> Bin {
-        Bin::from(self.proximity(anchor))
-    }
-
-    /// Helper function to calculate proximity with a maximum
-    #[allow(
-        clippy::arithmetic_side_effects,
-        clippy::indexing_slicing,
-        clippy::as_conversions
-    )]
-    // max is MAX_PO (31) or EXTENDED_PO (36), so i <= max_bytes = 4 < 32 and i * 8 + leading_zeros <= 40 fits u8; the casts to u8 (max, i, and the u8 xor's leading_zeros <= 8) are all within those bounds
-    #[inline(always)]
-    fn proximity_helper(&self, other: &Self, max: usize) -> u8 {
-        let max_bytes = max / 8;
-        let max_bits = max as u8;
-
-        let bytes1 = self.0.as_slice();
-        let bytes2 = other.0.as_slice();
-
-        for i in 0..=max_bytes {
-            let xor = bytes1[i] ^ bytes2[i];
-            if xor != 0 {
-                // Found a difference - use leading_zeros to count matching bits
-                let leading_zeros = xor.leading_zeros() as u8;
-                let proximity = (i as u8 * 8) + leading_zeros;
-
-                // Return the smaller of proximity or max_bits
-                return if proximity < max_bits {
-                    proximity
-                } else {
-                    max_bits
-                };
-            }
-
-            // If we're at the last byte we might need to check
-            if i == max_bytes {
-                return max_bits; // All bits match up to max
-            }
-        }
-
-        // If we've examined all bytes and found no differences
-        max_bits
+impl XorMetric for SwarmAddress {
+    fn point(&self) -> &[u8; 32] {
+        &self.0.0
     }
 }
 
@@ -318,14 +77,6 @@ impl Default for SwarmAddress {
 impl fmt::Display for SwarmAddress {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
-    }
-}
-
-impl Deref for SwarmAddress {
-    type Target = B256;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
     }
 }
 

--- a/crates/primitives/src/chunk/README.md
+++ b/crates/primitives/src/chunk/README.md
@@ -62,7 +62,7 @@ To create a new chunk type, you need to:
 
 ```rust
 use nectar_primitives::chunk::{Chunk, ContentChunk, SingleOwnerChunk};
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::ChunkAddress;
 
 // Create a content chunk
 let content_chunk = ContentChunk::new(b"Hello, world!").unwrap();

--- a/crates/primitives/src/chunk/address.rs
+++ b/crates/primitives/src/chunk/address.rs
@@ -1,0 +1,151 @@
+//! Typed content address for chunks.
+//!
+//! A [`ChunkAddress`] names a chunk by the hash the network validates it
+//! against: the BMT root for content chunks, `keccak256(id || owner)` for
+//! single-owner chunks. It is nominally distinct from the node-identity
+//! address kind; cross-kind proximity goes through
+//! [`XorMetric`](crate::XorMetric).
+
+use alloy_primitives::B256;
+use derive_more::{AsRef, Display, From, Into};
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Result, WrongLength};
+use crate::xor_metric::XorMetric;
+
+/// 32-byte content address of a chunk.
+///
+/// Transparent over the same 32 wire bytes as the alias it replaces: every
+/// reference, manifest slot and store key serializes identically.
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Display, From, Into, AsRef,
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+#[display("{_0}")]
+#[from(B256, [u8; 32])]
+#[into(B256, [u8; 32])]
+#[as_ref([u8])]
+#[repr(transparent)]
+pub struct ChunkAddress(B256);
+
+impl ChunkAddress {
+    /// Width in bytes of an address.
+    pub const SIZE: usize = size_of::<B256>();
+
+    /// Zero address, useful for tests and sentinel slots.
+    pub const ZERO: Self = Self(B256::ZERO);
+
+    /// Construct from raw 32 bytes. `const` for static contexts; for runtime
+    /// conversions prefer the `From` impls.
+    #[inline]
+    pub const fn new(bytes: [u8; 32]) -> Self {
+        Self(B256::new(bytes))
+    }
+
+    /// Borrow the underlying 32 bytes.
+    #[inline]
+    pub const fn as_bytes(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+
+    /// Creates a new address from a slice, checking the length.
+    ///
+    /// The error carries expected and actual lengths via [`WrongLength`].
+    pub fn from_slice(slice: &[u8]) -> Result<Self> {
+        Ok(Self::try_from(slice)?)
+    }
+
+    /// Checks if this address is zeros.
+    pub fn is_zero(&self) -> bool {
+        self.0.is_zero()
+    }
+
+    /// Create a new zero-filled address.
+    pub const fn zero() -> Self {
+        Self::ZERO
+    }
+}
+
+impl XorMetric for ChunkAddress {
+    fn point(&self) -> &[u8; 32] {
+        &self.0.0
+    }
+}
+
+impl TryFrom<&[u8]> for ChunkAddress {
+    type Error = WrongLength;
+
+    fn try_from(slice: &[u8]) -> std::result::Result<Self, Self::Error> {
+        let bytes: [u8; 32] = slice.try_into().map_err(|_| WrongLength {
+            expected: 32,
+            got: slice.len(),
+        })?;
+        Ok(Self::new(bytes))
+    }
+}
+
+#[cfg(any(test, feature = "arbitrary"))]
+impl<'a> arbitrary::Arbitrary<'a> for ChunkAddress {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self::new(u.arbitrary()?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::PrimitivesError;
+
+    #[test]
+    fn zero_is_all_zero_bytes() {
+        assert_eq!(ChunkAddress::ZERO.as_bytes(), &[0u8; 32]);
+        assert!(ChunkAddress::zero().is_zero());
+    }
+
+    #[test]
+    fn roundtrips_via_from_impls() {
+        let bytes = [7u8; 32];
+        let addr = ChunkAddress::new(bytes);
+        assert_eq!(B256::from(addr), B256::new(bytes));
+        assert_eq!(ChunkAddress::from(B256::new(bytes)), addr);
+        assert_eq!(<[u8; 32]>::from(addr), bytes);
+        assert_eq!(ChunkAddress::from(bytes), addr);
+    }
+
+    #[test]
+    fn try_from_slice_wrong_length() {
+        let short = [0u8; 31];
+        assert_eq!(
+            ChunkAddress::try_from(short.as_slice()).unwrap_err(),
+            WrongLength {
+                expected: 32,
+                got: 31
+            }
+        );
+    }
+
+    #[test]
+    fn from_slice_carries_lengths() {
+        let long = [0u8; 33];
+        let err = ChunkAddress::from_slice(&long).unwrap_err();
+        assert!(matches!(
+            err,
+            PrimitivesError::WrongLength(WrongLength {
+                expected: 32,
+                got: 33
+            })
+        ));
+    }
+
+    #[test]
+    fn display_matches_b256_lowercase_hex() {
+        let addr = ChunkAddress::new([0xab; 32]);
+        let rendered = format!("{addr}");
+        assert!(rendered.starts_with("0x"));
+        assert_eq!(rendered.len(), 66);
+        assert!(rendered.chars().skip(2).all(|c| c.is_ascii_hexdigit()));
+    }
+}

--- a/crates/primitives/src/chunk/any_chunk.rs
+++ b/crates/primitives/src/chunk/any_chunk.rs
@@ -9,10 +9,11 @@ use bytes::Bytes;
 use crate::bmt::DEFAULT_BODY_SIZE;
 use crate::error::Result;
 
+use super::address::ChunkAddress;
 use super::chunk_type::ChunkType;
 use super::content::ContentChunk;
 use super::single_owner::SingleOwnerChunk;
-use super::traits::{Chunk, ChunkAddress};
+use super::traits::Chunk;
 use super::type_id::ChunkTypeId;
 
 /// Type-erased chunk for runtime polymorphism with configurable body size.
@@ -138,7 +139,7 @@ impl<const BODY_SIZE: usize> AnyChunk<BODY_SIZE> {
             Self::SingleOwner(c) => {
                 let inner = c.inner_body().transformed_root(anchor);
                 let mut hasher = Keccak256::new();
-                hasher.update(c.address().as_slice());
+                hasher.update(c.address());
                 hasher.update(inner.as_slice());
                 ChunkAddress::from(hasher.finalize())
             }
@@ -607,7 +608,7 @@ mod tests {
 
         // The chunk's plain BMT address is the unprefixed root.
         assert_eq!(
-            hex::encode(content.address().as_slice()),
+            hex::encode(content.address().as_bytes()),
             WANT_CHUNK_ADDR,
             "plain BMT address must match bee's published vector",
         );
@@ -615,7 +616,7 @@ mod tests {
         let any: DefaultAnyChunk = content.into();
         let tr = any.transformed_address(ANCHOR);
         assert_eq!(
-            hex::encode(tr.as_slice()),
+            hex::encode(tr.as_bytes()),
             WANT_TRANSFORMED,
             "CAC transformed address must match bee byte-for-byte",
         );
@@ -647,7 +648,7 @@ mod tests {
 
         // Sanity: this SOC's own address matches the oracle.
         assert_eq!(
-            hex::encode(soc.address().as_slice()),
+            hex::encode(soc.address().as_bytes()),
             WANT_CHUNK_ADDR,
             "SOC address must match bee's oracle",
         );
@@ -661,7 +662,7 @@ mod tests {
         let any: DefaultAnyChunk = soc.into();
         let tr = any.transformed_address(ANCHOR);
         assert_eq!(
-            hex::encode(tr.as_slice()),
+            hex::encode(tr.as_bytes()),
             WANT_TRANSFORMED,
             "SOC transformed address must match bee byte-for-byte",
         );

--- a/crates/primitives/src/chunk/bmt_body.rs
+++ b/crates/primitives/src/chunk/bmt_body.rs
@@ -7,8 +7,8 @@ use bytes::{Bytes, BytesMut};
 use std::marker::PhantomData;
 use std::sync::OnceLock;
 
-use crate::SwarmAddress;
 use crate::bmt::{DEFAULT_BODY_SIZE, Hasher, SPAN_SIZE};
+use crate::chunk::ChunkAddress;
 use crate::chunk::error::{self, ChunkError};
 use crate::error::{PrimitivesError, Result};
 
@@ -17,7 +17,7 @@ use crate::error::{PrimitivesError, Result};
 pub struct BmtBody<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> {
     span: u64,
     data: Bytes,
-    cached_hash: OnceLock<SwarmAddress>,
+    cached_hash: OnceLock<ChunkAddress>,
 }
 
 impl<const BODY_SIZE: usize> BmtBody<BODY_SIZE> {
@@ -51,11 +51,11 @@ impl<const BODY_SIZE: usize> BmtBody<BODY_SIZE> {
     }
 
     /// Compute the BMT hash of this body
-    pub fn hash(&self) -> SwarmAddress {
+    pub fn hash(&self) -> ChunkAddress {
         *self.cached_hash.get_or_init(|| self.calculate_hash())
     }
 
-    fn calculate_hash(&self) -> SwarmAddress {
+    fn calculate_hash(&self) -> ChunkAddress {
         let mut hasher: Hasher<BODY_SIZE> = Hasher::new();
         hasher.set_span(self.span);
         hasher.update(self.data.as_ref());

--- a/crates/primitives/src/chunk/content.rs
+++ b/crates/primitives/src/chunk/content.rs
@@ -12,8 +12,9 @@ use crate::bmt::DEFAULT_BODY_SIZE;
 use crate::cache::OnceCache;
 use crate::error::{PrimitivesError, Result};
 
+use super::address::ChunkAddress;
 use super::bmt_body::BmtBody;
-use super::traits::{BmtChunk, Chunk, ChunkAddress, ChunkHeader, ChunkMetadata};
+use super::traits::{BmtChunk, Chunk, ChunkHeader, ChunkMetadata};
 
 /// A content-addressed chunk with configurable body size.
 ///

--- a/crates/primitives/src/chunk/error.rs
+++ b/crates/primitives/src/chunk/error.rs
@@ -1,4 +1,4 @@
-use crate::SwarmAddress;
+use super::address::ChunkAddress;
 use thiserror::Error;
 
 use super::type_id::ChunkTypeId;
@@ -25,8 +25,8 @@ pub enum ChunkError {
     /// Chunk address verification failed
     #[error("Chunk address verification failed: expected {expected}, got {actual}")]
     VerificationFailed {
-        expected: SwarmAddress,
-        actual: SwarmAddress,
+        expected: ChunkAddress,
+        actual: ChunkAddress,
     },
 
     /// Signature errors from the crypto library
@@ -59,7 +59,7 @@ impl ChunkError {
         Self::InvalidFormat(msg.into())
     }
 
-    pub const fn verification_failed(expected: SwarmAddress, actual: SwarmAddress) -> Self {
+    pub const fn verification_failed(expected: ChunkAddress, actual: ChunkAddress) -> Self {
         Self::VerificationFailed { expected, actual }
     }
 

--- a/crates/primitives/src/chunk/mod.rs
+++ b/crates/primitives/src/chunk/mod.rs
@@ -16,6 +16,7 @@
 //! The [`AnyChunk`] enum provides runtime polymorphism for chunks without
 //! requiring object-safe traits.
 
+mod address;
 mod any_chunk;
 mod bmt_body;
 mod chunk_type;
@@ -32,8 +33,9 @@ mod type_id;
 #[cfg(target_arch = "wasm32")]
 pub mod wasm;
 
-// Re-export the core traits
-pub use traits::{BmtChunk, Chunk, ChunkAddress, ChunkHeader, ChunkMetadata, ChunkSerialization};
+// Re-export the address type and core traits
+pub use address::ChunkAddress;
+pub use traits::{BmtChunk, Chunk, ChunkHeader, ChunkMetadata, ChunkSerialization};
 
 // Re-export the reference types
 pub use reference::{ChunkRef, RefKind, Reference, WrongRefKind};

--- a/crates/primitives/src/chunk/single_owner.rs
+++ b/crates/primitives/src/chunk/single_owner.rs
@@ -16,10 +16,11 @@ use crate::cache::OnceCache;
 use crate::chunk::error::{self, ChunkError};
 use crate::error::Result;
 
+use super::address::ChunkAddress;
 use super::bmt_body::BmtBody;
 use super::content::ContentChunk;
 use super::soc_id::SocId;
-use super::traits::{BmtChunk, Chunk, ChunkAddress, ChunkHeader, ChunkMetadata};
+use super::traits::{BmtChunk, Chunk, ChunkHeader, ChunkMetadata};
 
 // Constants for field sizes
 const ID_SIZE: usize = std::mem::size_of::<B256>();
@@ -283,7 +284,7 @@ impl<const BODY_SIZE: usize> SingleOwnerChunk<BODY_SIZE> {
     // Checks if the chunk is a valid dispersed replica
     #[allow(clippy::indexing_slicing)] // both id and body hash are fixed 32-byte values, so [1..] holds
     fn is_valid_replica(&self) -> bool {
-        self.id().as_slice()[1..] == self.body.hash().as_slice()[1..]
+        self.id().as_slice()[1..] == self.body.hash().as_bytes()[1..]
     }
 
     /// Get the ID of this chunk.
@@ -563,7 +564,7 @@ impl<const BODY_SIZE: usize> SingleOwnerChunkBuilderImpl<BODY_SIZE, WithData> {
         let body_hash = self.body.as_ref().unwrap().hash();
         let mut id = B256::default();
         id[0] = first_byte;
-        id[1..].copy_from_slice(&body_hash.as_slice()[1..]);
+        id[1..].copy_from_slice(&body_hash.as_bytes()[1..]);
 
         let signer = PrivateKeySigner::from_slice(DISPERSED_REPLICA_OWNER_PK.as_slice()).unwrap();
 

--- a/crates/primitives/src/chunk/traits.rs
+++ b/crates/primitives/src/chunk/traits.rs
@@ -3,13 +3,11 @@
 //! This module defines the core traits that all chunk types must implement,
 //! along with serialization and deserialization functionality.
 
-use crate::SwarmAddress;
 use crate::chunk::error;
 use crate::error::Result;
 use bytes::{BufMut, Bytes, BytesMut};
 
-/// Type alias for chunk addresses
-pub type ChunkAddress = SwarmAddress;
+use super::address::ChunkAddress;
 
 /// Core trait for chunk metadata
 pub trait ChunkMetadata {

--- a/crates/primitives/src/chunk/wasm.rs
+++ b/crates/primitives/src/chunk/wasm.rs
@@ -25,7 +25,7 @@ impl WasmContentChunk {
     #[wasm_bindgen]
     pub fn address(&self) -> Uint8Array {
         let result = Uint8Array::new_with_length(32);
-        result.copy_from(self.0.address().as_slice());
+        result.copy_from(self.0.address().as_bytes());
         result
     }
 
@@ -105,7 +105,7 @@ impl WasmSplitResult {
         let arr = Array::new();
         for chunk in &self.chunks {
             let addr = Uint8Array::new_with_length(32);
-            addr.copy_from(chunk.address().as_slice());
+            addr.copy_from(chunk.address().as_bytes());
             arr.push(&addr);
         }
         arr

--- a/crates/primitives/src/file/tests.rs
+++ b/crates/primitives/src/file/tests.rs
@@ -116,7 +116,7 @@ fn run_vector_test(size: usize, expected_hex: &str) {
     let (root, _) = splitter.finish().unwrap();
 
     assert_eq!(
-        hex::encode(root.as_slice()),
+        hex::encode(root.as_bytes()),
         expected_hex,
         "Root hash mismatch for size {} bytes",
         size

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -68,6 +68,7 @@ pub mod spec;
 pub mod store;
 pub mod timestamp;
 pub mod wire;
+pub mod xor_metric;
 
 #[cfg(target_arch = "wasm32")]
 pub mod wasm;
@@ -81,7 +82,7 @@ pub use chunk::encryption::{EncryptedChunkRef, EncryptionKey};
 pub use chunk::{ChunkEncrypt, EncryptedContentChunk};
 
 // Re-export core types
-pub use address::{EXTENDED_PO, MAX_PO, SwarmAddress};
+pub use address::SwarmAddress;
 pub use bin::{Bin, BinError};
 pub use error::{PrimitivesError, Result, WrongLength};
 pub use neighborhood_depth::recompute_neighborhood_depth;
@@ -91,6 +92,7 @@ pub use overlay::compute_overlay;
 pub use proximity_order::{ProximityOrder, ProximityOrderError};
 pub use spec::{MAINNET, StaticSpec, SwarmSpec, TESTNET};
 pub use timestamp::{Timestamp, TimestampError};
+pub use xor_metric::{EXTENDED_PO, MAX_PO, XorMetric};
 
 // Core BMT functionality
 pub use bmt::{Hasher, HasherFactory, Proof, Prover};

--- a/crates/primitives/src/proximity_order.rs
+++ b/crates/primitives/src/proximity_order.rs
@@ -1,7 +1,7 @@
 //! Typed Kademlia proximity order (PO) in the range `0..=MAX_PO`.
 //!
 //! See [`MAX_PO`] for the standard cap (31) and
-//! [`address`](crate::address) for the derivation from two [`SwarmAddress`es](crate::SwarmAddress).
+//! [`xor_metric`](crate::xor_metric) for the derivation from two address-space points.
 
 use crate::MAX_PO;
 use derive_more::{Display, Into};
@@ -45,7 +45,7 @@ impl ProximityOrder {
     /// Construct without bounds checking. Caller must ensure `raw <= MAX_PO`.
     ///
     /// Used by internal code that already validated the range (e.g.
-    /// `SwarmAddress::proximity_order`, which can never exceed `MAX_PO`).
+    /// `XorMetric::proximity`, which can never exceed `MAX_PO`).
     #[inline]
     pub(crate) const fn new_unchecked(raw: u8) -> Self {
         debug_assert!(raw <= MAX_PO);

--- a/crates/primitives/src/xor_metric.rs
+++ b/crates/primitives/src/xor_metric.rs
@@ -1,0 +1,309 @@
+//! XOR-metric operations over 32-byte address-space points.
+//!
+//! Kademlia routing measures closeness between two 256-bit points as the
+//! number of leading matching bits (the proximity order, PO) or as the full
+//! XOR distance. The address kinds ([`SwarmAddress`](crate::SwarmAddress),
+//! [`ChunkAddress`](crate::ChunkAddress)) are distinct nominal types over the
+//! same point space, and the protocol compares across kinds (a chunk address
+//! against a node overlay for the storage radius and pushsync targeting), so
+//! the ops live here on a shared trait rather than on any one kind.
+//!
+//! ## Standard vs extended proximity
+//!
+//! - **Standard PO** ([`MAX_PO`] = 31): most routing operations; 32 bins.
+//! - **Extended PO** ([`EXTENDED_PO`] = 36): Kademlia bin balancing, which
+//!   checks `po + BitSuffixLength + 1` (`BitSuffixLength = 4`), so bin 31
+//!   needs 31 + 4 + 1 = 36.
+//!
+//! Matches the Swarm reference implementation: leading matching bits (not
+//! bytes), capped at the respective maximum.
+//!
+//! ## Example
+//!
+//! ```
+//! use nectar_primitives::{SwarmAddress, XorMetric};
+//! use alloy_primitives::B256;
+//!
+//! let addr1 = SwarmAddress::from(B256::random());
+//! let addr2 = SwarmAddress::from(B256::random());
+//!
+//! let po = addr1.proximity(&addr2);
+//! let distance = addr1.distance(&addr2);
+//!
+//! let addr3 = SwarmAddress::from(B256::random());
+//! if addr1.closer(&addr2, &addr3) {
+//!     println!("addr1 is closer to addr2 than addr3");
+//! }
+//! ```
+
+use std::cmp::Ordering;
+
+use alloy_primitives::U256;
+
+use crate::{Bin, ProximityOrder};
+
+/// Maximum proximity order for standard routing operations.
+///
+/// Value 31 gives 32 Kademlia bins (0-31).
+pub const MAX_PO: u8 = 31;
+
+/// Extended proximity order for Kademlia bin balancing.
+///
+/// Value 36 = MaxPO (31) + BitSuffixLength (4) + 1. Used when the Kademlia
+/// bin balancing algorithm needs to check proximity at finer granularity
+/// than standard routing.
+pub const EXTENDED_PO: u8 = MAX_PO + 5;
+
+/// XOR-metric operations over a 32-byte point.
+///
+/// Every method takes `&impl XorMetric`, so proximity and distance are legal
+/// across address kinds; the kinds stay nominally distinct everywhere else.
+pub trait XorMetric {
+    /// The 32-byte point this value occupies in the XOR metric space.
+    fn point(&self) -> &[u8; 32];
+
+    /// Calculate the distance between `self` and `y` in big-endian.
+    #[allow(clippy::indexing_slicing)] // i < 32 from enumerating a 32-byte point, matching result's length
+    #[inline(always)]
+    #[must_use]
+    fn distance(&self, y: &impl XorMetric) -> U256 {
+        let mut result = [0u8; 32];
+
+        for (i, (&a, &b)) in self.point().iter().zip(y.point().iter()).enumerate() {
+            result[i] = a ^ b;
+        }
+
+        U256::from_be_bytes(result)
+    }
+
+    /// Compares points `x` and `y` by their distance from `self`.
+    ///
+    /// Returns:
+    /// - `Ordering::Less` if `x` is farther from `self` than `y` (i.e., `y` is closer)
+    /// - `Ordering::Greater` if `x` is closer to `self` than `y`
+    /// - `Ordering::Equal` if `x` and `y` are equidistant from `self`
+    ///
+    /// # Usage with `min_by`
+    ///
+    /// This comparator is designed for use with `Iterator::min_by` to find
+    /// the point closest to `self`:
+    ///
+    /// ```
+    /// # use nectar_primitives::{SwarmAddress, XorMetric};
+    /// # use alloy_primitives::B256;
+    /// let target = SwarmAddress::zero();
+    /// let addresses = vec![
+    ///     SwarmAddress::from(B256::repeat_byte(0x01)),
+    ///     SwarmAddress::from(B256::repeat_byte(0x02)),
+    /// ];
+    /// let closest = addresses.iter().min_by(|a, b| target.distance_cmp(a, b));
+    /// ```
+    ///
+    /// Note: The ordering may seem inverted from intuition. `Greater` means `x`
+    /// is closer (smaller distance), because `min_by` selects the element for
+    /// which the comparator returns `Less` - and we want to select the one
+    /// that is NOT closer (i.e., has a larger distance), leaving the closest.
+    #[allow(clippy::indexing_slicing)] // ab, xb and yb are all 32-byte points and i < ab.len()
+    #[inline(always)]
+    #[must_use]
+    fn distance_cmp(&self, x: &impl XorMetric, y: &impl XorMetric) -> Ordering {
+        let (ab, xb, yb) = (self.point(), x.point(), y.point());
+
+        for i in 0..ab.len() {
+            let dx = xb[i] ^ ab[i];
+            let dy = yb[i] ^ ab[i];
+
+            if dx != dy {
+                return match dx < dy {
+                    true => Ordering::Greater,
+                    false => Ordering::Less,
+                };
+            }
+        }
+
+        Ordering::Equal
+    }
+
+    /// Determine if `self` is closer to `x` than to `y`.
+    ///
+    /// Returns `true` if `distance(self, x) < distance(self, y)`.
+    #[must_use]
+    fn closer(&self, x: &impl XorMetric, y: &impl XorMetric) -> bool {
+        // distance_cmp returns Greater when x is closer to self
+        self.distance_cmp(x, y) == Ordering::Greater
+    }
+
+    /// Check if this point is within the given proximity to another point.
+    fn is_within_proximity(&self, other: &impl XorMetric, min_proximity: ProximityOrder) -> bool {
+        self.proximity(other) >= min_proximity
+    }
+
+    /// Calculate the proximity order between `self` and another point.
+    ///
+    /// Returns the number of leading bits that match between the two points,
+    /// capped at [`MAX_PO`] (31). Use this for standard Kademlia routing
+    /// operations.
+    ///
+    /// For operations requiring finer granularity (like reserve sampling),
+    /// use [`extended_proximity()`](Self::extended_proximity) instead.
+    #[inline(always)]
+    #[must_use]
+    fn proximity(&self, other: &impl XorMetric) -> ProximityOrder {
+        // `proximity_up_to` is bounded by MAX_PO, so the cast is sound.
+        ProximityOrder::new_unchecked(proximity_up_to(self.point(), other.point(), MAX_PO.into()))
+    }
+
+    /// Calculate the extended proximity order between `self` and another point.
+    ///
+    /// Returns the number of leading bits that match between the two points,
+    /// capped at [`EXTENDED_PO`] (36). Use this for Kademlia bin balancing
+    /// where the algorithm checks `po + BitSuffixLength + 1` (up to 36 for
+    /// bin 31).
+    ///
+    /// Returns a raw `u8` because the extended range exceeds `ProximityOrder`'s
+    /// invariant (`0..=MAX_PO`). For standard routing, use
+    /// [`proximity()`](Self::proximity) instead.
+    #[inline(always)]
+    #[must_use]
+    fn extended_proximity(&self, other: &impl XorMetric) -> u8 {
+        proximity_up_to(self.point(), other.point(), EXTENDED_PO.into())
+    }
+
+    /// XOR distance - bitwise XOR of the two 32-byte points as a new value of
+    /// the receiver's kind. Useful when callers want the raw distance bytes
+    /// (e.g. for content-routing bias) rather than the proximity-order metric.
+    #[allow(clippy::indexing_slicing)] // i < 32 from enumerating a 32-byte point, matching out's length
+    #[inline(always)]
+    #[must_use]
+    fn xor(&self, other: &impl XorMetric) -> Self
+    where
+        Self: Sized + From<[u8; 32]>,
+    {
+        let mut out = [0u8; 32];
+        for (i, (a, b)) in self.point().iter().zip(other.point()).enumerate() {
+            out[i] = a ^ b;
+        }
+        Self::from(out)
+    }
+
+    /// Kademlia bin index of `self` relative to `anchor` - semantic alias for
+    /// `Bin::from(self.proximity(anchor))`. The routing-table convention is
+    /// "the bin a peer occupies is its proximity order to our own overlay".
+    #[inline(always)]
+    #[must_use]
+    fn bin(&self, anchor: &impl XorMetric) -> Bin {
+        Bin::from(self.proximity(anchor))
+    }
+}
+
+// References are points too, so iterator adaptors (`min_by` over `&T` items)
+// pass without an explicit deref.
+impl<T: XorMetric> XorMetric for &T {
+    fn point(&self) -> &[u8; 32] {
+        (**self).point()
+    }
+}
+
+/// Count of leading matching bits between two points, capped at `max`.
+#[allow(
+    clippy::arithmetic_side_effects,
+    clippy::indexing_slicing,
+    clippy::as_conversions
+)]
+// max is MAX_PO (31) or EXTENDED_PO (36), so i <= max_bytes = 4 < 32 and i * 8 + leading_zeros <= 40 fits u8; the casts to u8 (max, i, and the u8 xor's leading_zeros <= 8) are all within those bounds
+#[inline(always)]
+fn proximity_up_to(bytes1: &[u8; 32], bytes2: &[u8; 32], max: usize) -> u8 {
+    let max_bytes = max / 8;
+    let max_bits = max as u8;
+
+    for i in 0..=max_bytes {
+        let xor = bytes1[i] ^ bytes2[i];
+        if xor != 0 {
+            // Found a difference - use leading_zeros to count matching bits
+            let leading_zeros = xor.leading_zeros() as u8;
+            let proximity = (i as u8 * 8) + leading_zeros;
+
+            // Return the smaller of proximity or max_bits
+            return if proximity < max_bits {
+                proximity
+            } else {
+                max_bits
+            };
+        }
+
+        // If we're at the last byte we might need to check
+        if i == max_bytes {
+            return max_bits; // All bits match up to max
+        }
+    }
+
+    // If we've examined all bytes and found no differences
+    max_bits
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ChunkAddress, SwarmAddress};
+    use alloy_primitives::B256;
+
+    #[test]
+    fn proximity_counts_leading_matching_bits() {
+        let base = SwarmAddress::with_first_byte(0b0000_0000);
+        let one_bit = SwarmAddress::with_first_byte(0b0100_0000);
+        assert_eq!(base.proximity(&one_bit).get(), 1);
+
+        let full_match = SwarmAddress::zero();
+        assert_eq!(base.proximity(&full_match).get(), MAX_PO);
+    }
+
+    #[test]
+    fn extended_proximity_exceeds_standard_cap() {
+        let base = SwarmAddress::zero();
+        assert_eq!(base.extended_proximity(&base), EXTENDED_PO);
+        assert_eq!(base.proximity(&base).get(), MAX_PO);
+    }
+
+    #[test]
+    fn distance_is_symmetric_xor() {
+        let a = SwarmAddress::from(B256::repeat_byte(0x0f));
+        let b = SwarmAddress::from(B256::repeat_byte(0xf0));
+        assert_eq!(a.distance(&b), b.distance(&a));
+        assert_eq!(
+            a.distance(&b),
+            U256::from_be_bytes([0xffu8; 32]),
+            "0x0f ^ 0xf0 = 0xff in every byte"
+        );
+    }
+
+    #[test]
+    fn distance_cmp_orders_by_closeness() {
+        let target = SwarmAddress::zero();
+        let near = SwarmAddress::from(B256::repeat_byte(0x01));
+        let far = SwarmAddress::from(B256::repeat_byte(0x02));
+        assert_eq!(target.distance_cmp(&near, &far), Ordering::Greater);
+        assert_eq!(target.distance_cmp(&far, &near), Ordering::Less);
+        assert_eq!(target.distance_cmp(&near, &near), Ordering::Equal);
+        assert!(target.closer(&near, &far));
+    }
+
+    #[test]
+    fn cross_kind_proximity_is_legal() {
+        // The protocol compares a chunk address against a node overlay
+        // (storage radius, pushsync targeting); the trait keeps that legal
+        // across the distinct kinds.
+        let chunk = ChunkAddress::from(B256::repeat_byte(0xaa));
+        let overlay = SwarmAddress::from(B256::repeat_byte(0xaa));
+        assert_eq!(chunk.proximity(&overlay).get(), MAX_PO);
+        assert_eq!(chunk.distance(&overlay), U256::ZERO);
+        assert_eq!(overlay.bin(&chunk), Bin::from(overlay.proximity(&chunk)));
+    }
+
+    #[test]
+    fn xor_returns_receiver_kind() {
+        let a = ChunkAddress::from(B256::repeat_byte(0x0f));
+        let b = SwarmAddress::from(B256::repeat_byte(0xf0));
+        let d: ChunkAddress = a.xor(&b);
+        assert_eq!(d, ChunkAddress::from(B256::repeat_byte(0xff)));
+    }
+}

--- a/fuzz/fuzz_targets/stamp_decode.rs
+++ b/fuzz/fuzz_targets/stamp_decode.rs
@@ -14,7 +14,7 @@
 
 use libfuzzer_sys::fuzz_target;
 use nectar_postage::{STAMP_SIZE, Stamp};
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::ChunkAddress;
 
 fuzz_target!(|data: &[u8]| {
     // Whole-input decode covers the exact-length check path.
@@ -24,7 +24,7 @@ fuzz_target!(|data: &[u8]| {
     // so signer recovery runs over arbitrary stamp fields.
     if data.len() >= STAMP_SIZE + 32
         && let Ok(stamp) = Stamp::try_from_slice(&data[..STAMP_SIZE])
-        && let Ok(address) = SwarmAddress::from_slice(&data[STAMP_SIZE..STAMP_SIZE + 32])
+        && let Ok(address) = ChunkAddress::from_slice(&data[STAMP_SIZE..STAMP_SIZE + 32])
     {
         let _ = stamp.recover_signer(&address);
     }


### PR DESCRIPTION
## What

Makes `ChunkAddress` a distinct `repr(transparent)` newtype over `alloy_primitives::B256`, following the `SocId` `derive_more` pattern (`From`/`Into` for `B256` and `[u8; 32]`, `AsRef<[u8]>`, `Display`, `serde(transparent)`, `arbitrary`, and a `WrongLength`-carrying `from_slice`/`TryFrom`).

Moves the XOR-metric operations (`distance`, `distance_cmp`, `closer`, `proximity`, `extended_proximity`, `is_within_proximity`, `xor`, `bin`) out of `SwarmAddress` inherent methods and into a new `XorMetric` trait in `crates/primitives/src/xor_metric.rs`, whose methods take `&impl XorMetric` over the 32-byte point. This keeps cross-kind proximity (chunk address vs node overlay) legal, since both `SwarmAddress` and `ChunkAddress` implement the trait; a new `cross_kind_proximity_is_legal` test covers this. `MAX_PO` and `EXTENDED_PO` moved to the same module and are still re-exported unchanged from the crate root.

`SwarmAddress` loses its public field and its `Deref<Target = B256>` impl, and is now scoped to node identity only (`overlay.rs`, `signing.rs`).

Downstream call sites across `postage`, `postage-issuer`, `postage-usage` and the primitives WASM demo/fuzz target are updated to call through the `XorMetric` trait instead of the old `SwarmAddress` inherent methods.

Closes #180

## Why

Chunk addresses and node overlay addresses are distinct concepts that happened to share a representation and, before this change, shared inherent methods defined on `SwarmAddress` alone. That made `ChunkAddress` effectively an alias rather than a nominal type, and forced any cross-kind proximity comparison (chunk vs overlay, needed for storage radius and pushsync targeting) through an implicit coercion. Giving `ChunkAddress` its own newtype and lifting the XOR-metric ops to a shared trait makes the two kinds nominally distinct while keeping the operations that legitimately compare across them well-typed and in one place.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --all-features` (638 tests run, 638 passed, 1 skipped)
- `cargo test --doc --workspace --all-features`

This is a stacked PR targeting `s187/14-length-errors`; no CI beyond CLA will run until the base is retargeted.

## AI Assistance

Claude (Sonnet) was used for the refactor implementation, adversarial red-team review, and independent test verification.

