### PR TITLE
feat(primitives): key store traits by ChunkRegistry with per-backend trust

### DIFF
--- a/crates/mantaray/benches/mantaray_bench.rs
+++ b/crates/mantaray/benches/mantaray_bench.rs
@@ -17,10 +17,10 @@ use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use futures::executor::block_on;
 use nectar_mantaray::hazmat;
 use nectar_mantaray::{MemoryStore, PlainManifest};
-use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
+use nectar_primitives::StandardChunkSet;
 use nectar_primitives::chunk::ChunkAddress;
 
-type Store = MemoryStore<DEFAULT_BODY_SIZE>;
+type Store = MemoryStore<StandardChunkSet>;
 
 /// Create a ChunkAddress from a path, left-padded with zeroes.
 fn make_addr(path: &[u8]) -> ChunkAddress {

--- a/crates/mantaray/src/builder.rs
+++ b/crates/mantaray/src/builder.rs
@@ -41,7 +41,8 @@ use alloc::collections::BTreeMap;
 use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{ChunkAddress, ChunkRef, Reference};
 use nectar_primitives::file::{ChunkPutExt, ReadAt};
-use nectar_primitives::store::{ChunkGet, ChunkPut, MaybeSend};
+use nectar_primitives::store::{ChunkPut, MaybeSend, TrustedStore};
+use nectar_primitives::{AnyChunkSet, Chunk};
 
 use crate::entry::Entry;
 use crate::manifest::Manifest;
@@ -93,7 +94,9 @@ impl<S, R: Reference, const BS: usize> ManifestBuilder<S, R, BS> {
     }
 }
 
