### PR TITLE
test(manifest): add fuzz + memory-bound conformance for mantaray 1.0

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -47,7 +47,7 @@ jobs:
         # `parallel` / `wasm-threads` features, so the crate builds for wasm32
         # single-threaded by default. A plain check on the default features is
         # therefore the faithful one.
-        name: wasm / postage-usage
+        name: wasm / browser crates
         runs-on: ubuntu-latest
         timeout-minutes: 30
         steps:
@@ -59,6 +59,13 @@ jobs:
               run: |
                   cargo check \
                     -p nectar-postage-usage --features client --locked \
+                    --target wasm32-unknown-unknown
+            - name: Check manifest builds for wasm32
+              # The mantaray 1.0 manifest is memory-bounded and browser-facing,
+              # so its default build must stay wasm32-clean.
+              run: |
+                  cargo check \
+                    -p nectar-manifest --locked \
                     --target wasm32-unknown-unknown
 
     unit-success:

--- a/crates/manifest/tests/membound.rs
+++ b/crates/manifest/tests/membound.rs
@@ -1,0 +1,265 @@
+//! Memory-bound conformance for the mantaray 1.0 builder and reader.
+//!
+//! The builder assembles bottom-up over an explicit stack of open nodes, so its
+//! peak retained node buffer count is the trie depth, never the key count; the
+//! reader follows one fork per node, so a lookup retains one node per level.
+//! These tests witness the O(depth) bound directly at a >= 10^6-key scale and
+//! pin the single-chunk-node invariant: no node the builder emits exceeds one
+//! chunk body.
+
+use std::error::Error;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use bytes::Bytes;
+use futures::executor::block_on;
+use nectar_manifest::{
+    ApplyError, BuildStats, Builder, Changeset, Entry, Key, KeyId, Metadata, Reader, V1, apply,
+};
+use nectar_primitives::store::{ChunkGet, MemoryStore};
+use nectar_primitives::{
+    Chunk, ChunkAddress, ChunkOps, ChunkRef, DEFAULT_BODY_SIZE, StandardChunkSet, Verified,
+};
+use proptest::prelude::*;
+
+type TestResult = Result<(), Box<dyn Error>>;
+
+/// A fallible assertion.
+fn ensure(cond: bool, what: String) -> TestResult {
+    if cond { Ok(()) } else { Err(what.into()) }
+}
+
+/// A reference-valued entry keyed on one byte.
+fn entry(byte: u8) -> Entry<V1> {
+    Entry::from(ChunkRef::new(ChunkAddress::new([byte; 32])))
+}
+
+/// A trusted store that counts every `get`, so a test reads off how many nodes a
+/// lookup fetched.
+#[derive(Debug, Default)]
+struct CountingStore {
+    inner: MemoryStore,
+    gets: AtomicUsize,
+}
+
+impl CountingStore {
+    fn gets(&self) -> usize {
+        self.gets.load(Ordering::Relaxed)
+    }
+}
+
+impl ChunkGet<StandardChunkSet> for CountingStore {
+    type Trust = Verified;
+    type Error = <MemoryStore as ChunkGet>::Error;
+
+    async fn get(
+        &self,
+        address: &ChunkAddress,
+    ) -> Result<Chunk<Verified, StandardChunkSet>, Self::Error> {
+        self.gets.fetch_add(1, Ordering::Relaxed);
+        ChunkGet::get(&self.inner, address).await
+    }
+}
+
+/// Stream every `radix`-ary key of the given byte length into the builder: the
+/// full odometer over the digit alphabet `0..radix`, `radix.pow(len)` distinct
+/// keys of a uniform trie depth `len`, generated one at a time so the test's own
+/// working set stays bounded.
+fn fill_radix(builder: &mut Builder<V1>, radix: u8, remaining: u32, key: &mut Vec<u8>, fill: u8) {
+    if remaining == 0 {
+        builder.insert(Key::from(key.clone()), entry(fill), None);
+        return;
+    }
+    for digit in 0..radix {
+        key.push(digit);
+        fill_radix(builder, radix, remaining.saturating_sub(1), key, fill);
+        key.pop();
+    }
+}
+
+/// Build every `radix`-ary key of length `len` into `store`, returning the build
+/// stats.
+fn build_radix(store: &MemoryStore, radix: u8, len: u32) -> Result<BuildStats, Box<dyn Error>> {
+    let mut builder = Builder::<V1>::new();
+    fill_radix(&mut builder, radix, len, &mut Vec::new(), 0x11);
+    let built = block_on(builder.build(store)).map_err(|e| e.to_string())?;
+    Ok(*built.stats())
+}
+
+/// Assert every stored node fits one chunk body: the single-chunk-node
+/// invariant, checked over the whole emitted set.
+fn assert_single_chunk_nodes(store: &MemoryStore) -> TestResult {
+    for chunk in store.clone().into_chunks().into_values() {
+        let len = chunk.envelope().data().len();
+        ensure(
+            len <= DEFAULT_BODY_SIZE,
+            format!("emitted node is {len} bytes, over one chunk body"),
+        )?;
+    }
+    Ok(())
+}
+
+#[test]
+fn peak_open_nodes_tracks_depth_not_width() -> TestResult {
+    // radix 10, depth 2 is 100 keys two nodes deep.
+    let shallow_narrow = build_radix(&MemoryStore::default(), 10, 2)?;
+    // radix 60, depth 2 is 3_600 keys, still two deep but far wider per level.
+    let shallow_wide = build_radix(&MemoryStore::default(), 60, 2)?;
+    // radix 10, depth 4 is 10_000 keys four nodes deep.
+    let deep = build_radix(&MemoryStore::default(), 10, 4)?;
+
+    // Same depth, very different width: identical peak, whatever the fan.
+    ensure(
+        shallow_narrow.peak_open_nodes() == shallow_wide.peak_open_nodes(),
+        format!(
+            "peak {} != {} across widths at equal depth",
+            shallow_narrow.peak_open_nodes(),
+            shallow_wide.peak_open_nodes(),
+        ),
+    )?;
+    // Greater depth raises the peak; width alone never does.
+    ensure(
+        deep.peak_open_nodes() > shallow_wide.peak_open_nodes(),
+        format!(
+            "deeper build peak {} did not exceed shallow peak {}",
+            deep.peak_open_nodes(),
+            shallow_wide.peak_open_nodes(),
+        ),
+    )?;
+    // The wide build writes far more nodes than its peak: work is O(tree), the
+    // retained frontier is O(depth).
+    ensure(
+        shallow_wide.nodes_written() > shallow_wide.peak_open_nodes().saturating_mul(10),
+        "wide build node count is not far above its peak".to_owned(),
+    )
+}
+
+#[test]
+fn a_million_key_manifest_is_depth_bounded() -> TestResult {
+    // radix 100, depth 3 is exactly 1_000_000 keys, three nodes deep. One build
+    // witnesses both bounds: the builder's peak retained buffer count is the
+    // depth, independent of the key count, and a lookup fetches one node per
+    // level rather than the wide sibling frontier.
+    let inner = MemoryStore::default();
+    let mut builder = Builder::<V1>::new();
+    fill_radix(&mut builder, 100, 3, &mut Vec::new(), 0x22);
+    let built = block_on(builder.build(&inner)).map_err(|e| e.to_string())?;
+    let stats = *built.stats();
+    let root = *built.root();
+
+    ensure(
+        stats.peak_open_nodes() <= 8,
+        format!(
+            "peak {} open nodes is not O(depth) at 10^6 keys",
+            stats.peak_open_nodes(),
+        ),
+    )?;
+    // The tree is spilled across many chunks, orders of magnitude above the
+    // peak, so the bound is a genuine streaming bound, not a small tree.
+    ensure(
+        stats.nodes_written() > stats.peak_open_nodes().saturating_mul(100),
+        format!(
+            "only {} nodes written, no wider than the peak",
+            stats.nodes_written(),
+        ),
+    )?;
+    // Every emitted node fits one chunk body, checked at 10^6-key scale.
+    assert_single_chunk_nodes(&inner)?;
+
+    // Read a spread of keys through a counting store: each lookup is O(depth).
+    let store = CountingStore {
+        inner,
+        gets: AtomicUsize::new(0),
+    };
+    let reader: Reader<_> = Reader::new(&store);
+    for probe in [[0u8, 0, 0], [50, 50, 50], [99, 99, 99], [7, 63, 12]] {
+        store.gets.store(0, Ordering::Relaxed);
+        let value =
+            block_on(reader.get(&root, &Key::from(&probe[..]))).map_err(|e| e.to_string())?;
+        ensure(value == Some(entry(0x22)), format!("missing key {probe:?}"))?;
+        // Depth three: at most the root and one node per level.
+        ensure(
+            store.gets() <= 4,
+            format!("lookup fetched {} nodes, not O(depth)", store.gets()),
+        )?;
+    }
+    Ok(())
+}
+
+/// Chunk payload lengths of a store, for the budget assertions below.
+fn chunk_lengths(store: &MemoryStore) -> Vec<usize> {
+    store
+        .clone()
+        .into_chunks()
+        .into_values()
+        .map(|chunk| chunk.envelope().data().len())
+        .collect()
+}
+
+/// A key-value set whose keys spread across many first bytes (wide) and whose
+/// values carry large metadata blocks (heavy), so a naive single-chunk node
+/// would overrun the body budget.
+fn wide_heavy_set() -> impl Strategy<Value = Vec<(Vec<u8>, u8, Option<usize>)>> {
+    let key = prop::collection::vec(any::<u8>(), 1..6);
+    let meta_len = prop::option::of(0usize..1000);
+    prop::collection::vec((key, any::<u8>(), meta_len), 0..400)
+}
+
+/// A metadata block of `len` filler bytes within a proptest body.
+fn filler_meta(len: usize) -> Result<Metadata<V1>, TestCaseError> {
+    Metadata::new(KeyId::ContentType, Bytes::from(vec![b'a'; len]))
+        .map_err(|e| TestCaseError::fail(e.to_string()))
+}
+
+proptest! {
+    // No node the builder emits ever exceeds one chunk body. A key set too wide
+    // or heavy to fit surfaces a typed error, never a panic and never an
+    // over-budget chunk written to the store.
+    #[test]
+    fn no_built_node_exceeds_budget(entries in wide_heavy_set()) {
+        let store = MemoryStore::default();
+        let mut builder = Builder::<V1>::new();
+        for (key, fill, meta) in &entries {
+            let metadata = match meta {
+                Some(len) => Some(filler_meta(*len)?),
+                None => None,
+            };
+            builder.insert(Key::from(key.clone()), entry(*fill), metadata);
+        }
+        if block_on(builder.build(&store)).is_ok() {
+            for len in chunk_lengths(&store) {
+                prop_assert!(len <= DEFAULT_BODY_SIZE, "built node over one chunk body");
+            }
+        }
+    }
+
+    // apply upholds the same invariant: folding a fuzzed changeset into a base
+    // never writes an over-budget node.
+    #[test]
+    fn apply_preserves_the_single_chunk_invariant(
+        base in wide_heavy_set(),
+        delta in wide_heavy_set(),
+    ) {
+        let store = MemoryStore::default();
+        let mut builder = Builder::<V1>::new();
+        for (key, fill, _) in &base {
+            builder.insert(Key::from(key.clone()), entry(*fill), None);
+        }
+        let Ok(built) = block_on(builder.build(&store)) else {
+            return Ok(());
+        };
+        let mut changeset = Changeset::<V1>::new();
+        for (key, fill, _) in &delta {
+            changeset.put(Key::from(key.clone()), entry(*fill), None);
+        }
+        match block_on(apply(&store, built.root(), &changeset)) {
+            Ok(_) => {
+                for len in chunk_lengths(&store) {
+                    prop_assert!(len <= DEFAULT_BODY_SIZE, "applied node over one chunk body");
+                }
+            }
+            // A wide/heavy merge that cannot fit a node reports a typed error.
+            Err(ApplyError::Build(_) | ApplyError::Store(_)) => {}
+            Err(other) => prop_assert!(false, "unexpected apply error: {:?}", other),
+        }
+    }
+}

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1920,11 +1920,23 @@ dependencies = [
  "alloy-signer-local",
  "arbitrary",
  "bytes",
+ "futures",
  "libfuzzer-sys",
+ "nectar-manifest",
  "nectar-mantaray",
  "nectar-postage",
  "nectar-postage-usage",
  "nectar-primitives",
+]
+
+[[package]]
+name = "nectar-manifest"
+version = "0.4.0"
+dependencies = [
+ "alloy-primitives",
+ "bytes",
+ "nectar-primitives",
+ "thiserror",
 ]
 
 [[package]]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -16,7 +16,12 @@ alloy-signer-local = { version = "2.0", default-features = false }
 # Chunk wire payloads are `Bytes`; the chunk targets build them from the
 # fuzzer's raw input.
 bytes = "1"
