### PR TITLE
refactor(primitives)!: extract ChunkOps behaviour trait and widen typed envelope

### DIFF
--- a/crates/mantaray/src/node.rs
+++ b/crates/mantaray/src/node.rs
@@ -8,7 +8,7 @@ use crate::error::{DecodeError, DecodeResult, MantarayError, Result};
 use crate::obfuscation::ObfuscationKey;
 use crate::{PATH_SEPARATOR, PREFIX_MAX_LEN};
 use bytes::Bytes;
-use nectar_primitives::chunk::{Chunk, ChunkAddress, ChunkRef, ContentChunk, Reference};
+use nectar_primitives::chunk::{ChunkAddress, ChunkOps, ChunkRef, ContentChunk, Reference};
 use nectar_primitives::store::{ChunkGet, ChunkPut, MaybeSend};
 use nectar_primitives::wire::{Cursor, FromCursor, ToWriter, Writer};
 use nectar_primitives::{EncryptedChunkRef, EncryptionKey};

--- a/crates/postage-usage/examples/roam_between_machines.rs
+++ b/crates/postage-usage/examples/roam_between_machines.rs
@@ -48,7 +48,7 @@ use nectar_postage_usage::{
     BatchStamper, ChunkAddress, Mutability, PublishedSequence, SealedChunk, Snapshot, SnapshotSink,
     SnapshotSource, UsageError, UsageTable,
 };
-use nectar_primitives::Chunk;
+use nectar_primitives::ChunkOps;
 
 /// A depth-20 batch with 65536 buckets of 16 slots each. Small enough that the
 /// whole snapshot fits inline in a single root chunk, so the cross-machine hop