-impl<S: ChunkGet<BS>, R: Reference + MaybeSend, const BS: usize> ManifestBuilder<S, R, BS> {
+impl<S: TrustedStore<AnyChunkSet<BS>>, R: Reference + MaybeSend, const BS: usize>
+    ManifestBuilder<S, R, BS>
+{
     /// Stage a path with a typed reference.
     pub async fn add(&mut self, path: &str, reference: impl Into<R>) -> Result<()> {
         self.manifest.add(path, reference).await
@@ -135,7 +138,9 @@ impl<S: ChunkGet<BS>, R: Reference + MaybeSend, const BS: usize> ManifestBuilder
     }
 }
 
-impl<S: ChunkGet<BS> + ChunkPut<BS>, const BS: usize> ManifestBuilder<S, ChunkRef, BS> {
+impl<S: TrustedStore<AnyChunkSet<BS>> + ChunkPut<AnyChunkSet<BS>>, const BS: usize>
+    ManifestBuilder<S, ChunkRef, BS>
+{
     /// Split `data`, store its chunks, and stage the resulting root at `path`.
     ///
     /// One mode end to end: a plain builder splits in plain mode and stages a
@@ -156,7 +161,7 @@ impl<S: ChunkGet<BS> + ChunkPut<BS>, const BS: usize> ManifestBuilder<S, ChunkRe
 }
 
 #[cfg(feature = "encryption")]
-impl<S: ChunkGet<BS> + ChunkPut<BS>, const BS: usize>
+impl<S: TrustedStore<AnyChunkSet<BS>> + ChunkPut<AnyChunkSet<BS>>, const BS: usize>
     ManifestBuilder<S, nectar_primitives::EncryptedChunkRef, BS>
 {
     /// Split `data` in encrypted mode, store its chunks, and stage the root at `path`.
@@ -173,13 +178,14 @@ impl<S: ChunkGet<BS> + ChunkPut<BS>, const BS: usize>
         let (root, chunks) = EncryptedParallelSplitter::<BS>::split_to_vec(&data)?;
         drop(data);
         for chunk in chunks {
-            self.store().put(chunk).await.map_err(FileError::store)?;
+            let sealed: Chunk<_, AnyChunkSet<BS>> = Chunk::from_envelope(chunk)?;
+            self.store().put(sealed).await.map_err(FileError::store)?;
         }
         self.add(path, root).await
     }
 }
 
-impl<S: ChunkGet<BS> + ChunkPut<BS>, const BS: usize>
+impl<S: TrustedStore<AnyChunkSet<BS>> + ChunkPut<AnyChunkSet<BS>>, const BS: usize>
     ManifestBuilder<S, nectar_primitives::EncryptedChunkRef, BS>
 {
     /// Persist the encrypted manifest, consuming the builder.
@@ -201,6 +207,7 @@ impl<S: ChunkGet<BS> + ChunkPut<BS>, const BS: usize>
 #[cfg(test)]
 mod tests {
     use futures::executor::block_on;
+    use nectar_primitives::StandardChunkSet;
     use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
     use nectar_primitives::chunk::ChunkAddress;
     use nectar_primitives::store::MemoryStore;
@@ -208,7 +215,7 @@ mod tests {
     use super::*;
     use crate::metadata;
 
-    type Store = MemoryStore<DEFAULT_BODY_SIZE>;
+    type Store = MemoryStore<StandardChunkSet>;
 
     fn make_addr(s: &str) -> ChunkAddress {
         let bytes = s.as_bytes();

--- a/crates/mantaray/src/lib.rs
+++ b/crates/mantaray/src/lib.rs
@@ -161,7 +161,7 @@ pub mod hazmat {
 
 // Re-export typed storage traits from primitives.
 pub use nectar_primitives::DefaultMemoryStore;
-pub use nectar_primitives::store::{ChunkGet, ChunkHas, ChunkPut, MemoryStore};
+pub use nectar_primitives::store::{ChunkGet, ChunkHas, ChunkPut, MemoryStore, TrustedStore};
 
 /// Default manifest type using [`DEFAULT_BODY_SIZE`] and plain mode.
 pub type DefaultManifest<S> = PlainManifest<S, DEFAULT_BODY_SIZE>;

--- a/crates/mantaray/src/manifest.rs
+++ b/crates/mantaray/src/manifest.rs
@@ -3,10 +3,11 @@
 use alloc::collections::BTreeMap;
 
 use futures::{Stream, StreamExt, TryStreamExt, stream};
+use nectar_primitives::AnyChunkSet;
 use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{ChunkAddress, ChunkRef, Reference};
 use nectar_primitives::file::join;
-use nectar_primitives::store::{ChunkGet, ChunkPut, MaybeSend};
+use nectar_primitives::store::{ChunkPut, MaybeSend, TrustedStore};
 
 use crate::entry::Entry;
 use crate::node::Node;
@@ -95,7 +96,9 @@ impl<S, R: Reference, const BS: usize> Manifest<S, R, BS> {
     }
 }
 
-impl<S: ChunkGet<BS>, R: Reference + MaybeSend, const BS: usize> Manifest<S, R, BS> {
+impl<S: TrustedStore<AnyChunkSet<BS>>, R: Reference + MaybeSend, const BS: usize>
+    Manifest<S, R, BS>
+{
     /// Add a path with a typed reference (compile-time enforced by entry type).
     pub async fn add(&mut self, path: &str, reference: impl Into<R>) -> Result<()> {
         let entry = reference.into();
@@ -372,7 +375,7 @@ impl<S: ChunkGet<BS>, R: Reference + MaybeSend, const BS: usize> Manifest<S, R, 
     }
 }
 
-impl<S: ChunkGet<BS>, const BS: usize> Manifest<S, ChunkRef, BS> {
+impl<S: TrustedStore<AnyChunkSet<BS>>, const BS: usize> Manifest<S, ChunkRef, BS> {
     /// Look up `path` and join the file it references into memory.
     ///
     /// Shared-read (`&self`); `None` when the path is absent or is not a value.
@@ -392,7 +395,9 @@ impl<S: ChunkGet<BS>, const BS: usize> Manifest<S, ChunkRef, BS> {
     }
 }
 
-impl<S: ChunkGet<BS> + ChunkPut<BS>, const BS: usize> Manifest<S, ChunkRef, BS> {
+impl<S: TrustedStore<AnyChunkSet<BS>> + ChunkPut<AnyChunkSet<BS>>, const BS: usize>
+    Manifest<S, ChunkRef, BS>
+{
     /// Persist the plain manifest trie to storage, returning the root chunk address.
     pub async fn save(&mut self) -> Result<ChunkAddress> {
         self.trie.save::<S, BS>(&self.store).await?;
@@ -405,7 +410,9 @@ impl<S: ChunkGet<BS> + ChunkPut<BS>, const BS: usize> Manifest<S, ChunkRef, BS> 
 }
 
 #[cfg(feature = "encryption")]
-impl<S: ChunkGet<BS>, const BS: usize> Manifest<S, nectar_primitives::EncryptedChunkRef, BS> {
+impl<S: TrustedStore<AnyChunkSet<BS>>, const BS: usize>
+    Manifest<S, nectar_primitives::EncryptedChunkRef, BS>
+{
     /// Look up `path` and join the encrypted file it references into memory.
     ///
     /// Shared-read (`&self`); `None` when the path is absent or is not a value.
@@ -426,7 +433,7 @@ impl<S: ChunkGet<BS>, const BS: usize> Manifest<S, nectar_primitives::EncryptedC
     }
 }
 
-impl<S: ChunkGet<BS> + ChunkPut<BS>, const BS: usize>
+impl<S: TrustedStore<AnyChunkSet<BS>> + ChunkPut<AnyChunkSet<BS>>, const BS: usize>
     Manifest<S, nectar_primitives::EncryptedChunkRef, BS>
 {
     /// Persist the encrypted manifest trie, returning a [`ManifestRef`](crate::ManifestRef).
@@ -484,7 +491,9 @@ struct IterFrame<R: Reference> {
     key_idx: usize,
 }
 
-impl<'a, S: ChunkGet<BS>, R: Reference, const BS: usize> ManifestIter<'a, S, R, BS> {
+impl<'a, S: TrustedStore<AnyChunkSet<BS>>, R: Reference, const BS: usize>
+    ManifestIter<'a, S, R, BS>
+{
     pub(crate) const fn new(trie: &'a mut Node<R>, store: &'a S) -> Self {
         Self {
             trie,
@@ -614,7 +623,7 @@ struct SharedFrame<R: Reference> {
     key_idx: usize,
 }
 
-impl<'a, S: ChunkGet<BS>, R: Reference, const BS: usize> SharedIter<'a, S, R, BS> {
+impl<'a, S: TrustedStore<AnyChunkSet<BS>>, R: Reference, const BS: usize> SharedIter<'a, S, R, BS> {
     const fn new(root: Node<R>, store: &'a S) -> Self {
         Self {
             store,
@@ -710,15 +719,16 @@ mod tests {
     use futures::executor::block_on;
     use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
     use nectar_primitives::chunk::ChunkAddress;
-    use nectar_primitives::store::MemoryStore;
+    use nectar_primitives::store::{ChunkGet, MemoryStore};
+    use nectar_primitives::{StandardChunkSet, Verified};
 
     use super::*;
 
-    type Store = MemoryStore<DEFAULT_BODY_SIZE>;
+    type Store = MemoryStore<StandardChunkSet>;
     type PlainManifest<S, const BS: usize = DEFAULT_BODY_SIZE> = super::Manifest<S, ChunkRef, BS>;
 
     /// Drain an async manifest iterator into a `Vec`, propagating the first error.
-    fn drain<S: ChunkGet<BS>, R: Reference, const BS: usize>(
+    fn drain<S: TrustedStore<AnyChunkSet<BS>>, R: Reference, const BS: usize>(
         mut iter: ManifestIter<'_, S, R, BS>,
     ) -> Result<Vec<Entry>> {
         block_on(async move {
@@ -1097,14 +1107,14 @@ mod tests {
         .await;
     }
 
-    impl ChunkGet<DEFAULT_BODY_SIZE> for TrackingStore {
-        type Error = <Store as ChunkGet<DEFAULT_BODY_SIZE>>::Error;
+    impl ChunkGet<StandardChunkSet> for TrackingStore {
+        type Trust = Verified;
+        type Error = <Store as ChunkGet<StandardChunkSet>>::Error;
 
         async fn get(
             &self,
             address: &ChunkAddress,
-        ) -> core::result::Result<nectar_primitives::chunk::AnyChunk<DEFAULT_BODY_SIZE>, Self::Error>
-        {
+        ) -> core::result::Result<nectar_primitives::Chunk, Self::Error> {
             use core::sync::atomic::Ordering::SeqCst;
             self.gets.fetch_add(1, SeqCst);
             let cur = self.inflight.fetch_add(1, SeqCst) + 1;
@@ -1371,7 +1381,7 @@ mod tests {
         block_on(m.add("a.txt", make_addr("a"))).unwrap();
 
         // All read accessors are callable through a shared borrow.
-        fn read_all<S: ChunkGet<DEFAULT_BODY_SIZE>>(m: &PlainManifest<S>) {
+        fn read_all<S: TrustedStore<StandardChunkSet>>(m: &PlainManifest<S>) {
             assert!(block_on(m.get("a.txt")).unwrap().is_some());
             assert_eq!(block_on(m.entries()).unwrap().len(), 2);
             assert_eq!(
@@ -1406,16 +1416,14 @@ mod tests {
             count: AtomicUsize,
         }
 
-        impl ChunkGet<DEFAULT_BODY_SIZE> for FailOnceStore {
+        impl ChunkGet<StandardChunkSet> for FailOnceStore {
+            type Trust = Verified;
             type Error = nectar_primitives::store::ChunkStoreError;
 
             async fn get(
                 &self,
                 address: &ChunkAddress,
-            ) -> core::result::Result<
-                nectar_primitives::chunk::AnyChunk<DEFAULT_BODY_SIZE>,
-                Self::Error,
-            > {
+            ) -> core::result::Result<nectar_primitives::Chunk, Self::Error> {
                 let n = self.count.fetch_add(1, Ordering::SeqCst) + 1;
                 if n == self.fail_on {
                     // Force a miss to surface a load error mid-traversal.

--- a/crates/mantaray/src/node.rs
+++ b/crates/mantaray/src/node.rs
@@ -9,9 +9,9 @@ use crate::obfuscation::ObfuscationKey;
 use crate::{PATH_SEPARATOR, PREFIX_MAX_LEN};
 use bytes::Bytes;
 use nectar_primitives::chunk::{ChunkAddress, ChunkOps, ChunkRef, ContentChunk, Reference};
-use nectar_primitives::store::{ChunkGet, ChunkPut, MaybeSend};
+use nectar_primitives::store::{ChunkPut, MaybeSend, TrustedStore};
 use nectar_primitives::wire::{Cursor, FromCursor, ToWriter, Writer};
-use nectar_primitives::{EncryptedChunkRef, EncryptionKey};
+use nectar_primitives::{AnyChunkSet, Chunk, EncryptedChunkRef, EncryptionKey};
 
 /// Boxed recursion future: `Send` on native, unbounded on wasm32 so `!Send`
 /// browser stores stay usable. `MaybeSend` cannot appear in a `dyn` bound
@@ -397,7 +397,10 @@ impl<R: Reference> Node<R> {
     }
 
     /// Load forks from storage if the node hasn't been loaded yet.
-    async fn ensure_loaded<S: ChunkGet<BS>, const BS: usize>(&mut self, store: &S) -> Result<()> {
+    async fn ensure_loaded<S: TrustedStore<AnyChunkSet<BS>>, const BS: usize>(
+        &mut self,
+        store: &S,
+    ) -> Result<()> {
         if !self.is_loaded() {
             self.load(store).await?;
         }
@@ -405,7 +408,10 @@ impl<R: Reference> Node<R> {
     }
 
     /// Load this node from storage by its reference.
-    pub(crate) async fn load<S: ChunkGet<BS>, const BS: usize>(&mut self, store: &S) -> Result<()> {
+    pub(crate) async fn load<S: TrustedStore<AnyChunkSet<BS>>, const BS: usize>(
+        &mut self,
+        store: &S,
+    ) -> Result<()> {
         let reference = match &self.state {
             NodeState::Stub(reference) | NodeState::Clean(reference) => reference.clone(),
             // A dirty node holds its content in memory; nothing to fetch.
@@ -419,7 +425,7 @@ impl<R: Reference> Node<R> {
             .map_err(|e| MantarayError::StoreGet {
                 source: alloc::sync::Arc::new(e),
             })?;
-        let mut loaded = Self::decode(chunk.data().as_ref())
+        let mut loaded = Self::decode(chunk.envelope().data().as_ref())
             .map_err(|source| MantarayError::Corrupt { address, source })?;
         loaded.mark_persisted(reference);
         // Preserve fields that live in the parent's fork data, not in this node's chunk:
@@ -432,7 +438,7 @@ impl<R: Reference> Node<R> {
 
     /// Look up the node at the given path, loading from storage as needed.
     #[allow(clippy::indexing_slicing)] // `rest` is checked non-empty before `rest[0]`; `c <= rest.len()` from common_prefix_len
-    pub(crate) async fn lookup_node<S: ChunkGet<BS>, const BS: usize>(
+    pub(crate) async fn lookup_node<S: TrustedStore<AnyChunkSet<BS>>, const BS: usize>(
         &mut self,
         path: &[u8],
         store: &S,
@@ -470,7 +476,7 @@ impl<R: Reference> Node<R> {
     /// `&self` and clones each descended fork, so reading a persisted manifest
     /// leaves the trie untouched. Returns `None` for an absent path.
     #[allow(clippy::indexing_slicing)] // `rest` is checked non-empty before `rest[0]`; `c <= rest.len()` from common_prefix_len
-    pub(crate) async fn get_node<S: ChunkGet<BS>, const BS: usize>(
+    pub(crate) async fn get_node<S: TrustedStore<AnyChunkSet<BS>>, const BS: usize>(
         &self,
         path: &[u8],
         store: &S,
@@ -502,7 +508,7 @@ impl<R: Reference> Node<R> {
 
     /// Look up the entry at the given path, loading from storage as needed.
     #[cfg(test)]
-    pub(crate) async fn lookup<S: ChunkGet<BS>, const BS: usize>(
+    pub(crate) async fn lookup<S: TrustedStore<AnyChunkSet<BS>>, const BS: usize>(
         &mut self,
         path: &[u8],
         store: &S,
@@ -525,7 +531,7 @@ impl<R: Reference> Node<R> {
     // <= min(prefix.len(), path.len()), bounding every split; the fork at
     // `path[0]` is checked present (`contains_key`) before each get/expect.
     #[allow(clippy::indexing_slicing, clippy::expect_used)]
-    pub(crate) fn add<'a, S: ChunkGet<BS>, const BS: usize>(
+    pub(crate) fn add<'a, S: TrustedStore<AnyChunkSet<BS>>, const BS: usize>(
         &'a mut self,
         path: &'a [u8],
         entry: Option<R>,
@@ -655,7 +661,7 @@ impl<R: Reference> Node<R> {
     // `path.starts_with(&prefix)` guarantees `prefix.len() <= path.len()`;
     // the fork at `first` is checked present before the get_mut/expect.
     #[allow(clippy::indexing_slicing, clippy::expect_used)]
-    pub(crate) fn remove<'a, S: ChunkGet<BS>, const BS: usize>(
+    pub(crate) fn remove<'a, S: TrustedStore<AnyChunkSet<BS>>, const BS: usize>(
         &'a mut self,
         path: &'a [u8],
         store: &'a S,
@@ -705,7 +711,7 @@ impl<R: Reference> Node<R> {
 
     /// Test whether a prefix exists in the trie, loading from storage as needed.
     #[allow(clippy::indexing_slicing)] // `rest` is checked non-empty before `rest[0]`; `c <= rest.len()` from common_prefix_len
-    pub(crate) async fn has_prefix<S: ChunkGet<BS>, const BS: usize>(
+    pub(crate) async fn has_prefix<S: TrustedStore<AnyChunkSet<BS>>, const BS: usize>(
         &mut self,
         path: &[u8],
         store: &S,
@@ -747,7 +753,10 @@ impl<R: Reference> Node<R> {
     /// recursion: each frame visits its forks (pushing unsaved children) before
     /// the node itself is encoded and put.
     #[allow(clippy::arithmetic_side_effects)] // the only arithmetic is the fork-cursor `key_idx += 1`, bounded by keys.len() <= 256
-    pub(crate) async fn save<S: ChunkPut<BS>, const BS: usize>(&mut self, store: &S) -> Result<()>
+    pub(crate) async fn save<S: ChunkPut<AnyChunkSet<BS>>, const BS: usize>(
+        &mut self,
+        store: &S,
+    ) -> Result<()>
     where
         R: StoredReference,
     {
@@ -799,8 +808,9 @@ impl<R: Reference> Node<R> {
             let data = node.encode()?;
             let chunk = ContentChunk::<BS>::new(Bytes::from(data))?;
             let address = *chunk.address();
+            let sealed: Chunk<_, AnyChunkSet<BS>> = Chunk::from_envelope(chunk.into())?;
             store
-                .put(chunk.into())
+                .put(sealed)
                 .await
                 .map_err(|e| MantarayError::StorePut {
                     source: alloc::sync::Arc::new(e),
@@ -816,7 +826,7 @@ impl<R: Reference> Node<R> {
     }
 
     /// Walk all nodes depth-first, calling `f` for each node with its path.
-    pub(crate) async fn walk<S: ChunkGet<BS>, const BS: usize, F>(
+    pub(crate) async fn walk<S: TrustedStore<AnyChunkSet<BS>>, const BS: usize, F>(
         &mut self,
         store: &S,
         f: &mut F,
@@ -829,7 +839,7 @@ impl<R: Reference> Node<R> {
     }
 
     /// Walk the subtree at `root`, calling `f` for each node.
-    pub(crate) async fn walk_from<S: ChunkGet<BS>, const BS: usize, F>(
+    pub(crate) async fn walk_from<S: TrustedStore<AnyChunkSet<BS>>, const BS: usize, F>(
         &mut self,
         root: &[u8],
         store: &S,
@@ -852,7 +862,7 @@ impl<R: Reference> Node<R> {
 ///
 /// The visitor `f` only reads loaded nodes, so it stays a synchronous `FnMut`.
 #[allow(clippy::arithmetic_side_effects)] // the only arithmetic is the fork-cursor `key_idx += 1`, bounded by keys.len() <= 256
-async fn walk_inner<R: Reference, S: ChunkGet<BS>, const BS: usize, F>(
+async fn walk_inner<R: Reference, S: TrustedStore<AnyChunkSet<BS>>, const BS: usize, F>(
     path_buf: &mut Vec<u8>,
     node: &mut Node<R>,
     store: &S,
@@ -1049,6 +1059,7 @@ mod arbitrary_impls {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nectar_primitives::StandardChunkSet;
     use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
     use nectar_primitives::store::{MemoryStore, NullLoader};
 
@@ -1440,7 +1451,7 @@ mod tests {
             node_add(&mut n, c.as_bytes(), e, BTreeMap::new());
         }
 
-        let store = MemoryStore::<{ DEFAULT_BODY_SIZE }>::new();
+        let store = MemoryStore::<StandardChunkSet>::new();
         block_on(n.save(&store)).unwrap();
 
         let mut n2: Node = Node::from_reference(*n.reference().unwrap());
@@ -1462,8 +1473,8 @@ mod tests {
         let chunk = ContentChunk::<{ DEFAULT_BODY_SIZE }>::new(Bytes::from(vec![1u8; 8])).unwrap();
         let address = *chunk.address();
 
-        let store = MemoryStore::<{ DEFAULT_BODY_SIZE }>::new();
-        block_on(store.put(chunk.into())).unwrap();
+        let store = MemoryStore::<StandardChunkSet>::new();
+        block_on(store.put(Chunk::from_envelope(chunk.into()).unwrap())).unwrap();
 
         let mut node: Node = Node::from_reference(ChunkRef::from(address));
         let err = block_on(node.load(&store)).unwrap_err();
@@ -1565,7 +1576,7 @@ mod tests {
     // Tests save->reload->remove->save->reload->verify-removed cycle.
 
     fn run_persist_remove(tc: RemoveTestCase) {
-        let store = MemoryStore::<{ DEFAULT_BODY_SIZE }>::new();
+        let store = MemoryStore::<StandardChunkSet>::new();
 
         // add entries and persist
         let mut n = Node::default();
@@ -1756,7 +1767,7 @@ mod tests {
             node_add(&mut n, path, entry, BTreeMap::new());
         }
 
-        let store = MemoryStore::<{ DEFAULT_BODY_SIZE }>::new();
+        let store = MemoryStore::<StandardChunkSet>::new();
         block_on(n.save(&store)).unwrap();
 
         let mut n2: Node = Node::from_reference(*n.reference().unwrap());

--- a/crates/mantaray/tests/file_manifest_integration.rs
+++ b/crates/mantaray/tests/file_manifest_integration.rs
@@ -14,12 +14,12 @@
 )]
 use futures::executor::block_on;
 use nectar_mantaray::PlainManifest;
-use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
+use nectar_primitives::StandardChunkSet;
 use nectar_primitives::chunk::ChunkAddress;
 use nectar_primitives::file::{ChunkPutExt, join};
 use nectar_primitives::store::MemoryStore;
 
-type Store = MemoryStore<DEFAULT_BODY_SIZE>;
+type Store = MemoryStore<StandardChunkSet>;
 
 /// Split files into a MemoryStore, create a manifest in the same store,
 /// then verify lookup and round-trip.

--- a/crates/postage-issuer/benches/upload_pipeline.rs
+++ b/crates/postage-issuer/benches/upload_pipeline.rs
@@ -31,9 +31,8 @@ use rand::{Rng, rng};
 use nectar_postage_issuer::{
     BatchId, BatchStamper, MemoryIssuer, ShardedIssuer, SigningError, Stamper, sign_stamps_parallel,
 };
-use nectar_primitives::DEFAULT_BODY_SIZE;
 use nectar_primitives::file::{ParallelSplitter, Splitter};
-use nectar_primitives::store::MemoryStore;
+use nectar_primitives::{ChunkOps, DEFAULT_BODY_SIZE};
 
 /// File sizes to benchmark, representing realistic upload scenarios.
 const SIZES: &[(u64, &str)] = &[
@@ -78,16 +77,14 @@ fn bench_pipeline_mock_sequential(c: &mut Criterion) {
                 let mut splitter = Splitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
                 splitter.write_all(data).unwrap();
                 let (root, chunks) = splitter.finish().unwrap();
-                let store = MemoryStore::from_chunks(chunks);
 
                 // Stamp each chunk
                 let issuer = MemoryIssuer::new(BatchId::ZERO, 32, 16);
                 let mut stamper = BatchStamper::new(issuer, MockSigner);
 
-                let chunks = store.into_chunks();
                 let stamps: Vec<_> = chunks
-                    .keys()
-                    .map(|addr| stamper.stamp(addr).unwrap())
+                    .iter()
+                    .map(|chunk| stamper.stamp(chunk.address()).unwrap())
                     .collect();
 
                 black_box((root, stamps))
@@ -112,16 +109,14 @@ fn bench_pipeline_mock_parallel_split(c: &mut Criterion) {
                 // Parallel split
                 let (root, chunks) =
                     ParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap();
-                let store = MemoryStore::from_chunks(chunks);
 
                 // Stamp each chunk (sequential)
                 let issuer = MemoryIssuer::new(BatchId::ZERO, 32, 16);
                 let mut stamper = BatchStamper::new(issuer, MockSigner);
 
-                let chunks = store.into_chunks();
                 let stamps: Vec<_> = chunks
-                    .keys()
-                    .map(|addr| stamper.stamp(addr).unwrap())
+                    .iter()
+                    .map(|chunk| stamper.stamp(chunk.address()).unwrap())
                     .collect();
 
                 black_box((root, stamps))
@@ -151,16 +146,14 @@ fn bench_pipeline_ecdsa_sequential(c: &mut Criterion) {
                 let mut splitter = Splitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
                 splitter.write_all(data).unwrap();
                 let (root, chunks) = splitter.finish().unwrap();
-                let store = MemoryStore::from_chunks(chunks);
 
                 // Stamp each chunk with real signatures
                 let issuer = MemoryIssuer::new(BatchId::ZERO, 32, 16);
                 let mut stamper = BatchStamper::new(issuer, &signer);
 
-                let chunks = store.into_chunks();
                 let stamps: Vec<_> = chunks
-                    .keys()
-                    .map(|addr| stamper.stamp(addr).unwrap())
+                    .iter()
+                    .map(|chunk| stamper.stamp(chunk.address()).unwrap())
                     .collect();
 
                 black_box((root, stamps))
@@ -195,11 +188,9 @@ fn bench_pipeline_fully_parallel(c: &mut Criterion) {
                 // Parallel split
                 let (root, chunks) =
                     ParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap();
-                let store = MemoryStore::from_chunks(chunks);
 
                 // Collect addresses for parallel signing
-                let chunks = store.into_chunks();
-                let addresses: Vec<_> = chunks.keys().copied().collect();
+                let addresses: Vec<_> = chunks.iter().map(|c| *c.address()).collect();
 
                 // Parallel stamp signing
                 let issuer = ShardedIssuer::new(BatchId::ZERO, 32, 16);
@@ -236,15 +227,13 @@ fn bench_pipeline_comparison(c: &mut Criterion) {
             let mut splitter = Splitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
             splitter.write_all(&data).unwrap();
             let (root, chunks) = splitter.finish().unwrap();
-            let store = MemoryStore::from_chunks(chunks);
 
             let issuer = MemoryIssuer::new(BatchId::ZERO, 32, 16);
             let mut stamper = BatchStamper::new(issuer, &signer);
 
-            let chunks = store.into_chunks();
             let stamps: Vec<_> = chunks
-                .keys()
-                .map(|addr| stamper.stamp(addr).unwrap())
+                .iter()
+                .map(|chunk| stamper.stamp(chunk.address()).unwrap())
                 .collect();
 
             black_box((root, stamps))
@@ -256,15 +245,13 @@ fn bench_pipeline_comparison(c: &mut Criterion) {
         b.iter(|| {
             let (root, chunks) =
                 ParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(&data).unwrap();
-            let store = MemoryStore::from_chunks(chunks);
 
             let issuer = MemoryIssuer::new(BatchId::ZERO, 32, 16);
             let mut stamper = BatchStamper::new(issuer, &signer);
 
-            let chunks = store.into_chunks();
             let stamps: Vec<_> = chunks
-                .keys()
-                .map(|addr| stamper.stamp(addr).unwrap())
+                .iter()
+                .map(|chunk| stamper.stamp(chunk.address()).unwrap())
                 .collect();
 
             black_box((root, stamps))
@@ -276,10 +263,8 @@ fn bench_pipeline_comparison(c: &mut Criterion) {
         b.iter(|| {
             let (root, chunks) =
                 ParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(&data).unwrap();
-            let store = MemoryStore::from_chunks(chunks);
 
-            let chunks = store.into_chunks();
-            let addresses: Vec<_> = chunks.keys().copied().collect();
+            let addresses: Vec<_> = chunks.iter().map(|c| *c.address()).collect();
 
             let issuer = ShardedIssuer::new(BatchId::ZERO, 32, 16);
             let stamps = sign_stamps_parallel(&issuer, &sign_fn, &addresses);
@@ -320,9 +305,7 @@ fn bench_pipeline_stages(c: &mut Criterion) {
     let mut splitter = Splitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
     splitter.write_all(&data).unwrap();
     let (_, chunks) = splitter.finish().unwrap();
-    let store = MemoryStore::from_chunks(chunks);
-    let chunks = store.into_chunks();
-    let addresses: Vec<_> = chunks.keys().copied().collect();
+    let addresses: Vec<_> = chunks.iter().map(|c| *c.address()).collect();
     let num_chunks = addresses.len();
 
     group.throughput(Throughput::Elements(num_chunks as u64));

--- a/crates/primitives/benches/encryption_bench.rs
+++ b/crates/primitives/benches/encryption_bench.rs
@@ -21,7 +21,7 @@ use rand::{Rng, rng};
 use nectar_primitives::chunk::encryption::{
     self, ChunkEncrypt, EncryptionKey, transcrypt, transcrypt_in_place,
 };
-use nectar_primitives::chunk::{AnyChunk, ChunkAddress};
+use nectar_primitives::chunk::{Chunk, ChunkAddress};
 use nectar_primitives::file::{
     EncryptedJoiner, EncryptedParallelSplitter, EncryptedSplitter, Joiner, ParallelSplitter,
     Splitter, split, split_encrypted,
@@ -144,17 +144,14 @@ fn random_data(size: u64) -> Vec<u8> {
     data
 }
 
-fn split_to_store(data: &[u8]) -> (ChunkAddress, HashMap<ChunkAddress, AnyChunk>) {
+fn split_to_store(data: &[u8]) -> (ChunkAddress, HashMap<ChunkAddress, Chunk>) {
     let (root, store) = split::<DEFAULT_BODY_SIZE>(data).unwrap();
     (root, store.into_chunks())
 }
 
 fn encrypted_split_to_store(
     data: &[u8],
-) -> (
-    encryption::EncryptedChunkRef,
-    HashMap<ChunkAddress, AnyChunk>,
-) {
+) -> (encryption::EncryptedChunkRef, HashMap<ChunkAddress, Chunk>) {
     let (root_ref, store) = split_encrypted::<DEFAULT_BODY_SIZE>(data).unwrap();
     (root_ref, store.into_chunks())
 }
@@ -340,7 +337,9 @@ fn bench_encrypted_roundtrip(c: &mut Criterion) {
             b.iter(|| {
                 let (root_ref, chunks) =
                     EncryptedParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap();
-                let store = MemoryStore::from_chunks(chunks);
+                let store = MemoryStore::from_chunks(
+                    chunks.into_iter().map(|c| Chunk::from_envelope(c).unwrap()),
+                );
                 let joiner = block_on(EncryptedJoiner::new(store, root_ref)).unwrap();
                 black_box(block_on(joiner.read_all()).unwrap())
             });

--- a/crates/primitives/benches/file_bench.rs
+++ b/crates/primitives/benches/file_bench.rs
@@ -26,7 +26,7 @@ use rand::{Rng, rng};
 use futures::executor::block_on;
 
 use nectar_primitives::DEFAULT_BODY_SIZE;
-use nectar_primitives::chunk::{AnyChunk, ChunkAddress};
+use nectar_primitives::chunk::{Chunk, ChunkAddress};
 use nectar_primitives::file::{Joiner, ParallelSplitter, Splitter, split};
 use nectar_primitives::store::MemoryStore;
 
@@ -58,7 +58,7 @@ fn random_data(size: u64) -> Vec<u8> {
     data
 }
 
-fn split_to_store(data: &[u8]) -> (ChunkAddress, HashMap<ChunkAddress, AnyChunk>) {
+fn split_to_store(data: &[u8]) -> (ChunkAddress, HashMap<ChunkAddress, Chunk>) {
     let (root, store) = split::<DEFAULT_BODY_SIZE>(data).unwrap();
     (root, store.into_chunks())
 }
@@ -218,7 +218,9 @@ fn bench_roundtrip(c: &mut Criterion) {
             b.iter(|| {
                 let (root, chunks) =
                     ParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap();
-                let store = MemoryStore::from_chunks(chunks);
+                let store = MemoryStore::from_chunks(
+                    chunks.into_iter().map(|c| Chunk::from_envelope(c).unwrap()),
+                );
                 let joiner = block_on(Joiner::new(store, root)).unwrap();
                 black_box(block_on(joiner.read_all()).unwrap())
             });

--- a/crates/primitives/src/chunk/mod.rs
+++ b/crates/primitives/src/chunk/mod.rs
@@ -61,7 +61,9 @@ pub use reference::{ChunkRef, RefKind, Reference, WrongRefKind};
 // Re-export the type system
 pub use any_chunk::AnyChunk;
 pub use chunk_type::ChunkType;
-pub use registry::{ChunkRegistry, ChunkTypeInfo, ContentOnlyChunkSet, StandardChunkSet};
+pub use registry::{
+    AnyChunkSet, ChunkRegistry, ChunkTypeInfo, ContentOnlyChunkSet, StandardChunkSet,
+};
 pub use type_id::ChunkTypeId;
 pub use type_tag::{ChunkTypeTag, ChunkVersion, TagWireError};
 

--- a/crates/primitives/src/chunk/registry.rs
+++ b/crates/primitives/src/chunk/registry.rs
@@ -6,6 +6,7 @@
 
 use bytes::Bytes;
 
+use crate::bmt::DEFAULT_BODY_SIZE;
 use crate::error::Result;
 
 use super::address::ChunkAddress;
@@ -145,13 +146,17 @@ pub trait ChunkRegistry: Send + Sync + 'static {
     fn encode_typed(chunk: &Self::Envelope) -> Vec<u8>;
 }
 
-/// Standard Swarm registry: content-addressed and single-owner chunks at the
-/// default body size, carried in [`AnyChunk`].
+/// Registry of content-addressed and single-owner chunks at body size
+/// `BODY_SIZE`, carried in [`AnyChunk`]. The registry carries the body size
+/// so no store trait restates it.
 #[derive(Debug, Clone, Copy, Default)]
-pub struct StandardChunkSet;
+pub struct AnyChunkSet<const BODY_SIZE: usize = DEFAULT_BODY_SIZE>;
 
-impl ChunkRegistry for StandardChunkSet {
-    type Envelope = AnyChunk;
+/// Standard Swarm registry: [`AnyChunkSet`] at the default body size.
+pub type StandardChunkSet = AnyChunkSet<DEFAULT_BODY_SIZE>;
+
+impl<const BODY_SIZE: usize> ChunkRegistry for AnyChunkSet<BODY_SIZE> {
+    type Envelope = AnyChunk<BODY_SIZE>;
 
     const MEMBERS: &'static [ChunkTypeInfo] = &[
         ChunkTypeInfo::of::<CacHeader>(),
@@ -159,11 +164,11 @@ impl ChunkRegistry for StandardChunkSet {
     ];
 
     fn parse_typed(bytes: &[u8]) -> Result<Self::Envelope> {
-        AnyChunk::parse_typed(bytes)
+        AnyChunk::<BODY_SIZE>::parse_typed(bytes)
     }
 
     fn decode_wire(address: &ChunkAddress, data: Bytes) -> Result<Self::Envelope> {
-        AnyChunk::from_wire_bytes(address, data)
+        AnyChunk::<BODY_SIZE>::from_wire_bytes(address, data)
     }
 
     fn encode_typed(chunk: &Self::Envelope) -> Vec<u8> {

--- a/crates/primitives/src/chunk/wasm.rs
+++ b/crates/primitives/src/chunk/wasm.rs
@@ -123,7 +123,11 @@ pub fn split_file(data: &Uint8Array) -> Result<WasmSplitResult, JsValue> {
 
     Ok(WasmSplitResult {
         root: root.into(),
-        chunks: store.into_chunks().into_values().collect(),
+        chunks: store
+            .into_chunks()
+            .into_values()
+            .map(|c| c.into_envelope())
+            .collect(),
     })
 }
 

--- a/crates/primitives/src/file/fold.rs
+++ b/crates/primitives/src/file/fold.rs
@@ -15,11 +15,12 @@ use futures::stream::StreamExt;
 use super::error::Result;
 use super::joiner::GenericJoiner;
 use super::mode::JoinMode;
-use crate::store::{ChunkGet, MaybeSend};
+use crate::chunk::AnyChunkSet;
+use crate::store::{MaybeSend, TrustedStore};
 
 impl<G, M, const BODY_SIZE: usize> GenericJoiner<G, M, BODY_SIZE>
 where
-    G: ChunkGet<BODY_SIZE> + 'static,
+    G: TrustedStore<AnyChunkSet<BODY_SIZE>> + 'static,
     M: JoinMode + MaybeSend + Sync,
 {
     /// Visit each leaf body as it lands, out of order, tagged with its absolute
@@ -68,13 +69,13 @@ where
 mod tests {
     use super::*;
     use crate::bmt::DEFAULT_BODY_SIZE;
-    use crate::chunk::{AnyChunk, ChunkAddress};
+    use crate::chunk::{Chunk, ChunkAddress};
     use crate::file::Joiner;
     use crate::file::split;
     use futures::executor::block_on;
     use std::collections::HashMap;
 
-    fn split_and_store(data: &[u8]) -> (ChunkAddress, HashMap<ChunkAddress, AnyChunk>) {
+    fn split_and_store(data: &[u8]) -> (ChunkAddress, HashMap<ChunkAddress, Chunk>) {
         let (root, store) = split::<DEFAULT_BODY_SIZE>(data).unwrap();
         (root, store.into_chunks())
     }
@@ -228,7 +229,7 @@ mod tests {
             data: &[u8],
         ) -> (
             crate::chunk::encryption::EncryptedChunkRef,
-            HashMap<ChunkAddress, AnyChunk>,
+            HashMap<ChunkAddress, Chunk>,
         ) {
             let (root_ref, store) = split_encrypted::<DEFAULT_BODY_SIZE>(data).unwrap();
             (root_ref, store.into_chunks())

--- a/crates/primitives/src/file/frontier.rs
+++ b/crates/primitives/src/file/frontier.rs
@@ -180,7 +180,7 @@ pub(crate) async fn expand_frontier<G, M, const BS: usize>(
     target_subtrees: usize,
 ) -> Result<Vec<SubtreeNode<M>>>
 where
-    G: crate::store::ChunkGet<BS>,
+    G: crate::store::TrustedStore<crate::chunk::AnyChunkSet<BS>>,
     M: JoinMode + MaybeSend + Sync,
 {
     use futures::stream::{self, StreamExt};
@@ -231,7 +231,7 @@ pub(crate) async fn read_subtree_bodies<G, M, const BS: usize>(
     chunk_range: &ChunkRange,
 ) -> Result<Vec<Bytes>>
 where
-    G: crate::store::ChunkGet<BS>,
+    G: crate::store::TrustedStore<crate::chunk::AnyChunkSet<BS>>,
     M: JoinMode + MaybeSend + Sync,
 {
     let mut out = Vec::new();

--- a/crates/primitives/src/file/joiner.rs
+++ b/crates/primitives/src/file/joiner.rs
@@ -32,7 +32,7 @@ use bytes::Bytes;
 use futures::stream::{self, FuturesUnordered, Stream, StreamExt};
 
 use crate::bmt::DEFAULT_BODY_SIZE;
-use crate::chunk::ChunkAddress;
+use crate::chunk::{AnyChunkSet, ChunkAddress};
 
 use super::error::{FileError, Result};
 use super::frontier::{
@@ -40,7 +40,7 @@ use super::frontier::{
 };
 use super::mode::{JoinMode, PlainMode};
 use super::tree::{ChunkRange, TreeParams};
-use crate::store::{ChunkGet, MaybeSend};
+use crate::store::{MaybeSend, TrustedStore};
 
 #[cfg(feature = "encryption")]
 use super::mode::EncryptedMode;
@@ -48,7 +48,7 @@ use super::mode::EncryptedMode;
 /// Generic async joiner parameterized by chunk mode.
 pub struct GenericJoiner<G, M: JoinMode, const BODY_SIZE: usize = DEFAULT_BODY_SIZE>
 where
-    G: ChunkGet<BODY_SIZE>,
+    G: TrustedStore<AnyChunkSet<BODY_SIZE>>,
 {
     getter: Arc<G>,
     root: ChunkAddress,
@@ -73,7 +73,7 @@ pub type EncryptedJoiner<G, const BODY_SIZE: usize = DEFAULT_BODY_SIZE> =
 
 impl<G, M, const BODY_SIZE: usize> std::fmt::Debug for GenericJoiner<G, M, BODY_SIZE>
 where
-    G: ChunkGet<BODY_SIZE>,
+    G: TrustedStore<AnyChunkSet<BODY_SIZE>>,
     M: JoinMode,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -94,7 +94,7 @@ async fn collect_subtree_bodies<G, M, const BODY_SIZE: usize>(
     concurrency: usize,
 ) -> Result<Vec<Bytes>>
 where
-    G: ChunkGet<BODY_SIZE>,
+    G: TrustedStore<AnyChunkSet<BODY_SIZE>>,
     M: JoinMode + MaybeSend + Sync,
 {
     let bodies: Vec<Bytes> = stream::iter(subtrees)
@@ -115,7 +115,7 @@ where
 
 impl<G, M, const BODY_SIZE: usize> GenericJoiner<G, M, BODY_SIZE>
 where
-    G: ChunkGet<BODY_SIZE>,
+    G: TrustedStore<AnyChunkSet<BODY_SIZE>>,
     M: JoinMode + MaybeSend + Sync,
 {
     /// Create an async joiner from a root reference.
@@ -269,21 +269,24 @@ where
     ) -> Result<Vec<u8>> {
         use super::helpers::{ReadRangeCheck, validate_read_range};
 
-        let (offset, actual_len) = match validate_read_range::<BODY_SIZE>(offset, len, span) {
-            ReadRangeCheck::Empty => return Ok(Vec::new()),
-            ReadRangeCheck::SingleChunk { offset, actual_len } => {
-                let chunk = getter.get(root).await.map_err(FileError::getter)?;
-                let chunk = chunk.into_content().ok_or(FileError::InvalidChunkType {
-                    type_name: "non-content",
-                })?;
-                let body = M::decode_body::<BODY_SIZE>(chunk, context, span)?;
-                // offset < span <= BODY_SIZE in the single-chunk case.
-                let start = crate::cast::usize_from_u64(offset);
-                let end = start + actual_len;
-                return Ok(body[start..end].to_vec());
-            }
-            ReadRangeCheck::MultiChunk { offset, actual_len } => (offset, actual_len),
-        };
+        let (offset, actual_len) =
+            match validate_read_range::<BODY_SIZE>(offset, len, span) {
+                ReadRangeCheck::Empty => return Ok(Vec::new()),
+                ReadRangeCheck::SingleChunk { offset, actual_len } => {
+                    let chunk = getter.get(root).await.map_err(FileError::getter)?;
+                    let chunk = chunk.into_envelope().into_content().ok_or(
+                        FileError::InvalidChunkType {
+                            type_name: "non-content",
+                        },
+                    )?;
+                    let body = M::decode_body::<BODY_SIZE>(chunk, context, span)?;
+                    // offset < span <= BODY_SIZE in the single-chunk case.
+                    let start = crate::cast::usize_from_u64(offset);
+                    let end = start + actual_len;
+                    return Ok(body[start..end].to_vec());
+                }
+                ReadRangeCheck::MultiChunk { offset, actual_len } => (offset, actual_len),
+            };
 
         let chunk_range = tree.chunks_for_range(offset, crate::cast::u64_from_usize(actual_len));
         let range_start_byte = chunk_range.start * crate::cast::u64_from_usize(BODY_SIZE);
@@ -502,7 +505,7 @@ where
             pending: Pending<M>,
         ) -> Resolved<M>
         where
-            G: ChunkGet<BS>,
+            G: TrustedStore<AnyChunkSet<BS>>,
             M: JoinMode + MaybeSend + Sync,
         {
             let node = &pending.node;
@@ -698,7 +701,7 @@ pub(crate) fn chunked_range_stream_from<G, M, const BODY_SIZE: usize>(
     len: u64,
 ) -> impl Stream<Item = Result<(u64, Bytes)>> + 'static
 where
-    G: ChunkGet<BODY_SIZE> + 'static,
+    G: TrustedStore<AnyChunkSet<BODY_SIZE>> + 'static,
     M: JoinMode + MaybeSend + Sync,
 {
     let width = concurrency.max(1);
@@ -744,7 +747,7 @@ where
         pending: Pending<M>,
     ) -> Resolved<M>
     where
-        G: ChunkGet<BS>,
+        G: TrustedStore<AnyChunkSet<BS>>,
         M: JoinMode + MaybeSend + Sync,
     {
         let node = &pending.node;
@@ -909,7 +912,7 @@ where
 #[cfg(feature = "tokio")]
 pub struct JoinerReader<G, M: JoinMode, const BODY_SIZE: usize = DEFAULT_BODY_SIZE>
 where
-    G: ChunkGet<BODY_SIZE>,
+    G: TrustedStore<AnyChunkSet<BODY_SIZE>>,
 {
     joiner: GenericJoiner<G, M, BODY_SIZE>,
     buffer: Bytes,
@@ -920,7 +923,7 @@ where
 #[cfg(feature = "tokio")]
 impl<G, M, const BODY_SIZE: usize> std::fmt::Debug for JoinerReader<G, M, BODY_SIZE>
 where
-    G: ChunkGet<BODY_SIZE>,
+    G: TrustedStore<AnyChunkSet<BODY_SIZE>>,
     M: JoinMode,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -935,7 +938,7 @@ where
 // Safety: JoinerReader contains no self-referential data.
 // The boxed future is heap-allocated and all other fields are plain data.
 #[cfg(feature = "tokio")]
-impl<G: ChunkGet<BODY_SIZE>, M: JoinMode, const BODY_SIZE: usize> Unpin
+impl<G: TrustedStore<AnyChunkSet<BODY_SIZE>>, M: JoinMode, const BODY_SIZE: usize> Unpin
     for JoinerReader<G, M, BODY_SIZE>
 {
 }
@@ -943,7 +946,7 @@ impl<G: ChunkGet<BODY_SIZE>, M: JoinMode, const BODY_SIZE: usize> Unpin
 #[cfg(feature = "tokio")]
 impl<G, M, const BODY_SIZE: usize> tokio::io::AsyncRead for JoinerReader<G, M, BODY_SIZE>
 where
-    G: ChunkGet<BODY_SIZE> + 'static,
+    G: TrustedStore<AnyChunkSet<BODY_SIZE>> + 'static,
     M: JoinMode + Send + Sync + 'static,
 {
     #[allow(
@@ -1029,7 +1032,7 @@ where
 #[cfg(feature = "tokio")]
 impl<G, M, const BODY_SIZE: usize> tokio::io::AsyncSeek for JoinerReader<G, M, BODY_SIZE>
 where
-    G: ChunkGet<BODY_SIZE> + 'static,
+    G: TrustedStore<AnyChunkSet<BODY_SIZE>> + 'static,
     M: JoinMode + Send + Sync + 'static,
 {
     fn start_seek(self: std::pin::Pin<&mut Self>, pos: SeekFrom) -> std::io::Result<()> {
@@ -1052,12 +1055,12 @@ where
 #[cfg(all(test, feature = "tokio"))]
 mod tests {
     use super::*;
-    use crate::chunk::AnyChunk;
-    use crate::chunk::ChunkOps;
+    use crate::chunk::{Chunk, ChunkOps, StandardChunkSet, Verified};
     use crate::file::split;
+    use crate::store::ChunkGet;
     use std::collections::HashMap;
 
-    fn split_and_store(data: &[u8]) -> (ChunkAddress, HashMap<ChunkAddress, AnyChunk>) {
+    fn split_and_store(data: &[u8]) -> (ChunkAddress, HashMap<ChunkAddress, Chunk>) {
         let (root, store) = split::<DEFAULT_BODY_SIZE>(data).unwrap();
         (root, store.into_chunks())
     }
@@ -1074,13 +1077,14 @@ mod tests {
     /// the frontier nor lets a slow intermediate stall other subtrees.
     #[derive(Clone)]
     struct ProbeStore {
-        inner: Arc<HashMap<ChunkAddress, AnyChunk>>,
+        inner: Arc<HashMap<ChunkAddress, Chunk>>,
         gets: Arc<AtomicUsize>,
     }
 
-    impl ChunkGet<DEFAULT_BODY_SIZE> for ProbeStore {
+    impl ChunkGet<StandardChunkSet> for ProbeStore {
+        type Trust = Verified;
         type Error = crate::store::ChunkStoreError;
-        async fn get(&self, address: &ChunkAddress) -> std::result::Result<AnyChunk, Self::Error> {
+        async fn get(&self, address: &ChunkAddress) -> std::result::Result<Chunk, Self::Error> {
             self.gets.fetch_add(1, Ordering::SeqCst);
             self.inner
                 .get(address)
@@ -1091,7 +1095,7 @@ mod tests {
 
     async fn drain_chunked_to_buf<G>(joiner: GenericJoiner<G, PlainMode>, total: usize) -> Vec<u8>
     where
-        G: ChunkGet<DEFAULT_BODY_SIZE> + 'static,
+        G: TrustedStore + 'static,
     {
         let stream = joiner.into_offset_stream_chunked();
         futures::pin_mut!(stream);
@@ -1366,15 +1370,16 @@ mod tests {
     /// chunk-granular stream reaches per-chunk (not per-subtree) concurrency.
     #[derive(Clone)]
     struct ConcurrencyProbe {
-        chunks: Arc<HashMap<ChunkAddress, AnyChunk>>,
+        chunks: Arc<HashMap<ChunkAddress, Chunk>>,
         in_flight: Arc<std::sync::atomic::AtomicUsize>,
         max_in_flight: Arc<std::sync::atomic::AtomicUsize>,
     }
 
-    impl crate::store::ChunkGet<DEFAULT_BODY_SIZE> for ConcurrencyProbe {
+    impl crate::store::ChunkGet<StandardChunkSet> for ConcurrencyProbe {
+        type Trust = Verified;
         type Error = crate::store::ChunkStoreError;
 
-        async fn get(&self, address: &ChunkAddress) -> std::result::Result<AnyChunk, Self::Error> {
+        async fn get(&self, address: &ChunkAddress) -> std::result::Result<Chunk, Self::Error> {
             use std::sync::atomic::Ordering;
             let now = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
             self.max_in_flight.fetch_max(now, Ordering::SeqCst);
@@ -1442,6 +1447,9 @@ mod tests {
     /// the intermediate cap.
     const TINY_BODY: usize = 256;
 
+    /// Sealed chunk currency at the tiny body size.
+    type TinyChunk = Chunk<Verified, AnyChunkSet<TINY_BODY>>;
+
     /// Content addresses of every data leaf for `data` under `TINY_BODY`, so a
     /// probe getter can tell a leaf fetch from an intermediate fetch.
     fn tiny_leaf_addresses(data: &[u8]) -> std::collections::HashSet<ChunkAddress> {
@@ -1458,7 +1466,7 @@ mod tests {
     /// chosen intermediate until the consumer has delivered `slow_gate` leaves.
     #[derive(Clone)]
     struct OrderProbe {
-        chunks: Arc<HashMap<ChunkAddress, AnyChunk<TINY_BODY>>>,
+        chunks: Arc<HashMap<ChunkAddress, TinyChunk>>,
         leaves: Arc<std::collections::HashSet<ChunkAddress>>,
         /// One entry per fetch in start order: `true` for a leaf fetch.
         kinds: Arc<std::sync::Mutex<Vec<bool>>>,
@@ -1470,7 +1478,7 @@ mod tests {
     }
 
     impl OrderProbe {
-        fn new(store: HashMap<ChunkAddress, AnyChunk<TINY_BODY>>, data: &[u8]) -> Self {
+        fn new(store: HashMap<ChunkAddress, TinyChunk>, data: &[u8]) -> Self {
             Self {
                 chunks: Arc::new(store),
                 leaves: Arc::new(tiny_leaf_addresses(data)),
@@ -1503,13 +1511,11 @@ mod tests {
         }
     }
 
-    impl crate::store::ChunkGet<TINY_BODY> for OrderProbe {
+    impl crate::store::ChunkGet<AnyChunkSet<TINY_BODY>> for OrderProbe {
+        type Trust = Verified;
         type Error = crate::store::ChunkStoreError;
 
-        async fn get(
-            &self,
-            address: &ChunkAddress,
-        ) -> std::result::Result<AnyChunk<TINY_BODY>, Self::Error> {
+        async fn get(&self, address: &ChunkAddress) -> std::result::Result<TinyChunk, Self::Error> {
             use std::sync::atomic::Ordering;
             let is_leaf = self.leaves.contains(address);
             self.kinds.lock().unwrap().push(is_leaf);
@@ -1625,7 +1631,7 @@ mod tests {
         let slow = *store
             .iter()
             .find(|(addr, chunk)| {
-                let body = chunk.data();
+                let body = chunk.envelope().data();
                 !leaves.contains(*addr)
                     && **addr != root
                     && body.len() % super::super::constants::REF_SIZE == 0
@@ -1879,7 +1885,7 @@ mod tests {
             data: &[u8],
         ) -> (
             crate::chunk::encryption::EncryptedChunkRef,
-            HashMap<ChunkAddress, AnyChunk>,
+            HashMap<ChunkAddress, Chunk>,
         ) {
             let (root_ref, store) = split_encrypted::<DEFAULT_BODY_SIZE>(data).unwrap();
             (root_ref, store.into_chunks())

--- a/crates/primitives/src/file/joiner_tests.rs
+++ b/crates/primitives/src/file/joiner_tests.rs
@@ -8,7 +8,7 @@
 ///
 /// The calling module must define:
 /// ```ignore
-/// fn split_and_store(data: &[u8]) -> (ChunkAddress, HashMap<ChunkAddress, AnyChunk>);
+/// fn split_and_store(data: &[u8]) -> (ChunkAddress, HashMap<ChunkAddress, Chunk>);
 /// ```
 macro_rules! generate_plain_joiner_tests {
     ($test_attr:meta, $Joiner:ident, [$($async_fn:tt)*], [$($aw:tt)*]) => {
@@ -145,7 +145,7 @@ macro_rules! generate_plain_joiner_tests {
 /// The calling module must define:
 /// ```ignore
 /// fn encrypted_split_and_store(data: &[u8])
-///     -> (EncryptedChunkRef, HashMap<ChunkAddress, AnyChunk>);
+///     -> (EncryptedChunkRef, HashMap<ChunkAddress, Chunk>);
 /// ```
 macro_rules! generate_encrypted_joiner_tests {
     ($test_attr:meta, $Joiner:ident, [$($async_fn:tt)*], [$($aw:tt)*]) => {

--- a/crates/primitives/src/file/mod.rs
+++ b/crates/primitives/src/file/mod.rs
@@ -8,10 +8,9 @@
 //! ```
 //! use futures::executor::block_on;
 //! use nectar_primitives::file::{ChunkGetExt, ChunkPutExt};
-//! use nectar_primitives::store::MemoryStore;
-//! use nectar_primitives::DEFAULT_BODY_SIZE;
+//! use nectar_primitives::DefaultMemoryStore;
 //!
-//! let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
+//! let store = DefaultMemoryStore::new();
 //! let addr = block_on(store.write_file(b"hello swarm".to_vec())).unwrap();
 //! let data = block_on(store.read_file(addr)).unwrap();
 //! assert_eq!(data, b"hello swarm");
@@ -66,10 +65,10 @@ mod tree;
 mod windowed;
 mod write_at;
 
-use crate::chunk::ChunkAddress;
 #[cfg(feature = "encryption")]
 use crate::chunk::encryption::EncryptedChunkRef;
-use crate::store::{ChunkPut, MaybeSend, MaybeSync};
+use crate::chunk::{AnyChunk, AnyChunkSet, Chunk, ChunkAddress, Verified};
+use crate::store::{ChunkPut, MaybeSend, MaybeSync, TrustedStore};
 
 // Async (primary) re-exports
 #[cfg(feature = "encryption")]
@@ -163,7 +162,7 @@ pub(crate) fn resolve_seek_position(
 pub async fn join<R, G, const BODY_SIZE: usize>(getter: G, root: R) -> error::Result<Vec<u8>>
 where
     R: JoinRef,
-    G: crate::store::ChunkGet<BODY_SIZE>,
+    G: TrustedStore<AnyChunkSet<BODY_SIZE>>,
 {
     GenericJoiner::<G, R::Mode, BODY_SIZE>::new(getter, root.into_root_ref())
         .await?
@@ -173,23 +172,45 @@ where
 
 // ---- Splitting (CPU-bound, rayon) ----
 
+/// Seal freshly split chunks for the store boundary.
+fn seal_chunks<const BODY_SIZE: usize>(
+    chunks: Vec<AnyChunk<BODY_SIZE>>,
+) -> error::Result<Vec<Chunk<Verified, AnyChunkSet<BODY_SIZE>>>> {
+    chunks
+        .into_iter()
+        .map(|chunk| Chunk::from_envelope(chunk).map_err(mode::chunk_creation_error))
+        .collect()
+}
+
 /// Split data into chunks, returning root address and chunk store.
 ///
 /// Uses `ParallelSplitter` for best performance on in-memory data.
 pub fn split<const BODY_SIZE: usize>(
     data: &[u8],
-) -> error::Result<(ChunkAddress, crate::store::MemoryStore<BODY_SIZE>)> {
+) -> error::Result<(
+    ChunkAddress,
+    crate::store::MemoryStore<AnyChunkSet<BODY_SIZE>>,
+)> {
     let (root, chunks) = ParallelSplitter::<BODY_SIZE>::split_to_vec(&data)?;
-    Ok((root, crate::store::MemoryStore::from_chunks(chunks)))
+    Ok((
+        root,
+        crate::store::MemoryStore::from_chunks(seal_chunks(chunks)?),
+    ))
 }
 
 /// Split data into encrypted chunks.
 #[cfg(feature = "encryption")]
 pub fn split_encrypted<const BODY_SIZE: usize>(
     data: &[u8],
-) -> error::Result<(EncryptedChunkRef, crate::store::MemoryStore<BODY_SIZE>)> {
+) -> error::Result<(
+    EncryptedChunkRef,
+    crate::store::MemoryStore<AnyChunkSet<BODY_SIZE>>,
+)> {
     let (root_ref, chunks) = EncryptedParallelSplitter::<BODY_SIZE>::split_to_vec(&data)?;
-    Ok((root_ref, crate::store::MemoryStore::from_chunks(chunks)))
+    Ok((
+        root_ref,
+        crate::store::MemoryStore::from_chunks(seal_chunks(chunks)?),
+    ))
 }
 
 /// Calculate tree depth for a given file size (plain mode).
@@ -203,7 +224,7 @@ pub(crate) const fn levels(length: u64, chunk_size: usize) -> usize {
 /// Extension methods for async chunk getters.
 ///
 /// Uses [`JoinRef`] for unified plain/encrypted dispatch.
-pub trait ChunkGetExt<const BODY_SIZE: usize>: crate::store::ChunkGet<BODY_SIZE> {
+pub trait ChunkGetExt<const BODY_SIZE: usize>: TrustedStore<AnyChunkSet<BODY_SIZE>> {
     /// Open a file for async reading.
     fn joiner<R: JoinRef>(
         self,
@@ -229,7 +250,7 @@ pub trait ChunkGetExt<const BODY_SIZE: usize>: crate::store::ChunkGet<BODY_SIZE>
 }
 
 impl<T, const BODY_SIZE: usize> ChunkGetExt<BODY_SIZE> for T where
-    T: crate::store::ChunkGet<BODY_SIZE>
+    T: TrustedStore<AnyChunkSet<BODY_SIZE>>
 {
 }
 
@@ -241,15 +262,14 @@ impl<T, const BODY_SIZE: usize> ChunkGetExt<BODY_SIZE> for T where
 /// ```
 /// use futures::executor::block_on;
 /// use nectar_primitives::file::{ChunkGetExt, ChunkPutExt};
-/// use nectar_primitives::store::MemoryStore;
-/// use nectar_primitives::DEFAULT_BODY_SIZE;
+/// use nectar_primitives::DefaultMemoryStore;
 ///
-/// let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
+/// let store = DefaultMemoryStore::new();
 /// let addr = block_on(store.write_file(b"hello swarm".to_vec())).unwrap();
 /// let recovered = block_on(store.read_file(addr)).unwrap();
 /// assert_eq!(recovered, b"hello swarm");
 /// ```
-pub trait ChunkPutExt<const BODY_SIZE: usize>: ChunkPut<BODY_SIZE> {
+pub trait ChunkPutExt<const BODY_SIZE: usize>: ChunkPut<AnyChunkSet<BODY_SIZE>> {
     /// Split `data` and store every produced chunk, returning the root address.
     ///
     /// Splitting runs on rayon up front; `data` is dropped before the first
@@ -264,7 +284,7 @@ pub trait ChunkPutExt<const BODY_SIZE: usize>: ChunkPut<BODY_SIZE> {
         let split = ParallelSplitter::<BODY_SIZE>::split_to_vec(&data);
         async move {
             let (root, chunks) = split?;
-            for chunk in chunks {
+            for chunk in seal_chunks(chunks)? {
                 self.put(chunk).await.map_err(FileError::store)?;
             }
             Ok(root)
@@ -286,7 +306,7 @@ pub trait ChunkPutExt<const BODY_SIZE: usize>: ChunkPut<BODY_SIZE> {
         let split = EncryptedParallelSplitter::<BODY_SIZE>::split_to_vec(&data);
         async move {
             let (root_ref, chunks) = split?;
-            for chunk in chunks {
+            for chunk in seal_chunks(chunks)? {
                 self.put(chunk).await.map_err(FileError::store)?;
             }
             Ok(root_ref)
@@ -294,7 +314,10 @@ pub trait ChunkPutExt<const BODY_SIZE: usize>: ChunkPut<BODY_SIZE> {
     }
 }
 
-impl<T, const BODY_SIZE: usize> ChunkPutExt<BODY_SIZE> for T where T: ChunkPut<BODY_SIZE> {}
+impl<T, const BODY_SIZE: usize> ChunkPutExt<BODY_SIZE> for T where
+    T: ChunkPut<AnyChunkSet<BODY_SIZE>>
+{
+}
 
 #[cfg(test)]
 mod tests;

--- a/crates/primitives/src/file/mode.rs
+++ b/crates/primitives/src/file/mode.rs
@@ -6,15 +6,16 @@ use bytes::Bytes;
 
 use crate::bmt::SPAN_SIZE;
 use crate::chunk::encryption::{EncryptedChunkRef, EncryptionKey, decrypt_chunk_data};
-use crate::chunk::{ChunkAddress, ChunkOps, ChunkRef, ContentChunk, Reference};
+use crate::chunk::{AnyChunkSet, ChunkAddress, ChunkOps, ChunkRef, ContentChunk, Reference};
 use crate::store::MaybeSend;
 use crate::wire::Cursor;
 
 use super::constants::{compute_spans_inline, subspan_for_spans};
 use super::error::{FileError, Result};
 
-/// Convert a `PrimitivesError` from chunk creation into a `FileError`.
-fn chunk_creation_error(e: crate::error::PrimitivesError) -> FileError {
+/// Convert a `PrimitivesError` from chunk creation or sealing into a
+/// `FileError`.
+pub(crate) fn chunk_creation_error(e: crate::error::PrimitivesError) -> FileError {
     match e {
         crate::error::PrimitivesError::Chunk(c) => FileError::Chunk(c),
         other => FileError::Store(Box::new(other)),
@@ -103,14 +104,18 @@ pub trait JoinMode: Sized + 'static {
 /// Initialize joiner: fetch root chunk, extract span and context.
 pub(crate) async fn joiner_init<
     M: JoinMode + MaybeSend + Sync,
-    G: crate::store::ChunkGet<BS>,
+    G: crate::store::TrustedStore<AnyChunkSet<BS>>,
     const BS: usize,
 >(
     getter: &G,
     input: M::RootRef,
 ) -> Result<(ChunkAddress, u64, M::JoinerContext)> {
     let addr = M::root_address(&input);
-    let any = getter.get(&addr).await.map_err(FileError::getter)?;
+    let any = getter
+        .get(&addr)
+        .await
+        .map_err(FileError::getter)?
+        .into_envelope();
     let chunk = any.into_content().ok_or(FileError::InvalidChunkType {
         type_name: "non-content",
     })?;
@@ -120,7 +125,7 @@ pub(crate) async fn joiner_init<
 /// Read chunk body at address with context. Returns body bytes (after decryption if needed).
 pub(crate) async fn read_chunk_body<
     M: JoinMode + MaybeSend + Sync,
-    G: crate::store::ChunkGet<BS>,
+    G: crate::store::TrustedStore<AnyChunkSet<BS>>,
     const BS: usize,
 >(
     getter: &G,
@@ -130,7 +135,11 @@ pub(crate) async fn read_chunk_body<
 ) -> Result<Bytes> {
     let address = *address;
     let context = context.clone();
-    let any = getter.get(&address).await.map_err(FileError::getter)?;
+    let any = getter
+        .get(&address)
+        .await
+        .map_err(FileError::getter)?
+        .into_envelope();
     let chunk = any.into_content().ok_or(FileError::InvalidChunkType {
         type_name: "non-content",
     })?;

--- a/crates/primitives/src/file/splitter.rs
+++ b/crates/primitives/src/file/splitter.rs
@@ -142,10 +142,16 @@ mod tests {
 
     fn split_and_store(
         data: &[u8],
-    ) -> (crate::chunk::ChunkAddress, MemoryStore<DEFAULT_BODY_SIZE>) {
+    ) -> (
+        crate::chunk::ChunkAddress,
+        MemoryStore<crate::chunk::StandardChunkSet>,
+    ) {
         let mut splitter = Splitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
         splitter.write_all(data).unwrap();
         let (root, chunks) = splitter.finish().unwrap();
+        let chunks = chunks
+            .into_iter()
+            .map(|c| crate::chunk::Chunk::from_envelope(c).unwrap());
         (root, MemoryStore::from_chunks(chunks))
     }
 
@@ -161,7 +167,11 @@ mod tests {
             splitter.write_all(chunk).unwrap();
         }
         let (root, chunks) = splitter.finish().unwrap();
-        let store = MemoryStore::from_chunks(chunks);
+        let store = MemoryStore::<crate::chunk::StandardChunkSet>::from_chunks(
+            chunks
+                .into_iter()
+                .map(|c| crate::chunk::Chunk::from_envelope(c).unwrap()),
+        );
 
         assert_eq!(store.len(), 4);
         assert!(!root.is_zero());
@@ -212,11 +222,14 @@ mod tests {
             data: &[u8],
         ) -> (
             crate::chunk::encryption::EncryptedChunkRef,
-            MemoryStore<DEFAULT_BODY_SIZE>,
+            MemoryStore<crate::chunk::StandardChunkSet>,
         ) {
             let mut splitter = EncryptedSplitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
             splitter.write_all(data).unwrap();
             let (root_ref, chunks) = splitter.finish().unwrap();
+            let chunks = chunks
+                .into_iter()
+                .map(|c| crate::chunk::Chunk::from_envelope(c).unwrap());
             (root_ref, MemoryStore::from_chunks(chunks))
         }
 

--- a/crates/primitives/src/file/splitter_parallel.rs
+++ b/crates/primitives/src/file/splitter_parallel.rs
@@ -209,8 +209,14 @@ mod tests {
 
     fn split_and_store(
         data: &[u8],
-    ) -> (crate::chunk::ChunkAddress, MemoryStore<DEFAULT_BODY_SIZE>) {
+    ) -> (
+        crate::chunk::ChunkAddress,
+        MemoryStore<crate::chunk::StandardChunkSet>,
+    ) {
         let (root, chunks) = ParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(&data).unwrap();
+        let chunks = chunks
+            .into_iter()
+            .map(|c| crate::chunk::Chunk::from_envelope(c).unwrap());
         (root, MemoryStore::from_chunks(chunks))
     }
 
@@ -255,10 +261,13 @@ mod tests {
             data: &[u8],
         ) -> (
             crate::chunk::encryption::EncryptedChunkRef,
-            MemoryStore<DEFAULT_BODY_SIZE>,
+            MemoryStore<crate::chunk::StandardChunkSet>,
         ) {
             let (root_ref, chunks) =
                 EncryptedParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(&data).unwrap();
+            let chunks = chunks
+                .into_iter()
+                .map(|c| crate::chunk::Chunk::from_envelope(c).unwrap());
             (root_ref, MemoryStore::from_chunks(chunks))
         }
 

--- a/crates/primitives/src/file/splitter_tests.rs
+++ b/crates/primitives/src/file/splitter_tests.rs
@@ -2,7 +2,7 @@
 ///
 /// The calling module must pass an adapter function:
 /// ```ignore
-/// fn split_and_store(data: &[u8]) -> (ChunkAddress, MemoryStore<DEFAULT_BODY_SIZE>);
+/// fn split_and_store(data: &[u8]) -> (ChunkAddress, MemoryStore<StandardChunkSet>);
 /// ```
 macro_rules! generate_plain_splitter_tests {
     ($split_fn:ident) => {
@@ -74,7 +74,7 @@ macro_rules! generate_plain_splitter_tests {
 /// The calling module must pass an adapter function:
 /// ```ignore
 /// fn encrypted_split_and_store(data: &[u8])
-///     -> (EncryptedChunkRef, MemoryStore<DEFAULT_BODY_SIZE>);
+///     -> (EncryptedChunkRef, MemoryStore<StandardChunkSet>);
 /// ```
 macro_rules! generate_encrypted_splitter_tests {
     ($split_fn:ident) => {

--- a/crates/primitives/src/file/tests.rs
+++ b/crates/primitives/src/file/tests.rs
@@ -224,7 +224,7 @@ mod write_file_ext {
 
     #[test]
     fn write_file_roundtrip() {
-        let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
+        let store = MemoryStore::<crate::chunk::StandardChunkSet>::new();
         let addr = block_on(store.write_file(b"hello swarm".to_vec())).unwrap();
         let recovered = block_on(store.read_file(addr)).unwrap();
         assert_eq!(recovered, b"hello swarm");
@@ -233,7 +233,7 @@ mod write_file_ext {
     #[test]
     fn write_file_large() {
         let data = vec![0xAB; 8192];
-        let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
+        let store = MemoryStore::<crate::chunk::StandardChunkSet>::new();
         let addr = block_on(store.write_file(data.clone())).unwrap();
         let recovered = block_on(store.read_file(addr)).unwrap();
         assert_eq!(recovered, data);
@@ -246,13 +246,14 @@ mod write_file_ext {
         use crate::file::Splitter;
         use crate::store::ChunkPut;
 
-        let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
+        let store = MemoryStore::<crate::chunk::StandardChunkSet>::new();
         let data = b"streaming via splitter";
         let mut splitter = Splitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
         splitter.write_all(data).unwrap();
         let (root, chunks) = splitter.finish().unwrap();
         for chunk in chunks {
-            block_on(store.put(chunk)).unwrap();
+            let sealed = crate::chunk::Chunk::from_envelope(chunk).unwrap();
+            block_on(store.put(sealed)).unwrap();
         }
         let recovered = block_on(store.read_file(root)).unwrap();
         assert_eq!(recovered, data);
@@ -260,7 +261,6 @@ mod write_file_ext {
 
     #[cfg(feature = "encryption")]
     mod encrypted {
-        use crate::bmt::DEFAULT_BODY_SIZE;
         use crate::file::{ChunkGetExt, ChunkPutExt};
         use crate::store::MemoryStore;
         use futures::executor::block_on;
@@ -268,7 +268,7 @@ mod write_file_ext {
         #[test]
         #[allow(deprecated)] // pins the deprecated ergonomic wrapper's behaviour until removal
         fn write_encrypted_file_roundtrip() {
-            let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
+            let store = MemoryStore::<crate::chunk::StandardChunkSet>::new();
             let enc_ref = block_on(store.write_encrypted_file(b"secret data".to_vec())).unwrap();
             let recovered = block_on(store.read_file(enc_ref)).unwrap();
             assert_eq!(recovered, b"secret data");

--- a/crates/primitives/src/file/windowed.rs
+++ b/crates/primitives/src/file/windowed.rs
@@ -17,14 +17,14 @@ use bytes::Bytes;
 use futures::stream::{self, FuturesUnordered, Stream, StreamExt};
 
 use crate::bmt::DEFAULT_BODY_SIZE;
-use crate::chunk::ChunkAddress;
+use crate::chunk::{AnyChunkSet, ChunkAddress};
 
 use super::error::{FileError, Result};
 use super::frontier::{SubtreeNode, overlapping_children};
 use super::joiner::{GenericJoiner, MAX_INTERMEDIATE_IN_FLIGHT};
 use super::mode::JoinMode;
 use super::tree::{ChunkRange, TreeParams};
-use crate::store::{ChunkGet, MaybeSend};
+use crate::store::{MaybeSend, TrustedStore};
 
 /// Number of times a failed leaf fetch is re-enqueued before the walk surfaces
 /// the error.
@@ -54,7 +54,7 @@ fn record_occupancy(occupancy: usize) {
 /// only repositions; it never re-fetches intermediates.
 pub struct WindowedReader<G, M: JoinMode, const BODY_SIZE: usize = DEFAULT_BODY_SIZE>
 where
-    G: ChunkGet<BODY_SIZE>,
+    G: TrustedStore<AnyChunkSet<BODY_SIZE>>,
 {
     getter: Arc<G>,
     subtrees: Vec<SubtreeNode<M>>,
@@ -72,7 +72,7 @@ where
 
 impl<G, M, const BODY_SIZE: usize> std::fmt::Debug for WindowedReader<G, M, BODY_SIZE>
 where
-    G: ChunkGet<BODY_SIZE>,
+    G: TrustedStore<AnyChunkSet<BODY_SIZE>>,
     M: JoinMode,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -86,7 +86,7 @@ where
 
 impl<G, M, const BODY_SIZE: usize> GenericJoiner<G, M, BODY_SIZE>
 where
-    G: ChunkGet<BODY_SIZE> + 'static,
+    G: TrustedStore<AnyChunkSet<BODY_SIZE>> + 'static,
     M: JoinMode + MaybeSend + Sync,
 {
     /// Seek-and-play reader over a window that slides with the read cursor. Peak
@@ -110,7 +110,7 @@ where
 
 impl<G, M, const BODY_SIZE: usize> WindowedReader<G, M, BODY_SIZE>
 where
-    G: ChunkGet<BODY_SIZE> + 'static,
+    G: TrustedStore<AnyChunkSet<BODY_SIZE>> + 'static,
     M: JoinMode + MaybeSend + Sync,
 {
     /// In-order leaf bodies from the current position to EOF. Each item is one
@@ -190,7 +190,7 @@ async fn fetch_one<G, M, const BS: usize>(
     pending: Pending<M>,
 ) -> Resolved<M>
 where
-    G: ChunkGet<BS>,
+    G: TrustedStore<AnyChunkSet<BS>>,
     M: JoinMode + MaybeSend + Sync,
 {
     let node = &pending.node;
@@ -264,7 +264,7 @@ fn windowed_walk<G, M, const BODY_SIZE: usize>(
     window: usize,
 ) -> impl Stream<Item = Result<Bytes>>
 where
-    G: ChunkGet<BODY_SIZE> + 'static,
+    G: TrustedStore<AnyChunkSet<BODY_SIZE>> + 'static,
     M: JoinMode + MaybeSend + Sync,
 {
     let width = concurrency.max(1);
@@ -470,7 +470,7 @@ where
 #[cfg(feature = "tokio")]
 pub struct WindowedJoinerReader<G, M: JoinMode, const BODY_SIZE: usize = DEFAULT_BODY_SIZE>
 where
-    G: ChunkGet<BODY_SIZE>,
+    G: TrustedStore<AnyChunkSet<BODY_SIZE>>,
 {
     reader: WindowedReader<G, M, BODY_SIZE>,
     residual: Bytes,
@@ -481,7 +481,7 @@ where
 #[cfg(feature = "tokio")]
 impl<G, M, const BODY_SIZE: usize> std::fmt::Debug for WindowedJoinerReader<G, M, BODY_SIZE>
 where
-    G: ChunkGet<BODY_SIZE>,
+    G: TrustedStore<AnyChunkSet<BODY_SIZE>>,
     M: JoinMode,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -496,7 +496,7 @@ where
 #[cfg(feature = "tokio")]
 impl<G, M, const BODY_SIZE: usize> WindowedReader<G, M, BODY_SIZE>
 where
-    G: ChunkGet<BODY_SIZE> + 'static,
+    G: TrustedStore<AnyChunkSet<BODY_SIZE>> + 'static,
     M: JoinMode + Send + Sync + 'static,
 {
     /// Wrap as a tokio `AsyncRead` + `AsyncSeek` reader. Native-only.
@@ -510,7 +510,7 @@ where
 }
 
 #[cfg(feature = "tokio")]
-impl<G: ChunkGet<BODY_SIZE>, M: JoinMode, const BODY_SIZE: usize> Unpin
+impl<G: TrustedStore<AnyChunkSet<BODY_SIZE>>, M: JoinMode, const BODY_SIZE: usize> Unpin
     for WindowedJoinerReader<G, M, BODY_SIZE>
 {
 }
@@ -518,7 +518,7 @@ impl<G: ChunkGet<BODY_SIZE>, M: JoinMode, const BODY_SIZE: usize> Unpin
 #[cfg(feature = "tokio")]
 impl<G, M, const BODY_SIZE: usize> tokio::io::AsyncRead for WindowedJoinerReader<G, M, BODY_SIZE>
 where
-    G: ChunkGet<BODY_SIZE> + 'static,
+    G: TrustedStore<AnyChunkSet<BODY_SIZE>> + 'static,
     M: JoinMode + Send + Sync + 'static,
 {
     #[allow(
@@ -580,7 +580,7 @@ where
 #[cfg(feature = "tokio")]
 impl<G, M, const BODY_SIZE: usize> tokio::io::AsyncSeek for WindowedJoinerReader<G, M, BODY_SIZE>
 where
-    G: ChunkGet<BODY_SIZE> + 'static,
+    G: TrustedStore<AnyChunkSet<BODY_SIZE>> + 'static,
     M: JoinMode + Send + Sync + 'static,
 {
     fn start_seek(self: Pin<&mut Self>, pos: SeekFrom) -> std::io::Result<()> {
@@ -603,20 +603,21 @@ where
 mod tests {
     use super::*;
     use crate::bmt::DEFAULT_BODY_SIZE;
-    use crate::chunk::AnyChunk;
+    use crate::chunk::{Chunk, StandardChunkSet, Verified};
     use crate::file::Joiner;
     use crate::file::split;
+    use crate::store::ChunkGet;
     use futures::executor::block_on;
     use std::collections::HashMap;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    fn split_and_store(data: &[u8]) -> (ChunkAddress, HashMap<ChunkAddress, AnyChunk>) {
+    fn split_and_store(data: &[u8]) -> (ChunkAddress, HashMap<ChunkAddress, Chunk>) {
         let (root, store) = split::<DEFAULT_BODY_SIZE>(data).unwrap();
         (root, store.into_chunks())
     }
 
     async fn drain(
-        reader: &mut WindowedReader<HashMap<ChunkAddress, AnyChunk>, super::super::mode::PlainMode>,
+        reader: &mut WindowedReader<HashMap<ChunkAddress, Chunk>, super::super::mode::PlainMode>,
     ) -> Vec<u8> {
         let stream = reader.stream();
         futures::pin_mut!(stream);
@@ -718,15 +719,16 @@ mod tests {
     /// reorder buffer never admits more than `window` leaves at once.
     #[derive(Clone)]
     struct BoundProbe {
-        chunks: Arc<HashMap<ChunkAddress, AnyChunk>>,
+        chunks: Arc<HashMap<ChunkAddress, Chunk>>,
         in_flight: Arc<AtomicUsize>,
         max_in_flight: Arc<AtomicUsize>,
     }
 
-    impl ChunkGet<DEFAULT_BODY_SIZE> for BoundProbe {
+    impl ChunkGet<StandardChunkSet> for BoundProbe {
+        type Trust = Verified;
         type Error = crate::store::ChunkStoreError;
 
-        async fn get(&self, address: &ChunkAddress) -> std::result::Result<AnyChunk, Self::Error> {
+        async fn get(&self, address: &ChunkAddress) -> std::result::Result<Chunk, Self::Error> {
             let now = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
             self.max_in_flight.fetch_max(now, Ordering::SeqCst);
             // Hold the fetch open across several self-waking yields so
@@ -794,7 +796,7 @@ mod tests {
     /// refuses to fetch past a free slot, holding the total at the window.
     #[derive(Clone)]
     struct HeadSlow {
-        chunks: Arc<HashMap<ChunkAddress, AnyChunk>>,
+        chunks: Arc<HashMap<ChunkAddress, Chunk>>,
         /// File offset of the head leaf to delay.
         slow_offset: u64,
         /// Number of leaves released so far (used to gate the slow leaf).
@@ -805,10 +807,11 @@ mod tests {
         leaf_offsets: Arc<HashMap<ChunkAddress, u64>>,
     }
 
-    impl ChunkGet<DEFAULT_BODY_SIZE> for HeadSlow {
+    impl ChunkGet<StandardChunkSet> for HeadSlow {
+        type Trust = Verified;
         type Error = crate::store::ChunkStoreError;
 
-        async fn get(&self, address: &ChunkAddress) -> std::result::Result<AnyChunk, Self::Error> {
+        async fn get(&self, address: &ChunkAddress) -> std::result::Result<Chunk, Self::Error> {
             let is_slow = self.leaf_offsets.get(address) == Some(&self.slow_offset);
             if is_slow {
                 // Park until the gate of other leaves has released, then a few
@@ -915,6 +918,9 @@ mod tests {
     /// leaves build a wide intermediate frontier with little data.
     const TINY_BODY: usize = 256;
 
+    /// Sealed chunk currency at the tiny body size.
+    type TinyChunk = Chunk<Verified, AnyChunkSet<TINY_BODY>>;
+
     fn tiny_leaf_addresses(data: &[u8]) -> HashMap<ChunkAddress, ()> {
         use crate::chunk::ChunkOps;
         let mut set = HashMap::new();
@@ -933,7 +939,7 @@ mod tests {
     /// peak concurrent intermediate fetches.
     #[derive(Clone)]
     struct TinyOrderProbe {
-        chunks: Arc<HashMap<ChunkAddress, AnyChunk<TINY_BODY>>>,
+        chunks: Arc<HashMap<ChunkAddress, TinyChunk>>,
         leaves: Arc<HashMap<ChunkAddress, ()>>,
         kinds: Arc<std::sync::Mutex<Vec<bool>>>,
         intermediate_in_flight: Arc<AtomicUsize>,
@@ -941,7 +947,7 @@ mod tests {
     }
 
     impl TinyOrderProbe {
-        fn new(store: HashMap<ChunkAddress, AnyChunk<TINY_BODY>>, data: &[u8]) -> Self {
+        fn new(store: HashMap<ChunkAddress, TinyChunk>, data: &[u8]) -> Self {
             Self {
                 chunks: Arc::new(store),
                 leaves: Arc::new(tiny_leaf_addresses(data)),
@@ -970,13 +976,11 @@ mod tests {
         }
     }
 
-    impl ChunkGet<TINY_BODY> for TinyOrderProbe {
+    impl ChunkGet<AnyChunkSet<TINY_BODY>> for TinyOrderProbe {
+        type Trust = Verified;
         type Error = crate::store::ChunkStoreError;
 
-        async fn get(
-            &self,
-            address: &ChunkAddress,
-        ) -> std::result::Result<AnyChunk<TINY_BODY>, Self::Error> {
+        async fn get(&self, address: &ChunkAddress) -> std::result::Result<TinyChunk, Self::Error> {
             let is_leaf = self.leaves.contains_key(address);
             self.kinds.lock().unwrap().push(is_leaf);
             if !is_leaf {
@@ -1132,14 +1136,15 @@ mod tests {
     #[cfg(feature = "encryption")]
     #[derive(Clone)]
     struct UniformSlow {
-        chunks: Arc<HashMap<ChunkAddress, AnyChunk>>,
+        chunks: Arc<HashMap<ChunkAddress, Chunk>>,
     }
 
     #[cfg(feature = "encryption")]
-    impl ChunkGet<DEFAULT_BODY_SIZE> for UniformSlow {
+    impl ChunkGet<StandardChunkSet> for UniformSlow {
+        type Trust = Verified;
         type Error = crate::store::ChunkStoreError;
 
-        async fn get(&self, address: &ChunkAddress) -> std::result::Result<AnyChunk, Self::Error> {
+        async fn get(&self, address: &ChunkAddress) -> std::result::Result<Chunk, Self::Error> {
             for _ in 0..4 {
                 yield_now().await;
             }
@@ -1158,7 +1163,7 @@ mod tests {
 
         async fn drain_enc(
             reader: &mut WindowedReader<
-                HashMap<ChunkAddress, AnyChunk>,
+                HashMap<ChunkAddress, Chunk>,
                 crate::file::mode::EncryptedMode,
             >,
         ) -> Vec<u8> {

--- a/crates/primitives/src/file/write_at.rs
+++ b/crates/primitives/src/file/write_at.rs
@@ -8,7 +8,8 @@ use futures::StreamExt;
 use super::error::FileError;
 use super::joiner::GenericJoiner;
 use super::mode::JoinMode;
-use crate::store::{ChunkGet, MaybeSend, MaybeSync};
+use crate::chunk::AnyChunkSet;
+use crate::store::{MaybeSend, MaybeSync, TrustedStore};
 
 /// Async random-access write sink. Each leaf body is written at its absolute
 /// offset; when every offset is written the sink is whole. Not `Send`-bound so
@@ -137,7 +138,7 @@ impl<T: WriteAt + ?Sized> WriteAt for &T {
 
 impl<G, M, const BODY_SIZE: usize> GenericJoiner<G, M, BODY_SIZE>
 where
-    G: ChunkGet<BODY_SIZE> + 'static,
+    G: TrustedStore<AnyChunkSet<BODY_SIZE>> + 'static,
     M: JoinMode + MaybeSend + Sync,
 {
     /// Reassemble the whole file into `sink`, writing each out-of-order leaf at
@@ -241,12 +242,12 @@ mod download_tests {
     use super::*;
 
     use crate::DEFAULT_BODY_SIZE;
-    use crate::chunk::AnyChunk;
+    use crate::chunk::Chunk;
     use crate::file::{Joiner, split};
     use futures::executor::block_on;
     use std::collections::HashMap;
 
-    type Store = HashMap<crate::ChunkAddress, AnyChunk>;
+    type Store = HashMap<crate::ChunkAddress, Chunk>;
 
     fn split_and_store(data: &[u8]) -> (crate::ChunkAddress, Store) {
         let (root, store) = split::<DEFAULT_BODY_SIZE>(data).unwrap();

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -105,6 +105,7 @@ pub use bmt::{Hasher, HasherFactory, Proof, Prover};
 pub use chunk::{
     // Type system
     AnyChunk,
+    AnyChunkSet,
     CacHeader,
     // The typestate chunk currency
     Chunk,
@@ -149,12 +150,12 @@ pub type DefaultSingleOwnerChunk = SingleOwnerChunk<DEFAULT_BODY_SIZE>;
 /// Default polymorphic chunk.
 pub type DefaultAnyChunk = AnyChunk<DEFAULT_BODY_SIZE>;
 /// Default in-memory chunk store.
-pub type DefaultMemoryStore = MemoryStore<DEFAULT_BODY_SIZE>;
+pub type DefaultMemoryStore = MemoryStore<StandardChunkSet>;
 
 // Chunk storage traits
 pub use store::{
     ChunkGet, ChunkHas, ChunkPut, ChunkStoreError, MemoryStore, RetryConfig, RetryingChunkGet,
-    Sleeper,
+    Sleeper, TrustedStore,
 };
 
 // File joining (async)

--- a/crates/primitives/src/store/memory.rs
+++ b/crates/primitives/src/store/memory.rs
@@ -4,22 +4,24 @@ use std::collections::HashMap;
 
 use parking_lot::RwLock;
 
-use crate::bmt::DEFAULT_BODY_SIZE;
-use crate::chunk::{AnyChunk, ChunkAddress, ChunkOps};
+use crate::chunk::{Chunk, ChunkAddress, ChunkRegistry, StandardChunkSet, Verified};
 
 use super::ChunkStoreError;
 use super::typed::{ChunkGet, ChunkHas, ChunkPut};
 
 /// In-memory chunk storage using a `RwLock<HashMap>`.
 ///
+/// Holds only sealed chunks and is process-private, so reads are `Verified`:
+/// nothing can alter a chunk between put and get.
+///
 /// Uses interior mutability so `ChunkPut::put(&self)` works without
 /// external synchronization.
 #[derive(Debug)]
-pub struct MemoryStore<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> {
-    chunks: RwLock<HashMap<ChunkAddress, AnyChunk<BODY_SIZE>>>,
+pub struct MemoryStore<R: ChunkRegistry = StandardChunkSet> {
+    chunks: RwLock<HashMap<ChunkAddress, Chunk<Verified, R>>>,
 }
 
-impl<const BODY_SIZE: usize> Clone for MemoryStore<BODY_SIZE> {
+impl<R: ChunkRegistry> Clone for MemoryStore<R> {
     fn clone(&self) -> Self {
         Self {
             chunks: RwLock::new(self.chunks.read().clone()),
@@ -27,13 +29,13 @@ impl<const BODY_SIZE: usize> Clone for MemoryStore<BODY_SIZE> {
     }
 }
 
-impl<const BODY_SIZE: usize> Default for MemoryStore<BODY_SIZE> {
+impl<R: ChunkRegistry> Default for MemoryStore<R> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<const BODY_SIZE: usize> MemoryStore<BODY_SIZE> {
+impl<R: ChunkRegistry> MemoryStore<R> {
     /// Create an empty memory store.
     pub fn new() -> Self {
         Self {
@@ -41,15 +43,15 @@ impl<const BODY_SIZE: usize> MemoryStore<BODY_SIZE> {
         }
     }
 
-    /// Build a store from a collection of chunks, keyed by address.
-    pub fn from_chunks(chunks: impl IntoIterator<Item = AnyChunk<BODY_SIZE>>) -> Self {
+    /// Build a store from a collection of sealed chunks, keyed by address.
+    pub fn from_chunks(chunks: impl IntoIterator<Item = Chunk<Verified, R>>) -> Self {
         Self {
             chunks: RwLock::new(chunks.into_iter().map(|c| (*c.address(), c)).collect()),
         }
     }
 
     /// Get a cloned chunk by address.
-    pub fn get(&self, address: &ChunkAddress) -> Option<AnyChunk<BODY_SIZE>> {
+    pub fn get(&self, address: &ChunkAddress) -> Option<Chunk<Verified, R>> {
         self.chunks.read().get(address).cloned()
     }
 
@@ -64,24 +66,25 @@ impl<const BODY_SIZE: usize> MemoryStore<BODY_SIZE> {
     }
 
     /// Consume the store and return all chunks.
-    pub fn into_chunks(self) -> HashMap<ChunkAddress, AnyChunk<BODY_SIZE>> {
+    pub fn into_chunks(self) -> HashMap<ChunkAddress, Chunk<Verified, R>> {
         self.chunks.into_inner()
     }
 }
 
-impl<const BODY_SIZE: usize> ChunkPut<BODY_SIZE> for MemoryStore<BODY_SIZE> {
+impl<R: ChunkRegistry> ChunkPut<R> for MemoryStore<R> {
     type Error = std::convert::Infallible;
 
-    async fn put(&self, chunk: AnyChunk<BODY_SIZE>) -> Result<(), Self::Error> {
+    async fn put(&self, chunk: Chunk<Verified, R>) -> Result<(), Self::Error> {
         self.chunks.write().insert(*chunk.address(), chunk);
         Ok(())
     }
 }
 
-impl<const BODY_SIZE: usize> ChunkGet<BODY_SIZE> for MemoryStore<BODY_SIZE> {
+impl<R: ChunkRegistry> ChunkGet<R> for MemoryStore<R> {
+    type Trust = Verified;
     type Error = ChunkStoreError;
 
-    async fn get(&self, address: &ChunkAddress) -> Result<AnyChunk<BODY_SIZE>, Self::Error> {
+    async fn get(&self, address: &ChunkAddress) -> Result<Chunk<Verified, R>, Self::Error> {
         self.chunks
             .read()
             .get(address)
@@ -90,23 +93,24 @@ impl<const BODY_SIZE: usize> ChunkGet<BODY_SIZE> for MemoryStore<BODY_SIZE> {
     }
 }
 
-impl<const BODY_SIZE: usize> ChunkHas<BODY_SIZE> for MemoryStore<BODY_SIZE> {
+impl<R: ChunkRegistry> ChunkHas for MemoryStore<R> {
     async fn has(&self, address: &ChunkAddress) -> bool {
         self.chunks.read().contains_key(address)
     }
 }
 
-impl<const BODY_SIZE: usize> ChunkGet<BODY_SIZE> for HashMap<ChunkAddress, AnyChunk<BODY_SIZE>> {
+impl<R: ChunkRegistry> ChunkGet<R> for HashMap<ChunkAddress, Chunk<Verified, R>> {
+    type Trust = Verified;
     type Error = ChunkStoreError;
 
-    async fn get(&self, address: &ChunkAddress) -> Result<AnyChunk<BODY_SIZE>, Self::Error> {
+    async fn get(&self, address: &ChunkAddress) -> Result<Chunk<Verified, R>, Self::Error> {
         self.get(address)
             .cloned()
             .ok_or_else(|| ChunkStoreError::not_found(address))
     }
 }
 
-impl<const BODY_SIZE: usize> ChunkHas<BODY_SIZE> for HashMap<ChunkAddress, AnyChunk<BODY_SIZE>> {
+impl<R: ChunkRegistry> ChunkHas for HashMap<ChunkAddress, Chunk<Verified, R>> {
     async fn has(&self, address: &ChunkAddress) -> bool {
         self.contains_key(address)
     }
@@ -120,16 +124,16 @@ mod tests {
 
     #[test]
     fn test_memory_store() {
-        let store = MemoryStore::<DEFAULT_BODY_SIZE>::new();
+        let store = MemoryStore::<StandardChunkSet>::new();
         assert!(store.is_empty());
 
         let chunk = ContentChunk::new(b"hello".as_slice()).unwrap();
         let addr = *chunk.address();
-        let any: AnyChunk = chunk.into();
+        let sealed: Chunk = Chunk::from_envelope(chunk.into()).unwrap();
 
-        block_on(ChunkPut::put(&store, any.clone())).unwrap();
+        block_on(ChunkPut::put(&store, sealed)).unwrap();
         assert_eq!(store.len(), 1);
         assert!(block_on(ChunkHas::has(&store, &addr)));
-        assert_eq!(store.get(&addr), Some(any));
+        assert_eq!(store.get(&addr).map(|c| *c.address()), Some(addr));
     }
 }

--- a/crates/primitives/src/store/mod.rs
+++ b/crates/primitives/src/store/mod.rs
@@ -11,10 +11,9 @@ mod typed;
 pub use maybe_send::{MaybeSend, MaybeSync};
 pub use memory::MemoryStore;
 pub use retry::{RetryConfig, RetryingChunkGet, Sleeper};
-pub use typed::{ChunkGet, ChunkHas, ChunkPut};
+pub use typed::{ChunkGet, ChunkHas, ChunkPut, TrustedStore};
 
-use crate::bmt::DEFAULT_BODY_SIZE;
-use crate::chunk::{AnyChunk, ChunkAddress};
+use crate::chunk::{Chunk, ChunkAddress, ChunkRegistry, Verified};
 
 /// Errors from chunk storage operations.
 #[non_exhaustive]
@@ -38,14 +37,16 @@ impl ChunkStoreError {
 /// A no-op loader that always returns [`ChunkStoreError::NotFound`].
 ///
 /// Used by `Node`'s public convenience methods to satisfy the generic
-/// constraint without requiring callers to specify a store type.
+/// constraint without requiring callers to specify a store type. It yields
+/// nothing, so its `Verified` trust declaration is vacuously true.
 #[derive(Debug)]
-pub struct NullLoader<const BODY_SIZE: usize = DEFAULT_BODY_SIZE>;
+pub struct NullLoader;
 
-impl<const BODY_SIZE: usize> ChunkGet<BODY_SIZE> for NullLoader<BODY_SIZE> {
+impl<R: ChunkRegistry> ChunkGet<R> for NullLoader {
+    type Trust = Verified;
     type Error = ChunkStoreError;
 
-    async fn get(&self, address: &ChunkAddress) -> Result<AnyChunk<BODY_SIZE>, Self::Error> {
+    async fn get(&self, address: &ChunkAddress) -> Result<Chunk<Verified, R>, Self::Error> {
         Err(ChunkStoreError::not_found(address))
     }
 }

--- a/crates/primitives/src/store/retry.rs
+++ b/crates/primitives/src/store/retry.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 
 use super::maybe_send::{MaybeSend, MaybeSync};
 use super::typed::{ChunkGet, ChunkHas, ChunkPut};
-use crate::chunk::{AnyChunk, ChunkAddress};
+use crate::chunk::{Chunk, ChunkAddress, ChunkRegistry, Verified};
 
 /// Injected async delay so the decorator owns its timer: nectar takes no new
 /// timer dependency and each consumer supplies its platform sleep.
@@ -120,11 +120,14 @@ impl<G, S> RetryingChunkGet<G, S> {
     }
 }
 
-impl<const BS: usize, G: ChunkGet<BS>, S: Sleeper> ChunkGet<BS> for RetryingChunkGet<G, S> {
+impl<R: ChunkRegistry, G: ChunkGet<R>, S: Sleeper> ChunkGet<R> for RetryingChunkGet<G, S> {
+    /// Retrying changes nothing about the medium: the inner trust level
+    /// passes through.
+    type Trust = G::Trust;
     type Error = G::Error;
 
     #[allow(clippy::arithmetic_side_effects)] // attempt only increments while < max_attempts (u32), so + 1 cannot overflow
-    async fn get(&self, address: &ChunkAddress) -> Result<AnyChunk<BS>, Self::Error> {
+    async fn get(&self, address: &ChunkAddress) -> Result<Chunk<G::Trust, R>, Self::Error> {
         let mut attempt = 1;
         loop {
             match self.inner.get(address).await {
@@ -143,19 +146,17 @@ impl<const BS: usize, G: ChunkGet<BS>, S: Sleeper> ChunkGet<BS> for RetryingChun
     }
 }
 
-impl<const BS: usize, G: ChunkPut<BS>, S: MaybeSend + MaybeSync> ChunkPut<BS>
+impl<R: ChunkRegistry, G: ChunkPut<R>, S: MaybeSend + MaybeSync> ChunkPut<R>
     for RetryingChunkGet<G, S>
 {
     type Error = G::Error;
 
-    async fn put(&self, chunk: AnyChunk<BS>) -> Result<(), Self::Error> {
+    async fn put(&self, chunk: Chunk<Verified, R>) -> Result<(), Self::Error> {
         self.inner.put(chunk).await
     }
 }
 
-impl<const BS: usize, G: ChunkHas<BS>, S: MaybeSend + MaybeSync> ChunkHas<BS>
-    for RetryingChunkGet<G, S>
-{
+impl<G: ChunkHas, S: MaybeSend + MaybeSync> ChunkHas for RetryingChunkGet<G, S> {
     async fn has(&self, address: &ChunkAddress) -> bool {
         self.inner.has(address).await
     }
@@ -171,8 +172,7 @@ mod tests {
     use futures::executor::block_on;
 
     use crate::DefaultContentChunk;
-    use crate::bmt::DEFAULT_BODY_SIZE;
-    use crate::chunk::ChunkOps;
+    use crate::chunk::StandardChunkSet;
 
     /// A [`Sleeper`] that returns immediately, so tests never wait real time.
     struct NoSleep;
@@ -188,7 +188,7 @@ mod tests {
     /// A store that fails its first `remaining_failures` gets then succeeds,
     /// counting every `get`, `put`, and `has` call.
     struct FlakyStore {
-        chunk: AnyChunk<DEFAULT_BODY_SIZE>,
+        chunk: Chunk,
         remaining_failures: Mutex<u32>,
         get_calls: AtomicU32,
         put_calls: AtomicU32,
@@ -197,9 +197,8 @@ mod tests {
 
     impl FlakyStore {
         fn new(remaining_failures: u32) -> Self {
-            let chunk = DefaultContentChunk::new("retry probe")
-                .expect("build content chunk")
-                .into();
+            let content = DefaultContentChunk::new("retry probe").expect("build content chunk");
+            let chunk = Chunk::from_envelope(content.into()).expect("seal content chunk");
             Self {
                 chunk,
                 remaining_failures: Mutex::new(remaining_failures),
@@ -210,13 +209,11 @@ mod tests {
         }
     }
 
-    impl ChunkGet<DEFAULT_BODY_SIZE> for FlakyStore {
+    impl ChunkGet<StandardChunkSet> for FlakyStore {
+        type Trust = Verified;
         type Error = Transient;
 
-        async fn get(
-            &self,
-            _address: &ChunkAddress,
-        ) -> Result<AnyChunk<DEFAULT_BODY_SIZE>, Self::Error> {
+        async fn get(&self, _address: &ChunkAddress) -> Result<Chunk, Self::Error> {
             self.get_calls.fetch_add(1, Ordering::SeqCst);
             let mut left = self.remaining_failures.lock().expect("lock");
             if *left > 0 {
@@ -227,16 +224,16 @@ mod tests {
         }
     }
 
-    impl ChunkPut<DEFAULT_BODY_SIZE> for FlakyStore {
+    impl ChunkPut<StandardChunkSet> for FlakyStore {
         type Error = Transient;
 
-        async fn put(&self, _chunk: AnyChunk<DEFAULT_BODY_SIZE>) -> Result<(), Self::Error> {
+        async fn put(&self, _chunk: Chunk) -> Result<(), Self::Error> {
             self.put_calls.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }
     }
 
-    impl ChunkHas<DEFAULT_BODY_SIZE> for FlakyStore {
+    impl ChunkHas for FlakyStore {
         async fn has(&self, _address: &ChunkAddress) -> bool {
             self.has_calls.fetch_add(1, Ordering::SeqCst);
             true

--- a/crates/primitives/src/store/typed.rs
+++ b/crates/primitives/src/store/typed.rs
@@ -1,16 +1,25 @@
 //! Typed chunk storage traits.
 //!
 //! `ChunkGet`, `ChunkPut`, and `ChunkHas` are async and carry `MaybeSend`/
-//! `MaybeSync` bounds so a store may be `!Send` on wasm.
+//! `MaybeSync` bounds so a store may be `!Send` on wasm. Writes are uniformly
+//! sealed ([`ChunkPut`] only accepts `Chunk<Verified, R>`); trust is a
+//! property of the read medium, declared once per backend through
+//! [`ChunkGet::Trust`].
 
 use std::future::Future;
 
 use super::maybe_send::{MaybeSend, MaybeSync};
-use crate::bmt::DEFAULT_BODY_SIZE;
-use crate::chunk::{AnyChunk, ChunkAddress};
+use crate::chunk::{Chunk, ChunkAddress, ChunkRegistry, StandardChunkSet, TrustState, Verified};
 
 /// Async chunk retrieval (primary API).
-pub trait ChunkGet<const BODY_SIZE: usize = DEFAULT_BODY_SIZE>: MaybeSend + MaybeSync {
+///
+/// [`Trust`](Self::Trust) states what the medium may have done to a sealed
+/// chunk since it was written: an exclusively held file reads back
+/// [`Verified`], a medium other parties can script reads back `Unverified`.
+pub trait ChunkGet<R: ChunkRegistry = StandardChunkSet>: MaybeSend + MaybeSync {
+    /// Trust level of chunks read back from this medium.
+    type Trust: TrustState;
+
     /// Error type for get operations.
     type Error: std::error::Error + Send + Sync + 'static;
 
@@ -18,27 +27,28 @@ pub trait ChunkGet<const BODY_SIZE: usize = DEFAULT_BODY_SIZE>: MaybeSend + Mayb
     fn get(
         &self,
         address: &ChunkAddress,
-    ) -> impl Future<Output = Result<AnyChunk<BODY_SIZE>, Self::Error>> + MaybeSend;
+    ) -> impl Future<Output = Result<Chunk<Self::Trust, R>, Self::Error>> + MaybeSend;
 }
 
-impl<T: ChunkGet<BS> + ?Sized, const BS: usize> ChunkGet<BS> for &T {
+impl<R: ChunkRegistry, T: ChunkGet<R> + ?Sized> ChunkGet<R> for &T {
+    type Trust = T::Trust;
     type Error = T::Error;
 
     fn get(
         &self,
         address: &ChunkAddress,
-    ) -> impl Future<Output = Result<AnyChunk<BS>, Self::Error>> + MaybeSend {
+    ) -> impl Future<Output = Result<Chunk<Self::Trust, R>, Self::Error>> + MaybeSend {
         (**self).get(address)
     }
 }
 
 /// Async chunk existence check (primary API).
-pub trait ChunkHas<const BODY_SIZE: usize = DEFAULT_BODY_SIZE>: MaybeSend + MaybeSync {
+pub trait ChunkHas: MaybeSend + MaybeSync {
     /// Check if a chunk exists.
     fn has(&self, address: &ChunkAddress) -> impl Future<Output = bool> + MaybeSend;
 }
 
-impl<T: ChunkHas<BS> + ?Sized, const BS: usize> ChunkHas<BS> for &T {
+impl<T: ChunkHas + ?Sized> ChunkHas for &T {
     fn has(&self, address: &ChunkAddress) -> impl Future<Output = bool> + MaybeSend {
         (**self).has(address)
     }
@@ -46,48 +56,64 @@ impl<T: ChunkHas<BS> + ?Sized, const BS: usize> ChunkHas<BS> for &T {
 
 /// Async chunk storage (primary API, `&self`).
 ///
-/// Implementors should use interior mutability (e.g. `Mutex`, `RwLock`).
-pub trait ChunkPut<const BODY_SIZE: usize = DEFAULT_BODY_SIZE>: MaybeSend + MaybeSync {
+/// Only accepts proof: there is no trust parameter to widen, so an
+/// uncertified chunk cannot enter any store. Implementors should use interior
+/// mutability (e.g. `Mutex`, `RwLock`).
+pub trait ChunkPut<R: ChunkRegistry = StandardChunkSet>: MaybeSend + MaybeSync {
     /// Error type for put operations.
     type Error: std::error::Error + Send + Sync + 'static;
 
-    /// Store a chunk.
+    /// Store a sealed chunk.
     fn put(
         &self,
-        chunk: AnyChunk<BODY_SIZE>,
+        chunk: Chunk<Verified, R>,
     ) -> impl Future<Output = Result<(), Self::Error>> + MaybeSend;
 }
 
-impl<T: ChunkPut<BS> + ?Sized, const BS: usize> ChunkPut<BS> for &T {
+impl<R: ChunkRegistry, T: ChunkPut<R> + ?Sized> ChunkPut<R> for &T {
     type Error = T::Error;
 
     fn put(
         &self,
-        chunk: AnyChunk<BS>,
+        chunk: Chunk<Verified, R>,
     ) -> impl Future<Output = Result<(), Self::Error>> + MaybeSend {
         (**self).put(chunk)
     }
 }
+
+/// Marker for stores whose read medium hands back exactly what was sealed:
+/// [`ChunkGet`] with `Trust = Verified`.
+///
+/// Blanket-implemented. Consensus consumers bound on this, so feeding them
+/// from an untrusted medium is a type error, not a runtime concern.
+pub trait TrustedStore<R: ChunkRegistry = StandardChunkSet>: ChunkGet<R, Trust = Verified> {}
+
+impl<R: ChunkRegistry, T: ChunkGet<R, Trust = Verified> + ?Sized> TrustedStore<R> for T {}
 
 #[cfg(target_arch = "wasm32")]
 mod wasm_send_sync_proof {
     // A store that is neither Send nor Sync (raw pointer marker) must still
     // satisfy ChunkGet on wasm32, proving the MaybeSend + MaybeSync relaxation.
     use super::*;
+    use crate::chunk::Unverified;
 
     struct NotSendSync(core::marker::PhantomData<*const ()>);
 
-    impl<const BS: usize> ChunkGet<BS> for NotSendSync {
+    impl ChunkGet<StandardChunkSet> for NotSendSync {
+        type Trust = Unverified;
         type Error = std::io::Error;
-        async fn get(&self, _addr: &ChunkAddress) -> Result<AnyChunk<BS>, Self::Error> {
+        async fn get(
+            &self,
+            _addr: &ChunkAddress,
+        ) -> Result<Chunk<Unverified, StandardChunkSet>, Self::Error> {
             unreachable!()
         }
     }
 
-    fn _assert<const BS: usize, S: ChunkGet<BS>>() {}
+    fn _assert<S: ChunkGet<StandardChunkSet>>() {}
 
     #[allow(dead_code)]
     fn _proof() {
-        _assert::<{ DEFAULT_BODY_SIZE }, NotSendSync>()
+        _assert::<NotSendSync>()
     }
 }


### PR DESCRIPTION
## What

Reworks the store traits (`ChunkGet`, `ChunkPut`, `ChunkHas`) to be keyed by `ChunkRegistry` rather than a bare `BODY_SIZE` const generic, and to carry per-backend trust.

`ChunkGet<R>` declares an associated `Trust: TrustState` and yields `Chunk<Self::Trust, R>`. `ChunkPut<R>` has no trust parameter and only accepts `Chunk<Verified, R>`, so writes are uniformly sealed and an uncertified chunk cannot enter any store. A new marker trait, `TrustedStore<R>: ChunkGet<R, Trust = Verified>`, is blanket-implemented so consensus consumers can bound on it and rule out untrusted media as a type error rather than a runtime concern. `ChunkHas` drops its now-unused `BODY_SIZE`/registry generic entirely.

The `const BODY_SIZE` generic that stores previously carried directly is folded into `R::Envelope` via a new `AnyChunkSet<const BODY_SIZE>` registry; `StandardChunkSet` is redefined as its default-size type alias (needed because const-generic defaults do not apply in expression position).

`MemoryStore<R>` now stores `HashMap<ChunkAddress, Chunk<Verified, R>>` instead of `HashMap<ChunkAddress, AnyChunk<BODY_SIZE>>`, closing its previous accept-anything hole. The `HashMap` blanket `ChunkGet`/`ChunkHas` impls follow the same shape. `NullLoader` re-declares a vacuously `Verified` medium, and `RetryingChunkGet` passes the inner `Trust` through unchanged.

Downstream call sites in `mantaray` and `primitives::file` (splitter, joiner, windowed, fold, frontier, write_at, mode) are updated for the new trait shapes, and the wasm-only `split_file` binding in `crates/primitives/src/chunk/wasm.rs` now maps each sealed chunk back to its envelope via `into_envelope()` for `MemoryStore::into_chunks()`'s new element type.

## Why

Closes #198

Prior to this change, store trust was implicit: any `AnyChunk` could be read from or written to any store regardless of whether that medium could actually be trusted not to have altered the bytes since sealing. Keying `ChunkGet`/`ChunkPut` on `ChunkRegistry` with an explicit per-backend `Trust` associated type makes that guarantee a property of the type system instead of a convention, and lets consensus-sensitive consumers require `TrustedStore` at compile time.

## Testing

Verified on detached `FETCH_HEAD` `8684bf2` over base `s202/30-typestate-chunk`. No CI beyond CLA runs until this PR is retargeted onto `main`, since the base is another feature branch in the stack.

## AI assistance

Implemented and red-teamed with Claude (Anthropic), per the org's [AI assistance disclosure policy](https://github.com/nxm-rs/.github/blob/main/CONTRIBUTING.md).

