### PR TITLE
feat(manifest): key, entry, and typed-metadata value model

### DIFF
--- a/crates/manifest/src/error.rs
+++ b/crates/manifest/src/error.rs
@@ -1,5 +1,7 @@
 //! Rejections from the bound-carrying constructors.
 
+use crate::meta::KeyId;
+
 /// Prefix rejected: length exceeds the format's `PLEN_MAX`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 #[error("prefix length {actual} exceeds the format maximum {max}")]
@@ -18,6 +20,35 @@ pub struct MetadataTooLong {
     pub actual: usize,
     /// The format's `META_MAX`.
     pub max: usize,
+}
+
+/// Inline value rejected: length exceeds the format's `VINLINE_MAX`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("inline value length {actual} exceeds the format maximum {max}")]
+pub struct ValueTooLong {
+    /// Rejected length in bytes.
+    pub actual: usize,
+    /// The format's `VINLINE_MAX`.
+    pub max: usize,
+}
+
+/// Custom metadata key rejected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum CustomKeyError {
+    /// The empty key is not encodable: the wire key length is `1..`.
+    #[error("custom metadata key is empty")]
+    Empty,
+    /// Length exceeds the format's `CKEY_MAX`.
+    #[error("custom metadata key length {actual} exceeds the format maximum {max}")]
+    TooLong {
+        /// Rejected length in bytes.
+        actual: usize,
+        /// The format's `CKEY_MAX`.
+        max: usize,
+    },
+    /// The key equals a registered name, which must travel as its id.
+    #[error("custom metadata key duplicates the registered name {}", .0.name())]
+    Registered(KeyId),
 }
 
 /// Segment weight rejected: exceeds the format's `BUDGET`.

--- a/crates/manifest/src/format.rs
+++ b/crates/manifest/src/format.rs
@@ -43,6 +43,9 @@ pub trait Format:
     /// Max encoded metadata length per meta block, in bytes.
     const META_MAX: usize;
 
+    /// Max custom metadata key length in bytes.
+    const CKEY_MAX: usize;
+
     /// Max forks per node: radix-256, one fork per distinct first byte.
     const FORKS_MAX: usize;
 
@@ -80,6 +83,7 @@ impl Format for V1 {
     const PLEN_MAX: usize = 255;
     const VINLINE_MAX: usize = 128;
     const META_MAX: usize = 1024;
+    const CKEY_MAX: usize = 64;
     const FORKS_MAX: usize = 256;
     const INLINE_MAX: usize = 1536;
     const SEG_TARGET: usize = 2048;
@@ -107,6 +111,10 @@ const _: () = {
         V1::VINLINE_MAX <= V1::INLINE_MAX && V1::INLINE_MAX < V1::BUDGET,
         "inline caps must nest below the body budget"
     );
+    assert!(
+        V1::VINLINE_MAX <= 0xFF && V1::CKEY_MAX <= 0xFF && V1::META_MAX <= 0xFFFF,
+        "bounded lengths must fit their one- or two-byte wire length fields"
+    );
 };
 
 #[cfg(test)]
