### PR TITLE
feat(manifest): history-independent batch apply for mantaray KV

### DIFF
--- a/crates/manifest/src/apply.rs
+++ b/crates/manifest/src/apply.rs
@@ -1,0 +1,698 @@
+//! History-independent batch update: fold a changeset into a manifest to a new
+//! root that is byte-identical to building the merged key set from scratch.
+//!
+//! The update is a bottom-up path-copy union: only the nodes on the touched
+//! paths are rewritten, and a shared ancestor is rewritten once per apply, not
+//! once per changeset entry, so a wide batch amortizes over its overlap. An
+//! unchanged fork is spliced in verbatim; an untouched referenced subtree is
+//! reused by address without a fetch. Because embedding is child-local and a
+//! cut is keyed on the fork-relative prefix, re-rooting a reused subtree does
+//! not churn its shape, so `apply(root, delta)` and a from-scratch build of the
+//! merged keys agree bit for bit (invariant I6 under updates).
+//!
+//! Peak retained state is O(depth + changeset frontier): the descent holds one
+//! node per level on the current path, never a whole subtree.
+
+use std::collections::BTreeMap;
+
+use bytes::Bytes;
+use nectar_primitives::ChunkAddress;
+use nectar_primitives::store::{ChunkPut, MaybeSync};
+
+use crate::bounded::Prefix;
+use crate::builder::{BuildError, BuildStats, Item, build_table, resolve};
+use crate::error::{ForkPrefixEmpty, PrefixTooLong};
+use crate::fork::{Child, ForkPayload, ForkRecord, ForkTable};
+use crate::format::{Format, V1};
+use crate::meta::Metadata;
+use crate::node::{Node, RootExtension};
+use crate::store::{NodeGet, NodePut, StoreError};
+use crate::value::{Entry, Key};
+
+/// One key's update within a changeset.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Op<F: Format> {
+    /// Bind the key to a value, with optional metadata.
+    Put {
+        /// The value to bind.
+        entry: Entry<F>,
+        /// The value's metadata, if any.
+        meta: Option<Metadata<F>>,
+    },
+    /// Remove the key.
+    Delete,
+}
+
+/// A batch of key updates to fold into a manifest in one pass.
+///
+/// Keys accumulate in a sorted map, so an [`apply`] is history-independent: the
+/// order updates were staged in never reaches the produced root. The empty key
+/// carries the manifest's own value.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Changeset<F: Format = V1> {
+    ops: BTreeMap<Bytes, Op<F>>,
+}
+
+impl<F: Format> Default for Changeset<F> {
+    fn default() -> Self {
+        Self {
+            ops: BTreeMap::new(),
+        }
+    }
+}
+
+impl<F: Format> Changeset<F> {
+    /// An empty changeset.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Stage a binding of `key` to `entry`, replacing any staged update for it.
+    /// The empty key sets the manifest's own value; its metadata, if any,
+    /// becomes the manifest metadata.
+    pub fn put(&mut self, key: Key, entry: Entry<F>, metadata: Option<Metadata<F>>) -> &mut Self {
+        self.ops.insert(
+            key.into_bytes(),
+            Op::Put {
+                entry,
+                meta: metadata,
+            },
+        );
+        self
+    }
+
+    /// Stage the removal of `key`, replacing any staged update for it.
+    pub fn remove(&mut self, key: Key) -> &mut Self {
+        self.ops.insert(key.into_bytes(), Op::Delete);
+        self
+    }
+
+    /// Number of staged updates.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.ops.len()
+    }
+
+    /// Returns `true` when nothing is staged.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.ops.is_empty()
+    }
+}
+
+/// An apply failure.
+#[non_exhaustive]
+#[derive(Debug, thiserror::Error)]
+pub enum ApplyError {
+    /// Loading or storing a node across the store seam failed.
+    #[error(transparent)]
+    Store(#[from] StoreError),
+    /// Building or spilling a rewritten subtree failed.
+    #[error(transparent)]
+    Build(#[from] BuildError),
+    /// A rewritten edge exceeded the format's prefix bound.
+    #[error(transparent)]
+    Prefix(#[from] PrefixTooLong),
+    /// A fork prefix consumed no byte to index under.
+    #[error(transparent)]
+    EmptyPrefix(#[from] ForkPrefixEmpty),
+    /// An update descended into an encrypted subtree the plain path cannot open.
+    #[error("descent reached an encrypted subtree")]
+    EncryptedChild,
+    /// A merge invariant did not hold; an apply bug rather than bad input.
+    #[error("apply invariant violated")]
+    Internal,
+}
+
+/// Fold `changeset` into the manifest rooted at `root`, returning the new root.
+///
+/// The result equals a from-scratch build of the merged key set, byte for byte:
+/// an empty changeset returns `root` unchanged, and a single update is just a
+/// one-entry changeset.
+pub async fn apply<S, F>(
+    store: &S,
+    root: &ChunkAddress,
+    changeset: &Changeset<F>,
+) -> Result<ChunkAddress, ApplyError>
+where
+    S: NodeGet + ChunkPut + MaybeSync,
+    F: Format,
+{
+    if changeset.is_empty() {
+        return Ok(*root);
+    }
+    let node = store.get_node::<F>(root).await?;
+
+    // The empty key is the root's own value; every other key descends the trie.
+    let mut root_entry = node.entry().cloned();
+    let mut root_meta = node.metadata().cloned();
+    match changeset.ops.get(&Bytes::new()) {
+        Some(Op::Put { entry, meta }) => {
+            root_entry = Some(entry.clone());
+            if meta.is_some() {
+                root_meta = meta.clone();
+            }
+        }
+        Some(Op::Delete) => root_entry = None,
+        None => {}
+    }
+    let root_ext = RootExtension::new(root_entry, root_meta);
+
+    let changes: Vec<Change<'_, F>> = changeset
+        .ops
+        .iter()
+        .filter(|(key, _)| !key.is_empty())
+        .map(|(key, op)| Change {
+            key: key.clone(),
+            op,
+        })
+        .collect();
+
+    let mut stats = BuildStats::default();
+    let forks = Box::pin(apply_forks(
+        store,
+        node.forks().clone(),
+        0,
+        &changes,
+        &mut stats,
+    ))
+    .await?;
+    let new_node = Node::new(root_ext, forks);
+    Ok(store.put_node(&new_node).await?)
+}
+
+/// One staged update paired with its key, borrowed for the length of the apply.
+struct Change<'c, F: Format> {
+    key: Bytes,
+    op: &'c Op<F>,
+}
+
+impl<F: Format> Change<'_, F> {
+    /// A cheap re-borrow, so a subset can be routed into a child without cloning
+    /// the operation.
+    fn reborrow(&self) -> Change<'_, F> {
+        Change {
+            key: self.key.clone(),
+            op: self.op,
+        }
+    }
+}
+
+/// Merge `changes` into the fork table at depth `consumed`, rewriting only the
+/// forks a change touches and splicing the rest in verbatim.
+///
+/// Every change shares the `consumed`-byte prefix that reaches this table, so a
+/// change group is the contiguous run sharing the byte at `consumed`.
+async fn apply_forks<'c, S, F>(
+    store: &S,
+    mut table: ForkTable<F>,
+    consumed: usize,
+    changes: &[Change<'c, F>],
+    stats: &mut BuildStats,
+) -> Result<ForkTable<F>, ApplyError>
+where
+    S: NodeGet + ChunkPut + MaybeSync,
+    F: Format,
+{
+    let mut i = 0usize;
+    while let Some(first) = changes.get(i) {
+        let Some(&byte) = first.key.get(consumed) else {
+            // A key with no byte here belongs to the parent boundary already.
+            i = i.saturating_add(1);
+            continue;
+        };
+        let mut j = i.saturating_add(1);
+        while changes.get(j).and_then(|c| c.key.get(consumed)) == Some(&byte) {
+            j = j.saturating_add(1);
+        }
+        let group = changes.get(i..j).ok_or(ApplyError::Internal)?;
+        let existing = table.remove(byte);
+        if let Some(record) =
+            Box::pin(reconcile(store, consumed, byte, existing, group, stats)).await?
+        {
+            table.insert_record(byte, record);
+        }
+        i = j;
+    }
+    Ok(table)
+}
+
+/// Reconcile the fork indexed under `byte` with its change group, returning the
+/// rewritten fork or `None` when it collapses away.
+async fn reconcile<'c, S, F>(
+    store: &S,
+    consumed: usize,
+    byte: u8,
+    existing: Option<ForkRecord<F>>,
+    group: &[Change<'c, F>],
+    stats: &mut BuildStats,
+) -> Result<Option<ForkRecord<F>>, ApplyError>
+where
+    S: NodeGet + ChunkPut + MaybeSync,
+    F: Format,
+{
+    let existing = match existing {
+        Some(record) => record,
+        None => {
+            // No fork here yet: build one from the group's insertions alone.
+            let items = inserts_to_items(group);
+            if items.is_empty() {
+                return Ok(None);
+            }
+            let mut fresh = build_table(store, &items, consumed, stats).await?;
+            return Ok(fresh.remove(byte));
+        }
+    };
+
+    // The fork's full edge: the index byte followed by its stored tail.
+    let mut edge = Vec::with_capacity(existing.tail().len().saturating_add(1));
+    edge.push(byte);
+    edge.extend_from_slice(existing.tail().as_bytes());
+    let plen = consumed.saturating_add(edge.len());
+
+    // The merged key set's compacted edge shortens to the least point any
+    // insertion diverges from the existing edge; deletions off the edge target
+    // no existing key and never move it.
+    let mut cut = edge.len();
+    for change in group {
+        if let Op::Put { .. } = change.op {
+            let suffix = change.key.get(consumed..).unwrap_or_default();
+            cut = cut.min(common_prefix(suffix, &edge));
+        }
+    }
+
+    if cut < edge.len() {
+        split(store, consumed, &edge, cut, existing, group, stats).await
+    } else {
+        Box::pin(descend(
+            store, consumed, &edge, plen, existing, group, stats,
+        ))
+        .await
+    }
+}
+
+/// The existing edge stays intact: update the terminal value and fold the
+/// deeper updates into the child.
+async fn descend<'c, S, F>(
+    store: &S,
+    consumed: usize,
+    edge: &[u8],
+    plen: usize,
+    existing: ForkRecord<F>,
+    group: &[Change<'c, F>],
+    stats: &mut BuildStats,
+) -> Result<Option<ForkRecord<F>>, ApplyError>
+where
+    S: NodeGet + ChunkPut + MaybeSync,
+    F: Format,
+{
+    let mut new_entry = existing.entry().cloned();
+    let mut new_meta = existing.metadata().cloned();
+    let mut deeper: Vec<Change<'_, F>> = Vec::new();
+    for change in group {
+        let suffix = change.key.get(consumed..).unwrap_or_default();
+        if !suffix.starts_with(edge) {
+            // Diverges off the intact edge: a deletion of an absent key.
+            continue;
+        }
+        if change.key.len() == plen {
+            match change.op {
+                Op::Put { entry, meta } => {
+                    new_entry = Some(entry.clone());
+                    new_meta = meta.clone();
+                }
+                Op::Delete => {
+                    new_entry = None;
+                    new_meta = None;
+                }
+            }
+        } else {
+            deeper.push(change.reborrow());
+        }
+    }
+
+    if deeper.is_empty() {
+        // The child is untouched: reuse it verbatim.
+        return finish(edge, new_entry, new_meta, existing.child().cloned());
+    }
+
+    let child_table = match existing.child() {
+        None => {
+            let items = inserts_to_items(&deeper);
+            if items.is_empty() {
+                // A deletion of an absent deeper key: the fork is unchanged bar
+                // its terminal value.
+                return finish(edge, new_entry, new_meta, None);
+            }
+            build_table(store, &items, plen, stats).await?
+        }
+        Some(Child::Embedded(inner)) => {
+            Box::pin(apply_forks(store, inner.clone(), plen, &deeper, stats)).await?
+        }
+        Some(Child::Ref32(reference)) => {
+            let node = store.get_node::<F>(reference.address()).await?;
+            Box::pin(apply_forks(
+                store,
+                node.forks().clone(),
+                plen,
+                &deeper,
+                stats,
+            ))
+            .await?
+        }
+        Some(Child::Ref64(_)) => return Err(ApplyError::EncryptedChild),
+    };
+    assemble(store, edge, new_entry, new_meta, child_table, stats).await
+}
+
+/// Fold a rewritten child table back into a fork record over `edge`, collapsing
+/// an empty or single-fork child so the result matches a from-scratch build.
+///
+/// The single-fork merge runs before the child is resolved, so a lone branch
+/// re-inlines whatever its size would spill to.
+async fn assemble<S, F>(
+    store: &S,
+    edge: &[u8],
+    entry: Option<Entry<F>>,
+    meta: Option<Metadata<F>>,
+    table: ForkTable<F>,
+    stats: &mut BuildStats,
+) -> Result<Option<ForkRecord<F>>, ApplyError>
+where
+    S: ChunkPut + MaybeSync,
+    F: Format,
+{
+    if table.is_empty() {
+        return finish(edge, entry, meta, None);
+    }
+    // Edge-compaction: a child-only fork over a single-fork child merges into
+    // one edge, exactly as a from-scratch build would compact the shared run.
+    if entry.is_none()
+        && table.len() == 1
+        && let Some((first, record)) = table.iter().next()
+    {
+        let combined = edge
+            .len()
+            .saturating_add(1)
+            .saturating_add(record.tail().len());
+        if combined <= F::PLEN_MAX {
+            let mut merged = edge.to_vec();
+            merged.push(first);
+            merged.extend_from_slice(record.tail().as_bytes());
+            return make_fork(
+                &merged,
+                record.payload().clone(),
+                record.metadata().cloned(),
+            );
+        }
+    }
+    let child = resolve(store, table, stats).await?.into_child();
+    finish(edge, entry, meta, Some(child))
+}
+
+/// An insertion diverges within the edge: branch at the divergence, re-rooting
+/// the existing subtree verbatim under the edge remainder.
+async fn split<'c, S, F>(
+    store: &S,
+    consumed: usize,
+    edge: &[u8],
+    cut: usize,
+    existing: ForkRecord<F>,
+    group: &[Change<'c, F>],
+    stats: &mut BuildStats,
+) -> Result<Option<ForkRecord<F>>, ApplyError>
+where
+    S: NodeGet + ChunkPut + MaybeSync,
+    F: Format,
+{
+    let boundary = consumed.saturating_add(cut);
+    let new_edge = edge.get(..cut).ok_or(ApplyError::Internal)?;
+    let mut split_entry: Option<Entry<F>> = None;
+    let mut split_meta: Option<Metadata<F>> = None;
+    let mut remaining: Vec<Change<'_, F>> = Vec::new();
+    for change in group {
+        let suffix = change.key.get(consumed..).unwrap_or_default();
+        if !suffix.starts_with(new_edge) {
+            // Diverges above the branch point: a deletion of an absent key.
+            // Every insertion shares the branch edge by construction.
+            continue;
+        }
+        if change.key.len() == boundary {
+            if let Op::Put { entry, meta } = change.op {
+                split_entry = Some(entry.clone());
+                split_meta = meta.clone();
+            }
+            // A deletion at the new boundary targets no existing key: drop it.
+        } else {
+            remaining.push(change.reborrow());
+        }
+    }
+
+    // The existing subtree hangs verbatim under the remainder of its edge.
+    let mut branch = ForkTable::new();
+    let remainder = Prefix::try_from(edge.get(cut..).ok_or(ApplyError::Internal)?)?;
+    branch.insert(
+        remainder,
+        existing.payload().clone(),
+        existing.metadata().cloned(),
+    )?;
+    let table = Box::pin(apply_forks(store, branch, boundary, &remaining, stats)).await?;
+    assemble(store, new_edge, split_entry, split_meta, table, stats).await
+}
+
+/// Assemble a fork record from an intact edge, its terminal value and its child,
+/// or `None` when neither survives.
+///
+/// A child-only fork over a single-fork embedded child compacts into one edge,
+/// so a deletion that strips a fork's terminal value re-inlines its lone
+/// remaining branch exactly as a from-scratch build would.
+fn finish<F: Format>(
+    edge: &[u8],
+    entry: Option<Entry<F>>,
+    meta: Option<Metadata<F>>,
+    child: Option<Child<F>>,
+) -> Result<Option<ForkRecord<F>>, ApplyError> {
+    if entry.is_none()
+        && let Some(Child::Embedded(table)) = &child
+        && table.len() == 1
+        && let Some((first, record)) = table.iter().next()
+    {
+        let combined = edge
+            .len()
+            .saturating_add(1)
+            .saturating_add(record.tail().len());
+        if combined <= F::PLEN_MAX {
+            let mut merged = edge.to_vec();
+            merged.push(first);
+            merged.extend_from_slice(record.tail().as_bytes());
+            return make_fork(
+                &merged,
+                record.payload().clone(),
+                record.metadata().cloned(),
+            );
+        }
+    }
+    let has_entry = entry.is_some();
+    ForkPayload::new(entry, child).map_or_else(
+        || Ok(None),
+        |payload| make_fork(edge, payload, if has_entry { meta } else { None }),
+    )
+}
+
+/// A fork record for `edge` (its index byte plus tail) carrying `payload`.
+fn make_fork<F: Format>(
+    edge: &[u8],
+    payload: ForkPayload<F>,
+    meta: Option<Metadata<F>>,
+) -> Result<Option<ForkRecord<F>>, ApplyError> {
+    let tail = Prefix::try_from(edge.get(1..).ok_or(ApplyError::Internal)?)?;
+    Ok(Some(ForkRecord::from_tail_parts(tail, payload, meta)))
+}
+
+/// The insertions of a change group as builder items, dropping deletions.
+fn inserts_to_items<F: Format>(changes: &[Change<'_, F>]) -> Vec<Item<F>> {
+    changes
+        .iter()
+        .filter_map(|change| match change.op {
+            Op::Put { entry, meta } => Some(Item {
+                key: change.key.clone(),
+                entry: entry.clone(),
+                meta: meta.clone(),
+            }),
+            Op::Delete => None,
+        })
+        .collect()
+}
+
+/// The length of the shared byte prefix of `a` and `b`.
+fn common_prefix(a: &[u8], b: &[u8]) -> usize {
+    let mut len = 0usize;
+    for (x, y) in a.iter().zip(b.iter()) {
+        if x != y {
+            break;
+        }
+        len = len.saturating_add(1);
+    }
+    len
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::executor::block_on;
+    use nectar_primitives::store::MemoryStore;
+    use nectar_primitives::{ChunkAddress, ChunkRef};
+
+    use crate::builder::Builder;
+    use crate::meta::{KeyId, Metadata};
+
+    use super::*;
+
+    fn entry(byte: u8) -> Entry {
+        ChunkRef::new(ChunkAddress::new([byte; 32])).into()
+    }
+
+    // Build a manifest from `keys` and return its root.
+    fn build(store: &MemoryStore, keys: &[(&[u8], u8)]) -> ChunkAddress {
+        let mut builder = Builder::<V1>::new();
+        for (key, fill) in keys {
+            builder.insert(Key::from(*key), entry(*fill), None);
+        }
+        *block_on(builder.build(store)).unwrap().root()
+    }
+
+    // The root a from-scratch build of `keys` produces, for the byte-identity
+    // check: a fresh store makes the address depend on the bytes alone.
+    fn rebuilt(keys: &[(&[u8], u8)]) -> ChunkAddress {
+        build(&MemoryStore::default(), keys)
+    }
+
+    #[test]
+    fn an_empty_changeset_returns_the_root_unchanged() {
+        let store = MemoryStore::default();
+        let root = build(&store, &[(b"a", 1), (b"b", 2)]);
+        let out = block_on(apply(&store, &root, &Changeset::<V1>::new())).unwrap();
+        assert_eq!(out, root);
+    }
+
+    #[test]
+    fn a_single_insert_equals_a_rebuild() {
+        let store = MemoryStore::default();
+        let root = build(&store, &[(b"a", 1), (b"c", 3)]);
+        let mut cs = Changeset::<V1>::new();
+        cs.put(Key::from(&b"b"[..]), entry(2), None);
+        let out = block_on(apply(&store, &root, &cs)).unwrap();
+        assert_eq!(out, rebuilt(&[(b"a", 1), (b"b", 2), (b"c", 3)]));
+    }
+
+    #[test]
+    fn a_batch_touching_one_ancestor_equals_a_rebuild() {
+        let store = MemoryStore::default();
+        let root = build(&store, &[(b"road", 1), (b"roam", 2)]);
+        // Two inserts under the shared "ro" ancestor, rewritten in one pass.
+        let mut cs = Changeset::<V1>::new();
+        cs.put(Key::from(&b"rock"[..]), entry(3), None);
+        cs.put(Key::from(&b"rose"[..]), entry(4), None);
+        let out = block_on(apply(&store, &root, &cs)).unwrap();
+        assert_eq!(
+            out,
+            rebuilt(&[(b"road", 1), (b"roam", 2), (b"rock", 3), (b"rose", 4)])
+        );
+    }
+
+    #[test]
+    fn an_update_overwrites_in_place() {
+        let store = MemoryStore::default();
+        let root = build(&store, &[(b"a", 1), (b"b", 2)]);
+        let mut cs = Changeset::<V1>::new();
+        cs.put(Key::from(&b"a"[..]), entry(9), None);
+        let out = block_on(apply(&store, &root, &cs)).unwrap();
+        assert_eq!(out, rebuilt(&[(b"a", 9), (b"b", 2)]));
+    }
+
+    #[test]
+    fn a_deletion_that_re_inlines_a_sibling_equals_a_rebuild() {
+        let store = MemoryStore::default();
+        // "roam"/"road" share a "roa" branch; deleting one collapses the branch
+        // back into a single compacted edge.
+        let root = build(&store, &[(b"roam", 1), (b"road", 2), (b"x", 3)]);
+        let mut cs = Changeset::<V1>::new();
+        cs.remove(Key::from(&b"road"[..]));
+        let out = block_on(apply(&store, &root, &cs)).unwrap();
+        assert_eq!(out, rebuilt(&[(b"roam", 1), (b"x", 3)]));
+    }
+
+    #[test]
+    fn deleting_the_last_child_removes_the_fork() {
+        let store = MemoryStore::default();
+        let root = build(&store, &[(b"a", 1), (b"b", 2)]);
+        let mut cs = Changeset::<V1>::new();
+        cs.remove(Key::from(&b"a"[..]));
+        let out = block_on(apply(&store, &root, &cs)).unwrap();
+        assert_eq!(out, rebuilt(&[(b"b", 2)]));
+    }
+
+    #[test]
+    fn deleting_an_absent_key_is_a_no_op() {
+        let store = MemoryStore::default();
+        let root = build(&store, &[(b"a", 1), (b"ab", 2)]);
+        let mut cs = Changeset::<V1>::new();
+        cs.remove(Key::from(&b"absent"[..]));
+        cs.remove(Key::from(&b"a"[..]));
+        cs.put(Key::from(&b"a"[..]), entry(1), None);
+        let out = block_on(apply(&store, &root, &cs)).unwrap();
+        assert_eq!(out, rebuilt(&[(b"a", 1), (b"ab", 2)]));
+    }
+
+    #[test]
+    fn a_split_within_an_edge_equals_a_rebuild() {
+        let store = MemoryStore::default();
+        // "abcdef" sits behind a long compacted edge; inserting "abz" branches
+        // inside that edge.
+        let root = build(&store, &[(b"abcdef", 1)]);
+        let mut cs = Changeset::<V1>::new();
+        cs.put(Key::from(&b"abz"[..]), entry(2), None);
+        let out = block_on(apply(&store, &root, &cs)).unwrap();
+        assert_eq!(out, rebuilt(&[(b"abcdef", 1), (b"abz", 2)]));
+    }
+
+    #[test]
+    fn the_empty_key_sets_and_clears_the_root_value() {
+        let store = MemoryStore::default();
+        let root = build(&store, &[(b"a", 1)]);
+        let mut set = Changeset::<V1>::new();
+        set.put(Key::empty(), entry(7), None);
+        let with_root = block_on(apply(&store, &root, &set)).unwrap();
+
+        let mut expect = Builder::<V1>::new();
+        expect.insert(Key::empty(), entry(7), None);
+        expect.insert(Key::from(&b"a"[..]), entry(1), None);
+        let rebuilt_root = *block_on(expect.build(&MemoryStore::default()))
+            .unwrap()
+            .root();
+        assert_eq!(with_root, rebuilt_root);
+
+        let mut clear = Changeset::<V1>::new();
+        clear.remove(Key::empty());
+        let cleared = block_on(apply(&store, &with_root, &clear)).unwrap();
+        assert_eq!(cleared, rebuilt(&[(b"a", 1)]));
+    }
+
+    #[test]
+    fn carried_metadata_survives_a_rebuild() {
+        let store = MemoryStore::default();
+        let meta = Metadata::new(KeyId::ContentType, Bytes::from_static(b"text/html")).unwrap();
+        let root = build(&store, &[(b"a", 1)]);
+        let mut cs = Changeset::<V1>::new();
+        cs.put(Key::from(&b"index.html"[..]), entry(2), Some(meta.clone()));
+        let out = block_on(apply(&store, &root, &cs)).unwrap();
+
+        let mut expect = Builder::<V1>::new();
+        expect.insert(Key::from(&b"a"[..]), entry(1), None);
+        expect.insert(Key::from(&b"index.html"[..]), entry(2), Some(meta));
+        let rebuilt_root = *block_on(expect.build(&MemoryStore::default()))
+            .unwrap()
+            .root();
+        assert_eq!(out, rebuilt_root);
+    }
+}

--- a/crates/manifest/src/apply.rs
+++ b/crates/manifest/src/apply.rs
@@ -5,10 +5,12 @@
 //! paths are rewritten, and a shared ancestor is rewritten once per apply, not
 //! once per changeset entry, so a wide batch amortizes over its overlap. An
 //! unchanged fork is spliced in verbatim; an untouched referenced subtree is
-//! reused by address without a fetch. Because embedding is child-local and a
-//! cut is keyed on the fork-relative prefix, re-rooting a reused subtree does
-//! not churn its shape, so `apply(root, delta)` and a from-scratch build of the
-//! merged keys agree bit for bit (invariant I6 under updates).
+//! reused by address without a fetch. Embedding is child-local and a cut is
+//! keyed on the fork-relative prefix, so a reused subtree keeps its shape;
+//! re-rooting only shifts where the `PLEN_MAX` edge cap falls, so a re-rooted or
+//! merged edge is re-compacted into the same chain a build at the new depth
+//! would. Hence `apply(root, delta)` and a from-scratch build of the merged keys
+//! agree bit for bit (invariant I6 under updates).
 //!
 //! Peak retained state is O(depth + changeset frontier): the descent holds one
 //! node per level on the current path, never a whole subtree.
@@ -334,7 +336,15 @@ where
 
     if deeper.is_empty() {
         // The child is untouched: reuse it verbatim.
-        return finish(edge, new_entry, new_meta, existing.child().cloned());
+        return finish(
+            store,
+            edge,
+            new_entry,
+            new_meta,
+            existing.child().cloned(),
+            stats,
+        )
+        .await;
     }
 
     let child_table = match existing.child() {
@@ -343,7 +353,7 @@ where
             if items.is_empty() {
                 // A deletion of an absent deeper key: the fork is unchanged bar
                 // its terminal value.
-                return finish(edge, new_entry, new_meta, None);
+                return finish(store, edge, new_entry, new_meta, None, stats).await;
             }
             build_table(store, &items, plen, stats).await?
         }
@@ -384,7 +394,7 @@ where
     F: Format,
 {
     if table.is_empty() {
-        return finish(edge, entry, meta, None);
+        return finish(store, edge, entry, meta, None, stats).await;
     }
     // Edge-compaction: a child-only fork over a single-fork child merges into
     // one edge, exactly as a from-scratch build would compact the shared run.
@@ -392,23 +402,10 @@ where
         && table.len() == 1
         && let Some((first, record)) = table.iter().next()
     {
-        let combined = edge
-            .len()
-            .saturating_add(1)
-            .saturating_add(record.tail().len());
-        if combined <= F::PLEN_MAX {
-            let mut merged = edge.to_vec();
-            merged.push(first);
-            merged.extend_from_slice(record.tail().as_bytes());
-            return make_fork(
-                &merged,
-                record.payload().clone(),
-                record.metadata().cloned(),
-            );
-        }
+        return compact(store, edge, first, record, stats).await;
     }
     let child = resolve(store, table, stats).await?.into_child();
-    finish(edge, entry, meta, Some(child))
+    finish(store, edge, entry, meta, Some(child), stats).await
 }
 
 /// An insertion diverges within the edge: branch at the divergence, re-rooting
@@ -449,16 +446,46 @@ where
         }
     }
 