+# The manifest build/apply targets drive the async builder and reader to
+# completion on the current thread.
+futures = "0.3"
 libfuzzer-sys = "0.4"
+# The mantaray 1.0 manifest codec, builder and apply path under test.
+nectar-manifest = { path = "../crates/manifest" }
 # No `encryption` feature: the `EncryptedChunkRef` representation the
 # mantaray targets drive for the 64-byte entry path is unconditional.
 # `hazmat` exposes the raw node types and codec the mantaray targets
@@ -97,6 +102,27 @@ bench = false
 [[bin]]
 name = "chunk_domain_separation"
 path = "fuzz_targets/chunk_domain_separation.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "manifest_node_decode"
+path = "fuzz_targets/manifest_node_decode.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "manifest_build_roundtrip"
+path = "fuzz_targets/manifest_build_roundtrip.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "manifest_apply_rebuild"
+path = "fuzz_targets/manifest_apply_rebuild.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz_targets/manifest_apply_rebuild.rs
+++ b/fuzz/fuzz_targets/manifest_apply_rebuild.rs
@@ -1,0 +1,88 @@
+//! Fuzz the mantaray 1.0 batch-apply history-independence property.
+//!
+//! A base key set is built, then a fuzzed changeset of puts and deletes is
+//! folded in with `apply`. The oracle is that folding a changeset into a
+//! manifest lands on the exact same root as building the merged key set from
+//! scratch: `apply(build(base), delta) == build(base <+ delta)`. The order the
+//! updates were staged in never reaches the root. A build or apply that cannot
+//! fit a node returns a typed error rather than panicking; equality is asserted
+//! only when both the apply and the rebuild succeed.
+
+#![no_main]
+
+use bytes::Bytes;
+use futures::executor::block_on;
+use libfuzzer_sys::fuzz_target;
+use nectar_manifest::{Builder, Changeset, Entry, Key, V1, apply};
+use nectar_primitives::store::MemoryStore;
+use nectar_primitives::{ChunkAddress, ChunkRef};
+
+use arbitrary::Arbitrary;
+use std::collections::BTreeMap;
+
+/// One fuzzed value: a plain reference or an inline byte string.
+#[derive(Arbitrary, Debug, Clone)]
+enum Val {
+    /// A 32-byte reference synthesised from one byte.
+    Ref(u8),
+    /// An inline value; capped to the format bound before insertion.
+    Inline(Vec<u8>),
+}
+
+/// Turn a fuzzed value into an entry, capping an inline value at the bound.
+fn entry(val: Val) -> Entry<V1> {
+    match val {
+        Val::Ref(byte) => Entry::from(ChunkRef::new(ChunkAddress::new([byte; 32]))),
+        Val::Inline(mut bytes) => {
+            bytes.truncate(128);
+            Entry::inline(Bytes::from(bytes))
+                .unwrap_or_else(|_| Entry::from(ChunkRef::new(ChunkAddress::new([0; 32]))))
+        }
+    }
+}
+
+/// Build a key set into a fresh store, returning the store and root.
+fn build(pairs: &BTreeMap<Vec<u8>, Entry<V1>>) -> Option<(MemoryStore, ChunkAddress)> {
+    let store = MemoryStore::default();
+    let mut builder = Builder::<V1>::new();
+    for (key, entry) in pairs {
+        builder.insert(Key::from(key.clone()), entry.clone(), None);
+    }
+    let built = block_on(builder.build(&store)).ok()?;
+    Some((store, *built.root()))
+}
+
+fuzz_target!(|input: (Vec<(Vec<u8>, Val)>, Vec<(Vec<u8>, Option<Val>)>)| {
+    let (base, delta) = input;
+
+    // The base state, deduplicated the way the builder's sorted map would.
+    let mut merged: BTreeMap<Vec<u8>, Entry<V1>> =
+        base.into_iter().map(|(k, v)| (k, entry(v))).collect();
+
+    let Some((store, root)) = build(&merged) else {
+        return;
+    };
+
+    // Stage the changeset and fold the same ops into the expected merged state.
+    let mut changeset = Changeset::<V1>::new();
+    for (key, op) in delta {
+        match op {
+            Some(val) => {
+                let e = entry(val);
+                changeset.put(Key::from(key.clone()), e.clone(), None);
+                merged.insert(key, e);
+            }
+            None => {
+                changeset.remove(Key::from(key.clone()));
+                merged.remove(&key);
+            }
+        }
+    }
+
+    let applied = block_on(apply(&store, &root, &changeset));
+    let rebuilt = build(&merged).map(|(_, root)| root);
+
+    if let (Ok(applied), Some(rebuilt)) = (applied, rebuilt) {
+        assert_eq!(applied, rebuilt, "apply must equal a from-scratch rebuild");
+    }
+});

