### PR TITLE
feat(manifest): memory-bounded streaming manifest builder

### DIFF
--- a/crates/manifest/src/builder.rs
+++ b/crates/manifest/src/builder.rs
@@ -1,0 +1,480 @@
+//! Memory-bounded streaming builder: files -> BMT -> assemble -> publish.
+//!
+//! The trie is assembled bottom-up over an explicit stack of open nodes. Each
+//! finished node is embedded into its parent when the packing predicate allows,
+//! otherwise sealed and spilled to the store the moment it is complete, so the
+//! peak retained node buffer count is the stack depth, never the key count. The
+//! key set enters through a sorted map, so the published tree is a pure function
+//! of the keys, identical whatever order the caller streamed them in.
+
+use std::collections::BTreeMap;
+use std::io::Write;
+
+use bytes::Bytes;
+use nectar_primitives::store::{ChunkPut, MaybeSync};
+use nectar_primitives::{
+    Chunk, ChunkAddress, ChunkRef, DefaultSplitter, FileError, PrimitivesError,
+};
+
+use crate::bounded::Prefix;
+use crate::error::{ForkPrefixEmpty, PrefixTooLong};
+use crate::fork::{Child, ForkPayload, ForkTable};
+use crate::format::{Format, V1};
+use crate::meta::Metadata;
+use crate::node::{Node, RootExtension};
+use crate::packing::{Domain, embed};
+use crate::store::{NodePut, StoreError};
+use crate::value::{Entry, Key};
+
+/// A build or publish failure.
+#[non_exhaustive]
+#[derive(Debug, thiserror::Error)]
+pub enum BuildError {
+    /// Sealing or storing a manifest node failed; over-budget nodes surface
+    /// here as an encode error.
+    #[error(transparent)]
+    Store(#[from] StoreError),
+    /// Splitting a file into BMT chunks failed.
+    #[error("split file")]
+    Split(#[source] FileError),
+    /// Buffering a file for splitting failed.
+    #[error("buffer file")]
+    Buffer(#[source] std::io::Error),
+    /// Sealing a file chunk failed.
+    #[error("seal file chunk")]
+    Seal(#[source] PrimitivesError),
+    /// The backing store rejected a file chunk.
+    #[error("store file chunk")]
+    Backend(#[source] Box<dyn core::error::Error + Send + Sync>),
+    /// A compacted edge exceeded the format's prefix bound.
+    #[error(transparent)]
+    Prefix(#[from] PrefixTooLong),
+    /// A fork prefix consumed no byte to index under.
+    #[error(transparent)]
+    EmptyPrefix(#[from] ForkPrefixEmpty),
+    /// A stack invariant did not hold; a builder bug rather than bad input.
+    #[error("builder invariant violated")]
+    Internal,
+}
+
+impl BuildError {
+    /// Box a backend error behind the seam.
+    fn backend<E: core::error::Error + Send + Sync + 'static>(err: E) -> Self {
+        Self::Backend(Box::new(err))
+    }
+}
+
+/// Peak and total work of one build, enough to witness the memory bound.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BuildStats {
+    peak_open_nodes: usize,
+    nodes_written: usize,
+    nodes_embedded: usize,
+}
+
+impl BuildStats {
+    /// Most nodes ever open at once: the stack depth, which is the trie's node
+    /// depth and independent of the key count.
+    #[must_use]
+    pub const fn peak_open_nodes(&self) -> usize {
+        self.peak_open_nodes
+    }
+
+    /// Node chunks spilled to the store, including the root.
+    #[must_use]
+    pub const fn nodes_written(&self) -> usize {
+        self.nodes_written
+    }
+
+    /// Subtrees inlined into their parent instead of spilled.
+    #[must_use]
+    pub const fn nodes_embedded(&self) -> usize {
+        self.nodes_embedded
+    }
+}
+
+/// The published manifest: the root chunk address and the build's work profile.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Built {
+    root: ChunkAddress,
+    stats: BuildStats,
+}
+
+impl Built {
+    /// The root chunk address; the reference a reader descends from.
+    #[must_use]
+    pub const fn root(&self) -> &ChunkAddress {
+        &self.root
+    }
+
+    /// The build's work profile.
+    #[must_use]
+    pub const fn stats(&self) -> &BuildStats {
+        &self.stats
+    }
+}
+
+/// Streaming manifest builder over key-value entries of format `F`.
+///
+/// Keys accumulate in a sorted map, so [`build`](Self::build) is
+/// history-independent. The empty key carries the manifest's own value, distinct
+/// from a fork.
+#[derive(Clone, Debug)]
+pub struct Builder<F: Format = V1> {
+    keys: BTreeMap<Bytes, (Entry<F>, Option<Metadata<F>>)>,
+    root_entry: Option<Entry<F>>,
+    root_metadata: Option<Metadata<F>>,
+}
+
+impl<F: Format> Default for Builder<F> {
+    fn default() -> Self {
+        Self {
+            keys: BTreeMap::new(),
+            root_entry: None,
+            root_metadata: None,
+        }
+    }
+}
+
+impl<F: Format> Builder<F> {
+    /// An empty builder.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Bind `key` to `entry`, replacing any prior binding. The empty key sets
+    /// the manifest's own value; its metadata, if any, becomes the manifest
+    /// metadata.
+    pub fn insert(
+        &mut self,
+        key: Key,
+        entry: Entry<F>,
+        metadata: Option<Metadata<F>>,
+    ) -> &mut Self {
+        if key.is_empty() {
+            self.root_entry = Some(entry);
+            if metadata.is_some() {
+                self.root_metadata = metadata;
+            }
+        } else {
+            self.keys.insert(key.into_bytes(), (entry, metadata));
+        }
+        self
+    }
+
+    /// Set the manifest-level metadata carried in the root extension.
+    pub fn manifest_metadata(&mut self, metadata: Metadata<F>) -> &mut Self {
+        self.root_metadata = Some(metadata);
+        self
+    }
+
+    /// Assemble and publish the manifest, returning the root address.
+    ///
+    /// Peak retained node buffers stay at the trie's node depth: a finished
+    /// subtree is embedded or spilled to `store` before the next sibling opens.
+    pub async fn build<S>(&self, store: &S) -> Result<Built, BuildError>
+    where
+        S: ChunkPut + MaybeSync,
+    {
+        let items: Vec<Item<F>> = self
+            .keys
+            .iter()
+            .map(|(key, (entry, meta))| Item {
+                key: key.clone(),
+                entry: entry.clone(),
+                meta: meta.clone(),
+            })
+            .collect();
+        let mut root_ext = RootExtension::new(self.root_entry.clone(), self.root_metadata.clone());
+        let mut stats = BuildStats::default();
+
+        let mut stack: Vec<Frame<'_, F>> = Vec::new();
+        stack.push(Frame::new(0, &items));
+        let mut returned: Option<Resolved<F>> = None;
+
+        loop {
+            stats.peak_open_nodes = stats.peak_open_nodes.max(stack.len());
+            let action = {
+                let frame = stack.last_mut().ok_or(BuildError::Internal)?;
+                if let Some(resolved) = returned.take() {
+                    frame.attach(resolved)?;
+                }
+                frame.step()?
+            };
+            match action {
+                Action::Continue => {}
+                Action::Descend(child_items, plen) => stack.push(Frame::new(plen, child_items)),
+                Action::Finalize => {
+                    let frame = stack.pop().ok_or(BuildError::Internal)?;
+                    if stack.is_empty() {
+                        let node = Node::new(root_ext.take(), frame.table);
+                        let root = put_counted(store, &node, &mut stats).await?;
+                        return Ok(Built { root, stats });
+                    }
+                    returned = Some(resolve(store, frame.table, &mut stats).await?);
+                }
+            }
+        }
+    }
+}
+
+/// One key-value binding, cloned into a linear array for indexed descent.
+struct Item<F: Format> {
+    key: Bytes,
+    entry: Entry<F>,
+    meta: Option<Metadata<F>>,
+}
+
+/// A resolved subtree bubbling up to its parent fork.
+enum Resolved<F: Format> {
+    /// Small enough to inline into the parent's chunk.
+    Embedded(ForkTable<F>),
+    /// Spilled to a chunk of its own.
+    Reference(ChunkRef),
+}
+
+/// A fork awaiting the subtree currently under construction.
+struct OpenFork<F: Format> {
+    prefix: Prefix<F>,
+    entry: Option<Entry<F>>,
+    meta: Option<Metadata<F>>,
+}
+
+/// One node under construction: the keys below it, the cursor into them, the
+/// table built so far, and the fork whose child is open.
+struct Frame<'a, F: Format> {
+    consumed: usize,
+    items: &'a [Item<F>],
+    cursor: usize,
+    table: ForkTable<F>,
+    open: Option<OpenFork<F>>,
+}
+
+/// What the driver does after one frame step.
+enum Action<'a, F: Format> {
+    /// A terminal fork was inserted; keep processing this frame.
+    Continue,
+    /// A fork opened onto the given child keys at the given consumed depth.
+    Descend(&'a [Item<F>], usize),
+    /// The frame is complete.
+    Finalize,
+}
+
+impl<'a, F: Format> Frame<'a, F> {
+    const fn new(consumed: usize, items: &'a [Item<F>]) -> Self {
+        Self {
+            consumed,
+            items,
+            cursor: 0,
+            table: ForkTable::new(),
+            open: None,
+        }
+    }
+
+    /// Close the open fork with its resolved child.
+    fn attach(&mut self, resolved: Resolved<F>) -> Result<(), BuildError> {
+        let open = self.open.take().ok_or(BuildError::Internal)?;
+        let child = match resolved {
+            Resolved::Embedded(table) => Child::Embedded(table),
+            Resolved::Reference(reference) => Child::Ref32(reference),
+        };
+        let payload = match open.entry {
+            Some(entry) => ForkPayload::Both { entry, child },
+            None => ForkPayload::Child(child),
+        };
+        self.table.insert(open.prefix, payload, open.meta)?;
+        Ok(())
+    }
+
+    /// Insert the next terminal fork, or open the next child, or finalise.
+    fn step(&mut self) -> Result<Action<'a, F>, BuildError> {
+        if self.cursor >= self.items.len() {
+            return Ok(Action::Finalize);
+        }
+        let group = next_group(self.items, self.cursor, self.consumed)?;
+        self.cursor = group.end;
+        match group.child {
+            None => {
+                let entry = group.entry.ok_or(BuildError::Internal)?;
+                self.table
+                    .insert(group.prefix, ForkPayload::Entry(entry), group.meta)?;
+                Ok(Action::Continue)
+            }
+            Some(child_items) => {
+                self.open = Some(OpenFork {
+                    prefix: group.prefix,
+                    entry: group.entry,
+                    meta: group.meta,
+                });
+                Ok(Action::Descend(child_items, group.plen))
+            }
+        }
+    }
+}
+
+/// The fork run sharing the byte at `consumed`, starting at `cursor`.
+struct Group<'a, F: Format> {
+    prefix: Prefix<F>,
+    plen: usize,
+    entry: Option<Entry<F>>,
+    meta: Option<Metadata<F>>,
+    child: Option<&'a [Item<F>]>,
+    end: usize,
+}
+
+/// Cut the next fork out of `items`: the run sharing the byte at `consumed`,
+/// its compacted edge (capped at the prefix bound), the value of any key that
+/// terminates on the edge, and the child keys that continue past it.
+fn next_group<'a, F: Format>(
+    items: &'a [Item<F>],
+    cursor: usize,
+    consumed: usize,
+) -> Result<Group<'a, F>, BuildError> {
+    let first = items.get(cursor).ok_or(BuildError::Internal)?;
+    let byte = first
+        .key
+        .get(consumed)
+        .copied()
+        .ok_or(BuildError::Internal)?;
+
+    let mut end = cursor.saturating_add(1);
+    while let Some(item) = items.get(end) {
+        match item.key.get(consumed).copied() {
+            Some(next) if next == byte => end = end.saturating_add(1),
+            _ => break,
+        }
+    }
+
+    let last = items
+        .get(end.saturating_sub(1))
+        .ok_or(BuildError::Internal)?;
+    let lcp = common_prefix_len(&first.key, &last.key, consumed, F::PLEN_MAX);
+    let plen = consumed.saturating_add(lcp);
+    let edge = first.key.get(consumed..plen).ok_or(BuildError::Internal)?;
+    let prefix = Prefix::try_from(edge)?;
+
+    let terminates = first.key.len() == plen;
+    let child_start = if terminates {
+        cursor.saturating_add(1)
+    } else {
+        cursor
+    };
+    let child = items.get(child_start..end).filter(|run| !run.is_empty());
+    let (entry, meta) = if terminates {
+        (Some(first.entry.clone()), first.meta.clone())
+    } else {
+        (None, None)
+    };
+
+    Ok(Group {
+        prefix,
+        plen,
+        entry,
+        meta,
+        child,
+        end,
+    })
+}
+
+/// The shared byte run of `a` and `b` from `consumed`, capped at `cap`. At
+/// least one: both share the byte at `consumed` by construction.
+fn common_prefix_len(a: &Bytes, b: &Bytes, consumed: usize, cap: usize) -> usize {
+    let tail_a = a.get(consumed..).unwrap_or_default();
+    let tail_b = b.get(consumed..).unwrap_or_default();
+    let mut len = 0usize;
+    for (x, y) in tail_a.iter().zip(tail_b.iter()) {
+        if len >= cap || x != y {
+            break;
+        }
+        len = len.saturating_add(1);
+    }
+    len
+}
+
+/// Embed a finished subtree into its parent, or spill it to the store.
+///
+/// The embed decision is child-local: it reads the subtree's flat length alone,
+/// so it is stable under re-rooting and history-independent.
+async fn resolve<S, F>(
+    store: &S,
+    table: ForkTable<F>,
+    stats: &mut BuildStats,
+) -> Result<Resolved<F>, BuildError>
+where
+    S: ChunkPut + MaybeSync,
+    F: Format,
+{
+    let flat = Node::new(None, table.clone())
+        .encoded_len()
+        .saturating_sub(F::PREAMBLE.len());
+    if embed::<F>(flat, Domain::Plain, Domain::Plain) {
+        stats.nodes_embedded = stats.nodes_embedded.saturating_add(1);
+        return Ok(Resolved::Embedded(table));
+    }
+    let node = Node::new(None, table);
+    let address = put_counted(store, &node, stats).await?;
+    Ok(Resolved::Reference(ChunkRef::new(address)))
+}
+
+/// Spill one node to the store, counting it.
+async fn put_counted<S, F>(
+    store: &S,
+    node: &Node<F>,
+    stats: &mut BuildStats,
+) -> Result<ChunkAddress, BuildError>
+where
+    S: ChunkPut + MaybeSync,
+    F: Format,
+{
+    let address = store.put_node(node).await?;
+    stats.nodes_written = stats.nodes_written.saturating_add(1);
+    Ok(address)
+}
+
+/// Split `data` through BMT, spill its chunks to `store`, and return its plain
+/// root reference. Reuses the primitives splitter, so the BMT is shared.
+async fn split_file<S>(store: &S, data: &[u8]) -> Result<ChunkRef, BuildError>
+where
+    S: ChunkPut + MaybeSync,
+{
+    let span = u64::try_from(data.len()).map_err(|_| BuildError::Internal)?;
+    let mut splitter = DefaultSplitter::new(span);
+    splitter.write_all(data).map_err(BuildError::Buffer)?;
+    let (root, chunks) = splitter.finish().map_err(BuildError::Split)?;
+    for chunk in chunks {
+        let sealed = Chunk::from_envelope(chunk.into()).map_err(BuildError::Seal)?;
+        store.put(sealed).await.map_err(BuildError::backend)?;
+    }
+    Ok(ChunkRef::new(root))
+}
+
+/// Stream files through BMT into one published manifest.
+///
+/// Each `(key, file)` pair is split into content chunks, stored, and bound to
+/// the file's root reference; the manifest is then assembled and published. The
+/// iteration order does not affect the published root.
+///
+/// ```
+/// use nectar_manifest::{build_files, Key};
+/// use nectar_primitives::MemoryStore;
+///
+/// # async fn demo() -> Result<(), nectar_manifest::BuildError> {
+/// let store = MemoryStore::default();
+/// let files = [(Key::from(&b"index.html"[..]), bytes::Bytes::from_static(b"<h1>hi</h1>"))];
+/// let built = build_files(&store, files).await?;
+/// let _root = built.root();
+/// # Ok(()) }
+/// ```
+pub async fn build_files<S, I>(store: &S, files: I) -> Result<Built, BuildError>
+where
+    S: ChunkPut + MaybeSync,
+    I: IntoIterator<Item = (Key, Bytes)>,
+{
+    let mut builder = Builder::<V1>::new();
+    for (key, data) in files {
+        let reference = split_file(store, &data).await?;
+        builder.insert(key, Entry::from(reference), None);
+    }
+    builder.build(store).await
+}

