### PR TITLE
feat(postage): seal StampedChunk on verified chunk carrier

### DIFF
--- a/crates/postage/src/generators.rs
+++ b/crates/postage/src/generators.rs
@@ -14,7 +14,7 @@
 use alloy_primitives::Address;
 use alloy_signer::SignerSync;
 use arbitrary::Unstructured;
-use nectar_primitives::{ChunkAddress, ChunkOps};
+use nectar_primitives::{AnyChunkSet, Chunk, ChunkAddress, Verified};
 
 use crate::{Batch, BatchId, Stamp, StampDigest, StampIndex, StampedChunk};
 
@@ -72,7 +72,10 @@ pub fn signed_stamped_chunk<const BODY_SIZE: usize>(
 ) -> arbitrary::Result<(StampedChunk<BODY_SIZE>, Batch)> {
     let signer = nectar_primitives::generators::signer(u)?;
     let batch = batch(u, signer.address())?;
-    let chunk = nectar_primitives::generators::any_chunk::<BODY_SIZE>(u)?;
+    let chunk = Chunk::<Verified, AnyChunkSet<BODY_SIZE>>::from_envelope(
+        nectar_primitives::generators::any_chunk::<BODY_SIZE>(u)?,
+    )
+    .map_err(|_| arbitrary::Error::IncorrectFormat)?;
     let stamp = signed_stamp(u, &signer, &batch, chunk.address())?;
     Ok((StampedChunk::new(chunk, stamp), batch))
 }

--- a/crates/postage/src/stamped.rs
+++ b/crates/postage/src/stamped.rs
@@ -1,58 +1,53 @@
-//! A chunk paired with the postage stamp that authorises its storage.
+//! A chunk paired with the postage stamp that authorizes its storage.
 //!
-//! [`StampedChunk`] is the pairing of an [`AnyChunk`] (a `nectar-primitives`
-//! type) with a [`Stamp`] (a `nectar-postage` type). A retrieval, a pushsync
-//! delivery, and an upload all move a *chunk plus its proof of payment* as one
-//! unit, so this pairing is the cohesive value that flows across those
-//! boundaries instead of two loose fields.
+//! [`StampedChunk`] is the pairing of a verified [`Chunk`] (a
+//! `nectar-primitives` type) with a [`Stamp`] (a `nectar-postage` type). A
+//! retrieval, a pushsync delivery, and an upload all move a *chunk plus its
+//! proof of payment* as one unit, so this pairing is the cohesive value that
+//! flows across those boundaries instead of two loose fields.
 //!
-//! Both halves are nectar types, so the pairing and its serialisation belong
-//! here. The wire codec is pure serialisation layered on top of the
-//! type-tagged [`AnyChunk`] codec and the fixed-size [`Stamp`] codec.
+//! Both halves are nectar types, so the pairing and its serialization belong
+//! here. The wire codec is pure serialization layered on top of the
+//! registry's type-tagged chunk codec and the fixed-size [`Stamp`] codec.
 
 use alloc::vec::Vec;
 
 use nectar_primitives::{
-    AnyChunk, ChunkAddress, ChunkOps, DEFAULT_BODY_SIZE, bytes::Bytes, wire::Cursor,
+    AnyChunkSet, Chunk, ChunkAddress, DEFAULT_BODY_SIZE, Unverified, Verified, bytes::Bytes,
+    wire::Cursor,
 };
 
 use crate::{BatchId, Stamp, StampError};
 
-/// A chunk together with its postage stamp.
+/// A verified chunk together with its postage stamp.
 ///
-/// [`AnyChunk`] holds the chunk bytes but carries no stamp, so this pairing is
-/// the always-stamped currency on the network paths (pushsync, upload, the
-/// stamped reserve). The address is the chunk's own address;
-/// [`address`](Self::address) delegates to it.
+/// The chunk half is `Chunk<Verified>`, so a stamped chunk can only be built
+/// around a certified address: every wire ingress runs parse then verify
+/// before this type exists. [`address`](Self::address) reads the certified
+/// fact; it never recomputes or recovers anything.
 ///
 /// # Equality
 ///