@@ -128,6 +136,7 @@ mod tests {
         assert_eq!(V1::PLEN_MAX, 255);
         assert_eq!(V1::VINLINE_MAX, 128);
         assert_eq!(V1::META_MAX, 1024);
+        assert_eq!(V1::CKEY_MAX, 64);
         assert_eq!(V1::FORKS_MAX, 256);
         assert_eq!(V1::INLINE_MAX, 1536);
         assert_eq!(V1::SEG_TARGET, 2048);

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -8,6 +8,10 @@
 //! check a format bound once at construction and carry it as a type
 //! invariant.
 //!
+//! The value model is [`Key`] (arbitrary bytes), [`Entry`] (a chunk
+//! reference or an inline value; absence is `Option` at the use site) and
+//! [`Metadata`] (typed key-registry pairs, sorted-unique and bounded).
+//!
 //! ```
 //! use nectar_manifest::{Format, Prefix, V1};
 //!
@@ -36,7 +40,11 @@
 mod bounded;
 mod error;
 mod format;
+mod meta;
+mod value;
 
 pub use bounded::{MetadataLen, Prefix, SegmentWeight};
-pub use error::{MetadataTooLong, PrefixTooLong, WeightOverBudget};
+pub use error::{CustomKeyError, MetadataTooLong, PrefixTooLong, ValueTooLong, WeightOverBudget};
 pub use format::{Format, V1};
+pub use meta::{CustomKey, KeyId, Metadata, MetadataKey};
+pub use value::{Entry, InlineValue, Key};

--- a/crates/manifest/src/meta.rs
+++ b/crates/manifest/src/meta.rs
@@ -366,6 +366,22 @@ mod tests {
     }
 
     #[test]
+    fn key_id_order_tracks_the_wire_id() {
+        // The canonical wire order of known pairs is ascending key_id, and the
+        // encoder emits them in the derived enum order: the two MUST coincide
+        // for every id, else a variant reorder silently drifts the address.
+        let mut by_ord = ALL_IDS;
+        by_ord.sort_unstable();
+        let mut by_id = ALL_IDS;
+        by_id.sort_unstable_by_key(|id| id.id());
+        assert_eq!(by_ord, by_id);
+        for pair in ALL_IDS.windows(2) {
+            assert!(pair[0].id() < pair[1].id());
+            assert!(MetadataKey::<V1>::from(pair[0]) < MetadataKey::from(pair[1]));
+        }
+    }
+
+    #[test]
     fn metadata_key_order_is_the_wire_order() {
         let known_last: MetadataKey = KeyId::SwarmFeedType.into();
         let custom_first: MetadataKey = custom(b"a").into();

--- a/crates/manifest/src/meta.rs
+++ b/crates/manifest/src/meta.rs
@@ -1,0 +1,447 @@
+//! Typed metadata: the u8 key registry plus the custom-key escape.
+//!
+//! Determinism is by rule, not by encoder behaviour: keys are sorted-unique,
+//! registered names always travel as their one-byte id, and the encoded
+//! length is bounded by `F::META_MAX` at construction.
+
+use core::marker::PhantomData;
+use core::mem::size_of;
+use std::collections::BTreeMap;
+
+use bytes::Bytes;
+
+use crate::bounded::MetadataLen;
+use crate::error::{CustomKeyError, MetadataTooLong};
+use crate::format::{Format, V1};
+
+/// Registered metadata key ids of registry version 1.
+///
+/// The registry is closed per format version: unassigned and reserved ids
+/// are unrepresentable here, so a decoder rejects them by construction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum KeyId {
+    /// MIME type bytes of the entry's content.
+    ContentType,
+    /// Original file name bytes.
+    Filename,
+    /// Site index document path bytes (root scope).
+    WebsiteIndexDocument,
+    /// Site error document path bytes (root scope).
+    WebsiteErrorDocument,
+    /// Feed owner, 20 bytes (root scope).
+    SwarmFeedOwner,
+    /// Feed topic, 32 bytes (root scope).
+    SwarmFeedTopic,
+    /// Feed type bytes (root scope).
+    SwarmFeedType,
+}
+
+impl KeyId {
+    /// The one-byte wire id.
+    #[must_use]
+    pub const fn id(self) -> u8 {
+        match self {
+            Self::ContentType => 0x01,
+            Self::Filename => 0x02,
+            Self::WebsiteIndexDocument => 0x03,
+            Self::WebsiteErrorDocument => 0x04,
+            Self::SwarmFeedOwner => 0x05,
+            Self::SwarmFeedTopic => 0x06,
+            Self::SwarmFeedType => 0x07,
+        }
+    }
+
+    /// The registered id for `id`, or `None` for unassigned and reserved
+    /// values.
+    #[must_use]
+    pub const fn from_id(id: u8) -> Option<Self> {
+        match id {
+            0x01 => Some(Self::ContentType),
+            0x02 => Some(Self::Filename),
+            0x03 => Some(Self::WebsiteIndexDocument),
+            0x04 => Some(Self::WebsiteErrorDocument),
+            0x05 => Some(Self::SwarmFeedOwner),
+            0x06 => Some(Self::SwarmFeedTopic),
+            0x07 => Some(Self::SwarmFeedType),
+            _ => None,
+        }
+    }
+
+    /// The registered key name this id replaces on the wire.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::ContentType => "content-type",
+            Self::Filename => "filename",
+            Self::WebsiteIndexDocument => "website-index-document",
+            Self::WebsiteErrorDocument => "website-error-document",
+            Self::SwarmFeedOwner => "swarm-feed-owner",
+            Self::SwarmFeedTopic => "swarm-feed-topic",
+            Self::SwarmFeedType => "swarm-feed-type",
+        }
+    }
+
+    /// The id registered for `name`, or `None` for unregistered names.
+    #[must_use]
+    pub const fn from_name(name: &[u8]) -> Option<Self> {
+        match name {
+            b"content-type" => Some(Self::ContentType),
+            b"filename" => Some(Self::Filename),
+            b"website-index-document" => Some(Self::WebsiteIndexDocument),
+            b"website-error-document" => Some(Self::WebsiteErrorDocument),
+            b"swarm-feed-owner" => Some(Self::SwarmFeedOwner),
+            b"swarm-feed-topic" => Some(Self::SwarmFeedTopic),
+            b"swarm-feed-type" => Some(Self::SwarmFeedType),
+            _ => None,
+        }
+    }
+}
+
+/// An unregistered metadata key, carried behind the 0xFF escape.
+///
+/// Non-empty, at most `F::CKEY_MAX` bytes, and never equal to a registered
+/// name: a registered name must travel as its id, so equality here would
+/// fork the canonical encoding.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CustomKey<F: Format = V1> {
+    bytes: Bytes,
+    _format: PhantomData<F>,
+}
+
+impl<F: Format> CustomKey<F> {
+    /// Wrap `bytes` as a custom key, rejecting the empty key, lengths above
+    /// `F::CKEY_MAX`, and registered names.
+    pub fn new(bytes: Bytes) -> Result<Self, CustomKeyError> {
+        check_ckey::<F>(&bytes)?;
+        Ok(Self {
+            bytes,
+            _format: PhantomData,
+        })
+    }
+
+    /// Key length in bytes; always in `1..=F::CKEY_MAX`.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    /// Always `false`: the empty key is rejected at construction.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        false
+    }
+
+    /// The key bytes.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// The key bytes as shared [`Bytes`].
+    #[must_use]
+    pub fn into_bytes(self) -> Bytes {
+        self.bytes
+    }
+}
+
+/// Validity gate shared by the owned and copying constructors, checked
+/// before any copy so a rejected slice never allocates.
+const fn check_ckey<F: Format>(bytes: &[u8]) -> Result<(), CustomKeyError> {
+    if bytes.is_empty() {
+        return Err(CustomKeyError::Empty);
+    }
+    if bytes.len() > F::CKEY_MAX {
+        return Err(CustomKeyError::TooLong {
+            actual: bytes.len(),
+            max: F::CKEY_MAX,
+        });
+    }
+    if let Some(id) = KeyId::from_name(bytes) {
+        return Err(CustomKeyError::Registered(id));
+    }
+    Ok(())
+}
+
+impl<F: Format> AsRef<[u8]> for CustomKey<F> {
+    fn as_ref(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+impl<F: Format> TryFrom<Bytes> for CustomKey<F> {
+    type Error = CustomKeyError;
+
+    fn try_from(bytes: Bytes) -> Result<Self, Self::Error> {
+        Self::new(bytes)
+    }
+}
+
+impl<F: Format> TryFrom<&[u8]> for CustomKey<F> {
+    type Error = CustomKeyError;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        check_ckey::<F>(bytes)?;
+        Ok(Self {
+            bytes: Bytes::copy_from_slice(bytes),
+            _format: PhantomData,
+        })
+    }
+}
+
+/// A metadata pair key: a registered id or a custom key.
+///
+/// The derived order is the wire order: registered ids ascending, then
+/// custom keys ascending bytewise.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum MetadataKey<F: Format = V1> {
+    /// A registered key, one byte on the wire.
+    Known(KeyId),
+    /// An unregistered key behind the 0xFF escape.
+    Custom(CustomKey<F>),
+}
+
+impl<F: Format> MetadataKey<F> {
+    /// Encoded key bytes on the wire: the id, or escape + length + key.
+    #[must_use]
+    pub const fn encoded_len(&self) -> usize {
+        match self {
+            Self::Known(_) => size_of::<u8>(),
+            Self::Custom(key) => size_of::<u8>()
+                .saturating_add(size_of::<u8>())
+                .saturating_add(key.len()),
+        }
+    }
+}
+
+impl<F: Format> From<KeyId> for MetadataKey<F> {
+    fn from(id: KeyId) -> Self {
+        Self::Known(id)
+    }
+}
+
+impl<F: Format> From<CustomKey<F>> for MetadataKey<F> {
+    fn from(key: CustomKey<F>) -> Self {
+        Self::Custom(key)
+    }
+}
+
+/// Typed metadata: sorted-unique pairs bounded by encoded length.
+///
+/// Non-empty by construction: an absent block is `Option<Metadata>` at the
+/// use site, so no in-band empty ambiguity exists. Iteration order is the
+/// wire order. Values are opaque bytes; fixed widths are registry
+/// convention, not enforced here.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Metadata<F: Format = V1> {
+    pairs: BTreeMap<MetadataKey<F>, Bytes>,
+    len: MetadataLen<F>,
+}
+
+impl<F: Format> Metadata<F> {
+    /// A block holding the single pair `key -> value`, rejecting an encoded
+    /// length above `F::META_MAX`.
+    pub fn new(key: impl Into<MetadataKey<F>>, value: Bytes) -> Result<Self, MetadataTooLong> {
+        let key = key.into();
+        let len = MetadataLen::new(pair_len(&key, &value))?;
+        let mut pairs = BTreeMap::new();
+        pairs.insert(key, value);
+        Ok(Self { pairs, len })
+    }
+
+    /// Insert `key -> value`, replacing any existing value for `key` and
+    /// returning it. Rejects the insert, leaving the block unchanged, when
+    /// the encoded length would exceed `F::META_MAX`.
+    pub fn insert(
+        &mut self,
+        key: impl Into<MetadataKey<F>>,
+        value: Bytes,
+    ) -> Result<Option<Bytes>, MetadataTooLong> {
+        let key = key.into();
+        let replaced = self.pairs.get(&key).map_or(0, |old| pair_len(&key, old));
+        let total = self
+            .len
+            .get()
+            .saturating_sub(replaced)
+            .saturating_add(pair_len(&key, &value));
+        self.len = MetadataLen::new(total)?;
+        Ok(self.pairs.insert(key, value))
+    }
+
+    /// The value stored for `key`.
+    #[must_use]
+    pub fn get(&self, key: &MetadataKey<F>) -> Option<&Bytes> {
+        self.pairs.get(key)
+    }
+
+    /// The pairs in wire order.
+    pub fn iter(&self) -> impl Iterator<Item = (&MetadataKey<F>, &Bytes)> {
+        self.pairs.iter()
+    }
+
+    /// Number of pairs; always at least one.
+    #[must_use]
+    pub fn pair_count(&self) -> usize {
+        self.pairs.len()
+    }
+
+    /// Encoded length of the pairs; always at most `F::META_MAX`.
+    #[must_use]
+    pub const fn encoded_len(&self) -> MetadataLen<F> {
+        self.len
+    }
+}
+
+/// Encoded bytes of one pair: key encoding, the two-byte value length, and
+/// the value. Saturating: an over-long value saturates past `F::META_MAX`
+/// and is rejected by the [`MetadataLen`] bound.
+const fn pair_len<F: Format>(key: &MetadataKey<F>, value: &Bytes) -> usize {
+    key.encoded_len()
+        .saturating_add(size_of::<u16>())
+        .saturating_add(value.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ALL_IDS: [KeyId; 7] = [
+        KeyId::ContentType,
+        KeyId::Filename,
+        KeyId::WebsiteIndexDocument,
+        KeyId::WebsiteErrorDocument,
+        KeyId::SwarmFeedOwner,
+        KeyId::SwarmFeedTopic,
+        KeyId::SwarmFeedType,
+    ];
+
+    fn custom(bytes: &[u8]) -> CustomKey {
+        CustomKey::try_from(bytes).unwrap()
+    }
+
+    #[test]
+    fn key_ids_round_trip_and_cover_the_registry() {
+        for (offset, id) in ALL_IDS.into_iter().enumerate() {
+            assert_eq!(id.id(), u8::try_from(offset).unwrap() + 1);
+            assert_eq!(KeyId::from_id(id.id()), Some(id));
+            assert_eq!(KeyId::from_name(id.name().as_bytes()), Some(id));
+        }
+    }
+
+    #[test]
+    fn key_ids_reject_reserved_and_unassigned() {
+        for id in [0x00, 0x08, 0x7F, 0x80, 0xFE, 0xFF] {
+            assert_eq!(KeyId::from_id(id), None);
+        }
+        assert_eq!(KeyId::from_name(b"x-custom"), None);
+    }
+
+    #[test]
+    fn custom_key_bounds() {
+        assert_eq!(
+            CustomKey::<V1>::try_from(&b""[..]),
+            Err(CustomKeyError::Empty)
+        );
+
+        let max = vec![0x78; V1::CKEY_MAX];
+        assert_eq!(custom(&max).len(), V1::CKEY_MAX);
+
+        let over = vec![0x78; V1::CKEY_MAX + 1];
+        assert_eq!(
+            CustomKey::<V1>::new(Bytes::from(over)),
+            Err(CustomKeyError::TooLong {
+                actual: V1::CKEY_MAX + 1,
+                max: V1::CKEY_MAX
+            })
+        );
+    }
+
+    #[test]
+    fn custom_key_rejects_registered_names() {
+        for id in ALL_IDS {
+            assert_eq!(
+                CustomKey::<V1>::try_from(id.name().as_bytes()),
+                Err(CustomKeyError::Registered(id))
+            );
+        }
+    }
+
+    #[test]
+    fn metadata_key_order_is_the_wire_order() {
+        let known_last: MetadataKey = KeyId::SwarmFeedType.into();
+        let custom_first: MetadataKey = custom(b"a").into();
+        assert!(known_last < custom_first);
+        assert!(MetadataKey::<V1>::from(KeyId::ContentType) < MetadataKey::from(KeyId::Filename));
+        assert!(MetadataKey::from(custom(b"a")) < MetadataKey::from(custom(b"ab")));
+        assert!(MetadataKey::from(custom(b"ab")) < MetadataKey::from(custom(b"b")));
+    }
+
+    #[test]
+    fn encoded_len_counts_exact_wire_bytes() {
+        // known: id (1) + vlen (2) + value.
+        let meta =
+            Metadata::<V1>::new(KeyId::ContentType, Bytes::from_static(b"text/html")).unwrap();
+        assert_eq!(meta.encoded_len().get(), 1 + 2 + 9);
+
+        // custom: escape (1) + klen (1) + key + vlen (2) + value.
+        let meta = Metadata::new(custom(b"note"), Bytes::from_static(b"hi")).unwrap();
+        assert_eq!(meta.encoded_len().get(), 2 + 4 + 2 + 2);
+    }
+
+    #[test]
+    fn insert_replaces_and_retotals() {
+        let mut meta =
+            Metadata::<V1>::new(KeyId::ContentType, Bytes::from_static(b"text/plain")).unwrap();
+        let old = meta
+            .insert(KeyId::ContentType, Bytes::from_static(b"text/html"))
+            .unwrap();
+        assert_eq!(old, Some(Bytes::from_static(b"text/plain")));
+        assert_eq!(meta.pair_count(), 1);
+        assert_eq!(meta.encoded_len().get(), 1 + 2 + 9);
+        assert_eq!(
+            meta.get(&KeyId::ContentType.into()),
+            Some(&Bytes::from_static(b"text/html"))
+        );
+    }
+
+    #[test]
+    fn iteration_is_wire_order_regardless_of_insertion_order() {
+        let mut meta = Metadata::new(custom(b"note"), Bytes::new()).unwrap();
+        meta.insert(KeyId::Filename, Bytes::new()).unwrap();
+        meta.insert(KeyId::ContentType, Bytes::new()).unwrap();
+        let keys: Vec<_> = meta.iter().map(|(k, _)| k.clone()).collect();
+        assert_eq!(
+            keys,
+            vec![
+                KeyId::ContentType.into(),
+                KeyId::Filename.into(),
+                custom(b"note").into(),
+            ]
+        );
+    }
+
+    #[test]
+    fn meta_max_bounds_the_block() {
+        // One known pair saturating the block: 1 + 2 + value = META_MAX.
+        let fit = Bytes::from(vec![0; V1::META_MAX - 3]);
+        let mut meta = Metadata::<V1>::new(KeyId::ContentType, fit).unwrap();
+        assert_eq!(meta.encoded_len().get(), V1::META_MAX);
+
+        // Any further pair overflows; the block is left unchanged.
+        let before = meta.clone();
+        let err = meta.insert(KeyId::Filename, Bytes::new()).unwrap_err();
+        assert_eq!(err.max, V1::META_MAX);
+        assert_eq!(meta, before);
+
+        let over = Bytes::from(vec![0; V1::META_MAX - 2]);
+        assert!(Metadata::<V1>::new(KeyId::ContentType, over).is_err());
+    }
+
+    #[test]
+    fn replacing_within_budget_at_the_boundary_is_accepted() {
+        let fit = Bytes::from(vec![0; V1::META_MAX - 3]);
+        let mut meta = Metadata::<V1>::new(KeyId::ContentType, fit.clone()).unwrap();
+        // Same key, same size: replaced length is credited before the check.
+        assert!(meta.insert(KeyId::ContentType, fit).is_ok());
+        assert_eq!(meta.encoded_len().get(), V1::META_MAX);
+    }
+}

--- a/crates/manifest/src/value.rs
+++ b/crates/manifest/src/value.rs
@@ -1,0 +1,327 @@
+//! Keys and entry values: what the map stores against each key.
+
+use core::marker::PhantomData;
+
+use bytes::Bytes;
+use nectar_primitives::{ChunkAddress, ChunkRef, EncryptedChunkRef};
+
+use crate::error::ValueTooLong;
+use crate::format::{Format, V1};
+
+/// An arbitrary-byte map key, ordered bytewise.
+///
+/// Unbounded: long keys chain through trie nodes on the wire, so no format
+/// bound applies to the key itself. The empty key is legal; its value lives
+/// in the root extension.
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Key(Bytes);
+
+impl Key {
+    /// The empty key.
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self(Bytes::new())
+    }
+
+    /// Wrap `bytes` as a key.
+    #[must_use]
+    pub const fn new(bytes: Bytes) -> Self {
+        Self(bytes)
+    }
+
+    /// Key length in bytes.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` for the empty key.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// The key bytes.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// The key bytes as shared [`Bytes`].
+    #[must_use]
+    pub fn into_bytes(self) -> Bytes {
+        self.0
+    }
+}
+
+impl AsRef<[u8]> for Key {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl From<Bytes> for Key {
+    fn from(bytes: Bytes) -> Self {
+        Self(bytes)
+    }
+}
+
+impl From<Vec<u8>> for Key {
+    fn from(bytes: Vec<u8>) -> Self {
+        Self(Bytes::from(bytes))
+    }
+}
+
+impl From<&[u8]> for Key {
+    fn from(bytes: &[u8]) -> Self {
+        Self(Bytes::copy_from_slice(bytes))
+    }
+}
+
+/// An inline value: at most `F::VINLINE_MAX` bytes, checked once here.
+///
+/// The empty value is legal and distinct from an absent entry, which is
+/// `Option::None` at the use site.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct InlineValue<F: Format = V1> {
+    bytes: Bytes,
+    _format: PhantomData<F>,
+}
+
+impl<F: Format> InlineValue<F> {
+    /// The empty value.
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self {
+            bytes: Bytes::new(),
+            _format: PhantomData,
+        }
+    }
+
+    /// Wrap `bytes` as an inline value, rejecting lengths above
+    /// `F::VINLINE_MAX`.
+    pub fn new(bytes: Bytes) -> Result<Self, ValueTooLong> {
+        check_vlen::<F>(bytes.len())?;
+        Ok(Self {
+            bytes,
+            _format: PhantomData,
+        })
+    }
+
+    /// Value length in bytes; always at most `F::VINLINE_MAX`.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    /// Returns `true` for the empty value.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.bytes.is_empty()
+    }
+
+    /// The value bytes.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// The value bytes as shared [`Bytes`].
+    #[must_use]
+    pub fn into_bytes(self) -> Bytes {
+        self.bytes
+    }
+}
+
+impl<F: Format> Default for InlineValue<F> {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+/// Length gate shared by the owned and copying constructors, checked before
+/// any copy so an over-long slice never allocates.
+const fn check_vlen<F: Format>(actual: usize) -> Result<(), ValueTooLong> {
+    if actual > F::VINLINE_MAX {
+        return Err(ValueTooLong {
+            actual,
+            max: F::VINLINE_MAX,
+        });
+    }
+    Ok(())
+}
+
+impl<F: Format> AsRef<[u8]> for InlineValue<F> {
+    fn as_ref(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+impl<F: Format> TryFrom<Bytes> for InlineValue<F> {
+    type Error = ValueTooLong;
+
+    fn try_from(bytes: Bytes) -> Result<Self, Self::Error> {
+        Self::new(bytes)
+    }
+}
+
+impl<F: Format> TryFrom<&[u8]> for InlineValue<F> {
+    type Error = ValueTooLong;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        check_vlen::<F>(bytes.len())?;
+        Ok(Self {
+            bytes: Bytes::copy_from_slice(bytes),
+            _format: PhantomData,
+        })
+    }
+}
+
+/// A key's value: a chunk reference or inline bytes.
+///
+/// Absence is `Option<Entry>` at the use site; the wire carries a presence
+/// discriminant, never an in-band null sentinel. Traversal follows the
+/// reference variants only; inline bytes are opaque. A ref64 asserts the
+/// target is an encrypted chunk and transports its decryption key in-band.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Entry<F: Format = V1> {
+    /// A plain 32-byte reference.
+    Ref32(ChunkRef),
+    /// An encrypted 64-byte reference: address plus decryption key.
+    Ref64(EncryptedChunkRef),
+    /// Opaque inline bytes, at most `F::VINLINE_MAX`.
+    Inline(InlineValue<F>),
+}
+
+impl<F: Format> Entry<F> {
+    /// Wrap `bytes` as an inline entry, rejecting lengths above
+    /// `F::VINLINE_MAX`. Longer byte values belong in content chunks behind
+    /// a reference variant.
+    pub fn inline(bytes: Bytes) -> Result<Self, ValueTooLong> {
+        Ok(Self::Inline(InlineValue::new(bytes)?))
+    }
+
+    /// The referenced chunk address; `None` for an inline value.
+    #[must_use]
+    pub const fn address(&self) -> Option<&ChunkAddress> {
+        match self {
+            Self::Ref32(r) => Some(r.address()),
+            Self::Ref64(r) => Some(r.address()),
+            Self::Inline(_) => None,
+        }
+    }
+
+    /// Returns `true` when traversal follows this entry to a chunk.
+    #[must_use]
+    pub const fn is_reference(&self) -> bool {
+        matches!(self, Self::Ref32(_) | Self::Ref64(_))
+    }
+}
+
+impl<F: Format> From<ChunkRef> for Entry<F> {
+    fn from(reference: ChunkRef) -> Self {
+        Self::Ref32(reference)
+    }
+}
+
+impl<F: Format> From<EncryptedChunkRef> for Entry<F> {
+    fn from(reference: EncryptedChunkRef) -> Self {
+        Self::Ref64(reference)
+    }
+}
+
+impl<F: Format> From<InlineValue<F>> for Entry<F> {
+    fn from(value: InlineValue<F>) -> Self {
+        Self::Inline(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nectar_primitives::EncryptionKey;
+
+    use super::*;
+
+    fn address(byte: u8) -> ChunkAddress {
+        ChunkAddress::new([byte; 32])
+    }
+
+    #[test]
+    fn key_orders_bytewise() {
+        let a = Key::from(&b"a"[..]);
+        let ab = Key::from(&b"ab"[..]);
+        let b = Key::from(&b"b"[..]);
+        assert!(Key::empty() < a);
+        assert!(a < ab);
+        assert!(ab < b);
+    }
+
+    #[test]
+    fn key_empty_is_default() {
+        let key = Key::default();
+        assert!(key.is_empty());
+        assert_eq!(key.len(), 0);
+        assert_eq!(key, Key::empty());
+    }
+
+    #[test]
+    fn key_round_trips_bytes() {
+        let key = Key::from(vec![0x00, 0xFF]);
+        assert_eq!(key.as_bytes(), &[0x00, 0xFF]);
+        assert_eq!(key.clone().into_bytes(), Bytes::from(vec![0x00, 0xFF]));
+        assert_eq!(Key::new(Bytes::from(vec![0x00, 0xFF])), key);
+    }
+
+    #[test]
+    fn inline_value_accepts_up_to_vinline_max() {
+        let bytes = vec![0xAB; V1::VINLINE_MAX];
+        let value = InlineValue::<V1>::try_from(bytes.as_slice()).unwrap();
+        assert_eq!(value.len(), V1::VINLINE_MAX);
+        assert_eq!(value.as_bytes(), bytes.as_slice());
+    }
+
+    #[test]
+    fn inline_value_rejects_over_vinline_max() {
+        let bytes = vec![0xAB; V1::VINLINE_MAX + 1];
+        let err = InlineValue::<V1>::new(Bytes::from(bytes)).unwrap_err();
+        assert_eq!(
+            err,
+            ValueTooLong {
+                actual: V1::VINLINE_MAX + 1,
+                max: V1::VINLINE_MAX
+            }
+        );
+    }
+
+    #[test]
+    fn inline_value_empty_is_legal_and_distinct_from_absent() {
+        let value = InlineValue::<V1>::empty();
+        assert!(value.is_empty());
+        assert_eq!(value, InlineValue::default());
+
+        let entry: Option<Entry> = Some(Entry::inline(Bytes::new()).unwrap());
+        assert_ne!(entry, None);
+    }
+
+    #[test]
+    fn entry_address_follows_references_only() {
+        let addr = address(0x11);
+        let plain: Entry = ChunkRef::new(addr).into();
+        assert_eq!(plain.address(), Some(&addr));
+        assert!(plain.is_reference());
+
+        let encrypted: Entry = EncryptedChunkRef::new(addr, EncryptionKey::from([0x22; 32])).into();
+        assert_eq!(encrypted.address(), Some(&addr));
+        assert!(encrypted.is_reference());
+
+        let inline: Entry = InlineValue::empty().into();
+        assert_eq!(inline.address(), None);
+        assert!(!inline.is_reference());
+    }
+
+    #[test]
+    fn entry_inline_rejects_over_vinline_max() {
+        let err = Entry::<V1>::inline(Bytes::from(vec![0; V1::VINLINE_MAX + 1])).unwrap_err();
+        assert_eq!(err.max, V1::VINLINE_MAX);
+    }
+}


### PR DESCRIPTION
## What

Adds the manifest value model in `crates/manifest`.

- `value.rs`: `Key` (arbitrary bytes, bytewise `Ord`, empty key legal), `InlineValue<F>` bounded by `F::VINLINE_MAX`, and `Entry<F>` as `Ref32(ChunkRef) | Ref64(EncryptedChunkRef) | Inline(InlineValue<F>)`, reusing the 0.6.0 `Reference` newtypes. Absence is carried by `Option`, not an in-band null variant.
- `meta.rs`: the typed `u8` key-registry TLV model per the frozen spec's metadata section. A closed `KeyId` enum covers registry v1 ids `0x01`-`0x07` (reserved/unassigned ids are unrepresentable), `CustomKey<F>` requires non-empty names bounded by `F::CKEY_MAX` and rejects registered names, `MetadataKey<F>`'s derived `Ord` matches wire order (known ids ascending, then custom bytewise), and `Metadata<F>` is a sorted-unique `BTreeMap` that is non-empty by construction with its encoded length tracked.
- `error.rs`, `format.rs`, `lib.rs`: supporting error types, format constants, and module wiring for the above.

This is the in-memory value model only; there is no `Cursor`/decode path in this change (clean-slate format).

## Why

Closes #249

The manifest wire format needs a typed representation of what each trie key maps to (chunk reference, encrypted chunk reference, or inline bytes) and of the per-entry metadata TLV registry, both bounded per the frozen mantaray 1.0 spec, before the decode/encode path can be built on top.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --all-features`
- `cargo test --doc --workspace`

All commands run via `nix develop --command`, all green. `nectar-postage-usage` and `fuzz/` are untouched, so wasm/fuzz checks are not applicable to this change.

Independent verification covered: `Entry` ref32/ref64/inline (<=128) encodings; `Metadata` TLV `encoded_len` byte counts against the grammar; `META_MAX` bounding `mlen` as pairs-bytes; sorted-unique and known-first ordering; `CustomKey` rejecting empty, over-`CKEY_MAX`, and registered names; boundary arithmetic and the saturating insert path; and the `CKEY_MAX = 64` trait/pin/wire-width assertion. A dedicated regression test (`2e6143f`) guards the known `KeyId` wire order against accidental variant reordering.

## AI assistance

Implemented and red-teamed with Claude Sonnet 5 (Anthropic), per the org AI-assistance contract (nxm-rs/.github CONTRIBUTING.md).

