### PR TITLE
fix(manifest): spill oversized nodes into segments, closing fixes

### DIFF
--- a/crates/manifest/Cargo.toml
+++ b/crates/manifest/Cargo.toml
@@ -29,11 +29,14 @@ proptest.workspace = true
 
 [features]
 default = [ "std" ]
-# Per-reference encryption crypto (deterministic key derivation, sealing and
+# Per-reference node encryption (deterministic key derivation, sealing and
 # opening). The 64-byte ref representation is always available; this feature
 # only adds the crypto over it, so a default build still decodes and
-# re-serializes encrypted manifests losslessly.
-encryption = [ "nectar-primitives/encryption" ]
+# re-serializes encrypted manifests losslessly. The crypto rides on
+# always-available primitives (transcrypt, keccak, the ref types), so it enables
+# no primitives feature and drags in no rng: the module is gated purely to keep
+# the surface opt-in.
+encryption = []
 std = [
 	"alloy-primitives/std",
 	"bytes/std",

--- a/crates/manifest/src/apply.rs
+++ b/crates/manifest/src/apply.rs
@@ -22,13 +22,13 @@ use nectar_primitives::ChunkAddress;
 use nectar_primitives::store::{ChunkPut, MaybeSync};
 
 use crate::bounded::Prefix;
-use crate::builder::{BuildError, BuildStats, Item, build_table, resolve};
+use crate::builder::{BuildError, BuildStats, Item, build_table, emit_node, resolve};
 use crate::error::{ForkPrefixEmpty, PrefixTooLong};
 use crate::fork::{Child, ForkPayload, ForkRecord, ForkTable};
 use crate::format::{Format, V1};
 use crate::meta::Metadata;
 use crate::node::{Node, RootExtension};
-use crate::store::{NodeGet, NodePut, StoreError};
+use crate::store::{NodeGet, StoreError};
 use crate::value::{Entry, Key};
 
 /// One key's update within a changeset.
@@ -181,7 +181,7 @@ where
     ))
     .await?;
     let new_node = Node::new(root_ext, forks);
-    Ok(store.put_node(&new_node).await?)
+    Ok(emit_node(store, &new_node, &mut stats).await?)
 }
 
 /// One staged update paired with its key, borrowed for the length of the apply.

--- a/crates/manifest/src/builder.rs
+++ b/crates/manifest/src/builder.rs
@@ -13,16 +13,20 @@ use std::io::Write;
 use bytes::Bytes;
 use nectar_primitives::store::{ChunkPut, MaybeSync};
 use nectar_primitives::{
-    Chunk, ChunkAddress, ChunkRef, DefaultSplitter, FileError, PrimitivesError,
+    Chunk, ChunkAddress, ChunkRef, ContentChunk, DefaultSplitter, FileError, PrimitivesError,
 };
 
-use crate::bounded::Prefix;
-use crate::error::{ForkPrefixEmpty, PrefixTooLong};
-use crate::fork::{Child, ForkPayload, ForkTable};
+use crate::bounded::{Prefix, SegmentWeight};
+use crate::codec::{
+    SegmentDir, body_len, encode_dir_segment, encode_leaf_segment, encode_segmented_node,
+    record_weight,
+};
+use crate::error::{ForkPrefixEmpty, PrefixTooLong, WeightOverBudget};
+use crate::fork::{Child, ForkPayload, ForkRecord, ForkTable};
 use crate::format::{Format, V1};
 use crate::meta::Metadata;
 use crate::node::{Node, RootExtension};
-use crate::packing::{Domain, embed};
+use crate::packing::{Domain, embed, spill};
 use crate::store::{NodePut, StoreError};
 use crate::value::{Entry, Key};
 
@@ -52,6 +56,11 @@ pub enum BuildError {
     /// A fork prefix consumed no byte to index under.
     #[error(transparent)]
     EmptyPrefix(#[from] ForkPrefixEmpty),
+    /// A single fork record outweighed a whole segment. Unreachable under the
+    /// frozen bounds (worst record weight 2952 <= CAP_FORK 4091); the guard
+    /// stays so a future parameter drift fails loud rather than silently.
+    #[error(transparent)]
+    Weight(#[from] WeightOverBudget),
     /// A stack invariant did not hold; a builder bug rather than bad input.
     #[error("builder invariant violated")]
     Internal,
@@ -190,7 +199,7 @@ impl<F: Format> Builder<F> {
         let mut stats = BuildStats::default();
         let table = build_table(store, &items, 0, &mut stats).await?;
         let node = Node::new(root_ext, table);
-        let root = put_counted(store, &node, &mut stats).await?;
+        let root = emit_node(store, &node, &mut stats).await?;
         Ok(Built { root, stats })
     }
 }
@@ -441,8 +450,105 @@ where
         return Ok(Resolved::Embedded(table));
     }
     let node = Node::new(None, table);
-    let address = put_counted(store, &node, stats).await?;
+    let address = emit_node(store, &node, stats).await?;
     Ok(Resolved::Reference(ChunkRef::new(address)))
+}
+
+/// Publish `node` as one chunk, or, when its flat body overruns the format
+/// budget, spill it into a segment directory of sub-chunks that each fit.
+///
+/// The single-chunk-node invariant holds here by construction: a body within
+/// `F::BUDGET` seals as one node, and a wider body partitions at content-defined
+/// boundaries into leaf and directory segments no larger than one chunk. The
+/// `OverBudget` guard on [`Node::encode`] therefore stays unreachable on this
+/// path, kept only as a fail-closed backstop for a future parameter drift.
+pub(crate) async fn emit_node<S, F>(
+    store: &S,
+    node: &Node<F>,
+    stats: &mut BuildStats,
+) -> Result<ChunkAddress, BuildError>
+where
+    S: ChunkPut + MaybeSync,
+    F: Format,
+{
+    if body_len(node) <= F::BUDGET {
+        return put_counted(store, node, stats).await;
+    }
+    spill_node(store, node, stats).await
+}
+
+/// Spill an over-budget node into a `<=` depth-two segment directory, storing
+/// each leaf and directory segment and returning the segmented node's address.
+async fn spill_node<S, F>(
+    store: &S,
+    node: &Node<F>,
+    stats: &mut BuildStats,
+) -> Result<ChunkAddress, BuildError>
+where
+    S: ChunkPut + MaybeSync,
+    F: Format,
+{
+    let forks: Vec<(u8, &ForkRecord<F>)> = node.forks().iter().collect();
+    let mut items: Vec<(Prefix<F>, SegmentWeight<F>)> = Vec::with_capacity(forks.len());
+    for (first, record) in &forks {
+        let mut full = Vec::with_capacity(record.tail().len().saturating_add(1));
+        full.push(*first);
+        full.extend_from_slice(record.tail().as_bytes());
+        items.push((
+            Prefix::try_from(full.as_slice())?,
+            SegmentWeight::new(record_weight(record))?,
+        ));
+    }
+
+    let directory = spill::<F>(&items, Domain::Plain);
+    let mut leaf_descs: Vec<(u8, ChunkAddress)> = Vec::with_capacity(directory.leaves().len());
+    for range in directory.leaves() {
+        let slice = forks.get(range.clone()).ok_or(BuildError::Internal)?;
+        let &(first_key, _) = slice.first().ok_or(BuildError::Internal)?;
+        let mut leaf = ForkTable::new();
+        for (byte, record) in slice {
+            leaf.insert_record(*byte, (*record).clone());
+        }
+        let address = put_payload(store, encode_leaf_segment(&leaf), stats).await?;
+        leaf_descs.push((first_key, address));
+    }
+
+    let top = if directory.dirs().len() <= 1 {
+        SegmentDir::plain(leaf_descs)
+    } else {
+        let mut dir_descs: Vec<(u8, ChunkAddress)> = Vec::with_capacity(directory.dirs().len());
+        for range in directory.dirs() {
+            let group = leaf_descs.get(range.clone()).ok_or(BuildError::Internal)?;
+            let &(first_key, _) = group.first().ok_or(BuildError::Internal)?;
+            let address = put_payload(
+                store,
+                encode_dir_segment::<F>(&SegmentDir::plain(group.to_vec())),
+                stats,
+            )
+            .await?;
+            dir_descs.push((first_key, address));
+        }
+        SegmentDir::plain(dir_descs)
+    };
+
+    put_payload(store, encode_segmented_node::<F>(node.root(), &top), stats).await
+}
+
+/// Seal a ready payload into a content chunk, store it, and count it.
+async fn put_payload<S>(
+    store: &S,
+    payload: Vec<u8>,
+    stats: &mut BuildStats,
+) -> Result<ChunkAddress, BuildError>
+where
+    S: ChunkPut + MaybeSync,
+{
+    let content = ContentChunk::new(payload).map_err(BuildError::Seal)?;
+    let chunk = Chunk::from_envelope(content.into()).map_err(BuildError::Seal)?;
+    let address = *chunk.address();
+    store.put(chunk).await.map_err(BuildError::backend)?;
+    stats.nodes_written = stats.nodes_written.saturating_add(1);
+    Ok(address)
 }
 
 /// Spill one node to the store, counting it.

