### PR TITLE
refactor(primitives)!: prune dead chunk trait surface

### DIFF
--- a/crates/primitives/src/chunk/README.md
+++ b/crates/primitives/src/chunk/README.md
@@ -1,6 +1,6 @@
 # Chunk Module
 
-The chunk module provides implementations of different chunk types used in the storage system.
+The chunk module provides implementations of the chunk types used in the storage system.
 
 ## Architecture
 
@@ -8,15 +8,18 @@ The chunk module is built around a trait-based architecture that allows for diff
 
 ### Core Traits
 
-- `Chunk`: The main trait that all chunk types implement, defining common operations
-- `DeserializableChunk`: A super trait that provides deserialization capabilities
-- `ChunkSerialization`: A trait for serializing chunks with type prefixes
-- `BMTChunk`: A trait for chunks that contain a BMT body (most chunk types)
+- `Chunk`: The main trait that all chunk types implement, defining common operations (address, header, data, verify)
+- `ChunkHeader`: The wire header bytes that precede a chunk's BMT body
+- `BmtChunk`: A trait for chunks that contain a BMT body (most chunk types)
+- `ChunkType`: Compile-time type identification (type ID and name)
+- `ChunkTypeSet`: The set of chunk types a system supports
 
 ### Chunk Types
 
 - `ContentChunk`: A chunk whose address is derived from its content hash
 - `SingleOwnerChunk`: A chunk owned by a specific account, with signature verification
+
+`AnyChunk` is the type-erased enum over these for runtime polymorphism.
 
 ## Content-Addressed Chunks
 
@@ -38,41 +41,25 @@ Key features:
 
 ## Serialization and Deserialization
 
-Chunks support two forms of serialization:
+Serializing a chunk (`Into<Bytes>`) produces its bare wire bytes: `span || payload` for a content chunk, `id || signature || span || payload` for a single-owner chunk.
 
-1. **Raw serialization**: Just the chunk data without type information
-2. **Prefixed serialization**: Includes type ID and version prefix
+For deserialization, you can:
 
-For deserialization, you can either:
-
-1. Use `deserialize_chunk` with prefixed data
-2. Use type-specific parsing with `try_from` for raw data
-3. Use `infer_and_deserialize` to attempt automatic type detection
-
-## Extending with New Chunk Types
-
-To create a new chunk type, you need to:
-
-1. Create a struct that implements the `Chunk` trait
-2. Define the `ID`, `VERSION`, and `TYPE_NAME` constants
-3. Implement parsing and serialization logic
-4. Update the `deserialize_chunk` function to handle your new type
+1. Use type-specific parsing with `try_from` when the chunk type is known
+2. Use `AnyChunk::from_wire_bytes` when only the expected address is known: the address disambiguates content vs single-owner
+3. Use `AnyChunk::from_typed_bytes` for the self-describing `[type_id][wire bytes]` storage form produced by `AnyChunk::to_typed_bytes`
 
 ## Usage Examples
 
 ```rust
-use nectar_primitives::chunk::{Chunk, ContentChunk, SingleOwnerChunk};
-use nectar_primitives::ChunkAddress;
+use nectar_primitives::{AnyChunk, Chunk, ContentChunk};
 
 // Create a content chunk
-let content_chunk = ContentChunk::new(b"Hello, world!").unwrap();
-let address = content_chunk.address();
+let chunk = ContentChunk::new(&b"Hello, world!"[..]).unwrap();
+let address = *chunk.address();
 
-// Create a single-owner chunk
-let wallet = LocalWallet::random();
-let id = FixedBytes::random();
-let owner_chunk = SingleOwnerChunk::new(id, b"My data", &wallet).unwrap();
-
-// Verify ownership
-owner_chunk.verify_signature().unwrap();
+// Serialize, then recover it from the wire bytes and its address
+let wire: bytes::Bytes = chunk.into();
+let recovered = AnyChunk::from_wire_bytes(&address, wire).unwrap();
+assert_eq!(*recovered.address(), address);
 ```

