### PR TITLE
feat(manifest): node, fork-record, and fork-table data model

### DIFF
--- a/crates/manifest/src/bounded.rs
+++ b/crates/manifest/src/bounded.rs
@@ -60,6 +60,21 @@ impl<F: Format> Prefix<F> {
     pub fn into_bytes(self) -> Bytes {
         self.bytes
     }
+
+    /// Split off the first byte, sharing the tail; `None` when empty.
+    ///
+    /// The tail is strictly shorter, so its bound needs no re-check.
+    #[must_use]
+    pub fn split_first(self) -> Option<(u8, Self)> {
+        let first = *self.bytes.first()?;
+        Some((
+            first,
+            Self {
+                bytes: self.bytes.slice(1..),
+                _format: PhantomData,
+            },
+        ))
+    }
 }
 
 /// Length gate shared by the owned and copying constructors, checked before

--- a/crates/manifest/src/error.rs
+++ b/crates/manifest/src/error.rs
@@ -51,6 +51,11 @@ pub enum CustomKeyError {
     Registered(KeyId),
 }
 
+/// Fork prefix rejected: the empty prefix has no first byte to index under.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("fork prefix is empty")]
+pub struct ForkPrefixEmpty;
+
 /// Segment weight rejected: exceeds the format's `BUDGET`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 #[error("segment weight {actual} exceeds the format budget {max}")]

