### PR TITLE
manifest: add memory-bounded streaming Reader

### DIFF
--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -63,6 +63,7 @@ mod format;
 mod meta;
 mod node;
 mod packing;
+mod reader;
 mod store;
 mod value;
 
@@ -77,5 +78,6 @@ pub use format::{Format, V1};
 pub use meta::{CustomKey, KeyId, Metadata, MetadataKey};
 pub use node::{Node, RootExtension};
 pub use packing::{Directory, Domain, SegmentKind, cut, embed, h64, segment, spill};
+pub use reader::{Reader, ReaderError};
 pub use store::{NodeChunk, NodeGet, NodePut, StoreError};
 pub use value::{Entry, InlineValue, Key};

--- a/crates/manifest/src/reader.rs
+++ b/crates/manifest/src/reader.rs
@@ -1,0 +1,290 @@
+//! Memory-bounded streaming reader: lazy, fetch-on-demand descent of the trie.
+//!
+//! A lookup follows one fork per node down the radix-256 trie, fetching only
+//! the single child on the key's path at each referenced hop; a whole level is
+//! never materialized, so peak retained state is O(depth), not O(level width).
+//! The reader holds nothing but the store trait, so a caching store composes
+//! beneath it without the reader's knowledge.
+
+use core::marker::PhantomData;
+
+use nectar_primitives::ChunkAddress;
+use nectar_primitives::store::MaybeSync;
+
+use crate::fork::{Child, ForkTable};
+use crate::format::{Format, V1};
+use crate::store::{NodeGet, StoreError};
+use crate::value::{Entry, Key};
+
+/// A lookup failure.
+#[non_exhaustive]
+#[derive(Debug, thiserror::Error)]
+pub enum ReaderError {
+    /// Loading or decoding a node across the store seam failed.
+    #[error(transparent)]
+    Store(#[from] StoreError),
+    /// Descent reached an encrypted subtree; following it needs the
+    /// decryption key the plain reader does not carry.
+    #[error("descent reached an encrypted subtree")]
+    EncryptedChild,
+}
+
+/// Lazy trie reader over a trusted node store of format `F`.
+///
+/// Descent is serial: each referenced hop is one fetch, so a lookup costs
+/// O(depth) round trips and retains one node at a time, never a whole level.
+#[derive(Clone, Copy, Debug)]
+pub struct Reader<S, F: Format = V1> {
+    store: S,
+    _format: PhantomData<F>,
+}
+
+impl<S, F: Format> Reader<S, F> {
+    /// Wrap `store` as a reader; compose a caching store here to cache hops.
+    #[must_use]
+    pub const fn new(store: S) -> Self {
+        Self {
+            store,
+            _format: PhantomData,
+        }
+    }
+
+    /// The backing store.
+    #[must_use]
+    pub const fn store(&self) -> &S {
+        &self.store
+    }
+
+    /// Unwrap the backing store.
+    #[must_use]
+    pub fn into_store(self) -> S {
+        self.store
+    }
+}
+
+impl<S, F: Format> Reader<S, F>
+where
+    S: NodeGet + MaybeSync,
+{
+    /// The value bound to `key` under the manifest rooted at `root`, or `None`
+    /// when the key is absent.
+    ///
+    /// The empty key reads the root extension's own value; every other key
+    /// descends the trie, matching each compacted edge byte for byte and
+    /// fetching one node per referenced hop.
+    pub async fn get(
+        &self,
+        root: &ChunkAddress,
+        key: &Key,
+    ) -> Result<Option<Entry<F>>, ReaderError> {
+        let mut node = self.store.get_node::<F>(root).await?;
+        let key = key.as_bytes();
+        if key.is_empty() {
+            return Ok(node.entry().cloned());
+        }
+        let mut pos = 0usize;
+        loop {
+            match descend(node.forks(), key, pos) {
+                Descent::Absent => return Ok(None),
+                Descent::Found(entry) => return Ok(Some(entry)),
+                Descent::Encrypted => return Err(ReaderError::EncryptedChild),
+                Descent::Follow(address, next) => {
+                    node = self.store.get_node::<F>(&address).await?;
+                    pos = next;
+                }
+            }
+        }
+    }
+}
+
+/// The outcome of walking one node's embedded tables as far as they reach.
+enum Descent<F: Format> {
+    /// No fork matches the key below this node: the key is absent.
+    Absent,
+    /// The key terminates here with this value.
+    Found(Entry<F>),
+    /// The key continues into a referenced child at the given address, with
+    /// this many key bytes already consumed.
+    Follow(ChunkAddress, usize),
+    /// The key continues into an encrypted child the plain reader cannot open.
+    Encrypted,
+}
+
+/// Walk `key` from `pos` down a node's fork table and its embedded children,
+/// stopping at the first terminal, absent branch, or referenced child.
+///
+/// Stays within one chunk: an embedded child lives in the parent's bytes, so
+/// the walk crosses embedded tables without a fetch and only a referenced edge
+/// bubbles up as a hop.
+fn descend<F: Format>(table: &ForkTable<F>, key: &[u8], pos: usize) -> Descent<F> {
+    let mut table = table;
+    let mut pos = pos;
+    loop {
+        let Some(&byte) = key.get(pos) else {
+            return Descent::Absent;
+        };
+        let Some(record) = table.get(byte) else {
+            return Descent::Absent;
+        };
+        // Match the compacted edge: the fork-table byte plus the record tail.
+        let tail = record.tail().as_bytes();
+        let Some(start) = pos.checked_add(1) else {
+            return Descent::Absent;
+        };
+        let Some(end) = start.checked_add(tail.len()) else {
+            return Descent::Absent;
+        };
+        match key.get(start..end) {
+            Some(rest) if rest == tail => {}
+            _ => return Descent::Absent,
+        }
+        pos = end;
+        if pos == key.len() {
+            return record
+                .entry()
+                .map_or(Descent::Absent, |entry| Descent::Found(entry.clone()));
+        }
+        match record.child() {
+            Some(Child::Embedded(inner)) => table = inner,
+            Some(Child::Ref32(reference)) => return Descent::Follow(*reference.address(), pos),
+            Some(Child::Ref64(_)) => return Descent::Encrypted,
+            None => return Descent::Absent,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use futures::executor::block_on;
+    use nectar_primitives::store::MemoryStore;
+    use nectar_primitives::{ChunkAddress, ChunkRef};
+
+    use crate::bounded::Prefix;
+    use crate::fork::{Child, ForkPayload, ForkTable};
+    use crate::node::Node;
+    use crate::store::NodePut;
+    use crate::value::{Entry, Key};
+
+    use super::*;
+
+    fn entry(byte: u8) -> Entry {
+        ChunkRef::new(ChunkAddress::new([byte; 32])).into()
+    }
+
+    fn prefix(bytes: &[u8]) -> Prefix {
+        Prefix::try_from(bytes).unwrap()
+    }
+
+    #[test]
+    fn descends_embedded_and_referenced_children_alike() {
+        let store = MemoryStore::default();
+
+        // A leaf reached by reference, holding the key "img/logo.png".
+        let mut leaf = ForkTable::new();
+        leaf.insert(prefix(b"logo.png"), entry(0xBB).into(), None)
+            .unwrap();
+        let leaf_ref = block_on(store.put_node(&Node::new(None, leaf))).unwrap();
+
+        // The root: "index.html" behind an embedded child, "mg/" behind the
+        // referenced leaf.
+        let mut embedded = ForkTable::new();
+        embedded
+            .insert(prefix(b"ndex.html"), entry(0xAA).into(), None)
+            .unwrap();
+        let mut forks = ForkTable::new();
+        forks
+            .insert(prefix(b"i"), Child::Embedded(embedded).into(), None)
+            .unwrap();
+        forks
+            .insert(
+                prefix(b"mg/"),
+                Child::Ref32(ChunkRef::new(leaf_ref)).into(),
+                None,
+            )
+            .unwrap();
+        let root = block_on(store.put_node(&Node::new(None, forks))).unwrap();
+
+        let reader: Reader<_> = Reader::new(&store);
+        assert_eq!(
+            block_on(reader.get(&root, &Key::from(&b"index.html"[..]))).unwrap(),
+            Some(entry(0xAA)),
+        );
+        assert_eq!(
+            block_on(reader.get(&root, &Key::from(&b"mg/logo.png"[..]))).unwrap(),
+            Some(entry(0xBB)),
+        );
+        // A key that prefixes an edge without reaching its end is absent.
+        assert_eq!(
+            block_on(reader.get(&root, &Key::from(&b"mg/logo"[..]))).unwrap(),
+            None,
+        );
+        // A key past a fork with no matching continuation is absent.
+        assert_eq!(
+            block_on(reader.get(&root, &Key::from(&b"other"[..]))).unwrap(),
+            None,
+        );
+    }
+
+    #[test]
+    fn a_fork_with_only_a_child_holds_no_value_at_its_own_prefix() {
+        let store = MemoryStore::default();
+        let mut child = ForkTable::new();
+        child.insert(prefix(b"b"), entry(1).into(), None).unwrap();
+        let mut forks = ForkTable::new();
+        forks
+            .insert(prefix(b"a"), Child::Embedded(child).into(), None)
+            .unwrap();
+        let root = block_on(store.put_node(&Node::new(None, forks))).unwrap();
+
+        let reader: Reader<_> = Reader::new(&store);
+        // "ab" terminates, "a" is only a branch.
+        assert_eq!(
+            block_on(reader.get(&root, &Key::from(&b"ab"[..]))).unwrap(),
+            Some(entry(1)),
+        );
+        assert_eq!(
+            block_on(reader.get(&root, &Key::from(&b"a"[..]))).unwrap(),
+            None,
+        );
+    }
+
+    #[test]
+    fn the_empty_key_reads_the_root_extension_value() {
+        let store = MemoryStore::default();
+        let root_ext = crate::node::RootExtension::new(Some(entry(9)), None);
+        let root = block_on(store.put_node(&Node::new(root_ext, ForkTable::new()))).unwrap();
+
+        let reader: Reader<_> = Reader::new(&store);
+        assert_eq!(
+            block_on(reader.get(&root, &Key::empty())).unwrap(),
+            Some(entry(9)),
+        );
+    }
+
+    #[test]
+    fn inline_values_read_back_whole() {
+        let store = MemoryStore::default();
+        let value = Entry::inline(Bytes::from_static(b"hi")).unwrap();
+        let mut forks = ForkTable::new();
+        forks
+            .insert(prefix(b"k"), ForkPayload::Entry(value.clone()), None)
+            .unwrap();
+        let root = block_on(store.put_node(&Node::new(None, forks))).unwrap();
+
+        let reader: Reader<_> = Reader::new(&store);
+        assert_eq!(
+            block_on(reader.get(&root, &Key::from(&b"k"[..]))).unwrap(),
+            Some(value),
+        );
+    }
+
+    #[test]
+    fn a_missing_root_is_a_store_error() {
+        let store = MemoryStore::default();
+        let reader: Reader<_> = Reader::new(&store);
+        let err =
+            block_on(reader.get(&ChunkAddress::new([0; 32]), &Key::from(&b"x"[..]))).unwrap_err();
+        assert!(matches!(err, ReaderError::Store(StoreError::Store(_))));
+    }
+}

--- a/crates/manifest/tests/reader.rs
+++ b/crates/manifest/tests/reader.rs
@@ -1,0 +1,134 @@
+//! The streaming reader through the public API: descent follows one fork per
+//! node, so a lookup down a wide manifest fetches O(depth) nodes and never a
+//! whole level. A counting store witnesses the bound directly.
+
+use std::error::Error;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use futures::executor::block_on;
+use nectar_manifest::{Child, Entry, ForkTable, Key, Node, NodePut, Prefix, Reader, V1};
+use nectar_primitives::store::{ChunkGet, MemoryStore};
+use nectar_primitives::{Chunk, ChunkAddress, ChunkRef, StandardChunkSet, Verified};
+
+type TestResult = Result<(), Box<dyn Error>>;
+
+/// A fallible assertion.
+fn ensure(cond: bool, what: &str) -> TestResult {
+    if cond { Ok(()) } else { Err(what.into()) }
+}
+
+/// A fallible equality assertion.
+fn ensure_eq<T: PartialEq + core::fmt::Debug>(left: T, right: T, what: &str) -> TestResult {
+    if left == right {
+        Ok(())
+    } else {
+        Err(format!("{what}: {left:?} != {right:?}").into())
+    }
+}
+
+/// A trusted store that counts every `get`, so a test can read off how many
+/// nodes a lookup fetched.
+#[derive(Debug, Default)]
+struct CountingStore {
+    inner: MemoryStore,
+    gets: AtomicUsize,
+}
+
+impl CountingStore {
+    fn gets(&self) -> usize {
+        self.gets.load(Ordering::Relaxed)
+    }
+}
+
+impl ChunkGet<StandardChunkSet> for CountingStore {
+    type Trust = Verified;
+    type Error = <MemoryStore as ChunkGet>::Error;
+
+    async fn get(
+        &self,
+        address: &ChunkAddress,
+    ) -> Result<Chunk<Verified, StandardChunkSet>, Self::Error> {
+        self.gets.fetch_add(1, Ordering::Relaxed);
+        ChunkGet::get(&self.inner, address).await
+    }
+}
+
+fn entry(byte: u8) -> Entry {
+    ChunkRef::new(ChunkAddress::new([byte; 32])).into()
+}
+
+/// Build a deliberately wide two-level manifest: a root whose fork table holds
+/// one referenced leaf per first byte, each leaf terminating a single key. The
+/// second level is `width` chunks wide, but any one key sits two nodes deep.
+fn wide_manifest(store: &MemoryStore, width: u16) -> Result<ChunkAddress, Box<dyn Error>> {
+    let mut forks = ForkTable::<V1>::new();
+    for first in 0..width {
+        let first = u8::try_from(first)?;
+        let mut leaf = ForkTable::new();
+        leaf.insert(Prefix::try_from(&[0xFFu8][..])?, entry(first).into(), None)?;
+        let leaf_ref = block_on(store.put_node(&Node::new(None, leaf)))?;
+        forks.insert(
+            Prefix::try_from(&[first][..])?,
+            Child::Ref32(ChunkRef::new(leaf_ref)).into(),
+            None,
+        )?;
+    }
+    Ok(block_on(store.put_node(&Node::new(None, forks)))?)
+}
+
+#[test]
+fn a_lookup_fetches_depth_nodes_not_the_wide_level() -> TestResult {
+    // Wide enough to dwarf the depth-2 path, yet inside one root chunk (a
+    // radix-full root spills to a directory, which is a later car's concern).
+    let width = 100u16;
+    let memory = MemoryStore::default();
+    let root = wide_manifest(&memory, width)?;
+
+    // The whole manifest is one root plus `width` leaves.
+    ensure_eq(memory.len(), usize::from(width) + 1, "stored node count")?;
+
+    let store = CountingStore {
+        inner: memory,
+        gets: AtomicUsize::new(0),
+    };
+    let reader: Reader<_> = Reader::new(&store);
+
+    // Look up one key: first byte 0x2A, then the leaf's 0xFF fork.
+    let key = Key::from(&[0x2Au8, 0xFF][..]);
+    let value = block_on(reader.get(&root, &key))?;
+    ensure_eq(value, Some(entry(0x2A)), "looked-up value")?;
+
+    // Two hops: the root and the single leaf on the path. Never the wide
+    // sibling level, so fetches track depth, not width.
+    ensure_eq(store.gets(), 2, "fetches equal path depth")?;
+    ensure(
+        store.gets() < usize::from(width),
+        "fetches below level width",
+    )?;
+
+    // A second lookup on a different branch is again two hops: the frontier is
+    // never widened, each key pays only its own path.
+    store.gets.store(0, Ordering::Relaxed);
+    let value = block_on(reader.get(&root, &Key::from(&[0x50u8, 0xFF][..])))?;
+    ensure_eq(value, Some(entry(0x50)), "second value")?;
+    ensure_eq(store.gets(), 2, "second lookup is also depth-bounded")
+}
+
+#[test]
+fn an_absent_key_stops_at_the_first_unmatched_fork() -> TestResult {
+    let width = 64u16;
+    let memory = MemoryStore::default();
+    let root = wide_manifest(&memory, width)?;
+
+    let store = CountingStore {
+        inner: memory,
+        gets: AtomicUsize::new(0),
+    };
+    let reader: Reader<_> = Reader::new(&store);
+
+    // A first byte no root fork carries: the walk stops at the root without
+    // fetching any leaf.
+    let value = block_on(reader.get(&root, &Key::from(&[0xFFu8, 0x00][..])))?;
+    ensure_eq(value, None, "absent value")?;
+    ensure_eq(store.gets(), 1, "only the root is fetched")
+}

--- a/crates/manifest/tests/reader.rs
+++ b/crates/manifest/tests/reader.rs
@@ -5,8 +5,9 @@
 use std::error::Error;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use bytes::Bytes;
 use futures::executor::block_on;
-use nectar_manifest::{Child, Entry, ForkTable, Key, Node, NodePut, Prefix, Reader, V1};
+use nectar_manifest::{Builder, Child, Entry, ForkTable, Key, Node, NodePut, Prefix, Reader, V1};
 use nectar_primitives::store::{ChunkGet, MemoryStore};
 use nectar_primitives::{Chunk, ChunkAddress, ChunkRef, StandardChunkSet, Verified};
 
@@ -112,6 +113,94 @@ fn a_lookup_fetches_depth_nodes_not_the_wide_level() -> TestResult {
     let value = block_on(reader.get(&root, &Key::from(&[0x50u8, 0xFF][..])))?;
     ensure_eq(value, Some(entry(0x50)), "second value")?;
     ensure_eq(store.gets(), 2, "second lookup is also depth-bounded")
+}
+
+#[test]
+fn every_builder_key_reads_back_through_referenced_hops() -> TestResult {
+    // Build a real manifest through the builder so the reader is exercised
+    // against the wire structure it exists to read, not a hand-laid table: the
+    // shared-prefix grid forces compacted edges, embedded subtrees and, once a
+    // subtree outgrows the inline bound, referenced children the reader must
+    // fetch and descend.
+    let memory = MemoryStore::default();
+    let mut builder = Builder::new();
+    let mut expected: Vec<(String, Entry)> = Vec::new();
+    for dir in 0u8..16 {
+        for file in 0u8..40 {
+            let key = format!("dir{dir:02}/file{file:04}.txt");
+            let value = entry((dir ^ file).wrapping_add(1));
+            builder.insert(Key::from(key.clone().into_bytes()), value.clone(), None);
+            expected.push((key, value));
+        }
+    }
+    // A key that is a strict prefix of another exercises a fork carrying both a
+    // terminal value and a continuation.
+    builder.insert(Key::from(&b"pre"[..]), entry(0x11), None);
+    expected.push(("pre".to_owned(), entry(0x11)));
+    builder.insert(Key::from(&b"prefix"[..]), entry(0x22), None);
+    expected.push(("prefix".to_owned(), entry(0x22)));
+    // An inline value must read back whole, not as a reference.
+    let inline = Entry::inline(Bytes::from_static(b"hello")).map_err(|e| e.to_string())?;
+    builder.insert(Key::from(&b"inline.txt"[..]), inline.clone(), None);
+    expected.push(("inline.txt".to_owned(), inline));
+    // The empty key sets the manifest's own value in the root extension.
+    builder.insert(Key::empty(), entry(0x99), None);
+
+    let built = block_on(builder.build(&memory)).map_err(|e| e.to_string())?;
+    let root = *built.root();
+    // More than one node spilled: the builder emitted referenced children, so
+    // reading keys beneath them genuinely drives the fetch-and-descend path.
+    ensure(
+        built.stats().nodes_written() > 1,
+        "builder spilled referenced children",
+    )?;
+
+    let store = CountingStore {
+        inner: memory,
+        gets: AtomicUsize::new(0),
+    };
+    let reader: Reader<_> = Reader::new(&store);
+
+    // The root extension answers the empty key.
+    ensure_eq(
+        block_on(reader.get(&root, &Key::empty())).map_err(|e| e.to_string())?,
+        Some(entry(0x99)),
+        "empty key reads the root value",
+    )?;
+
+    // Every key reads back its exact value, and no single lookup ever fetches a
+    // whole level: the deepest path stays a small multiple of the tree depth,
+    // far below the spilled node count.
+    let mut deepest = 0usize;
+    for (key, value) in &expected {
+        store.gets.store(0, Ordering::Relaxed);
+        let got = block_on(reader.get(&root, &Key::from(key.clone().into_bytes())))
+            .map_err(|e| e.to_string())?;
+        ensure_eq(got.as_ref(), Some(value), key)?;
+        deepest = deepest.max(store.gets());
+    }
+    ensure(deepest >= 2, "at least one key descends a referenced hop")?;
+    ensure(
+        deepest < built.stats().nodes_written(),
+        "no lookup fetches the whole tree",
+    )?;
+
+    // Keys that diverge from, fall short of, or overrun a stored key are absent.
+    for absent in [
+        "nope",
+        "dir99/file0000.txt",
+        "dir00/file9999.txt",
+        "pr",
+        "prefixed",
+    ] {
+        ensure_eq(
+            block_on(reader.get(&root, &Key::from(absent.as_bytes())))
+                .map_err(|e| e.to_string())?,
+            None,
+            absent,
+        )?;
+    }
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
## What

Adds `Reader<S, F = V1>` to `nectar-manifest`, a memory-bounded streaming reader over the trie produced by the `Builder` (crates/manifest/src/reader.rs, +290; wired up in crates/manifest/src/lib.rs, +2 as `pub use Reader, ReaderError`).

`Reader` wraps any `NodeGet` (`TrustedStore`), so a caching store can compose underneath it. `Reader::get(root, key)` does a lazy, fetch-on-demand descent of the radix-256 trie: at each node it matches the compacted edge byte-for-byte (fork-table byte plus record tail) and fetches only the single referenced (`Ref32`) child on the key's path. Embedded children are walked in place within the parent's already-fetched bytes, so no extra hop is made for them and a whole trie level is never materialised. The loop retains one node at a time, giving peak `O(depth)` memory rather than `O(level-width)`. An empty key reads the root extension's own value. All byte access goes through checked `.get()` / `checked_add`, with no indexing (`[]`), no `unwrap`/`expect`, and no `#[allow]`.

## Why

Closes #257

The `Builder` (base branch `s264/42-builder`) produces the on-disk trie; this reader is the corresponding lookup path, needed before manifests built with it can be queried without loading an entire level (or the whole trie) into memory.

## Testing

crates/manifest/tests/reader.rs (+223, new) exercises the reader end to end against the real `Builder`: a 643-key round trip covering referenced multi-hop children, both-forks nodes, inline values, the empty/root key, and absent keys.

Full battery run via `nix develop --command`:
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean.
- `cargo nextest run --workspace --all-features`: 823 passed, 1 skipped, 0 failed, including the 5 unit tests in `reader::tests` and the 3 integration tests in `tests/reader.rs`.

This is a stacked PR targeting `s264/42-builder`, not `main`; no CI beyond CLA runs until the stack is retargeted.

## AI Assistance

AI Assistance: Claude (Anthropic) used for implementation, red-team review, and independent verification of this change.