-/// `PartialEq`/`Eq` are derived. The chunk component therefore inherits
-/// [`AnyChunk`]'s own equality, which compares chunks *by address only* (a
-/// chunk's address is the cryptographic commitment to its bytes, so equal
-/// addresses mean equal chunks), and the stamp component compares all stamp
-/// fields. Two stamped chunks are equal when their chunks share an address and
-/// their stamps are field-for-field identical. This matches the semantics of
-/// the original vertex `StampedChunk`, which also derived equality over the
-/// same two fields.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// Structural: the chunk half compares its address and decoded envelope, the
+/// stamp half all stamp fields.
+#[derive(Debug, Clone)]
 pub struct StampedChunk<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> {
-    chunk: AnyChunk<BODY_SIZE>,
+    chunk: Chunk<Verified, AnyChunkSet<BODY_SIZE>>,
     stamp: Stamp,
 }
 
 impl<const BODY_SIZE: usize> StampedChunk<BODY_SIZE> {
-    /// Pair a chunk with its stamp.
+    /// Pair a verified chunk with its stamp.
     #[inline]
     #[must_use]
-    pub const fn new(chunk: AnyChunk<BODY_SIZE>, stamp: Stamp) -> Self {
+    pub const fn new(chunk: Chunk<Verified, AnyChunkSet<BODY_SIZE>>, stamp: Stamp) -> Self {
         Self { chunk, stamp }
     }
 
-    /// The chunk.
+    /// The verified chunk.
     #[inline]
     #[must_use]
-    pub const fn chunk(&self) -> &AnyChunk<BODY_SIZE> {
+    pub const fn chunk(&self) -> &Chunk<Verified, AnyChunkSet<BODY_SIZE>> {
         &self.chunk
     }
 
@@ -63,17 +58,17 @@ impl<const BODY_SIZE: usize> StampedChunk<BODY_SIZE> {
         &self.stamp
     }
 
-    /// The chunk's address (delegates to the chunk).
+    /// The chunk's certified address: a stored fact, free to read.
     #[inline]
     #[must_use]
-    pub fn address(&self) -> &ChunkAddress {
+    pub const fn address(&self) -> &ChunkAddress {
         self.chunk.address()
     }
 
-    /// Split into the chunk and its stamp.
+    /// Split into the verified chunk and its stamp.
     #[inline]
     #[must_use]
-    pub fn into_parts(self) -> (AnyChunk<BODY_SIZE>, Stamp) {
+    pub fn into_parts(self) -> (Chunk<Verified, AnyChunkSet<BODY_SIZE>>, Stamp) {
         (self.chunk, self.stamp)
     }
 
@@ -82,16 +77,13 @@ impl<const BODY_SIZE: usize> StampedChunk<BODY_SIZE> {
     ///
     /// The layout is `[stamp: STAMP_SIZE][id: 1][version: 1][chunk wire
     /// bytes]`, the stamp's fixed-size encoding ([`Stamp::to_bytes`],
-    /// `STAMP_SIZE = 113` bytes) followed by the chunk's type-tagged encoding
-    /// ([`AnyChunk::to_typed_bytes`]). Decode with
-    /// [`from_typed_bytes`](Self::from_typed_bytes).
+    /// `STAMP_SIZE = 113` bytes) followed by the chunk's registry typed
+    /// encoding. Decode with [`from_typed_bytes`](Self::from_typed_bytes).
     #[must_use]
     pub fn to_typed_bytes(&self) -> Vec<u8> {
         let stamp = self.stamp.to_bytes();
-        let chunk = self.chunk.to_typed_bytes();
-        #[allow(clippy::arithmetic_side_effects)]
-        // capacity hint: sum of two in-memory buffer lengths cannot overflow usize
-        let mut out = Vec::with_capacity(stamp.len() + chunk.len());
+        let chunk = self.chunk.typed_bytes();
+        let mut out = Vec::with_capacity(stamp.len().saturating_add(chunk.len()));
         out.extend_from_slice(&stamp);
         out.extend_from_slice(&chunk);
         out
@@ -100,19 +92,21 @@ impl<const BODY_SIZE: usize> StampedChunk<BODY_SIZE> {
     /// Decode a stamped chunk produced by [`to_typed_bytes`](Self::to_typed_bytes).
     ///
     /// The first `STAMP_SIZE` bytes are the stamp ([`Stamp::from_bytes`]); the
-    /// remainder is the type-tagged chunk ([`AnyChunk::from_typed_bytes`]),
-    /// verified against `address`.
+    /// remainder is the type-tagged chunk, parsed under `address` as a claim
+    /// and then verified, so the result holds a certified address.
     ///
     /// # Errors
     ///
     /// Returns an error (and never panics) when the input is shorter than a
-    /// stamp, the stamp bytes are invalid, the chunk payload cannot be decoded,
-    /// or the chunk's computed address does not match `address`.
+    /// stamp, the stamp bytes are invalid, the chunk payload cannot be parsed,
+    /// or the chunk fails verification against `address`.
     pub fn from_typed_bytes(address: &ChunkAddress, bytes: &[u8]) -> Result<Self, StampError> {
         let mut cur = Cursor::new(bytes);
         let stamp = cur.take::<Stamp>()?;
-        let chunk = AnyChunk::<BODY_SIZE>::from_typed_bytes(address, cur.finish())
-            .map_err(|_| StampError::Chunk("failed to decode typed chunk"))?;
+        let chunk = Chunk::<Unverified, AnyChunkSet<BODY_SIZE>>::parse(*address, cur.finish())
+            .map_err(|_| StampError::Chunk("failed to parse typed chunk"))?
+            .verify()
+            .map_err(|_| StampError::Chunk("chunk does not verify at the claimed address"))?;
         Ok(Self::new(chunk, stamp))
     }
 
@@ -120,19 +114,20 @@ impl<const BODY_SIZE: usize> StampedChunk<BODY_SIZE> {
     /// address, and a separately-carried stamp.
     ///
     /// `data` is the bare chunk wire bytes (no type tag), as carried in a
-    /// `Delivery { data, stamp }` wire message; the address disambiguates the
-    /// chunk variant (see [`AnyChunk::from_wire_bytes`]).
+    /// `Delivery { data, stamp }` wire message. Bare wire bytes carry no tag,
+    /// so the address routes the decode and certification is inseparable from
+    /// it: the result holds a verified chunk at `expected`.
     ///
     /// # Errors
     ///
-    /// Returns an error (and never panics) when `data` does not hash to
-    /// `expected` as either a content or a single-owner chunk.
+    /// Returns an error (and never panics) when `data` does not verify at
+    /// `expected` as any registry member.
     pub fn reconstruct(
         expected: ChunkAddress,
         data: Bytes,
         stamp: Stamp,
     ) -> Result<Self, StampError> {
-        let chunk = AnyChunk::<BODY_SIZE>::from_wire_bytes(&expected, data)
+        let chunk = Chunk::<Verified, AnyChunkSet<BODY_SIZE>>::decode_wire(expected, data)
             .map_err(|_| StampError::Chunk("chunk bytes do not match expected address"))?;
         Ok(Self::new(chunk, stamp))
     }
@@ -153,16 +148,25 @@ impl<const BODY_SIZE: usize> StampedChunk<BODY_SIZE> {
     }
 }
 
+impl<const BODY_SIZE: usize> PartialEq for StampedChunk<BODY_SIZE> {
+    fn eq(&self, other: &Self) -> bool {
+        self.chunk == other.chunk && self.stamp == other.stamp
+    }
+}
+
+impl<const BODY_SIZE: usize> Eq for StampedChunk<BODY_SIZE> {}
+
 #[cfg(any(test, feature = "arbitrary"))]
 impl<'a, const BODY_SIZE: usize> arbitrary::Arbitrary<'a> for StampedChunk<BODY_SIZE> {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        // Raw tier: the stamp is structurally valid but not signed over the
-        // chunk's address. Use `crate::generators::signed_stamped_chunk` for a
-        // pairing whose stamp verifies.
-        Ok(Self::new(
-            nectar_primitives::AnyChunk::arbitrary(u)?,
-            Stamp::arbitrary(u)?,
-        ))
+        // The chunk half is valid by construction: the sealed verified type
+        // admits nothing less. The stamp is structurally valid but not signed
+        // over the chunk's address; use `crate::generators::signed_stamped_chunk`
+        // for a pairing whose stamp verifies.
+        let envelope = nectar_primitives::generators::any_chunk::<BODY_SIZE>(u)?;
+        let chunk =
+            Chunk::from_envelope(envelope).map_err(|_| arbitrary::Error::IncorrectFormat)?;
+        Ok(Self::new(chunk, Stamp::arbitrary(u)?))
     }
 }
 
@@ -170,7 +174,9 @@ impl<'a, const BODY_SIZE: usize> arbitrary::Arbitrary<'a> for StampedChunk<BODY_
 mod tests {
     use alloy_primitives::{B256, Signature};
     use alloy_signer_local::PrivateKeySigner;
-    use nectar_primitives::{ChunkOps, ContentChunk, SingleOwnerChunk, SocId, bytes::Bytes};
+    use nectar_primitives::{
+        AnyChunk, ChunkOps, ContentChunk, SingleOwnerChunk, SocId, bytes::Bytes,
+    };
 
     use super::*;
     use crate::STAMP_SIZE;
@@ -196,14 +202,19 @@ mod tests {
         .expect("valid soc")
     }
 
+    fn verified(chunk: impl Into<AnyChunk<DEFAULT_BODY_SIZE>>) -> Chunk<Verified> {
+        Chunk::from_envelope(chunk.into()).expect("locally built chunk certifies")
+    }
+
     #[test]
     fn into_parts_round_trips_the_fields() {
-        let chunk: AnyChunk = content_chunk().into();
+        let chunk = verified(content_chunk());
+        let address = *chunk.address();
         let stamp = test_stamp();
-        let stamped = DefaultStampedChunk::new(chunk.clone(), stamp.clone());
-        assert_eq!(stamped.address(), chunk.address());
+        let stamped = DefaultStampedChunk::new(chunk, stamp.clone());
+        assert_eq!(stamped.address(), &address);
         let (got_chunk, got_stamp) = stamped.into_parts();
-        assert_eq!(got_chunk, chunk);
+        assert_eq!(got_chunk.address(), &address);
         assert_eq!(got_stamp, stamp);
     }
 
@@ -212,12 +223,12 @@ mod tests {
         let chunk = content_chunk();
         let address = *chunk.address();
         let stamp = test_stamp();
-        let stamped = DefaultStampedChunk::new(chunk.into(), stamp.clone());
+        let stamped = DefaultStampedChunk::new(verified(chunk), stamp.clone());
 
         let bytes = stamped.to_typed_bytes();
         let decoded = DefaultStampedChunk::from_typed_bytes(&address, &bytes).expect("decode");
 
-        assert!(decoded.chunk().is_content());
+        assert!(decoded.chunk().envelope().is_content());
         assert_eq!(*decoded.address(), address);
         assert_eq!(decoded.stamp().batch(), stamp.batch());
         assert_eq!(decoded.stamp().timestamp(), stamp.timestamp());
@@ -229,12 +240,12 @@ mod tests {
         let chunk = single_owner_chunk();
         let address = *chunk.address();
         let stamp = test_stamp();
-        let stamped = DefaultStampedChunk::new(chunk.into(), stamp.clone());
+        let stamped = DefaultStampedChunk::new(verified(chunk), stamp.clone());
 
         let bytes = stamped.to_typed_bytes();
         let decoded = DefaultStampedChunk::from_typed_bytes(&address, &bytes).expect("decode");
 
-        assert!(decoded.chunk().is_single_owner());
+        assert!(decoded.chunk().envelope().is_single_owner());
         assert_eq!(*decoded.address(), address);
         assert_eq!(decoded.stamp().batch(), stamp.batch());
         assert_eq!(decoded.stamp().timestamp(), stamp.timestamp());
@@ -250,10 +261,10 @@ mod tests {
 
         let rebuilt = DefaultStampedChunk::reconstruct(address, data.clone(), stamp.clone())
             .expect("rebuild");
-        assert!(rebuilt.chunk().is_content());
+        assert!(rebuilt.chunk().envelope().is_content());
         assert_eq!(*rebuilt.address(), address);
         assert_eq!(rebuilt.stamp(), &stamp);
-        assert_eq!(rebuilt.into_parts().0.into_bytes(), data);
+        assert_eq!(rebuilt.into_parts().0.into_envelope().into_bytes(), data);
     }
 
     #[test]
@@ -265,16 +276,32 @@ mod tests {
 
         let rebuilt =
             DefaultStampedChunk::reconstruct(address, data, stamp.clone()).expect("rebuild");
-        assert!(rebuilt.chunk().is_single_owner());
+        assert!(rebuilt.chunk().envelope().is_single_owner());
         assert_eq!(*rebuilt.address(), address);
         assert_eq!(rebuilt.stamp(), &stamp);
+    }
+
+    #[test]
+    fn equality_compares_address_and_stamp() {
+        let stamp = test_stamp();
+        let a = DefaultStampedChunk::new(verified(content_chunk()), stamp.clone());
+        let b = DefaultStampedChunk::new(verified(content_chunk()), stamp.clone());
+        assert_eq!(a, b);
+
+        let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
+        let other_stamp = Stamp::new(BatchId::new([0xbb; 32]), 3, 7, 42, sig);
+        let c = DefaultStampedChunk::new(verified(content_chunk()), other_stamp);
+        assert_ne!(a, c);
+
+        let d = DefaultStampedChunk::new(verified(single_owner_chunk()), stamp);
+        assert_ne!(a, d);
     }
 
     #[test]
     fn batch_id_matches_stamp_and_leading_bytes() {
         let chunk = content_chunk();
         let stamp = test_stamp();
-        let stamped = DefaultStampedChunk::new(chunk.into(), stamp.clone());
+        let stamped = DefaultStampedChunk::new(verified(chunk), stamp.clone());
         let bytes = stamped.to_typed_bytes();
 
         let id = DefaultStampedChunk::batch_id(&bytes).expect("batch id");
@@ -300,7 +327,7 @@ mod tests {
     #[test]
     fn from_typed_bytes_address_mismatch_errors() {
         let chunk = content_chunk();
-        let stamped = DefaultStampedChunk::new(chunk.into(), test_stamp());
+        let stamped = DefaultStampedChunk::new(verified(chunk), test_stamp());
         let bytes = stamped.to_typed_bytes();
 
         let wrong: ChunkAddress = [0xFFu8; 32].into();


### PR DESCRIPTION
## What

Re-ports `StampedChunk` onto `Chunk<Verified, AnyChunkSet<BODY_SIZE>>` paired with `Stamp`, instead of the previous `AnyChunk<BODY_SIZE>` carrier.

- `from_typed_bytes` runs parse then verify through the sealed carrier.
- `reconstruct` returns the sealed type via `Chunk::<Verified>::decode_wire`.
- `address()` is now a const free read of the certified fact.
- `PartialEq`/`Eq` are hand-written to compare the stored address plus stamp fields, eliminating the silent `ecrecover` path through the envelope's lazy `address()`.
- Removed the sole `#[allow]` in the codec (`saturating_add` capacity).
- The raw `Arbitrary` tier and `generators::signed_stamped_chunk` now build the chunk half valid-by-construction via `Chunk::from_envelope`.

Diff is confined to `crates/postage/src/{stamped.rs,generators.rs}`.

Closes #199

## Why

The previous `StampedChunk` carried an unverified `AnyChunk`, so equality and address derivation could silently re-run `ecrecover` via the envelope's lazy `address()`. Sealing the chunk as `Chunk<Verified, AnyChunkSet<BODY_SIZE>>` makes the verified state part of the type, turns `address()` into a const read of an already-certified fact, and makes equality compare that certified address plus the stamp fields rather than re-deriving trust on every comparison.

## Testing

Independently re-verified on a fresh clone of the branch at its base (single commit `4b75ed4`), all commands run via `nix develop --command`:

- `cargo fmt --all -- --check`: clean.
- Scope confirmed as exactly `crates/postage/src/generators.rs` and `crates/postage/src/stamped.rs`; no changes to `nectar-postage-usage` or under `fuzz/`, so the wasm check and cargo-fuzz build/smoke are correctly out of scope and were skipped.
- Wire compatibility preserved: `to_typed_bytes`/`from_typed_bytes`/`reconstruct` all delegate to the unchanged `AnyChunk` codecs (`encode_typed` == `to_typed_bytes` byte-for-byte per the registry interop contract; parse+verify == `from_typed_bytes`; `decode_wire` == `from_wire_bytes`), and stamp-first ordering stays pinned by `batch_id_matches_stamp_and_leading_bytes`.

Red-teamed independently against the s202/34-stamped-verified diff (postage crate only): no real bugs, no spec misses, and no house-rule violations found.

This is a stacked PR targeting `s202/32-store-traits`; no CI beyond CLA runs until it is retargeted onto that branch's eventual base.

## AI Assistance

Implementation, red-team review, and independent verification testing were performed by Claude (Anthropic), per the AI assistance disclosure requirements in [nxm-rs/.github CONTRIBUTING.md](https://github.com/nxm-rs/.github/blob/main/CONTRIBUTING.md).