--- a/crates/postage-usage/src/client.rs
+++ b/crates/postage-usage/src/client.rs
@@ -362,7 +362,7 @@ mod tests {
     impl SnapshotSink for MemNet {
         type Error = MemError;
         async fn push(&self, sealed: &SealedChunk) -> Result<(), Self::Error> {
-            use nectar_primitives::Chunk;
+            use nectar_primitives::ChunkOps;
             let address = *sealed.chunk.address();
             let payload = Bytes::copy_from_slice(sealed.chunk.data().as_ref());
             self.chunks.lock().unwrap().insert(address, payload);

--- a/crates/postage-usage/src/seal.rs
+++ b/crates/postage-usage/src/seal.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 
 use alloy_signer::SignerSync;
 use nectar_postage::{Stamp, StampDigest};
-use nectar_primitives::{Chunk, SingleOwnerChunk};
+use nectar_primitives::{ChunkOps, SingleOwnerChunk};
 use thiserror::Error;
 
 use crate::snapshot::{PersistPlan, Snapshot};

--- a/crates/postage-usage/tests/seal.rs
+++ b/crates/postage-usage/tests/seal.rs
@@ -19,7 +19,7 @@ use nectar_postage_usage::{
     BatchId, Mutability, PublishedSequence, SealError, Snapshot, UsageTable, seal_plan,
     usage_chunk_address,
 };
-use nectar_primitives::Chunk;
+use nectar_primitives::ChunkOps;
 
 const BUCKET_DEPTH: u8 = 16;
 

--- a/crates/postage/src/generators.rs
+++ b/crates/postage/src/generators.rs
@@ -14,7 +14,7 @@
 use alloy_primitives::Address;
 use alloy_signer::SignerSync;
 use arbitrary::Unstructured;
-use nectar_primitives::ChunkAddress;
+use nectar_primitives::{ChunkAddress, ChunkOps};
 
 use crate::{Batch, BatchId, Stamp, StampDigest, StampIndex, StampedChunk};
 

--- a/crates/postage/src/stamped.rs
+++ b/crates/postage/src/stamped.rs
@@ -12,7 +12,9 @@
 
 use alloc::vec::Vec;
 
-use nectar_primitives::{AnyChunk, ChunkAddress, DEFAULT_BODY_SIZE, bytes::Bytes, wire::Cursor};
+use nectar_primitives::{
+    AnyChunk, ChunkAddress, ChunkOps, DEFAULT_BODY_SIZE, bytes::Bytes, wire::Cursor,
+};
 
 use crate::{BatchId, Stamp, StampError};
 
@@ -78,9 +80,9 @@ impl<const BODY_SIZE: usize> StampedChunk<BODY_SIZE> {
     /// Encode to a self-describing byte string: the stamp followed by the
     /// type-tagged chunk.
     ///
-    /// The layout is `[stamp: STAMP_SIZE][type_id: 1][chunk wire bytes]`, the
-    /// stamp's fixed-size encoding ([`Stamp::to_bytes`], `STAMP_SIZE = 113`
-    /// bytes) followed by the chunk's type-tagged encoding
+    /// The layout is `[stamp: STAMP_SIZE][id: 1][version: 1][chunk wire
+    /// bytes]`, the stamp's fixed-size encoding ([`Stamp::to_bytes`],
+    /// `STAMP_SIZE = 113` bytes) followed by the chunk's type-tagged encoding
     /// ([`AnyChunk::to_typed_bytes`]). Decode with
     /// [`from_typed_bytes`](Self::from_typed_bytes).
     #[must_use]
@@ -168,7 +170,7 @@ impl<'a, const BODY_SIZE: usize> arbitrary::Arbitrary<'a> for StampedChunk<BODY_
 mod tests {
     use alloy_primitives::{B256, Signature};
     use alloy_signer_local::PrivateKeySigner;
-    use nectar_primitives::{Chunk, ContentChunk, SingleOwnerChunk, SocId, bytes::Bytes};
+    use nectar_primitives::{ChunkOps, ContentChunk, SingleOwnerChunk, SocId, bytes::Bytes};
 
     use super::*;
     use crate::STAMP_SIZE;

--- a/crates/primitives/examples/basic_usage.rs
+++ b/crates/primitives/examples/basic_usage.rs
@@ -20,7 +20,7 @@ use alloy_signer_local::LocalSigner;
 use bytes::Bytes;
 
 use nectar_primitives::bmt::Prover;
-use nectar_primitives::chunk::{BmtChunk, Chunk};
+use nectar_primitives::chunk::ChunkOps;
 use nectar_primitives::{DefaultContentChunk, DefaultHasher, DefaultSingleOwnerChunk, SocId};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/primitives/examples/builder_patterns.rs
+++ b/crates/primitives/examples/builder_patterns.rs
@@ -18,7 +18,7 @@
 use alloy_signer::SignerSync;
 use alloy_signer_local::LocalSigner;
 
-use nectar_primitives::chunk::{BmtChunk, Chunk};
+use nectar_primitives::chunk::ChunkOps;
 use nectar_primitives::{DefaultContentChunk, DefaultSingleOwnerChunk, SocId};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/primitives/examples/wasm-demo/src/lib.rs
+++ b/crates/primitives/examples/wasm-demo/src/lib.rs
@@ -6,7 +6,7 @@ use alloy_primitives::{hex, Address, B256};
 use alloy_signer_local::PrivateKeySigner;
 use bytes::Bytes;
 use nectar_primitives::{
-    Chunk, ChunkAddress, DefaultContentChunk, DefaultHasher, DefaultSingleOwnerChunk, SocId,
+    ChunkAddress, ChunkOps, DefaultContentChunk, DefaultHasher, DefaultSingleOwnerChunk, SocId,
 };
 use wasm_bindgen::prelude::*;
 

--- a/crates/primitives/src/chunk/README.md
+++ b/crates/primitives/src/chunk/README.md
@@ -8,9 +8,9 @@ The chunk module is built around a trait-based architecture that allows for diff
 
 ### Core Traits
 
-- `Chunk`: The main trait that all chunk types implement, defining common operations (address, header, data, verify)
+- `ChunkOps`: The header-free behaviour every chunk value offers (address, data, span, verify, transformed address, wire encode); implemented by the concrete chunk types and by `AnyChunk`
+- `Chunk`: Ties a carrier to its header type
 - `ChunkHeader`: The unsealed predicate a chunk type is: address derivation (`commit`), self-certification (`validate`), transformed-address sealing, and the wire header codec (`CacHeader` is empty, `SocHeader` is `id || signature`)
-- `BmtChunk`: A trait for chunks that contain a BMT body (most chunk types)
 - `ChunkType`: Compile-time type identification (type ID and name)
 - `ChunkTypeSet`: The set of chunk types a system supports
 

--- a/crates/primitives/src/chunk/any_chunk.rs
+++ b/crates/primitives/src/chunk/any_chunk.rs
@@ -10,26 +10,27 @@ use crate::error::Result;
 
 use super::address::ChunkAddress;
 use super::chunk_type::ChunkType;
-use super::content::ContentChunk;
-use super::single_owner::SingleOwnerChunk;
-use super::traits::{Chunk, ChunkHeader};
+use super::content::{CacHeader, ContentChunk};
+use super::single_owner::{SingleOwnerChunk, SocHeader};
+use super::traits::{ChunkHeader, ChunkOps};
 use super::type_id::ChunkTypeId;
+use super::type_tag::ChunkTypeTag;
 
 /// Type-erased chunk for runtime polymorphism with configurable body size.
 ///
-/// This enum provides dynamic dispatch for chunks without requiring object-safe traits.
-/// Use this when you need to store heterogeneous chunk types in collections or pass
-/// chunks through interfaces that can't be generic.
+/// This enum provides dynamic dispatch for chunks without requiring trait
+/// objects. Use this when you need to store heterogeneous chunk types in
+/// collections or pass chunks through interfaces that can't be generic.
 ///
-/// # Why an enum instead of `Box<dyn Chunk>`?
-///
-/// The [`Chunk`] trait has an associated type (`type Header`) which makes it not
-/// object-safe. This enum provides the same functionality while maintaining type safety.
+/// The behaviour surface comes from the [`ChunkOps`] impl, shared with the
+/// concrete chunk types. The enum is the closed, exhaustive set of chunk types
+/// this network accepts: adding a variant is deliberately semver-major and
+/// breaks every downstream match.
 ///
 /// # Examples
 ///
 /// ```
-/// use nectar_primitives::{AnyChunk, Chunk, ContentChunk, ChunkTypeId};
+/// use nectar_primitives::{AnyChunk, ChunkOps, ContentChunk, ChunkTypeId};
 ///
 /// // Create a content chunk
 /// let content = ContentChunk::new(&b"hello world"[..]).unwrap();
@@ -51,23 +52,61 @@ pub enum AnyChunk<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> {
     SingleOwner(SingleOwnerChunk<BODY_SIZE>),
 }
 
-impl<const BODY_SIZE: usize> AnyChunk<BODY_SIZE> {
-    /// Get the address of this chunk.
-    pub fn address(&self) -> &ChunkAddress {
+/// Match-delegation to the variants' own [`ChunkOps`] impls. A new variant
+/// extends every arm here, which is part of the deliberate semver-major
+/// surface of adding a chunk type.
+impl<const BODY_SIZE: usize> ChunkOps for AnyChunk<BODY_SIZE> {
+    fn address(&self) -> &ChunkAddress {
         match self {
             Self::Content(c) => c.address(),
             Self::SingleOwner(c) => c.address(),
         }
     }
 
-    /// Get the raw data contained in this chunk.
-    pub fn data(&self) -> &Bytes {
+    fn data(&self) -> &Bytes {
         match self {
             Self::Content(c) => c.data(),
             Self::SingleOwner(c) => c.data(),
         }
     }
 
+    fn size(&self) -> usize {
+        match self {
+            Self::Content(c) => c.size(),
+            Self::SingleOwner(c) => c.size(),
+        }
+    }
+
+    fn span(&self) -> u64 {
+        match self {
+            Self::Content(c) => c.span(),
+            Self::SingleOwner(c) => c.span(),
+        }
+    }
+
+    fn verify(&self, expected: &ChunkAddress) -> Result<()> {
+        match self {
+            Self::Content(c) => c.verify(expected),
+            Self::SingleOwner(c) => c.verify(expected),
+        }
+    }
+
+    fn transformed_address(&self, anchor: &[u8]) -> ChunkAddress {
+        match self {
+            Self::Content(c) => c.transformed_address(anchor),
+            Self::SingleOwner(c) => c.transformed_address(anchor),
+        }
+    }
+
+    fn into_bytes(self) -> Bytes {
+        match self {
+            Self::Content(c) => c.into_bytes(),
+            Self::SingleOwner(c) => c.into_bytes(),
+        }
+    }
+}
+
+impl<const BODY_SIZE: usize> AnyChunk<BODY_SIZE> {
     /// Get the type ID of this chunk.
     pub const fn type_id(&self) -> ChunkTypeId {
         match self {
@@ -76,80 +115,12 @@ impl<const BODY_SIZE: usize> AnyChunk<BODY_SIZE> {
         }
     }
 
-    /// Get the total size of this chunk in bytes.
-    pub fn size(&self) -> usize {
+    /// Get the versioned type tag of this chunk: the variant's `(id, version)`
+    /// pair, taken from its header predicate.
+    pub const fn type_tag(&self) -> ChunkTypeTag {
         match self {
-            Self::Content(c) => c.size(),
-            Self::SingleOwner(c) => c.size(),
-        }
-    }
-
-    /// Get the span (logical data length) of this chunk: the BMT span of its
-    /// underlying body.
-    pub fn span(&self) -> u64 {
-        match self {
-            Self::Content(c) => super::traits::BmtChunk::span(c),
-            Self::SingleOwner(c) => super::traits::BmtChunk::span(c),
-        }
-    }
-
-    /// Compute the anchor-keyed *transformed address* of this chunk.
-    ///
-    /// The transformed address is the redistribution sampler's per-round,
-    /// per-node re-hash of a chunk. It is a prefixed BMT root keyed by the
-    /// node's `anchor`, used to order reserve chunks deterministically while
-    /// binding the ordering to the proving node. This reproduces bee's
-    /// `storer.transformedAddress` (`pkg/storer/sample.go`) byte-for-byte.
-    ///
-    /// # Derivation
-    ///
-    /// - The anchor-keyed BMT root of the chunk body is computed by
-    ///   [`BmtBody::transformed_root`](super::bmt_body::BmtBody::transformed_root) on the
-    ///   chunk's borrowed body, which mixes the anchor into *every* node hash.
-    ///   For a SOC the wrapped content body is the one re-hashed.
-    /// - The root is then sealed into the transformed address by the chunk's
-    ///   header predicate
-    ///   ([`ChunkHeader::seal_transformed`](super::traits::ChunkHeader::seal_transformed)):
-    ///   the root itself for a CAC, the plain (unprefixed, no anchor)
-    ///   `keccak256(soc_address || inner)` for a SOC.
-    ///
-    /// # Endianness
-    ///
-    /// The span is serialised little-endian inside the BMT. Do not confuse this
-    /// with the big-endian encodings used elsewhere on the redistribution wire
-    /// (e.g. proof witness indices); the BMT span is always LE.
-    ///
-    /// # Borrowing
-    ///
-    /// Both paths dispatch through the carrier's borrowed body accessor
-    /// ([`ChunkInner::body`](super::inner::ChunkInner::body)), so no chunk or
-    /// body is cloned. For a SOC the wrapped body already *is* the content
-    /// chunk's `span || payload`, so the inner root needs no `32 + 65`
-    /// (id + signature) header slicing.
-    pub fn transformed_address(&self, anchor: &[u8]) -> ChunkAddress {
-        match self {
-            Self::Content(c) => c
-                .header()
-                .seal_transformed(c.address(), c.body().transformed_root(anchor)),
-            Self::SingleOwner(c) => c
-                .header()
-                .seal_transformed(c.address(), c.body().transformed_root(anchor)),
-        }
-    }
-
-    /// Verify that this chunk's address matches an expected address.
-    pub fn verify(&self, expected: &ChunkAddress) -> Result<()> {
-        match self {
-            Self::Content(c) => c.verify(expected),
-            Self::SingleOwner(c) => c.verify(expected),
-        }
-    }
-
-    /// Convert this chunk into its serialized bytes representation.
-    pub fn into_bytes(self) -> Bytes {
-        match self {
-            Self::Content(c) => c.into(),
-            Self::SingleOwner(c) => c.into(),
+            Self::Content(_) => ChunkTypeTag::new(CacHeader::TYPE_ID, CacHeader::VERSION),
+            Self::SingleOwner(_) => ChunkTypeTag::new(SocHeader::TYPE_ID, SocHeader::VERSION),
         }
     }
 
@@ -202,9 +173,15 @@ impl<const BODY_SIZE: usize> AnyChunk<BODY_SIZE> {
 
     /// Encode this chunk as a type-tagged, self-describing byte string.
     ///
-    /// The layout is `[type_id: 1 byte][chunk wire bytes]`, where the chunk
-    /// wire bytes are the same form produced by [`AnyChunk::into_bytes`] (the
-    /// inverse of [`ContentChunk::try_from`]/[`SingleOwnerChunk::try_from`]).
+    /// The layout is `[id: 1 byte][version: 1 byte][chunk wire bytes]`: the
+    /// chunk's [`ChunkTypeTag`] in its two-byte form
+    /// ([`ChunkTypeTag::to_bytes`]), then the same wire bytes produced by
+    /// [`ChunkOps::into_bytes`] (the inverse of
+    /// [`ContentChunk::try_from`]/[`SingleOwnerChunk::try_from`]).
+    ///
+    /// Stored-format change: earlier releases wrote a one-byte `[id]` prefix.
+    /// Stores holding the old form must re-encode; this decoder does not
+    /// accept it.
     ///
     /// The chunk address is deliberately *not* embedded. It is supplied from
     /// context on decode (for example the redb key when reading from storage,
@@ -212,73 +189,76 @@ impl<const BODY_SIZE: usize> AnyChunk<BODY_SIZE> {
     /// reconstruction paths that take an expected address.
     ///
     /// Unlike the address-disambiguating reconstruction path, decoding the
-    /// result of this method dispatches purely by `type_id`, so it never has
+    /// result of this method dispatches purely by the tag, so it never has
     /// to trial-parse both the content and single-owner shapes.
     ///
     /// # Examples
     ///
     /// ```
-    /// use nectar_primitives::{AnyChunk, Chunk, ContentChunk};
+    /// use nectar_primitives::{AnyChunk, ChunkOps, ContentChunk};
     ///
     /// let content = ContentChunk::new(&b"hello world"[..]).unwrap();
     /// let address = *content.address();
     /// let any: AnyChunk = content.into();
     ///
     /// let encoded = any.to_typed_bytes();
-    /// assert_eq!(encoded[0], 0); // CONTENT type id
+    /// assert_eq!(encoded[..2], [0, 0]); // CONTENT id, version 0
     ///
     /// let decoded: AnyChunk = AnyChunk::from_typed_bytes(&address, &encoded).unwrap();
     /// assert_eq!(decoded.address(), any.address());
     /// ```
-    #[allow(clippy::arithmetic_side_effects)] // 1 + a chunk wire length bounded by the chunk format is a capacity hint far below usize::MAX
     pub fn to_typed_bytes(&self) -> Vec<u8> {
-        let tag = self.type_id().as_u8();
+        let tag = self.type_tag().to_bytes();
         // Clone is required because `into_bytes` consumes the chunk; chunk
         // payloads are reference-counted `Bytes`, so this is cheap.
         let wire = self.clone().into_bytes();
-        let mut out = Vec::with_capacity(1 + wire.len());
-        out.push(tag);
+        // Capacity hint: a tag plus a wire length bounded by the chunk format.
+        let mut out = Vec::with_capacity(wire.len().saturating_add(tag.len()));
+        out.extend_from_slice(&tag);
         out.extend_from_slice(&wire);
         out
     }
 
     /// Decode a type-tagged chunk produced by [`AnyChunk::to_typed_bytes`].
     ///
-    /// The leading byte selects the chunk type and the remainder is the chunk
-    /// wire payload. `address` is the expected chunk address (for example the
-    /// redb storage key or the wire message address field); the decoded chunk
-    /// is verified against it.
+    /// The leading two bytes are the [`ChunkTypeTag`] selecting the chunk
+    /// type's acceptance rule; the remainder is the chunk wire payload.
+    /// `address` is the expected chunk address (for example the redb storage
+    /// key or the wire message address field); the decoded chunk is verified
+    /// against it.
     ///
-    /// Decoding dispatches by the type tag and therefore never trial-parses the
-    /// other chunk shape. Only the standard content and single-owner types are
-    /// recognised; any other tag is an error (custom chunk types are tracked
-    /// separately as a future registration mechanism).
+    /// Decoding dispatches by the tag and therefore never trial-parses the
+    /// other chunk shape. Only the current content and single-owner tags are
+    /// recognised; an unknown id *or* an unknown version of a known id is an
+    /// error, because each `(id, version)` pair is a distinct acceptance rule.
     ///
     /// # Errors
     ///
     /// Returns an error (and never panics) when:
-    /// - the input is empty (no type tag),
-    /// - the type tag is not a recognised standard chunk type,
+    /// - the input is shorter than the two-byte type tag,
+    /// - the tag is not a recognised `(id, version)` pair,
     /// - the payload cannot be decoded as the tagged chunk type, or
-    /// - a standard chunk's computed address does not match `address`.
+    /// - the chunk's computed address does not match `address`.
     pub fn from_typed_bytes(address: &ChunkAddress, bytes: &[u8]) -> crate::error::Result<Self> {
-        let (&tag, payload) = bytes.split_first().ok_or_else(|| {
-            super::error::ChunkError::invalid_format("empty typed-chunk encoding: missing type tag")
+        let (tag, payload) = bytes.split_first_chunk::<2>().ok_or_else(|| {
+            super::error::ChunkError::invalid_format(
+                "typed-chunk encoding shorter than the two-byte type tag",
+            )
         })?;
 
-        let type_id = ChunkTypeId::from(tag);
-        match type_id {
-            ChunkTypeId::CONTENT => {
+        let tag = ChunkTypeTag::from(*tag);
+        match tag {
+            t if t == ChunkTypeTag::new(CacHeader::TYPE_ID, CacHeader::VERSION) => {
                 let chunk = ContentChunk::try_from(Bytes::copy_from_slice(payload))?;
                 chunk.verify(address)?;
                 Ok(Self::Content(chunk))
             }
-            ChunkTypeId::SINGLE_OWNER => {
+            t if t == ChunkTypeTag::new(SocHeader::TYPE_ID, SocHeader::VERSION) => {
                 let chunk = SingleOwnerChunk::try_from(Bytes::copy_from_slice(payload))?;
                 chunk.verify(address)?;
                 Ok(Self::SingleOwner(chunk))
             }
-            other => Err(super::error::ChunkError::unsupported_type(other).into()),
+            other => Err(super::error::ChunkError::unsupported_tag(other).into()),
         }
     }
 
@@ -357,7 +337,7 @@ impl<'a, const BODY_SIZE: usize> arbitrary::Arbitrary<'a> for AnyChunk<BODY_SIZE
 
 #[cfg(test)]
 mod tests {
-    use super::super::traits::{BmtChunk, Chunk};
+    use super::super::traits::ChunkOps;
     use super::*;
 
     type DefaultContentChunk = ContentChunk<DEFAULT_BODY_SIZE>;
@@ -435,7 +415,7 @@ mod tests {
         let any: DefaultAnyChunk = content.into();
 
         let encoded = any.to_typed_bytes();
-        assert_eq!(encoded[0], 0, "CONTENT tag must be 0");
+        assert_eq!(encoded[..2], [0, 0], "CONTENT tag must be id 0, version 0");
 
         let decoded = DefaultAnyChunk::from_typed_bytes(&address, &encoded).unwrap();
         assert!(decoded.is_content());
@@ -451,7 +431,11 @@ mod tests {
         let any: DefaultAnyChunk = soc.into();
 
         let encoded = any.to_typed_bytes();
-        assert_eq!(encoded[0], 1, "SINGLE_OWNER tag must be 1");
+        assert_eq!(
+            encoded[..2],
+            [1, 0],
+            "SINGLE_OWNER tag must be id 1, version 0",
+        );
 
         let decoded = DefaultAnyChunk::from_typed_bytes(&address, &encoded).unwrap();
         assert!(decoded.is_single_owner());
@@ -464,13 +448,13 @@ mod tests {
     fn test_typed_custom_round_trip() {
         // The Custom variant has been removed; an unrecognised type tag must now
         // error rather than round-trip as an opaque blob.
-        let type_id = ChunkTypeId::custom(200);
+        let tag = ChunkTypeTag::new(ChunkTypeId::custom(200), crate::ChunkVersion::new(0));
         let address: ChunkAddress = [0x11u8; 32].into();
         let data = Bytes::from_static(b"opaque custom chunk bytes");
 
         let encoded = {
-            let mut out = Vec::with_capacity(1 + data.len());
-            out.push(type_id.as_u8());
+            let mut out = Vec::with_capacity(2 + data.len());
+            out.extend_from_slice(&tag.to_bytes());
             out.extend_from_slice(&data);
             out
         };
@@ -480,6 +464,40 @@ mod tests {
             result.is_err(),
             "unrecognised type tags must error now that Custom is removed",
         );
+    }
+
+    #[test]
+    fn test_typed_unknown_version_errors() {
+        // A known id under an unknown version is a distinct, unrecognised
+        // acceptance rule; the payload must not be decoded under version 0.
+        let content = DefaultContentChunk::new(&b"future revision"[..]).unwrap();
+        let address = *content.address();
+        let mut encoded = DefaultAnyChunk::from(content).to_typed_bytes();
+        encoded[1] = 7;
+
+        let result = DefaultAnyChunk::from_typed_bytes(&address, &encoded);
+        assert!(result.is_err(), "unknown version of a known id must error");
+    }
+
+    #[test]
+    fn test_typed_legacy_one_byte_prefix_rejected() {
+        // Stored-format change: the old `[id][wire]` form is one byte shorter,
+        // so under the two-byte tag its first span byte is read as a version
+        // and the payload shifts. It must never decode to the original chunk.
+        let content = DefaultContentChunk::new(&b"legacy stored form"[..]).unwrap();
+        let address = *content.address();
+        let any = DefaultAnyChunk::from(content);
+
+        let legacy = {
+            let wire = any.clone().into_bytes();
+            let mut out = Vec::with_capacity(1 + wire.len());
+            out.push(any.type_id().as_u8());
+            out.extend_from_slice(&wire);
+            out
+        };
+
+        let result = DefaultAnyChunk::from_typed_bytes(&address, &legacy);
+        assert!(result.is_err(), "legacy one-byte-prefix form must error");
     }
 
     #[test]

--- a/crates/primitives/src/chunk/chunk_type_set.rs
+++ b/crates/primitives/src/chunk/chunk_type_set.rs
@@ -141,7 +141,7 @@ mod tests {
     use super::super::content::ContentChunk;
     use super::super::error::ChunkError;
     use super::super::single_owner::SingleOwnerChunk;
-    use super::super::traits::Chunk;
+    use super::super::traits::ChunkOps;
     use super::*;
     use crate::error::Result;
 

--- a/crates/primitives/src/chunk/content.rs
+++ b/crates/primitives/src/chunk/content.rs
@@ -16,7 +16,7 @@ use super::address::ChunkAddress;
 use super::bmt_body::BmtBody;
 use super::error::ChunkError;
 use super::inner::ChunkInner;
-use super::traits::{Chunk, ChunkHeader};
+use super::traits::{ChunkHeader, ChunkOps};
 use super::type_id::ChunkTypeId;
 use super::type_tag::ChunkVersion;
 
@@ -162,7 +162,7 @@ impl<const BODY_SIZE: usize> super::encryption::ChunkEncrypt for ContentChunk<BO
     /// - `encrypted_ref`: the 64-byte reference (new address + decryption key)
     ///
     /// ```
-    /// # use nectar_primitives::{Chunk, ContentChunk};
+    /// # use nectar_primitives::{ChunkOps, ContentChunk};
     /// # use nectar_primitives::chunk::encryption::{ChunkEncrypt, EncryptionKey};
     /// # use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
     /// let chunk = ContentChunk::<DEFAULT_BODY_SIZE>::new(b"secret data".to_vec()).unwrap();
@@ -212,7 +212,7 @@ impl<'a, const BODY_SIZE: usize> arbitrary::Arbitrary<'a> for ContentChunk<BODY_
 mod tests {
     use crate::{
         DEFAULT_BODY_SIZE,
-        chunk::{BmtChunk, error::ChunkError},
+        chunk::{ChunkOps, error::ChunkError},
         error::PrimitivesError,
     };
 

--- a/crates/primitives/src/chunk/error.rs
+++ b/crates/primitives/src/chunk/error.rs
@@ -1,7 +1,7 @@
 use super::address::ChunkAddress;
 use thiserror::Error;
 
-use super::type_id::ChunkTypeId;
+use super::type_tag::ChunkTypeTag;
 
 /// Result type for chunk operations
 pub(crate) type Result<T> = std::result::Result<T, ChunkError>;
@@ -46,9 +46,10 @@ pub enum ChunkError {
     #[error("Invalid chunk signature: {0}")]
     InvalidSignature(String),
 
-    /// Unsupported chunk type
-    #[error("Unsupported chunk type: {0}")]
-    UnsupportedType(ChunkTypeId),
+    /// Unsupported chunk type tag: an unknown id, or an unknown version of a
+    /// known id (each `(id, version)` pair is a distinct acceptance rule)
+    #[error("Unsupported chunk type tag: {0}")]
+    UnsupportedTag(ChunkTypeTag),
 
     /// Wire buffer underrun
     #[error(transparent)]
@@ -80,8 +81,8 @@ impl ChunkError {
         Self::InvalidSignature(msg.into())
     }
 
-    /// Construct an [`UnsupportedType`](Self::UnsupportedType) error
-    pub const fn unsupported_type(type_id: ChunkTypeId) -> Self {
-        Self::UnsupportedType(type_id)
+    /// Construct an [`UnsupportedTag`](Self::UnsupportedTag) error
+    pub const fn unsupported_tag(tag: ChunkTypeTag) -> Self {
+        Self::UnsupportedTag(tag)
     }
 }

--- a/crates/primitives/src/chunk/inner.rs
+++ b/crates/primitives/src/chunk/inner.rs
@@ -15,7 +15,7 @@ use crate::wire;
 use super::address::ChunkAddress;
 use super::bmt_body::BmtBody;
 use super::chunk_type::ChunkType;
-use super::traits::{BmtChunk, Chunk, ChunkHeader};
+use super::traits::{Chunk, ChunkHeader, ChunkOps};
 
 /// A chunk: a wire header committing to a BMT body.
 ///
@@ -65,16 +65,10 @@ impl<H: ChunkHeader, const BODY_SIZE: usize> ChunkInner<H, BODY_SIZE> {
     }
 }
 
-impl<H: ChunkHeader, const BODY_SIZE: usize> Chunk for ChunkInner<H, BODY_SIZE> {
-    type Header = H;
-
+impl<H: ChunkHeader, const BODY_SIZE: usize> ChunkOps for ChunkInner<H, BODY_SIZE> {
     fn address(&self) -> &ChunkAddress {
         self.address
             .get_or_compute(|| self.header.commit(self.body.hash().into()))
-    }
-
-    fn header(&self) -> &H {
-        &self.header
     }
 
     fn data(&self) -> &Bytes {
@@ -86,16 +80,35 @@ impl<H: ChunkHeader, const BODY_SIZE: usize> Chunk for ChunkInner<H, BODY_SIZE> 
         H::SIZE.saturating_add(self.body.size())
     }
 
+    fn span(&self) -> u64 {
+        self.body.span()
+    }
+
     /// Certify through [`ChunkHeader::validate`]: the header's full acceptance
     /// rule runs, not an address compare against the cached address.
     fn verify(&self, expected: &ChunkAddress) -> Result<()> {
         Ok(self.header.validate(self.body.hash().into(), expected)?)
     }
+
+    /// Runs on the carrier's borrowed body ([`ChunkInner::body`]), so no
+    /// chunk or body is cloned. For a SOC the wrapped body already *is* the
+    /// content chunk's `span || payload`, so the inner root needs no
+    /// `32 + 65` (id + signature) header slicing.
+    fn transformed_address(&self, anchor: &[u8]) -> ChunkAddress {
+        self.header
+            .seal_transformed(self.address(), self.body.transformed_root(anchor))
+    }
+
+    fn into_bytes(self) -> Bytes {
+        self.into()
+    }
 }
 
-impl<H: ChunkHeader, const BODY_SIZE: usize> BmtChunk for ChunkInner<H, BODY_SIZE> {
-    fn span(&self) -> u64 {
-        self.body.span()
+impl<H: ChunkHeader, const BODY_SIZE: usize> Chunk for ChunkInner<H, BODY_SIZE> {
+    type Header = H;
+
+    fn header(&self) -> &H {
+        &self.header
     }
 }
 

--- a/crates/primitives/src/chunk/mod.rs
+++ b/crates/primitives/src/chunk/mod.rs
@@ -11,7 +11,9 @@
 //!   a chunk type ([`CacHeader`], [`SocHeader`])
 //! - [`ChunkInner`] - The single carrier: one header plus one BMT body;
 //!   [`ContentChunk`] and [`SingleOwnerChunk`] are its aliases
-//! - [`Chunk`] - Core trait for all chunk types
+//! - [`ChunkOps`] - Header-free behaviour shared by concrete chunks and
+//!   [`AnyChunk`]
+//! - [`Chunk`] - Ties a carrier to its header type
 //! - [`ChunkType`] - Adds compile-time type identification
 //! - [`ChunkTypeSet`] - Defines which chunk types a system supports
 //!
@@ -43,7 +45,7 @@ pub mod wasm;
 pub use address::ChunkAddress;
 pub use error::ChunkError;
 pub use inner::ChunkInner;
-pub use traits::{BmtChunk, Chunk, ChunkHeader};
+pub use traits::{Chunk, ChunkHeader, ChunkOps};
 
 // Re-export the reference types
 pub use reference::{ChunkRef, RefKind, Reference, WrongRefKind};

--- a/crates/primitives/src/chunk/single_owner.rs
+++ b/crates/primitives/src/chunk/single_owner.rs
@@ -493,7 +493,7 @@ impl<'a, const BODY_SIZE: usize> arbitrary::Arbitrary<'a> for SingleOwnerChunk<B
 
 #[cfg(test)]
 mod tests {
-    use crate::{DEFAULT_BODY_SIZE, PrimitivesError, chunk::Chunk};
+    use crate::{DEFAULT_BODY_SIZE, PrimitivesError, chunk::ChunkOps};
 
     use super::*;
     use alloy_primitives::hex;

--- a/crates/primitives/src/chunk/traits.rs
+++ b/crates/primitives/src/chunk/traits.rs
@@ -1,8 +1,8 @@
 //! Core traits for chunk types and operations.
 //!
 //! [`ChunkHeader`] is the predicate a chunk type *is*: its address derivation
-//! and self-certification rule. [`Chunk`] and [`BmtChunk`] are the carrier
-//! traits over a header plus a BMT body.
+//! and self-certification rule. [`ChunkOps`] is the header-free behaviour
+//! every chunk value offers; [`Chunk`] ties a carrier to its header type.
 
 use alloy_primitives::B256;
 use bytes::{Bytes, BytesMut};
@@ -106,27 +106,24 @@ pub trait ChunkHeader: Sized + Send + Sync + 'static {
     fn decode(cursor: &mut wire::Cursor<'_>) -> Result<Self, ChunkError>;
 }
 
-/// Core trait for all chunk types in the system.
+/// Header-free behaviour common to every chunk value.
 ///
-/// This trait defines the common interface that all chunk implementations must provide.
-pub trait Chunk: Send + Sync + 'static {
-    /// The header type for this chunk
-    type Header: ChunkHeader;
-
-    /// Get the address of this chunk
+/// No `Header` associated type, so the boundary enum
+/// ([`AnyChunk`](super::any_chunk::AnyChunk)) implements it alongside the
+/// concrete carriers and generic code accepts both through one bound.
+pub trait ChunkOps: Send + Sync + 'static {
+    /// Get the address of this chunk.
     fn address(&self) -> &ChunkAddress;
 
-    /// Get the header for this chunk
-    fn header(&self) -> &Self::Header;
-
-    /// Get the raw data contained in this chunk
+    /// Get the raw payload of this chunk (the BMT body without its span).
     fn data(&self) -> &Bytes;
 
-    /// Get the total size of this chunk in bytes
-    fn size(&self) -> usize {
-        // Header and payload are both bounded by the chunk wire size.
-        Self::Header::SIZE.saturating_add(self.data().len())
-    }
+    /// Get the total wire size of this chunk in bytes.
+    fn size(&self) -> usize;
+
+    /// Get the span (logical data length) of this chunk: the BMT span of its
+    /// underlying body.
+    fn span(&self) -> u64;
 
     /// Certify this chunk against an expected address.
     ///
@@ -134,10 +131,48 @@ pub trait Chunk: Send + Sync + 'static {
     /// header's full acceptance rule ([`ChunkHeader::validate`]), never a bare
     /// compare against the chunk's own derived address.
     fn verify(&self, expected: &ChunkAddress) -> Result<(), PrimitivesError>;
+
+    /// Compute the anchor-keyed *transformed address* of this chunk.
+    ///
+    /// The transformed address is the redistribution sampler's per-round,
+    /// per-node re-hash of a chunk. It is a prefixed BMT root keyed by the
+    /// node's `anchor`, used to order reserve chunks deterministically while
+    /// binding the ordering to the proving node.
+    ///
+    /// # Derivation
+    ///
+    /// - The anchor-keyed BMT root of the chunk body is computed by
+    ///   [`BmtBody::transformed_root`](super::bmt_body::BmtBody::transformed_root)
+    ///   on the chunk's borrowed body, which mixes the anchor into *every* node
+    ///   hash. For a SOC the wrapped content body is the one re-hashed.
+    /// - The root is then sealed into the transformed address by the chunk's
+    ///   header predicate ([`ChunkHeader::seal_transformed`]): the root itself
+    ///   for a CAC, the plain (unprefixed, no anchor)
+    ///   `keccak256(soc_address || inner)` for a SOC.
+    ///
+    /// # Endianness
+    ///
+    /// The span is serialised little-endian inside the BMT. Do not confuse this
+    /// with the big-endian encodings used elsewhere on the redistribution wire
+    /// (e.g. proof witness indices); the BMT span is always LE.
+    fn transformed_address(&self, anchor: &[u8]) -> ChunkAddress;
+
+    /// Convert this chunk into its bare wire bytes (`header || span ||
+    /// payload`), the inverse of the carrier's `TryFrom<Bytes>` decode.
+    fn into_bytes(self) -> Bytes
+    where
+        Self: Sized;
 }
 
-/// Trait for chunks that contain a BMT body
-pub trait BmtChunk: Chunk {
-    /// Get the span of the chunk data
-    fn span(&self) -> u64;
+/// Carrier trait tying a chunk to its wire header type.
+///
+/// The behaviour surface lives on the [`ChunkOps`] supertrait; this trait adds
+/// only the header association, so it is exactly the part the header-free
+/// boundary enum cannot implement.
+pub trait Chunk: ChunkOps {
+    /// The header type for this chunk
+    type Header: ChunkHeader;
+
+    /// Get the header for this chunk
+    fn header(&self) -> &Self::Header;
 }

--- a/crates/primitives/src/chunk/type_tag.rs
+++ b/crates/primitives/src/chunk/type_tag.rs
@@ -46,7 +46,8 @@ impl ChunkVersion {
 /// assert_eq!(tag.to_bytes(), [0x01, 0x02]);
 /// assert_eq!(ChunkTypeTag::try_from(u32::from(tag)), Ok(tag));
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display)]
+#[display("{id} v{version}")]
 pub struct ChunkTypeTag {
     /// Wire-level chunk type identifier.
     pub id: ChunkTypeId,

--- a/crates/primitives/src/chunk/wasm.rs
+++ b/crates/primitives/src/chunk/wasm.rs
@@ -2,7 +2,7 @@
 
 use super::any_chunk::AnyChunk;
 use super::content::ContentChunk;
-use super::traits::{BmtChunk, Chunk};
+use super::traits::ChunkOps;
 use crate::bmt::{BRANCHES, DEFAULT_BODY_SIZE, HASH_SIZE, SPAN_SIZE};
 use js_sys::{Array, Uint8Array};
 use wasm_bindgen::prelude::*;

--- a/crates/primitives/src/file/joiner.rs
+++ b/crates/primitives/src/file/joiner.rs
@@ -1053,6 +1053,7 @@ where
 mod tests {
     use super::*;
     use crate::chunk::AnyChunk;
+    use crate::chunk::ChunkOps;
     use crate::file::split;
     use std::collections::HashMap;
 
@@ -1444,7 +1445,6 @@ mod tests {
     /// Content addresses of every data leaf for `data` under `TINY_BODY`, so a
     /// probe getter can tell a leaf fetch from an intermediate fetch.
     fn tiny_leaf_addresses(data: &[u8]) -> std::collections::HashSet<ChunkAddress> {
-        use crate::chunk::Chunk;
         let mut set = std::collections::HashSet::new();
         for block in data.chunks(TINY_BODY) {
             let chunk = crate::chunk::ContentChunk::<TINY_BODY>::new(block.to_vec()).unwrap();

--- a/crates/primitives/src/file/mode.rs
+++ b/crates/primitives/src/file/mode.rs
@@ -6,7 +6,7 @@ use bytes::Bytes;
 
 use crate::bmt::SPAN_SIZE;
 use crate::chunk::encryption::{EncryptedChunkRef, EncryptionKey, decrypt_chunk_data};
-use crate::chunk::{BmtChunk, Chunk, ChunkAddress, ChunkRef, ContentChunk, Reference};
+use crate::chunk::{ChunkAddress, ChunkOps, ChunkRef, ContentChunk, Reference};
 use crate::store::MaybeSend;
 use crate::wire::Cursor;
 

--- a/crates/primitives/src/file/windowed.rs
+++ b/crates/primitives/src/file/windowed.rs
@@ -847,7 +847,7 @@ mod tests {
     /// content-addressed, so rebuilding each leaf from `unique_byte` reproduces
     /// the stored address.
     fn leaf_offsets_of(total: u64) -> HashMap<ChunkAddress, u64> {
-        use crate::chunk::Chunk;
+        use crate::chunk::ChunkOps;
         let mut map = HashMap::new();
         let leaves = total.div_ceil(DEFAULT_BODY_SIZE as u64);
         for i in 0..leaves {
@@ -916,7 +916,7 @@ mod tests {
     const TINY_BODY: usize = 256;
 
     fn tiny_leaf_addresses(data: &[u8]) -> HashMap<ChunkAddress, ()> {
-        use crate::chunk::Chunk;
+        use crate::chunk::ChunkOps;
         let mut set = HashMap::new();
         for block in data.chunks(TINY_BODY) {
             let chunk = crate::chunk::ContentChunk::<TINY_BODY>::new(block.to_vec()).unwrap();

--- a/crates/primitives/src/generators.rs
+++ b/crates/primitives/src/generators.rs
@@ -76,6 +76,7 @@ pub fn any_chunk<const BODY_SIZE: usize>(
 mod tests {
     use super::*;
     use crate::DEFAULT_BODY_SIZE;
+    use crate::chunk::ChunkOps;
     use proptest::prelude::*;
 
     proptest! {

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -12,7 +12,7 @@
 //! ## Usage Examples
 //!
 //! ```
-//! use nectar_primitives::{Chunk, DefaultContentChunk, DefaultSingleOwnerChunk, SocId};
+//! use nectar_primitives::{ChunkOps, DefaultContentChunk, DefaultSingleOwnerChunk, SocId};
 //! use alloy_signer_local::LocalSigner;
 //!
 //! // Creating content chunks; the address is derived from the content
@@ -105,15 +105,15 @@ pub use bmt::{Hasher, HasherFactory, Proof, Prover};
 pub use chunk::{
     // Type system
     AnyChunk,
-    // Core traits
-    BmtChunk,
     CacHeader,
+    // Core traits
     Chunk,
     ChunkAddress,
     ChunkError,
     ChunkHeader,
     // Concrete chunk types
     ChunkInner,
+    ChunkOps,
     ChunkRef,
     ChunkType,
     ChunkTypeId,

--- a/crates/primitives/src/store/memory.rs
+++ b/crates/primitives/src/store/memory.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use parking_lot::RwLock;
 
 use crate::bmt::DEFAULT_BODY_SIZE;
-use crate::chunk::{AnyChunk, ChunkAddress};
+use crate::chunk::{AnyChunk, ChunkAddress, ChunkOps};
 
 use super::ChunkStoreError;
 use super::typed::{ChunkGet, ChunkHas, ChunkPut};
@@ -115,7 +115,7 @@ impl<const BODY_SIZE: usize> ChunkHas<BODY_SIZE> for HashMap<ChunkAddress, AnyCh
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::chunk::{Chunk, ContentChunk};
+    use crate::chunk::{ChunkOps, ContentChunk};
     use futures::executor::block_on;
 
     #[test]

--- a/crates/primitives/src/store/retry.rs
+++ b/crates/primitives/src/store/retry.rs
@@ -172,6 +172,7 @@ mod tests {
 
     use crate::DefaultContentChunk;
     use crate::bmt::DEFAULT_BODY_SIZE;
+    use crate::chunk::ChunkOps;
 
     /// A [`Sleeper`] that returns immediately, so tests never wait real time.
     struct NoSleep;

--- a/fuzz/fuzz_targets/chunk_decode.rs
+++ b/fuzz/fuzz_targets/chunk_decode.rs
@@ -22,7 +22,7 @@
 use bytes::Bytes;
 use libfuzzer_sys::fuzz_target;
 use nectar_primitives::{
-    AnyChunk, Chunk, ChunkAddress, ContentChunk, DEFAULT_BODY_SIZE, SingleOwnerChunk,
+    AnyChunk, ChunkAddress, ChunkOps, ContentChunk, DEFAULT_BODY_SIZE, SingleOwnerChunk,
 };
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/chunk_roundtrip.rs
+++ b/fuzz/fuzz_targets/chunk_roundtrip.rs
@@ -22,7 +22,7 @@ use alloy_signer_local::PrivateKeySigner;
 use arbitrary::{Arbitrary, Unstructured};
 use libfuzzer_sys::fuzz_target;
 use nectar_primitives::{
-    BmtChunk, Chunk, ContentChunk, DEFAULT_BODY_SIZE, SingleOwnerChunk, bytes::Bytes,
+    ChunkOps, ContentChunk, DEFAULT_BODY_SIZE, SingleOwnerChunk, bytes::Bytes,
 };
 
 /// One structured input: either chunk kind, so a single corpus drives both


### PR DESCRIPTION
Closes #194

## What

Extracts a header-free `ChunkOps` behaviour trait (`address`/`data`/`size`/`span`/`verify`/`transformed_address`/`into_bytes`) out of `Chunk` in `crates/primitives/src/chunk/traits.rs`, and shrinks `Chunk` to the header association (`type Header` + `header()`) with `ChunkOps` as its supertrait. `span` moves onto `ChunkOps` from the now-deleted `BmtChunk` trait.

`ChunkInner` implements `ChunkOps` once (`transformed_address` moved in from the enum, its doc moved to the trait). `AnyChunk` implements `ChunkOps` by match-delegation to its variants, deleting the hand-maintained mirror of these methods that previously lived directly on `any_chunk.rs`; `AnyChunk` stays the closed, exhaustive enum, with a semver-major note added to both its rustdoc and the `ChunkOps` impl doc (adding a variant extends every match arm).

The typed storage envelope widens from `[id][wire]` to `[id][version][wire]` via a new `AnyChunk::type_tag()` and `ChunkTypeTag::to_bytes`; `from_typed_bytes` decodes the wider form. This is a stored-format break: stores holding the old one-byte-prefix form must re-encode, and the decoder does not accept the old form.

`ChunkError::UnsupportedType(ChunkTypeId)` is renamed to `ChunkError::UnsupportedTag(ChunkTypeTag)` to match, since each `(id, version)` pair is now a distinct acceptance rule.

## Why

`Chunk` carries an associated `Header` type, so it cannot be implemented by `AnyChunk` (an object-safety/associated-type mismatch), which is why `AnyChunk` previously had to hand-duplicate the same method bodies (`address`, `data`, `size`, `span`, `verify`, `transformed_address`, `into_bytes`) rather than implement the trait directly. Splitting the header-free behaviour into `ChunkOps` lets `AnyChunk` implement the real trait via match-delegation, so generic code can accept both concrete carriers and the boundary enum through one bound, and the two behaviour surfaces cannot drift apart again.

Widening the typed envelope to carry a version alongside the id lets a future chunk-type upgrade change acceptance rules for an existing id without breaking decode of chunks written under the old version.

## Testing

Independently verified against this branch (single commit `d2ad52d` on base `s202/16-chunk-inner`), all via `nix develop`:

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean.
- `cargo nextest run --workspace --all-features`: 686 passed, 1 skipped.
- `cargo test --doc --workspace`: all passed.
- `cargo check` for the wasm-facing `postage-usage` crate (touched by this diff): clean.

A red-team pass found no bugs: the moved `ChunkOps` methods are byte-for-byte behaviour-preserving against the base `inner.rs`, and the bare chunk wire form (`into_bytes`/`from_wire_bytes`, the bee-compat peer path) is untouched, so peer wire compatibility is intact.

## AI Assistance

Implemented, red-teamed and independently verified by Claude, per the org's AI assistance disclosure requirements (nxm-rs/.github `CONTRIBUTING.md`).