-    // The existing subtree hangs verbatim under the remainder of its edge.
+    // The existing subtree hangs under the remainder of its edge. Shortening
+    // the edge can bring a chained child-only fork back within the prefix
+    // bound, so the re-root re-compacts exactly as a build at the new depth
+    // would rather than splicing the old shape in verbatim.
     let mut branch = ForkTable::new();
-    let remainder = Prefix::try_from(edge.get(cut..).ok_or(ApplyError::Internal)?)?;
-    branch.insert(
+    let remainder = edge.get(cut..).ok_or(ApplyError::Internal)?;
+    let first = *remainder.first().ok_or(ApplyError::Internal)?;
+    if let Some(record) = reroot(store, remainder, existing, stats).await? {
+        branch.insert_record(first, record);
+    }
+    let table = Box::pin(apply_forks(store, branch, boundary, &remaining, stats)).await?;
+    assemble(store, new_edge, split_entry, split_meta, table, stats).await
+}
+
+/// Re-root an existing fork under a shortened `remainder` edge, re-compacting a
+/// child-only chain fork that the shorter edge now brings within the prefix
+/// bound. A fork with a terminal value, or one whose single continuation still
+/// overruns the bound, is depth-independent and re-roots verbatim.
+async fn reroot<S, F>(
+    store: &S,
+    remainder: &[u8],
+    existing: ForkRecord<F>,
+    stats: &mut BuildStats,
+) -> Result<Option<ForkRecord<F>>, ApplyError>
+where
+    S: ChunkPut + MaybeSync,
+    F: Format,
+{
+    if existing.entry().is_none()
+        && let Some(Child::Embedded(table)) = existing.child()
+        && table.len() == 1
+        && let Some((first, record)) = table.iter().next()
+    {
+        return compact(store, remainder, first, record, stats).await;
+    }
+    make_fork(
         remainder,
         existing.payload().clone(),
         existing.metadata().cloned(),
-    )?;
-    let table = Box::pin(apply_forks(store, branch, boundary, &remaining, stats)).await?;
-    assemble(store, new_edge, split_entry, split_meta, table, stats).await
+    )
 }
 
 /// Assemble a fork record from an intact edge, its terminal value and its child,