--- a/crates/manifest/src/fork.rs
+++ b/crates/manifest/src/fork.rs
@@ -1,0 +1,434 @@
+//! Fork records and the per-node fork table.
+//!
+//! The table is keyed on the first prefix byte, so sorted-unique order and
+//! the radix-256 fork bound are structural facts, not runtime checks. Wire
+//! flag bits carry no independent state and are never stored: presence is
+//! derived from the structure at encode time.
+
+use std::collections::BTreeMap;
+
+use nectar_primitives::{ChunkAddress, ChunkRef, EncryptedChunkRef};
+
+use crate::bounded::Prefix;
+use crate::error::ForkPrefixEmpty;
+use crate::format::{Format, V1};
+use crate::meta::Metadata;
+use crate::value::Entry;
+
+/// A fork's child: the trie continuation below the fork's prefix.
+///
+/// An embedded child is its fork table alone: an embedded body carries no
+/// root extension and is never segmented, so nothing else survives the
+/// type. Its encoded size bound (`F::INLINE_MAX`) and non-emptiness are the
+/// packing and codec cars' checks.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Child<F: Format = V1> {
+    /// A plain 32-byte reference to the child chunk.
+    Ref32(ChunkRef),
+    /// An encrypted 64-byte reference: address plus decryption key.
+    Ref64(EncryptedChunkRef),
+    /// The child's body held in the parent instead of a chunk of its own.
+    Embedded(ForkTable<F>),
+}
+
+impl<F: Format> Child<F> {
+    /// The referenced chunk address; `None` for an embedded child.
+    #[must_use]
+    pub const fn address(&self) -> Option<&ChunkAddress> {
+        match self {
+            Self::Ref32(r) => Some(r.address()),
+            Self::Ref64(r) => Some(r.address()),
+            Self::Embedded(_) => None,
+        }
+    }
+
+    /// Returns `true` when the child lives in a chunk of its own.
+    #[must_use]
+    pub const fn is_reference(&self) -> bool {
+        matches!(self, Self::Ref32(_) | Self::Ref64(_))
+    }
+}
+
+impl<F: Format> From<ChunkRef> for Child<F> {
+    fn from(reference: ChunkRef) -> Self {
+        Self::Ref32(reference)
+    }
+}
+
+impl<F: Format> From<EncryptedChunkRef> for Child<F> {
+    fn from(reference: EncryptedChunkRef) -> Self {
+        Self::Ref64(reference)
+    }
+}
+
+impl<F: Format> From<ForkTable<F>> for Child<F> {
+    fn from(forks: ForkTable<F>) -> Self {
+        Self::Embedded(forks)
+    }
+}
+
+/// What a fork holds: it terminates a key, continues the trie, or both.
+///
+/// Neither is unrepresentable: a fork with no entry and no child has no
+/// meaning.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ForkPayload<F: Format = V1> {
+    /// The accumulated path ending in this prefix is a key with this value.
+    Entry(Entry<F>),
+    /// The trie continues below this prefix.
+    Child(Child<F>),
+    /// A key terminates here and the trie continues below it.
+    Both {
+        /// The value at the accumulated path.
+        entry: Entry<F>,
+        /// The continuation below the prefix.
+        child: Child<F>,
+    },
+}
+
+impl<F: Format> ForkPayload<F> {
+    /// Assemble from parts; `None` when both are absent.
+    #[must_use]
+    pub fn new(entry: Option<Entry<F>>, child: Option<Child<F>>) -> Option<Self> {
+        match (entry, child) {
+            (Some(entry), Some(child)) => Some(Self::Both { entry, child }),
+            (Some(entry), None) => Some(Self::Entry(entry)),
+            (None, Some(child)) => Some(Self::Child(child)),
+            (None, None) => None,
+        }
+    }
+
+    /// The value terminating a key at this fork.
+    #[must_use]
+    pub const fn entry(&self) -> Option<&Entry<F>> {
+        match self {
+            Self::Entry(entry) | Self::Both { entry, .. } => Some(entry),
+            Self::Child(_) => None,
+        }
+    }
+
+    /// The trie continuation below this fork.
+    #[must_use]
+    pub const fn child(&self) -> Option<&Child<F>> {
+        match self {
+            Self::Child(child) | Self::Both { child, .. } => Some(child),
+            Self::Entry(_) => None,
+        }
+    }
+}
+
+impl<F: Format> From<Entry<F>> for ForkPayload<F> {
+    fn from(entry: Entry<F>) -> Self {
+        Self::Entry(entry)
+    }
+}
+
+impl<F: Format> From<Child<F>> for ForkPayload<F> {
+    fn from(child: Child<F>) -> Self {
+        Self::Child(child)
+    }
+}
+
+/// One fork: the prefix tail plus what hangs off it.
+///
+/// The prefix's first byte is not stored here: it is the fork-table key, so
+/// a record cannot disagree with its index position, and the full prefix
+/// length stays in `1..=F::PLEN_MAX` by construction.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ForkRecord<F: Format = V1> {
+    tail: Prefix<F>,
+    payload: ForkPayload<F>,
+    metadata: Option<Metadata<F>>,
+}
+
+impl<F: Format> ForkRecord<F> {
+    /// Split `prefix` into its first byte (the table key) and a record
+    /// holding the tail. Rejects the empty prefix: a fork consumes at least
+    /// the byte it is indexed under.
+    pub fn new(
+        prefix: Prefix<F>,
+        payload: ForkPayload<F>,
+        metadata: Option<Metadata<F>>,
+    ) -> Result<(u8, Self), ForkPrefixEmpty> {
+        let (first, tail) = prefix.split_first().ok_or(ForkPrefixEmpty)?;
+        Ok((
+            first,
+            Self {
+                tail,
+                payload,
+                metadata,
+            },
+        ))
+    }
+
+    /// The prefix tail: everything after the fork-table key byte.
+    #[must_use]
+    pub const fn tail(&self) -> &Prefix<F> {
+        &self.tail
+    }
+
+    /// Full prefix length in bytes; always in `1..=F::PLEN_MAX`.
+    #[must_use]
+    pub const fn prefix_len(&self) -> usize {
+        self.tail.len().saturating_add(1)
+    }
+
+    /// What the fork holds.
+    #[must_use]
+    pub const fn payload(&self) -> &ForkPayload<F> {
+        &self.payload
+    }
+
+    /// Mutable access to what the fork holds.
+    pub const fn payload_mut(&mut self) -> &mut ForkPayload<F> {
+        &mut self.payload
+    }
+
+    /// The value terminating a key at this fork.
+    #[must_use]
+    pub const fn entry(&self) -> Option<&Entry<F>> {
+        self.payload.entry()
+    }
+
+    /// The trie continuation below this fork.
+    #[must_use]
+    pub const fn child(&self) -> Option<&Child<F>> {
+        self.payload.child()
+    }
+
+    /// The metadata of the key terminating at this fork.
+    #[must_use]
+    pub const fn metadata(&self) -> Option<&Metadata<F>> {
+        self.metadata.as_ref()
+    }
+
+    /// Mutable access to the fork's metadata slot.
+    pub const fn metadata_mut(&mut self) -> &mut Option<Metadata<F>> {
+        &mut self.metadata
+    }
+}
+
+/// The per-node fork table, keyed on the first prefix byte.
+///
+/// Radix-256: the `u8` key makes the table sorted-unique and caps it at
+/// `F::FORKS_MAX` records structurally. Iteration order is the wire order.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ForkTable<F: Format = V1> {
+    records: BTreeMap<u8, ForkRecord<F>>,
+}
+
+impl<F: Format> ForkTable<F> {
+    /// The empty table.
+    #[must_use]
+    pub const fn new() -> Self {
+        // The structural cap is the key type's cardinality.
+        const { assert!(F::FORKS_MAX == 256) };
+        Self {
+            records: BTreeMap::new(),
+        }
+    }
+
+    /// Insert the fork for `prefix`, replacing and returning any record
+    /// already indexed under its first byte. Rejects the empty prefix.
+    pub fn insert(
+        &mut self,
+        prefix: Prefix<F>,
+        payload: ForkPayload<F>,
+        metadata: Option<Metadata<F>>,
+    ) -> Result<Option<ForkRecord<F>>, ForkPrefixEmpty> {
+        let (first, record) = ForkRecord::new(prefix, payload, metadata)?;
+        Ok(self.records.insert(first, record))
+    }
+
+    /// The record indexed under `first`.
+    #[must_use]
+    pub fn get(&self, first: u8) -> Option<&ForkRecord<F>> {
+        self.records.get(&first)
+    }
+
+    /// Mutable access to the record indexed under `first`.
+    pub fn get_mut(&mut self, first: u8) -> Option<&mut ForkRecord<F>> {
+        self.records.get_mut(&first)
+    }
+
+    /// Remove and return the record indexed under `first`.
+    pub fn remove(&mut self, first: u8) -> Option<ForkRecord<F>> {
+        self.records.remove(&first)
+    }
+
+    /// The forks in wire order: ascending first byte.
+    pub fn iter(&self) -> impl Iterator<Item = (u8, &ForkRecord<F>)> {
+        self.records.iter().map(|(first, record)| (*first, record))
+    }
+
+    /// Number of forks; always at most `F::FORKS_MAX`.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.records.len()
+    }
+
+    /// Returns `true` when the table holds no forks.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+}
+
+impl<F: Format> Default for ForkTable<F> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+
+    use super::*;
+
+    fn entry(byte: u8) -> Entry {
+        ChunkRef::new(ChunkAddress::new([byte; 32])).into()
+    }
+
+    fn prefix(bytes: &[u8]) -> Prefix {
+        Prefix::try_from(bytes).unwrap()
+    }
+
+    #[test]
+    fn insert_splits_the_prefix_and_iterates_in_wire_order() {
+        let mut table = ForkTable::new();
+        table
+            .insert(prefix(b"beta"), entry(1).into(), None)
+            .unwrap();
+        table
+            .insert(prefix(b"alpha"), entry(2).into(), None)
+            .unwrap();
+
+        let forks: Vec<_> = table
+            .iter()
+            .map(|(first, record)| (first, record.tail().as_bytes().to_vec()))
+            .collect();
+        assert_eq!(
+            forks,
+            vec![(b'a', b"lpha".to_vec()), (b'b', b"eta".to_vec())]
+        );
+    }
+
+    #[test]
+    fn empty_prefix_is_rejected() {
+        let mut table = ForkTable::new();
+        let err = table
+            .insert(Prefix::empty(), entry(1).into(), None)
+            .unwrap_err();
+        assert_eq!(err, ForkPrefixEmpty);
+        assert!(table.is_empty());
+    }
+
+    #[test]
+    fn full_prefix_length_is_bounded_by_plen_max() {
+        let bytes = vec![0x61; V1::PLEN_MAX];
+        let (first, record) = ForkRecord::new(prefix(&bytes), entry(1).into(), None).unwrap();
+        assert_eq!(first, 0x61);
+        assert_eq!(record.tail().len(), V1::PLEN_MAX - 1);
+        assert_eq!(record.prefix_len(), V1::PLEN_MAX);
+    }
+
+    #[test]
+    fn single_byte_prefix_has_an_empty_tail() {
+        let (first, record) = ForkRecord::new(prefix(b"x"), entry(1).into(), None).unwrap();
+        assert_eq!(first, b'x');
+        assert!(record.tail().is_empty());
+        assert_eq!(record.prefix_len(), 1);
+    }
+
+    #[test]
+    fn a_shared_first_byte_replaces_the_record() {
+        let mut table = ForkTable::new();
+        table.insert(prefix(b"aa"), entry(1).into(), None).unwrap();
+        let replaced = table
+            .insert(prefix(b"ab"), entry(2).into(), None)
+            .unwrap()
+            .unwrap();
+        assert_eq!(replaced.tail().as_bytes(), b"a");
+        assert_eq!(table.len(), 1);
+        assert_eq!(table.get(b'a').unwrap().tail().as_bytes(), b"b");
+    }
+
+    #[test]
+    fn the_table_saturates_at_forks_max() {
+        let mut table = ForkTable::new();
+        for first in u8::MIN..=u8::MAX {
+            table
+                .insert(prefix(&[first]), entry(first).into(), None)
+                .unwrap();
+        }
+        assert_eq!(table.len(), V1::FORKS_MAX);
+
+        table.insert(prefix(&[0]), entry(1).into(), None).unwrap();
+        assert_eq!(table.len(), V1::FORKS_MAX);
+    }
+
+    #[test]
+    fn payload_requires_an_entry_or_a_child() {
+        assert_eq!(ForkPayload::<V1>::new(None, None), None);
+
+        let only_entry = ForkPayload::new(Some(entry(1)), None).unwrap();
+        assert_eq!(only_entry.entry(), Some(&entry(1)));
+        assert_eq!(only_entry.child(), None);
+
+        let child = Child::from(ChunkRef::new(ChunkAddress::new([2; 32])));
+        let only_child = ForkPayload::new(None, Some(child.clone())).unwrap();
+        assert_eq!(only_child.entry(), None);
+        assert_eq!(only_child.child(), Some(&child));
+
+        let both = ForkPayload::new(Some(entry(1)), Some(child.clone())).unwrap();
+        assert_eq!(both.entry(), Some(&entry(1)));
+        assert_eq!(both.child(), Some(&child));
+    }
+
+    #[test]
+    fn an_embedded_child_is_a_fork_table() {
+        let mut inner = ForkTable::new();
+        inner
+            .insert(prefix(b"leaf"), entry(3).into(), None)
+            .unwrap();
+
+        let embedded = Child::from(inner.clone());
+        assert_eq!(embedded.address(), None);
+        assert!(!embedded.is_reference());
+
+        let mut outer = ForkTable::new();
+        outer
+            .insert(prefix(b"dir/"), embedded.into(), None)
+            .unwrap();
+        let child = outer.get(b'd').unwrap().child().unwrap();
+        assert_eq!(child, &Child::Embedded(inner));
+    }
+
+    #[test]
+    fn record_carries_metadata() {
+        let meta = Metadata::new(
+            crate::meta::KeyId::ContentType,
+            Bytes::from_static(b"text/html"),
+        )
+        .unwrap();
+        let (_, record) =
+            ForkRecord::new(prefix(b"index.html"), entry(1).into(), Some(meta.clone())).unwrap();
+        assert_eq!(record.metadata(), Some(&meta));
+    }
+
+    #[test]
+    fn removal_and_mutation_address_the_first_byte() {
+        let mut table = ForkTable::new();
+        table.insert(prefix(b"aa"), entry(1).into(), None).unwrap();
+        table.insert(prefix(b"bb"), entry(2).into(), None).unwrap();
+
+        *table.get_mut(b'a').unwrap().payload_mut() = entry(9).into();
+        assert_eq!(table.get(b'a').unwrap().entry(), Some(&entry(9)));
+
+        let removed = table.remove(b'b').unwrap();
+        assert_eq!(removed.tail().as_bytes(), b"b");
+        assert_eq!(table.len(), 1);
+        assert_eq!(table.remove(b'b'), None);
+    }
+}

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -12,6 +12,12 @@
 //! reference or an inline value; absence is `Option` at the use site) and
 //! [`Metadata`] (typed key-registry pairs, sorted-unique and bounded).
 //!