--- a/crates/manifest/src/builder.rs
+++ b/crates/manifest/src/builder.rs
@@ -287,7 +287,7 @@ impl<'a, F: Format> Frame<'a, F> {
         Ok(())
     }
 
-    /// Insert the next terminal fork, or open the next child, or finalise.
+    /// Insert the next terminal fork, or open the next child, or finalize.
     fn step(&mut self) -> Result<Action<'a, F>, BuildError> {
         if self.cursor >= self.items.len() {
             return Ok(Action::Finalize);

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -55,6 +55,7 @@
 )]
 
 mod bounded;
+mod builder;
 mod codec;
 mod error;
 mod fork;
@@ -66,6 +67,7 @@ mod store;
 mod value;
 
 pub use bounded::{MetadataLen, Prefix, SegmentWeight};
+pub use builder::{BuildError, BuildStats, Builder, Built, build_files};
 pub use codec::{DecodeError, EncodeError};
 pub use error::{
     CustomKeyError, ForkPrefixEmpty, MetadataTooLong, PrefixTooLong, ValueTooLong, WeightOverBudget,

--- a/crates/manifest/tests/builder.rs
+++ b/crates/manifest/tests/builder.rs
@@ -1,0 +1,260 @@
+//! The streaming builder through the public API: the worked example is
+//! reproduced byte-for-byte from a key set, the published root is a pure
+//! function of the keys whatever order they arrive in, peak retained node
+//! buffers track the trie depth rather than the key count, and the files path
+//! splits through BMT and references the stored roots.
+
+use std::error::Error;
+
+use bytes::Bytes;
+use futures::executor::block_on;
+use nectar_manifest::{
+    BuildStats, Builder, Child, Entry, ForkPayload, ForkTable, Key, KeyId, Metadata, Node, NodeGet,
+    Prefix, RootExtension, V1, build_files,
+};
+use nectar_primitives::{ChunkAddress, ChunkOps, ChunkRef, DEFAULT_BODY_SIZE, MemoryStore, split};
+
+type TestResult = Result<(), Box<dyn Error>>;
+
+/// A fallible assertion: Result-returning tests report failures as errors.
+fn ensure(cond: bool, what: &str) -> TestResult {
+    if cond { Ok(()) } else { Err(what.into()) }
+}
+
+/// A fallible equality assertion.
+fn ensure_eq<T: PartialEq + core::fmt::Debug>(left: T, right: T, what: &str) -> TestResult {
+    if left == right {
+        Ok(())
+    } else {
+        Err(format!("{what}: {left:?} != {right:?}").into())
+    }
+}
+
+const fn ref32(byte: u8) -> ChunkRef {
+    ChunkRef::new(ChunkAddress::new([byte; 32]))
+}
+
+fn content_type(value: &'static [u8]) -> Result<Metadata, Box<dyn Error>> {
+    Ok(Metadata::new(
+        KeyId::ContentType,
+        Bytes::from_static(value),
+    )?)
+}
+
+fn website_index() -> Result<Metadata, Box<dyn Error>> {
+    Ok(Metadata::new(
+        KeyId::WebsiteIndexDocument,
+        Bytes::from_static(b"index.html"),
+    )?)
+}
+
+// The spec's worked example, built manually: a two-file website behind one
+// shared embedded child, the same node the codec conformance pins to 150 bytes.
+fn worked_example_node() -> Result<Node, Box<dyn Error>> {
+    let mut child = ForkTable::new();
+    child.insert(
+        Prefix::try_from(&b"mg/logo.png"[..])?,
+        Entry::from(ref32(0xBB)).into(),
+        Some(content_type(b"image/png")?),
+    )?;
+    child.insert(
+        Prefix::try_from(&b"ndex.html"[..])?,
+        Entry::from(ref32(0xAA)).into(),
+        Some(content_type(b"text/html")?),
+    )?;
+
+    let mut forks = ForkTable::new();
+    forks.insert(
+        Prefix::try_from(&b"i"[..])?,
+        Child::Embedded(child).into(),
+        None,
+    )?;
+
+    Ok(Node::new(
+        RootExtension::new(None, Some(website_index()?)),
+        forks,
+    ))
+}
+
+#[test]
+fn builds_the_worked_example_byte_for_byte() -> TestResult {
+    let store = MemoryStore::default();
+    let mut builder: Builder = Builder::new();
+    builder
+        .insert(
+            Key::from(&b"index.html"[..]),
+            Entry::from(ref32(0xAA)),
+            Some(content_type(b"text/html")?),
+        )
+        .insert(
+            Key::from(&b"img/logo.png"[..]),
+            Entry::from(ref32(0xBB)),
+            Some(content_type(b"image/png")?),
+        )
+        .manifest_metadata(website_index()?);
+
+    let built = block_on(builder.build(&store))?;
+
+    // The shared child is inlined, so the whole manifest is one chunk.
+    ensure_eq(built.stats().nodes_written(), 1, "one node written")?;
+    ensure_eq(built.stats().nodes_embedded(), 1, "one child embedded")?;
+
+    let chunk = store.get(built.root()).ok_or("root not stored")?;
+    let expected = worked_example_node()?.encode()?;
+    ensure_eq(expected.len(), 150, "worked example is 150 bytes")?;
+    ensure_eq(
+        chunk.envelope().data().as_ref(),
+        expected.as_slice(),
+        "root payload",
+    )?;
+
+    let decoded: Node = block_on(store.get_node(built.root()))?;
+    ensure_eq(decoded, worked_example_node()?, "decoded root")
+}
+
+fn root_of(order: &[(&[u8], u8)]) -> Result<ChunkAddress, Box<dyn Error>> {
+    let store = MemoryStore::default();
+    let mut builder: Builder = Builder::new();
+    for (key, fill) in order {
+        builder.insert(Key::from(*key), Entry::from(ref32(*fill)), None);
+    }
+    Ok(*block_on(builder.build(&store))?.root())
+}
+
+#[test]
+fn the_published_root_is_history_independent() -> TestResult {
+    // A key set that exercises a terminating-and-continuing fork ("a" under
+    // "about"), a nested shared edge ("about-us"), and a shared directory
+    // ("img/").
+    let order: [(&[u8], u8); 6] = [
+        (b"a", 1),
+        (b"about", 2),
+        (b"about-us", 3),
+        (b"img/logo.png", 4),
+        (b"img/icon.svg", 5),
+        (b"index.html", 6),
+    ];
+    let forward = root_of(&order)?;
+
+    let mut reversed = order;
+    reversed.reverse();
+    ensure_eq(root_of(&reversed)?, forward, "reversed order")?;
+
+    let mut rotated = order;
+    rotated.rotate_left(3);
+    ensure_eq(root_of(&rotated)?, forward, "rotated order")
+}
+
+fn two_level_stats(store: &MemoryStore, fan: u16, width: u8) -> Result<BuildStats, Box<dyn Error>> {
+    let mut builder: Builder<V1> = Builder::new();
+    for hi in 0..fan {
+        let hi = u8::try_from(hi)?;
+        for lo in 0..width {
+            builder.insert(Key::from(&[hi, lo][..]), Entry::from(ref32(hi)), None);
+        }
+    }
+    Ok(*block_on(builder.build(store))?.stats())
+}
+
+#[test]
+fn peak_node_buffers_track_depth_not_key_count() -> TestResult {
+    // Two two-level manifests whose second level is wide enough that each child
+    // spills to its own chunk. The narrow build has 8 subtrees, the wide one 64;
+    // the wide build stores many more nodes, yet both keep the same tiny number
+    // of nodes open at once, so peak memory follows depth, not key count.
+    let narrow = MemoryStore::default();
+    let wide = MemoryStore::default();
+    let narrow_stats = two_level_stats(&narrow, 8, 80)?;
+    let wide_stats = two_level_stats(&wide, 64, 80)?;
+
+    // Root plus one open child: never a whole level or frontier.
+    ensure_eq(narrow_stats.peak_open_nodes(), 2, "narrow peak")?;
+    ensure_eq(wide_stats.peak_open_nodes(), 2, "wide peak")?;
+
+    // The children are spilled, not embedded, so work scales with the fan.
+    ensure_eq(narrow_stats.nodes_embedded(), 0, "narrow spills all")?;
+    ensure_eq(narrow_stats.nodes_written(), 9, "narrow node count")?;
+    ensure_eq(wide_stats.nodes_written(), 65, "wide node count")?;
+
+    // Eight times the keys, eight times the stored nodes, identical peak.
+    ensure(
+        wide_stats.nodes_written() > narrow_stats.nodes_written().saturating_mul(7),
+        "work scales with keys",
+    )?;
+    ensure_eq(
+        narrow_stats.peak_open_nodes(),
+        wide_stats.peak_open_nodes(),
+        "peak is key-count independent",
+    )
+}
+
+#[test]
+fn the_empty_builder_publishes_the_empty_root() -> TestResult {
+    let store = MemoryStore::default();
+    let builder: Builder = Builder::new();
+    let built = block_on(builder.build(&store))?;
+
+    ensure_eq(built.stats().peak_open_nodes(), 1, "one open node")?;
+    ensure_eq(built.stats().nodes_written(), 1, "one node written")?;
+
+    let node: Node = block_on(store.get_node(built.root()))?;
+    ensure(node.is_empty(), "root is the empty map")
+}
+
+#[test]
+fn build_files_splits_through_bmt_and_references_the_stored_roots() -> TestResult {
+    let store = MemoryStore::default();
+    let logo = Bytes::from(vec![0x42u8; 12_000]); // several chunks
+    let page = Bytes::from_static(b"<h1>hello</h1>");
+    let files = [
+        (Key::from(&b"index.html"[..]), page.clone()),
+        (Key::from(&b"logo.png"[..]), logo.clone()),
+    ];
+
+    let built = block_on(build_files(&store, files))?;
+    let node: Node = block_on(store.get_node(built.root()))?;
+
+    // Each file's manifest entry is its independent BMT root, and every file
+    // chunk is present in the same store.
+    for (first, tail, data) in [
+        (b'i', &b"ndex.html"[..], page),
+        (b'l', &b"ogo.png"[..], logo),
+    ] {
+        let record = node.forks().get(first).ok_or("missing fork")?;
+        ensure_eq(record.tail().as_bytes(), tail, "fork tail")?;
+        let address = record
+            .entry()
+            .ok_or("fork has no entry")?
+            .address()
+            .ok_or("entry is not a reference")?;
+
+        let (expected_root, _) = split::<DEFAULT_BODY_SIZE>(&data)?;
+        ensure_eq(address, &expected_root, "file root reference")?;
+        ensure(store.get(address).is_some(), "file root stored")?;
+    }
+    Ok(())
+}
+
+#[test]
+fn a_key_that_prefixes_another_shares_a_fork() -> TestResult {
+    let store = MemoryStore::default();
+    let mut builder: Builder = Builder::new();
+    builder
+        .insert(Key::from(&b"a"[..]), Entry::from(ref32(1)), None)
+        .insert(Key::from(&b"ab"[..]), Entry::from(ref32(2)), None);
+    let built = block_on(builder.build(&store))?;
+
+    let node: Node = block_on(store.get_node(built.root()))?;
+    let record = node.forks().get(b'a').ok_or("missing fork a")?;
+    ensure(record.tail().is_empty(), "single-byte edge")?;
+    // "a" terminates here and the trie continues to "ab".
+    ensure(
+        matches!(record.payload(), ForkPayload::Both { .. }),
+        "fork is entry-and-child",
+    )?;
+    ensure_eq(
+        record.entry(),
+        Some(&Entry::from(ref32(1))),
+        "terminating value",
+    )
+}


### PR DESCRIPTION
Closes #256

## What

Adds a memory-bounded streaming manifest builder in a new `crates/manifest/src/builder.rs`, wired into `lib.rs` via `mod builder` and `pub use builder::{BuildError, BuildStats, Builder, Built, build_files}`.

Key-to-entry bindings accumulate in a sorted `BTreeMap`, so the published root is a pure function of the key set and is independent of insertion order. The compacted radix-256 trie is assembled bottom-up over an explicit stack of open nodes. Each finished subtree is either embedded into its parent via the packing `embed()` predicate, or sealed and spilled to the store the moment it completes, through the `#255` `NodePut`/`ChunkPut` seam.

`BuildStats` tracks `peak_open_nodes`, `nodes_written`, and `nodes_embedded`, so the memory bound (stack depth, not key count) is directly observable rather than merely asserted.

Errors are surfaced through a `BuildError` enum covering store, split, buffer, seal, backend, prefix, and empty-prefix failures, plus an internal-invariant variant for stack-bug conditions that should not occur on valid input.

The diff is additive only: `builder.rs` (480 lines), the 2-line `lib.rs` export, and `tests/builder.rs` (260 lines) of integration tests. No other files are touched.

## Why

Building a manifest by materializing the whole trie (or a whole level/frontier of it) in memory does not scale to large key sets. This builder keeps peak retained node buffers bounded by trie depth rather than by key count, while still producing a byte-identical, history-independent published tree, by spilling each completed subtree to the store as soon as it is sealed instead of holding it.

## Testing

Ran the full workspace battery from a fresh clone against this branch:

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean, no warnings on the new code.
- `cargo test --workspace --all-features`: all green, including the 6 new integration tests in `tests/builder.rs` and the existing manifest unit suite.
- `cargo test --doc -p nectar-manifest`: 4 doctests pass, including the new `build_files` doctest.

AI Assistance: Claude (Anthropic) used for implementation, adversarial review, and independent test verification of this module.

