### PR TITLE
refactor(primitives)!: make ChunkHeader an unsealed predicate trait

### DIFF
--- a/crates/primitives/src/chunk/README.md
+++ b/crates/primitives/src/chunk/README.md
@@ -9,7 +9,7 @@ The chunk module is built around a trait-based architecture that allows for diff
 ### Core Traits
 
 - `Chunk`: The main trait that all chunk types implement, defining common operations (address, header, data, verify)
-- `ChunkHeader`: The wire header bytes that precede a chunk's BMT body
+- `ChunkHeader`: The unsealed predicate a chunk type is: address derivation (`commit`), self-certification (`validate`), transformed-address sealing, and the wire header codec (`CacHeader` is empty, `SocHeader` is `id || signature`)
 - `BmtChunk`: A trait for chunks that contain a BMT body (most chunk types)
 - `ChunkType`: Compile-time type identification (type ID and name)
 - `ChunkTypeSet`: The set of chunk types a system supports

--- a/crates/primitives/src/chunk/any_chunk.rs
+++ b/crates/primitives/src/chunk/any_chunk.rs
@@ -3,7 +3,6 @@
 //! This module provides [`AnyChunk`], an enum that can hold any chunk type
 //! for runtime polymorphism without requiring trait objects.
 
-use alloy_primitives::Keccak256;
 use bytes::Bytes;
 
 use crate::bmt::DEFAULT_BODY_SIZE;
@@ -13,7 +12,7 @@ use super::address::ChunkAddress;
 use super::chunk_type::ChunkType;
 use super::content::ContentChunk;
 use super::single_owner::SingleOwnerChunk;
-use super::traits::Chunk;
+use super::traits::{Chunk, ChunkHeader};
 use super::type_id::ChunkTypeId;
 
 /// Type-erased chunk for runtime polymorphism with configurable body size.