+//! The data model is [`Node`]: an optional [`RootExtension`] (the root's
+//! own entry and manifest metadata, complete in the root's own bytes) over
+//! a [`ForkTable`] of [`ForkRecord`]s keyed on the first prefix byte, so
+//! fork order and the radix-256 bound are structural. No flags are stored;
+//! presence bits are derived from the structure at encode time.
+//!
 //! ```
 //! use nectar_manifest::{Format, Prefix, V1};
 //!
@@ -39,12 +45,18 @@
 
 mod bounded;
 mod error;
+mod fork;
 mod format;
 mod meta;
+mod node;
 mod value;
 
 pub use bounded::{MetadataLen, Prefix, SegmentWeight};
-pub use error::{CustomKeyError, MetadataTooLong, PrefixTooLong, ValueTooLong, WeightOverBudget};
+pub use error::{
+    CustomKeyError, ForkPrefixEmpty, MetadataTooLong, PrefixTooLong, ValueTooLong, WeightOverBudget,
+};
+pub use fork::{Child, ForkPayload, ForkRecord, ForkTable};
 pub use format::{Format, V1};
 pub use meta::{CustomKey, KeyId, Metadata, MetadataKey};
+pub use node::{Node, RootExtension};
 pub use value::{Entry, InlineValue, Key};