--- a/fuzz/fuzz_targets/manifest_build_roundtrip.rs
+++ b/fuzz/fuzz_targets/manifest_build_roundtrip.rs
@@ -1,0 +1,88 @@
+//! Structured build round-trip and canonical-bijection fuzz for mantaray 1.0.
+//!
+//! An arbitrary key set is streamed through the builder into a memory store.
+//! The oracle is threefold: every node chunk the builder emits must decode and
+//! re-encode to the exact bytes it was sealed from (encode -> decode identity
+//! and canonical form), no emitted node may exceed one chunk body (the
+//! single-chunk-node invariant), and two builds of the same key set must
+//! produce the identical root and node set (history independence). A build that
+//! cannot fit a node returns a typed error rather than panicking; that is an
+//! accepted outcome, so the target skips it.
+
+#![no_main]
+
+use bytes::Bytes;
+use futures::executor::block_on;
+use libfuzzer_sys::fuzz_target;
+use nectar_manifest::{Builder, Entry, Key, Node, V1};
+use nectar_primitives::store::MemoryStore;
+use nectar_primitives::{ChunkAddress, ChunkOps, ChunkRef, DEFAULT_BODY_SIZE};
+
+use arbitrary::Arbitrary;
+
+/// One fuzzed value: a plain reference or an inline byte string.
+#[derive(Arbitrary, Debug)]
+enum Val {
+    /// A 32-byte reference synthesised from one byte.
+    Ref(u8),
+    /// An inline value; capped to the format bound before insertion.
+    Inline(Vec<u8>),
+}
+
+/// Turn a fuzzed value into an entry, capping an inline value at the bound.
+fn entry(val: Val) -> Entry<V1> {
+    match val {
+        Val::Ref(byte) => Entry::from(ChunkRef::new(ChunkAddress::new([byte; 32]))),
+        Val::Inline(mut bytes) => {
+            bytes.truncate(128);
+            Entry::inline(Bytes::from(bytes))
+                .unwrap_or_else(|_| Entry::from(ChunkRef::new(ChunkAddress::new([0; 32]))))
+        }
+    }
+}
+
+/// Build the key set into a fresh store, returning the root and the store.
+fn build(pairs: &[(Key, Entry<V1>)]) -> Option<(ChunkAddress, MemoryStore)> {
+    let store = MemoryStore::default();
+    let mut builder = Builder::<V1>::new();
+    for (key, entry) in pairs {
+        builder.insert(key.clone(), entry.clone(), None);
+    }
+    let built = block_on(builder.build(&store)).ok()?;
+    Some((*built.root(), store))
+}
+
+fuzz_target!(|input: Vec<(Vec<u8>, Val)>| {
+    let pairs: Vec<(Key, Entry<V1>)> = input
+        .into_iter()
+        .map(|(key, val)| (Key::from(key), entry(val)))
+        .collect();
+
+    let Some((root, store)) = build(&pairs) else {
+        return;
+    };
+
+    // Every emitted node chunk round-trips through the codec byte for byte and
+    // fits one chunk body: no builder output can be an over-budget or
+    // non-canonical image.
+    for chunk in store.into_chunks().into_values() {
+        let payload = chunk.envelope().data();
+        assert!(
+            payload.len() <= DEFAULT_BODY_SIZE,
+            "node chunk {} bytes exceeds one chunk body",
+            payload.len(),
+        );
+        let node = Node::<V1>::decode(payload.as_ref()).expect("a stored node must decode");
+        let reencoded = node.encode().expect("a decoded node must re-encode");
+        assert_eq!(
+            reencoded.as_slice(),
+            payload.as_ref(),
+            "node encoding must be canonical",
+        );
+    }
+
+    // History independence: a second build of the same key set reproduces the
+    // root and the whole node set.
+    let (root2, _store2) = build(&pairs).expect("a repeat build must also succeed");
+    assert_eq!(root, root2, "two builds of one key set must match");
+});