@@ -467,37 +494,86 @@ where
 /// A child-only fork over a single-fork embedded child compacts into one edge,
 /// so a deletion that strips a fork's terminal value re-inlines its lone
 /// remaining branch exactly as a from-scratch build would.
-fn finish<F: Format>(
+async fn finish<S, F>(
+    store: &S,
     edge: &[u8],
     entry: Option<Entry<F>>,
     meta: Option<Metadata<F>>,
     child: Option<Child<F>>,
-) -> Result<Option<ForkRecord<F>>, ApplyError> {
+    stats: &mut BuildStats,
+) -> Result<Option<ForkRecord<F>>, ApplyError>
+where
+    S: ChunkPut + MaybeSync,
+    F: Format,
+{
     if entry.is_none()
         && let Some(Child::Embedded(table)) = &child
         && table.len() == 1
         && let Some((first, record)) = table.iter().next()
     {
-        let combined = edge
-            .len()
-            .saturating_add(1)
-            .saturating_add(record.tail().len());
-        if combined <= F::PLEN_MAX {
-            let mut merged = edge.to_vec();
-            merged.push(first);
-            merged.extend_from_slice(record.tail().as_bytes());
-            return make_fork(
-                &merged,
-                record.payload().clone(),
-                record.metadata().cloned(),
-            );
-        }
+        return compact(store, edge, first, record, stats).await;
     }
     let has_entry = entry.is_some();
     ForkPayload::new(entry, child).map_or_else(
         || Ok(None),
         |payload| make_fork(edge, payload, if has_entry { meta } else { None }),
     )
+}
+
+/// Merge a child-only `edge` into its lone child fork (index byte `first` plus
+/// `record`), emitting the compacted fork a from-scratch build would produce.
+async fn compact<S, F>(
+    store: &S,
+    edge: &[u8],
+    first: u8,
+    record: &ForkRecord<F>,
+    stats: &mut BuildStats,
+) -> Result<Option<ForkRecord<F>>, ApplyError>
+where
+    S: ChunkPut + MaybeSync,
+    F: Format,
+{
+    let mut merged = edge.to_vec();
+    merged.push(first);
+    merged.extend_from_slice(record.tail().as_bytes());
+    chain(
+        store,
+        &merged,
+        record.payload().clone(),
+        record.metadata().cloned(),
+        stats,
+    )
+    .await
+}
+
+/// A fork record over `prefix`, split into a `PLEN_MAX`-capped chain of
+/// child-only nodes when it overruns the bound, exactly as the builder compacts
+/// an over-long shared run. The innermost fork carries the payload and its
+/// metadata; every wrapping fork carries only the continuation.
+async fn chain<S, F>(
+    store: &S,
+    prefix: &[u8],
+    payload: ForkPayload<F>,
+    meta: Option<Metadata<F>>,
+    stats: &mut BuildStats,
+) -> Result<Option<ForkRecord<F>>, ApplyError>
+where
+    S: ChunkPut + MaybeSync,
+    F: Format,
+{
+    if prefix.len() <= F::PLEN_MAX {
+        return make_fork(prefix, payload, meta);
+    }
+    let head = prefix.get(..F::PLEN_MAX).ok_or(ApplyError::Internal)?;
+    let rest = prefix.get(F::PLEN_MAX..).ok_or(ApplyError::Internal)?;
+    let &first = rest.first().ok_or(ApplyError::Internal)?;
+    let inner = Box::pin(chain(store, rest, payload, meta, stats))
+        .await?
+        .ok_or(ApplyError::Internal)?;
+    let mut table = ForkTable::new();
+    table.insert_record(first, inner);
+    let child = resolve(store, table, stats).await?.into_child();
+    make_fork(head, ForkPayload::Child(child), None)
 }
 
 /// A fork record for `edge` (its index byte plus tail) carrying `payload`.
@@ -657,6 +733,23 @@ mod tests {
     }
 
     #[test]
+    fn a_split_above_a_chain_boundary_recompacts_like_a_rebuild() {
+        let store = MemoryStore::default();
+        // A 256-byte key sits behind a PLEN_MAX(255) chain: one 255-byte edge
+        // over a child holding its last byte. Inserting a key that shares only
+        // the first byte branches above that chain, shortening the existing edge
+        // so its final byte re-merges into the edge, no longer a child hop.
+        let mut base = vec![2u8];
+        base.extend(std::iter::repeat_n(0u8, 255));
+        let root = build(&store, &[(&base[..], 1)]);
+        let mut cs = Changeset::<V1>::new();
+        let branched = [2u8, 2, 1];
+        cs.put(Key::from(&branched[..]), entry(2), None);
+        let out = block_on(apply(&store, &root, &cs)).unwrap();
+        assert_eq!(out, rebuilt(&[(&base[..], 1), (&branched[..], 2)]));
+    }
+
+    #[test]
     fn the_empty_key_sets_and_clears_the_root_value() {
         let store = MemoryStore::default();
         let root = build(&store, &[(b"a", 1)]);
@@ -676,6 +769,23 @@ mod tests {
         clear.remove(Key::empty());
         let cleared = block_on(apply(&store, &with_root, &clear)).unwrap();
         assert_eq!(cleared, rebuilt(&[(b"a", 1)]));
+    }
+
+    #[test]
+    fn a_collapse_past_the_prefix_bound_chains_like_a_rebuild() {
+        let store = MemoryStore::default();
+        // Two keys sharing a 200-byte prefix, total length 260: the fork over
+        // the shared run terminates one key and continues to the other. Deleting
+        // the terminal leaves a single 260-byte key whose from-scratch shape is
+        // a PLEN_MAX(255)-capped chain, not one over-long edge.
+        let short = vec![b'a'; 200];
+        let mut long = short.clone();
+        long.extend(std::iter::repeat_n(b'b', 60));
+        let root = build(&store, &[(&short[..], 1), (&long[..], 2)]);
+        let mut cs = Changeset::<V1>::new();
+        cs.remove(Key::from(&short[..]));
+        let out = block_on(apply(&store, &root, &cs)).unwrap();
+        assert_eq!(out, rebuilt(&[(&long[..], 2)]));
     }
 
     #[test]

--- a/crates/manifest/src/builder.rs
+++ b/crates/manifest/src/builder.rs
@@ -186,52 +186,80 @@ impl<F: Format> Builder<F> {
                 meta: meta.clone(),
             })
             .collect();
-        let mut root_ext = RootExtension::new(self.root_entry.clone(), self.root_metadata.clone());
+        let root_ext = RootExtension::new(self.root_entry.clone(), self.root_metadata.clone());
         let mut stats = BuildStats::default();
+        let table = build_table(store, &items, 0, &mut stats).await?;
+        let node = Node::new(root_ext, table);
+        let root = put_counted(store, &node, &mut stats).await?;
+        Ok(Built { root, stats })
+    }
+}
 
