### PR TITLE
refactor(primitives)!: seal chunk trust state in a typestate carrier

### DIFF
--- a/crates/primitives/src/chunk/any_chunk.rs
+++ b/crates/primitives/src/chunk/any_chunk.rs
@@ -84,6 +84,13 @@ impl<const BODY_SIZE: usize> ChunkOps for AnyChunk<BODY_SIZE> {
         }
     }
 
+    fn owner(&self) -> Option<alloy_primitives::Address> {
+        match self {
+            Self::Content(c) => ChunkOps::owner(c),
+            Self::SingleOwner(c) => ChunkOps::owner(c),
+        }
+    }
+
     fn verify(&self, expected: &ChunkAddress) -> Result<()> {
         match self {
             Self::Content(c) => c.verify(expected),
@@ -240,6 +247,15 @@ impl<const BODY_SIZE: usize> AnyChunk<BODY_SIZE> {
     /// - the payload cannot be decoded as the tagged chunk type, or
     /// - the chunk's computed address does not match `address`.
     pub fn from_typed_bytes(address: &ChunkAddress, bytes: &[u8]) -> crate::error::Result<Self> {
+        let chunk = Self::parse_typed(bytes)?;
+        chunk.verify(address)?;
+        Ok(chunk)
+    }
+
+    /// Structurally decode the typed form: the tag routes to a variant and
+    /// the payload is decoded, but nothing certifies. Callers must certify
+    /// the result against an expected address before trusting it.
+    pub(crate) fn parse_typed(bytes: &[u8]) -> crate::error::Result<Self> {
         let (tag, payload) = bytes.split_first_chunk::<2>().ok_or_else(|| {
             super::error::ChunkError::invalid_format(
                 "typed-chunk encoding shorter than the two-byte type tag",
@@ -248,16 +264,12 @@ impl<const BODY_SIZE: usize> AnyChunk<BODY_SIZE> {
 
         let tag = ChunkTypeTag::from(*tag);
         match tag {
-            t if t == ChunkTypeTag::new(CacHeader::TYPE_ID, CacHeader::VERSION) => {
-                let chunk = ContentChunk::try_from(Bytes::copy_from_slice(payload))?;
-                chunk.verify(address)?;
-                Ok(Self::Content(chunk))
-            }
-            t if t == ChunkTypeTag::new(SocHeader::TYPE_ID, SocHeader::VERSION) => {
-                let chunk = SingleOwnerChunk::try_from(Bytes::copy_from_slice(payload))?;
-                chunk.verify(address)?;
-                Ok(Self::SingleOwner(chunk))
-            }
+            t if t == ChunkTypeTag::new(CacHeader::TYPE_ID, CacHeader::VERSION) => Ok(
+                Self::Content(ContentChunk::try_from(Bytes::copy_from_slice(payload))?),
+            ),
+            t if t == ChunkTypeTag::new(SocHeader::TYPE_ID, SocHeader::VERSION) => Ok(
+                Self::SingleOwner(SingleOwnerChunk::try_from(Bytes::copy_from_slice(payload))?),
+            ),
             other => Err(super::error::ChunkError::unsupported_tag(other).into()),
         }
     }
@@ -406,6 +418,19 @@ mod tests {
     fn sample_single_owner() -> DefaultSingleOwnerChunk {
         let id = crate::SocId::ZERO;
         DefaultSingleOwnerChunk::new(id, b"single owner payload".to_vec(), &test_signer()).unwrap()
+    }
+
+    /// [`ChunkOps::owner`] delegates by variant: content chunks bind no
+    /// owner, single-owner chunks recover the signer.
+    #[test]
+    fn chunk_ops_owner_delegates_by_variant() {
+        let content: DefaultAnyChunk = DefaultContentChunk::new(&b"ownerless"[..]).unwrap().into();
+        assert_eq!(content.owner(), None);
+
+        let soc = sample_single_owner();
+        let expected = soc.owner().unwrap();
+        let any: DefaultAnyChunk = soc.into();
+        assert_eq!(ChunkOps::owner(&any), Some(expected));
     }
 
     #[test]

--- a/crates/primitives/src/chunk/chunk_type.rs
+++ b/crates/primitives/src/chunk/chunk_type.rs
@@ -3,12 +3,12 @@
 //! This module provides the [`ChunkType`] trait which adds compile-time type
 //! information to chunk implementations.
 
-use super::traits::Chunk;
+use super::traits::HeaderedChunk;
 use super::type_id::ChunkTypeId;
 
 /// Trait for chunk types with compile-time type information.
 ///
-/// This trait extends [`Chunk`] with static type metadata, enabling:
+/// This trait extends [`HeaderedChunk`] with static type metadata, enabling:
 /// - Compile-time type identification via [`TYPE_ID`](ChunkType::TYPE_ID)
 /// - Type-safe serialization/deserialization
 /// - Generic programming over chunk types
@@ -16,14 +16,14 @@ use super::type_id::ChunkTypeId;
 /// # Implementing ChunkType
 ///
 /// All implementations must also implement:
-/// - [`Chunk`] trait
+/// - [`HeaderedChunk`] trait
 /// - [`TryFrom<Bytes>`] for deserialization
 /// - [`Into<Bytes>`] for serialization
 ///
 /// # Example
 ///
 /// ```ignore
-/// use nectar_primitives::{Chunk, ChunkType, ChunkTypeId};
+/// use nectar_primitives::{ChunkType, ChunkTypeId, HeaderedChunk};
 ///
 /// struct MyCustomChunk { /* ... */ }
 ///
@@ -32,7 +32,7 @@ use super::type_id::ChunkTypeId;
 ///     const TYPE_NAME: &'static str = "my_custom";
 /// }
 /// ```
-pub trait ChunkType: Chunk + Sized {
+pub trait ChunkType: HeaderedChunk + Sized {
     /// The wire-level type identifier for this chunk type.
     ///
     /// This ID is used in chunk headers for serialization and must be unique

--- a/crates/primitives/src/chunk/inner.rs
+++ b/crates/primitives/src/chunk/inner.rs
@@ -15,7 +15,7 @@ use crate::wire;
 use super::address::ChunkAddress;
 use super::bmt_body::BmtBody;
 use super::chunk_type::ChunkType;
-use super::traits::{Chunk, ChunkHeader, ChunkOps};
+use super::traits::{ChunkHeader, ChunkOps, HeaderedChunk};
 
 /// A chunk: a wire header committing to a BMT body.
 ///
@@ -84,6 +84,10 @@ impl<H: ChunkHeader, const BODY_SIZE: usize> ChunkOps for ChunkInner<H, BODY_SIZ
         self.body.span()
     }
 
+    fn owner(&self) -> Option<alloy_primitives::Address> {
+        self.header.recover_owner(self.body.hash().into())
+    }
+
     /// Certify through [`ChunkHeader::validate`]: the header's full acceptance
     /// rule runs, not an address compare against the cached address.
     fn verify(&self, expected: &ChunkAddress) -> Result<()> {
@@ -104,7 +108,7 @@ impl<H: ChunkHeader, const BODY_SIZE: usize> ChunkOps for ChunkInner<H, BODY_SIZ
     }
 }
 
-impl<H: ChunkHeader, const BODY_SIZE: usize> Chunk for ChunkInner<H, BODY_SIZE> {
+impl<H: ChunkHeader, const BODY_SIZE: usize> HeaderedChunk for ChunkInner<H, BODY_SIZE> {
     type Header = H;
 
     fn header(&self) -> &H {

--- a/crates/primitives/src/chunk/mod.rs
+++ b/crates/primitives/src/chunk/mod.rs
@@ -13,10 +13,13 @@
 //!   [`ContentChunk`] and [`SingleOwnerChunk`] are its aliases
 //! - [`ChunkOps`] - Header-free behaviour shared by concrete chunks and
 //!   [`AnyChunk`]
-//! - [`Chunk`] - Ties a carrier to its header type
+//! - [`HeaderedChunk`] - Ties a carrier to its header type
 //! - [`ChunkType`] - Adds compile-time type identification
 //! - [`ChunkRegistry`] - Compile-time registry of the chunk types a network
 //!   accepts, keyed by its closed envelope type
+//! - [`Chunk`] - The public chunk currency: a registry envelope under a
+//!   sealed [`TrustState`], parse then verify from every source, with
+//!   [`TrustedSource`] gating the single trusted-store skip
 //!
 //! # Type-Erased Chunks
 //!
@@ -36,6 +39,7 @@ mod registry;
 mod single_owner;
 mod soc_id;
 mod traits;
+mod trust;
 mod type_id;
 mod type_tag;
 
@@ -46,7 +50,10 @@ pub mod wasm;
 pub use address::ChunkAddress;
 pub use error::ChunkError;
 pub use inner::ChunkInner;
-pub use traits::{Chunk, ChunkHeader, ChunkOps};
+pub use traits::{ChunkHeader, ChunkOps, HeaderedChunk};
+
+// Re-export the typestate trust carrier
+pub use trust::{Chunk, IntoVerified, TrustState, TrustedSource, Unverified, Verified};
 
 // Re-export the reference types
 pub use reference::{ChunkRef, RefKind, Reference, WrongRefKind};

--- a/crates/primitives/src/chunk/registry.rs
+++ b/crates/primitives/src/chunk/registry.rs
@@ -104,16 +104,32 @@ pub trait ChunkRegistry: Send + Sync + 'static {
         Self::MEMBERS.iter().any(|member| member.tag.id == id)
     }
 
+    /// Structurally decode the typed form produced by
+    /// [`encode_typed`](Self::encode_typed): the tag routes to a member and
+    /// the payload is decoded, but nothing certifies. The result is only a
+    /// claim; certify it via [`decode_typed`](Self::decode_typed) or the
+    /// typestate carrier's parse-then-verify.
+    ///
+    /// # Errors
+    ///
+    /// A tag outside [`MEMBERS`](Self::MEMBERS) is a distinct
+    /// [`ChunkError::UnsupportedTag`] carrying the tag, never a format
+    /// error; a structurally malformed payload errors, never panics.
+    fn parse_typed(bytes: &[u8]) -> Result<Self::Envelope>;
+
     /// Decode the self-describing typed form produced by
     /// [`encode_typed`](Self::encode_typed): the tag routes to a member,
     /// the address certifies the payload.
     ///
     /// # Errors
     ///
-    /// A tag outside [`MEMBERS`](Self::MEMBERS) is a distinct
-    /// [`ChunkError::UnsupportedTag`] carrying the tag, never a format
-    /// error; a payload that fails the member's acceptance rule errors.
-    fn decode_typed(address: &ChunkAddress, bytes: &[u8]) -> Result<Self::Envelope>;
+    /// Errors as [`parse_typed`](Self::parse_typed) does, plus when the
+    /// payload fails the member's acceptance rule against `address`.
+    fn decode_typed(address: &ChunkAddress, bytes: &[u8]) -> Result<Self::Envelope> {
+        let chunk = Self::parse_typed(bytes)?;
+        chunk.verify(address)?;
+        Ok(chunk)
+    }
 
     /// Decode bare wire bytes (no type tag), trial-parsing members in
     /// declaration order; the address is the disambiguator.
@@ -142,8 +158,8 @@ impl ChunkRegistry for StandardChunkSet {
         ChunkTypeInfo::of::<SocHeader>(),
     ];
 
-    fn decode_typed(address: &ChunkAddress, bytes: &[u8]) -> Result<Self::Envelope> {
-        AnyChunk::from_typed_bytes(address, bytes)
+    fn parse_typed(bytes: &[u8]) -> Result<Self::Envelope> {
+        AnyChunk::parse_typed(bytes)
     }
 
     fn decode_wire(address: &ChunkAddress, data: Bytes) -> Result<Self::Envelope> {
@@ -167,7 +183,7 @@ impl ChunkRegistry for ContentOnlyChunkSet {
 
     const MEMBERS: &'static [ChunkTypeInfo] = &[ChunkTypeInfo::of::<CacHeader>()];
 
-    fn decode_typed(address: &ChunkAddress, bytes: &[u8]) -> Result<Self::Envelope> {
+    fn parse_typed(bytes: &[u8]) -> Result<Self::Envelope> {
         let (tag, payload) = bytes.split_first_chunk::<2>().ok_or_else(|| {
             ChunkError::invalid_format("typed-chunk encoding shorter than the two-byte type tag")
         })?;
@@ -175,9 +191,7 @@ impl ChunkRegistry for ContentOnlyChunkSet {
         if !Self::supports(tag) {
             return Err(ChunkError::unsupported_tag(tag).into());
         }
-        let chunk = ContentChunk::try_from(Bytes::copy_from_slice(payload))?;
-        chunk.verify(address)?;
-        Ok(chunk)
+        ContentChunk::try_from(Bytes::copy_from_slice(payload))
     }
 
     fn decode_wire(address: &ChunkAddress, data: Bytes) -> Result<Self::Envelope> {
@@ -328,6 +342,22 @@ mod tests {
         assert!(decoded.is_single_owner());
         assert_eq!(decoded.address(), any.address());
         assert_eq!(decoded.into_bytes(), wire);
+    }
+
+    /// parse_typed is structural only: the same bytes that decode_typed
+    /// rejects at a wrong address still parse.
+    #[test]
+    fn parse_typed_is_structural_only() {
+        let content = DefaultContentChunk::new(&b"structural"[..]).unwrap();
+        let wrong: ChunkAddress = [0xFFu8; 32].into();
+
+        let standard = StandardChunkSet::encode_typed(&content.clone().into());
+        assert!(StandardChunkSet::parse_typed(&standard).is_ok());
+        assert!(StandardChunkSet::decode_typed(&wrong, &standard).is_err());
+
+        let content_only = ContentOnlyChunkSet::encode_typed(&content);
+        assert!(ContentOnlyChunkSet::parse_typed(&content_only).is_ok());
+        assert!(ContentOnlyChunkSet::decode_typed(&wrong, &content_only).is_err());
     }
 
     #[test]

--- a/crates/primitives/src/chunk/single_owner.rs
+++ b/crates/primitives/src/chunk/single_owner.rs
@@ -141,6 +141,10 @@ impl ChunkHeader for SocHeader {
         Ok(())
     }
 
+    fn recover_owner(&self, body_hash: B256) -> Option<Address> {
+        self.owner(body_hash).ok()
+    }
+
     /// Plain (unprefixed) `keccak256(soc_address || transformed_root)`.
     fn seal_transformed(&self, address: &ChunkAddress, transformed_root: B256) -> ChunkAddress {
         let mut hasher = Keccak256::new();

--- a/crates/primitives/src/chunk/traits.rs
+++ b/crates/primitives/src/chunk/traits.rs
@@ -2,9 +2,10 @@
 //!
 //! [`ChunkHeader`] is the predicate a chunk type *is*: its address derivation
 //! and self-certification rule. [`ChunkOps`] is the header-free behaviour
-//! every chunk value offers; [`Chunk`] ties a carrier to its header type.
+//! every chunk value offers; [`HeaderedChunk`] ties a carrier to its header
+//! type.
 
-use alloy_primitives::B256;
+use alloy_primitives::{Address, B256};
 use bytes::{Bytes, BytesMut};
 
 use crate::error::PrimitivesError;
@@ -93,6 +94,15 @@ pub trait ChunkHeader: Sized + Send + Sync + 'static {
     /// not recover, so every header must state its full acceptance rule.
     fn validate(&self, body_hash: B256, expected: &ChunkAddress) -> Result<(), ChunkError>;
 
+    /// Recover the owner this header binds the body to.
+    ///
+    /// `None` for ownerless types (the default) and for a signature that
+    /// does not recover; [`validate`](Self::validate), not this hook,
+    /// decides whether that is an error.
+    fn recover_owner(&self, _body_hash: B256) -> Option<Address> {
+        None
+    }
+
     /// Seal the anchor-keyed `transformed_root` of the body into the chunk's
     /// transformed address (the redistribution sampler's re-hash).
     fn seal_transformed(&self, address: &ChunkAddress, transformed_root: B256) -> ChunkAddress;
@@ -124,6 +134,10 @@ pub trait ChunkOps: Send + Sync + 'static {
     /// Get the span (logical data length) of this chunk: the BMT span of its
     /// underlying body.
     fn span(&self) -> u64;
+
+    /// Get the owner this chunk's type binds, if it has one and the
+    /// signature recovers ([`ChunkHeader::recover_owner`]).
+    fn owner(&self) -> Option<Address>;
 
     /// Certify this chunk against an expected address.
     ///
@@ -169,7 +183,7 @@ pub trait ChunkOps: Send + Sync + 'static {
 /// The behaviour surface lives on the [`ChunkOps`] supertrait; this trait adds
 /// only the header association, so it is exactly the part the header-free
 /// boundary enum cannot implement.
-pub trait Chunk: ChunkOps {
+pub trait HeaderedChunk: ChunkOps {
     /// The header type for this chunk
     type Header: ChunkHeader;
 

--- a/crates/primitives/src/chunk/trust.rs
+++ b/crates/primitives/src/chunk/trust.rs
@@ -1,0 +1,498 @@
+//! Typestate trust carrier for chunks.
+//!
+//! [`Chunk`] is the public chunk currency: whether its address is a verified
+//! fact or an unverified claim is a sealed type parameter, so an unverified
+//! chunk cannot flow where a verified one is required. Every source is parse
+//! then verify; a store holding a [`TrustedSource`] capability is the single
+//! gated exception ([`Chunk::assume_verified`]).
+
+use std::marker::PhantomData;
+
+use alloy_primitives::Address;
+use bytes::Bytes;
+
+use crate::cache::OnceCache;
+use crate::error::Result;
+
+use super::address::ChunkAddress;
+use super::registry::{ChunkRegistry, StandardChunkSet};
+use super::traits::ChunkOps;
+
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for super::Verified {}
+    impl Sealed for super::Unverified {}
+}
+
+/// Sealed trust state of a chunk's address: [`Verified`] or [`Unverified`].
+pub trait TrustState: sealed::Sealed + Send + Sync + 'static {
+    /// State name for diagnostics.
+    const NAME: &'static str;
+}
+
+/// The address is a fact: it was certified by the member's full acceptance
+/// rule, or vouched for by a [`TrustedSource`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Verified;
+
+impl TrustState for Verified {
+    const NAME: &'static str = "verified";
+}
+
+/// The address is a claim taken from context (a storage key, a wire field)
+/// that nothing has certified yet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Unverified;
+
+impl TrustState for Unverified {
+    const NAME: &'static str = "unverified";
+}
+
+/// Zero-sized capability vouching that a byte source only yields bytes that
+/// were certified before they were stored.
+///
+/// Unforgeable in safe code: the only constructor is the `unsafe`
+/// [`grant`](Self::grant). Mint one per trusted store and pass it to
+/// [`Chunk::assume_verified`]; every other source is parse then verify.
+#[derive(Debug)]
+pub struct TrustedSource(());
+
+impl TrustedSource {
+    /// Mint the capability for one trusted read medium.
+    ///
+    /// # Safety
+    ///
+    /// This is a trust contract, not a memory-safety obligation: no
+    /// undefined behaviour can result. The caller asserts that every byte
+    /// the source yields was certified before it was stored and cannot have
+    /// changed since; a false assertion puts lying addresses into
+    /// consensus-critical state instead of tripping a verifier.
+    #[must_use]
+    pub const unsafe fn grant() -> Self {
+        Self(())
+    }
+}
+
+/// A chunk whose address carries its trust state in the type.
+///
+/// `S` is the sealed [`TrustState`]: for [`Unverified`] the address is a
+/// claim, for [`Verified`] a fact. `R` is the [`ChunkRegistry`] the bytes
+/// are decoded under. The only transitions are [`verify`](Self::verify),
+/// which runs the member's full acceptance rule, and
+/// [`assume_verified`](Self::assume_verified), gated on a [`TrustedSource`].
+///
+/// ```
+/// use nectar_primitives::{Chunk, ChunkOps, ChunkRegistry, ContentChunk, StandardChunkSet, Unverified};
+///
+/// let content = ContentChunk::new(&b"currency"[..]).unwrap();
+/// let claimed = *content.address();
+/// let typed = StandardChunkSet::encode_typed(&content.into());
+///
+/// let verified = Chunk::<Unverified>::parse(claimed, &typed)
+///     .unwrap()
+///     .verify()
+///     .unwrap();
+/// assert_eq!(verified.address(), &claimed);
+/// ```
+pub struct Chunk<S: TrustState = Verified, R: ChunkRegistry = StandardChunkSet> {
+    /// `S = Verified`: fact. `S = Unverified`: claim.
+    address: ChunkAddress,
+    /// The envelope decoded under `R`.
+    inner: R::Envelope,
+    /// Lazily recovered owner; only ever written in the verified state.
+    owner: OnceCache<Option<Address>>,
+    _state: PhantomData<S>,
+}
+
+/// Structural equality over the address and the decoded envelope (the owner
+/// cache is ignored). A SOC address does not commit to the body, so address
+/// equality alone is slot identity, not chunk equality.
+impl<S: TrustState, R: ChunkRegistry> PartialEq for Chunk<S, R>
+where
+    R::Envelope: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.address == other.address && self.inner == other.inner
+    }
+}
+
+impl<S: TrustState, R: ChunkRegistry> Eq for Chunk<S, R> where R::Envelope: Eq {}
+
+impl<R: ChunkRegistry> Chunk<Unverified, R> {
+    /// Structurally parse the registry's typed (store) encoding under a
+    /// claimed address.
+    ///
+    /// The tag routes to a registry member and the payload is decoded;
+    /// nothing certifies `claimed`. Errors on malformed input or an
+    /// unsupported tag, never panics.
+    pub fn parse(claimed: ChunkAddress, bytes: &[u8]) -> Result<Self> {
+        Ok(Self {
+            address: claimed,
+            inner: R::parse_typed(bytes)?,
+            owner: OnceCache::new(),
+            _state: PhantomData,
+        })
+    }
+
+    /// The address this chunk claims to live at; a claim until
+    /// [`verify`](Self::verify).
+    pub const fn claimed_address(&self) -> &ChunkAddress {
+        &self.address
+    }
+
+    /// Certify the claimed address by the member's full acceptance rule.
+    ///
+    /// The rule recomputes everything from the parsed bytes with empty
+    /// caches; nothing is compared against a stored derivation, so an
+    /// internally consistent lie about the address cannot certify itself.
+    pub fn verify(self) -> Result<Chunk<Verified, R>> {
+        self.inner.verify(&self.address)?;
+        Ok(Chunk::from_verified_parts(self.address, self.inner))
+    }
+
+    /// Take the claimed address on trust: the single gated skip of
+    /// [`verify`](Self::verify), for bytes read back from a medium that only
+    /// ever stored verified chunks.
+    #[must_use]
+    pub fn assume_verified(self, _source: &TrustedSource) -> Chunk<Verified, R> {
+        Chunk::from_verified_parts(self.address, self.inner)
+    }
+}
+
+impl<R: ChunkRegistry> Chunk<Verified, R> {
+    /// Seed the address fact; the owner cache starts empty so recovery stays
+    /// lazy.
+    pub(crate) const fn from_verified_parts(address: ChunkAddress, inner: R::Envelope) -> Self {
+        Self {
+            address,
+            inner,
+            owner: OnceCache::new(),
+            _state: PhantomData,
+        }
+    }
+
+    /// Certify a locally built envelope at its own derived address.
+    ///
+    /// For upload paths where the value was constructed, not decoded. The
+    /// address is key-sourced from the envelope's derivation, never
+    /// caller-supplied, and the member's full acceptance rule still runs
+    /// against it: derivation alone is not certification (a single-owner
+    /// chunk with an unrecoverable signature derives a zero-owner address
+    /// that must not certify).
+    pub fn from_envelope(inner: R::Envelope) -> Result<Self> {
+        let address = *inner.address();
+        inner.verify(&address)?;
+        Ok(Self::from_verified_parts(address, inner))
+    }
+
+    /// Decode and certify bare wire bytes (no type tag) in one step.
+    ///
+    /// Without a tag the address is the only member router, so parsing and
+    /// certification are inseparable and the result is already verified.
+    pub fn decode_wire(address: ChunkAddress, data: Bytes) -> Result<Self> {
+        Ok(Self::from_verified_parts(
+            address,
+            R::decode_wire(&address, data)?,
+        ))
+    }
+
+    /// The chunk's address: a certified fact, free to read.
+    pub const fn address(&self) -> &ChunkAddress {
+        &self.address
+    }
+
+    /// Encode into the registry's self-describing typed form, the store
+    /// encoding. Only a verified chunk can produce it.
+    pub fn typed_bytes(&self) -> Vec<u8> {
+        R::encode_typed(&self.inner)
+    }
+
+    /// The owner the chunk's type binds, if it has one.
+    ///
+    /// Lazy and memoized: signature recovery runs on the first call only.
+    /// `None` for ownerless types.
+    pub fn owner(&self) -> Option<Address> {
+        *self.owner.get_or_compute(|| self.inner.owner())
+    }
+
+    /// Borrow the decoded envelope.
+    pub const fn envelope(&self) -> &R::Envelope {
+        &self.inner
+    }
+
+    /// Consume into the decoded envelope.
+    pub fn into_envelope(self) -> R::Envelope {
+        self.inner
+    }
+}
+
+impl<S: TrustState, R: ChunkRegistry> Clone for Chunk<S, R> {
+    fn clone(&self) -> Self {
+        Self {
+            address: self.address,
+            inner: self.inner.clone(),
+            owner: self.owner.clone(),
+            _state: PhantomData,
+        }
+    }
+}
+
+impl<S: TrustState, R: ChunkRegistry> std::fmt::Debug for Chunk<S, R> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Chunk")
+            .field("state", &S::NAME)
+            .field("address", &self.address)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Unifier over the trust states: identity for a verified chunk, a full
+/// [`Chunk::verify`] for an unverified one. Monomorphizes to zero cost.
+pub trait IntoVerified {
+    /// Registry the chunk is decoded under.
+    type Registry: ChunkRegistry;
+
+    /// Certify into the verified state.
+    fn into_verified(self) -> Result<Chunk<Verified, Self::Registry>>;
+}
+
+impl<R: ChunkRegistry> IntoVerified for Chunk<Verified, R> {
+    type Registry = R;
+
+    fn into_verified(self) -> Result<Self> {
+        Ok(self)
+    }
+}
+
+impl<R: ChunkRegistry> IntoVerified for Chunk<Unverified, R> {
+    type Registry = R;
+
+    fn into_verified(self) -> Result<Chunk<Verified, R>> {
+        self.verify()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::hex;
+    use alloy_signer_local::PrivateKeySigner;
+
+    use super::super::content::ContentChunk;
+    use super::super::registry::ContentOnlyChunkSet;
+    use super::super::single_owner::SingleOwnerChunk;
+    use super::*;
+    use crate::bmt::DEFAULT_BODY_SIZE;
+    use crate::chunk::{ChunkError, SocId};
+    use crate::error::PrimitivesError;
+
+    type DefaultContentChunk = ContentChunk<DEFAULT_BODY_SIZE>;
+    type DefaultSingleOwnerChunk = SingleOwnerChunk<DEFAULT_BODY_SIZE>;
+
+    fn test_signer() -> PrivateKeySigner {
+        // Fixed key so addresses are deterministic across runs.
+        PrivateKeySigner::from_slice(&[0x42u8; 32]).unwrap()
+    }
+
+    /// Go-interop single-owner vector: id(32) || signature(65) || span(8) || "foo".
+    fn soc_test_vector() -> Vec<u8> {
+        hex!(
+            "000000000000000000000000000000000000000000000000000000000000000\
+            05acd384febc133b7b245e5ddc62d82d2cded9182d2716126cd8844509af65a05\
+            3deb418208027f548e3e88343af6f84a8772fb3cebc0a1833a0ea7ec0c134831\
+            1b0300000000000000666f6f"
+        )
+        .to_vec()
+    }
+
+    #[test]
+    fn parse_then_verify_content_round_trips() {
+        let content = DefaultContentChunk::new(&b"typestate currency"[..]).unwrap();
+        let claimed = *content.address();
+        let typed = StandardChunkSet::encode_typed(&content.into());
+
+        let unverified = Chunk::<Unverified>::parse(claimed, &typed).unwrap();
+        assert_eq!(unverified.claimed_address(), &claimed);
+
+        let verified = unverified.verify().unwrap();
+        assert_eq!(verified.address(), &claimed);
+        assert_eq!(verified.typed_bytes(), typed);
+        assert_eq!(verified.owner(), None, "a content chunk binds no owner");
+    }
+
+    #[test]
+    fn verified_owner_is_recovered_and_memoized() {
+        let signer = test_signer();
+        let soc =
+            DefaultSingleOwnerChunk::new(SocId::ZERO, b"owned payload".to_vec(), &signer).unwrap();
+        let claimed = *soc.address();
+        let verified = Chunk::<Verified>::from_envelope(soc.into()).unwrap();
+
+        assert_eq!(verified.address(), &claimed);
+        let owner = verified.owner();
+        assert_eq!(owner, Some(signer.address()));
+        // Second read serves the memoized value.
+        assert_eq!(verified.owner(), owner);
+        assert!(verified.envelope().is_single_owner());
+    }
+
+    /// Key regression: an internally consistent lie must be rejected. A
+    /// single-owner chunk whose signature recovers to nobody still derives
+    /// *some* address (the zero-owner one); parsing its bytes under exactly
+    /// that claimed address must fail verify, where any path that trusted a
+    /// stored or cached derivation would pass it.
+    #[test]
+    fn verify_rejects_internally_consistent_lie() {
+        let mut wire = soc_test_vector();
+        // Clobber the 65 signature bytes after the 32-byte id.
+        for byte in wire.iter_mut().skip(32).take(65) {
+            *byte = 0xff;
+        }
+        let lying = DefaultSingleOwnerChunk::try_from(wire.as_slice()).unwrap();
+        let committed = *lying.address();
+        let typed = StandardChunkSet::encode_typed(&lying.into());
+
+        let unverified = Chunk::<Unverified>::parse(committed, &typed).unwrap();
+        assert!(unverified.verify().is_err());
+    }
+
+    #[test]
+    fn parse_is_structural_and_verify_certifies_the_claim() {
+        let content = DefaultContentChunk::new(&b"honest bytes"[..]).unwrap();
+        let typed = StandardChunkSet::encode_typed(&content.into());
+        let lie: ChunkAddress = [0xFFu8; 32].into();
+
+        // A lying claim parses fine: parse certifies nothing.
+        let unverified = Chunk::<Unverified>::parse(lie, &typed).unwrap();
+        assert_eq!(unverified.claimed_address(), &lie);
+
+        // Verification is what rejects it.
+        assert!(matches!(
+            unverified.verify(),
+            Err(PrimitivesError::Chunk(
+                ChunkError::VerificationFailed { .. }
+            ))
+        ));
+    }
+
+    #[test]
+    fn parse_malformed_input_errors_never_panics() {
+        for bytes in [&[][..], &[0x00][..], &[0x00, 0x00][..]] {
+            assert!(Chunk::<Unverified>::parse(ChunkAddress::default(), bytes).is_err());
+        }
+
+        // An unsupported tag is a distinct error carrying the tag.
+        let unknown = [200u8, 0, 1, 2, 3, 4, 5, 6, 7, 8];
+        assert!(matches!(
+            Chunk::<Unverified>::parse(ChunkAddress::default(), &unknown),
+            Err(PrimitivesError::Chunk(ChunkError::UnsupportedTag(_)))
+        ));
+    }
+
+    /// The gated skip takes the claim on trust, even a false one: the
+    /// capability holder vouches for the medium, nothing re-checks.
+    #[test]
+    fn assume_verified_skips_certification() {
+        let content = DefaultContentChunk::new(&b"trusted medium"[..]).unwrap();
+        let typed = StandardChunkSet::encode_typed(&content.into());
+        let lie: ChunkAddress = [0xEEu8; 32].into();
+
+        let source = unsafe { TrustedSource::grant() };
+        let assumed = Chunk::<Unverified>::parse(lie, &typed)
+            .unwrap()
+            .assume_verified(&source);
+        assert_eq!(assumed.address(), &lie);
+    }
+
+    #[test]
+    fn decode_wire_certifies_in_one_step() {
+        let signer = test_signer();
+        let soc =
+            DefaultSingleOwnerChunk::new(SocId::ZERO, b"wire form".to_vec(), &signer).unwrap();
+        let address = *soc.address();
+        let wire: Bytes = soc.into();
+
+        let verified = Chunk::<Verified>::decode_wire(address, wire.clone()).unwrap();
+        assert_eq!(verified.address(), &address);
+        assert_eq!(verified.owner(), Some(signer.address()));
+
+        let wrong: ChunkAddress = [0x11u8; 32].into();
+        assert!(Chunk::<Verified>::decode_wire(wrong, wire).is_err());
+    }
+
+    #[test]
+    fn into_verified_unifies_both_states() {
+        fn certify<C: IntoVerified>(chunk: C) -> Result<Chunk<Verified, C::Registry>> {
+            chunk.into_verified()
+        }
+
+        let content = DefaultContentChunk::new(&b"unifier"[..]).unwrap();
+        let claimed = *content.address();
+        let typed = StandardChunkSet::encode_typed(&content.into());
+
+        // Unverified: runs the full acceptance rule.
+        let via_unverified = certify(Chunk::<Unverified>::parse(claimed, &typed).unwrap()).unwrap();
+        assert_eq!(via_unverified.address(), &claimed);
+
+        // Verified: identity.
+        let via_verified = certify(via_unverified).unwrap();
+        assert_eq!(via_verified.address(), &claimed);
+
+        // The unverified arm still rejects a lie.
+        let lie: ChunkAddress = [0xAAu8; 32].into();
+        assert!(certify(Chunk::<Unverified>::parse(lie, &typed).unwrap()).is_err());
+    }
+
+    #[test]
+    fn content_only_registry_rejects_single_owner_tags() {
+        let signer = test_signer();
+        let soc =
+            DefaultSingleOwnerChunk::new(SocId::ZERO, b"wrong network".to_vec(), &signer).unwrap();
+        let claimed = *soc.address();
+        let typed = StandardChunkSet::encode_typed(&soc.into());
+
+        assert!(matches!(
+            Chunk::<Unverified, ContentOnlyChunkSet>::parse(claimed, &typed),
+            Err(PrimitivesError::Chunk(ChunkError::UnsupportedTag(_)))
+        ));
+
+        let content = DefaultContentChunk::new(&b"right network"[..]).unwrap();
+        let claimed = *content.address();
+        let typed = ContentOnlyChunkSet::encode_typed(&content);
+        let verified = Chunk::<Unverified, ContentOnlyChunkSet>::parse(claimed, &typed)
+            .unwrap()
+            .verify()
+            .unwrap();
+        assert_eq!(verified.address(), &claimed);
+    }
+
+    #[test]
+    fn from_envelope_derives_and_certifies() {
+        let content = DefaultContentChunk::new(&b"local upload"[..]).unwrap();
+        let derived = *content.address();
+
+        let verified = Chunk::<Verified>::from_envelope(content.into()).unwrap();
+        assert_eq!(verified.address(), &derived);
+        assert_eq!(verified.into_envelope().address(), &derived);
+
+        // Derivation is not certification: a single-owner envelope whose
+        // signature recovers to nobody derives a zero-owner address but must
+        // not certify at it.
+        let mut wire = soc_test_vector();
+        for byte in wire.iter_mut().skip(32).take(65) {
+            *byte = 0xff;
+        }
+        let lying = DefaultSingleOwnerChunk::try_from(wire.as_slice()).unwrap();
+        assert!(Chunk::<Verified>::from_envelope(lying.into()).is_err());
+    }
+
+    #[test]
+    fn debug_names_the_trust_state() {
+        let content = DefaultContentChunk::new(&b"debuggable"[..]).unwrap();
+        let claimed = *content.address();
+        let typed = StandardChunkSet::encode_typed(&content.into());
+
+        let unverified = Chunk::<Unverified>::parse(claimed, &typed).unwrap();
+        assert!(format!("{unverified:?}").contains("unverified"));
+        assert!(format!("{:?}", unverified.verify().unwrap()).contains("verified"));
+    }
+}

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -106,10 +106,11 @@ pub use chunk::{
     // Type system
     AnyChunk,
     CacHeader,
-    // Core traits
+    // The typestate chunk currency
     Chunk,
     ChunkAddress,
     ChunkError,
+    // Core traits
     ChunkHeader,
     // Concrete chunk types
     ChunkInner,
@@ -123,6 +124,8 @@ pub use chunk::{
     ChunkVersion,
     ContentChunk,
     ContentOnlyChunkSet,
+    HeaderedChunk,
+    IntoVerified,
     RefKind,
     Reference,
     SingleOwnerChunk,
@@ -130,6 +133,10 @@ pub use chunk::{
     SocId,
     StandardChunkSet,
     TagWireError,
+    TrustState,
+    TrustedSource,
+    Unverified,
+    Verified,
     WrongRefKind,
 };
 


### PR DESCRIPTION
## What

Introduces a typestate `Chunk<S, R>` carrier in `crates/primitives/src/chunk/trust.rs` that makes verification a fact tracked in the type system rather than a runtime flag.

`Chunk<S: TrustState = Verified, R: ChunkRegistry = StandardChunkSet>` wraps `{ address, inner: R::Envelope, owner: OnceCache<Option<Address>>, _state }`, with `Verified`/`Unverified` as sealed markers so no external code can invent a new trust state.

Unverified surface: `parse(claimed, bytes)` does a structural, tag-routed decode via a new `ChunkRegistry::parse_typed` hook and never panics on adversarial input; `verify()` runs the member's full acceptance rule against the claim and returns `Chunk<Verified>`; `assume_verified(&TrustedSource)` is the one gated skip; `claimed_address()` reads the unverified claim.

Verified surface: `address()` is a free fact accessor, `typed_bytes()` re-encodes for the registry store, and `owner()` is a lazily memoized `ecrecover` via a new `ChunkOps` extension.

The change touches `any_chunk.rs`, `chunk_type.rs`, `inner.rs`, `mod.rs`, `registry.rs`, `single_owner.rs`, `traits.rs` and `lib.rs` to route existing chunk types through the new registry hook and re-export the typestate API; `trust.rs` is new (484 lines). Single signed commit `3be0933`, +608/-33, all within `crates/primitives`.

## Why

Before this change, whether a chunk's address had actually been checked against its bytes was a runtime property that had to be tracked by convention. This let unverified claims and verified facts flow through the same type, with no compiler help to catch a call site that skipped verification.

The typestate carrier makes that distinction structural: only `verify()` or an explicit `TrustedSource`-gated `assume_verified()` can produce a `Chunk<Verified>`, and `Chunk::from_verified_parts` stays `pub(crate)`, so no safe external path can manufacture a verified chunk without going through the acceptance rule. The wire format is unchanged; the refactor only splits verification out of parsing.

## Testing

Independent verification against a clean clone of this commit, base `origin/s202/22-chunk-registry`, all commands run via `nix develop --command`:

- `cargo fmt --all -- --check`: pass.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: pass, no warnings.
- `cargo nextest` is not installed in this repo's nix devshell, so ran the equivalent `cargo test --workspace --all-features` instead: 0 failures across the workspace (386 passed / 1 ignored in `primitives`, plus all other crates).
- `cargo test --doc --workspace`: 0 failures across all 8 doc-test targets, including the `nectar_primitives` doctest that compiles and runs the `trust.rs` parse-then-verify example.
- Wasm check skipped: `nectar-postage-usage` is not touched by this change; all changed files are confined to `crates/primitives`.

An adversarial red-team pass on this change found no blocking or major defects and pushed no fixes because none were warranted. It confirmed the typestate carrier is sound (no safe path reaches `Verified` without `verify()` or the `TrustedSource`-gated `assume_verified`, `from_verified_parts` is `pub(crate)`), that decode paths never panic on truncated or adversarial input (cursor underrun checks, `split_first_chunk`, post-decode slicing), and that the wire format is byte-for-byte unchanged and guarded by an old-encoder/new-decoder interop test.

This PR targets `s202/22-chunk-registry` as part of the chunk-registry stack; no CI beyond CLA will run until it is retargeted onto that branch's own base.

Closes #197

## AI Assistance

This change was implemented, red-teamed and independently verified with Claude (Anthropic), per the AI-assistance disclosure required by [nxm-rs/.github CONTRIBUTING.md](https://github.com/nxm-rs/.github/blob/main/CONTRIBUTING.md).