--- a/crates/manifest/src/codec.rs
+++ b/crates/manifest/src/codec.rs
@@ -12,7 +12,7 @@ use core::mem::size_of;
 
 use bytes::Bytes;
 use nectar_primitives::wire::{Cursor, FromCursor, ToWriter, Underrun, Writer};
-use nectar_primitives::{ChunkAddress, ChunkRef, EncryptedChunkRef};
+use nectar_primitives::{ChunkAddress, ChunkRef, EncryptedChunkRef, EncryptionKey};
 
 use crate::bounded::{MetadataLen, Prefix};
 use crate::error::{CustomKeyError, ForkPrefixEmpty, MetadataTooLong, PrefixTooLong, ValueTooLong};
@@ -243,6 +243,19 @@ pub enum DecodeError {
     /// Bytes remain after the body's last record.
     #[error("{0} trailing bytes after the body")]
     Trailing(usize),
+    /// A segment directory sflags byte sets a reserved bit.
+    #[error("illegal segment directory flags {0:#04x}")]
+    SegmentFlags(u8),
+    /// A segment directory descriptor count of zero or over `FORKS_MAX`.
+    #[error("segment descriptor count {0} outside the format bounds")]
+    SegmentCount(usize),
+    /// Segment directory first keys are not strictly ascending.
+    #[error("segment directory keys not strictly ascending")]
+    SegmentOrder,
+    /// A reference reached a bare segment, or a directory nested past depth two;
+    /// segments are plumbing, never a node a fork points at (spec 5.3).
+    #[error("segment reached out of directory context")]
+    SegmentContext,
 }
 
 /// Rejections from [`Node::encode`]: the in-memory tree cannot form a legal
@@ -328,8 +341,15 @@ fn table_len<F: Format>(table: &ForkTable<F>) -> usize {
     len
 }
 
+/// The packing weight of one fork: its record bytes plus the three-byte fork
+/// index slot the record sits behind (spec 5.2).
+pub(crate) fn record_weight<F: Format>(record: &ForkRecord<F>) -> usize {
+    let slot = size_of::<u8>().saturating_add(size_of::<u16>());
+    slot.saturating_add(record_len(record))
+}
+
 /// Exact encoded bytes of a node body: flags, root extension, fork table.
