### PR TITLE
feat(manifest): feature-gated per-reference encryption

### DIFF
--- a/crates/manifest/Cargo.toml
+++ b/crates/manifest/Cargo.toml
@@ -29,6 +29,11 @@ proptest.workspace = true
 
 [features]
 default = [ "std" ]
+# Per-reference encryption crypto (deterministic key derivation, sealing and
+# opening). The 64-byte ref representation is always available; this feature
+# only adds the crypto over it, so a default build still decodes and
+# re-serializes encrypted manifests losslessly.
+encryption = [ "nectar-primitives/encryption" ]
 std = [
 	"alloy-primitives/std",
 	"bytes/std",

--- a/crates/manifest/src/encryption.rs
+++ b/crates/manifest/src/encryption.rs
@@ -1,0 +1,302 @@
+//! Per-reference encryption: deterministic, feature-gated crypto over nodes.
+//!
+//! A ref64 carries `address || key`: the parent record transports the child's
+//! decryption key in band, with no side channel, so whoever reads a node can
+//! open every child it references, recursively. The key is derived
+//! deterministically as `keccak256(F::DERIVE_TAG || secret || plaintext)`, so
+//! an identical subtree under the same secret yields the same key, the same
+//! ciphertext and the same address: canonical bytes and cross-build dedup
+//! survive encryption.
+//!
+//! Encryption is a stream cipher over the exact node payload, so ciphertext
+//! length equals plaintext length and the sealed chunk stays within one chunk
+//! body. The chunk body is opaque to a plain reader: its bytes are not a
+//! manifest preamble, so a plain decode of an encrypted chunk fails loud.
+//!
+//! # Privacy
+//!
+//! A ref64 IS a read capability for the whole subtree beneath it. Writing a
+//! ref64 into a PLAINTEXT parent therefore PUBLISHES that child's key to anyone
+//! who can read the parent. Confidentiality rests entirely on the outermost
+//! ref64 being distributed privately: the root reference of an encrypted tree
+//! is the single secret. Never place an encrypted reference in a plaintext
+//! manifest you intend to publish.
+//!
+//! Embedding never crosses the encryption boundary (see [`embed`]): an
+//! encrypted subtree inlines only into an encrypted parent, so the boundary is
+//! structural, never a runtime choice.
+//!
+//! [`embed`]: crate::embed
+
+use core::future::Future;
+
+use alloy_primitives::Keccak256;
+use nectar_primitives::store::{ChunkPut, MaybeSend, MaybeSync, TrustedStore};
+use nectar_primitives::{
+    Chunk, ChunkOps, ContentChunk, EncryptedChunkRef, EncryptionKey, transcrypt_in_place,
+};
+
+use crate::codec::DecodeError;
+use crate::format::Format;
+use crate::node::Node;
+use crate::store::{NodeChunk, StoreError};
+
+/// Derive the deterministic reference key `keccak256(DERIVE_TAG || secret ||
+/// plaintext)`.
+///
+/// Keyed on the child's own plaintext, so the same plaintext under the same
+/// secret always derives the same key. The tag separates this derivation from
+/// any other keccak use.
+#[must_use]
+pub fn derive_key<F: Format>(secret: &[u8], plaintext: &[u8]) -> EncryptionKey {
+    let mut hasher = Keccak256::new();
+    hasher.update(F::DERIVE_TAG);
+    hasher.update(secret);
+    hasher.update(plaintext);
+    EncryptionKey::from(hasher.finalize())
+}
+
+/// A node sealed as an encrypted chunk together with the ref64 that opens it.
+///
+/// The chunk is the ciphertext under its own derived address; the reference is
+/// `address || key`, the capability a parent record carries to reach and
+/// decrypt this node.
+#[derive(Debug)]
+pub struct EncryptedNode {
+    chunk: NodeChunk,
+    reference: EncryptedChunkRef,
+}
+
+impl EncryptedNode {
+    /// The ciphertext chunk, ready to store under its derived address.
+    #[must_use]
+    pub const fn chunk(&self) -> &NodeChunk {
+        &self.chunk
+    }
+
+    /// The ref64 that reaches and decrypts this node.
+    #[must_use]
+    pub const fn reference(&self) -> &EncryptedChunkRef {
+        &self.reference
+    }
+
+    /// Consume into the ciphertext chunk and its ref64.
+    #[must_use]
+    pub fn into_parts(self) -> (NodeChunk, EncryptedChunkRef) {
+        (self.chunk, self.reference)
+    }
+}
+
+impl<F: Format> Node<F> {
+    /// Seal this node as an encrypted content chunk under a key derived from
+    /// `secret` and the node's own plaintext.
+    ///
+    /// The address is the BMT of the ciphertext, so an identical node under the
+    /// same secret always seals to the same chunk and ref64.
+    pub fn to_encrypted_chunk(&self, secret: &[u8]) -> Result<EncryptedNode, StoreError> {
+        let mut payload = self.encode()?;
+        let key = derive_key::<F>(secret, &payload);
+        transcrypt_in_place(&key, 0, &mut payload);
+        let content = ContentChunk::new(payload).map_err(StoreError::Seal)?;
+        let chunk = Chunk::from_envelope(content.into()).map_err(StoreError::Seal)?;
+        let reference = EncryptedChunkRef::new(*chunk.address(), key);
+        Ok(EncryptedNode { chunk, reference })
+    }
+
+    /// Decrypt and decode a node from a certified encrypted chunk and its key.
+    ///
+    /// A wrong key decrypts to bytes that are not a manifest and the decode
+    /// fails loud rather than producing a spurious node.
+    pub fn from_encrypted_chunk(
+        chunk: &NodeChunk,
+        key: &EncryptionKey,
+    ) -> Result<Self, DecodeError> {
+        let mut payload = chunk.envelope().data().to_vec();
+        transcrypt_in_place(key, 0, &mut payload);
+        Self::decode(&payload)
+    }
+}
+
+/// Async encrypted-node storage over a chunk putter.
+///
+/// Blanket-implemented for every [`ChunkPut`]; sealing happens before the first
+/// await, so the returned future never holds the source node.
+pub trait EncryptedNodePut: ChunkPut {
+    /// Seal `node` under `secret`, store its ciphertext chunk, and return the
+    /// ref64 that reaches and decrypts it.
+    fn put_node_encrypted<F: Format>(
+        &self,
+        node: &Node<F>,
+        secret: &[u8],
+    ) -> impl Future<Output = Result<EncryptedChunkRef, StoreError>> + MaybeSend
+    where
+        Self: Sized + MaybeSync,
+    {
+        let sealed = node.to_encrypted_chunk(secret);
+        async move {
+            let (chunk, reference) = sealed?.into_parts();
+            self.put(chunk)
+                .await
+                .map_err(|err| StoreError::Store(Box::new(err)))?;
+            Ok(reference)
+        }
+    }
+}
+
+impl<T: ChunkPut> EncryptedNodePut for T {}
+
+/// Async encrypted-node retrieval over a trusted store.
+///
+/// Blanket-implemented for every [`TrustedStore`]; the ref64 carries both the
+/// address to fetch and the key to decrypt with.
+pub trait EncryptedNodeGet: TrustedStore {
+    /// Load the chunk at `reference`'s address and decrypt it with its key.
+    fn get_node_encrypted<F: Format>(
+        &self,
+        reference: &EncryptedChunkRef,
+    ) -> impl Future<Output = Result<Node<F>, StoreError>> + MaybeSend
+    where
+        Self: Sized + MaybeSync,
+    {
+        async move {
+            let chunk = self
+                .get(reference.address())
+                .await
+                .map_err(|err| StoreError::Store(Box::new(err)))?;
+            Ok(Node::from_encrypted_chunk(&chunk, reference.key())?)
+        }
+    }
+}
+
+impl<T: TrustedStore> EncryptedNodeGet for T {}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use futures::executor::block_on;
+    use nectar_primitives::store::MemoryStore;
+    use nectar_primitives::{ChunkAddress, ChunkRef};
+
+    use crate::bounded::Prefix;
+    use crate::fork::Child;
+    use crate::meta::{KeyId, Metadata};
+    use crate::node::RootExtension;
+    use crate::value::Entry;
+
+    use super::*;
+
+    const SECRET: &[u8] = b"correct horse battery staple";
+
+    fn sample() -> Node {
+        let root = RootExtension::new(
+            Some(Entry::from(ChunkRef::new(ChunkAddress::new([1; 32])))),
+            Some(
+                Metadata::new(
+                    KeyId::WebsiteIndexDocument,
+                    Bytes::from_static(b"index.html"),
+                )
+                .unwrap(),
+            ),
+        );
+        let mut node = Node::new(root, Default::default());
+        node.forks_mut()
+            .insert(
+                Prefix::try_from(&b"index.html"[..]).unwrap(),
+                Entry::from(ChunkRef::new(ChunkAddress::new([7; 32]))).into(),
+                None,
+            )
+            .unwrap();
+        node
+    }
+
+    #[test]
+    fn derivation_is_deterministic_and_secret_dependent() {
+        let plaintext = b"payload bytes";
+        let a = derive_key::<crate::V1>(SECRET, plaintext);
+        let b = derive_key::<crate::V1>(SECRET, plaintext);
+        assert_eq!(a, b);
+        assert_ne!(a, derive_key::<crate::V1>(b"other secret", plaintext));
+        assert_ne!(a, derive_key::<crate::V1>(SECRET, b"other payload"));
+    }
+
+    #[test]
+    fn sealing_is_deterministic_and_dedups() {
+        let node = sample();
+        let first = node.to_encrypted_chunk(SECRET).unwrap();
+        let second = node.to_encrypted_chunk(SECRET).unwrap();
+        // Same plaintext, same secret: same key, ciphertext and address.
+        assert_eq!(first.reference(), second.reference());
+        assert_eq!(first.chunk().address(), second.chunk().address());
+        // A different secret reseals to a different address and key.
+        let other = node.to_encrypted_chunk(b"different").unwrap();
+        assert_ne!(first.reference(), other.reference());
+        assert_ne!(first.chunk().address(), other.chunk().address());
+    }
+
+    #[test]
+    fn ciphertext_is_opaque_to_a_plain_reader() {
+        let node = sample();
+        let plaintext = node.encode().unwrap();
+        let sealed = node.to_encrypted_chunk(SECRET).unwrap();
+        // The stored body is neither the plaintext nor a decodable manifest.
+        assert_ne!(
+            sealed.chunk().envelope().data().as_ref(),
+            plaintext.as_slice()
+        );
+        assert!(Node::<crate::V1>::from_chunk(sealed.chunk()).is_err());
+    }
+
+    #[test]
+    fn round_trips_through_the_derived_key() {
+        let node = sample();
+        let sealed = node.to_encrypted_chunk(SECRET).unwrap();
+        let (chunk, reference) = sealed.into_parts();
+        let opened: Node = Node::from_encrypted_chunk(&chunk, reference.key()).unwrap();
+        assert_eq!(opened, node);
+    }
+
+    #[test]
+    fn a_wrong_key_fails_to_decode() {
+        let node = sample();
+        let sealed = node.to_encrypted_chunk(SECRET).unwrap();
+        let wrong = derive_key::<crate::V1>(b"wrong", &node.encode().unwrap());
+        assert!(Node::<crate::V1>::from_encrypted_chunk(sealed.chunk(), &wrong).is_err());
+    }
+
+    #[test]
+    fn round_trips_through_a_memory_store() {
+        let store = MemoryStore::default();
+        let node = sample();
+        let reference = block_on(store.put_node_encrypted(&node, SECRET)).unwrap();
+        let opened: Node = block_on(store.get_node_encrypted(&reference)).unwrap();
+        assert_eq!(opened, node);
+    }
+
+    #[test]
+    fn a_ref64_transports_the_child_key_into_its_parent() {
+        // The privacy rule made concrete: sealing a child yields a ref64 whose
+        // key is exactly the child's derived key, so a parent that records the
+        // ref64 carries that key in its own bytes.
+        let store = MemoryStore::default();
+        let child = sample();
+        let reference = block_on(store.put_node_encrypted(&child, SECRET)).unwrap();
+        assert_eq!(
+            reference.key(),
+            &derive_key::<crate::V1>(SECRET, &child.encode().unwrap())
+        );
+
+        let mut parent = Node::empty();
+        parent
+            .forks_mut()
+            .insert(
+                Prefix::try_from(&b"dir/"[..]).unwrap(),
+                Child::Ref64(reference).into(),
+                None,
+            )
+            .unwrap();
+        // The child key round-trips through the parent's own wire bytes.
+        let bytes = parent.encode().unwrap();
+        let decoded: Node = Node::decode(&bytes).unwrap();
+        assert_eq!(decoded, parent);
+    }
+}