--- a/fuzz/fuzz_targets/manifest_node_decode.rs
+++ b/fuzz/fuzz_targets/manifest_node_decode.rs
@@ -1,0 +1,33 @@
+//! Fuzz the mantaray 1.0 manifest node decoder with raw attacker-controlled
+//! bytes.
+//!
+//! `Node::decode` is the entry point through which untrusted manifest chunks
+//! from the network are parsed. The codec's only fallible byte access is the
+//! primitives cursor, so the reject-or-accept contract must hold for every
+//! input: the oracle is "no panic, no OOM, no hang", never a slice or unwrap
+//! out of bounds on a truncated or adversarial image.
+//!
+//! Whenever an image is accepted, it is canonical by construction, so it must
+//! re-encode to the exact bytes decoded and decode again to the same node: the
+//! decode -> encode bijection proven here on arbitrary input complements the
+//! structured round-trip target.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use nectar_manifest::{Node, V1};
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(node) = Node::<V1>::decode(data) else {
+        return;
+    };
+    // An accepted image is canonical, so re-encoding reproduces the bytes and
+    // decoding the re-encoding reproduces the node. Encode can still reject an
+    // over-budget image longer than one chunk body; that is not a bijection
+    // break, so only assert when it succeeds.
+    if let Ok(encoded) = node.encode() {
+        assert_eq!(encoded, data, "accepted image must be canonical");
+        let redecoded = Node::<V1>::decode(&encoded).expect("re-encoding must decode");
+        assert_eq!(redecoded, node, "decode(encode(node)) must reproduce the node");
+    }
+});