-        let mut stack: Vec<Frame<'_, F>> = Vec::new();
-        stack.push(Frame::new(0, &items));
-        let mut returned: Option<Resolved<F>> = None;
+/// Assemble the top fork table for `items` at depth `consumed`, resolving every
+/// finished subtree to an embedded table or a spilled reference as it closes.
+///
+/// The returned table is the caller's to wrap: a root wears its extension and
+/// always spills, a subtree defers its own embed decision to [`resolve`].
+pub(crate) async fn build_table<S, F>(
+    store: &S,
+    items: &[Item<F>],
+    consumed: usize,
+    stats: &mut BuildStats,
+) -> Result<ForkTable<F>, BuildError>
+where
+    S: ChunkPut + MaybeSync,
+    F: Format,
+{
+    let mut stack: Vec<Frame<'_, F>> = Vec::new();
+    stack.push(Frame::new(consumed, items));
+    let mut returned: Option<Resolved<F>> = None;
 
-        loop {
-            stats.peak_open_nodes = stats.peak_open_nodes.max(stack.len());
-            let action = {
-                let frame = stack.last_mut().ok_or(BuildError::Internal)?;
-                if let Some(resolved) = returned.take() {
-                    frame.attach(resolved)?;
+    loop {
+        stats.peak_open_nodes = stats.peak_open_nodes.max(stack.len());
+        let action = {
+            let frame = stack.last_mut().ok_or(BuildError::Internal)?;
+            if let Some(resolved) = returned.take() {
+                frame.attach(resolved)?;
+            }
+            frame.step()?
+        };
+        match action {
+            Action::Continue => {}
+            Action::Descend(child_items, plen) => stack.push(Frame::new(plen, child_items)),
+            Action::Finalize => {
+                let frame = stack.pop().ok_or(BuildError::Internal)?;
+                if stack.is_empty() {
+                    return Ok(frame.table);
                 }
-                frame.step()?
-            };
-            match action {
-                Action::Continue => {}
-                Action::Descend(child_items, plen) => stack.push(Frame::new(plen, child_items)),
-                Action::Finalize => {
-                    let frame = stack.pop().ok_or(BuildError::Internal)?;
-                    if stack.is_empty() {
-                        let node = Node::new(root_ext.take(), frame.table);
-                        let root = put_counted(store, &node, &mut stats).await?;
-                        return Ok(Built { root, stats });
-                    }
-                    returned = Some(resolve(store, frame.table, &mut stats).await?);
-                }
+                returned = Some(resolve(store, frame.table, stats).await?);
             }
         }
     }
 }
 
 /// One key-value binding, cloned into a linear array for indexed descent.
-struct Item<F: Format> {
-    key: Bytes,
-    entry: Entry<F>,
-    meta: Option<Metadata<F>>,
+pub(crate) struct Item<F: Format> {
+    pub(crate) key: Bytes,
+    pub(crate) entry: Entry<F>,
+    pub(crate) meta: Option<Metadata<F>>,
 }
 
 /// A resolved subtree bubbling up to its parent fork.
-enum Resolved<F: Format> {
+pub(crate) enum Resolved<F: Format> {
     /// Small enough to inline into the parent's chunk.
     Embedded(ForkTable<F>),
     /// Spilled to a chunk of its own.
     Reference(ChunkRef),
+}
+
+impl<F: Format> Resolved<F> {
+    /// The child a parent fork holds for this resolved subtree.
+    pub(crate) fn into_child(self) -> Child<F> {
+        match self {
+            Self::Embedded(table) => Child::Embedded(table),
+            Self::Reference(reference) => Child::Ref32(reference),
+        }
+    }
 }
 
 /// A fork awaiting the subtree currently under construction.
@@ -396,7 +424,7 @@ fn common_prefix_len(a: &Bytes, b: &Bytes, consumed: usize, cap: usize) -> usize
 ///
 /// The embed decision is child-local: it reads the subtree's flat length alone,
 /// so it is stable under re-rooting and history-independent.
-async fn resolve<S, F>(
+pub(crate) async fn resolve<S, F>(
     store: &S,
     table: ForkTable<F>,
     stats: &mut BuildStats,

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -54,6 +54,7 @@
     )
 )]
 
+mod apply;
 mod bounded;
 mod builder;
 mod codec;
@@ -68,6 +69,7 @@ mod scan;
 mod store;
 mod value;
 
+pub use apply::{ApplyError, Changeset, apply};
 pub use bounded::{MetadataLen, Prefix, SegmentWeight};
 pub use builder::{BuildError, BuildStats, Builder, Built, build_files};
 pub use codec::{DecodeError, EncodeError};

--- a/crates/manifest/tests/apply.proptest-regressions
+++ b/crates/manifest/tests/apply.proptest-regressions
@@ -1,0 +1,9 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc f940676ff3c129a82784c35dac784b59de63b6aacf785fc03467e86d40c0e397 # shrinks to base = [([4, 2, 0], (false, 0, [], false)), ([4, 2], (false, 0, [], false))], changes = [([4, 2], None)]
+cc 1cb7761c5940b43f1ba16ee5d2964e105e2eae954c71502e25633f15858b588a # shrinks to base = [([1, 3, 4, 1], (false, 0, [], false))], changes = [([1], Some((false, 0, [], false))), ([1, 3, 4, 1], None)]
+cc 8e84fef34381739f0e73eaa5df42392f44fdc2538285a0eaa29cc51ed8f1c992 # shrinks to base = [([2, 2, 1, 1, 4], (false, 0, [], false))], changes = [([2, 0, 0, 0, 4], None), ([2, 2, 1, 1], Some((false, 0, [], false)))]

--- a/crates/manifest/tests/apply.rs
+++ b/crates/manifest/tests/apply.rs
@@ -84,6 +84,79 @@ fn change_set() -> impl Strategy<Value = Vec<(Vec<u8>, Option<Parts>)>> {
     prop::collection::vec((key_bytes(), prop::option::of(value_parts())), 0..=40)
 }
 
+/// A long, low-entropy key: a binary alphabet over up to 400 bytes, so pairs
+/// share prefixes past the 255-byte bound while the two-way fanout keeps every
+/// node within budget. Chains form, and a split above a chain boundary
+/// re-compacts into a `PLEN_MAX`-capped chain rather than one over-long edge.
+fn long_key_bytes() -> impl Strategy<Value = Vec<u8>> {
+    prop::collection::vec(0u8..2, 1..=400)
+}
+
+/// A base key set of long keys.
+fn long_base_set() -> impl Strategy<Value = Vec<(Vec<u8>, Parts)>> {
+    prop::collection::vec((long_key_bytes(), value_parts()), 0..=8)
+}
+
+/// A changeset over long keys.
+fn long_change_set() -> impl Strategy<Value = Vec<(Vec<u8>, Option<Parts>)>> {
+    prop::collection::vec((long_key_bytes(), prop::option::of(value_parts())), 0..=6)
+}
+
+/// Fold `changes` into a manifest built from `base` and assert the applied root
+/// is byte-identical to a from-scratch build of the merged key set.
+fn assert_apply_equals_rebuild(
+    base: &[(Vec<u8>, Parts)],
+    changes: &[(Vec<u8>, Option<Parts>)],
+) -> Result<(), TestCaseError> {
+    // The base map and its published manifest.
+    let mut map: BTreeMap<Vec<u8>, Value> = BTreeMap::new();
+    for (key, (inline, fill, blob, meta)) in base {
+        map.insert(key.clone(), value(*inline, *fill, blob, *meta)?);
+    }
+    let store = MemoryStore::default();
+    let mut builder = Builder::<V1>::new();
+    for (key, val) in &map {
+        builder.insert(Key::from(key.clone()), val.0.clone(), val.1.clone());
+    }
+    let root = *block_on(builder.build(&store))
+        .map_err(|e| TestCaseError::fail(e.to_string()))?
+        .root();
+
+    // Stage the batch into a changeset and, in the same order, into the
+    // expected merged map so the last update per key wins in both.
+    let mut changeset = Changeset::<V1>::new();
+    let mut updates: Vec<Update> = Vec::new();
+    for (key, op) in changes {
+        match op {
+            Some((inline, fill, blob, meta)) => {
+                let val = value(*inline, *fill, blob, *meta)?;
+                changeset.put(Key::from(key.clone()), val.0.clone(), val.1.clone());
+                updates.push((key.clone(), Some(val)));
+            }
+            None => {
+                changeset.remove(Key::from(key.clone()));
+                updates.push((key.clone(), None));
+            }
+        }
+    }
+    for (key, op) in updates {
+        match op {
+            Some(val) => {
+                map.insert(key, val);
+            }
+            None => {
+                map.remove(&key);
+            }
+        }
+    }
+
+    let applied = block_on(apply(&store, &root, &changeset))
+        .map_err(|e| TestCaseError::fail(e.to_string()))?;
+    let expected = rebuild(&map)?;
+    prop_assert_eq!(applied, expected);
+    Ok(())
+}
+
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(256))]
 
@@ -92,47 +165,13 @@ proptest! {
     // inserts, updates and deletes, some overlapping near the root.
     #[test]
     fn apply_equals_rebuild(base in base_set(), changes in change_set()) {
-        // The base map and its published manifest.
-        let mut map: BTreeMap<Vec<u8>, Value> = BTreeMap::new();
-        for (key, (inline, fill, blob, meta)) in &base {
-            map.insert(key.clone(), value(*inline, *fill, blob, *meta)?);
-        }
-        let store = MemoryStore::default();
-        let mut builder = Builder::<V1>::new();
-        for (key, val) in &map {
-            builder.insert(Key::from(key.clone()), val.0.clone(), val.1.clone());
-        }
-        let root = *block_on(builder.build(&store))
-            .map_err(|e| TestCaseError::fail(e.to_string()))?
-            .root();
+        assert_apply_equals_rebuild(&base, &changes)?;
+    }
 
-        // Stage the batch into a changeset and, in the same order, into the
-        // expected merged map so the last update per key wins in both.
-        let mut changeset = Changeset::<V1>::new();
-        let mut updates: Vec<Update> = Vec::new();
-        for (key, op) in &changes {
-            match op {
-                Some((inline, fill, blob, meta)) => {
-                    let val = value(*inline, *fill, blob, *meta)?;
-                    changeset.put(Key::from(key.clone()), val.0.clone(), val.1.clone());
-                    updates.push((key.clone(), Some(val)));
-                }
-                None => {
-                    changeset.remove(Key::from(key.clone()));
-                    updates.push((key.clone(), None));
-                }
-            }
-        }
-        for (key, op) in updates {
-            match op {
-                Some(val) => { map.insert(key, val); }
-                None => { map.remove(&key); }
-            }
-        }
-
-        let applied = block_on(apply(&store, &root, &changeset))
-            .map_err(|e| TestCaseError::fail(e.to_string()))?;
-        let expected = rebuild(&map)?;
-        prop_assert_eq!(applied, expected);
+    // The same equation over long, low-entropy keys, so collapses cross the
+    // 255-byte prefix bound and exercise the chain-compaction path.
+    #[test]
+    fn apply_equals_rebuild_over_long_keys(base in long_base_set(), changes in long_change_set()) {
+        assert_apply_equals_rebuild(&base, &changes)?;
     }
 }

--- a/crates/manifest/tests/apply.rs
+++ b/crates/manifest/tests/apply.rs
@@ -1,0 +1,138 @@
+//! History-independent apply through the public API: folding a changeset into a
+//! manifest lands on the exact root a from-scratch build of the merged key set
+//! produces, byte for byte, over random bases and random update batches.
+//!
+//! This is the conformance equation `apply(root(M), D) == root(M + D)`, the
+//! guarantee that content addressing and dedup survive an update stream.
+
+use std::collections::BTreeMap;
+
+use bytes::Bytes;
+use futures::executor::block_on;
+use nectar_manifest::{Builder, Changeset, Entry, Key, KeyId, Metadata, V1, apply};
+use nectar_primitives::{ChunkAddress, ChunkRef, MemoryStore};
+use proptest::prelude::*;
+
+/// A key's value plus optional metadata, the payload both paths carry.
+type Value = (Entry<V1>, Option<Metadata<V1>>);
+
+/// One staged update: a value to bind, or `None` to delete.
+type Update = (Vec<u8>, Option<Value>);
+
+/// The generated parts of a value: inline flag, fill byte, blob, metadata flag.
+type Parts = (bool, u8, Vec<u8>, bool);
+
+fn ref32(fill: u8) -> Entry<V1> {
+    Entry::from(ChunkRef::new(ChunkAddress::new([fill; 32])))
+}
+
+/// A value from its generated parts: a short inline blob or a plain reference,
+/// with metadata on request.
+fn value(inline: bool, fill: u8, blob: &[u8], meta: bool) -> Result<Value, TestCaseError> {
+    let entry = if inline {
+        Entry::inline(Bytes::copy_from_slice(blob))
+            .map_err(|e| TestCaseError::fail(e.to_string()))?
+    } else {
+        ref32(fill)
+    };
+    let metadata = if meta {
+        Some(
+            Metadata::new(KeyId::ContentType, Bytes::from_static(b"text/html"))
+                .map_err(|e| TestCaseError::fail(e.to_string()))?,
+        )
+    } else {
+        None
+    };
+    Ok((entry, metadata))
+}
+
+/// The root a from-scratch build of `map` produces in a fresh store, so the
+/// address depends on the merged bytes alone.
+fn rebuild(map: &BTreeMap<Vec<u8>, Value>) -> Result<ChunkAddress, TestCaseError> {
+    let store = MemoryStore::default();
+    let mut builder = Builder::<V1>::new();
+    for (key, (entry, meta)) in map {
+        builder.insert(Key::from(key.clone()), entry.clone(), meta.clone());
+    }
+    let built = block_on(builder.build(&store)).map_err(|e| TestCaseError::fail(e.to_string()))?;
+    Ok(*built.root())
+}
+
+/// A short key over a five-symbol alphabet, so keys share prefixes and the trie
+/// branches, compacts and spills.
+fn key_bytes() -> impl Strategy<Value = Vec<u8>> {
+    prop::collection::vec(0u8..5, 1..=8)
+}
+
+/// A generated value: inline-or-reference, a fill byte, a short blob, metadata.
+fn value_parts() -> impl Strategy<Value = Parts> {
+    (
+        any::<bool>(),
+        any::<u8>(),
+        prop::collection::vec(any::<u8>(), 0..=6),
+        any::<bool>(),
+    )
+}
+
+/// A base key set: distinct keys collapse in a map, so the build is well-defined.
+fn base_set() -> impl Strategy<Value = Vec<(Vec<u8>, Parts)>> {
+    prop::collection::vec((key_bytes(), value_parts()), 0..=60)
+}
+
+/// A changeset: each entry binds a value or, on `None`, deletes the key.
+fn change_set() -> impl Strategy<Value = Vec<(Vec<u8>, Option<Parts>)>> {
+    prop::collection::vec((key_bytes(), prop::option::of(value_parts())), 0..=40)
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    // apply(root(M), D) == root(M + D), byte-identical: the applied root equals a
+    // from-scratch build of the merged key set. Random base, random batch of
+    // inserts, updates and deletes, some overlapping near the root.
+    #[test]
+    fn apply_equals_rebuild(base in base_set(), changes in change_set()) {
+        // The base map and its published manifest.
+        let mut map: BTreeMap<Vec<u8>, Value> = BTreeMap::new();
+        for (key, (inline, fill, blob, meta)) in &base {
+            map.insert(key.clone(), value(*inline, *fill, blob, *meta)?);
+        }
+        let store = MemoryStore::default();
+        let mut builder = Builder::<V1>::new();
+        for (key, val) in &map {
+            builder.insert(Key::from(key.clone()), val.0.clone(), val.1.clone());
+        }
+        let root = *block_on(builder.build(&store))
+            .map_err(|e| TestCaseError::fail(e.to_string()))?
+            .root();
+
+        // Stage the batch into a changeset and, in the same order, into the
+        // expected merged map so the last update per key wins in both.
+        let mut changeset = Changeset::<V1>::new();
+        let mut updates: Vec<Update> = Vec::new();
+        for (key, op) in &changes {
+            match op {
+                Some((inline, fill, blob, meta)) => {
+                    let val = value(*inline, *fill, blob, *meta)?;
+                    changeset.put(Key::from(key.clone()), val.0.clone(), val.1.clone());
+                    updates.push((key.clone(), Some(val)));
+                }
+                None => {
+                    changeset.remove(Key::from(key.clone()));
+                    updates.push((key.clone(), None));
+                }
+            }
+        }
+        for (key, op) in updates {
+            match op {
+                Some(val) => { map.insert(key, val); }
+                None => { map.remove(&key); }
+            }
+        }
+
+        let applied = block_on(apply(&store, &root, &changeset))
+            .map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let expected = rebuild(&map)?;
+        prop_assert_eq!(applied, expected);
+    }
+}


### PR DESCRIPTION
## What

Adds a new `src/apply.rs` to `nectar-manifest` implementing history-independent batch apply for the mantaray 1.0 KV manifest.

It introduces a public `Changeset<F>` (put/remove, backed by a sorted map so staging order never leaks into the resulting root), an `apply(store, root, changeset) -> ChunkAddress` entry point, and an `ApplyError` type.

`apply` is a bottom-up path-copy union over the existing trie: at each node it groups the changeset by the byte at the current depth and reconciles only the touched forks, splicing unchanged forks and untouched referenced subtrees in verbatim, so a shared ancestor is rewritten once per apply rather than once per entry.

It handles edge splits (an insert diverging inside a compacted edge branches at the divergence point and re-roots the existing subtree verbatim under the edge remainder), terminal updates and deletes, fresh-subtree creation, and the deletion-collapse rules (last-child removal plus single-branch edge re-inlining), producing the same canonical shape the builder produces.

`crates/manifest/src/builder.rs` and `crates/manifest/src/lib.rs` are extended in support of this (`apply` reuses the builder's `build_table`/`resolve` so wire format stays compatible), and `crates/manifest/tests/apply.rs` adds property tests checking apply-equals-rebuild.

A second commit (`9011433`) fixes a follow-up bug in the first: a deletion collapse whose merged edge exceeded `PLEN_MAX` was left nested instead of being re-chained; this commit re-compacts chained edges so apply's output matches the builder's canonical shape in that case too.

## Why

Closes #259

Prior to this, updating a mantaray manifest required rebuilding the tree from its full entry history. Batch apply lets a client union a set of puts/removes directly onto an existing root without replaying history, which is required for the KV store's write path.

## Testing

Verified on this branch against base `s264/50-read-ops` (2 commits: `46740fe` feat history-independent apply, `9011433` fix re-compact chained edges), all commands run via `nix develop --command`:

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean, for `nectar-manifest` and the whole workspace.
- `cargo test --workspace --all-features` (substituted for `cargo nextest`, which is not present in the flake devShell): all suites pass, including both `tests/apply.rs` proptests (`apply_equals_rebuild`, `apply_equals_rebuild_over_long_ke...`).

A prior red-team pass over this branch found the spec's apply-equals-rebuild bit-identity property broken in the greater-than-255-byte-prefix chain regime (declared unreachable by the implementer and excluded from the proptest), and two distinct reachable bugs: a deletion collapse whose merged edge exceeded `PLEN_MAX` staying nested instead of chaining, and an un-flagged dual-split case on re-rooting an existing chain. The `PLEN_MAX` chaining issue is addressed by commit `9011433`.

This is a stacked PR targeting `s264/50-read-ops`; no meaningful CI runs until it is retargeted onto that branch's own base.

AI Assistance: Claude (Anthropic, Sonnet) used for implementation, red-teaming, and verification testing of this change.

