### PR TITLE
fix: gate builder tests and add nominal distinctness proofs

### DIFF
--- a/crates/mantaray/src/builder.rs
+++ b/crates/mantaray/src/builder.rs
@@ -296,6 +296,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn encrypted_builder_round_trips_the_reference() {
         use nectar_primitives::file::EntryRef;
@@ -317,6 +318,7 @@ mod tests {
         assert_eq!(entry.reference(), Some(&EntryRef::Encrypted(eref)));
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn encrypted_builder_rejects_root_metadata() {
         use nectar_primitives::{EncryptedChunkRef, EncryptionKey};

--- a/crates/primitives/src/address.rs
+++ b/crates/primitives/src/address.rs
@@ -4,7 +4,7 @@
 //! `keccak256(ethereum_address || network_id || nonce)` (see
 //! [`compute_overlay`](crate::compute_overlay)). It is nominally distinct
 //! from the content-address kind; cross-kind proximity goes through
-//! [`XorMetric`](crate::XorMetric).
+//! [`XorMetric`].
 
 use alloy_primitives::B256;
 use derive_more::{AsRef, Display, From, Into};
@@ -19,6 +19,16 @@ use crate::xor_metric::XorMetric;
 ///
 /// Transparent over the same 32 wire bytes as the alias it replaces: every
 /// handshake sign-data buffer and routing-table key serializes identically.
+///
+/// Nominally distinct from the content-address kind: a [`ChunkAddress`](crate::ChunkAddress)
+/// is rejected where an `OverlayAddress` is expected.
+///
+/// ```compile_fail
+/// use nectar_primitives::{ChunkAddress, OverlayAddress};
+///
+/// fn route_to(_addr: OverlayAddress) {}
+/// route_to(ChunkAddress::zero());
+/// ```
 #[derive(
     Debug, Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Display, From, Into, AsRef,
 )]

--- a/crates/primitives/src/chunk/soc_id.rs
+++ b/crates/primitives/src/chunk/soc_id.rs
@@ -17,6 +17,17 @@ use serde::{Deserialize, Serialize};
 /// still serializes as `id || signature || body`. Dispersed replicas
 /// constrain `id[1..]` to the wrapped body hash, leaving only the first byte
 /// mined.
+///
+/// Nominally distinct from the raw hash it wraps: a bare `B256` is rejected
+/// where a `SocId` is expected.
+///
+/// ```compile_fail
+/// use alloy_primitives::B256;
+/// use nectar_primitives::SocId;
+///
+/// fn sign_under(_id: SocId) {}
+/// sign_under(B256::ZERO);
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Display, From, Into, AsRef)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
@@ -24,6 +35,7 @@ use serde::{Deserialize, Serialize};
 #[from(B256, [u8; 32])]
 #[into(B256, [u8; 32])]
 #[as_ref([u8])]
+#[repr(transparent)]
 pub struct SocId(B256);
 
 impl SocId {


### PR DESCRIPTION
## What

- Gate the two encrypted-builder tests behind `std`, matching the std-gated `ManifestBuilder::new_encrypted`; the mantaray lib tests now compile and pass under `--no-default-features`.
- Mark `SocId` as `#[repr(transparent)]`, matching `BatchId`, `ChunkAddress`, and `OverlayAddress`.
- Pin nominal distinctness with `compile_fail` doctests: `B256` is rejected where `SocId` is expected, and `ChunkAddress` is rejected where `OverlayAddress` is expected.
- Drop a redundant explicit `XorMetric` intra-doc link that tripped a rustdoc warning.

## Why

Sweep fixes from the #187 phase QA battery, closing out the s187 series.

## Testing

`cargo fmt --check`, strict clippy (`--workspace --all-targets --all-features -D warnings`), workspace tests, and doctests (including the three new `compile_fail` proofs) all pass. All nine fuzz targets build, with the mantaray seed corpora replaying clean. The wasm32 check of `nectar-postage-usage --features client` passes.

## AI Assistance

Written with AI assistance; reviewed and tested by the author.
