### PR TITLE
refactor(postage): route stamp codec through wire::Cursor/Writer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2082,7 +2082,6 @@ dependencies = [
  "alloy-signer",
  "alloy-signer-local",
  "arbitrary",
- "byteorder",
  "codspeed-criterion-compat",
  "derive_more",
  "k256",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,6 @@ rayon = "1.10"
 
 # Core dependencies
 bytes = { version = "1.11", default-features = false }
-byteorder = { version = "1.5", default-features = false }
 thiserror = { version = "2.0", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }

--- a/crates/postage/Cargo.toml
+++ b/crates/postage/Cargo.toml
@@ -21,7 +21,6 @@ workspace = true
 nectar-primitives = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy-signer = { workspace = true }
-byteorder = { workspace = true }
 derive_more = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/postage/src/batch.rs
+++ b/crates/postage/src/batch.rs
@@ -2,7 +2,10 @@
 
 use alloy_primitives::{Address, B256};
 use derive_more::{AsRef, Display, From, Into};
-use nectar_primitives::ChunkAddress;
+use nectar_primitives::{
+    ChunkAddress,
+    wire::{Cursor, FromCursor, ToWriter, Underrun, Writer},
+};
 
 use crate::{StampError, StampIndex, calculate_bucket};
 
@@ -22,6 +25,9 @@ use crate::{StampError, StampIndex, calculate_bucket};
 pub struct BatchId(B256);
 
 impl BatchId {
+    /// Width in bytes of an id.
+    pub const SIZE: usize = size_of::<B256>();
+
     /// Zero id, useful for tests and deterministic vectors.
     pub const ZERO: Self = Self(B256::ZERO);
 
@@ -46,6 +52,22 @@ impl BatchId {
     #[inline]
     pub fn from_slice(slice: &[u8]) -> Self {
         Self(B256::from_slice(slice))
+    }
+}
+
+/// Reads the id as its raw 32 bytes.
+impl FromCursor for BatchId {
+    type Error = Underrun;
+
+    fn take_from(cur: &mut Cursor<'_>) -> Result<Self, Underrun> {
+        cur.take::<[u8; Self::SIZE]>().map(Self::new)
+    }
+}
+
+/// Writes the raw 32 bytes, the mirror of the `FromCursor` impl above.
+impl ToWriter for BatchId {
+    fn put_into(&self, w: &mut Writer<'_>) {
+        w.put(&<[u8; Self::SIZE]>::from(*self));
     }
 }
 

--- a/crates/postage/src/error.rs
+++ b/crates/postage/src/error.rs
@@ -2,6 +2,7 @@
 
 use crate::BatchId;
 use alloy_primitives::Address;
+use nectar_primitives::wire::Underrun;
 use thiserror::Error;
 
 /// Errors that can occur when working with stamps.
@@ -68,6 +69,15 @@ pub enum StampError {
     #[error("invalid signature")]
     InvalidSignature,
 
+    /// The wire buffer ended before a field was fully read.
+    #[error("buffer underrun: need {expected} bytes, have {available}")]
+    Underrun {
+        /// Bytes the field required.
+        expected: usize,
+        /// Bytes remaining in the buffer.
+        available: usize,
+    },
+
     /// A chunk operation in `nectar-primitives` failed (for example decoding or
     /// address verification of the chunk half of a stamped chunk).
     ///
@@ -78,4 +88,13 @@ pub enum StampError {
     /// without `alloc`, so an owned `String` message is not available either.
     #[error("chunk error: {0}")]
     Chunk(&'static str),
+}
+
+impl From<Underrun> for StampError {
+    fn from(underrun: Underrun) -> Self {
+        Self::Underrun {
+            expected: underrun.expected,
+            available: underrun.available,
+        }
+    }
 }

--- a/crates/postage/src/stamp.rs
+++ b/crates/postage/src/stamp.rs
@@ -1,9 +1,13 @@
 //! Postage stamp types.
 
+use alloc::vec::Vec;
+
 use alloy_primitives::{Address, B256, Signature, eip191_hash_message};
 use alloy_signer::k256::ecdsa::VerifyingKey;
-use byteorder::{BigEndian, ByteOrder};
-use nectar_primitives::ChunkAddress;
+use nectar_primitives::{
+    ChunkAddress,
+    wire::{Cursor, FromCursor, ToWriter, Underrun, Writer},
+};
 
 use crate::{BatchId, StampError};
 
@@ -11,6 +15,20 @@ use crate::{BatchId, StampError};
 ///
 /// Layout: batch_id (32) + bucket (4) + index (4) + timestamp (8) + signature (65) = 113 bytes
 pub const STAMP_SIZE: usize = 113;
+
+/// Wire width of a stamp index: bucket (4) + index (4), big-endian.
+const INDEX_SIZE: usize = size_of::<u64>();
+/// Wire width of the big-endian timestamp.
+const TIMESTAMP_SIZE: usize = size_of::<u64>();
+/// Wire width of the signature: `r || s || v`.
+const SIG_SIZE: usize = 65;
+
+// The four field widths fill the stamp exactly.
+const _: () = assert!(BatchId::SIZE + INDEX_SIZE + TIMESTAMP_SIZE + SIG_SIZE == STAMP_SIZE);
+
+/// Size of the digest preimage: chunk address, then the three signed stamp
+/// fields.
+const PREHASH_SIZE: usize = ChunkAddress::SIZE + BatchId::SIZE + INDEX_SIZE + TIMESTAMP_SIZE;
 
 /// A serialized postage stamp as a fixed-size byte array.
 pub type StampBytes = [u8; STAMP_SIZE];
@@ -119,6 +137,22 @@ impl From<StampIndex> for (u32, u32) {
     }
 }
 
+/// Reads the index from its 8 wire bytes; see [`StampIndex::from_be_bytes`].
+impl FromCursor for StampIndex {
+    type Error = Underrun;
+
+    fn take_from(cur: &mut Cursor<'_>) -> Result<Self, Underrun> {
+        cur.take::<[u8; INDEX_SIZE]>().map(Self::from_be_bytes)
+    }
+}
+
+/// Writes the 8 wire bytes, the mirror of the `FromCursor` impl above.
+impl ToWriter for StampIndex {
+    fn put_into(&self, w: &mut Writer<'_>) {
+        w.put(&self.to_be_bytes());
+    }
+}
+
 /// A postage stamp represents proof of payment for storing a chunk.
 ///
 /// Stamps are created by signing a message containing the chunk address,
@@ -218,12 +252,13 @@ impl Stamp {
     /// Serializes the stamp to a 113-byte array.
     #[inline]
     pub fn to_bytes(&self) -> StampBytes {
+        let mut buf = Vec::with_capacity(STAMP_SIZE);
+        Writer::new(&mut buf).put(self);
+
+        // The field widths sum to STAMP_SIZE (asserted at compile time above),
+        // so the writer filled the array exactly.
         let mut bytes = [0u8; STAMP_SIZE];
-        bytes[..32].copy_from_slice(self.batch.as_slice());
-        BigEndian::write_u32(&mut bytes[32..36], self.index.bucket());
-        BigEndian::write_u32(&mut bytes[36..40], self.index.index());
-        BigEndian::write_u64(&mut bytes[40..48], self.timestamp);
-        bytes[48..STAMP_SIZE].copy_from_slice(&self.sig.as_bytes());
+        bytes.copy_from_slice(&buf);
         bytes
     }
 
@@ -232,20 +267,7 @@ impl Stamp {
     /// Returns an error if the signature bytes are invalid.
     #[inline]
     pub fn from_bytes(bytes: &StampBytes) -> Result<Self, StampError> {
-        let batch = BatchId::from_slice(&bytes[..32]);
-        let bucket = BigEndian::read_u32(&bytes[32..36]);
-        let index = BigEndian::read_u32(&bytes[36..40]);
-        let timestamp = BigEndian::read_u64(&bytes[40..48]);
-
-        let sig = Signature::from_raw(&bytes[48..STAMP_SIZE])
-            .map_err(|_| StampError::InvalidSignature)?;
-
-        Ok(Self {
-            batch,
-            index: StampIndex::new(bucket, index),
-            timestamp,
-            sig,
-        })
+        Cursor::new(bytes).take::<Self>()
     }
 
     /// Attempts to deserialize a stamp from a byte slice.
@@ -253,14 +275,12 @@ impl Stamp {
     /// Returns an error if the slice is not exactly 113 bytes or if the signature is invalid.
     #[inline]
     pub fn try_from_slice(bytes: &[u8]) -> Result<Self, StampError> {
-        if bytes.len() != STAMP_SIZE {
+        let mut cur = Cursor::new(bytes);
+        let stamp = cur.take::<Self>()?;
+        if !cur.is_empty() {
             return Err(StampError::InvalidData("stamp must be exactly 113 bytes"));
         }
-
-        // Safety: we verified the length above
-        let mut stamp_bytes = [0u8; STAMP_SIZE];
-        stamp_bytes.copy_from_slice(bytes);
-        Self::from_bytes(&stamp_bytes)
+        Ok(stamp)
     }
 
     /// Recovers the signer address from this stamp using EIP-191 message recovery.
@@ -432,6 +452,37 @@ impl Stamp {
     }
 }
 
+/// Reads a stamp from its 113 wire bytes: batch id, stamp index, big-endian
+/// timestamp, then the 65-byte signature.
+impl FromCursor for Stamp {
+    type Error = StampError;
+
+    fn take_from(cur: &mut Cursor<'_>) -> Result<Self, StampError> {
+        let batch = cur.take::<BatchId>()?;
+        let index = cur.take::<StampIndex>()?;
+        let timestamp = u64::from_be_bytes(cur.take::<[u8; TIMESTAMP_SIZE]>()?);
+        // from_raw_array compile-checks SIG_SIZE against alloy's signature width.
+        let sig = Signature::from_raw_array(&cur.take::<[u8; SIG_SIZE]>()?)
+            .map_err(|_| StampError::InvalidSignature)?;
+        Ok(Self {
+            batch,
+            index,
+            timestamp,
+            sig,
+        })
+    }
+}
+
+/// Writes the 113 wire bytes, the mirror of the `FromCursor` impl above.
+impl ToWriter for Stamp {
+    fn put_into(&self, w: &mut Writer<'_>) {
+        w.put(&self.batch);
+        w.put(&self.index);
+        w.put(&self.timestamp.to_be_bytes());
+        w.put(&self.sig.as_bytes());
+    }
+}
+
 /// The digest that must be signed to create a valid stamp.
 ///
 /// The digest is computed as: `keccak256(chunk_address || batch_id || index || timestamp)`
@@ -480,11 +531,12 @@ impl StampDigest {
     pub fn to_prehash(&self) -> B256 {
         use alloy_primitives::keccak256;
 
-        let mut data = [0u8; 32 + 32 + 8 + 8]; // 80 bytes
-        data[..32].copy_from_slice(self.chunk_address.as_bytes());
-        data[32..64].copy_from_slice(self.batch_id.as_slice());
-        data[64..72].copy_from_slice(&self.index.to_be_bytes());
-        data[72..80].copy_from_slice(&self.timestamp.to_be_bytes());
+        let mut data = Vec::with_capacity(PREHASH_SIZE);
+        let mut w = Writer::new(&mut data);
+        w.put(self.chunk_address.as_bytes());
+        w.put(&self.batch_id);
+        w.put(&self.index);
+        w.put(&self.timestamp.to_be_bytes());
 
         keccak256(data)
     }
@@ -612,8 +664,14 @@ mod tests {
 
     #[test]
     fn test_invalid_slice_size() {
-        let bytes = [0u8; 100];
-        let result = Stamp::try_from_slice(&bytes);
+        // Short input underruns the cursor.
+        let short = [0u8; 100];
+        let result = Stamp::try_from_slice(&short);
+        assert!(matches!(result, Err(StampError::Underrun { .. })));
+
+        // Trailing bytes are rejected explicitly.
+        let long = [0u8; STAMP_SIZE + 1];
+        let result = Stamp::try_from_slice(&long);
         assert!(matches!(result, Err(StampError::InvalidData(_))));
     }
 

--- a/crates/postage/src/stamp.rs
+++ b/crates/postage/src/stamp.rs
@@ -643,6 +643,11 @@ mod tests {
         assert_eq!(stamp.bucket(), 52197); // 0x0000cbe5
         assert_eq!(stamp.index(), 0);
         assert_eq!(stamp.timestamp(), 1688492510651);
+
+        // Re-encoding reproduces the reference bytes exactly, pinning the encode
+        // path against the external vector rather than only against its own
+        // decoder.
+        assert_eq!(stamp.to_bytes().as_slice(), bytes.as_slice());
     }
 
     #[test]

--- a/crates/postage/src/stamped.rs
+++ b/crates/postage/src/stamped.rs
@@ -12,9 +12,9 @@
 
 use alloc::vec::Vec;
 
-use nectar_primitives::{AnyChunk, ChunkAddress, DEFAULT_BODY_SIZE, bytes::Bytes};
+use nectar_primitives::{AnyChunk, ChunkAddress, DEFAULT_BODY_SIZE, bytes::Bytes, wire::Cursor};
 
-use crate::{BatchId, STAMP_SIZE, Stamp, StampError};
+use crate::{BatchId, Stamp, StampError};
 
 /// A chunk together with its postage stamp.
 ///
@@ -107,14 +107,9 @@ impl<const BODY_SIZE: usize> StampedChunk<BODY_SIZE> {
     /// stamp, the stamp bytes are invalid, the chunk payload cannot be decoded,
     /// or the chunk's computed address does not match `address`.
     pub fn from_typed_bytes(address: &ChunkAddress, bytes: &[u8]) -> Result<Self, StampError> {
-        if bytes.len() < STAMP_SIZE {
-            return Err(StampError::InvalidData(
-                "stamped chunk shorter than a stamp",
-            ));
-        }
-        let (stamp_bytes, chunk_bytes) = bytes.split_at(STAMP_SIZE);
-        let stamp = Stamp::try_from_slice(stamp_bytes)?;
-        let chunk = AnyChunk::<BODY_SIZE>::from_typed_bytes(address, chunk_bytes)
+        let mut cur = Cursor::new(bytes);
+        let stamp = cur.take::<Stamp>()?;
+        let chunk = AnyChunk::<BODY_SIZE>::from_typed_bytes(address, cur.finish())
             .map_err(|_| StampError::Chunk("failed to decode typed chunk"))?;
         Ok(Self::new(chunk, stamp))
     }
@@ -143,19 +138,16 @@ impl<const BODY_SIZE: usize> StampedChunk<BODY_SIZE> {
     /// Read the batch id from a [`to_typed_bytes`](Self::to_typed_bytes) value
     /// without a full decode.
     ///
-    /// The stamp leads the encoding and [`Stamp::to_bytes`] places the batch id
-    /// in its first 32 bytes, so the batch id is `typed_bytes[0..32]`. This lets
-    /// a store index a stamped chunk by batch without decoding the chunk.
+    /// The stamp leads the encoding and the batch id is the stamp's first wire
+    /// field, so a cursor over the typed bytes yields it directly. This lets a
+    /// store index a stamped chunk by batch without decoding the chunk.
     ///
     /// # Errors
     ///
-    /// Returns an error (and never panics) when `typed_bytes` is shorter than 32
-    /// bytes.
+    /// Returns an error (and never panics) when `typed_bytes` is shorter than a
+    /// batch id.
     pub fn batch_id(typed_bytes: &[u8]) -> Result<BatchId, StampError> {
-        let id = typed_bytes.get(..32).ok_or(StampError::InvalidData(
-            "typed bytes shorter than a batch id",
-        ))?;
-        Ok(BatchId::from_slice(id))
+        Ok(Cursor::new(typed_bytes).take::<BatchId>()?)
     }
 }
 
@@ -179,6 +171,7 @@ mod tests {
     use nectar_primitives::{Chunk, ContentChunk, SingleOwnerChunk, SocId, bytes::Bytes};
 
     use super::*;
+    use crate::STAMP_SIZE;
 
     type DefaultStampedChunk = StampedChunk<DEFAULT_BODY_SIZE>;
 
@@ -299,7 +292,7 @@ mod tests {
         let short = [0u8; STAMP_SIZE - 1];
         let err = DefaultStampedChunk::from_typed_bytes(&address, &short)
             .expect_err("short input must error");
-        assert!(matches!(err, StampError::InvalidData(_)));
+        assert!(matches!(err, StampError::Underrun { .. }));
     }
 
     #[test]


### PR DESCRIPTION
## What

Routes the postage `Stamp`, `StampIndex` and `BatchId` encode/decode paths through `nectar-primitives`' `wire::Cursor`/`wire::Writer` instead of hand-rolled `byteorder` calls and manual offset slicing.

- `Stamp::to_bytes`/`from_bytes`/`try_from_slice`, `StampDigest::to_prehash` and `StampedChunk::batch_id`/`from_typed_bytes` now encode and decode via `FromCursor`/`ToWriter` implementations on `Stamp`, `StampIndex` and `BatchId`.
- The `typed_bytes[..32]` peek and every hand-summed byte offset are removed.
- A compile-time assertion pins the field widths (`BatchId::SIZE` + index 8 + timestamp 8 + signature 65) to sum exactly to `STAMP_SIZE` (113 bytes).
- Short reads now surface as a new `StampError::Underrun { expected, available }` variant, added via `From<wire::Underrun>`. The enum is `#[non_exhaustive]`, so this is an additive change.
- The direct `byteorder` dependency is dropped from `crates/postage/Cargo.toml` and `Cargo.lock`, and the now-orphaned `[workspace.dependencies] byteorder` entry is removed from the root `Cargo.toml` (postage was its last consumer).

Closes #185

## Why

The 113-byte stamp layout was previously stated in several places (constant, doc comment, and each hand-summed slice offset), which made it easy for the layout to drift out of sync on a future field change. Centralizing the layout through a single `wire::Cursor`/`wire::Writer` pair states the layout once and removes the manual offset arithmetic and the `byteorder` dependency.

## Testing

Wire bytes are byte-identical to the previous encoder: the Go interop signer-recovery/verify vectors, `test_stamp_from_known_data`, the `stamp_decode` seed-corpus replay and the arbitrary/fuzz round-trip tests all stay green. `cargo check --workspace --all-features` is clean with `Cargo.lock` unchanged after the workspace-level `byteorder` entry removal.

## AI assistance

Implemented with Claude (Sonnet), red-teamed and independently verified with Claude (Opus), per github.com/nxm-rs/.github CONTRIBUTING.md.