-fn body_len<F: Format>(node: &Node<F>) -> usize {
+pub(crate) fn body_len<F: Format>(node: &Node<F>) -> usize {
     let mut len = size_of::<u8>();
     if let Some(entry) = node.entry() {
         len = len.saturating_add(entry_len(entry));
@@ -456,15 +476,21 @@ impl<F: Format> FromCursor for Node<F> {
             return Err(DecodeError::NotAManifest { found });
         }
         let flags = node_flags_checked(cur.take::<u8>()?)?;
-        let entry = take_entry(cur, WireFmt::from_entry(flags))?;
-        let metadata = if flags & Wire::HAS_META != 0 {
-            Some(cur.take::<Metadata<F>>()?)
-        } else {
-            None
-        };
-        let forks = take_fork_table(cur)?;
-        Ok(Self::new(RootExtension::new(entry, metadata), forks))
+        take_plain_body(cur, flags)
     }
+}
+
+/// Reads a plain node body (root extension then fork table) behind an already
+/// validated, already consumed flags byte.
+fn take_plain_body<F: Format>(cur: &mut Cursor<'_>, flags: u8) -> Result<Node<F>, DecodeError> {
+    let entry = take_entry(cur, WireFmt::from_entry(flags))?;
+    let metadata = if flags & Wire::HAS_META != 0 {
+        Some(cur.take::<Metadata<F>>()?)
+    } else {
+        None
+    };
+    let forks = take_fork_table(cur)?;
+    Ok(Node::new(RootExtension::new(entry, metadata), forks))
 }
 
 impl<F: Format> ToWriter for Node<F> {
@@ -789,6 +815,259 @@ impl<F: Format> ToWriter for Metadata<F> {
             w.put(value.as_ref());
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Segment directories (spec 5.2, 5.3): the wire form an oversized node spills
+// into. A leaf segment carries a fork-table fragment; a directory segment
+// routes a first-byte range to its children; a SEGMENTED node holds the top
+// directory in place of its fork table. Widths are uniform per directory tree.
+// ---------------------------------------------------------------------------
+
+/// Node/segment flags for a leaf segment body: the `SEGMENT` bit alone.
+const SEG_LEAF: u8 = Wire::SEGMENT;
+/// Node/segment flags for a directory segment body: `SEGMENT | SEGMENTED`.
+const SEG_DIR: u8 = Wire::SEGMENT | Wire::SEGMENTED;
+/// Segment-directory sflags bit 0: descriptors carry ref64, not ref32.
+const WIDE_REFS: u8 = 0b0000_0001;
+
+/// One segment-directory descriptor: the first fork key of the child segment
+/// it routes to, and the reference that reaches that segment chunk.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct SegDesc {
+    /// The key of the child segment's first fork; the segment covers keys from
+    /// here up to the next descriptor's key.
+    pub(crate) first_key: u8,
+    /// The child segment chunk address.
+    pub(crate) address: ChunkAddress,
+    /// The child's decryption key, present iff the directory is wide.
+    pub(crate) key: Option<EncryptionKey>,
+}
+
+/// A decoded segment directory: uniform-width descriptors in ascending key
+/// order. Directory depth never exceeds two by the frozen bounds (spec 5.4).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct SegmentDir {
+    /// Whether the descriptors carry ref64; set iff the node's chunks are
+    /// encrypted, so a tree's descriptor widths stay uniform.
+    pub(crate) wide: bool,
+    /// The descriptors, strictly ascending by `first_key`.
+    pub(crate) descriptors: Vec<SegDesc>,
+}
+
+impl SegmentDir {
+    /// A plaintext directory over `(first_key, address)` descriptors.
+    pub(crate) fn plain(descriptors: Vec<(u8, ChunkAddress)>) -> Self {
+        Self {
+            wide: false,
+            descriptors: descriptors
+                .into_iter()
+                .map(|(first_key, address)| SegDesc {
+                    first_key,
+                    address,
+                    key: None,
+                })
+                .collect(),
+        }
+    }
+}
+
+/// A decoded manifest chunk: a plain node, a segmented node, or a segment.
+///
+/// Every kind round-trips through [`reencode`](Self::reencode) to its exact
+/// bytes, so canonical-form validation is decode-then-re-encode-and-compare
+/// (spec 6.2) whatever the chunk kind.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum DecodedChunk<F: Format> {
+    /// A one-chunk node: root extension over a fork table.
+    Node(Node<F>),
+    /// An oversized node: root extension over the top segment directory.
+    Segmented(Option<RootExtension<F>>, SegmentDir),
+    /// A leaf segment: a fork-table fragment of a spilled node.
+    Leaf(ForkTable<F>),
+    /// A directory segment: an inner level of a spilled node's directory.
+    Directory(SegmentDir),
+}
+
+impl<F: Format> DecodedChunk<F> {
+    /// Re-encode to the exact chunk bytes; total, so it never rejects a value
+    /// decode already accepted.
+    pub(crate) fn reencode(&self) -> Vec<u8> {
+        match self {
+            Self::Node(node) => {
+                let mut payload = Vec::with_capacity(node.encoded_len());
+                Writer::new(&mut payload).put(node);
+                payload
+            }
+            Self::Segmented(root, dir) => encode_segmented_node::<F>(root.as_ref(), dir),
+            Self::Leaf(table) => encode_leaf_segment(table),
+            Self::Directory(dir) => encode_dir_segment::<F>(dir),
+        }
+    }
+}
+
+/// Emit a segment directory body: sflags, count, the ascending keys, then the
+/// uniform-width references.
+fn put_segment_dir(w: &mut Writer<'_>, dir: &SegmentDir) {
+    w.put(&(if dir.wide { WIDE_REFS } else { 0u8 }));
+    w.put(&U16Le::of(dir.descriptors.len()));
+    for desc in &dir.descriptors {
+        w.put(&desc.first_key);
+    }
+    for desc in &dir.descriptors {
+        w.put(desc.address.as_bytes());
+        if let Some(key) = &desc.key {
+            w.put(key.as_bytes());
+        }
+    }
+}
+
+/// Encode a leaf segment chunk: preamble, the leaf marker, then the fragment's
+/// fork table.
+pub(crate) fn encode_leaf_segment<F: Format>(table: &ForkTable<F>) -> Vec<u8> {
+    let mut payload = Vec::new();
+    let mut w = Writer::new(&mut payload);
+    w.put(&F::PREAMBLE);
+    w.put(&SEG_LEAF);
+    put_fork_table(&mut w, table);
+    payload
+}
+
+/// Encode a directory segment chunk: preamble, the directory marker, then the
+/// segment directory.
+pub(crate) fn encode_dir_segment<F: Format>(dir: &SegmentDir) -> Vec<u8> {
+    let mut payload = Vec::new();
+    let mut w = Writer::new(&mut payload);
+    w.put(&F::PREAMBLE);
+    w.put(&SEG_DIR);
+    put_segment_dir(&mut w, dir);
+    payload
+}
+
+/// Encode a segmented node chunk: preamble, `SEGMENTED` flags with any root
+/// extension bits, the root extension, then the top segment directory.
+pub(crate) fn encode_segmented_node<F: Format>(
+    root: Option<&RootExtension<F>>,
+    dir: &SegmentDir,
+) -> Vec<u8> {
+    let entry = root.and_then(RootExtension::entry);
+    let metadata = root.and_then(RootExtension::metadata);
+    let mut flags = WireFmt::of_entry(entry).entry_bits() | Wire::SEGMENTED;
+    if metadata.is_some() {
+        flags |= Wire::HAS_META;
+    }
+    let mut payload = Vec::new();
+    let mut w = Writer::new(&mut payload);
+    w.put(&F::PREAMBLE);
+    w.put(&flags);
+    if let Some(entry) = entry {
+        w.put(entry);
+    }
+    if let Some(metadata) = metadata {
+        w.put(metadata);
+    }
+    put_segment_dir(&mut w, dir);
+    payload
+}
+
+/// Read a segment directory body behind an already consumed marker.
+fn take_segment_dir<F: Format>(cur: &mut Cursor<'_>) -> Result<SegmentDir, DecodeError> {
+    let sflags = cur.take::<u8>()?;
+    if sflags & !WIDE_REFS != 0 {
+        return Err(DecodeError::SegmentFlags(sflags));
+    }
+    let wide = sflags & WIDE_REFS != 0;
+    let scount = cur.take::<U16Le>()?.get();
+    if scount == 0 || scount > F::FORKS_MAX {
+        return Err(DecodeError::SegmentCount(scount));
+    }
+    let mut keys = Vec::with_capacity(scount);
+    let mut previous: Option<u8> = None;
+    for _ in 0..scount {
+        let key = cur.take::<u8>()?;
+        if previous.is_some_and(|p| p >= key) {
+            return Err(DecodeError::SegmentOrder);
+        }
+        previous = Some(key);
+        keys.push(key);
+    }
+    let mut descriptors = Vec::with_capacity(scount);
+    for &first_key in &keys {
+        let address = ChunkAddress::new(cur.take::<[u8; ChunkAddress::SIZE]>()?);
+        let key = if wide {
+            Some(EncryptionKey::from(
+                cur.take::<[u8; EncryptionKey::SIZE]>()?,
+            ))
+        } else {
+            None
+        };
+        descriptors.push(SegDesc {
+            first_key,
+            address,
+            key,
+        });
+    }
+    Ok(SegmentDir { wide, descriptors })
+}
+
+/// A leaf segment carries a fork table that must hold at least one fork; the
+/// empty-map root is never a segment.
+fn take_leaf_segment<F: Format>(cur: &mut Cursor<'_>) -> Result<ForkTable<F>, DecodeError> {
+    let table = take_fork_table(cur)?;
+    if table.is_empty() {
+        return Err(DecodeError::EmbeddedEmpty);
+    }
+    Ok(table)
+}
+
+impl<F: Format> Node<F> {
+    /// Decode any manifest chunk: a plain node, a segmented node, or a segment.
+    ///
+    /// Dispatches on the flags byte after the preamble. A plain node decodes
+    /// through [`decode`](Self::decode); the segmented and segment bodies carry
+    /// the packing grammar and decode here into a [`DecodedChunk`].
+    pub(crate) fn decode_chunk(payload: &[u8]) -> Result<DecodedChunk<F>, DecodeError> {
+        let mut cur = Cursor::new(payload);
+        let found = cur.take::<[u8; 2]>()?;
+        if found != F::PREAMBLE {
+            return Err(DecodeError::NotAManifest { found });
+        }
+        let flags = cur.take::<u8>()?;
+        let decoded = if flags & Wire::SEGMENT != 0 {
+            match flags {
+                SEG_LEAF => DecodedChunk::Leaf(take_leaf_segment(&mut cur)?),
+                SEG_DIR => DecodedChunk::Directory(take_segment_dir::<F>(&mut cur)?),
+                _ => return Err(DecodeError::NodeFlags(flags)),
+            }
+        } else if flags & Wire::SEGMENTED != 0 {
+            if flags & (Wire::RESERVED | Wire::CHILD_MASK) != 0 {
+                return Err(DecodeError::NodeFlags(flags));
+            }
+            let entry = take_entry(&mut cur, WireFmt::from_entry(flags))?;
+            let metadata = if flags & Wire::HAS_META != 0 {
+                Some(cur.take::<Metadata<F>>()?)
+            } else {
+                None
+            };
+            let dir = take_segment_dir::<F>(&mut cur)?;
+            DecodedChunk::Segmented(RootExtension::new(entry, metadata), dir)
+        } else {
+            DecodedChunk::Node(take_plain_body(&mut cur, node_flags_checked(flags)?)?)
+        };
+        if !cur.is_empty() {
+            return Err(DecodeError::Trailing(cur.remaining().len()));
+        }
+        Ok(decoded)
+    }
+}
+
+/// Re-encode a manifest chunk to its canonical bytes, whatever its kind.
+///
+/// The spec's canonical-form check (`encode(decode(bytes)) == bytes`, spec 6.2)
+/// for a whole stored chunk set, including the segmented nodes and segments a
+/// spilled node produces.
+pub fn recanonicalize<F: Format>(payload: &[u8]) -> Result<Vec<u8>, DecodeError> {
+    Ok(Node::<F>::decode_chunk(payload)?.reencode())
 }
 
 #[cfg(test)]