--- a/crates/primitives/src/chunk/chunk_type_set.rs
+++ b/crates/primitives/src/chunk/chunk_type_set.rs
@@ -7,22 +7,17 @@ extern crate alloc;
 
 use alloc::string::String;
 use alloc::vec::Vec;
-use bytes::Bytes;
 
 use crate::bmt::DEFAULT_BODY_SIZE;
-use crate::error::Result;
 
-use super::any_chunk::AnyChunk;
-use super::content::ContentChunk;
-use super::error::ChunkError;
-use super::single_owner::SingleOwnerChunk;
 use super::type_id::ChunkTypeId;
 
 /// Trait defining a set of supported chunk types with configurable body size.
 ///
 /// This trait is implemented by marker types that define which chunk types
-/// a system supports. It enables compile-time configuration of valid chunk types
-/// while providing runtime polymorphism through [`AnyChunk`].
+/// a system supports. It enables compile-time configuration of valid chunk
+/// types; decoding into a runtime-polymorphic chunk goes through
+/// [`AnyChunk::from_wire_bytes`](super::any_chunk::AnyChunk::from_wire_bytes).
 ///
 /// # Design Rationale
 ///
@@ -31,7 +26,6 @@ use super::type_id::ChunkTypeId;
 ///
 /// - Zero-cost type checking at compile time
 /// - Generic programming over chunk type sets
-/// - Runtime dispatch only when necessary (deserialization)
 ///
 /// # Example
 ///
@@ -59,17 +53,6 @@ pub trait ChunkTypeSet<const BODY_SIZE: usize = DEFAULT_BODY_SIZE>: Send + Sync 
     /// Returns `true` if chunks with the given type ID can be
     /// deserialized and processed by this set.
     fn supports(type_id: ChunkTypeId) -> bool;
-
-    /// Deserialize bytes into the appropriate chunk type.
-    ///
-    /// The first byte of the input should be the chunk type ID.
-    /// Returns an error if the type is not supported or deserialization fails.
-    ///
-    /// # Errors
-    ///
-    /// Returns `ChunkError::UnsupportedType` if the type ID is not in this set.
-    /// May return other errors from the underlying chunk deserialization.
-    fn deserialize(bytes: &[u8]) -> Result<AnyChunk<BODY_SIZE>>;
 
     /// Get the list of all supported type IDs.
     ///
@@ -119,10 +102,6 @@ pub trait ChunkTypeSet<const BODY_SIZE: usize = DEFAULT_BODY_SIZE>: Send + Sync 
 /// // Check support
 /// assert!(StandardChunkSet::supports(ChunkTypeId::CONTENT));
 /// assert!(StandardChunkSet::supports(ChunkTypeId::SINGLE_OWNER));
-///
-/// // Deserialize a chunk
-/// let bytes: &[u8] = /* serialized chunk bytes */;
-/// let chunk = StandardChunkSet::deserialize(bytes)?;
 /// ```
 #[derive(Debug, Clone, Copy, Default)]
 pub struct StandardChunkSet;
