### PR TITLE
feat(manifest): folder and website view over the KV core

### DIFF
--- a/crates/manifest/src/folder.rs
+++ b/crates/manifest/src/folder.rs
@@ -385,6 +385,26 @@ mod tests {
     }
 
     #[test]
+    fn list_collapses_consecutive_subdirectories() {
+        let store = MemoryStore::default();
+        // Two subdirectories in a row exercise the reseek-then-collapse-again
+        // path: each named subtree must be skipped without swallowing the next.
+        let root = manifest(
+            &store,
+            &[
+                (b"a/1", 0x01),
+                (b"a/2", 0x02),
+                (b"b/1", 0x03),
+                (b"c.txt", 0x04),
+            ],
+        );
+        let reader: Reader<_> = Reader::new(&store);
+
+        let got = entries(block_on(reader.list(&root, &Key::empty())).unwrap());
+        assert_eq!(got, vec![dir(b"a/"), dir(b"b/"), file(b"c.txt", 0x04)]);
+    }
+
+    #[test]
     fn list_skips_the_directory_key_itself() {
         let store = MemoryStore::default();
         // A key exactly equal to the listed directory path is the directory

--- a/crates/manifest/src/folder.rs
+++ b/crates/manifest/src/folder.rs
@@ -1,0 +1,571 @@
+//! Folder and website views: a path interpretation layered over the flat
+//! byte-keyed KV core.
+//!
+//! The separator is `F::SEPARATOR`, derived from the key bytes at read time and
+//! never stored: a folder is an interpretation of one flat trie, not a second
+//! structure. A directory listing is an ordered prefix scan that collapses
+//! deeper keys at the next separator and seeks past each subtree it names, so a
+//! level lists in O(depth) retained state and never fetches a value chunk.
+//! Website serving reads the index- and error-document conventions from the
+//! root's typed metadata, so the conventions travel as registered metadata,
+//! never magic keys.
+
+use core::mem::size_of;
+
+use bytes::Bytes;
+use nectar_primitives::ChunkAddress;
+use nectar_primitives::store::MaybeSync;
+
+use crate::format::{Format, V1};
+use crate::meta::{KeyId, MetadataKey};
+use crate::node::Node;
+use crate::reader::{Reader, ReaderError};
+use crate::scan::{Cursor, successor};
+use crate::store::NodeGet;
+use crate::value::{Entry, Key};
+
+/// One immediate child of a listed directory.
+///
+/// A subdirectory collapses every key beneath it into a single entry whose key
+/// ends in the separator; a file is a key with no further separator below the
+/// directory.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DirEntry<F: Format = V1> {
+    /// A file directly in the directory: its full key and bound value.
+    File {
+        /// The file's full key.
+        key: Key,
+        /// The bound value.
+        entry: Entry<F>,
+    },
+    /// A subdirectory: its full key path including the trailing separator.
+    Dir {
+        /// The subdirectory path, ending in the separator.
+        key: Key,
+    },
+}
+
+impl<F: Format> DirEntry<F> {
+    /// The entry's full key path.
+    #[must_use]
+    pub const fn key(&self) -> &Key {
+        match self {
+            Self::File { key, .. } | Self::Dir { key } => key,
+        }
+    }
+
+    /// Whether the entry names a subdirectory.
+    #[must_use]
+    pub const fn is_dir(&self) -> bool {
+        matches!(self, Self::Dir { .. })
+    }
+}
+
+/// A streaming listing of one directory's immediate children in key order.
+///
+/// Deeper keys collapse at the next separator into one `Dir` entry, and the
+/// walk seeks past each named subtree rather than descending it, so a directory
+/// of any width or depth lists in O(depth) retained state and no value fetch.
+#[derive(Debug)]
+pub struct Listing<'a, S, F: Format = V1> {
+    store: &'a S,
+    root: ChunkAddress,
+    /// The exclusive bound of the directory's prefix range.
+    end: Option<Bytes>,
+    /// Key bytes consumed by the directory prefix; a child's segment starts
+    /// here.
+    dir_len: usize,
+    /// Set once a named subtree has no successor, so the walk stops.
+    done: bool,
+    cursor: Cursor<'a, S, F>,
+}
+
+impl<S, F> Listing<'_, S, F>
+where
+    S: NodeGet + MaybeSync,
+    F: Format,
+{
+    /// The next immediate child of the directory in key order, or `None` at its
+    /// end.
+    ///
+    /// Naming a subdirectory reseeks the walk to the least key past that
+    /// subtree, so the collapsed keys are never revisited and the value chunks
+    /// are never pulled.
+    pub async fn next(&mut self) -> Result<Option<DirEntry<F>>, ReaderError> {
+        loop {
+            if self.done {
+                return Ok(None);
+            }
+            let Some((key, entry)) = self.cursor.next().await? else {
+                return Ok(None);
+            };
+            let bytes = key.as_bytes();
+            let suffix = bytes.get(self.dir_len..).unwrap_or(&[]);
+            // The directory path itself is not one of its own children.
+            if suffix.is_empty() {
+                continue;
+            }
+            match suffix.iter().position(|&byte| byte == F::SEPARATOR) {
+                None => return Ok(Some(DirEntry::File { key, entry })),
+                Some(cut) => {
+                    let through = self.dir_len.saturating_add(cut).saturating_add(1);
+                    let dir = bytes.get(..through).unwrap_or(bytes);
+                    let dir_key = Key::from(dir);
+                    match successor(dir) {
+                        Some(start) => {
+                            self.cursor =
+                                Cursor::seek(self.store, &self.root, &start, self.end.clone())
+                                    .await?;
+                        }
+                        None => self.done = true,
+                    }
+                    return Ok(Some(DirEntry::Dir { key: dir_key }));
+                }
+            }
+        }
+    }
+}
+
+/// The site-level document conventions read from a manifest's root metadata.
+///
+/// Both are optional and root-scope: an index document is served for a
+/// directory path, an error document for an otherwise unresolved path.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Website {
+    index: Option<Bytes>,
+    error: Option<Bytes>,
+}
+
+impl Website {
+    /// The index-document key bytes, if the manifest declares one.
+    #[must_use]
+    pub fn index(&self) -> Option<&[u8]> {
+        self.index.as_deref()
+    }
+
+    /// The error-document key bytes, if the manifest declares one.
+    #[must_use]
+    pub fn error(&self) -> Option<&[u8]> {
+        self.error.as_deref()
+    }
+}
+
+/// What serving a request path resolves to under the website conventions.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Served<F: Format = V1> {
+    /// The path matched a key exactly.
+    Exact {
+        /// The matched key.
+        key: Key,
+        /// The bound value.
+        entry: Entry<F>,
+    },
+    /// No exact key matched; the index document for the directory path did.
+    Index {
+        /// The index-document key that matched.
+        key: Key,
+        /// The bound value.
+        entry: Entry<F>,
+    },
+    /// Neither the path nor its index document matched; the error document did.
+    Error {
+        /// The error-document key that matched.
+        key: Key,
+        /// The bound value.
+        entry: Entry<F>,
+    },
+    /// No key, index document, or error document matched.
+    Missing,
+}
+
+impl<F: Format> Served<F> {
+    /// The resolved value, or `None` when nothing matched.
+    #[must_use]
+    pub const fn entry(&self) -> Option<&Entry<F>> {
+        match self {
+            Self::Exact { entry, .. } | Self::Index { entry, .. } | Self::Error { entry, .. } => {
+                Some(entry)
+            }
+            Self::Missing => None,
+        }
+    }
+
+    /// The resolved key, or `None` when nothing matched.
+    #[must_use]
+    pub const fn key(&self) -> Option<&Key> {
+        match self {
+            Self::Exact { key, .. } | Self::Index { key, .. } | Self::Error { key, .. } => {
+                Some(key)
+            }
+            Self::Missing => None,
+        }
+    }
+}
+
+impl<S, F> Reader<S, F>
+where
+    S: NodeGet + MaybeSync,
+    F: Format,
+{
+    /// List the immediate children of the directory named by `dir` in key
+    /// order, collapsing deeper keys at the next separator.
+    ///
+    /// `dir` is used as a key prefix: the root is the empty key and a nested
+    /// directory conventionally ends with the separator. Only the trie nodes on
+    /// the frontier are fetched; the value chunks a listing names are not.
+    pub async fn list(
+        &self,
+        root: &ChunkAddress,
+        dir: &Key,
+    ) -> Result<Listing<'_, S, F>, ReaderError> {
+        let prefix = dir.as_bytes();
+        let end = successor(prefix);
+        let cursor = Cursor::seek(self.store(), root, prefix, end.clone()).await?;
+        Ok(Listing {
+            store: self.store(),
+            root: *root,
+            end,
+            dir_len: prefix.len(),
+            done: false,
+            cursor,
+        })
+    }
+
+    /// The manifest's site-level document conventions, read from the root's
+    /// typed metadata.
+    pub async fn website(&self, root: &ChunkAddress) -> Result<Website, ReaderError> {
+        let node = self.store().get_node::<F>(root).await?;
+        Ok(Website {
+            index: document(&node, KeyId::WebsiteIndexDocument),
+            error: document(&node, KeyId::WebsiteErrorDocument),
+        })
+    }
+
+    /// Resolve a request path to the entry a website server would return.
+    ///
+    /// An exact key wins; otherwise the path is read as a directory and its
+    /// index document is tried, then the error document. The empty path and a
+    /// path already ending in the separator name a directory directly; any
+    /// other path is read as a directory by inserting a separator before the
+    /// index document.
+    pub async fn serve(&self, root: &ChunkAddress, path: &Key) -> Result<Served<F>, ReaderError> {
+        if let Some(entry) = self.get(root, path).await? {
+            return Ok(Served::Exact {
+                key: path.clone(),
+                entry,
+            });
+        }
+        let site = self.website(root).await?;
+        if let Some(index) = site.index {
+            let key = directory_index::<F>(path.as_bytes(), &index);
+            if let Some(entry) = self.get(root, &key).await? {
+                return Ok(Served::Index { key, entry });
+            }
+        }
+        if let Some(error) = site.error {
+            let key = Key::from(&error[..]);
+            if let Some(entry) = self.get(root, &key).await? {
+                return Ok(Served::Error { key, entry });
+            }
+        }
+        Ok(Served::Missing)
+    }
+}
+
+/// A root-scope metadata document value, cloned out of the node's metadata.
+fn document<F: Format>(node: &Node<F>, id: KeyId) -> Option<Bytes> {
+    node.metadata()?.get(&MetadataKey::from(id)).cloned()
+}
+
+/// The index-document key for `path` read as a directory: `path`, a separator
+/// unless `path` is empty or already ends with one, then the index document.
+fn directory_index<F: Format>(path: &[u8], index: &[u8]) -> Key {
+    let mut out = Vec::with_capacity(
+        path.len()
+            .saturating_add(index.len())
+            .saturating_add(size_of::<u8>()),
+    );
+    out.extend_from_slice(path);
+    if !path.is_empty() && path.last() != Some(&F::SEPARATOR) {
+        out.push(F::SEPARATOR);
+    }
+    out.extend_from_slice(index);
+    Key::from(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use futures::executor::block_on;
+    use nectar_primitives::store::MemoryStore;
+    use nectar_primitives::{ChunkAddress, ChunkRef};
+
+    use crate::builder::Builder;
+    use crate::meta::{KeyId, Metadata};
+
+    use super::*;
+
+    fn entry(byte: u8) -> Entry {
+        ChunkRef::new(ChunkAddress::new([byte; 32])).into()
+    }
+
+    /// Build a manifest from `(key, value)` pairs and return its root address.
+    fn manifest(store: &MemoryStore, pairs: &[(&[u8], u8)]) -> ChunkAddress {
+        let mut builder = Builder::new();
+        for (key, byte) in pairs {
+            builder.insert(Key::from(&key[..]), entry(*byte), None);
+        }
+        *block_on(builder.build(store)).unwrap().root()
+    }
+
+    /// Drain a listing into its entries.
+    fn entries(mut listing: Listing<'_, &MemoryStore>) -> Vec<DirEntry> {
+        let mut out = Vec::new();
+        while let Some(item) = block_on(listing.next()).unwrap() {
+            out.push(item);
+        }
+        out
+    }
+
+    fn file(key: &[u8], byte: u8) -> DirEntry {
+        DirEntry::File {
+            key: Key::from(key),
+            entry: entry(byte),
+        }
+    }
+
+    fn dir(key: &[u8]) -> DirEntry {
+        DirEntry::Dir {
+            key: Key::from(key),
+        }
+    }
+
+    #[test]
+    fn list_collapses_subdirectories_at_the_separator() {
+        let store = MemoryStore::default();
+        let root = manifest(
+            &store,
+            &[
+                (b"index.html", 0x01),
+                (b"img/logo.png", 0x02),
+                (b"img/icons/a.png", 0x03),
+                (b"style.css", 0x04),
+            ],
+        );
+        let reader: Reader<_> = Reader::new(&store);
+
+        // The root lists two files and one collapsed directory, in key order.
+        let got = entries(block_on(reader.list(&root, &Key::empty())).unwrap());
+        assert_eq!(
+            got,
+            vec![
+                dir(b"img/"),
+                file(b"index.html", 0x01),
+                file(b"style.css", 0x04),
+            ]
+        );
+    }
+
+    #[test]
+    fn list_of_a_nested_directory_reads_one_level() {
+        let store = MemoryStore::default();
+        let root = manifest(
+            &store,
+            &[
+                (b"img/logo.png", 0x02),
+                (b"img/icons/a.png", 0x03),
+                (b"img/icons/b.png", 0x05),
+                (b"other.txt", 0x06),
+            ],
+        );
+        let reader: Reader<_> = Reader::new(&store);
+
+        let got = entries(block_on(reader.list(&root, &Key::from(&b"img/"[..]))).unwrap());
+        assert_eq!(got, vec![dir(b"img/icons/"), file(b"img/logo.png", 0x02)]);
+    }
+
+    #[test]
+    fn list_skips_the_directory_key_itself() {
+        let store = MemoryStore::default();
+        // A key exactly equal to the listed directory path is the directory
+        // itself, not a child.
+        let root = manifest(&store, &[(b"dir/", 0x01), (b"dir/a", 0x02)]);
+        let reader: Reader<_> = Reader::new(&store);
+
+        let got = entries(block_on(reader.list(&root, &Key::from(&b"dir/"[..]))).unwrap());
+        assert_eq!(got, vec![file(b"dir/a", 0x02)]);
+    }
+
+    #[test]
+    fn list_does_not_fetch_deeper_subtrees() {
+        let store = CountingStore::default();
+        // A wide, deep subdirectory the listing must not descend into.
+        let mut pairs: Vec<(Vec<u8>, u8)> = Vec::new();
+        for i in 0u8..64 {
+            pairs.push((format!("deep/{i:03}/leaf").into_bytes(), i));
+        }
+        pairs.push((b"top.txt".to_vec(), 0xFF));
+        let refs: Vec<(&[u8], u8)> = pairs.iter().map(|(k, v)| (k.as_slice(), *v)).collect();
+        let root = manifest(&store.inner, &refs);
+        store.reset();
+
+        let reader: Reader<_> = Reader::new(&store);
+        let got = entries_counting(block_on(reader.list(&root, &Key::empty())).unwrap());
+        assert_eq!(got, vec![dir(b"deep/"), file(b"top.txt", 0xFF)]);
+        // Seeking past the subtree keeps the fetch count to the frontier, far
+        // below the 64 leaves under it.
+        assert!(store.gets() < 16, "fetched {} nodes", store.gets());
+    }
+
+    #[test]
+    fn serve_prefers_an_exact_key() {
+        let store = MemoryStore::default();
+        let root = manifest(&store, &[(b"a.html", 0x01)]);
+        let reader: Reader<_> = Reader::new(&store);
+        assert_eq!(
+            block_on(reader.serve(&root, &Key::from(&b"a.html"[..]))).unwrap(),
+            Served::Exact {
+                key: Key::from(&b"a.html"[..]),
+                entry: entry(0x01),
+            }
+        );
+    }
+
+    #[test]
+    fn serve_falls_back_to_the_index_document() {
+        let store = MemoryStore::default();
+        let mut builder = Builder::new();
+        builder.insert(Key::from(&b"index.html"[..]), entry(0x01), None);
+        builder.insert(Key::from(&b"docs/index.html"[..]), entry(0x02), None);
+        builder.manifest_metadata(
+            Metadata::new(
+                KeyId::WebsiteIndexDocument,
+                Bytes::from_static(b"index.html"),
+            )
+            .unwrap(),
+        );
+        let root = *block_on(builder.build(&store)).unwrap().root();
+        let reader: Reader<_> = Reader::new(&store);
+
+        // The root path resolves to the top-level index document.
+        assert_eq!(
+            block_on(reader.serve(&root, &Key::empty())).unwrap(),
+            Served::Index {
+                key: Key::from(&b"index.html"[..]),
+                entry: entry(0x01),
+            }
+        );
+        // A directory path (trailing separator) resolves to its index document.
+        assert_eq!(
+            block_on(reader.serve(&root, &Key::from(&b"docs/"[..]))).unwrap(),
+            Served::Index {
+                key: Key::from(&b"docs/index.html"[..]),
+                entry: entry(0x02),
+            }
+        );
+        // A directory path without a trailing separator is read as one too.
+        assert_eq!(
+            block_on(reader.serve(&root, &Key::from(&b"docs"[..]))).unwrap(),
+            Served::Index {
+                key: Key::from(&b"docs/index.html"[..]),
+                entry: entry(0x02),
+            }
+        );
+    }
+
+    #[test]
+    fn serve_falls_back_to_the_error_document() {
+        let store = MemoryStore::default();
+        let mut builder = Builder::new();
+        builder.insert(Key::from(&b"404.html"[..]), entry(0x09), None);
+        builder.manifest_metadata(
+            Metadata::new(KeyId::WebsiteErrorDocument, Bytes::from_static(b"404.html")).unwrap(),
+        );
+        let root = *block_on(builder.build(&store)).unwrap().root();
+        let reader: Reader<_> = Reader::new(&store);
+
+        assert_eq!(
+            block_on(reader.serve(&root, &Key::from(&b"missing"[..]))).unwrap(),
+            Served::Error {
+                key: Key::from(&b"404.html"[..]),
+                entry: entry(0x09),
+            }
+        );
+    }
+
+    #[test]
+    fn serve_missing_without_conventions_is_missing() {
+        let store = MemoryStore::default();
+        let root = manifest(&store, &[(b"a.html", 0x01)]);
+        let reader: Reader<_> = Reader::new(&store);
+        assert_eq!(
+            block_on(reader.serve(&root, &Key::from(&b"nope"[..]))).unwrap(),
+            Served::Missing
+        );
+    }
+
+    #[test]
+    fn website_reads_the_root_conventions() {
+        let store = MemoryStore::default();
+        let mut builder = Builder::new();
+        builder.insert(Key::from(&b"index.html"[..]), entry(0x01), None);
+        let mut meta = Metadata::new(
+            KeyId::WebsiteIndexDocument,
+            Bytes::from_static(b"index.html"),
+        )
+        .unwrap();
+        meta.insert(KeyId::WebsiteErrorDocument, Bytes::from_static(b"404.html"))
+            .unwrap();
+        builder.manifest_metadata(meta);
+        let root = *block_on(builder.build(&store)).unwrap().root();
+        let reader: Reader<_> = Reader::new(&store);
+
+        let site = block_on(reader.website(&root)).unwrap();
+        assert_eq!(site.index(), Some(&b"index.html"[..]));
+        assert_eq!(site.error(), Some(&b"404.html"[..]));
+    }
+
+    // A trusted store that counts each fetch, so a test can read off how many
+    // nodes a listing pulled.
+    use core::sync::atomic::{AtomicUsize, Ordering};
+
+    use nectar_primitives::store::ChunkGet;
+    use nectar_primitives::{Chunk, StandardChunkSet, Verified};
+
+    #[derive(Debug, Default)]
+    struct CountingStore {
+        inner: MemoryStore,
+        gets: AtomicUsize,
+    }
+
+    impl CountingStore {
+        fn gets(&self) -> usize {
+            self.gets.load(Ordering::Relaxed)
+        }
+
+        fn reset(&self) {
+            self.gets.store(0, Ordering::Relaxed);
+        }
+    }
+
+    impl ChunkGet<StandardChunkSet> for CountingStore {
+        type Trust = Verified;
+        type Error = <MemoryStore as ChunkGet>::Error;
+
+        async fn get(
+            &self,
+            address: &ChunkAddress,
+        ) -> Result<Chunk<Verified, StandardChunkSet>, Self::Error> {
+            self.gets.fetch_add(1, Ordering::Relaxed);
+            ChunkGet::get(&self.inner, address).await
+        }
+    }
+
+    fn entries_counting(mut listing: Listing<'_, &CountingStore>) -> Vec<DirEntry> {
+        let mut out = Vec::new();
+        while let Some(item) = block_on(listing.next()).unwrap() {
+            out.push(item);
+        }
+        out
+    }
+}

--- a/crates/manifest/src/format.rs
+++ b/crates/manifest/src/format.rs
@@ -31,6 +31,11 @@ pub trait Format:
     /// The two payload bytes preceding the node body: `MAGIC || VERSION`.
     const PREAMBLE: [u8; 2] = [Self::MAGIC, Self::VERSION];
 
+    /// Folder-view path separator (ASCII `/`). The byte the folder and website
+    /// views split keys into path segments on; a view-layer interpretation,
+    /// never stored in the trie.
+    const SEPARATOR: u8 = b'/';
+
     /// Max node body bytes: the chunk body minus [`Self::PREAMBLE`].
     const BUDGET: usize;
 
@@ -140,6 +145,7 @@ mod tests {
     fn v1_parameters_are_frozen() {
         assert_eq!(V1::MAGIC, 0x6D);
         assert_eq!(V1::VERSION, 0x01);
+        assert_eq!(V1::SEPARATOR, b'/');
         assert_eq!(V1::BUDGET, 4094);
         assert_eq!(V1::PLEN_MAX, 255);
         assert_eq!(V1::VINLINE_MAX, 128);

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -38,6 +38,13 @@
 //! opening) sits behind the feature. The key derivation is deterministic, so an
 //! encrypted tree keeps canonical bytes and cross-build dedup.
 //!
+//! The folder view ([`Reader::list`], [`Reader::serve`]) is a path
+//! interpretation over the flat KV core: the separator is [`Format::SEPARATOR`],
+//! derived from the key bytes at read time and never stored, and the website
+//! index- and error-document conventions ride in the root's typed metadata, not
+//! magic keys. A listing collapses deeper keys at the next separator and seeks
+//! past each named subtree, so it stays O(depth) and fetches no value chunk.
+//!
 //! PRIVACY: a ref64 IS a read capability for its whole subtree. Writing one
 //! into a PLAINTEXT parent publishes that key to anyone who reads the parent;
 //! confidentiality rests solely on the outermost ref64 being distributed
@@ -75,6 +82,7 @@ mod codec;
 #[cfg(feature = "encryption")]
 mod encryption;
 mod error;
+mod folder;
 mod fork;
 mod format;
 mod meta;
@@ -95,6 +103,7 @@ pub use encryption::{EncryptedNode, EncryptedNodeGet, EncryptedNodePut, derive_k
 pub use error::{
     CustomKeyError, ForkPrefixEmpty, MetadataTooLong, PrefixTooLong, ValueTooLong, WeightOverBudget,
 };
+pub use folder::{DirEntry, Listing, Served, Website};
 pub use fork::{Child, ForkPayload, ForkRecord, ForkTable};
 pub use format::{Format, V1};
 pub use meta::{CustomKey, KeyId, Metadata, MetadataKey};

--- a/crates/manifest/src/scan.rs
+++ b/crates/manifest/src/scan.rs
@@ -104,7 +104,7 @@ where
 {
     /// Position a cursor at the least key `>= start`, streaming forward until
     /// `end` (exclusive), descending only the referenced hops on the seek path.
-    async fn seek(
+    pub(crate) async fn seek(
         store: &'a S,
         root: &ChunkAddress,
         start: &[u8],
@@ -479,7 +479,7 @@ fn join(base: &[u8], suffix: &[u8]) -> Vec<u8> {
 /// The least byte string strictly greater than every string starting with
 /// `prefix`: increment the last byte below `0xFF` after dropping the trailing
 /// `0xFF` run. `None` when the prefix is empty or all `0xFF`, i.e. unbounded.
-fn successor(prefix: &[u8]) -> Option<Bytes> {
+pub(crate) fn successor(prefix: &[u8]) -> Option<Bytes> {
     let mut bytes = prefix.to_vec();
     while let Some(&last) = bytes.last() {
         if last == 0xFF {


### PR DESCRIPTION
## What

Implements issue #261: a folder and website view over the KV core in `nectar-manifest`, as a path interpretation layered on the existing flat byte-keyed trie, not a change to the core encoding.

`crates/manifest/src/folder.rs` (new, 591 lines) adds:

- `DirEntry`: one immediate child of a listed directory, either `File { key, entry }` or `Dir { key }` (a collapsed subdirectory whose key ends in the separator).
- `Listing`: a streaming directory listing built on the existing prefix-scan `Cursor`. `Listing::next` walks the cursor in key order, collapses every key beneath a subdirectory into a single `Dir` entry at the next separator, and reseeks the cursor past that subtree via `successor`, so a level lists in `O(depth)` retained state and never fetches a value chunk. The directory's own key is skipped as not-a-child-of-itself.
- `Served` and `Website`: result types for `Reader::serve` and `Reader::website`.
- `Reader::serve`, which resolves a request path with exact-key match first, then falls back to the index-document convention, then the error-document convention.
- `Reader::website`, which reads those two conventions from the root's typed metadata via `KeyId::WebsiteIndexDocument` / `KeyId::WebsiteErrorDocument`, rather than magic keys.

`crates/manifest/src/format.rs` adds `Format::SEPARATOR` (defaulted to ASCII `/`) as a sealed-trait associated const: a view-layer constant, never stored in the trie or serialized on the wire, so it is non-breaking.

`crates/manifest/src/lib.rs` gains the module and re-exports plus updated crate-level docs describing the folder view. `crates/manifest/src/scan.rs` has a small change in support of the collapse/reseek walk.

## Why

Issue #261 asks for a directory/website-style view over the manifest's flat key-value trie, so callers can list a "directory" and serve a "website" (index/error document fallback) without the core codec or storage model changing. Keeping this as a read-only interpretation layer means no wire round-trip risk and no new encoder path: the separator is derived from key bytes at read time, and the website conventions ride in already-typed root metadata.

Closes #261

## Testing

Full battery run via `nix develop --command` against the branch detached at `2d7b98b` (two commits atop `origin/s264/54-encryption`; changed files `crates/manifest/src/{folder.rs,format.rs,lib.rs,scan.rs}`, +608/-2):

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean, no warnings.
- `cargo nextest run --workspace --all-features` (via `nix shell nixpkgs#cargo-nextest`, not in the devshell): 870 passed, 1 skipped, 0 failed, including the 9 new `folder.rs` tests covering subdirectory collapse, one-level nested listing, consecutive-subdirectory collapse, directory-key self-skip, no deeper-subtree fetch, exact-key serve precedence, and the website index/error-document conventions.

Adversarial review traced the collapse/reseek logic across prefix boundaries, separator-adjacent sibling ordering, prefix-of-prefix directory names, all-0xFF keys, and the directory-key-self skip, and found no panic surface (guarded `.get`/`unwrap_or` plus saturating arithmetic); `serve` precedence and directory-index separator insertion match the documented behaviour.

## AI assistance

Implemented and reviewed with Claude (Anthropic), per the org AI-assistance disclosure contract in `nxm-rs/.github`'s `CONTRIBUTING.md`.