@@ -1446,5 +1725,71 @@ mod tests {
             }
             let _ = Node::<V1>::decode(&image);
         }
+    }
+
+    #[test]
+    fn segment_chunks_round_trip_and_classify() {
+        let mut leaf_table = ForkTable::new();
+        leaf_table
+            .insert(prefix(b"ab"), Entry::from(ref32(1)).into(), None)
+            .unwrap();
+        leaf_table
+            .insert(prefix(b"cd"), Entry::from(ref32(2)).into(), None)
+            .unwrap();
+        let leaf = encode_leaf_segment::<V1>(&leaf_table);
+        assert!(matches!(
+            Node::<V1>::decode_chunk(&leaf).unwrap(),
+            DecodedChunk::Leaf(_)
+        ));
+        assert_eq!(recanonicalize::<V1>(&leaf).unwrap(), leaf);
+
+        let dir = SegmentDir::plain(vec![(b'a', addr(1)), (b'c', addr(2))]);
+        let directory = encode_dir_segment::<V1>(&dir);
+        assert!(matches!(
+            Node::<V1>::decode_chunk(&directory).unwrap(),
+            DecodedChunk::Directory(_)
+        ));
+        assert_eq!(recanonicalize::<V1>(&directory).unwrap(), directory);
+
+        let root = RootExtension::new(Some(Entry::from(ref32(9))), None);
+        let segmented = encode_segmented_node::<V1>(root.as_ref(), &dir);
+        assert!(matches!(
+            Node::<V1>::decode_chunk(&segmented).unwrap(),
+            DecodedChunk::Segmented(Some(_), _)
+        ));
+        assert_eq!(recanonicalize::<V1>(&segmented).unwrap(), segmented);
+    }
+
+    #[test]
+    fn segment_bodies_reject_malformed_images() {
+        // A leaf segment with no forks: an empty node never rides a segment.
+        assert!(matches!(
+            Node::<V1>::decode_chunk(&[0x6D, 0x01, 0x40, 0x00, 0x00]),
+            Err(DecodeError::EmbeddedEmpty)
+        ));
+        // A segment directory with a reserved sflags bit set.
+        assert!(matches!(
+            Node::<V1>::decode_chunk(&[0x6D, 0x01, 0x60, 0x02]),
+            Err(DecodeError::SegmentFlags(0x02))
+        ));
+        // A segment directory of zero descriptors.
+        assert!(matches!(
+            Node::<V1>::decode_chunk(&[0x6D, 0x01, 0x60, 0x00, 0x00, 0x00]),
+            Err(DecodeError::SegmentCount(0))
+        ));
+        // The segment bit with an illegal extra bit is neither leaf nor
+        // directory.
+        assert!(matches!(
+            Node::<V1>::decode_chunk(&[0x6D, 0x01, 0x41]),
+            Err(DecodeError::NodeFlags(0x41))
+        ));
+        // Non-ascending directory keys.
+        let mut image = vec![0x6D, 0x01, 0x60, 0x00, 0x02, 0x00, b'b', b'a'];
+        image.extend_from_slice(&[0x11; 32]);
+        image.extend_from_slice(&[0x22; 32]);
+        assert!(matches!(
+            Node::<V1>::decode_chunk(&image),
+            Err(DecodeError::SegmentOrder)
+        ));
     }
 }