### PR DESCRIPTION
## What

Adds mantaray 1.0 fuzz and memory-bound conformance for issue #263, scoped to additive test/fuzz surface only (no product code touched).

Three new cargo-fuzz targets in `fuzz/` against `nectar-manifest`:
- `manifest_node_decode`: no-panic decode of arbitrary/truncated bytes, plus a decode -> encode -> decode canonical-bijection check, proving the codec never slices or unwraps on adversarial input.
- `manifest_build_roundtrip`: every builder-emitted chunk decodes and re-encodes byte-identically, checks the single-chunk-node budget, and confirms two builds of one key set match.
- `manifest_apply_rebuild`: `apply(build(base), delta) == build(merged)`.

New `crates/manifest/tests/membound.rs`:
- `peak_open_nodes_tracks_depth_not_width`: peak retained node buffers are identical across widths at equal depth and only rise with depth.
- `a_million_key_manifest_is_depth_bounded`: a real 10^6-key build, asserting `peak_open_nodes` is O(depth) and independent of key count, `nodes_written` is orders of magnitude larger (O(tree)), every emitted node fits one chunk body, and lookups fetch O(depth) chunks.
- `no_built_node_exceeds_budget` / `apply_preserves_the_single_chunk_invariant` (proptest): wide/heavy key sets never produce an over-budget node from either builder or apply, surfacing a typed error instead of a panic.

