### PR TITLE
refactor(primitives)!: rename SwarmAddress to OverlayAddress

### DIFF
--- a/crates/primitives/benches/address.rs
+++ b/crates/primitives/benches/address.rs
@@ -13,7 +13,7 @@
 )]
 use alloy_primitives::{B256, b256};
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
-use nectar_primitives::{SwarmAddress, XorMetric};
+use nectar_primitives::{OverlayAddress, XorMetric};
 use rand::prelude::*;
 
 pub fn address_benchmarks(c: &mut Criterion) {
@@ -21,22 +21,22 @@ pub fn address_benchmarks(c: &mut Criterion) {
     let mut rng = rand::rng();
 
     // Generate random addresses for benchmarking
-    let addresses: Vec<SwarmAddress> = (0..1000)
+    let addresses: Vec<OverlayAddress> = (0..1000)
         .map(|_| {
             let mut bytes = [0u8; 32];
             rng.fill(&mut bytes);
-            SwarmAddress::from(B256::from_slice(&bytes))
+            OverlayAddress::from(B256::from_slice(&bytes))
         })
         .collect();
 
     // Define some fixed addresses for consistent benchmarks
-    let base_addr = SwarmAddress::from(b256!(
+    let base_addr = OverlayAddress::from(b256!(
         "9100000000000000000000000000000000000000000000000000000000000000"
     ));
-    let near_addr = SwarmAddress::from(b256!(
+    let near_addr = OverlayAddress::from(b256!(
         "9180000000000000000000000000000000000000000000000000000000000000"
     ));
-    let far_addr = SwarmAddress::from(b256!(
+    let far_addr = OverlayAddress::from(b256!(
         "1100000000000000000000000000000000000000000000000000000000000000"
     ));
 
@@ -109,11 +109,11 @@ pub fn address_benchmarks(c: &mut Criterion) {
 
     for (i, &addr_bytes) in po_test_cases.iter().enumerate() {
         let expected_po = i * 8;
-        let test_addr = SwarmAddress::from(addr_bytes);
+        let test_addr = OverlayAddress::from(addr_bytes);
         group.bench_with_input(
             BenchmarkId::new("proximity_po", expected_po),
             &expected_po,
-            |b, _| b.iter(|| black_box(SwarmAddress::zero().proximity(&test_addr))),
+            |b, _| b.iter(|| black_box(OverlayAddress::zero().proximity(&test_addr))),
         );
     }
 

--- a/crates/primitives/src/address.rs
+++ b/crates/primitives/src/address.rs
@@ -156,4 +156,13 @@ mod tests {
             })
         ));
     }
+
+    #[test]
+    fn display_matches_b256_lowercase_hex() {
+        let addr = OverlayAddress::new([0xab; 32]);
+        let rendered = format!("{addr}");
+        assert!(rendered.starts_with("0x"));
+        assert_eq!(rendered.len(), 66);
+        assert!(rendered.chars().skip(2).all(|c| c.is_ascii_hexdigit()));
+    }
 }

--- a/crates/primitives/src/address.rs
+++ b/crates/primitives/src/address.rs
@@ -1,13 +1,13 @@
-//! Swarm address implementation
+//! Typed overlay address for node identity.
 //!
-//! This module provides the [`SwarmAddress`] type, a 32-byte identifier used
-//! for addressing nodes in the swarm network. The XOR-metric operations
-//! (distance, proximity) shared with the other address kinds live on the
-//! [`XorMetric`](crate::XorMetric) trait.
-
-use std::fmt;
+//! An [`OverlayAddress`] names a node by the canonical derivation
+//! `keccak256(ethereum_address || network_id || nonce)` (see
+//! [`compute_overlay`](crate::compute_overlay)). It is nominally distinct
+//! from the content-address kind; cross-kind proximity goes through
+//! [`XorMetric`](crate::XorMetric).
 
 use alloy_primitives::B256;
+use derive_more::{AsRef, Display, From, Into};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -15,15 +15,35 @@ use serde::{Deserialize, Serialize};
 use crate::error::{Result, WrongLength};
 use crate::xor_metric::XorMetric;
 
-/// A 256-bit address in the Swarm network
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+/// 32-byte overlay address of a node.
+///
+/// Transparent over the same 32 wire bytes as the alias it replaces: every
+/// handshake sign-data buffer and routing-table key serializes identically.
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Display, From, Into, AsRef,
+)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
-pub struct SwarmAddress(B256);
+#[display("{_0}")]
+#[from(B256, [u8; 32])]
+#[into(B256, [u8; 32])]
+#[as_ref([u8])]
+#[repr(transparent)]
+pub struct OverlayAddress(B256);
 
-impl SwarmAddress {
+impl OverlayAddress {
     /// Width in bytes of an address.
     pub const SIZE: usize = size_of::<B256>();
+
+    /// Zero address, useful for tests and sentinel slots.
+    pub const ZERO: Self = Self(B256::ZERO);
+
+    /// Construct from raw 32 bytes. `const` for static contexts; for runtime
+    /// conversions prefer the `From` impls.
+    #[inline]
+    pub const fn new(bytes: [u8; 32]) -> Self {
+        Self(B256::new(bytes))
+    }
 
     /// Creates an address with only the first byte set, rest zeros.
     ///
@@ -34,12 +54,8 @@ impl SwarmAddress {
         Self(B256::new(bytes))
     }
 
-    /// Creates a new SwarmAddress from raw bytes
-    pub fn new(bytes: [u8; 32]) -> Self {
-        Self(B256::from(bytes))
-    }
-
-    /// Returns the underlying bytes
+    /// Borrow the underlying 32 bytes.
+    #[inline]
     pub const fn as_bytes(&self) -> &[u8] {
         self.0.as_slice()
     }
@@ -51,60 +67,24 @@ impl SwarmAddress {
         Ok(Self::try_from(slice)?)
     }
 
-    /// Checks if this address is zeros
+    /// Checks if this address is zeros.
     pub fn is_zero(&self) -> bool {
         self.0.is_zero()
     }
 
-    /// Create a new zero-filled address
+    /// Create a new zero-filled address.
     pub const fn zero() -> Self {
-        Self(B256::ZERO)
+        Self::ZERO
     }
 }
 
-impl XorMetric for SwarmAddress {
+impl XorMetric for OverlayAddress {
     fn point(&self) -> &[u8; 32] {
         &self.0.0
     }
 }
 
-impl Default for SwarmAddress {
-    fn default() -> Self {
-        Self(B256::ZERO)
-    }
-}
-
-impl fmt::Display for SwarmAddress {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl From<B256> for SwarmAddress {
-    fn from(value: B256) -> Self {
-        Self(value)
-    }
-}
-
-impl From<[u8; 32]> for SwarmAddress {
-    fn from(bytes: [u8; 32]) -> Self {
-        Self::new(bytes)
-    }
-}
-
-impl From<SwarmAddress> for B256 {
-    fn from(addr: SwarmAddress) -> Self {
-        addr.0
-    }
-}
-
-impl AsRef<[u8]> for SwarmAddress {
-    fn as_ref(&self) -> &[u8] {
-        self.as_bytes()
-    }
-}
-
-impl TryFrom<&[u8]> for SwarmAddress {
+impl TryFrom<&[u8]> for OverlayAddress {
     type Error = WrongLength;
 
     fn try_from(slice: &[u8]) -> std::result::Result<Self, Self::Error> {
@@ -116,16 +96,10 @@ impl TryFrom<&[u8]> for SwarmAddress {
     }
 }
 
-impl From<SwarmAddress> for [u8; 32] {
-    fn from(addr: SwarmAddress) -> Self {
-        addr.0.into()
-    }
-}
-
 #[cfg(any(test, feature = "arbitrary"))]
-impl<'a> arbitrary::Arbitrary<'a> for SwarmAddress {
+impl<'a> arbitrary::Arbitrary<'a> for OverlayAddress {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(Self(B256::arbitrary(u)?))
+        Ok(Self::new(u.arbitrary()?))
     }
 }
 
@@ -135,19 +109,34 @@ mod tests {
     use crate::error::PrimitivesError;
 
     #[test]
-    fn try_from_slice_valid() {
+    fn zero_is_all_zero_bytes() {
+        assert_eq!(OverlayAddress::ZERO.as_bytes(), &[0u8; 32]);
+        assert!(OverlayAddress::zero().is_zero());
+    }
+
+    #[test]
+    fn roundtrips_via_from_impls() {
         let bytes = [0x5au8; 32];
-        assert_eq!(
-            SwarmAddress::try_from(bytes.as_slice()).unwrap(),
-            SwarmAddress::new(bytes)
-        );
+        let addr = OverlayAddress::new(bytes);
+        assert_eq!(B256::from(addr), B256::new(bytes));
+        assert_eq!(OverlayAddress::from(B256::new(bytes)), addr);
+        assert_eq!(<[u8; 32]>::from(addr), bytes);
+        assert_eq!(OverlayAddress::from(bytes), addr);
+    }
+
+    #[test]
+    fn with_first_byte_sets_only_the_first_byte() {
+        let addr = OverlayAddress::with_first_byte(0x80);
+        let mut expected = [0u8; 32];
+        expected[0] = 0x80;
+        assert_eq!(addr.as_bytes(), &expected);
     }
 
     #[test]
     fn try_from_slice_wrong_length() {
         let short = [0u8; 31];
         assert_eq!(
-            SwarmAddress::try_from(short.as_slice()).unwrap_err(),
+            OverlayAddress::try_from(short.as_slice()).unwrap_err(),
             WrongLength {
                 expected: 32,
                 got: 31
@@ -158,7 +147,7 @@ mod tests {
     #[test]
     fn from_slice_carries_lengths() {
         let long = [0u8; 33];
-        let err = SwarmAddress::from_slice(&long).unwrap_err();
+        let err = OverlayAddress::from_slice(&long).unwrap_err();
         assert!(matches!(
             err,
             PrimitivesError::WrongLength(WrongLength {

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! - **Chunks**: Content-addressed and signed data chunks ([`ContentChunk`], [`SingleOwnerChunk`])
 //! - **Binary Merkle Tree**: Efficient content addressing and proof generation ([`bmt::Hasher`])
-//! - **SwarmAddress**: 256-bit identifiers for network addressing
+//! - **OverlayAddress**: 256-bit identifiers for network addressing
 //!
 //! ## Usage Examples
 //!
@@ -82,7 +82,7 @@ pub use chunk::encryption::{EncryptedChunkRef, EncryptionKey};
 pub use chunk::{ChunkEncrypt, EncryptedContentChunk};
 
 // Re-export core types
-pub use address::SwarmAddress;
+pub use address::OverlayAddress;
 pub use bin::{Bin, BinError};
 pub use error::{PrimitivesError, Result, WrongLength};
 pub use neighborhood_depth::recompute_neighborhood_depth;
@@ -93,6 +93,10 @@ pub use proximity_order::{ProximityOrder, ProximityOrderError};
 pub use spec::{MAINNET, StaticSpec, SwarmSpec, TESTNET};
 pub use timestamp::{Timestamp, TimestampError};
 pub use xor_metric::{EXTENDED_PO, MAX_PO, XorMetric};
+
+/// Former name of the node-identity address kind.
+#[deprecated(note = "use `OverlayAddress`; this alias is removed in the next release")]
+pub type SwarmAddress = OverlayAddress;
 
 // Core BMT functionality
 pub use bmt::{Hasher, HasherFactory, Proof, Prover};

--- a/crates/primitives/src/overlay.rs
+++ b/crates/primitives/src/overlay.rs
@@ -7,7 +7,7 @@
 
 use alloy_primitives::{Address, Keccak256};
 
-use crate::{NetworkId, Nonce, SwarmAddress};
+use crate::{NetworkId, Nonce, OverlayAddress};
 
 /// Compute the Swarm overlay address from `eth_addr`, `network_id`, `nonce`.
 ///
@@ -16,12 +16,12 @@ use crate::{NetworkId, Nonce, SwarmAddress};
 /// This is the **only** canonical derivation - any other formula creates a
 /// peer with a different overlay that won't be reachable on the same network.
 #[must_use]
-pub fn compute_overlay(eth_addr: &Address, network_id: NetworkId, nonce: &Nonce) -> SwarmAddress {
+pub fn compute_overlay(eth_addr: &Address, network_id: NetworkId, nonce: &Nonce) -> OverlayAddress {
     let mut hasher = Keccak256::new();
     hasher.update(eth_addr.as_slice());
     hasher.update(network_id.to_le_bytes());
     hasher.update(nonce.as_slice());
-    SwarmAddress::from(hasher.finalize())
+    OverlayAddress::from(hasher.finalize())
 }
 
 #[cfg(test)]
@@ -40,7 +40,7 @@ mod tests {
         h.update([0u8; 20]);
         h.update(1u64.to_le_bytes());
         h.update([0u8; 32]);
-        let expected = SwarmAddress::from(h.finalize());
+        let expected = OverlayAddress::from(h.finalize());
         assert_eq!(overlay, expected);
     }
 
@@ -73,14 +73,14 @@ mod tests {
         h.update(eth.as_slice());
         h.update([0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01]); // LE bytes
         h.update(nonce.as_slice());
-        assert_eq!(overlay, SwarmAddress::from(h.finalize()));
+        assert_eq!(overlay, OverlayAddress::from(h.finalize()));
 
         // Sanity-check the BE encoding would have produced a different overlay.
         let mut h_be = Keccak256::new();
         h_be.update(eth.as_slice());
         h_be.update([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]); // BE bytes
         h_be.update(nonce.as_slice());
-        let be_overlay = SwarmAddress::from(h_be.finalize());
+        let be_overlay = OverlayAddress::from(h_be.finalize());
         assert_ne!(overlay, be_overlay);
         let _ = b256!("0000000000000000000000000000000000000000000000000000000000000000");
     }

--- a/crates/primitives/src/signing.rs
+++ b/crates/primitives/src/signing.rs
@@ -36,7 +36,7 @@
 
 use alloy_primitives::Address;
 
-use crate::{NetworkId, Nonce, SwarmAddress, Timestamp};
+use crate::{NetworkId, Nonce, OverlayAddress, Timestamp};
 
 /// Magic prefix matching bee `pkg/bzz/address.go:138` (`signDataPrefix`).
 pub const SIGN_DATA_PREFIX: &[u8] = b"bee-handshake-";
@@ -52,7 +52,7 @@ pub const SIGN_DATA_PREFIX: &[u8] = b"bee-handshake-";
 #[allow(clippy::arithmetic_side_effects)] // capacity hint summing an underlay address plus ~100 bytes of fixed-size fields, far below usize::MAX
 pub fn sign_data(
     underlay_bytes: &[u8],
-    overlay: &SwarmAddress,
+    overlay: &OverlayAddress,
     network_id: NetworkId,
     nonce: &Nonce,
     timestamp: Timestamp,
@@ -90,7 +90,7 @@ mod tests {
 
     #[test]
     fn layout_matches_bee_spec() {
-        let overlay = SwarmAddress::new([0xaa; 32]);
+        let overlay = OverlayAddress::new([0xaa; 32]);
         let net = NetworkId::MAINNET;
         let nonce = Nonce::new([0xbb; 32]);
         let ts = Timestamp::from(0x0102_0304_0506_0708_i64);
@@ -116,7 +116,7 @@ mod tests {
     fn no_chequebook_is_byte_identical_to_zero_chequebook() {
         let a = sign_data(
             &[],
-            &SwarmAddress::zero(),
+            &OverlayAddress::zero(),
             NetworkId::MAINNET,
             &Nonce::ZERO,
             Timestamp::ZERO,
@@ -124,7 +124,7 @@ mod tests {
         );
         let b = sign_data(
             &[],
-            &SwarmAddress::zero(),
+            &OverlayAddress::zero(),
             NetworkId::MAINNET,
             &Nonce::ZERO,
             Timestamp::ZERO,

--- a/crates/primitives/src/xor_metric.rs
+++ b/crates/primitives/src/xor_metric.rs
@@ -2,7 +2,7 @@
 //!
 //! Kademlia routing measures closeness between two 256-bit points as the
 //! number of leading matching bits (the proximity order, PO) or as the full
-//! XOR distance. The address kinds ([`SwarmAddress`](crate::SwarmAddress),
+//! XOR distance. The address kinds ([`OverlayAddress`](crate::OverlayAddress),
 //! [`ChunkAddress`](crate::ChunkAddress)) are distinct nominal types over the
 //! same point space, and the protocol compares across kinds (a chunk address
 //! against a node overlay for the storage radius and pushsync targeting), so
@@ -21,16 +21,16 @@
 //! ## Example
 //!
 //! ```
-//! use nectar_primitives::{SwarmAddress, XorMetric};
+//! use nectar_primitives::{OverlayAddress, XorMetric};
 //! use alloy_primitives::B256;
 //!
-//! let addr1 = SwarmAddress::from(B256::random());
-//! let addr2 = SwarmAddress::from(B256::random());
+//! let addr1 = OverlayAddress::from(B256::random());
+//! let addr2 = OverlayAddress::from(B256::random());
 //!
 //! let po = addr1.proximity(&addr2);
 //! let distance = addr1.distance(&addr2);
 //!
-//! let addr3 = SwarmAddress::from(B256::random());
+//! let addr3 = OverlayAddress::from(B256::random());
 //! if addr1.closer(&addr2, &addr3) {
 //!     println!("addr1 is closer to addr2 than addr3");
 //! }
@@ -89,12 +89,12 @@ pub trait XorMetric {
     /// the point closest to `self`:
     ///
     /// ```
-    /// # use nectar_primitives::{SwarmAddress, XorMetric};
+    /// # use nectar_primitives::{OverlayAddress, XorMetric};
     /// # use alloy_primitives::B256;
-    /// let target = SwarmAddress::zero();
+    /// let target = OverlayAddress::zero();
     /// let addresses = vec![
-    ///     SwarmAddress::from(B256::repeat_byte(0x01)),
-    ///     SwarmAddress::from(B256::repeat_byte(0x02)),
+    ///     OverlayAddress::from(B256::repeat_byte(0x01)),
+    ///     OverlayAddress::from(B256::repeat_byte(0x02)),
     /// ];
     /// let closest = addresses.iter().min_by(|a, b| target.distance_cmp(a, b));
     /// ```
@@ -244,30 +244,30 @@ fn proximity_up_to(bytes1: &[u8; 32], bytes2: &[u8; 32], max: usize) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ChunkAddress, SwarmAddress};
+    use crate::{ChunkAddress, OverlayAddress};
     use alloy_primitives::B256;
 
     #[test]
     fn proximity_counts_leading_matching_bits() {
-        let base = SwarmAddress::with_first_byte(0b0000_0000);
-        let one_bit = SwarmAddress::with_first_byte(0b0100_0000);
+        let base = OverlayAddress::with_first_byte(0b0000_0000);
+        let one_bit = OverlayAddress::with_first_byte(0b0100_0000);
         assert_eq!(base.proximity(&one_bit).get(), 1);
 
-        let full_match = SwarmAddress::zero();
+        let full_match = OverlayAddress::zero();
         assert_eq!(base.proximity(&full_match).get(), MAX_PO);
     }
 
     #[test]
     fn extended_proximity_exceeds_standard_cap() {
-        let base = SwarmAddress::zero();
+        let base = OverlayAddress::zero();
         assert_eq!(base.extended_proximity(&base), EXTENDED_PO);
         assert_eq!(base.proximity(&base).get(), MAX_PO);
     }
 
     #[test]
     fn distance_is_symmetric_xor() {
-        let a = SwarmAddress::from(B256::repeat_byte(0x0f));
-        let b = SwarmAddress::from(B256::repeat_byte(0xf0));
+        let a = OverlayAddress::from(B256::repeat_byte(0x0f));
+        let b = OverlayAddress::from(B256::repeat_byte(0xf0));
         assert_eq!(a.distance(&b), b.distance(&a));
         assert_eq!(
             a.distance(&b),
@@ -278,9 +278,9 @@ mod tests {
 
     #[test]
     fn distance_cmp_orders_by_closeness() {
-        let target = SwarmAddress::zero();
-        let near = SwarmAddress::from(B256::repeat_byte(0x01));
-        let far = SwarmAddress::from(B256::repeat_byte(0x02));
+        let target = OverlayAddress::zero();
+        let near = OverlayAddress::from(B256::repeat_byte(0x01));
+        let far = OverlayAddress::from(B256::repeat_byte(0x02));
         assert_eq!(target.distance_cmp(&near, &far), Ordering::Greater);
         assert_eq!(target.distance_cmp(&far, &near), Ordering::Less);
         assert_eq!(target.distance_cmp(&near, &near), Ordering::Equal);
@@ -293,7 +293,7 @@ mod tests {
         // (storage radius, pushsync targeting); the trait keeps that legal
         // across the distinct kinds.
         let chunk = ChunkAddress::from(B256::repeat_byte(0xaa));
-        let overlay = SwarmAddress::from(B256::repeat_byte(0xaa));
+        let overlay = OverlayAddress::from(B256::repeat_byte(0xaa));
         assert_eq!(chunk.proximity(&overlay).get(), MAX_PO);
         assert_eq!(chunk.distance(&overlay), U256::ZERO);
         assert_eq!(overlay.bin(&chunk), Bin::from(overlay.proximity(&chunk)));
@@ -302,7 +302,7 @@ mod tests {
     #[test]
     fn xor_returns_receiver_kind() {
         let a = ChunkAddress::from(B256::repeat_byte(0x0f));
-        let b = SwarmAddress::from(B256::repeat_byte(0xf0));
+        let b = OverlayAddress::from(B256::repeat_byte(0xf0));
         let d: ChunkAddress = a.xor(&b);
         assert_eq!(d, ChunkAddress::from(B256::repeat_byte(0xff)));
     }


### PR DESCRIPTION
Closes #181

## What

Renames `SwarmAddress` to `OverlayAddress` as the node-identity newtype in `nectar-primitives`, restyled on the `ChunkAddress` `derive_more` machinery (`repr(transparent)` over `B256`, `XorMetric` for cross-kind proximity).

`compute_overlay` now returns `OverlayAddress` (bit-identical bytes, byte-exact tests kept). `sign_data`, the `xor_metric` docs/tests, and the address bench are retyped to match.

`SwarmAddress` is kept for one release as a deprecated crate-root type alias defined in `lib.rs`:

```rust
#[deprecated(note = "use `OverlayAddress`; this alias is removed in the next release")]
pub type SwarmAddress = OverlayAddress;
```

An alias definition does not itself fire the `deprecated` lint, so no `expect`/`allow` was needed anywhere in the crate.

## Why

`SwarmAddress` conflated the general 256-bit addressing concept with the specific node-identity kind. Renaming to `OverlayAddress` and mirroring the established `ChunkAddress` pattern makes the two address kinds consistent and the node-identity role explicit, while the deprecated alias gives downstream consumers a release to migrate.

## Diff

Confined to `crates/primitives` (6 files): `benches/address.rs`, `src/address.rs`, `src/lib.rs`, `src/overlay.rs`, `src/signing.rs`, `src/xor_metric.rs`.

Two commits: `35a25e5` (rename + alias) and `9f61158` (Display lowercase-hex assertion), both GPG-signed.

## Testing

Independent re-verification of branch `s187/30-overlay-address` (HEAD 9f61158), diffed against base `origin/s187/22-ungate-encrypted-ref` (merge-base 7eff004, clean linear 2-commit delta). All commands run via `nix develop --command`. Changed files are confined to `crates/primitives/` (benches/address.rs, src/{address,lib,overlay,signing,xor_metric}.rs).

Full battery, all green:

- `cargo fmt --all -- --check`: pass.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: pass.
- `cargo nextest run --workspace --all-features`: 646 passed, 1 skipped, 0 failed. (`cargo-nextest` is not in the flake devShell; injected ephemerally from nixpkgs `cargo-nextest` 0.9.138 layered over the devShell toolchain.)
- `cargo test --doc --workspace`: pass; the updated `xor_metric.rs` doc examples using `OverlayAddress` compile and run.

As this is a stacked PR (base `s187/22-ungate-encrypted-ref` is itself a feature branch, not `main`), no CI beyond CLA will run until retargeted.

AI Assistance: Claude (Anthropic, Sonnet 5) used for the rename implementation, red-team review, and independent re-verification testing described above.