--- a/crates/manifest/src/format.rs
+++ b/crates/manifest/src/format.rs
@@ -71,6 +71,13 @@ pub trait Format:
     /// product fits u64 for every sub-target weight. Typed `u64`, not
     /// `usize`: the value exceeds a 32-bit `usize` on wasm32.
     const CUT_SCALE: u64;
+
+    /// Domain-separation tag for the deterministic per-reference key
+    /// derivation `keccak256(DERIVE_TAG || secret || plaintext)`. Frozen per
+    /// version so encrypting the same plaintext under the same secret always
+    /// yields the same key, ciphertext and address, keeping canonical bytes
+    /// and cross-build dedup intact for encrypted trees.
+    const DERIVE_TAG: &'static [u8];
 }
 
 /// The frozen `tag_version 0x01` parameter set.
@@ -91,6 +98,7 @@ impl Format for V1 {
     const CAP_FORK: usize = 4091;
     const CAP_DIR: usize = 4090;
     const CUT_SCALE: u64 = 9_007_199_254_740_992;
+    const DERIVE_TAG: &'static [u8] = b"mantaray-1.0-encryption";
 }
 
 // Frozen cross-parameter facts, kept honest at compile time.
@@ -144,6 +152,7 @@ mod tests {
         assert_eq!(V1::CAP_FORK, 4091);
         assert_eq!(V1::CAP_DIR, 4090);
         assert_eq!(V1::CUT_SCALE, 9_007_199_254_740_992);
+        assert_eq!(V1::DERIVE_TAG, b"mantaray-1.0-encryption");
     }
 
     #[test]

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -29,6 +29,20 @@
 //! oversized fork table). Every boundary is a pure function of content, so an
 //! insert disturbs `O(1)` boundaries and re-rooting does not churn.
 //!
