### PR TITLE
refactor(primitives)!: ungate encrypted reference representation

### DIFF
--- a/crates/mantaray/src/builder.rs
+++ b/crates/mantaray/src/builder.rs
@@ -66,7 +66,7 @@ impl<S, const BS: usize> ManifestBuilder<S, ChunkRef, BS> {
     }
 }
 
-#[cfg(feature = "encryption")]
+#[cfg(feature = "std")]
 impl<S, const BS: usize> ManifestBuilder<S, nectar_primitives::EncryptedChunkRef, BS> {
     /// Create a new encrypted builder (random obfuscation key, 64-byte refs).
     pub fn new_encrypted(store: S) -> Self {
@@ -177,7 +177,11 @@ impl<S: ChunkGet<BS> + ChunkPut<BS>, const BS: usize>
         }
         self.add(path, root).await
     }
+}
 
+impl<S: ChunkGet<BS> + ChunkPut<BS>, const BS: usize>
+    ManifestBuilder<S, nectar_primitives::EncryptedChunkRef, BS>
+{
     /// Persist the encrypted manifest, consuming the builder.
     ///
     /// Returns a [`ManifestRef`](crate::ManifestRef) and a read handle over the
@@ -292,7 +296,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "encryption")]
     #[test]
     fn encrypted_builder_round_trips_the_reference() {
         use nectar_primitives::file::EntryRef;
@@ -314,7 +317,6 @@ mod tests {
         assert_eq!(entry.reference(), Some(&EntryRef::Encrypted(eref)));
     }
 
-    #[cfg(feature = "encryption")]
     #[test]
     fn encrypted_builder_rejects_root_metadata() {
         use nectar_primitives::{EncryptedChunkRef, EncryptionKey};

--- a/crates/mantaray/src/codec.rs
+++ b/crates/mantaray/src/codec.rs
@@ -917,7 +917,6 @@ mod tests {
     /// the `EncryptedChunkRef` entry, so the 64-byte slicing arithmetic in
     /// `decode_v01`/`decode_v02` is exercised on stable (the fuzz target
     /// drives this width too, but only under libfuzzer mutation on nightly).
-    #[cfg(feature = "encryption")]
     fn truncated_encref_node_bytes(version: &VersionHash, len: usize) -> Vec<u8> {
         assert!(len >= NodeHeader::SIZE);
         let mut data = vec![0u8; len];
@@ -931,7 +930,6 @@ mod tests {
     /// slot is `data[64..128]` and the forks index `data[128..160]`, so every
     /// length below 160 must return `Err` (the PR bounds check, exercised for
     /// the encrypted-ref path), never panic.
-    #[cfg(feature = "encryption")]
     #[test]
     fn decode_encref_truncated_lengths_return_err() {
         use nectar_primitives::EncryptedChunkRef;
@@ -949,7 +947,6 @@ mod tests {
 
     /// A full 160-byte encrypted-ref node whose index demands a fork ref that
     /// is not present must hit the guarded error path, not panic.
-    #[cfg(feature = "encryption")]
     #[test]
     fn decode_encref_index_demands_missing_fork_returns_err() {
         use nectar_primitives::EncryptedChunkRef;
@@ -967,9 +964,9 @@ mod tests {
 
     /// Replay the committed seed corpus of the `mantaray_node_decode` fuzz
     /// target through the exact decode entry points the fuzzer exercises
-    /// (`Node::<ChunkRef>` for 32-byte plain entries and, under the
-    /// `encryption` feature, `Node::<EncryptedChunkRef>` for 64-byte
-    /// entries). The oracle is "no panic";
+    /// (`Node::<ChunkRef>` for 32-byte plain entries and
+    /// `Node::<EncryptedChunkRef>` for 64-byte entries).
+    /// The oracle is "no panic";
     /// `Err` is an acceptable outcome for any seed. Additionally pin the
     /// intent of each seed by name: `crash-*` seeds must stay `Err` (they
     /// are fixed panic reproducers), `valid-*` seeds must decode `Ok`.
@@ -989,10 +986,8 @@ mod tests {
             let data = std::fs::read(&path).unwrap();
 
             // The fuzz oracle: must not panic. Drive both entry widths the
-            // fuzz target drives; the 64-byte `EncryptedChunkRef` path only
-            // exists under the `encryption` feature.
+            // fuzz target drives.
             let result = Node::<ChunkRef>::decode(data.as_slice());
-            #[cfg(feature = "encryption")]
             let _ = Node::<nectar_primitives::EncryptedChunkRef>::decode(data.as_slice());
 
             if name.starts_with("crash-") {
@@ -1052,7 +1047,6 @@ mod tests {
             .join("../../fuzz/seeds/mantaray_record_roundtrip");
         let mut replayed = 0usize;
         let mut plain_decoded = 0usize;
-        #[cfg(feature = "encryption")]
         let mut wide_decoded = 0usize;
         for entry in std::fs::read_dir(&seed_dir)
             .unwrap_or_else(|e| panic!("seed dir {} must exist: {e}", seed_dir.display()))
@@ -1063,7 +1057,6 @@ mod tests {
             if record_round_trip::<ChunkRef>(&data) {
                 plain_decoded += 1;
             }
-            #[cfg(feature = "encryption")]
             if record_round_trip::<nectar_primitives::EncryptedChunkRef>(&data) {
                 wide_decoded += 1;
             }
@@ -1077,7 +1070,6 @@ mod tests {
             plain_decoded >= 2,
             "expected the v0.1 and v0.2 manifests to round-trip at the ChunkRef width, decoded {plain_decoded}"
         );
-        #[cfg(feature = "encryption")]
         assert!(
             wide_decoded >= 1,
             "expected the ref_size=64 seed to decode at the EncryptedChunkRef width"

--- a/crates/mantaray/src/entry.rs
+++ b/crates/mantaray/src/entry.rs
@@ -110,7 +110,6 @@ impl From<ChunkAddress> for Entry {
     }
 }
 
-#[cfg(feature = "encryption")]
 impl From<nectar_primitives::EncryptedChunkRef> for Entry {
     fn from(enc_ref: nectar_primitives::EncryptedChunkRef) -> Self {
         Self::new(enc_ref)

--- a/crates/mantaray/src/lib.rs
+++ b/crates/mantaray/src/lib.rs
@@ -170,6 +170,5 @@ pub type DefaultManifest<S> = PlainManifest<S, DEFAULT_BODY_SIZE>;
 pub type PlainManifest<S, const BS: usize = DEFAULT_BODY_SIZE> = Manifest<S, ChunkRef, BS>;
 
 /// Encrypted manifest: 64-byte refs, random obfuscation key.
-#[cfg(feature = "encryption")]
 pub type EncryptedManifest<S, const BS: usize = DEFAULT_BODY_SIZE> =
     Manifest<S, nectar_primitives::EncryptedChunkRef, BS>;

--- a/crates/mantaray/src/manifest.rs
+++ b/crates/mantaray/src/manifest.rs
@@ -44,9 +44,9 @@ impl<S, const BS: usize> Manifest<S, ChunkRef, BS> {
     }
 }
 
-#[cfg(feature = "encryption")]
 impl<S, const BS: usize> Manifest<S, nectar_primitives::EncryptedChunkRef, BS> {
     /// Create a new encrypted manifest (random obfuscation key, 64-byte refs).
+    #[cfg(feature = "std")]
     pub fn new_encrypted(store: S) -> Self {
         use crate::obfuscation::ObfuscationKey;
         let trie = Node {
@@ -423,7 +423,6 @@ impl<S: ChunkGet<BS>, const BS: usize> Manifest<S, nectar_primitives::EncryptedC
     }
 }
 
-#[cfg(feature = "encryption")]
 impl<S: ChunkGet<BS> + ChunkPut<BS>, const BS: usize>
     Manifest<S, nectar_primitives::EncryptedChunkRef, BS>
 {

--- a/crates/primitives/src/file/entry_ref.rs
+++ b/crates/primitives/src/file/entry_ref.rs
@@ -60,3 +60,42 @@ impl From<&EntryRef> for Vec<u8> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chunk::encryption::{EncryptedChunkRef, EncryptionKey};
+
+    /// Both widths parse and re-serialize without the `encryption` feature:
+    /// the representation is unconditional, only key generation and joining
+    /// are gated.
+    #[test]
+    fn parses_and_reserializes_both_widths() {
+        let plain_bytes = [0x11u8; ChunkRef::SIZE];
+        let plain = EntryRef::try_from_bytes(&plain_bytes).unwrap();
+        assert!(matches!(plain, EntryRef::Plain(_)));
+        assert_eq!(Vec::<u8>::from(&plain), plain_bytes);
+
+        let mut enc_bytes = [0x22u8; EncryptedChunkRef::SIZE];
+        enc_bytes[ChunkRef::SIZE..].fill(0x33);
+        let encrypted = EntryRef::try_from_bytes(&enc_bytes).unwrap();
+        let EntryRef::Encrypted(ref enc) = encrypted else {
+            panic!("64 bytes must parse as an encrypted reference");
+        };
+        assert_eq!(enc.address().as_bytes(), &[0x22u8; ChunkRef::SIZE]);
+        assert_eq!(
+            enc.key(),
+            &EncryptionKey::from([0x33u8; EncryptionKey::SIZE])
+        );
+        assert_eq!(Vec::<u8>::from(&encrypted), enc_bytes);
+    }
+
+    #[test]
+    fn rejects_other_widths() {
+        for len in [0usize, 31, 33, 63, 65, 96] {
+            let bytes = vec![0u8; len];
+            let err = EntryRef::try_from_bytes(&bytes).unwrap_err();
+            assert!(matches!(err, FileError::InvalidEntryRef { len: got } if got == len));
+        }
+    }
+}

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,12 +14,12 @@ alloy-primitives = { version = "1.6", default-features = false }
 arbitrary = { version = "1", features = ["derive"] }
 alloy-signer-local = { version = "2.0", default-features = false }
 libfuzzer-sys = "0.4"
-# `encryption` gates the `Reference for EncryptedChunkRef` impl that
-# `mantaray_node_decode` uses to drive the 64-byte entry path; `hazmat`
-# exposes the raw node types and codec the mantaray targets exercise.
+# No `encryption` feature: the `EncryptedChunkRef` representation the
+# mantaray targets drive for the 64-byte entry path is unconditional.
+# `hazmat` exposes the raw node types and codec the mantaray targets
+# exercise.
 nectar-mantaray = { path = "../crates/mantaray", features = [
 	"arbitrary",
-	"encryption",
 	"hazmat",
 ] }
 nectar-postage = { path = "../crates/postage", features = ["arbitrary"] }


### PR DESCRIPTION
Closes #183

## What

Ungates the encrypted-reference representation in `nectar-mantaray` so it is available in every build, not just under the `encryption` feature:

- `From<EncryptedChunkRef> for Entry` (`crates/mantaray/src/entry.rs`) is now unconditional.
- The `EncryptedManifest` type alias (`crates/mantaray/src/lib.rs`) is now unconditional.
- `Manifest::open_encrypted` (`crates/mantaray/src/manifest.rs`) is now unconditional.
- `Manifest::new_encrypted` and `ManifestBuilder::new_encrypted` move from the `encryption` gate to the `std` gate, since they only generate a random obfuscation key via `rand` and never touch chunk-encryption material.
- The encrypted `Manifest::save -> ManifestRef` and `ManifestBuilder::save` paths are now unconditional; the latter required splitting the encrypted-builder `impl` block out of the encrypt-only `put_file` block in `crates/mantaray/src/builder.rs`.
- The encref-width codec regression tests in `crates/mantaray/src/codec.rs` (truncated-length bounds checks, missing-fork-index guard) and both fuzz-seed replay paths (`mantaray_node_decode`, `mantaray_record_roundtrip`) are ungated so the 64-byte `EncryptedChunkRef` path is exercised on stable, not only under the `encryption` feature.
- `fuzz/Cargo.toml` drops the now-unneeded `encryption` feature from the `nectar-mantaray` dependency, since the `Reference` impl for `EncryptedChunkRef` it enabled is unconditional.
- `crates/primitives/src/file/entry_ref.rs` gains crypto-free tests confirming both `EntryRef::Plain` and `EntryRef::Encrypted` parse and re-serialize without the `encryption` feature.
- An unused `alloy_primitives::B256` import is dropped from `crates/postage-usage/src/lib.rs`.

Key generation (`EncryptionKey::generate`), chunk encryption/decryption, joining and `put_file`/`EncryptedParallelSplitter` remain behind the `encryption` feature; only the representation, its byte codecs and the `Reference` impl are ungated.

## Why

Issue #183 asks for the encrypted-chunk-reference representation to be usable without the `encryption` feature, since earlier cars in this train had already made `EncryptedChunkRef`, its byte codecs, the `Reference` impl and `EntryRef::Encrypted` unconditional in `nectar-primitives`. This car removes the residual gating in `nectar-mantaray` that still required `encryption` to construct, store and reload an encrypted manifest's structure, and pins the `new_encrypted` constructors to the gate they actually depend on (`std`, for `rand`) rather than `encryption`, fixing a no-std+encryption combination that never compiled.

## Testing

- `cargo test` at both the default feature set and with `encryption` enabled, covering the newly-ungated codec regression tests, the two fuzz-seed replay paths and the crypto-free builder round-trip tests.
- `crates/primitives/src/file/entry_ref.rs` unit tests confirming both reference widths parse and re-serialize without `encryption`.

AI Assistance: Claude (Anthropic), via Claude Code, used for the full implementation, per github.com/nxm-rs/.github CONTRIBUTING.md.