--- a/crates/manifest/src/node.rs
+++ b/crates/manifest/src/node.rs
@@ -1,0 +1,229 @@
+//! The in-memory manifest node: an optional root extension over a fork
+//! table.
+//!
+//! Magic, version and every bound come from `F`; no flags are stored, the
+//! presence bits are derived from the structure at encode time.
+
+use crate::fork::ForkTable;
+use crate::format::{Format, V1};
+use crate::meta::Metadata;
+use crate::value::Entry;
+
+/// The root extension: what a trie root carries about itself, complete in
+/// the root's own bytes.
+///
+/// At least one part is always present; an absent extension is
+/// `Option<RootExtension>` on the node, so no in-band empty exists. Only a
+/// trie root may carry one; the fetching party enforces that on fetch.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RootExtension<F: Format = V1> {
+    /// The value at the empty key.
+    Entry(Entry<F>),
+    /// Manifest-level metadata.
+    Metadata(Metadata<F>),
+    /// Both the empty-key value and manifest-level metadata.
+    Both {
+        /// The value at the empty key.
+        entry: Entry<F>,
+        /// Manifest-level metadata.
+        metadata: Metadata<F>,
+    },
+}
+
+impl<F: Format> RootExtension<F> {
+    /// Assemble from parts; `None` when both are absent.
+    #[must_use]
+    pub fn new(entry: Option<Entry<F>>, metadata: Option<Metadata<F>>) -> Option<Self> {
+        match (entry, metadata) {
+            (Some(entry), Some(metadata)) => Some(Self::Both { entry, metadata }),
+            (Some(entry), None) => Some(Self::Entry(entry)),
+            (None, Some(metadata)) => Some(Self::Metadata(metadata)),
+            (None, None) => None,
+        }
+    }
+
+    /// The value at the empty key.
+    #[must_use]
+    pub const fn entry(&self) -> Option<&Entry<F>> {
+        match self {
+            Self::Entry(entry) | Self::Both { entry, .. } => Some(entry),
+            Self::Metadata(_) => None,
+        }
+    }
+
+    /// The manifest-level metadata.
+    #[must_use]
+    pub const fn metadata(&self) -> Option<&Metadata<F>> {
+        match self {
+            Self::Metadata(metadata) | Self::Both { metadata, .. } => Some(metadata),
+            Self::Entry(_) => None,
+        }
+    }
+}
+
+impl<F: Format> From<Entry<F>> for RootExtension<F> {
+    fn from(entry: Entry<F>) -> Self {
+        Self::Entry(entry)
+    }
+}
+
+impl<F: Format> From<Metadata<F>> for RootExtension<F> {
+    fn from(metadata: Metadata<F>) -> Self {
+        Self::Metadata(metadata)
+    }
+}
+
+/// One in-memory manifest node of format `F`.
+///
+/// The wire preamble is `F::PREAMBLE`, carried by the type, not the value.
+/// A node reached through a fork child must have no root extension; the
+/// fetching party knows the context and enforces that on fetch.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Node<F: Format = V1> {
+    root: Option<RootExtension<F>>,
+    forks: ForkTable<F>,
+}
+
+impl<F: Format> Node<F> {
+    /// The empty-map root: no extension, no forks.
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self {
+            root: None,
+            forks: ForkTable::new(),
+        }
+    }
+
+    /// A node from its parts.
+    #[must_use]
+    pub const fn new(root: Option<RootExtension<F>>, forks: ForkTable<F>) -> Self {
+        Self { root, forks }
+    }
+
+    /// Returns `true` for the empty-map root.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.root.is_none() && self.forks.is_empty()
+    }
+
+    /// The root extension.
+    #[must_use]
+    pub const fn root(&self) -> Option<&RootExtension<F>> {
+        self.root.as_ref()
+    }
+
+    /// Set or clear the root extension.
+    pub fn set_root(&mut self, root: Option<RootExtension<F>>) {
+        self.root = root;
+    }
+
+    /// The value at the empty key.
+    #[must_use]
+    pub const fn entry(&self) -> Option<&Entry<F>> {
+        match &self.root {
+            Some(root) => root.entry(),
+            None => None,
+        }
+    }
+
+    /// The manifest-level metadata.
+    #[must_use]
+    pub const fn metadata(&self) -> Option<&Metadata<F>> {
+        match &self.root {
+            Some(root) => root.metadata(),
+            None => None,
+        }
+    }
+
+    /// The fork table.
+    #[must_use]
+    pub const fn forks(&self) -> &ForkTable<F> {
+        &self.forks
+    }
+
+    /// Mutable access to the fork table.
+    pub const fn forks_mut(&mut self) -> &mut ForkTable<F> {
+        &mut self.forks
+    }
+}
+
+impl<F: Format> Default for Node<F> {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use nectar_primitives::{ChunkAddress, ChunkRef};
+
+    use crate::bounded::Prefix;
+    use crate::meta::KeyId;
+
+    use super::*;
+
+    fn entry() -> Entry {
+        ChunkRef::new(ChunkAddress::new([1; 32])).into()
+    }
+
+    fn metadata() -> Metadata {
+        Metadata::new(
+            KeyId::WebsiteIndexDocument,
+            Bytes::from_static(b"index.html"),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn the_empty_map_root_is_the_default() {
+        let node: Node = Node::default();
+        assert!(node.is_empty());
+        assert_eq!(node, Node::empty());
+        assert_eq!(node.root(), None);
+        assert_eq!(node.entry(), None);
+        assert_eq!(node.metadata(), None);
+        assert!(node.forks().is_empty());
+    }
+
+    #[test]
+    fn root_extension_requires_at_least_one_part() {
+        assert_eq!(RootExtension::<V1>::new(None, None), None);
+
+        let only_entry = RootExtension::new(Some(entry()), None).unwrap();
+        assert_eq!(only_entry.entry(), Some(&entry()));
+        assert_eq!(only_entry.metadata(), None);
+
+        let only_meta = RootExtension::new(None, Some(metadata())).unwrap();
+        assert_eq!(only_meta.entry(), None);
+        assert_eq!(only_meta.metadata(), Some(&metadata()));
+
+        let both = RootExtension::new(Some(entry()), Some(metadata())).unwrap();
+        assert_eq!(both.entry(), Some(&entry()));
+        assert_eq!(both.metadata(), Some(&metadata()));
+    }
+
+    #[test]
+    fn node_reads_through_the_root_extension() {
+        let mut node = Node::new(
+            RootExtension::new(Some(entry()), Some(metadata())),
+            ForkTable::new(),
+        );
+        assert!(!node.is_empty());
+        assert_eq!(node.entry(), Some(&entry()));
+        assert_eq!(node.metadata(), Some(&metadata()));
+
+        node.set_root(None);
+        assert!(node.is_empty());
+    }
+
+    #[test]
+    fn forks_make_a_node_non_empty() {
+        let mut node = Node::empty();
+        node.forks_mut()
+            .insert(Prefix::try_from(&b"a"[..]).unwrap(), entry().into(), None)
+            .unwrap();
+        assert!(!node.is_empty());
+        assert_eq!(node.forks().len(), 1);
+    }
+}


### PR DESCRIPTION
Closes #250

## What

Adds the in-memory manifest data model on top of the value model from #s264/12-value-model:

- `crates/manifest/src/node.rs`: `RootExtension<F>` (entry, metadata, or both — assembled via `RootExtension::new`, `None` when both parts are absent) and `Node<F>` (`Option<RootExtension<F>>` over a `ForkTable<F>`).
- `crates/manifest/src/fork.rs`: `Child<F>` (`Ref32`/`Ref64`/`Embedded(ForkTable<F>)`), `ForkPayload<F>` (`Entry`/`Child`/`Both`, assembled via `ForkPayload::new`), `ForkRecord<F>` (prefix tail, payload, optional metadata), and `ForkTable<F>` (a `BTreeMap<u8, ForkRecord<F>>`).
- `crates/manifest/src/bounded.rs`: `Prefix::split_first`, splitting off the first byte and sharing the (strictly shorter, so unchecked) tail.
- `crates/manifest/src/error.rs`: `ForkPrefixEmpty`, returned by `ForkRecord::new` when given an empty prefix.
- `crates/manifest/src/lib.rs`: re-exports for the new types plus a crate-doc paragraph describing the data model.

Design points reflected in the diff:

- Magic, version and every bound come from `F` (`F::PREAMBLE` etc.); no flags are stored anywhere. Presence bits (entry/child/metadata) are derived from the enum structure at encode time rather than persisted.
- `ForkTable` keys on the first prefix byte in a `BTreeMap<u8, _>`, so sorted-unique order and the radix-256 (`F::FORKS_MAX`) bound are structural rather than runtime-checked.
- `ForkRecord::new` splits a non-empty `Prefix<F>` into the table key (first byte) and the stored tail via `Prefix::split_first`, so a record can never disagree with its index byte, and the full prefix length stays in `1..=F::PLEN_MAX` by construction. An empty prefix is rejected with `ForkPrefixEmpty`.
- `ForkPayload` and `RootExtension` make "neither part present" unrepresentable in the in-band variants, with absence handled by wrapping the whole thing in `Option` at the use site.

This PR is scoped to the in-memory model only: no codec/decode path is introduced, so this diff does not implement wire encoding, decoding, or round-trip behaviour.

## Why

Implements issue #250 (manifest data model), the next step in the s264 stack after the value model, giving the manifest crate the `Node`/`ForkTable`/`ForkRecord` types that the eventual codec will encode and decode.

## Testing

Verified independently against commit f615f70 (single commit in range, base `s264/12-value-model`):

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean, no warnings.
- `cargo test --workspace --all-features`: all suites pass, including 42 unit tests in `nectar-manifest` covering the new `fork.rs`/`node.rs` code.
- `cargo test --doc --workspace`: pass.

As this diff adds pure in-memory model types with no codec/decode path, wire round-trip and adversarial-decode checks are not applicable here.

## AI Assistance

Claude (Anthropic) was used for implementation, adversarial/red-team review, and independent test verification of this change, run through this repository's structured implement-review-verify workflow.