+//! Encryption is per-reference: a ref64 ([`Entry::Ref64`], [`Child::Ref64`])
+//! carries `address || key`, transporting the child's decryption key in the
+//! parent record with no side channel, so reading a node opens every child it
+//! references, recursively. The 64-byte representation is always available, so
+//! a build without the `encryption` feature still decodes and re-serializes an
+//! encrypted manifest losslessly; only the crypto (key derivation, sealing,
+//! opening) sits behind the feature. The key derivation is deterministic, so an
+//! encrypted tree keeps canonical bytes and cross-build dedup.
+//!
+//! PRIVACY: a ref64 IS a read capability for its whole subtree. Writing one
+//! into a PLAINTEXT parent publishes that key to anyone who reads the parent;
+//! confidentiality rests solely on the outermost ref64 being distributed
+//! privately. See the `encryption` module.
+//!
 //! ```
 //! use nectar_manifest::{Format, Prefix, V1};
 //!
@@ -58,6 +72,8 @@ mod apply;
 mod bounded;
 mod builder;
 mod codec;
+#[cfg(feature = "encryption")]
+mod encryption;
 mod error;
 mod fork;
 mod format;
@@ -73,6 +89,9 @@ pub use apply::{ApplyError, Changeset, apply};
 pub use bounded::{MetadataLen, Prefix, SegmentWeight};
 pub use builder::{BuildError, BuildStats, Builder, Built, build_files};
 pub use codec::{DecodeError, EncodeError};