@@ -104,18 +103,15 @@ impl<const BODY_SIZE: usize> AnyChunk<BODY_SIZE> {
     ///
     /// # Derivation
     ///
-    /// - For a content-addressed chunk (CAC) the transformed address is the
-    ///   prefixed BMT of the chunk body, i.e. `BMT(prefix = anchor, span,
-    ///   payload)`. This is computed by
+    /// - The anchor-keyed BMT root of the chunk body is computed by
     ///   [`BmtBody::transformed_root`](super::bmt_body::BmtBody::transformed_root) on the
-    ///   chunk's borrowed body, which mixes the anchor into *every* node hash,
-    ///   matching bee's prefix hasher.
-    /// - For a single-owner chunk (SOC) the wrapped content body is re-hashed
-    ///   the same way to obtain `inner`, then the SOC's transformed address is
-    ///   a **plain, unprefixed** `keccak256(soc_address || inner)`. The outer
-    ///   wrap is a flat Keccak256, *not* a prefixed BMT, mirroring bee's
-    ///   `transformedAddressSOC` which uses `swarm.NewHasher()` (no anchor) for
-    ///   the final combine.
+    ///   chunk's borrowed body, which mixes the anchor into *every* node hash.
+    ///   For a SOC the wrapped content body is the one re-hashed.
+    /// - The root is then sealed into the transformed address by the chunk's
+    ///   header predicate
+    ///   ([`ChunkHeader::seal_transformed`](super::traits::ChunkHeader::seal_transformed)):
+    ///   the root itself for a CAC, the plain (unprefixed, no anchor)
+    ///   `keccak256(soc_address || inner)` for a SOC.
     ///
     /// # Endianness
     ///
@@ -132,17 +128,12 @@ impl<const BODY_SIZE: usize> AnyChunk<BODY_SIZE> {
     /// `32 + 65` (id + signature) header slicing.
     pub fn transformed_address(&self, anchor: &[u8]) -> ChunkAddress {
         match self {
-            // CAC: the prefixed BMT root of the (borrowed) body is the address.
-            Self::Content(c) => ChunkAddress::from(c.body().transformed_root(anchor)),
-            // SOC: re-hash the (borrowed) wrapped body, then take the plain
-            // (unprefixed) keccak256(soc_address || inner).
-            Self::SingleOwner(c) => {
-                let inner = c.inner_body().transformed_root(anchor);
-                let mut hasher = Keccak256::new();
-                hasher.update(c.address());
-                hasher.update(inner.as_slice());
-                ChunkAddress::from(hasher.finalize())
-            }
+            Self::Content(c) => c
+                .header()
+                .seal_transformed(c.address(), c.body().transformed_root(anchor)),
+            Self::SingleOwner(c) => c
+                .header()
+                .seal_transformed(c.address(), c.inner_body().transformed_root(anchor)),
         }
     }
 

--- a/crates/primitives/src/chunk/content.rs
+++ b/crates/primitives/src/chunk/content.rs
@@ -3,18 +3,22 @@
 //! This module provides the implementation of content-addressed chunks,
 //! which are chunks whose address is derived from the hash of their content.
 
-use alloy_primitives::hex;
-use bytes::Bytes;
+use alloy_primitives::{B256, hex};
+use bytes::{Bytes, BytesMut};
 use std::fmt;
 use std::marker::PhantomData;
 
 use crate::bmt::DEFAULT_BODY_SIZE;
 use crate::cache::OnceCache;
 use crate::error::{PrimitivesError, Result};
+use crate::wire;
 
 use super::address::ChunkAddress;
 use super::bmt_body::BmtBody;
+use super::error::ChunkError;
 use super::traits::{BmtChunk, Chunk, ChunkHeader};
+use super::type_id::ChunkTypeId;
+use super::type_tag::ChunkVersion;
 
 /// A content-addressed chunk with configurable body size.
 ///
@@ -23,30 +27,53 @@ use super::traits::{BmtChunk, Chunk, ChunkHeader};
 #[derive(Debug, Clone)]
 pub struct ContentChunk<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> {
     /// The (empty) wire header
-    header: ContentChunkHeader,
+    header: CacHeader,
     /// The body of the chunk, containing the actual data
     body: BmtBody<BODY_SIZE>,
     /// Cache for the chunk's address
     address_cache: OnceCache<ChunkAddress>,
 }
 
-/// Header for a content-addressed chunk
+/// Header of a content-addressed chunk (CAC).
 ///
-/// Content chunks carry no wire header: the body (`span || payload`) is the
-/// whole encoding.
-#[derive(Debug, Clone, Default)]
-pub struct ContentChunkHeader;
+/// A CAC carries no wire header and commits to its own body hash; the empty
+/// header is a type fact ([`SIZE`](ChunkHeader::SIZE) is 0), not a runtime
+/// check.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CacHeader;
 
-impl ContentChunkHeader {
-    /// Create a new header
-    pub const fn new() -> Self {
-        Self
+impl ChunkHeader for CacHeader {
+    const TYPE_ID: ChunkTypeId = ChunkTypeId::CONTENT;
+    const VERSION: ChunkVersion = ChunkVersion::new(0);
+    const NAME: &'static str = "content";
+    const SIZE: usize = 0;
+
+    /// The address is the BMT body hash itself.
+    fn commit(&self, body_hash: B256) -> ChunkAddress {
+        ChunkAddress::from(body_hash)
     }
-}
 
-impl ChunkHeader for ContentChunkHeader {
-    fn bytes(&self) -> Bytes {
-        Bytes::new()
+    fn validate(
+        &self,
+        body_hash: B256,
+        expected: &ChunkAddress,
+    ) -> std::result::Result<(), ChunkError> {
+        let actual = self.commit(body_hash);
+        if actual != *expected {
+            return Err(ChunkError::verification_failed(*expected, actual));
+        }
+        Ok(())
+    }
+
+    /// The transformed address is the anchor-keyed BMT root itself.
+    fn seal_transformed(&self, _address: &ChunkAddress, transformed_root: B256) -> ChunkAddress {
+        ChunkAddress::from(transformed_root)
+    }
+
+    fn encode(&self, _out: &mut BytesMut) {}
+
+    fn decode(_cursor: &mut wire::Cursor<'_>) -> std::result::Result<Self, ChunkError> {
+        Ok(Self)
     }
 }
 
@@ -98,7 +125,7 @@ impl<const BODY_SIZE: usize> ContentChunk<BODY_SIZE> {
     #[must_use]
     pub const fn from_body(body: BmtBody<BODY_SIZE>) -> Self {
         Self {
-            header: ContentChunkHeader::new(),
+            header: CacHeader,
             body,
             address_cache: OnceCache::new(),
         }
@@ -121,7 +148,7 @@ impl<const BODY_SIZE: usize> ContentChunk<BODY_SIZE> {
     #[must_use]
     pub fn from_body_with_address(body: BmtBody<BODY_SIZE>, address: ChunkAddress) -> Self {
         Self {
-            header: ContentChunkHeader::new(),
+            header: CacHeader,
             body,
             address_cache: OnceCache::with_value(address),
         }
@@ -220,23 +247,28 @@ impl<const BODY_SIZE: usize> super::encryption::ChunkEncrypt for ContentChunk<BO
 }
 
 impl<const BODY_SIZE: usize> Chunk for ContentChunk<BODY_SIZE> {
-    type Header = ContentChunkHeader;
+    type Header = CacHeader;
 
     fn address(&self) -> &ChunkAddress {
-        self.address_cache.get_or_compute(|| self.body.hash())
+        self.address_cache
+            .get_or_compute(|| self.header.commit(self.body.hash().into()))
     }
 
     fn data(&self) -> &Bytes {
         self.body.data()
     }
 
-    #[allow(clippy::arithmetic_side_effects)] // header (0 bytes) plus a body bounded by BODY_SIZE cannot overflow usize
     fn size(&self) -> usize {
-        self.header().bytes().len() + self.body.size()
+        // Header (0 bytes) plus a body bounded by BODY_SIZE cannot overflow.
+        CacHeader::SIZE.saturating_add(self.body.size())
     }
 
     fn header(&self) -> &Self::Header {
         &self.header
+    }
+
+    fn verify(&self, expected: &ChunkAddress) -> Result<()> {
+        Ok(self.header.validate(self.body.hash().into(), expected)?)
     }
 }
 
@@ -257,7 +289,7 @@ impl<const BODY_SIZE: usize> TryFrom<Bytes> for ContentChunk<BODY_SIZE> {
 
     fn try_from(bytes: Bytes) -> Result<Self> {
         Ok(Self {
-            header: ContentChunkHeader::new(),
+            header: CacHeader,
             body: BmtBody::try_from(bytes)?,
             address_cache: OnceCache::new(),
         })
@@ -365,7 +397,7 @@ impl<const BODY_SIZE: usize> ContentChunkBuilderImpl<BODY_SIZE, ReadyToBuild> {
             .map_or_else(OnceCache::new, OnceCache::with_value);
 
         ContentChunk {
-            header: ContentChunkHeader::new(),
+            header: CacHeader,
             body,
             address_cache,
         }
@@ -510,5 +542,60 @@ mod tests {
         assert_eq!(chunk.span(), 0);
         assert_eq!(chunk.data(), &[0u8; 0].as_slice());
         assert_eq!(chunk.size(), 8);
+    }
+
+    /// The commit rule is the body hash itself, pinned on a known vector.
+    #[test]
+    fn cac_header_commit_is_body_hash() {
+        let chunk = DefaultContentChunk::new(b"foo".to_vec()).unwrap();
+        let body_hash: B256 = chunk.body().hash().into();
+
+        let expected = b256!("2387e8e7d8a48c2a9339c97c1dc3461a9a7aa07e994c5cb8b38fd7c1b3e6ea48");
+        assert_eq!(CacHeader.commit(body_hash), ChunkAddress::from(expected));
+        assert!(CacHeader.validate(body_hash, &expected.into()).is_ok());
+    }
+
+    #[test]
+    fn cac_header_validate_rejects_wrong_address() {
+        let body_hash = B256::repeat_byte(0x11);
+        let wrong = ChunkAddress::from(B256::repeat_byte(0x22));
+        assert!(matches!(
+            CacHeader.validate(body_hash, &wrong),
+            Err(ChunkError::VerificationFailed { .. })
+        ));
+    }
+
+    /// The wire header is empty: encode writes nothing, decode consumes nothing.
+    #[test]
+    fn cac_header_wire_shape_is_empty() {
+        let mut out = BytesMut::new();
+        CacHeader.encode(&mut out);
+        assert_eq!(out.len(), CacHeader::SIZE);
+        assert!(out.is_empty());
+
+        let data = [0xaau8; 4];
+        let mut cursor = wire::Cursor::new(&data);
+        let _ = CacHeader::decode(&mut cursor).unwrap();
+        assert_eq!(cursor.remaining(), &data);
+    }
+
+    /// The transformed address is the anchor-keyed root itself; nothing is
+    /// sealed over the chunk address.
+    #[test]
+    fn cac_header_seal_transformed_is_root() {
+        let address = ChunkAddress::from(B256::repeat_byte(0x33));
+        let root = B256::repeat_byte(0x44);
+        assert_eq!(
+            CacHeader.seal_transformed(&address, root),
+            ChunkAddress::from(root)
+        );
+    }
+
+    #[test]
+    fn cac_header_constants() {
+        assert_eq!(CacHeader::SIZE, 0);
+        assert_eq!(CacHeader::TYPE_ID, ChunkTypeId::CONTENT);
+        assert_eq!(CacHeader::VERSION, ChunkVersion::new(0));
+        assert_eq!(CacHeader::NAME, "content");
     }
 }

--- a/crates/primitives/src/chunk/error.rs
+++ b/crates/primitives/src/chunk/error.rs
@@ -13,8 +13,11 @@ pub enum ChunkError {
     /// Chunk size is invalid
     #[error("Invalid chunk size: {message} (expected: {expected}, got: {actual})")]
     InvalidSize {
+        /// What was being sized when the mismatch was found
         message: &'static str,
+        /// Byte width the format requires
         expected: usize,
+        /// Byte width actually observed
         actual: usize,
     },
 
@@ -25,7 +28,9 @@ pub enum ChunkError {
     /// Chunk address verification failed
     #[error("Chunk address verification failed: expected {expected}, got {actual}")]
     VerificationFailed {
+        /// Address the chunk was checked against
         expected: ChunkAddress,
+        /// Address the chunk actually derives
         actual: ChunkAddress,
     },
 
@@ -44,9 +49,14 @@ pub enum ChunkError {
     /// Unsupported chunk type
     #[error("Unsupported chunk type: {0}")]
     UnsupportedType(ChunkTypeId),
+
+    /// Wire buffer underrun
+    #[error(transparent)]
+    Underrun(#[from] crate::wire::Underrun),
 }
 
 impl ChunkError {
+    /// Construct an [`InvalidSize`](Self::InvalidSize) error
     pub const fn invalid_size(message: &'static str, expected: usize, actual: usize) -> Self {
         Self::InvalidSize {
             message,
@@ -55,18 +65,22 @@ impl ChunkError {
         }
     }
 
+    /// Construct an [`InvalidFormat`](Self::InvalidFormat) error
     pub fn invalid_format<S: Into<String>>(msg: S) -> Self {
         Self::InvalidFormat(msg.into())
     }
 
+    /// Construct a [`VerificationFailed`](Self::VerificationFailed) error
     pub const fn verification_failed(expected: ChunkAddress, actual: ChunkAddress) -> Self {
         Self::VerificationFailed { expected, actual }
     }
 
+    /// Construct an [`InvalidSignature`](Self::InvalidSignature) error
     pub fn invalid_signature<S: Into<String>>(msg: S) -> Self {
         Self::InvalidSignature(msg.into())
     }
 
+    /// Construct an [`UnsupportedType`](Self::UnsupportedType) error
     pub const fn unsupported_type(type_id: ChunkTypeId) -> Self {
         Self::UnsupportedType(type_id)
     }

--- a/crates/primitives/src/chunk/mod.rs
+++ b/crates/primitives/src/chunk/mod.rs
@@ -7,6 +7,8 @@
 //!
 //! The chunk system is built around a hierarchy of traits:
 //!
+//! - [`ChunkHeader`] - Address-derivation and self-certification predicate of
+//!   a chunk type ([`CacHeader`], [`SocHeader`])
 //! - [`Chunk`] - Core trait for all chunk types
 //! - [`ChunkType`] - Adds compile-time type identification
 //! - [`ChunkTypeSet`] - Defines which chunk types a system supports
@@ -34,8 +36,9 @@ mod type_tag;
 #[cfg(target_arch = "wasm32")]
 pub mod wasm;
 
-// Re-export the address type and core traits
+// Re-export the address type, error type, and core traits
 pub use address::ChunkAddress;
+pub use error::ChunkError;
 pub use traits::{BmtChunk, Chunk, ChunkHeader};
 
 // Re-export the reference types
@@ -48,11 +51,11 @@ pub use chunk_type_set::{ChunkTypeSet, ContentOnlyChunkSet, StandardChunkSet};
 pub use type_id::ChunkTypeId;
 pub use type_tag::{ChunkTypeTag, ChunkVersion, TagWireError};
 
-// Re-export the concrete chunk types
-pub use content::ContentChunk;
+// Re-export the concrete chunk types and their headers
 #[cfg(feature = "encryption")]
 pub use content::EncryptedContentChunk;
+pub use content::{CacHeader, ContentChunk};
 #[cfg(feature = "encryption")]
 pub use encryption::ChunkEncrypt;
-pub use single_owner::SingleOwnerChunk;
+pub use single_owner::{SingleOwnerChunk, SocHeader};
 pub use soc_id::SocId;

--- a/crates/primitives/src/chunk/single_owner.rs
+++ b/crates/primitives/src/chunk/single_owner.rs
@@ -15,17 +15,19 @@ use crate::bmt::DEFAULT_BODY_SIZE;
 use crate::cache::OnceCache;
 use crate::chunk::error::{self, ChunkError};
 use crate::error::Result;
+use crate::wire;
 
 use super::address::ChunkAddress;
 use super::bmt_body::BmtBody;
 use super::content::ContentChunk;
 use super::soc_id::SocId;
 use super::traits::{BmtChunk, Chunk, ChunkHeader};
+use super::type_id::ChunkTypeId;
+use super::type_tag::ChunkVersion;
 
 // Constants for field sizes
 const ID_SIZE: usize = std::mem::size_of::<B256>();
 const SIGNATURE_SIZE: usize = 65;
-const MIN_SOC_FIELDS_SIZE: usize = ID_SIZE + SIGNATURE_SIZE;
 
 /// The address of the owner of the SOC for dispersed replicas.
 const DISPERSED_REPLICA_OWNER: Address = address!("0xdc5b20847f43d67928f49cd4f85d696b5a7617b5");
@@ -40,7 +42,7 @@ const DISPERSED_REPLICA_OWNER_PK: B256 =
 #[derive(Debug, Clone)]
 pub struct SingleOwnerChunk<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> {
     /// The wire header (ID and signature)
-    header: SingleOwnerChunkHeader,
+    header: SocHeader,
     /// The body of the chunk, containing the actual data
     body: BmtBody<BODY_SIZE>,
     /// Cache for the chunk's address
@@ -49,56 +51,121 @@ pub struct SingleOwnerChunk<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> {
     owner_cache: OnceCache<Address>,
 }
 
-/// Metadata for a single-owner chunk
-#[derive(Debug, Clone)]
-pub struct SingleOwnerChunkMetadata {
-    /// Unique identifier for this chunk
+/// Header of a single-owner chunk (SOC): `id || signature`, 97 wire bytes.
+///
+/// The address is `keccak256(id || owner)`, with the owner recovered from
+/// the signature over `keccak256(id || body_hash)`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SocHeader {
+    /// Unique identifier the chunk is signed under
     id: SocId,
-    /// Digital signature of the chunk's ID and body hash
+    /// Digital signature over the chunk's ID and body hash
     signature: Signature,
 }
 
-impl SingleOwnerChunkMetadata {
-    /// Create a new metadata instance with the given ID and signature
+impl SocHeader {
+    /// Create a new header with the given ID and signature
     pub const fn new(id: SocId, signature: Signature) -> Self {
         Self { id, signature }
     }
 
-    /// Get the unique ID of this chunk
+    /// Get the unique ID of this header
     pub const fn id(&self) -> SocId {
         self.id
     }
 
-    /// Get the signature of this chunk
+    /// Get the signature of this header
     pub const fn signature(&self) -> &Signature {
         &self.signature
     }
 
-    /// Get the wire bytes of this metadata: `id || signature`
-    pub fn bytes(&self) -> Bytes {
-        let mut bytes = BytesMut::with_capacity(ID_SIZE + SIGNATURE_SIZE);
-        bytes.extend_from_slice(self.id.as_ref());
-        bytes.extend_from_slice(&self.signature.as_bytes());
-        bytes.freeze()
+    /// EIP-191 message the owner signs: `keccak256(id || body_hash)`.
+    pub fn owner_message(id: SocId, body_hash: B256) -> B256 {
+        let mut hasher = Keccak256::new();
+        hasher.update(id.as_slice());
+        hasher.update(body_hash);
+        hasher.finalize()
+    }
+
+    /// Recover the owner's address from the signature over `body_hash`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ChunkError::Signature` if the signature recovery fails.
+    pub fn owner(&self, body_hash: B256) -> error::Result<Address> {
+        self.signature
+            .recover_address_from_msg(Self::owner_message(self.id, body_hash))
+            .map_err(Into::into)
+    }
+
+    /// The SOC address derivation: `keccak256(id || owner)`.
+    fn address_for(id: SocId, owner: Address) -> ChunkAddress {
+        let mut hasher = Keccak256::new();
+        hasher.update(id.as_slice());
+        hasher.update(owner);
+        ChunkAddress::from(hasher.finalize())
+    }
+
+    /// Dispersed-replica rule: `id[1..]` must equal `body_hash[1..]`; only the
+    /// first id byte is mined.
+    fn is_valid_replica(&self, body_hash: B256) -> bool {
+        // Both slices are fixed 32-byte values, so split_first is always Some.
+        let id_tail = self.id.as_slice().split_first().map(|(_, tail)| tail);
+        let hash_tail = body_hash.as_slice().split_first().map(|(_, tail)| tail);
+        id_tail == hash_tail
     }
 }
 
-/// Header for a single-owner chunk
-#[derive(Debug, Clone)]
-pub struct SingleOwnerChunkHeader {
-    metadata: SingleOwnerChunkMetadata,
-}
+impl ChunkHeader for SocHeader {
+    const TYPE_ID: ChunkTypeId = ChunkTypeId::SINGLE_OWNER;
+    const VERSION: ChunkVersion = ChunkVersion::new(0);
+    const NAME: &'static str = "single_owner";
+    const SIZE: usize = ID_SIZE + SIGNATURE_SIZE;
 
-impl SingleOwnerChunkHeader {
-    /// Create a new header with the given metadata
-    pub const fn new(metadata: SingleOwnerChunkMetadata) -> Self {
-        Self { metadata }
+    /// Total commitment: an unrecoverable signature commits under the zero
+    /// owner, an address [`validate`](ChunkHeader::validate) then rejects.
+    fn commit(&self, body_hash: B256) -> ChunkAddress {
+        let owner = self.owner(body_hash).unwrap_or(Address::ZERO);
+        Self::address_for(self.id, owner)
     }
-}
 
-impl ChunkHeader for SingleOwnerChunkHeader {
-    fn bytes(&self) -> Bytes {
-        self.metadata.bytes()
+    fn validate(
+        &self,
+        body_hash: B256,
+        expected: &ChunkAddress,
+    ) -> std::result::Result<(), ChunkError> {
+        let owner = self.owner(body_hash)?;
+
+        // If the owner is the replica chunk owner, the ID must adhere to the
+        // dispersed-replica semantics.
+        if owner == DISPERSED_REPLICA_OWNER && !self.is_valid_replica(body_hash) {
+            return Err(ChunkError::invalid_format("invalid dispersed replica"));
+        }
+
+        let actual = Self::address_for(self.id, owner);
+        if actual != *expected {
+            return Err(ChunkError::verification_failed(*expected, actual));
+        }
+        Ok(())
+    }
+
+    /// Plain (unprefixed) `keccak256(soc_address || transformed_root)`.
+    fn seal_transformed(&self, address: &ChunkAddress, transformed_root: B256) -> ChunkAddress {
+        let mut hasher = Keccak256::new();
+        hasher.update(address);
+        hasher.update(transformed_root);
+        ChunkAddress::from(hasher.finalize())
+    }
+
+    fn encode(&self, out: &mut BytesMut) {
+        out.extend_from_slice(self.id.as_slice());
+        out.extend_from_slice(&self.signature.as_bytes());
+    }
+
+    fn decode(cursor: &mut wire::Cursor<'_>) -> std::result::Result<Self, ChunkError> {
+        let id = SocId::new(cursor.take::<[u8; ID_SIZE]>()?);
+        let signature = Signature::from_raw(&cursor.take::<[u8; SIGNATURE_SIZE]>()?)?;
+        Ok(Self::new(id, signature))
     }
 }
 
@@ -174,11 +241,8 @@ impl<const BODY_SIZE: usize> SingleOwnerChunk<BODY_SIZE> {
     /// * `body` - The BMT body containing the data.
     #[must_use]
     pub const fn from_parts(id: SocId, signature: Signature, body: BmtBody<BODY_SIZE>) -> Self {
-        let metadata = SingleOwnerChunkMetadata::new(id, signature);
-        let header = SingleOwnerChunkHeader::new(metadata);
-
         Self {
-            header,
+            header: SocHeader::new(id, signature),
             body,
             chunk_address_cache: OnceCache::new(),
             owner_cache: OnceCache::new(),
@@ -197,11 +261,8 @@ impl<const BODY_SIZE: usize> SingleOwnerChunk<BODY_SIZE> {
         address: ChunkAddress,
         owner: Address,
     ) -> Self {
-        let metadata = SingleOwnerChunkMetadata::new(id, signature);
-        let header = SingleOwnerChunkHeader::new(metadata);
-
         Self {
-            header,
+            header: SocHeader::new(id, signature),
             body,
             chunk_address_cache: OnceCache::with_value(address),
             owner_cache: OnceCache::with_value(owner),
@@ -237,49 +298,23 @@ impl<const BODY_SIZE: usize> SingleOwnerChunk<BODY_SIZE> {
 
     /// Calculate the owner's address from the signature.
     fn calculate_owner(&self) -> error::Result<Address> {
-        // Generate the hash to verify
-        let hash = Self::to_sign(&self.header.metadata.id, &self.body);
-
-        // Recover the address from the signature
-        self.signature()
-            .recover_address_from_msg(hash)
-            .map_err(Into::into)
-    }
-
-    /// Compute the data to be signed for this chunk.
-    ///
-    /// This combines the chunk's ID and body hash to create the data
-    /// that is signed to prove ownership.
-    ///
-    /// # Arguments
-    ///
-    /// * `id` - The chunk's ID.
-    /// * `body` - The chunk's body.
-    ///
-    /// # Returns
-    ///
-    /// A 32-byte hash representing the data to sign.
-    fn to_sign(id: &SocId, body: &BmtBody<BODY_SIZE>) -> B256 {
-        let mut hasher = Keccak256::new();
-        hasher.update(id);
-        hasher.update(body.hash());
-        hasher.finalize()
+        self.header.owner(self.body.hash().into())
     }
 
     // Checks if the chunk is a valid dispersed replica
-    #[allow(clippy::indexing_slicing)] // both id and body hash are fixed 32-byte values, so [1..] holds
+    #[cfg(test)]
     fn is_valid_replica(&self) -> bool {
-        self.id().as_slice()[1..] == self.body.hash().as_bytes()[1..]
+        self.header.is_valid_replica(self.body.hash().into())
     }
 
     /// Get the ID of this chunk.
     pub const fn id(&self) -> SocId {
-        self.header.metadata.id
+        self.header.id()
     }
 
     /// Get the signature of this chunk.
     pub const fn signature(&self) -> &Signature {
-        &self.header.metadata.signature
+        self.header.signature()
     }
 
     /// Borrow the inner content body wrapped by this single-owner chunk.
@@ -295,9 +330,8 @@ impl<const BODY_SIZE: usize> SingleOwnerChunk<BODY_SIZE> {
 
     /// Extract the content-addressed chunk (CAC) wrapped inside this SOC.
     ///
-    /// Mirrors bee's `soc.UnwrapCAC` (`pkg/soc/soc.go`): the SOC body *is* a
-    /// CAC body (`span || payload`), so this rebuilds the [`ContentChunk`] from
-    /// it without any manual `HashSize + SignatureSize` cursor arithmetic. The
+    /// The SOC body *is* a CAC body (`span || payload`), so this rebuilds the
+    /// [`ContentChunk`] from it without any manual cursor arithmetic. The
     /// returned chunk's address is the wrapped content address, not the SOC
     /// address.
     #[must_use]
@@ -307,29 +341,20 @@ impl<const BODY_SIZE: usize> SingleOwnerChunk<BODY_SIZE> {
 }
 
 impl<const BODY_SIZE: usize> Chunk for SingleOwnerChunk<BODY_SIZE> {
-    type Header = SingleOwnerChunkHeader;
+    type Header = SocHeader;
 
     fn address(&self) -> &ChunkAddress {
-        self.chunk_address_cache.get_or_compute(|| {
-            // Compute address from id and owner
-            // Note: If owner recovery fails, we use Address::ZERO which will cause
-            // address verification to fail, which is the correct behavior.
-            let owner = self.owner().unwrap_or(Address::ZERO);
-            let mut hasher = Keccak256::new();
-            hasher.update(self.id());
-            hasher.update(owner);
-
-            hasher.finalize().into()
-        })
+        self.chunk_address_cache
+            .get_or_compute(|| self.header.commit(self.body.hash().into()))
     }
 
     fn data(&self) -> &Bytes {
         self.body.data()
     }
 
-    #[allow(clippy::arithmetic_side_effects)] // header (97 bytes) plus a body bounded by BODY_SIZE cannot overflow usize
     fn size(&self) -> usize {
-        self.header().bytes().len() + self.body.size()
+        // Header (97 bytes) plus a body bounded by BODY_SIZE cannot overflow.
+        SocHeader::SIZE.saturating_add(self.body.size())
     }
 
     fn header(&self) -> &Self::Header {
@@ -337,19 +362,7 @@ impl<const BODY_SIZE: usize> Chunk for SingleOwnerChunk<BODY_SIZE> {
     }
 
     fn verify(&self, expected: &ChunkAddress) -> Result<()> {
-        let actual = self.address();
-
-        // At this point, the owner has been recovered. Now check if the owner
-        // is the replica chunk owner, the ID must adhere to specific semantics.
-        let owner = self.owner()?;
-        if owner == DISPERSED_REPLICA_OWNER && !self.is_valid_replica() {
-            return Err(error::ChunkError::invalid_format("invalid dispersed replica").into());
-        }
-
-        if actual != expected {
-            return Err(error::ChunkError::verification_failed(*expected, *actual).into());
-        }
-        Ok(())
+        Ok(self.header.validate(self.body.hash().into(), expected)?)
     }
 }
 
@@ -362,7 +375,7 @@ impl<const BODY_SIZE: usize> BmtChunk for SingleOwnerChunk<BODY_SIZE> {
 impl<const BODY_SIZE: usize> From<SingleOwnerChunk<BODY_SIZE>> for Bytes {
     fn from(chunk: SingleOwnerChunk<BODY_SIZE>) -> Self {
         let mut bytes = BytesMut::with_capacity(chunk.size());
-        bytes.extend_from_slice(chunk.header().bytes().as_ref());
+        chunk.header.encode(&mut bytes);
         bytes.extend_from_slice(&Self::from(chunk.body));
         bytes.freeze()
     }
@@ -372,32 +385,11 @@ impl<const BODY_SIZE: usize> TryFrom<Bytes> for SingleOwnerChunk<BODY_SIZE> {
     type Error = PrimitivesError;
 
     fn try_from(bytes: Bytes) -> Result<Self> {
-        if bytes.len() < MIN_SOC_FIELDS_SIZE {
-            return Err(ChunkError::invalid_size(
-                "insufficient data for single-owner chunk",
-                MIN_SOC_FIELDS_SIZE,
-                bytes.len(),
-            )
-            .into());
-        }
+        let mut cursor = wire::Cursor::new(&bytes);
+        let header = SocHeader::decode(&mut cursor)?;
 
-        // Extract ID
-        let id_slice = &bytes.slice(0..ID_SIZE);
-        let mut id = B256::default();
-        id.copy_from_slice(id_slice);
-        let id = SocId::from(id);
-
-        // Extract signature
-        let sig_slice = &bytes.slice(ID_SIZE..ID_SIZE + SIGNATURE_SIZE);
-        let signature = Signature::from_raw(sig_slice).map_err(ChunkError::from)?;
-
-        // Extract body
-        let body_bytes = bytes.slice(ID_SIZE + SIGNATURE_SIZE..);
-        let body = BmtBody::try_from(body_bytes)?;
-
-        // Create metadata and header
-        let metadata = SingleOwnerChunkMetadata::new(id, signature);
-        let header = SingleOwnerChunkHeader::new(metadata);
+        // decode consumed exactly SocHeader::SIZE bytes, so the slice holds.
+        let body = BmtBody::try_from(bytes.slice(SocHeader::SIZE..))?;
 
         Ok(Self {
             header,
@@ -566,10 +558,10 @@ impl<const BODY_SIZE: usize> SingleOwnerChunkBuilderImpl<BODY_SIZE, WithId> {
     ) -> Result<SingleOwnerChunkBuilderImpl<BODY_SIZE, ReadyToBuild>> {
         // Get body and ID - these are guaranteed to be Some by the state
         let body = self.body.as_ref().unwrap();
-        let id = self.id.as_ref().unwrap();
+        let id = *self.id.as_ref().unwrap();
 
         // Compute hash to sign
-        let hash = SingleOwnerChunk::<BODY_SIZE>::to_sign(id, body);
+        let hash = SocHeader::owner_message(id, body.hash().into());
 
         // Sign the hash
         let signature = signer
@@ -684,7 +676,7 @@ mod tests {
     proptest! {
         #[test]
         fn test_chunk_properties(chunk in chunk_strategy()) {
-            prop_assert!(chunk.size() >= MIN_SOC_FIELDS_SIZE);
+            prop_assert!(chunk.size() >= SocHeader::SIZE);
 
             // Test round-trip conversion of the raw parts
             let bytes: Bytes = chunk.clone().into();
@@ -789,7 +781,7 @@ mod tests {
         }
 
         #[test]
-        fn test_chunk_too_small(data in proptest::collection::vec(any::<u8>(), 1..MIN_SOC_FIELDS_SIZE)) {
+        fn test_chunk_too_small(data in proptest::collection::vec(any::<u8>(), 1..SocHeader::SIZE)) {
             // Test insufficient data size
             let chunk = DefaultSingleOwnerChunk::try_from(data.as_slice());
             prop_assert!(chunk.is_err());
@@ -886,5 +878,121 @@ mod tests {
         ));
 
         Ok(())
+    }
+
+    /// Decode the go-interop test vector's header and pin its wire shape:
+    /// `id || signature`, 97 bytes, no type or version prefix.
+    #[test]
+    fn soc_header_decode_encode_round_trips_go_vector() {
+        let wire = get_test_chunk_data();
+        let mut cursor = wire::Cursor::new(&wire);
+        let header = SocHeader::decode(&mut cursor).unwrap();
+
+        assert_eq!(header.id(), SocId::ZERO);
+        assert_eq!(cursor.remaining(), &wire[SocHeader::SIZE..]);
+
+        let mut out = BytesMut::new();
+        header.encode(&mut out);
+        assert_eq!(out.len(), SocHeader::SIZE);
+        assert_eq!(out.as_ref(), &wire[..SocHeader::SIZE]);
+    }
+
+    #[test]
+    fn soc_header_decode_underrun_errors() {
+        for len in [0, ID_SIZE, SocHeader::SIZE - 1] {
+            let short = vec![0u8; len];
+            let mut cursor = wire::Cursor::new(&short);
+            assert!(matches!(
+                SocHeader::decode(&mut cursor),
+                Err(ChunkError::Underrun(_))
+            ));
+        }
+    }
+
+    /// The commit rule on the go vector: `keccak256(id || owner)` with the
+    /// owner recovered over `keccak256(id || body_hash)`.
+    #[test]
+    fn soc_header_commit_reproduces_go_vector_address() {
+        let chunk = DefaultSingleOwnerChunk::try_from(get_test_chunk_data().as_slice()).unwrap();
+        let body_hash: B256 = chunk.inner_body().hash().into();
+
+        let expected = b256!("9d453ebb73b2fedaaf44ceddcf7a0aa37f3e3d6453fea5841c31f0ea6d61dc85");
+        assert_eq!(
+            chunk.header().commit(body_hash),
+            ChunkAddress::from(expected)
+        );
+        assert!(chunk.header().validate(body_hash, &expected.into()).is_ok());
+    }
+
+    /// An unrecoverable signature commits under the zero owner and validate
+    /// rejects it with a signature error, never an address compare.
+    #[test]
+    fn soc_header_bad_signature_commits_zero_owner_and_fails_validate() {
+        let mut wire = get_test_chunk_data();
+        wire[ID_SIZE..ID_SIZE + SIGNATURE_SIZE].copy_from_slice(&[0xff; SIGNATURE_SIZE]);
+
+        let chunk = DefaultSingleOwnerChunk::try_from(wire.as_slice()).unwrap();
+        let body_hash: B256 = chunk.inner_body().hash().into();
+        let header = chunk.header();
+
+        // Commit is total: the zero owner stands in.
+        let zero_owner_address = SocHeader::address_for(header.id(), Address::ZERO);
+        assert_eq!(header.commit(body_hash), zero_owner_address);
+
+        // Validate is not: even the committed (lying) address is rejected.
+        assert!(matches!(
+            header.validate(body_hash, &zero_owner_address),
+            Err(ChunkError::Signature(_))
+        ));
+    }
+
+    /// The dispersed-replica rule lives inside validate: a replica-owner
+    /// signature over a non-replica id fails even at its committed address.
+    #[test]
+    fn soc_header_validate_enforces_replica_rule() {
+        let signer = PrivateKeySigner::from_slice(DISPERSED_REPLICA_OWNER_PK.as_slice()).unwrap();
+        let chunk = DefaultSingleOwnerChunk::new(SocId::ZERO, b"data".to_vec(), &signer).unwrap();
+        let body_hash: B256 = chunk.inner_body().hash().into();
+        let committed = chunk.header().commit(body_hash);
+
+        assert!(matches!(
+            chunk.header().validate(body_hash, &committed),
+            Err(ChunkError::InvalidFormat(_))
+        ));
+
+        // A well-formed replica id passes.
+        let replica =
+            DefaultSingleOwnerChunk::new_dispersed_replica(0x2a, chunk.inner_body().clone())
+                .unwrap();
+        let replica_body_hash: B256 = replica.inner_body().hash().into();
+        assert!(
+            replica
+                .header()
+                .validate(replica_body_hash, replica.address())
+                .is_ok()
+        );
+    }
+
+    /// SOC transformed sealing is the plain `keccak256(address || root)`.
+    #[test]
+    fn soc_header_seal_transformed_is_plain_keccak() {
+        let chunk = DefaultSingleOwnerChunk::try_from(get_test_chunk_data().as_slice()).unwrap();
+        let address = *chunk.address();
+        let root = B256::repeat_byte(0x5a);
+
+        let mut hasher = Keccak256::new();
+        hasher.update(address);
+        hasher.update(root);
+        let expected = ChunkAddress::from(hasher.finalize());
+
+        assert_eq!(chunk.header().seal_transformed(&address, root), expected);
+    }
+
+    #[test]
+    fn soc_header_constants() {
+        assert_eq!(SocHeader::SIZE, 97);
+        assert_eq!(SocHeader::TYPE_ID, ChunkTypeId::SINGLE_OWNER);
+        assert_eq!(SocHeader::VERSION, ChunkVersion::new(0));
+        assert_eq!(SocHeader::NAME, "single_owner");
     }
 }

--- a/crates/primitives/src/chunk/traits.rs
+++ b/crates/primitives/src/chunk/traits.rs
@@ -1,19 +1,109 @@
-//! Traits for chunk types and operations
+//! Core traits for chunk types and operations.
 //!
-//! This module defines the core traits that all chunk types must implement.
+//! [`ChunkHeader`] is the predicate a chunk type *is*: its address derivation
+//! and self-certification rule. [`Chunk`] and [`BmtChunk`] are the carrier
+//! traits over a header plus a BMT body.
 
-use crate::chunk::error;
-use crate::error::Result;
-use bytes::Bytes;
+use alloy_primitives::B256;
+use bytes::{Bytes, BytesMut};
+
+use crate::error::PrimitivesError;
+use crate::wire;
 
 use super::address::ChunkAddress;
+use super::error::ChunkError;
+use super::type_id::ChunkTypeId;
+use super::type_tag::ChunkVersion;
 
-/// Core trait for chunk header
-pub trait ChunkHeader {
-    /// Get the wire header bytes for this chunk: everything that precedes the
-    /// BMT body in the chunk's encoding (empty for a content chunk,
-    /// `id || signature` for a single-owner chunk).
-    fn bytes(&self) -> Bytes;
+/// Address-derivation and self-certification predicate of one chunk type.
+///
+/// A chunk is `header || span || payload`: the header is everything that
+/// precedes the BMT body on the wire, and everything that turns the body hash
+/// into an address. Implementing this trait defines a chunk type; custom
+/// swarms use ids 128-255 ([`ChunkTypeId::custom`]). The trait is deliberately
+/// unsealed: auditability lives in each network's closed envelope enum, not
+/// in sealing.
+///
+/// ```
+/// use alloy_primitives::{B256, Keccak256};
+/// use nectar_primitives::bytes::BytesMut;
+/// use nectar_primitives::chunk::{ChunkAddress, ChunkError, ChunkHeader};
+/// use nectar_primitives::{ChunkTypeId, ChunkVersion, wire};
+///
+/// /// Custom headerless type: address = keccak256(0xC0 || body_hash).
+/// struct TaggedHeader;
+///
+/// impl ChunkHeader for TaggedHeader {
+///     const TYPE_ID: ChunkTypeId = ChunkTypeId::custom(200);
+///     const VERSION: ChunkVersion = ChunkVersion::new(0);
+///     const NAME: &'static str = "tagged";
+///     const SIZE: usize = 0;
+///
+///     fn commit(&self, body_hash: B256) -> ChunkAddress {
+///         let mut hasher = Keccak256::new();
+///         hasher.update([0xC0]);
+///         hasher.update(body_hash);
+///         ChunkAddress::from(hasher.finalize())
+///     }
+///
+///     fn validate(&self, body_hash: B256, expected: &ChunkAddress) -> Result<(), ChunkError> {
+///         let actual = self.commit(body_hash);
+///         if actual == *expected {
+///             Ok(())
+///         } else {
+///             Err(ChunkError::verification_failed(*expected, actual))
+///         }
+///     }
+///
+///     fn seal_transformed(&self, _address: &ChunkAddress, transformed_root: B256) -> ChunkAddress {
+///         ChunkAddress::from(transformed_root)
+///     }
+///
+///     fn encode(&self, _out: &mut BytesMut) {}
+///
+///     fn decode(_cursor: &mut wire::Cursor<'_>) -> Result<Self, ChunkError> {
+///         Ok(Self)
+///     }
+/// }
+/// ```
+pub trait ChunkHeader: Sized + Send + Sync + 'static {
+    /// Wire-level type id of this chunk type.
+    const TYPE_ID: ChunkTypeId;
+
+    /// Revision of this type id's acceptance rule.
+    const VERSION: ChunkVersion;
+
+    /// Human-readable type name.
+    const NAME: &'static str;
+
+    /// Exact wire width of the header in bytes; [`encode`](Self::encode)
+    /// writes exactly this many.
+    const SIZE: usize;
+
+    /// Derive the chunk address this header commits to over `body_hash`.
+    ///
+    /// Total: inputs that cannot certify still commit to *some* address,
+    /// which [`validate`](Self::validate) then rejects.
+    fn commit(&self, body_hash: B256) -> ChunkAddress;
+
+    /// Certify that this header and `body_hash` derive `expected`.
+    ///
+    /// Required, deliberately without a default: an address-compare-only
+    /// implementation would accept single-owner chunks whose signatures do
+    /// not recover, so every header must state its full acceptance rule.
+    fn validate(&self, body_hash: B256, expected: &ChunkAddress) -> Result<(), ChunkError>;
+
+    /// Seal the anchor-keyed `transformed_root` of the body into the chunk's
+    /// transformed address (the redistribution sampler's re-hash).
+    fn seal_transformed(&self, address: &ChunkAddress, transformed_root: B256) -> ChunkAddress;
+
+    /// Append the wire header bytes, exactly [`SIZE`](Self::SIZE) of them,
+    /// to `out`.
+    fn encode(&self, out: &mut BytesMut);
+
+    /// Read a header from the cursor, consuming exactly [`SIZE`](Self::SIZE)
+    /// bytes.
+    fn decode(cursor: &mut wire::Cursor<'_>) -> Result<Self, ChunkError>;
 }
 
 /// Core trait for all chunk types in the system.
@@ -33,16 +123,16 @@ pub trait Chunk: Send + Sync + 'static {
     fn data(&self) -> &Bytes;
 
     /// Get the total size of this chunk in bytes
-    #[allow(clippy::arithmetic_side_effects)] // header and payload are both bounded by the chunk wire size, far below usize::MAX
     fn size(&self) -> usize {
-        self.header().bytes().len() + self.data().len()
+        // Header and payload are both bounded by the chunk wire size.
+        Self::Header::SIZE.saturating_add(self.data().len())
     }
 
     /// Verify that this chunk matches an expected address
-    fn verify(&self, expected: &ChunkAddress) -> Result<()> {
+    fn verify(&self, expected: &ChunkAddress) -> Result<(), PrimitivesError> {
         let actual = self.address();
         if actual != expected {
-            return Err(error::ChunkError::verification_failed(*expected, *actual).into());
+            return Err(ChunkError::verification_failed(*expected, *actual).into());
         }
         Ok(())
     }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -107,8 +107,11 @@ pub use chunk::{
     AnyChunk,
     // Core traits
     BmtChunk,
+    CacHeader,
     Chunk,
     ChunkAddress,
+    ChunkError,
+    ChunkHeader,
     // Concrete chunk types
     ChunkRef,
     ChunkType,
@@ -121,6 +124,7 @@ pub use chunk::{
     RefKind,
     Reference,
     SingleOwnerChunk,
+    SocHeader,
     SocId,
     StandardChunkSet,
     TagWireError,


### PR DESCRIPTION
Closes #192

## What

Replaces the `bytes()`-only `ChunkHeader` trait with an unsealed predicate trait, matching the issue's specced signature: `TYPE_ID`, `VERSION`, `NAME`, `SIZE` constants, `commit`, a required `validate` (no default), `seal_transformed`, `encode` into a `BytesMut`, and `decode` from a `wire::Cursor`. A doctest on the trait proves a custom implementation with `id >= 128` (`ChunkTypeId::custom`) compiles against the new signature.

`content.rs`: `ContentChunkHeader` is replaced by `CacHeader`, a zero-sized type (`SIZE = 0`) whose `commit` is the body hash itself, `seal_transformed` passes the root through unchanged, and whose wire codec is empty.

`single_owner.rs`: `SingleOwnerChunkHeader`/`SingleOwnerChunkMetadata` are replaced by `SocHeader { id: SocId, signature }` (`SIZE = 97`). The owner is recovered as `ecrecover(signature, keccak256(id || body_hash))` under EIP-191 personal-sign, unchanged from before. `commit` falls back to the zero address when recovery fails, and `validate` keeps the fallible-recovery path together with the dispersed-replica `id[1..] == body_hash[1..]` rule and the final address comparison.

`traits.rs`, `any_chunk.rs`, `error.rs`, `mod.rs`, and `lib.rs` carry the supporting plumbing: the new trait definition, updated call sites, and new error variants.

## Why

The previous `ChunkHeader::bytes()` trait only exposed encoded bytes and left address derivation and self-certification implicit in each chunk type. Per issue #192, `ChunkHeader` should instead be the address-derivation and self-certification predicate a chunk type *is*, with `validate` required (not defaulted) so an address-compare-only implementation cannot silently accept a single-owner chunk whose signature does not recover. The trait is deliberately left unsealed: auditability is intended to live in each network's closed envelope enum rather than in trait sealing.

## Testing

Verified independently against the single commit on this branch, atop `s202/12-chunk-type-tag`, via a fresh clone checked out at `FETCH_HEAD` detached, all commands run through `nix develop`:

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean. The refactor drops several `#[allow(clippy::arithmetic_side_effects)]`/`indexing_slicing` shims in favour of `saturating_add` and `split_first`, and clippy still passes without them.
- `cargo nextest run --workspace --all-features`: 680 passed, 1 skipped, 0 failed.
- `cargo test --doc --workspace --all-features`: pass, including the new `ChunkHeader` doctest.
- The go-interop wire vector round-trips old-bytes -> new `Cursor` decoder -> new encoder identically, and `to_sign`/`address_for`/`transformed_address` are byte-identical to the prior encoder, so the wire format and consensus vectors are unchanged.

An independent adversarial review of the same commit found no bugs requiring a fix.

## AI Assistance

This PR's implementation, review, and verification were carried out by AI assistants (Claude models, Anthropic) operating under human supervision, per the process described in [nxm-rs/.github CONTRIBUTING.md](https://github.com/nxm-rs/.github/blob/main/CONTRIBUTING.md).