`.github/workflows/unit.yml`: renames the wasm job to "wasm / browser crates" and adds a `cargo check -p nectar-manifest --target wasm32-unknown-unknown` step, since the manifest is browser-facing and must stay wasm32-clean.

`fuzz/Cargo.toml` / `fuzz/Cargo.lock`: wires `nectar-manifest` and `futures` into the fuzz crate and registers the three new fuzz binaries.

Closes #263

## Why

Issue #263 calls for fuzz and memory-bound conformance coverage proving the mantaray 1.0 codec never panics on untrusted input and that the builder/reader are genuinely O(depth) in memory rather than O(key count), at a scale (10^6 keys) large enough to make that a real streaming bound rather than an artefact of a small tree. The single-chunk-node invariant (no node the builder or `apply` emits exceeds one chunk body) also needed a fuzz-level guard, since that is the wire-format contract the whole manifest depends on.

## Testing

Independent re-verification against HEAD `71fca43`, diffed off `origin/s264/62-dx`. Full battery via `nix develop --command`:
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean, including `nectar-manifest` and the fuzz targets.
- `cargo nextest run --workspace --all-features`: 877 passed, 1 skipped, 0 failed, including all four membound tests (`peak_open_nodes_tracks_depth_not_width`, `a_million_key_manifest_is_depth_bounded`, and the two proptest cases).
- All three fuzz targets build and pass a 30s smoke run clean (`manifest_node_decode` hit 7.5M execs, no panic or OOM).
- `cargo check -p nectar-manifest --target wasm32-unknown-unknown`: clean.

No CI beyond CLA runs until this PR is retargeted onto its base branch's eventual home.

AI Assistance: Claude (Anthropic) used for implementation, red-team review and independent re-verification testing.