+#[cfg(feature = "encryption")]
+#[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
+pub use encryption::{EncryptedNode, EncryptedNodeGet, EncryptedNodePut, derive_key};
 pub use error::{
     CustomKeyError, ForkPrefixEmpty, MetadataTooLong, PrefixTooLong, ValueTooLong, WeightOverBudget,
 };

--- a/crates/manifest/src/packing.rs
+++ b/crates/manifest/src/packing.rs
@@ -14,7 +14,9 @@ use alloy_primitives::keccak256;
 use nectar_primitives::{ChunkRef, EncryptedChunkRef};
 
 use crate::bounded::{Prefix, SegmentWeight};
+use crate::fork::Child;
 use crate::format::Format;
+use crate::value::Entry;
 
 /// The encryption regime of a subtree: plaintext 32-byte references, or
 /// encrypted 64-byte references carrying in-band keys.
@@ -27,6 +29,34 @@ pub enum Domain {
     Plain,
     /// Encrypted subtree: 64-byte references carrying in-band keys.
     Encrypted,
+}
+
+impl Domain {
+    /// The domain a resolved entry reference belongs to: plaintext for a
+    /// 32-byte reference, encrypted for a key-carrying 64-byte reference.
+    /// `None` for inline bytes, which are not a reference and so have no
+    /// independent domain.
+    #[must_use]
+    pub const fn of_entry<F: Format>(entry: &Entry<F>) -> Option<Self> {
+        match entry {
+            Entry::Ref32(_) => Some(Self::Plain),
+            Entry::Ref64(_) => Some(Self::Encrypted),
+            Entry::Inline(_) => None,
+        }
+    }
+
+    /// The domain a resolved child reference belongs to: plaintext for a
+    /// 32-byte reference, encrypted for a key-carrying 64-byte reference.
+    /// `None` for an embedded subtree, which carries no reference and inherits
+    /// its parent's domain.
+    #[must_use]
+    pub const fn of_child<F: Format>(child: &Child<F>) -> Option<Self> {
+        match child {
+            Child::Ref32(_) => Some(Self::Plain),
+            Child::Ref64(_) => Some(Self::Encrypted),
+            Child::Embedded(_) => None,
+        }
+    }
 }
 
 /// Which capacity a segment run is held to: a leaf run of fork records, or a