@@ -130,35 +109,6 @@ pub struct StandardChunkSet;
 impl<const BODY_SIZE: usize> ChunkTypeSet<BODY_SIZE> for StandardChunkSet {
     fn supports(type_id: ChunkTypeId) -> bool {
         matches!(type_id, ChunkTypeId::CONTENT | ChunkTypeId::SINGLE_OWNER)
-    }
-
-    fn deserialize(bytes: &[u8]) -> Result<AnyChunk<BODY_SIZE>> {
-        if bytes.is_empty() {
-            return Err(ChunkError::invalid_format("empty chunk data").into());
-        }
-
-        // Note: For CAC/SOC, the type ID is in the header, but for raw chunk data
-        // coming off the wire, we typically don't have the header prefix.
-        // The actual deserialization happens based on the chunk structure.
-        //
-        // For CAC: just BMT body (span + data)
-        // For SOC: id + signature + BMT body
-        //
-        // We'll try ContentChunk first (simpler structure), then SingleOwnerChunk.
-        // This is a heuristic - in practice, callers should know the expected type.
-
-        // Try as ContentChunk first
-        if let Ok(content) = ContentChunk::<BODY_SIZE>::try_from(Bytes::copy_from_slice(bytes)) {
-            return Ok(AnyChunk::Content(content));
-        }
-
-        // Try as SingleOwnerChunk
-        if let Ok(soc) = SingleOwnerChunk::<BODY_SIZE>::try_from(Bytes::copy_from_slice(bytes)) {
-            return Ok(AnyChunk::SingleOwner(soc));
-        }
-
-        // If neither worked, it's an invalid format
-        Err(ChunkError::invalid_format("could not deserialize as any supported chunk type").into())
     }
 
     fn supported_types() -> &'static [ChunkTypeId] {
@@ -177,14 +127,6 @@ impl<const BODY_SIZE: usize> ChunkTypeSet<BODY_SIZE> for ContentOnlyChunkSet {
         type_id == ChunkTypeId::CONTENT
     }
 
-    fn deserialize(bytes: &[u8]) -> Result<AnyChunk<BODY_SIZE>> {
-        if bytes.is_empty() {
-            return Err(ChunkError::invalid_format("empty chunk data").into());
-        }
-
-        ContentChunk::<BODY_SIZE>::try_from(Bytes::copy_from_slice(bytes)).map(AnyChunk::Content)
-    }
-
     fn supported_types() -> &'static [ChunkTypeId] {
         &[ChunkTypeId::CONTENT]
     }