--- a/crates/manifest/src/dx.rs
+++ b/crates/manifest/src/dx.rs
@@ -26,10 +26,11 @@ pub enum FetchError {
     /// Reassembling the referenced file from its chunks failed.
     #[error("join file")]
     Join(#[source] FileError),
-    /// The entry names an encrypted file this build cannot open; the
-    /// `encryption` feature carries the joiner that reads it.
-    #[cfg(not(feature = "encryption"))]
-    #[error("encrypted file needs the encryption feature")]
+    /// The entry names an encrypted file body. Per-reference node encryption
+    /// (the `encryption` feature) seals and opens nodes; reassembling an
+    /// encrypted file's own chunks is a separate decrypting joiner the manifest
+    /// does not carry.
+    #[error("encrypted file body is not reassembled by the manifest")]
     Encrypted,
 }
 
@@ -40,8 +41,9 @@ where
 {
     /// Reassemble the full file bytes `entry` names.
     ///
-    /// Inline bytes return directly; a reference is joined from its BMT chunks
-    /// over the reader's store. A ref64 needs the `encryption` feature to open.
+    /// Inline bytes return directly; a plain reference is joined from its BMT
+    /// chunks over the reader's store. A ref64 names an encrypted file body,
+    /// which the manifest does not reassemble.
     pub async fn read(&self, entry: &Entry<F>) -> Result<Bytes, FetchError> {
         match entry {
             Entry::Inline(value) => Ok(value.clone().into_bytes()),
@@ -52,17 +54,6 @@ where
                         .map_err(FetchError::Join)?;
                 Ok(Bytes::from(bytes))
             }
-            #[cfg(feature = "encryption")]
-            Entry::Ref64(reference) => {
-                let bytes = join::<nectar_primitives::EncryptedChunkRef, _, DEFAULT_BODY_SIZE>(
-                    self.store(),
-                    reference.clone(),
-                )
-                .await
-                .map_err(FetchError::Join)?;
-                Ok(Bytes::from(bytes))
-            }
-            #[cfg(not(feature = "encryption"))]
             Entry::Ref64(_) => Err(FetchError::Encrypted),
         }
     }

--- a/crates/manifest/src/fork.rs
+++ b/crates/manifest/src/fork.rs
@@ -285,6 +285,11 @@ impl<F: Format> ForkTable<F> {
         self.records.iter().map(|(first, record)| (*first, record))
     }
 
+    /// Consume the table into its records in ascending first-byte order.
+    pub(crate) fn into_records(self) -> impl Iterator<Item = (u8, ForkRecord<F>)> {
+        self.records.into_iter()
+    }
+
     /// Number of forks; always at most `F::FORKS_MAX`.
     #[must_use]
     pub fn len(&self) -> usize {

--- a/crates/manifest/src/format.rs
+++ b/crates/manifest/src/format.rs
@@ -103,7 +103,7 @@ impl Format for V1 {
     const CAP_FORK: usize = 4091;
     const CAP_DIR: usize = 4090;
     const CUT_SCALE: u64 = 9_007_199_254_740_992;
-    const DERIVE_TAG: &'static [u8] = b"mantaray-1.0-encryption";
+    const DERIVE_TAG: &'static [u8] = b"mantaray/1.0/key";
 }
 
 // Frozen cross-parameter facts, kept honest at compile time.
@@ -158,12 +158,36 @@ mod tests {
         assert_eq!(V1::CAP_FORK, 4091);
         assert_eq!(V1::CAP_DIR, 4090);
         assert_eq!(V1::CUT_SCALE, 9_007_199_254_740_992);
-        assert_eq!(V1::DERIVE_TAG, b"mantaray-1.0-encryption");
+        assert_eq!(V1::DERIVE_TAG, b"mantaray/1.0/key");
+        // The spec fixes the KDF domain tag at 16 ASCII bytes (spec 12.2).
+        assert_eq!(V1::DERIVE_TAG.len(), 16);
     }
 
     #[test]
     fn cut_scale_divides_the_hash_space_by_seg_target() {
         let product = u128::from(V1::CUT_SCALE) * u128::try_from(V1::SEG_TARGET).unwrap();
         assert_eq!(product, 1u128 << 64);
+    }
+
+    // The frozen bounds that make spill terminate and keep the OverBudget guard
+    // unreachable: the heaviest fork record still fits a leaf segment alone, so
+    // every node partitions into one-chunk segments (spec 5.4).
+    #[test]
+    fn the_worst_fork_record_fits_a_segment_alone() {
+        // A Both fork at the worst case: index slot, flags, plen, the longest
+        // tail, an inline value, an embedded child and two full metadata blocks.
+        let worst = 3
+            + 1
+            + 1
+            + (V1::PLEN_MAX - 1)
+            + (1 + V1::VINLINE_MAX)
+            + (2 + V1::INLINE_MAX)
+            + (2 + V1::META_MAX);
+        assert_eq!(worst, 2952);
+        // Any single record fits a leaf segment, so partitioning terminates.
+        assert!(worst <= V1::CAP_FORK);
+        // The forced-cut margin leaves room for a minimum-weight segment, so
+        // every segment but the last reaches SEG_MIN.
+        assert!(V1::CAP_FORK - worst >= V1::SEG_MIN);
     }
 }

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -97,7 +97,7 @@ mod value;
 pub use apply::{ApplyError, Changeset, apply};
 pub use bounded::{MetadataLen, Prefix, SegmentWeight};
 pub use builder::{BuildError, BuildStats, Builder, Built, build_files};
-pub use codec::{DecodeError, EncodeError};
+pub use codec::{DecodeError, EncodeError, recanonicalize};
 pub use dx::FetchError;
 #[cfg(feature = "encryption")]
 #[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]

--- a/crates/manifest/src/reader.rs
+++ b/crates/manifest/src/reader.rs
@@ -8,11 +8,13 @@
 
 use core::marker::PhantomData;
 
-use nectar_primitives::ChunkAddress;
 use nectar_primitives::store::MaybeSync;
+use nectar_primitives::{ChunkAddress, ChunkOps};
 
+use crate::codec::{DecodedChunk, SegmentDir};
 use crate::fork::{Child, ForkTable};
 use crate::format::{Format, V1};
+use crate::node::{Node, RootExtension};
 use crate::store::{NodeGet, StoreError};
 use crate::value::{Entry, Key};
 
@@ -77,24 +79,112 @@ where
         root: &ChunkAddress,
         key: &Key,
     ) -> Result<Option<Entry<F>>, ReaderError> {
-        let mut node = self.store.get_node::<F>(root).await?;
         let key = key.as_bytes();
-        if key.is_empty() {
-            return Ok(node.entry().cloned());
-        }
+        let mut address = *root;
         let mut pos = 0usize;
+        let mut is_root = true;
         loop {
-            match descend(node.forks(), key, pos) {
+            let chunk = self.store.get(&address).await.map_err(StoreError::store)?;
+            let decoded =
+                Node::<F>::decode_chunk(chunk.envelope().data()).map_err(StoreError::Decode)?;
+            // The empty key reads the root's own value; a spilled root carries
+            // it in the segmented node's bytes just as a plain root does.
+            if is_root && key.is_empty() {
+                return Ok(root_entry(&decoded));
+            }
+            let descent = match &decoded {
+                DecodedChunk::Node(node) => descend(node.forks(), key, pos),
+                DecodedChunk::Segmented(_, dir) => {
+                    covering_leaf::<S, F>(&self.store, dir, key, pos)
+                        .await?
+                        .map_or(Descent::Absent, |table| descend(&table, key, pos))
+                }
+                DecodedChunk::Leaf(_) | DecodedChunk::Directory(_) => {
+                    return Err(ReaderError::Store(StoreError::Decode(
+                        crate::codec::DecodeError::SegmentContext,
+                    )));
+                }
+            };
+            match descent {
                 Descent::Absent => return Ok(None),
                 Descent::Found(entry) => return Ok(Some(entry)),
                 Descent::Encrypted => return Err(ReaderError::EncryptedChild),
-                Descent::Follow(address, next) => {
-                    node = self.store.get_node::<F>(&address).await?;
+                Descent::Follow(next_address, next) => {
+                    address = next_address;
                     pos = next;
+                    is_root = false;
                 }
             }
         }
     }
+}
+
+/// The empty-key value a decoded root carries: its root extension entry.
+fn root_entry<F: Format>(decoded: &DecodedChunk<F>) -> Option<Entry<F>> {
+    match decoded {
+        DecodedChunk::Node(node) => node.entry().cloned(),
+        DecodedChunk::Segmented(root, _) => root.as_ref().and_then(RootExtension::entry).cloned(),
+        DecodedChunk::Leaf(_) | DecodedChunk::Directory(_) => None,
+    }
+}
+
+/// The descriptor covering `byte`: the one with the greatest first key not past
+/// it. `None` when `byte` precedes the first fork, so the key is absent.
+fn covering_desc(dir: &SegmentDir, byte: u8) -> Option<&crate::codec::SegDesc> {
+    dir.descriptors
+        .iter()
+        .take_while(|desc| desc.first_key <= byte)
+        .last()
+}
+
+/// Fetch the one leaf segment of a spilled node that covers `key[pos]`,
+/// descending at most one intermediate directory level (spec 5.4).
+///
+/// One segment per directory level, never the whole node, so a lookup through a
+/// spilled node stays O(depth) in fetches, not O(node width).
+async fn covering_leaf<S, F>(
+    store: &S,
+    top: &SegmentDir,
+    key: &[u8],
+    pos: usize,
+) -> Result<Option<ForkTable<F>>, ReaderError>
+where
+    S: NodeGet + MaybeSync,
+    F: Format,
+{
+    let Some(&byte) = key.get(pos) else {
+        return Ok(None);
+    };
+    // Route through the top directory, then, when it points at another
+    // directory, once more; a leaf ends the descent.
+    let mut current = match covering_desc(top, byte) {
+        Some(desc) => desc.clone(),
+        None => return Ok(None),
+    };
+    for _ in 0..2 {
+        if current.key.is_some() {
+            return Err(ReaderError::EncryptedChild);
+        }
+        let chunk = store
+            .get(&current.address)
+            .await
+            .map_err(StoreError::store)?;
+        match Node::<F>::decode_chunk(chunk.envelope().data()).map_err(StoreError::Decode)? {
+            DecodedChunk::Leaf(table) => return Ok(Some(table)),
+            DecodedChunk::Directory(dir) => match covering_desc(&dir, byte) {
+                Some(desc) => current = desc.clone(),
+                None => return Ok(None),
+            },
+            _ => {
+                return Err(ReaderError::Store(StoreError::Decode(
+                    crate::codec::DecodeError::SegmentContext,
+                )));
+            }
+        }
+    }
+    Err(ReaderError::Store(StoreError::Decode(
+        crate::codec::DecodeError::SegmentContext,
+    )))
 }
 
 /// The outcome of walking one node's embedded tables as far as they reach.

--- a/crates/manifest/src/store.rs
+++ b/crates/manifest/src/store.rs
@@ -14,7 +14,8 @@ use core::future::Future;
 use nectar_primitives::store::{ChunkPut, MaybeSend, MaybeSync, TrustedStore};
 use nectar_primitives::{Chunk, ChunkAddress, ChunkOps, ContentChunk, Verified};
 
-use crate::codec::{DecodeError, EncodeError};
+use crate::codec::{DecodeError, DecodedChunk, EncodeError};
+use crate::fork::ForkTable;
 use crate::format::Format;
 use crate::node::Node;
 
@@ -42,7 +43,7 @@ pub enum StoreError {
 
 impl StoreError {
     /// Box a backend error behind the seam.
-    fn store<E: core::error::Error + Send + Sync + 'static>(err: E) -> Self {
+    pub(crate) fn store<E: core::error::Error + Send + Sync + 'static>(err: E) -> Self {
         Self::Store(Box::new(err))
     }
 }
@@ -70,7 +71,12 @@ impl<F: Format> Node<F> {
 /// Blanket-implemented for every [`TrustedStore`]; the `Trust = Verified`
 /// bound is what lets [`get_node`](Self::get_node) skip re-hashing.
 pub trait NodeGet: TrustedStore {
-    /// Load and decode the node at `address`.
+    /// Load and decode the node at `address`, materializing a spilled node's
+    /// forks from its segments so the caller always sees one logical node.
+    ///
+    /// Reassembling a segmented node fetches its segment chunks and holds only
+    /// that one node's forks, bounded by the fork count, so peak retained state
+    /// stays O(depth).
     fn get_node<F: Format>(
         &self,
         address: &ChunkAddress,
@@ -78,14 +84,82 @@ pub trait NodeGet: TrustedStore {
     where
         Self: Sized + MaybeSync,
     {
-        async move {
-            let chunk = self.get(address).await.map_err(StoreError::store)?;
-            Ok(Node::from_chunk(&chunk)?)
-        }
+        materialize_node::<Self, F>(self, address)
     }
 }
 
 impl<T: TrustedStore> NodeGet for T {}
+
+/// The greatest legal segment-directory depth (spec 5.4); a deeper nesting is a
+/// malformed image, not a tree this format ever produces.
+const MAX_DIR_DEPTH: usize = 2;
+
+/// Load the node at `address`, reassembling a segmented node's forks in place.
+async fn materialize_node<S, F>(store: &S, address: &ChunkAddress) -> Result<Node<F>, StoreError>
+where
+    S: TrustedStore + MaybeSync,
+    F: Format,
+{
+    let chunk = store.get(address).await.map_err(StoreError::store)?;
+    match Node::<F>::decode_chunk(chunk.envelope().data())? {
+        DecodedChunk::Node(node) => Ok(node),
+        DecodedChunk::Segmented(root, dir) => {
+            let forks = Box::pin(collect_segment_forks::<S, F>(store, &dir, 0)).await?;
+            Ok(Node::new(root, forks))
+        }
+        // A fork child reference names a node, never a bare segment.
+        DecodedChunk::Leaf(_) | DecodedChunk::Directory(_) => {
+            Err(StoreError::Decode(DecodeError::SegmentContext))
+        }
+    }
+}
+
+/// Gather every fork of a spilled node by fetching the segments its directory
+/// routes to, descending one directory level at a time.
+async fn collect_segment_forks<S, F>(
+    store: &S,
+    dir: &crate::codec::SegmentDir,
+    depth: usize,
+) -> Result<ForkTable<F>, StoreError>
+where
+    S: TrustedStore + MaybeSync,
+    F: Format,
+{
+    if depth >= MAX_DIR_DEPTH {
+        return Err(StoreError::Decode(DecodeError::SegmentContext));
+    }
+    let mut table = ForkTable::new();
+    for descriptor in &dir.descriptors {
+        // The plain read path cannot open an encrypted segment tree.
+        if descriptor.key.is_some() {
+            return Err(StoreError::Decode(DecodeError::SegmentContext));
+        }
+        let chunk = store
+            .get(&descriptor.address)
+            .await
+            .map_err(StoreError::store)?;
+        let sub = match Node::<F>::decode_chunk(chunk.envelope().data())? {
+            DecodedChunk::Leaf(sub) => sub,
+            DecodedChunk::Directory(inner) => {
+                Box::pin(collect_segment_forks::<S, F>(
+                    store,
+                    &inner,
+                    depth.saturating_add(1),
+                ))
+                .await?
+            }
+            DecodedChunk::Node(_) | DecodedChunk::Segmented(_, _) => {
+                return Err(StoreError::Decode(DecodeError::SegmentContext));
+            }
+        };
+        for (first, record) in sub.into_records() {
+            if table.insert_record(first, record).is_some() {
+                return Err(StoreError::Decode(DecodeError::SegmentContext));
+            }
+        }
+    }
+    Ok(table)
+}
 
 /// Async node storage over a chunk putter.
 ///

--- a/crates/manifest/tests/membound.rs
+++ b/crates/manifest/tests/membound.rs
@@ -14,6 +14,7 @@ use bytes::Bytes;
 use futures::executor::block_on;
 use nectar_manifest::{
     ApplyError, BuildStats, Builder, Changeset, Entry, Key, KeyId, Metadata, Reader, V1, apply,
+    recanonicalize,
 };
 use nectar_primitives::store::{ChunkGet, MemoryStore};
 use nectar_primitives::{
@@ -133,15 +134,36 @@ fn peak_open_nodes_tracks_depth_not_width() -> TestResult {
     )
 }
 
+/// Stream a byte-keyed profile into the builder: the first two key positions
+/// range over all 256 byte values and the third over `0..tail`, so every level-0
+/// and level-1 node is a full radix-256 fork table that overruns one chunk and
+/// must spill. `tail = 16` yields `256*256*16 = 1_048_576` keys.
+fn fill_radix256(builder: &mut Builder<V1>, tail: u16, fill: u8) -> Result<(), Box<dyn Error>> {
+    let mut key = [0u8; 3];
+    for a in 0u16..256 {
+        key[0] = u8::try_from(a)?;
+        for b in 0u16..256 {
+            key[1] = u8::try_from(b)?;
+            for c in 0u16..tail {
+                key[2] = u8::try_from(c)?;
+                builder.insert(Key::from(&key[..]), entry(fill), None);
+            }
+        }
+    }
+    Ok(())
+}
+
 #[test]
 fn a_million_key_manifest_is_depth_bounded() -> TestResult {
-    // radix 100, depth 3 is exactly 1_000_000 keys, three nodes deep. One build
-    // witnesses both bounds: the builder's peak retained buffer count is the
-    // depth, independent of the key count, and a lookup fetches one node per
-    // level rather than the wide sibling frontier.
+    // A byte-keyed radix-256 profile: 256*256*16 = 1_048_576 keys three nodes
+    // deep, whose level-0 and level-1 nodes are full 256-fork tables that a
+    // naive encoder would reject as over-budget. Spill packs each into a segment
+    // directory, so one build witnesses all three bounds: the builder's peak
+    // retained buffer count is the depth, every emitted chunk fits one chunk
+    // body, and a lookup stays O(depth) even through the spilled levels.
     let inner = MemoryStore::default();
     let mut builder = Builder::<V1>::new();
-    fill_radix(&mut builder, 100, 3, &mut Vec::new(), 0x22);
+    fill_radix256(&mut builder, 16, 0x22)?;
     let built = block_on(builder.build(&inner)).map_err(|e| e.to_string())?;
     let stats = *built.stats();
     let root = *built.root();
@@ -162,26 +184,106 @@ fn a_million_key_manifest_is_depth_bounded() -> TestResult {
             stats.nodes_written(),
         ),
     )?;
-    // Every emitted node fits one chunk body, checked at 10^6-key scale.
+    // Every emitted node fits one chunk body, checked at 10^6-key scale over a
+    // profile whose interior nodes are all spilled.
     assert_single_chunk_nodes(&inner)?;
 
     // Read a spread of keys through a counting store: each lookup is O(depth).
+    // A spilled level costs its segmented node plus the covering segments, a
+    // small constant per level, so the fetch count is bounded independent of the
+    // key count.
     let store = CountingStore {
         inner,
         gets: AtomicUsize::new(0),
     };
     let reader: Reader<_> = Reader::new(&store);
-    for probe in [[0u8, 0, 0], [50, 50, 50], [99, 99, 99], [7, 63, 12]] {
+    for probe in [[0u8, 0, 0], [255, 255, 15], [128, 64, 8], [7, 200, 3]] {
         store.gets.store(0, Ordering::Relaxed);
         let value =
             block_on(reader.get(&root, &Key::from(&probe[..]))).map_err(|e| e.to_string())?;
         ensure(value == Some(entry(0x22)), format!("missing key {probe:?}"))?;
-        // Depth three: at most the root and one node per level.
+        // Three levels, each at most a segmented node and its covering segments.
         ensure(
-            store.gets() <= 4,
+            store.gets() <= 24,
             format!("lookup fetched {} nodes, not O(depth)", store.gets()),
         )?;
     }
+    Ok(())
+}
+
+#[test]
+fn a_full_radix_256_node_of_heavy_records_packs_and_reads() -> TestResult {
+    // A single node holding all 256 first-byte forks, each carrying a heavy
+    // metadata block: a ~9.5 KB fork table that far overruns one chunk. The
+    // builder spills it into a segment directory; every emitted chunk still fits
+    // one body, and each key reads back through the reassembled node.
+    let store = MemoryStore::default();
+    let mut builder = Builder::<V1>::new();
+    for first in 0u16..256 {
+        let byte = u8::try_from(first)?;
+        let meta = Metadata::new(KeyId::ContentType, Bytes::from(vec![b'a'; 900]))
+            .map_err(|e| e.to_string())?;
+        builder.insert(Key::from(vec![byte]), entry(byte), Some(meta));
+    }
+    let built = block_on(builder.build(&store)).map_err(|e| e.to_string())?;
+
+    // The node did not fit one chunk, so it was spilled across several.
+    ensure(
+        built.stats().nodes_written() > 1,
+        "a full radix-256 heavy node must spill into several chunks".to_owned(),
+    )?;
+    assert_single_chunk_nodes(&store)?;
+
+    let reader: Reader<_> = Reader::new(&store);
+    for first in [0u8, 1, 127, 200, 255] {
+        let value = block_on(reader.get(built.root(), &Key::from(vec![first])))
+            .map_err(|e| e.to_string())?;
+        ensure(
+            value == Some(entry(first)),
+            format!("missing key {first} after spill"),
+        )?;
+    }
+    Ok(())
+}
+
+#[test]
+fn every_spilled_chunk_re_encodes_to_its_own_bytes() -> TestResult {
+    // The canonical-form check (spec 6.2) over a whole spilled node set: decode
+    // each stored chunk and re-encode it, and the bytes must match, plain node,
+    // segmented node and segment alike. This is the build-roundtrip fuzz oracle
+    // exercised on a deterministic set that is known to spill.
+    let store = MemoryStore::default();
+    let mut builder = Builder::<V1>::new();
+    for first in 0u16..256 {
+        let byte = u8::try_from(first)?;
+        let meta = Metadata::new(KeyId::ContentType, Bytes::from(vec![b'a'; 700]))
+            .map_err(|e| e.to_string())?;
+        builder.insert(Key::from(vec![byte]), entry(byte), Some(meta));
+    }
+    block_on(builder.build(&store)).map_err(|e| e.to_string())?;
+
+    let mut saw_segment = false;
+    for chunk in store.into_chunks().into_values() {
+        let payload = chunk.envelope().data();
+        let reencoded = recanonicalize::<V1>(payload.as_ref()).map_err(|e| e.to_string())?;
+        ensure(
+            reencoded.as_slice() == payload.as_ref(),
+            "a stored chunk did not re-encode to its own bytes".to_owned(),
+        )?;
+        // The flags byte follows the two preamble bytes; a set SEGMENTED or
+        // SEGMENT bit witnesses that spill actually fired.
+        if payload
+            .as_ref()
+            .get(2)
+            .is_some_and(|flags| flags & 0x60 != 0)
+        {
+            saw_segment = true;
+        }
+    }
+    ensure(
+        saw_segment,
+        "the heavy set did not spill into segments".to_owned(),
+    )?;
     Ok(())
 }
 
@@ -211,9 +313,10 @@ fn filler_meta(len: usize) -> Result<Metadata<V1>, TestCaseError> {
 }
 
 proptest! {
-    // No node the builder emits ever exceeds one chunk body. A key set too wide
-    // or heavy to fit surfaces a typed error, never a panic and never an
-    // over-budget chunk written to the store.
+    // No node the builder emits ever exceeds one chunk body. A wide or heavy
+    // node is spilled into a segment directory rather than surfacing an
+    // over-budget error, so the single-chunk-node invariant holds by
+    // construction across arbitrary key sets.
     #[test]
     fn no_built_node_exceeds_budget(entries in wide_heavy_set()) {
         let store = MemoryStore::default();
@@ -225,10 +328,10 @@ proptest! {
             };
             builder.insert(Key::from(key.clone()), entry(*fill), metadata);
         }
-        if block_on(builder.build(&store)).is_ok() {
-            for len in chunk_lengths(&store) {
-                prop_assert!(len <= DEFAULT_BODY_SIZE, "built node over one chunk body");
-            }
+        let built = block_on(builder.build(&store));
+        prop_assert!(built.is_ok(), "a wide/heavy set must spill, not error: {built:?}");
+        for len in chunk_lengths(&store) {
+            prop_assert!(len <= DEFAULT_BODY_SIZE, "built node over one chunk body");
         }
     }
 

--- a/crates/manifest/tests/membound.rs
+++ b/crates/manifest/tests/membound.rs
@@ -287,6 +287,68 @@ fn every_spilled_chunk_re_encodes_to_its_own_bytes() -> TestResult {
     Ok(())
 }
 
+#[test]
+fn apply_over_a_spilled_node_matches_a_from_scratch_build() -> TestResult {
+    // History independence across the spill boundary: folding a changeset into a
+    // base whose root node spills must reach the exact root a from-scratch build
+    // of the merged key set reaches, byte for byte. This drives the whole
+    // materialize-then-re-spill path apply now takes over a segmented node.
+    let heavy = || Metadata::new(KeyId::ContentType, Bytes::from(vec![b'a'; 800]));
+
+    // The base: 200 single-byte keys whose root node overruns one chunk.
+    let base_store = MemoryStore::default();
+    let mut base_builder = Builder::<V1>::new();
+    for first in 0u16..200 {
+        let byte = u8::try_from(first)?;
+        base_builder.insert(
+            Key::from(vec![byte]),
+            entry(byte),
+            Some(heavy().map_err(|e| e.to_string())?),
+        );
+    }
+    let base = block_on(base_builder.build(&base_store)).map_err(|e| e.to_string())?;
+    ensure(
+        base.stats().nodes_written() > 1,
+        "the base root node must spill".to_owned(),
+    )?;
+
+    // The changeset overwrites the tail of the base and extends past it, so the
+    // merged key set is 0..256.
+    let mut changeset = Changeset::<V1>::new();
+    for first in 150u16..256 {
+        let byte = u8::try_from(first)?;
+        changeset.put(
+            Key::from(vec![byte]),
+            entry(byte),
+            Some(heavy().map_err(|e| e.to_string())?),
+        );
+    }
+    let applied =
+        block_on(apply(&base_store, base.root(), &changeset)).map_err(|e| e.to_string())?;
+
+    // A from-scratch build of the merged key set.
+    let scratch_store = MemoryStore::default();
+    let mut scratch_builder = Builder::<V1>::new();
+    for first in 0u16..256 {
+        let byte = u8::try_from(first)?;
+        scratch_builder.insert(
+            Key::from(vec![byte]),
+            entry(byte),
+            Some(heavy().map_err(|e| e.to_string())?),
+        );
+    }
+    let scratch = block_on(scratch_builder.build(&scratch_store)).map_err(|e| e.to_string())?;
+
+    ensure(
+        applied == *scratch.root(),
+        format!(
+            "apply root {applied:?} diverged from the from-scratch root {:?}",
+            scratch.root()
+        ),
+    )?;
+    Ok(())
+}
+
 /// Chunk payload lengths of a store, for the budget assertions below.
 fn chunk_lengths(store: &MemoryStore) -> Vec<usize> {
     store

--- a/fuzz/fuzz_targets/manifest_build_roundtrip.rs
+++ b/fuzz/fuzz_targets/manifest_build_roundtrip.rs
@@ -14,7 +14,7 @@
 use bytes::Bytes;
 use futures::executor::block_on;
 use libfuzzer_sys::fuzz_target;
-use nectar_manifest::{Builder, Entry, Key, Node, V1};
+use nectar_manifest::{Builder, Entry, Key, V1, recanonicalize};
 use nectar_primitives::store::MemoryStore;
 use nectar_primitives::{ChunkAddress, ChunkOps, ChunkRef, DEFAULT_BODY_SIZE};
 
@@ -62,22 +62,22 @@ fuzz_target!(|input: Vec<(Vec<u8>, Val)>| {
         return;
     };
 
-    // Every emitted node chunk round-trips through the codec byte for byte and
-    // fits one chunk body: no builder output can be an over-budget or
-    // non-canonical image.
+    // Every emitted chunk round-trips through the codec byte for byte and fits
+    // one chunk body: no builder output, plain node or spilled segment, can be
+    // an over-budget or non-canonical image.
     for chunk in store.into_chunks().into_values() {
         let payload = chunk.envelope().data();
         assert!(
             payload.len() <= DEFAULT_BODY_SIZE,
-            "node chunk {} bytes exceeds one chunk body",
+            "chunk {} bytes exceeds one chunk body",
             payload.len(),
         );
-        let node = Node::<V1>::decode(payload.as_ref()).expect("a stored node must decode");
-        let reencoded = node.encode().expect("a decoded node must re-encode");
+        let reencoded =
+            recanonicalize::<V1>(payload.as_ref()).expect("a stored chunk must decode");
         assert_eq!(
             reencoded.as_slice(),
             payload.as_ref(),
-            "node encoding must be canonical",
+            "chunk encoding must be canonical",
         );
     }
 

--- a/zepter.yaml
+++ b/zepter.yaml
@@ -12,6 +12,10 @@ workflows:
         "--left-side-feature-missing=ignore",
         "--left-side-outside-workspace=ignore",
         "--dep-kinds=normal:check,dev:ignore",
+        # The manifest encryption crypto rides on always-available primitives
+        # (transcrypt, keccak, the ref types), so the feature deliberately
+        # enables no primitives feature.
+        "--ignore-missing-propagate=nectar-manifest/encryption:nectar-primitives/encryption",
         "--workspace",
         "--show-path",
         "--quiet",


### PR DESCRIPTION
Refs #256, #259, #260 (epic #264)

## What

Implements the three closing fixes for epic #264 on top of `s264/70-fuzz-membound`, across two commits (`6004d6b`, `5347e44`).

- Wires the packing-layer spill into the builder/apply emit path. A new `emit_node` helper (used by `Builder::build`, `resolve`, and `apply`'s root) spills any node whose flat body would exceed `BUDGET` into a depth<=2 segment directory of one-chunk leaf/dir segments, instead of surfacing `EncodeError::OverBudget`.
- Adds the segment wire grammar to `codec.rs`: leaf (`0x40`), dir (`0x60`) and `SEGMENTED` node (`0x20`) tags, plus `SegmentDir`, `DecodedChunk`, `decode_chunk`, and `recanonicalize`. Decoding is cursor-based and panic-free, with new reject variants for malformed/truncated segment input.
- Corrects the `DERIVE_TAG` constant and decouples the encryption feature so it no longer bleeds into non-encrypted code paths; `dx.rs` is updated for encrypted-file handling accordingly.
- The store seam reassembles a spilled node's forks in O(depth) memory, and the reader performs spec-conformant targeted single-segment-per-level descent for point lookups, so the single-chunk-node invariant now holds by construction.
- Extends `tests/membound.rs` (the second commit) with an assertion that `apply` over a spilled node matches a from-scratch `build`.

## Why

Epic #264 requires that manifest nodes never exceed a single chunk. Before this change, oversized nodes surfaced `EncodeError::OverBudget` instead of being packed; this closes that gap by spilling into segment directories at encode time, and teaches the codec/reader/store the corresponding wire format so spilled nodes round-trip and are readable without materializing more than O(depth) state.

## Testing

Full diff stat:

```
crates/manifest/Cargo.toml                    |   9 +-
crates/manifest/src/apply.rs                  |   6 +-
crates/manifest/src/builder.rs                | 120 ++++++++-
crates/manifest/src/codec.rs                  | 365 +++++++++++++++++++++++++-
crates/manifest/src/dx.rs                     |  25 +-
crates/manifest/src/fork.rs                   |   5 +
crates/manifest/src/format.rs                 |  28 +-
crates/manifest/src/lib.rs                    |   2 +-
crates/manifest/src/reader.rs                 | 106 +++++++-
crates/manifest/src/store.rs                  |  88 ++++++-
crates/manifest/tests/membound.rs             | 197 ++++++++++++--
fuzz/fuzz_targets/manifest_build_roundtrip.rs |  16 +-
12 files changed, 885 insertions(+), 82 deletions(-)
```

Independent re-verification (HEAD `5347e44`) ran the full battery via `nix develop`, substituting `cargo test --workspace --all-features` for `cargo nextest` and adding the wasm32 target and `cargo-fuzz` ephemerally, since neither is in the repo's devShell (environment substitution only, no code deviation):

- `cargo fmt --all -- --check`: pass.
- `cargo clippy --workspace --all-targets --all-features -D warnings`: pass, no warnings.
- `cargo test --workspace --all-features`: pass, 931 tests across 35 binaries.

An adversarial review of the segment spill, `DERIVE_TAG` fix, encryption feature decoupling, and `dx.rs` encrypted-file handling found no correctness bugs: segment encode/decode round-trips canonically (the `recanonicalize` oracle is sound), the plain-node path is byte-unchanged, decoding is panic-free on adversarial/truncated input, routing is correct (`CAP_FORK = 4091` fits a leaf into exactly 4096 bytes), `get_node` materialization dedups soundly, and the `DERIVE_TAG` change is spec-conformant with no stale pinned test vectors.

This is a stacked PR: base is `s264/70-fuzz-membound`, not `main`. No CI beyond CLA checks will run until the stack is retargeted.

## AI assistance

Implemented and tested with Claude (Anthropic), per the org contract in nxm-rs/.github `CONTRIBUTING.md`.