@@ -291,6 +321,35 @@ mod tests {
             .chain(base.iter().map(|r| r.start + 1..r.end + 1))
             .collect();
         assert_eq!(shifted, expected);
+    }
+
+    #[test]
+    fn reference_domains_gate_cross_boundary_embedding() {
+        use nectar_primitives::{ChunkAddress, ChunkRef, EncryptedChunkRef, EncryptionKey};
+
+        let addr = ChunkAddress::new([7; 32]);
+        let plain = Entry::<V1>::from(ChunkRef::new(addr));
+        let encrypted =
+            Entry::<V1>::from(EncryptedChunkRef::new(addr, EncryptionKey::from([9; 32])));
+
+        let plain_dom = Domain::of_entry(&plain).unwrap();
+        let enc_dom = Domain::of_entry(&encrypted).unwrap();
+        assert_eq!(plain_dom, Domain::Plain);
+        assert_eq!(enc_dom, Domain::Encrypted);
+        // Inline bytes carry no reference, so no domain.
+        let inline = Entry::<V1>::inline(bytes::Bytes::from_static(b"v")).unwrap();
+        assert_eq!(Domain::of_entry(&inline), None);
+
+        let plain_child = Child::<V1>::from(ChunkRef::new(addr));
+        let enc_child =
+            Child::<V1>::from(EncryptedChunkRef::new(addr, EncryptionKey::from([9; 32])));
+        assert_eq!(Domain::of_child(&plain_child), Some(Domain::Plain));
+        assert_eq!(Domain::of_child(&enc_child), Some(Domain::Encrypted));
+
+        // An encrypted child never inlines into a plaintext parent, however
+        // small: the boundary is structural, not a size decision.
+        assert!(!embed::<V1>(1, plain_dom, enc_dom));
+        assert!(embed::<V1>(1, enc_dom, enc_dom));
     }
 
     #[test]

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -77,7 +77,7 @@ pub mod wasm;
 pub use bmt::DEFAULT_BODY_SIZE;
 
 // Re-export core encryption types