@@ -192,8 +134,16 @@ impl<const BODY_SIZE: usize> ChunkTypeSet<BODY_SIZE> for ContentOnlyChunkSet {
 
 #[cfg(test)]
 mod tests {
+    use bytes::Bytes;
+
+    use super::super::address::ChunkAddress;
+    use super::super::any_chunk::AnyChunk;
+    use super::super::content::ContentChunk;
+    use super::super::error::ChunkError;
+    use super::super::single_owner::SingleOwnerChunk;
     use super::super::traits::Chunk;
     use super::*;
+    use crate::error::Result;
 
     type DefaultContentChunk = ContentChunk<DEFAULT_BODY_SIZE>;
 
@@ -256,22 +206,23 @@ mod tests {
     }
 
     #[test]
-    fn test_deserialize_content_chunk() {
+    fn test_from_wire_bytes_content_chunk() {
         // Create a content chunk and serialize it
         let content = DefaultContentChunk::new(&b"hello world"[..]).unwrap();
         let bytes: Bytes = content.clone().into();
 
-        // Deserialize through StandardChunkSet
+        // Decode through the address-keyed wire decoder
         let any_chunk =
-            <StandardChunkSet as ChunkTypeSet<DEFAULT_BODY_SIZE>>::deserialize(&bytes).unwrap();
+            AnyChunk::<DEFAULT_BODY_SIZE>::from_wire_bytes(content.address(), bytes).unwrap();
 
         assert!(any_chunk.is_content());
         assert_eq!(*any_chunk.address(), *content.address());
     }
 
     #[test]
-    fn test_deserialize_empty_bytes_fails() {
-        let result = <StandardChunkSet as ChunkTypeSet<DEFAULT_BODY_SIZE>>::deserialize(&[]);
+    fn test_from_wire_bytes_empty_bytes_fails() {
+        let result =
+            AnyChunk::<DEFAULT_BODY_SIZE>::from_wire_bytes(&ChunkAddress::default(), Bytes::new());
         assert!(result.is_err());
     }
 
@@ -280,16 +231,31 @@ mod tests {
     /// address/owner computations. The fuzz oracle is "no panic"; `Err` is an
     /// acceptable outcome for arbitrary bytes.
     fn exercise_chunk_decode(data: &[u8]) -> Result<AnyChunk<DEFAULT_BODY_SIZE>> {
-        let result = <StandardChunkSet as ChunkTypeSet<DEFAULT_BODY_SIZE>>::deserialize(data);
-        if let Ok(chunk) = &result {
-            let _ = chunk.address();
-        }
+        let bytes = Bytes::copy_from_slice(data);
 
-        let _ = ContentChunk::<DEFAULT_BODY_SIZE>::try_from(data);
-        if let Ok(soc) = SingleOwnerChunk::<DEFAULT_BODY_SIZE>::try_from(data) {
+        // Address-mismatch arm: the zero address matches (almost) no input,
+        // so both trial parses and their address computations run to `Err`.
+        let _ =
+            AnyChunk::<DEFAULT_BODY_SIZE>::from_wire_bytes(&ChunkAddress::default(), bytes.clone());
+
+        let content = ContentChunk::<DEFAULT_BODY_SIZE>::try_from(data);
+        let soc = SingleOwnerChunk::<DEFAULT_BODY_SIZE>::try_from(data);
+        if let Ok(soc) = &soc {
             // ECDSA public-key recovery over bytes 32..97 must not panic.
             let _ = soc.owner();
             let _ = soc.address();
+        }
+
+        // Ok arm: key the wire decoder by the address of whichever direct
+        // parse succeeded, CAC first (the same trial order the decoder uses).
+        let address = content
+            .ok()
+            .map(|c| *c.address())
+            .or_else(|| soc.ok().map(|s| *s.address()))
+            .ok_or_else(|| ChunkError::invalid_format("no structural parse"))?;
+        let result = AnyChunk::from_wire_bytes(&address, bytes);
+        if let Ok(chunk) = &result {
+            let _ = chunk.address();
         }
         result
     }

--- a/crates/primitives/src/chunk/content.rs
+++ b/crates/primitives/src/chunk/content.rs
@@ -14,7 +14,7 @@ use crate::error::{PrimitivesError, Result};
 
 use super::address::ChunkAddress;
 use super::bmt_body::BmtBody;
-use super::traits::{BmtChunk, Chunk, ChunkHeader, ChunkMetadata};
+use super::traits::{BmtChunk, Chunk, ChunkHeader};
 
 /// A content-addressed chunk with configurable body size.
 ///
@@ -22,7 +22,7 @@ use super::traits::{BmtChunk, Chunk, ChunkHeader, ChunkMetadata};
 /// of its contents. It is immutable once created.
 #[derive(Debug, Clone)]
 pub struct ContentChunk<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> {
-    /// The header containing type ID, version, and metadata
+    /// The (empty) wire header
     header: ContentChunkHeader,
     /// The body of the chunk, containing the actual data
     body: BmtBody<BODY_SIZE>,
@@ -30,54 +30,21 @@ pub struct ContentChunk<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> {
     address_cache: OnceCache<ChunkAddress>,
 }
 
-/// Metadata for a content-addressed chunk
-///
-/// Content chunks don't have any specific metadata, so this is empty.
-#[derive(Debug, Clone)]
-pub struct ContentChunkMetadata;
-
-impl ChunkMetadata for ContentChunkMetadata {
-    fn bytes(&self) -> Bytes {
-        Bytes::new()
-    }
-}
-
 /// Header for a content-addressed chunk
-#[derive(Debug, Clone)]
-pub struct ContentChunkHeader {
-    metadata: ContentChunkMetadata,
-}
+///
+/// Content chunks carry no wire header: the body (`span || payload`) is the
+/// whole encoding.
+#[derive(Debug, Clone, Default)]
+pub struct ContentChunkHeader;
 
 impl ContentChunkHeader {
-    /// Create a new header with default metadata
+    /// Create a new header
     pub const fn new() -> Self {
-        Self {
-            metadata: ContentChunkMetadata,
-        }
-    }
-}
-
-impl Default for ContentChunkHeader {
-    fn default() -> Self {
-        Self::new()
+        Self
     }
 }
 
 impl ChunkHeader for ContentChunkHeader {
-    type Metadata = ContentChunkMetadata;
-
-    fn id(&self) -> u8 {
-        0
-    }
-
-    fn version(&self) -> u8 {
-        1
-    }
-
-    fn metadata(&self) -> &Self::Metadata {
-        &self.metadata
-    }
-
     fn bytes(&self) -> Bytes {
         Bytes::new()
     }

--- a/crates/primitives/src/chunk/mod.rs
+++ b/crates/primitives/src/chunk/mod.rs
@@ -35,7 +35,7 @@ pub mod wasm;
 
 // Re-export the address type and core traits
 pub use address::ChunkAddress;
-pub use traits::{BmtChunk, Chunk, ChunkHeader, ChunkMetadata, ChunkSerialization};
+pub use traits::{BmtChunk, Chunk, ChunkHeader};
 
 // Re-export the reference types
 pub use reference::{ChunkRef, RefKind, Reference, WrongRefKind};

--- a/crates/primitives/src/chunk/single_owner.rs
+++ b/crates/primitives/src/chunk/single_owner.rs
@@ -20,7 +20,7 @@ use super::address::ChunkAddress;
 use super::bmt_body::BmtBody;
 use super::content::ContentChunk;
 use super::soc_id::SocId;
-use super::traits::{BmtChunk, Chunk, ChunkHeader, ChunkMetadata};
+use super::traits::{BmtChunk, Chunk, ChunkHeader};
 
 // Constants for field sizes
 const ID_SIZE: usize = std::mem::size_of::<B256>();
@@ -39,7 +39,7 @@ const DISPERSED_REPLICA_OWNER_PK: B256 =
 /// and includes a digital signature proving ownership.
 #[derive(Debug, Clone)]
 pub struct SingleOwnerChunk<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> {
-    /// The header containing type ID, version, and metadata (ID and signature)
+    /// The wire header (ID and signature)
     header: SingleOwnerChunkHeader,
     /// The body of the chunk, containing the actual data
     body: BmtBody<BODY_SIZE>,
@@ -73,10 +73,9 @@ impl SingleOwnerChunkMetadata {
     pub const fn signature(&self) -> &Signature {
         &self.signature
     }
-}
 
-impl ChunkMetadata for SingleOwnerChunkMetadata {
-    fn bytes(&self) -> Bytes {
+    /// Get the wire bytes of this metadata: `id || signature`
+    pub fn bytes(&self) -> Bytes {
         let mut bytes = BytesMut::with_capacity(ID_SIZE + SIGNATURE_SIZE);
         bytes.extend_from_slice(self.id.as_ref());
         bytes.extend_from_slice(&self.signature.as_bytes());
@@ -98,20 +97,6 @@ impl SingleOwnerChunkHeader {
 }
 
 impl ChunkHeader for SingleOwnerChunkHeader {
-    type Metadata = SingleOwnerChunkMetadata;
-
-    fn id(&self) -> u8 {
-        1
-    }
-
-    fn version(&self) -> u8 {
-        1
-    }
-
-    fn metadata(&self) -> &Self::Metadata {
-        &self.metadata
-    }
-
     fn bytes(&self) -> Bytes {
         self.metadata.bytes()
     }

--- a/crates/primitives/src/chunk/traits.rs
+++ b/crates/primitives/src/chunk/traits.rs
@@ -1,48 +1,24 @@
 //! Traits for chunk types and operations
 //!
-//! This module defines the core traits that all chunk types must implement,
-//! along with serialization and deserialization functionality.
+//! This module defines the core traits that all chunk types must implement.
 
 use crate::chunk::error;
 use crate::error::Result;
-use bytes::{BufMut, Bytes, BytesMut};
+use bytes::Bytes;
 
 use super::address::ChunkAddress;
 
-/// Core trait for chunk metadata
-pub trait ChunkMetadata {
-    /// Get the metadata bytes for this chunk
-    fn bytes(&self) -> Bytes;
-}
-
 /// Core trait for chunk header
 pub trait ChunkHeader {
-    /// The metadata type for this chunk
-    type Metadata: ChunkMetadata;
-
-    /// Get the identifier byte for this chunk type
-    fn id(&self) -> u8;
-
-    /// Get the version byte for this chunk type
-    fn version(&self) -> u8;
-
-    /// Get the metadata bytes for this chunk
-    fn metadata(&self) -> &Self::Metadata;
-
-    /// Get the header bytes for this chunk
-    fn bytes(&self) -> Bytes {
-        let mut buf = BytesMut::with_capacity(2);
-        buf.put_u8(self.id());
-        buf.put_u8(self.version());
-        buf.put_slice(self.metadata().bytes().as_ref());
-        buf.freeze()
-    }
+    /// Get the wire header bytes for this chunk: everything that precedes the
+    /// BMT body in the chunk's encoding (empty for a content chunk,
+    /// `id || signature` for a single-owner chunk).
+    fn bytes(&self) -> Bytes;
 }
 
 /// Core trait for all chunk types in the system.
 ///
 /// This trait defines the common interface that all chunk implementations must provide.
-/// Each implementation must specify its type ID and version as associated constants.
 pub trait Chunk: Send + Sync + 'static {
     /// The header type for this chunk
     type Header: ChunkHeader;
@@ -69,25 +45,6 @@ pub trait Chunk: Send + Sync + 'static {
             return Err(error::ChunkError::verification_failed(*expected, *actual).into());
         }
         Ok(())
-    }
-}
-
-/// Trait for serializing chunks with type prefix.
-///
-/// This trait provides methods for serializing a chunk with its type
-/// ID and version prefix.
-pub trait ChunkSerialization {
-    /// Serialize this chunk with its type ID and version prefix
-    fn serialize_with_prefix(&self) -> Bytes;
-}
-
-impl<T: Chunk> ChunkSerialization for T {
-    #[allow(clippy::arithmetic_side_effects)] // 2 + a chunk size bounded by the wire format is a capacity hint far below usize::MAX
-    fn serialize_with_prefix(&self) -> Bytes {
-        let mut bytes = BytesMut::with_capacity(2 + self.size());
-        bytes.extend(self.header().bytes());
-        bytes.extend(self.data());
-        bytes.freeze()
     }
 }
 

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -111,7 +111,6 @@ pub use chunk::{
     ChunkAddress,
     // Concrete chunk types
     ChunkRef,
-    ChunkSerialization,
     ChunkType,
     ChunkTypeId,
     ChunkTypeSet,

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1919,6 +1919,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer-local",
  "arbitrary",
+ "bytes",
  "libfuzzer-sys",
  "nectar-mantaray",
  "nectar-postage",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,6 +13,9 @@ cargo-fuzz = true
 alloy-primitives = { version = "1.6", default-features = false }
 arbitrary = { version = "1", features = ["derive"] }
 alloy-signer-local = { version = "2.0", default-features = false }
+# Chunk wire payloads are `Bytes`; the chunk targets build them from the
+# fuzzer's raw input.
+bytes = "1"
 libfuzzer-sys = "0.4"
 # No `encryption` feature: the `EncryptedChunkRef` representation the
 # mantaray targets drive for the 64-byte entry path is unconditional.

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -39,7 +39,7 @@ OOM, no hang*:
 | Target | Entry point | Invariant |
 |---|---|---|
 | `mantaray_node_decode` | `hazmat::decode` over raw bytes | manifest decoding never panics |
-| `chunk_decode` | `StandardChunkSet::deserialize` + direct CAC/SOC `TryFrom` | chunk decoding, BMT address forcing, and SOC owner recovery never panic |
+| `chunk_decode` | `AnyChunk::from_wire_bytes` + direct CAC/SOC `TryFrom` | chunk decoding, BMT address forcing, and SOC owner recovery never panic |
 | `stamp_decode` | `Stamp::try_from_slice` (+ `recover_signer` over a stamp‖address split) | stamp decoding and EIP-191 signer recovery never panic |
 | `usage_snapshot_decode` | `RootInfo::parse` | SBU1 root parsing (geometry/packed-length arithmetic) never panics |
 

--- a/fuzz/fuzz_targets/chunk_decode.rs
+++ b/fuzz/fuzz_targets/chunk_decode.rs
@@ -1,14 +1,17 @@
 //! Fuzz the chunk wire decoders with raw attacker-controlled bytes.
 //!
-//! `StandardChunkSet::deserialize` is the polymorphic entry point through
-//! which untrusted chunk payloads from the network are parsed (it tries
-//! `ContentChunk`, then `SingleOwnerChunk`). The direct `TryFrom<&[u8]>`
-//! decoders are also driven so the SOC path is reached even when the CAC
-//! decoder accepts the input first. For every successfully decoded chunk the
-//! lazy address computation is forced, and for SOCs the owner recovery —
-//! ECDSA public-key recovery over the id/signature header (bytes 32..97) —
-//! which must be panic-free on arbitrary input. Any returned `Err` is
-//! success; the oracle is "no panic, no OOM, no hang".
+//! `AnyChunk::from_wire_bytes` is the polymorphic entry point through which
+//! untrusted chunk payloads from the network are parsed (it tries
+//! `ContentChunk`, then `SingleOwnerChunk`, keyed by the expected address).
+//! It is driven twice: with the zero address, exercising the mismatch arm on
+//! arbitrary input, and with the address recovered from a direct parse,
+//! exercising the `Ok` arm on structurally valid input. The direct
+//! `TryFrom<&[u8]>` decoders are also driven so the SOC path is reached even
+//! when the CAC decoder accepts the input first. For every successfully
+//! decoded chunk the lazy address computation is forced, and for SOCs the
+//! owner recovery (ECDSA public-key recovery over the id/signature header,
+//! bytes 32..97), which must be panic-free on arbitrary input. Any returned
+//! `Err` is success; the oracle is "no panic, no OOM, no hang".
 //!
 //! Seeds live in `fuzz/seeds/chunk_decode/` and are replayed on stable by
 //! `seed_replay_chunk_decode` in
@@ -16,23 +19,38 @@
 
 #![no_main]
 
+use bytes::Bytes;
 use libfuzzer_sys::fuzz_target;
 use nectar_primitives::{
-    Chunk, ChunkTypeSet, ContentChunk, DEFAULT_BODY_SIZE, SingleOwnerChunk, StandardChunkSet,
+    AnyChunk, Chunk, ChunkAddress, ContentChunk, DEFAULT_BODY_SIZE, SingleOwnerChunk,
 };
 
 fuzz_target!(|data: &[u8]| {
-    // Polymorphic wire decoder (CAC first, then SOC).
-    if let Ok(chunk) = <StandardChunkSet as ChunkTypeSet<DEFAULT_BODY_SIZE>>::deserialize(data) {
-        // Force the lazy address computation (BMT hash / keccak(id || owner)).
-        let _ = chunk.address();
-    }
+    let bytes = Bytes::copy_from_slice(data);
+
+    // Address-mismatch arm: the zero address matches (almost) no input, so
+    // both trial parses and their address computations run to `Err`.
+    let _ = AnyChunk::<DEFAULT_BODY_SIZE>::from_wire_bytes(&ChunkAddress::default(), bytes.clone());
 
     // Direct decoders, so the SOC branch is exercised even for inputs the
     // CAC decoder accepts.
-    let _ = ContentChunk::<DEFAULT_BODY_SIZE>::try_from(data);
-    if let Ok(soc) = SingleOwnerChunk::<DEFAULT_BODY_SIZE>::try_from(data) {
+    let content = ContentChunk::<DEFAULT_BODY_SIZE>::try_from(data);
+    let soc = SingleOwnerChunk::<DEFAULT_BODY_SIZE>::try_from(data);
+    if let Ok(soc) = &soc {
         let _ = soc.owner();
         let _ = soc.address();
+    }
+
+    // Ok arm: key the wire decoder by the address of whichever direct parse
+    // succeeded, CAC first (the same trial order the decoder uses).
+    let address = content
+        .ok()
+        .map(|c| *c.address())
+        .or_else(|| soc.ok().map(|s| *s.address()));
+    if let Some(address) = address
+        && let Ok(chunk) = AnyChunk::<DEFAULT_BODY_SIZE>::from_wire_bytes(&address, bytes)
+    {
+        // Force the lazy address computation (BMT hash / keccak(id || owner)).
+        let _ = chunk.address();
     }
 });


### PR DESCRIPTION
## What

Prunes the dead chunk trait surface in `nectar-primitives`.

Removed:

- `ChunkMetadata` trait, along with the ceremonial `ContentChunkMetadata` unit struct.
- `ChunkHeader::{id(), version(), type Metadata, metadata()}` and the wire-drift-trap default `bytes()` implementation; `bytes()` is now a required method. Both `ContentChunkHeader` and `SingleOwnerChunkHeader` keep their existing bee-parity bodies, so wire bytes are byte-identical.
- `ChunkSerialization::serialize_with_prefix` (zero callers).
- `ChunkTypeSet::deserialize` from the trait, and both `StandardChunkSet`/`ContentOnlyChunkSet` implementations.

`ContentChunkHeader` collapses to a unit struct; `SingleOwnerChunkMetadata` keeps its wire-format logic as an inherent `bytes()` method rather than a trait implementation.

The removed `deserialize` callers - the `chunk_decode` fuzz target and the `chunk_type_set` tests, including the stable seed-replay mirror - are folded onto `AnyChunk::from_wire_bytes`, keyed by the address recovered from the direct `TryFrom` parses (CAC first, matching the decoder's own trial order). Ok/Err classification is preserved for every seed, including max-size SOCs. The fuzz target's `Cargo.toml`/`Cargo.lock` gain a `bytes` dependency to drive the new entry point, and `chunk/README.md` and `fuzz/README.md` are updated to match.

## Why

Issue #190 identified this surface as dead: no production caller exercised `ChunkMetadata`, the default `ChunkHeader::bytes()` prefix, `serialize_with_prefix`, or the trait-level `ChunkTypeSet::deserialize`. Carrying it forward risked wire-format drift, since the default `ChunkHeader::bytes()` implementation was a footgun that neither concrete header actually used (both `ContentChunk` and `SingleOwnerChunk` override `bytes()` directly).

## Testing

Independently re-verified from a fresh clone at the base, atop the single commit `01e7b47`. The wire format is confirmed byte-for-byte identical: the removed default header prefix (`[id, version, metadata]`) was never on any serialization path, since both `ContentChunk` (empty override) and `SingleOwnerChunk` (`id || signature` override) override `bytes()`, matching bee's parity vectors. A follow-up mechanical doc fix (`93d53e9`) updates the fuzz README's stated entry point to `AnyChunk::from_wire_bytes`.

Adversarial (red-team) review of this branch found no defects; no fixes were needed or pushed.

## AI Assistance

This PR was implemented with assistance from Claude (Anthropic), per the org contract in github.com/nxm-rs/.github CONTRIBUTING.md.

Closes #190

