### PR TITLE
refactor(primitives)!: genericize the file pipeline below the store boundary

### DIFF
--- a/crates/mantaray/src/builder.rs
+++ b/crates/mantaray/src/builder.rs
@@ -178,7 +178,7 @@ impl<S: TrustedStore<AnyChunkSet<BS>> + ChunkPut<AnyChunkSet<BS>>, const BS: usi
         let (root, chunks) = EncryptedParallelSplitter::<BS>::split_to_vec(&data)?;
         drop(data);
         for chunk in chunks {
-            let sealed: Chunk<_, AnyChunkSet<BS>> = Chunk::from_envelope(chunk)?;
+            let sealed: Chunk<_, AnyChunkSet<BS>> = Chunk::from_envelope(chunk.into())?;
             self.store().put(sealed).await.map_err(FileError::store)?;
         }
         self.add(path, root).await

--- a/crates/primitives/benches/encryption_bench.rs
+++ b/crates/primitives/benches/encryption_bench.rs
@@ -338,7 +338,9 @@ fn bench_encrypted_roundtrip(c: &mut Criterion) {
                 let (root_ref, chunks) =
                     EncryptedParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap();
                 let store = MemoryStore::from_chunks(
-                    chunks.into_iter().map(|c| Chunk::from_envelope(c).unwrap()),
+                    chunks
+                        .into_iter()
+                        .map(|c| Chunk::from_envelope(c.into()).unwrap()),
                 );
                 let joiner = block_on(EncryptedJoiner::new(store, root_ref)).unwrap();
                 black_box(block_on(joiner.read_all()).unwrap())

--- a/crates/primitives/benches/file_bench.rs
+++ b/crates/primitives/benches/file_bench.rs
@@ -219,7 +219,9 @@ fn bench_roundtrip(c: &mut Criterion) {
                 let (root, chunks) =
                     ParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap();
                 let store = MemoryStore::from_chunks(
-                    chunks.into_iter().map(|c| Chunk::from_envelope(c).unwrap()),
+                    chunks
+                        .into_iter()
+                        .map(|c| Chunk::from_envelope(c.into()).unwrap()),
                 );
                 let joiner = block_on(Joiner::new(store, root)).unwrap();
                 black_box(block_on(joiner.read_all()).unwrap())

--- a/crates/primitives/src/file/error.rs
+++ b/crates/primitives/src/file/error.rs
@@ -77,13 +77,6 @@ pub enum FileError {
         /// Actual byte length of the reference.
         len: usize,
     },
-
-    /// Expected a content chunk but got a different chunk type.
-    #[error("expected content chunk, got {type_name}")]
-    InvalidChunkType {
-        /// Name of the chunk type that was received.
-        type_name: &'static str,
-    },
 }
 
 impl FileError {

--- a/crates/primitives/src/file/joiner.rs
+++ b/crates/primitives/src/file/joiner.rs
@@ -269,24 +269,18 @@ where
     ) -> Result<Vec<u8>> {
         use super::helpers::{ReadRangeCheck, validate_read_range};
 
-        let (offset, actual_len) =
-            match validate_read_range::<BODY_SIZE>(offset, len, span) {
-                ReadRangeCheck::Empty => return Ok(Vec::new()),
-                ReadRangeCheck::SingleChunk { offset, actual_len } => {
-                    let chunk = getter.get(root).await.map_err(FileError::getter)?;
-                    let chunk = chunk.into_envelope().into_content().ok_or(
-                        FileError::InvalidChunkType {
-                            type_name: "non-content",
-                        },
-                    )?;
-                    let body = M::decode_body::<BODY_SIZE>(chunk, context, span)?;
-                    // offset < span <= BODY_SIZE in the single-chunk case.
-                    let start = crate::cast::usize_from_u64(offset);
-                    let end = start + actual_len;
-                    return Ok(body[start..end].to_vec());
-                }
-                ReadRangeCheck::MultiChunk { offset, actual_len } => (offset, actual_len),
-            };
+        let (offset, actual_len) = match validate_read_range::<BODY_SIZE>(offset, len, span) {
+            ReadRangeCheck::Empty => return Ok(Vec::new()),
+            ReadRangeCheck::SingleChunk { offset, actual_len } => {
+                let chunk = getter.get(root).await.map_err(FileError::getter)?;
+                let body = M::decode_body::<_, BODY_SIZE>(chunk.into_envelope(), context, span)?;
+                // offset < span <= BODY_SIZE in the single-chunk case.
+                let start = crate::cast::usize_from_u64(offset);
+                let end = start + actual_len;
+                return Ok(body[start..end].to_vec());
+            }
+            ReadRangeCheck::MultiChunk { offset, actual_len } => (offset, actual_len),
+        };
 
         let chunk_range = tree.chunks_for_range(offset, crate::cast::u64_from_usize(actual_len));
         let range_start_byte = chunk_range.start * crate::cast::u64_from_usize(BODY_SIZE);

--- a/crates/primitives/src/file/mod.rs
+++ b/crates/primitives/src/file/mod.rs
@@ -67,7 +67,7 @@ mod write_at;
 
 #[cfg(feature = "encryption")]
 use crate::chunk::encryption::EncryptedChunkRef;
-use crate::chunk::{AnyChunk, AnyChunkSet, Chunk, ChunkAddress, Verified};
+use crate::chunk::{AnyChunkSet, Chunk, ChunkAddress, ContentChunk, Verified};
 use crate::store::{ChunkPut, MaybeSend, MaybeSync, TrustedStore};
 
 // Async (primary) re-exports
@@ -172,13 +172,14 @@ where
 
 // ---- Splitting (CPU-bound, rayon) ----
 
-/// Seal freshly split chunks for the store boundary.
+/// Seal freshly split chunks for the store boundary: the sole upcast into
+/// the store's envelope.
 fn seal_chunks<const BODY_SIZE: usize>(
-    chunks: Vec<AnyChunk<BODY_SIZE>>,
+    chunks: Vec<ContentChunk<BODY_SIZE>>,
 ) -> error::Result<Vec<Chunk<Verified, AnyChunkSet<BODY_SIZE>>>> {
     chunks
         .into_iter()
-        .map(|chunk| Chunk::from_envelope(chunk).map_err(mode::chunk_creation_error))
+        .map(|chunk| Chunk::from_envelope(chunk.into()).map_err(mode::chunk_creation_error))
         .collect()
 }
 

--- a/crates/primitives/src/file/mode.rs
+++ b/crates/primitives/src/file/mode.rs
@@ -83,14 +83,18 @@ pub trait JoinMode: Sized + 'static {
     fn root_address(input: &Self::RootRef) -> ChunkAddress;
 
     /// Initialize joiner from a root ref and pre-fetched root chunk.
-    fn init_from_chunk<const BS: usize>(
+    ///
+    /// Generic over [`ChunkOps`], so the store's envelope flows in directly.
+    fn init_from_chunk<C: ChunkOps, const BS: usize>(
         input: Self::RootRef,
-        chunk: ContentChunk<BS>,
+        chunk: C,
     ) -> Result<(ChunkAddress, u64, Self::JoinerContext)>;
 
     /// Decode a fetched chunk into body bytes (decrypting if needed).
-    fn decode_body<const BS: usize>(
-        chunk: ContentChunk<BS>,
+    ///
+    /// Generic over [`ChunkOps`], so the store's envelope flows in directly.
+    fn decode_body<C: ChunkOps, const BS: usize>(
+        chunk: C,
         context: &Self::JoinerContext,
         span: u64,
     ) -> Result<Bytes>;
@@ -111,15 +115,12 @@ pub(crate) async fn joiner_init<
     input: M::RootRef,
 ) -> Result<(ChunkAddress, u64, M::JoinerContext)> {
     let addr = M::root_address(&input);
-    let any = getter
+    let chunk = getter
         .get(&addr)
         .await
         .map_err(FileError::getter)?
         .into_envelope();
-    let chunk = any.into_content().ok_or(FileError::InvalidChunkType {
-        type_name: "non-content",
-    })?;
-    M::init_from_chunk::<BS>(input, chunk)
+    M::init_from_chunk::<_, BS>(input, chunk)
 }
 
 /// Read chunk body at address with context. Returns body bytes (after decryption if needed).
@@ -135,15 +136,12 @@ pub(crate) async fn read_chunk_body<
 ) -> Result<Bytes> {
     let address = *address;
     let context = context.clone();
-    let any = getter
+    let chunk = getter
         .get(&address)
         .await
         .map_err(FileError::getter)?
         .into_envelope();
-    let chunk = any.into_content().ok_or(FileError::InvalidChunkType {
-        type_name: "non-content",
-    })?;
-    M::decode_body::<BS>(chunk, &context, span)
+    M::decode_body::<_, BS>(chunk, &context, span)
 }
 
 /// Splitter-side chunk mode operations (extends JoinMode).
@@ -180,17 +178,17 @@ impl JoinMode for PlainMode {
         *input
     }
 
-    fn init_from_chunk<const BS: usize>(
+    fn init_from_chunk<C: ChunkOps, const BS: usize>(
         root: ChunkAddress,
-        chunk: ContentChunk<BS>,
+        chunk: C,
     ) -> Result<(ChunkAddress, u64, ())> {
         let span = chunk.span();
         Ok((root, span, ()))
     }
 
     #[inline]
-    fn decode_body<const BS: usize>(
-        chunk: ContentChunk<BS>,
+    fn decode_body<C: ChunkOps, const BS: usize>(
+        chunk: C,
         _context: &(),
         _span: u64,
     ) -> Result<Bytes> {
@@ -259,11 +257,11 @@ impl JoinMode for EncryptedMode {
         *input.address()
     }
 
-    fn init_from_chunk<const BS: usize>(
+    fn init_from_chunk<C: ChunkOps, const BS: usize>(
         root_ref: EncryptedChunkRef,
-        chunk: ContentChunk<BS>,
+        chunk: C,
     ) -> Result<(ChunkAddress, u64, EncryptionKey)> {
-        let encrypted_data: Bytes = chunk.into();
+        let encrypted_data = chunk.into_bytes();
 
         let span_buf = decrypt_span::<BS>(&encrypted_data, root_ref.key())?;
         let span = u64::from_le_bytes(span_buf);
@@ -272,12 +270,12 @@ impl JoinMode for EncryptedMode {
         Ok((address, span, key))
     }
 
-    fn decode_body<const BS: usize>(
-        chunk: ContentChunk<BS>,
+    fn decode_body<C: ChunkOps, const BS: usize>(
+        chunk: C,
         key: &EncryptionKey,
         span: u64,
     ) -> Result<Bytes> {
-        let encrypted_data: Bytes = chunk.into();
+        let encrypted_data = chunk.into_bytes();
 
         let data_length = Self::decrypt_data_length::<BS>(span);
         let decrypted = decrypt_chunk_data::<BS>(&encrypted_data, key, data_length)?;

--- a/crates/primitives/src/file/splitter.rs
+++ b/crates/primitives/src/file/splitter.rs
@@ -9,7 +9,7 @@ use std::io::{self, Write};
 use std::marker::PhantomData;
 
 use crate::bmt::DEFAULT_BODY_SIZE;
-use crate::chunk::AnyChunk;
+use crate::chunk::ContentChunk;
 
 use super::error::{FileError, Result};
 use super::mode::{PlainMode, SplitMode};
@@ -89,7 +89,7 @@ where
     M: SplitMode + Send + Sync,
 {
     /// Finalize, returning the root reference and the produced chunks.
-    pub fn finish(self) -> Result<(M::RootRef, Vec<AnyChunk<BODY_SIZE>>)> {
+    pub fn finish(self) -> Result<(M::RootRef, Vec<ContentChunk<BODY_SIZE>>)> {
         if crate::cast::u64_from_usize(self.buffer.len()) != self.span_length {
             return Err(FileError::SpanMismatch {
                 expected: self.span_length,
@@ -99,7 +99,7 @@ where
 
         if self.buffer.is_empty() {
             let (chunk, root) = M::empty_chunk::<BODY_SIZE>()?;
-            return Ok((root, vec![chunk.into()]));
+            return Ok((root, vec![chunk]));
         }
 
         GenericParallelSplitter::<M, BODY_SIZE>::split_to_vec(&self.buffer)
@@ -151,7 +151,7 @@ mod tests {
         let (root, chunks) = splitter.finish().unwrap();
         let chunks = chunks
             .into_iter()
-            .map(|c| crate::chunk::Chunk::from_envelope(c).unwrap());
+            .map(|c| crate::chunk::Chunk::from_envelope(c.into()).unwrap());
         (root, MemoryStore::from_chunks(chunks))
     }
 
@@ -170,7 +170,7 @@ mod tests {
         let store = MemoryStore::<crate::chunk::StandardChunkSet>::from_chunks(
             chunks
                 .into_iter()
-                .map(|c| crate::chunk::Chunk::from_envelope(c).unwrap()),
+                .map(|c| crate::chunk::Chunk::from_envelope(c.into()).unwrap()),
         );
 
         assert_eq!(store.len(), 4);
@@ -229,7 +229,7 @@ mod tests {
             let (root_ref, chunks) = splitter.finish().unwrap();
             let chunks = chunks
                 .into_iter()
-                .map(|c| crate::chunk::Chunk::from_envelope(c).unwrap());
+                .map(|c| crate::chunk::Chunk::from_envelope(c.into()).unwrap());
             (root_ref, MemoryStore::from_chunks(chunks))
         }
 

--- a/crates/primitives/src/file/splitter_parallel.rs
+++ b/crates/primitives/src/file/splitter_parallel.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 use rayon::prelude::*;
 
 use crate::bmt::DEFAULT_BODY_SIZE;
-use crate::chunk::AnyChunk;
+use crate::chunk::ContentChunk;
 
 use super::constants::{LEVEL_LIMIT, compute_spans_inline};
 use super::error::{FileError, Result};
@@ -55,7 +55,7 @@ where
     pub fn split_into<R, F>(source: &R, sink: F) -> Result<M::RootRef>
     where
         R: ReadAt + Sync,
-        F: Fn(AnyChunk<BODY_SIZE>) + Sync,
+        F: Fn(ContentChunk<BODY_SIZE>) + Sync,
     {
         const { super::constants::assert_valid_body_size::<BODY_SIZE>() };
         let size = source.len();
@@ -63,7 +63,7 @@ where
 
         if size == 0 {
             let (chunk, root) = M::empty_chunk::<BODY_SIZE>()?;
-            sink(chunk.into());
+            sink(chunk);
             return Ok(root);
         }
 
@@ -83,7 +83,7 @@ where
     #[allow(clippy::unwrap_used)] // Mutex poisoning requires a sink panic, which itself already aborts the rayon join; both unwraps are on that same local mutex
     pub fn split_to_vec<R: ReadAt + Sync>(
         source: &R,
-    ) -> Result<(M::RootRef, Vec<AnyChunk<BODY_SIZE>>)> {
+    ) -> Result<(M::RootRef, Vec<ContentChunk<BODY_SIZE>>)> {
         let chunks = std::sync::Mutex::new(Vec::new());
         let root = Self::split_into(source, |chunk| chunks.lock().unwrap().push(chunk))?;
         Ok((root, chunks.into_inner().unwrap()))
@@ -97,7 +97,7 @@ where
     ) -> Result<Vec<M::Ref>>
     where
         R: ReadAt + Sync,
-        F: Fn(AnyChunk<BODY_SIZE>) + Sync,
+        F: Fn(ContentChunk<BODY_SIZE>) + Sync,
     {
         let data_chunks = tree.data_chunks();
         let size = tree.size();
@@ -123,7 +123,7 @@ where
                 let chunk_bytes = super::helpers::build_intermediate_payload(span, &buf);
 
                 let (chunk, reference) = M::prepare_chunk::<BODY_SIZE>(chunk_bytes)?;
-                sink(chunk.into());
+                sink(chunk);
                 Ok(reference)
             })
             .collect();
@@ -139,7 +139,7 @@ where
         sink: &F,
     ) -> Result<M::RootRef>
     where
-        F: Fn(AnyChunk<BODY_SIZE>) + Sync,
+        F: Fn(ContentChunk<BODY_SIZE>) + Sync,
     {
         let mut level = 1;
 
@@ -161,7 +161,7 @@ where
         sink: &F,
     ) -> Result<Vec<M::Ref>>
     where
-        F: Fn(AnyChunk<BODY_SIZE>) + Sync,
+        F: Fn(ContentChunk<BODY_SIZE>) + Sync,
     {
         let refs_per_chunk = M::refs_per_chunk(BODY_SIZE);
         let chunks_at_level = refs.len().div_ceil(refs_per_chunk);
@@ -192,7 +192,7 @@ where
                 let chunk_bytes = super::helpers::build_intermediate_payload(span, &ref_data);
 
                 let (chunk, reference) = M::prepare_chunk::<BODY_SIZE>(chunk_bytes)?;
-                sink(chunk.into());
+                sink(chunk);
                 Ok(reference)
             })
             .collect();
@@ -216,7 +216,7 @@ mod tests {
         let (root, chunks) = ParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(&data).unwrap();
         let chunks = chunks
             .into_iter()
-            .map(|c| crate::chunk::Chunk::from_envelope(c).unwrap());
+            .map(|c| crate::chunk::Chunk::from_envelope(c.into()).unwrap());
         (root, MemoryStore::from_chunks(chunks))
     }
 
@@ -267,7 +267,7 @@ mod tests {
                 EncryptedParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(&data).unwrap();
             let chunks = chunks
                 .into_iter()
-                .map(|c| crate::chunk::Chunk::from_envelope(c).unwrap());
+                .map(|c| crate::chunk::Chunk::from_envelope(c.into()).unwrap());
             (root_ref, MemoryStore::from_chunks(chunks))
         }
 

--- a/crates/primitives/src/file/tests.rs
+++ b/crates/primitives/src/file/tests.rs
@@ -252,7 +252,7 @@ mod write_file_ext {
         splitter.write_all(data).unwrap();
         let (root, chunks) = splitter.finish().unwrap();
         for chunk in chunks {
-            let sealed = crate::chunk::Chunk::from_envelope(chunk).unwrap();
+            let sealed = crate::chunk::Chunk::from_envelope(chunk.into()).unwrap();
             block_on(store.put(sealed)).unwrap();
         }
         let recovered = block_on(store.read_file(root)).unwrap();


### PR DESCRIPTION
Closes #200

## What

Removes the `ContentChunk` -> `AnyChunk` -> `ContentChunk` round-trip through the file pipeline.

- Splitters (`GenericSplitter::finish`, `GenericParallelSplitter::split_into`/`split_to_vec` and its level builders) now produce `ContentChunk<BODY_SIZE>` directly instead of upcasting to `AnyChunk<BODY_SIZE>`.
- `JoinMode::init_from_chunk` and `JoinMode::decode_body` are now generic over `C: ChunkOps` rather than fixed to `ContentChunk<BS>`, so `mode::joiner_init`, `mode::read_chunk_body`, and the joiner's single-chunk `read_range` path pass the store's envelope straight through with no `into_content()` downcast.
- `EncryptedMode` now uses `ChunkOps::into_bytes` in place of the `ContentChunk -> Bytes` conversion; byte-identical for a CAC.
- The sole remaining upcast into the store's envelope is at the store boundary: `file/mod.rs::seal_chunks`, mantaray's `ManifestBuilder::put_file`, and the test/bench seal sites, all of which now call `.into()` explicitly before `Chunk::from_envelope`.
- The now-unconstructable `FileError::InvalidChunkType` variant is removed, since a downcast that could fail no longer exists on this path.

Store traits are unaffected and remain on the envelope (`TrustedStore<AnyChunkSet<BS>>`).

## Why

The splitter produced `ContentChunk`, immediately upcast it to `AnyChunk` to satisfy the old fixed-type `JoinMode` signatures, and the joiner then downcast it straight back to `ContentChunk` via a fallible `into_content()`. That downcast could never fail in practice, since chunks flowing this path are always content chunks, but it still forced a `Result`-returning conversion and kept `FileError::InvalidChunkType` alive as dead-letter error handling. Genericizing over `ChunkOps` collapses the round-trip to a single upcast at the actual store boundary, where the envelope type is genuinely needed.

## Testing

Existing `crates/primitives/src/file/tests.rs` and inline splitter/joiner unit tests exercise the changed seal/read paths; these were updated in place to call `.into()` before `Chunk::from_envelope` where chunks are now sealed from `ContentChunk` rather than `AnyChunk`. No new test coverage was added since this is a type-only refactor with no behavioural change.

## AI assistance

Implemented with Claude Opus 4.5 (Anthropic), per the AI-assistance disclosure in [nxm-rs/.github CONTRIBUTING.md](https://github.com/nxm-rs/.github/blob/main/CONTRIBUTING.md).