-pub use chunk::encryption::{EncryptedChunkRef, EncryptionKey};
+pub use chunk::encryption::{EncryptedChunkRef, EncryptionKey, transcrypt, transcrypt_in_place};
 #[cfg(feature = "encryption")]
 pub use chunk::{ChunkEncrypt, EncryptedContentChunk};
 


### PR DESCRIPTION
## What

Implements per-reference encryption for mantaray 1.0 (issue #260, epic #264), feature-gated behind `encryption`.

- `format.rs`: `DERIVE_TAG` is now a type-carried const on the sealed `Format` trait (`V1 = b"mantaray-1.0-encryption"`), pinned in the frozen-parameter test.
- `encryption.rs` (new, gated): `derive_key<F>(secret, plaintext)` = `keccak256(F::DERIVE_TAG || secret || plaintext)`; `Node::to_encrypted_chunk(secret)` seals a node as a deterministic-length ciphertext content chunk and returns an `EncryptedNode` (chunk + ref64 = `address || key`); `Node::from_encrypted_chunk(chunk, key)` decrypts and decodes; blanket store-seam traits `EncryptedNodePut::put_node_encrypted` / `EncryptedNodeGet::get_node_encrypted`.
- `packing.rs`: `Domain::of_entry` / `Domain::of_child` helpers classify a resolved `Entry`/`Child` as `Plain`, `Encrypted`, or no domain (inline/embedded), plus a new test `reference_domains_gate_cross_boundary_embedding` confirming an encrypted subtree never embeds into a plaintext parent.
- `lib.rs`: gated module wiring, public re-export of the new encryption items, and a PRIVACY doc comment: a ref64 is a read capability, so writing one into a plaintext parent publishes its key; confidentiality rests solely on the outermost ref64 being distributed privately.
- `primitives/src/lib.rs`: one-line re-export of `transcrypt` / `transcrypt_in_place` alongside the existing `EncryptedChunkRef`/`EncryptionKey` re-exports.
- `manifest/Cargo.toml`: new `encryption` feature, gated on `nectar-primitives/encryption`.

The diff is purely additive. Without the `encryption` feature, the 64-byte ref64 representation is still available and decodes/re-serializes losslessly; only the crypto (key derivation, sealing, opening) sits behind the feature.

## Why

Per-reference encryption is a mantaray 1.0 requirement so a manifest tree can carry confidential subtrees without a side-channel key store: the decryption key for a child travels in band inside its parent's ref64. Key derivation is deterministic so an encrypted tree keeps canonical bytes and cross-build dedup, matching the plaintext tree's properties.

## Testing

Full battery run via `nix develop`:

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean, no warnings.
- `cargo nextest run --workspace --all-features` (ephemeral `nix-shell -p cargo-nextest`): 860 passed, 1 skipped, 0 failed. Includes the 8 new `encryption.rs` tests (deterministic/secret-dependent derivation, deterministic sealing and dedup, opaque-to-plain-reader, derived-key round-trip, wrong-key-fails-decode, memory-store round-trip, ref64-carries-child-key-into-parent) and the new packing test `reference_domains_gate_cross_boundary_embedding`.
- `cargo test --doc --workspace` and with `--all-features`: pass.
- Default (no-encryption) manifest build and `--no-default-features` primitives build both verified.

This is a stacked PR: base is `s264/52-apply`, not `main`.

Closes #260

## AI Assistance

Implementation, adversarial review and independent verification were performed by Claude (Anthropic), per the org contract in nxm-rs/.github's CONTRIBUTING.md.

