### PR TITLE
bench(manifest): mantaray 1.0 vs 0.2 empirical performance harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2071,6 +2071,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nectar-manifest-sim"
+version = "0.4.0"
+dependencies = [
+ "bytes",
+ "codspeed-criterion-compat",
+ "futures",
+ "nectar-manifest",
+ "nectar-mantaray",
+ "nectar-primitives",
+ "serde",
+ "serde_json",
+ "sha2",
+]
+
+[[package]]
 name = "nectar-mantaray"
 version = "0.4.0"
 dependencies = [

--- a/crates/manifest-sim/Cargo.toml
+++ b/crates/manifest-sim/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "nectar-manifest-sim"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+publish = false
+description = "Empirical performance harness comparing mantaray 1.0 (nectar-manifest) and mantaray 0.2 (nectar-mantaray)"
+
+# NOTE: this harness crate deliberately does NOT inherit the workspace
+# restriction lints (`[lints] workspace = true` is omitted). A measurement
+# harness is test/bench code: fallible `?` is used throughout, but the
+# arithmetic and unwrap restriction lints that guard production wire paths are
+# not appropriate here, and the house rules forbid `#[allow]` to suppress them
+# one by one. `cargo clippy -D warnings` still holds the crate to the default
+# clippy correctness/style/complexity/perf lints.
+
+[dependencies]
+bytes.workspace = true
+nectar-manifest = { workspace = true }
+nectar-mantaray = { workspace = true }
+nectar-primitives = { workspace = true }
+futures.workspace = true
+serde = { version = "1", features = ["derive"] }
+serde_json = { version = "1", features = ["std"] }
+sha2 = "0.10"
+
+[dev-dependencies]
+criterion.workspace = true
+
+[[bin]]
+name = "manifest-sim"
+path = "src/bin/manifest_sim.rs"
+
+[[bench]]
+name = "manifest_perf"
+path = "benches/manifest_perf.rs"
+harness = false

--- a/crates/manifest-sim/benches/manifest_perf.rs
+++ b/crates/manifest-sim/benches/manifest_perf.rs
@@ -1,0 +1,184 @@
+//! Criterion ns/op benches for build / get / apply, both formats.
+//!
+//! Timed on the kiwix corpus (a natively byte-identical path corpus, the fair
+//! headline comparison) at N in {1e3, 1e4, 1e5}. Build is timed to 1e4 to keep
+//! the 0.2 whole-trie seal within a sane wall budget; get and single-key apply
+//! are cheap and timed to 1e5. Ids match `criterion_fold::bench_id`, so the
+//! sim bin folds these straight into the result cells.
+
+use bytes::Bytes;
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use futures::executor::block_on;
+
+use nectar_manifest::{Builder, Changeset, Entry, Key, KeyId, Metadata, Reader, V1, apply};
+use nectar_mantaray::{Manifest, PlainManifest};
+use nectar_primitives::{AnyChunkSet, ChunkAddress, ChunkRef, StandardChunkSet};
+
+use nectar_manifest_sim::corpus::{self, Corpus, GenKey, tagged_addr, value_addr};
+use nectar_manifest_sim::criterion_fold::bench_id;
+use nectar_manifest_sim::store::CountingStore;
+
+const F10: &str = "mantaray_1_0";
+const F02: &str = "mantaray_0_2";
+const BUILD_SCALES: [u64; 2] = [1_000, 10_000];
+const OP_SCALES: [u64; 3] = [1_000, 10_000, 100_000];
+
+fn ref32(addr: [u8; 32]) -> ChunkRef {
+    ChunkRef::new(ChunkAddress::new(addr))
+}
+
+fn meta10(k: &GenKey) -> Option<Metadata<V1>> {
+    k.content_type.map(|ct| {
+        Metadata::<V1>::new(KeyId::ContentType, Bytes::from_static(ct.as_bytes())).unwrap()
+    })
+}
+
+fn build_10(keys: &[GenKey]) -> ChunkAddress {
+    let store = CountingStore::<StandardChunkSet>::new();
+    let mut b = Builder::<V1>::new();
+    for k in keys {
+        b.insert(
+            Key::from(k.raw.as_slice()),
+            Entry::from(ref32(value_addr(&k.raw))),
+            meta10(k),
+        );
+    }
+    *block_on(b.build(&store)).unwrap().root()
+}
+
+fn build_02(keys: &[GenKey]) -> ChunkAddress {
+    let store = CountingStore::<AnyChunkSet<4096>>::new();
+    let mut m: PlainManifest<&CountingStore<AnyChunkSet<4096>>> = Manifest::new(&store);
+    for k in keys {
+        block_on(m.add(&k.path, ref32(value_addr(k.path.as_bytes())))).unwrap();
+    }
+    block_on(m.save()).unwrap()
+}
+
+fn bench_build(c: &mut Criterion) {
+    let corpus = Corpus::Kiwix;
+    let mut g = c.benchmark_group("build");
+    for &scale in &BUILD_SCALES {
+        let keys = corpus::generate(corpus, scale as usize);
+        g.bench_with_input(
+            BenchmarkId::from_parameter(bench_id(F10, corpus.name(), scale)),
+            &keys,
+            |b, keys| b.iter(|| build_10(keys)),
+        );
+        g.bench_with_input(
+            BenchmarkId::from_parameter(bench_id(F02, corpus.name(), scale)),
+            &keys,
+            |b, keys| b.iter(|| build_02(keys)),
+        );
+    }
+    g.finish();
+}
+
+fn bench_get(c: &mut Criterion) {
+    let corpus = Corpus::Kiwix;
+    let mut g = c.benchmark_group("get");
+    for &scale in &OP_SCALES {
+        let keys = corpus::generate(corpus, scale as usize);
+        let probe = keys[keys.len() / 2].clone();
+
+        // 1.0
+        let store10 = CountingStore::<StandardChunkSet>::new();
+        let mut b10 = Builder::<V1>::new();
+        for k in &keys {
+            b10.insert(
+                Key::from(k.raw.as_slice()),
+                Entry::from(ref32(value_addr(&k.raw))),
+                meta10(k),
+            );
+        }
+        let root10 = *block_on(b10.build(&store10)).unwrap().root();
+        let reader10: Reader<&CountingStore<StandardChunkSet>, V1> = Reader::new(&store10);
+        let key10 = Key::from(probe.raw.as_slice());
+        g.bench_with_input(
+            BenchmarkId::from_parameter(bench_id(F10, corpus.name(), scale)),
+            &scale,
+            |b, _| b.iter(|| block_on(reader10.get(&root10, &key10)).unwrap()),
+        );
+
+        // 0.2
+        let store02 = CountingStore::<AnyChunkSet<4096>>::new();
+        let root02 = {
+            let mut m: PlainManifest<&CountingStore<AnyChunkSet<4096>>> = Manifest::new(&store02);
+            for k in &keys {
+                block_on(m.add(&k.path, ref32(value_addr(k.path.as_bytes())))).unwrap();
+            }
+            block_on(m.save()).unwrap()
+        };
+        let reader02: PlainManifest<&CountingStore<AnyChunkSet<4096>>> =
+            Manifest::open(root02, &store02);
+        let path = probe.path.clone();
+        g.bench_with_input(
+            BenchmarkId::from_parameter(bench_id(F02, corpus.name(), scale)),
+            &scale,
+            |b, _| b.iter(|| block_on(reader02.get(&path)).unwrap()),
+        );
+    }
+    g.finish();
+}
+
+fn bench_apply(c: &mut Criterion) {
+    let corpus = Corpus::Kiwix;
+    let mut g = c.benchmark_group("apply");
+    for &scale in &OP_SCALES {
+        let keys = corpus::generate(corpus, scale as usize);
+        let probe = keys[keys.len() / 2].clone();
+
+        // 1.0: single-key apply
+        let store10 = CountingStore::<StandardChunkSet>::new();
+        let mut b10 = Builder::<V1>::new();
+        for k in &keys {
+            b10.insert(
+                Key::from(k.raw.as_slice()),
+                Entry::from(ref32(value_addr(&k.raw))),
+                meta10(k),
+            );
+        }
+        let root10 = *block_on(b10.build(&store10)).unwrap().root();
+        let key10 = Key::from(probe.raw.as_slice());
+        let val10 = Entry::from(ref32(tagged_addr(b"upd", &probe.raw)));
+        g.bench_with_input(
+            BenchmarkId::from_parameter(bench_id(F10, corpus.name(), scale)),
+            &scale,
+            |b, _| {
+                b.iter(|| {
+                    let mut cs = Changeset::<V1>::new();
+                    cs.put(key10.clone(), val10.clone(), None);
+                    block_on(apply(&store10, &root10, &cs)).unwrap()
+                })
+            },
+        );
+
+        // 0.2: single-key add + save
+        let store02 = CountingStore::<AnyChunkSet<4096>>::new();
+        let root02 = {
+            let mut m: PlainManifest<&CountingStore<AnyChunkSet<4096>>> = Manifest::new(&store02);
+            for k in &keys {
+                block_on(m.add(&k.path, ref32(value_addr(k.path.as_bytes())))).unwrap();
+            }
+            block_on(m.save()).unwrap()
+        };
+        let path = probe.path.clone();
+        let upd = ref32(tagged_addr(b"upd", probe.path.as_bytes()));
+        g.bench_with_input(
+            BenchmarkId::from_parameter(bench_id(F02, corpus.name(), scale)),
+            &scale,
+            |b, _| {
+                b.iter(|| {
+                    let mut m: PlainManifest<&CountingStore<AnyChunkSet<4096>>> =
+                        Manifest::open(root02, &store02);
+                    block_on(m.add(&path, upd)).unwrap();
+                    block_on(m.save()).unwrap()
+                })
+            },
+        );
+    }
+    g.finish();
+}
+
+criterion_group!(benches, bench_build, bench_get, bench_apply);
+criterion_main!(benches);

--- a/crates/manifest-sim/benches/manifest_perf.rs
+++ b/crates/manifest-sim/benches/manifest_perf.rs
@@ -56,126 +56,131 @@ fn build_02(keys: &[GenKey]) -> ChunkAddress {
 }
 
 fn bench_build(c: &mut Criterion) {
-    let corpus = Corpus::Kiwix;
     let mut g = c.benchmark_group("build");
-    for &scale in &BUILD_SCALES {
-        let keys = corpus::generate(corpus, scale as usize);
-        g.bench_with_input(
-            BenchmarkId::from_parameter(bench_id(F10, corpus.name(), scale)),
-            &keys,
-            |b, keys| b.iter(|| build_10(keys)),
-        );
-        g.bench_with_input(
-            BenchmarkId::from_parameter(bench_id(F02, corpus.name(), scale)),
-            &keys,
-            |b, keys| b.iter(|| build_02(keys)),
-        );
+    for corpus in Corpus::all() {
+        for &scale in &BUILD_SCALES {
+            let keys = corpus::generate(corpus, scale as usize);
+            g.bench_with_input(
+                BenchmarkId::from_parameter(bench_id(F10, corpus.name(), scale)),
+                &keys,
+                |b, keys| b.iter(|| build_10(keys)),
+            );
+            g.bench_with_input(
+                BenchmarkId::from_parameter(bench_id(F02, corpus.name(), scale)),
+                &keys,
+                |b, keys| b.iter(|| build_02(keys)),
+            );
+        }
     }
     g.finish();
 }
 
 fn bench_get(c: &mut Criterion) {
-    let corpus = Corpus::Kiwix;
     let mut g = c.benchmark_group("get");
-    for &scale in &OP_SCALES {
-        let keys = corpus::generate(corpus, scale as usize);
-        let probe = keys[keys.len() / 2].clone();
+    for corpus in Corpus::all() {
+        for &scale in &OP_SCALES {
+            let keys = corpus::generate(corpus, scale as usize);
+            let probe = keys[keys.len() / 2].clone();
 
-        // 1.0
-        let store10 = CountingStore::<StandardChunkSet>::new();
-        let mut b10 = Builder::<V1>::new();
-        for k in &keys {
-            b10.insert(
-                Key::from(k.raw.as_slice()),
-                Entry::from(ref32(value_addr(&k.raw))),
-                meta10(k),
+            // 1.0
+            let store10 = CountingStore::<StandardChunkSet>::new();
+            let mut b10 = Builder::<V1>::new();
+            for k in &keys {
+                b10.insert(
+                    Key::from(k.raw.as_slice()),
+                    Entry::from(ref32(value_addr(&k.raw))),
+                    meta10(k),
+                );
+            }
+            let root10 = *block_on(b10.build(&store10)).unwrap().root();
+            let reader10: Reader<&CountingStore<StandardChunkSet>, V1> = Reader::new(&store10);
+            let key10 = Key::from(probe.raw.as_slice());
+            g.bench_with_input(
+                BenchmarkId::from_parameter(bench_id(F10, corpus.name(), scale)),
+                &scale,
+                |b, _| b.iter(|| block_on(reader10.get(&root10, &key10)).unwrap()),
+            );
+
+            // 0.2
+            let store02 = CountingStore::<AnyChunkSet<4096>>::new();
+            let root02 = {
+                let mut m: PlainManifest<&CountingStore<AnyChunkSet<4096>>> =
+                    Manifest::new(&store02);
+                for k in &keys {
+                    block_on(m.add(&k.path, ref32(value_addr(k.path.as_bytes())))).unwrap();
+                }
+                block_on(m.save()).unwrap()
+            };
+            let reader02: PlainManifest<&CountingStore<AnyChunkSet<4096>>> =
+                Manifest::open(root02, &store02);
+            let path = probe.path.clone();
+            g.bench_with_input(
+                BenchmarkId::from_parameter(bench_id(F02, corpus.name(), scale)),
+                &scale,
+                |b, _| b.iter(|| block_on(reader02.get(&path)).unwrap()),
             );
         }
-        let root10 = *block_on(b10.build(&store10)).unwrap().root();
-        let reader10: Reader<&CountingStore<StandardChunkSet>, V1> = Reader::new(&store10);
-        let key10 = Key::from(probe.raw.as_slice());
-        g.bench_with_input(
-            BenchmarkId::from_parameter(bench_id(F10, corpus.name(), scale)),
-            &scale,
-            |b, _| b.iter(|| block_on(reader10.get(&root10, &key10)).unwrap()),
-        );
-
-        // 0.2
-        let store02 = CountingStore::<AnyChunkSet<4096>>::new();
-        let root02 = {
-            let mut m: PlainManifest<&CountingStore<AnyChunkSet<4096>>> = Manifest::new(&store02);
-            for k in &keys {
-                block_on(m.add(&k.path, ref32(value_addr(k.path.as_bytes())))).unwrap();
-            }
-            block_on(m.save()).unwrap()
-        };
-        let reader02: PlainManifest<&CountingStore<AnyChunkSet<4096>>> =
-            Manifest::open(root02, &store02);
-        let path = probe.path.clone();
-        g.bench_with_input(
-            BenchmarkId::from_parameter(bench_id(F02, corpus.name(), scale)),
-            &scale,
-            |b, _| b.iter(|| block_on(reader02.get(&path)).unwrap()),
-        );
     }
     g.finish();
 }
 
 fn bench_apply(c: &mut Criterion) {
-    let corpus = Corpus::Kiwix;
     let mut g = c.benchmark_group("apply");
-    for &scale in &OP_SCALES {
-        let keys = corpus::generate(corpus, scale as usize);
-        let probe = keys[keys.len() / 2].clone();
+    for corpus in Corpus::all() {
+        for &scale in &OP_SCALES {
+            let keys = corpus::generate(corpus, scale as usize);
+            let probe = keys[keys.len() / 2].clone();
 
-        // 1.0: single-key apply
-        let store10 = CountingStore::<StandardChunkSet>::new();
-        let mut b10 = Builder::<V1>::new();
-        for k in &keys {
-            b10.insert(
-                Key::from(k.raw.as_slice()),
-                Entry::from(ref32(value_addr(&k.raw))),
-                meta10(k),
+            // 1.0: single-key apply
+            let store10 = CountingStore::<StandardChunkSet>::new();
+            let mut b10 = Builder::<V1>::new();
+            for k in &keys {
+                b10.insert(
+                    Key::from(k.raw.as_slice()),
+                    Entry::from(ref32(value_addr(&k.raw))),
+                    meta10(k),
+                );
+            }
+            let root10 = *block_on(b10.build(&store10)).unwrap().root();
+            let key10 = Key::from(probe.raw.as_slice());
+            let val10 = Entry::from(ref32(tagged_addr(b"upd", &probe.raw)));
+            g.bench_with_input(
+                BenchmarkId::from_parameter(bench_id(F10, corpus.name(), scale)),
+                &scale,
+                |b, _| {
+                    b.iter(|| {
+                        let mut cs = Changeset::<V1>::new();
+                        cs.put(key10.clone(), val10.clone(), None);
+                        block_on(apply(&store10, &root10, &cs)).unwrap()
+                    })
+                },
+            );
+
+            // 0.2: single-key add + save
+            let store02 = CountingStore::<AnyChunkSet<4096>>::new();
+            let root02 = {
+                let mut m: PlainManifest<&CountingStore<AnyChunkSet<4096>>> =
+                    Manifest::new(&store02);
+                for k in &keys {
+                    block_on(m.add(&k.path, ref32(value_addr(k.path.as_bytes())))).unwrap();
+                }
+                block_on(m.save()).unwrap()
+            };
+            let path = probe.path.clone();
+            let upd = ref32(tagged_addr(b"upd", probe.path.as_bytes()));
+            g.bench_with_input(
+                BenchmarkId::from_parameter(bench_id(F02, corpus.name(), scale)),
+                &scale,
+                |b, _| {
+                    b.iter(|| {
+                        let mut m: PlainManifest<&CountingStore<AnyChunkSet<4096>>> =
+                            Manifest::open(root02, &store02);
+                        block_on(m.add(&path, upd)).unwrap();
+                        block_on(m.save()).unwrap()
+                    })
+                },
             );
         }
-        let root10 = *block_on(b10.build(&store10)).unwrap().root();
-        let key10 = Key::from(probe.raw.as_slice());
-        let val10 = Entry::from(ref32(tagged_addr(b"upd", &probe.raw)));
-        g.bench_with_input(
-            BenchmarkId::from_parameter(bench_id(F10, corpus.name(), scale)),
-            &scale,
-            |b, _| {
-                b.iter(|| {
-                    let mut cs = Changeset::<V1>::new();
-                    cs.put(key10.clone(), val10.clone(), None);
-                    block_on(apply(&store10, &root10, &cs)).unwrap()
-                })
-            },
-        );
-
-        // 0.2: single-key add + save
-        let store02 = CountingStore::<AnyChunkSet<4096>>::new();
-        let root02 = {
-            let mut m: PlainManifest<&CountingStore<AnyChunkSet<4096>>> = Manifest::new(&store02);
-            for k in &keys {
-                block_on(m.add(&k.path, ref32(value_addr(k.path.as_bytes())))).unwrap();
-            }
-            block_on(m.save()).unwrap()
-        };
-        let path = probe.path.clone();
-        let upd = ref32(tagged_addr(b"upd", probe.path.as_bytes()));
-        g.bench_with_input(
-            BenchmarkId::from_parameter(bench_id(F02, corpus.name(), scale)),
-            &scale,
-            |b, _| {
-                b.iter(|| {
-                    let mut m: PlainManifest<&CountingStore<AnyChunkSet<4096>>> =
-                        Manifest::open(root02, &store02);
-                    block_on(m.add(&path, upd)).unwrap();
-                    block_on(m.save()).unwrap()
-                })
-            },
-        );
     }
     g.finish();
 }

--- a/crates/manifest-sim/src/bin/manifest_sim.rs
+++ b/crates/manifest-sim/src/bin/manifest_sim.rs
@@ -9,9 +9,12 @@ use std::process::Command;
 use nectar_manifest_sim::corpus::{self, Corpus};
 use nectar_manifest_sim::criterion_fold;
 use nectar_manifest_sim::measure::{self, Cfg};
-use nectar_manifest_sim::results::{Cell, CorpusBlock, Document, FormatBlock, Meta};
+use nectar_manifest_sim::results::{
+    CapabilityRow, Cell, CorpusBlock, Document, Fallback, FormatBlock, Headline, Headlines, LogLog,
+    Meta,
+};
 
-const DEFAULT_OUT: &str = "/home/mfw78/.claude/jobs/ba6b8d73/tmp/manifest-sim-results.json";
+const DEFAULT_OUT: &str = "/home/mfw78/.claude/jobs/ba6b8d73/tmp/manifest-sim-results-v2.json";
 const F10: &str = "mantaray_1_0";
 const F02: &str = "mantaray_0_2";
 
@@ -123,6 +126,542 @@ fn skipped_cell(reason: &str, n: u64, encoding: &str) -> Cell {
     }
 }
 
+const NOT_RUN: &str = "0.2 not run at this scale";
+
+/// Fill 1.0-only op fallback costs + multipliers from the matching 0.2 cell.
+fn cross_fill(c10: &mut BTreeMap<String, CorpusBlock>, c02: &BTreeMap<String, CorpusBlock>) {
+    for (corpus, block) in c10.iter_mut() {
+        for (scale, cell) in block.scales.iter_mut() {
+            let peer = c02
+                .get(corpus)
+                .and_then(|b| b.scales.get(scale))
+                .filter(|c| c.ran);
+            let walk = peer.and_then(|c| c.full_entries_walk_fetches);
+            let peer_walk_from = peer
+                .and_then(|c| c.listing.as_ref())
+                .and_then(|l| l.fallback_02_walk_from.as_ref())
+                .map(|k| k.fetches);
+
+            // floor
+            if let Some(f) = cell.floor.as_mut() {
+                let native = f.hops_mean.unwrap_or(0.0);
+                f.fallback_02 = Some(match walk {
+                    Some(fetches) => Fallback {
+                        method: "entries() full walk + client scan".to_string(),
+                        fetches: Some(fetches),
+                        multiplier: (native > 0.0).then(|| fetches as f64 / native),
+                        reason_if_null: None,
+                    },
+                    None => Fallback {
+                        method: "entries() full walk + client scan".to_string(),
+                        fetches: None,
+                        multiplier: None,
+                        reason_if_null: Some(NOT_RUN.to_string()),
+                    },
+                });
+            }
+            // ceiling
+            if let Some(cl) = cell.ceiling.as_mut() {
+                let native = cl.native_seek_hops_mean.unwrap_or(0.0);
+                cl.fallback_02 = Some(match walk {
+                    Some(fetches) => Fallback {
+                        method: "entries() full walk + client scan".to_string(),
+                        fetches: Some(fetches),
+                        multiplier: (native > 0.0).then(|| fetches as f64 / native),
+                        reason_if_null: None,
+                    },
+                    None => Fallback {
+                        method: "entries() full walk + client scan".to_string(),
+                        fetches: None,
+                        multiplier: None,
+                        reason_if_null: Some(NOT_RUN.to_string()),
+                    },
+                });
+            }
+            // range windows
+            if let Some(r) = cell.range.as_mut() {
+                for win in r.windows.iter_mut() {
+                    match (walk, win.fetch_count) {
+                        (Some(w), Some(native)) if native > 0 => {
+                            win.fallback_02_fetches = Some(w);
+                            win.multiplier = Some(w as f64 / native as f64);
+                        }
+                        (None, _) => win.reason_if_null = Some(NOT_RUN.to_string()),
+                        _ => {}
+                    }
+                }
+            }
+            // listing fair multiplier
+            if let Some(l) = cell.listing.as_mut()
+                && let (Some(wf), Some(native)) = (peer_walk_from, l.fetch_count)
+                && native > 0
+            {
+                l.multiplier_fair = Some(wf as f64 / native as f64);
+            }
+        }
+    }
+}
+
+/// Least-squares fit of log(build wall_ns) vs log(N) per corpus, stored on every
+/// scale's cell. A single cold pass, so it is indicative not a precise
+/// asymptote (see caveats); r2 and n_points are reported for that reason.
+fn fit_loglog(corpora: &mut BTreeMap<String, CorpusBlock>) {
+    for block in corpora.values_mut() {
+        let mut pts: Vec<(f64, f64)> = Vec::new();
+        for cell in block.scales.values() {
+            if let (Some(n), Some(b)) = (cell.n_keys, cell.build.as_ref())
+                && let Some(ns) = b.wall_ns
+                && n > 0
+                && ns > 0
+            {
+                pts.push(((n as f64).ln(), (ns as f64).ln()));
+            }
+        }
+        if pts.len() < 2 {
+            continue;
+        }
+        let fit = least_squares(&pts);
+        for cell in block.scales.values_mut() {
+            if let Some(b) = cell.build.as_mut() {
+                b.cpu_loglog = Some(LogLog {
+                    slope: fit.0,
+                    intercept: fit.1,
+                    r2: fit.2,
+                    n_points: pts.len() as u32,
+                    basis: "build wall_ns, single cold pass".to_string(),
+                });
+            }
+        }
+    }
+}
+
+/// (slope, intercept, r2) of ys on xs.
+fn least_squares(pts: &[(f64, f64)]) -> (f64, f64, f64) {
+    let n = pts.len() as f64;
+    let mx = pts.iter().map(|p| p.0).sum::<f64>() / n;
+    let my = pts.iter().map(|p| p.1).sum::<f64>() / n;
+    let mut sxx = 0.0;
+    let mut sxy = 0.0;
+    let mut syy = 0.0;
+    for &(x, y) in pts {
+        sxx += (x - mx) * (x - mx);
+        sxy += (x - mx) * (y - my);
+        syy += (y - my) * (y - my);
+    }
+    let slope = if sxx == 0.0 { 0.0 } else { sxy / sxx };
+    let intercept = my - slope * mx;
+    let r2 = if sxx == 0.0 || syy == 0.0 {
+        0.0
+    } else {
+        (sxy * sxy) / (sxx * syy)
+    };
+    (slope, intercept, r2)
+}
+
+/// Cross-cell headline multipliers, derived from executed cells only.
+fn build_headlines(
+    c10: &BTreeMap<String, CorpusBlock>,
+    c02: &BTreeMap<String, CorpusBlock>,
+) -> Headlines {
+    let mut entries: Vec<Headline> = Vec::new();
+    for (corpus, block) in c10 {
+        for (scale, cell) in &block.scales {
+            let scale_n: u64 = scale.parse().unwrap_or(0);
+            // floor multiplier (native hops vs 0.2 full-walk fetches)
+            if let Some(f) = &cell.floor
+                && let Some(fb) = &f.fallback_02
+            {
+                entries.push(Headline {
+                    metric: "floor_multiplier".to_string(),
+                    corpus: corpus.clone(),
+                    scale: scale_n,
+                    native: f.hops_mean.unwrap_or(0.0),
+                    native_unit: "hops".to_string(),
+                    fallback: fb.fetches.map(|x| x as f64),
+                    fallback_unit: "fetches".to_string(),
+                    multiplier: fb.multiplier,
+                    reason_if_null: fb.reason_if_null.clone(),
+                });
+            }
+            // range @ 10% window
+            if let Some(r) = &cell.range
+                && let Some(w) = r.windows.iter().find(|w| (w.w - 0.10).abs() < 1e-9)
+            {
+                entries.push(Headline {
+                    metric: "range_multiplier_w0.10".to_string(),
+                    corpus: corpus.clone(),
+                    scale: scale_n,
+                    native: w.fetch_count.unwrap_or(0) as f64,
+                    native_unit: "fetches".to_string(),
+                    fallback: w.fallback_02_fetches.map(|x| x as f64),
+                    fallback_unit: "fetches".to_string(),
+                    multiplier: w.multiplier,
+                    reason_if_null: w.reason_if_null.clone(),
+                });
+            }
+            // listing fair multiplier
+            if let Some(l) = &cell.listing {
+                entries.push(Headline {
+                    metric: "listing_fair_multiplier".to_string(),
+                    corpus: corpus.clone(),
+                    scale: scale_n,
+                    native: l.fetch_count.unwrap_or(0) as f64,
+                    native_unit: "fetches".to_string(),
+                    fallback: l.fallback_02_walk_from.as_ref().map(|k| k.fetches as f64),
+                    fallback_unit: "fetches (walk_from)".to_string(),
+                    multiplier: l.multiplier_fair,
+                    reason_if_null: (l.multiplier_fair.is_none()).then(|| NOT_RUN.to_string()),
+                });
+            }
+            // build-scale ceiling: 1.0 frontier vs 0.2 (absent above cap)
+            if let Some(b) = &cell.build {
+                let peer_ran = c02
+                    .get(corpus)
+                    .and_then(|bl| bl.scales.get(scale))
+                    .is_some_and(|c| c.ran);
+                let peer_frontier = c02
+                    .get(corpus)
+                    .and_then(|bl| bl.scales.get(scale))
+                    .and_then(|c| c.build.as_ref())
+                    .and_then(|bb| bb.builder_frontier_nodes);
+                entries.push(Headline {
+                    metric: "build_frontier_nodes".to_string(),
+                    corpus: corpus.clone(),
+                    scale: scale_n,
+                    native: b.builder_frontier_nodes.unwrap_or(0) as f64,
+                    native_unit: "open nodes (O(depth))".to_string(),
+                    fallback: peer_frontier.map(|x| x as f64),
+                    fallback_unit: "resident nodes (O(N))".to_string(),
+                    multiplier: match (b.builder_frontier_nodes, peer_frontier) {
+                        (Some(nat), Some(pf)) if nat > 0 => Some(pf as f64 / nat as f64),
+                        _ => None,
+                    },
+                    reason_if_null: (!peer_ran).then(|| NOT_RUN.to_string()),
+                });
+            }
+        }
+    }
+    Headlines {
+        notes: "Every multiplier is native-vs-0.2-fallback at a scale where BOTH ran; where 0.2 did not run the fallback is null with reason. Units are store fetches (hardware-independent) or hop counts, never wall-clock.".to_string(),
+        entries,
+    }
+}
+
+/// One capability-matrix row as fixed data: see [`CapabilityRow`] for fields.
+type Row = (
+    u32,
+    &'static str,
+    bool,
+    Option<&'static str>,
+    &'static str,
+    bool,
+    Option<&'static str>,
+    &'static str,
+    Option<&'static str>,
+    Option<&'static str>,
+    &'static str,
+);
+
+fn cap(r: Row) -> CapabilityRow {
+    CapabilityRow {
+        n: r.0,
+        op: r.1.to_string(),
+        v1_supported: r.2,
+        v1_api: r.3.map(str::to_string),
+        v1_class: r.4.to_string(),
+        v02_supported: r.5,
+        v02_api: r.6.map(str::to_string),
+        v02_class: r.7.to_string(),
+        v02_fallback: r.8.map(str::to_string),
+        v02_asymptote: r.9.map(str::to_string),
+        notes: r.10.to_string(),
+    }
+}
+
+/// The exhaustive op x format capability matrix (fixed API facts verified on
+/// the source tree at build time).
+fn capability_matrix() -> Vec<CapabilityRow> {
+    const ROWS: [Row; 20] = [
+        (
+            1,
+            "build-from-scratch",
+            true,
+            Some("Builder::insert+build"),
+            "native",
+            true,
+            Some("Manifest::new+add*+save"),
+            "native",
+            None,
+            Some("O(N) RAM"),
+            "1.0 frontier O(depth) (peak_open_nodes ~6..11); 0.2 holds whole trie -> O(N) RAM, ran:false at 1e6.",
+        ),
+        (
+            2,
+            "build_files",
+            true,
+            Some("build_files(store, iter)"),
+            "native",
+            false,
+            None,
+            "fallback",
+            Some("hand-rolled BMT loop + add-loop + save"),
+            Some("O(N)"),
+            "1.0 one-call ingest; 0.2 dev writes the loop.",
+        ),
+        (
+            3,
+            "get",
+            true,
+            Some("Reader::get"),
+            "seek",
+            true,
+            Some("Manifest::get"),
+            "seek",
+            None,
+            Some("O(depth)"),
+            "Both O(depth) hop-counted descent.",
+        ),
+        (
+            4,
+            "has/contains",
+            true,
+            Some("get(...).is_some()"),
+            "seek",
+            true,
+            Some("get(...).is_some()"),
+            "seek",
+            None,
+            Some("O(depth)"),
+            "Neither ships a dedicated has; equal.",
+        ),
+        (
+            5,
+            "folder-exists",
+            true,
+            Some("prefix(p).next().is_some()"),
+            "seek",
+            true,
+            Some("Manifest::has_prefix"),
+            "seek",
+            None,
+            Some("O(depth)"),
+            "0.2 has the only named prefix-existence probe; cost equal.",
+        ),
+        (
+            6,
+            "floor",
+            true,
+            Some("Reader::floor"),
+            "seek",
+            false,
+            None,
+            "unsupported",
+            Some("entries() full walk + client scan"),
+            Some("O(N)"),
+            "HARD 0.2 gap; multiplier measured per cell (floor.fallback_02).",
+        ),
+        (
+            7,
+            "ceiling",
+            true,
+            Some("range(key, MAX).next()"),
+            "seek",
+            false,
+            None,
+            "unsupported",
+            Some("entries() full walk + client scan"),
+            Some("O(N)"),
+            "Soft gap in both (neither names it); 1.0 emulates by seek O(depth), 0.2 pays O(N).",
+        ),
+        (
+            8,
+            "range",
+            true,
+            Some("Reader::range / Cursor"),
+            "seek",
+            false,
+            None,
+            "unsupported",
+            Some("entries() full walk + filter"),
+            Some("O(N)"),
+            "HARD 0.2 gap; selectivity sweep in range.windows.",
+        ),
+        (
+            9,
+            "prefix-scan / listing",
+            true,
+            Some("prefix / folder::list"),
+            "native",
+            true,
+            Some("walk_from(prefix) or entries()"),
+            "partial",
+            Some("walk_from = O(subtree); entries = O(N); no ordered seek"),
+            Some("O(subtree)"),
+            "1.0 embeds children; fair multiplier in listing.multiplier_fair.",
+        ),
+        (
+            10,
+            "ordered iter (full)",
+            true,
+            Some("Cursor::iter"),
+            "native",
+            false,
+            Some("entries() (DFS, unguaranteed)"),
+            "partial",
+            Some("materialise all N then maybe sort"),
+            Some("O(N) mem"),
+            "1.0 first key after O(depth); 0.2 after loading everything; entries_concurrent unordered.",
+        ),
+        (
+            11,
+            "serve / website-view",
+            true,
+            Some("Reader::serve + website()"),
+            "native",
+            false,
+            Some("index_document/error_document"),
+            "partial",
+            Some("client re-implements exact->index->error via repeated get"),
+            Some("O(depth) per probe"),
+            "Site metadata in both; resolver is 1.0-only.",
+        ),
+        (
+            12,
+            "single-key insert",
+            true,
+            Some("apply(Changeset{put})"),
+            "native",
+            true,
+            Some("add+save"),
+            "native",
+            None,
+            None,
+            "1.0 CoW new root; 0.2 reseals touched spine.",
+        ),
+        (
+            13,
+            "single-key update",
+            true,
+            Some("apply(Changeset{put})"),
+            "native",
+            true,
+            Some("add(overwrite)+save"),
+            "native",
+            None,
+            None,
+            "1.0 rewrites more spine per isolated edit; batch reverses it.",
+        ),
+        (
+            14,
+            "single-key remove",
+            true,
+            Some("apply(Changeset{remove})"),
+            "native",
+            true,
+            Some("remove+save"),
+            "native",
+            None,
+            None,
+            "Plus collapse cost (update.subtree_delete).",
+        ),
+        (
+            15,
+            "batch apply(changeset)",
+            true,
+            Some("apply(store, root, Changeset)"),
+            "native",
+            false,
+            Some("K add/remove + one save"),
+            "fallback",
+            Some("O(K*depth) in-RAM mutations + reseal; no declarative delta"),
+            Some("O(K*depth)"),
+            "1.0 batch write-amp far lower; the amortisation story (update.batch_sweep).",
+        ),
+        (
+            16,
+            "metadata read/write",
+            true,
+            Some("Metadata<KeyId/CustomKey>"),
+            "native",
+            true,
+            Some("add_with_metadata (BTreeMap)"),
+            "native",
+            None,
+            None,
+            "0.2 arbitrary map -> dedup hazard; 1.0 typed TLV canonical.",
+        ),
+        (
+            17,
+            "inline values",
+            true,
+            Some("Entry::Inline (<=128B)"),
+            "native",
+            false,
+            None,
+            "unsupported",
+            Some("store a content chunk + 1 extra fetch/read"),
+            Some("O(1) extra"),
+            "HARD 1.0-only; not exercised here (synthetic ref32 values).",
+        ),
+        (
+            18,
+            "referenced values (ref32)",
+            true,
+            Some("Entry::Ref32"),
+            "native",
+            true,
+            Some("ChunkRef"),
+            "native",
+            None,
+            None,
+            "Both; the exercised value model.",
+        ),
+        (
+            19,
+            "encrypted refs (ref64)",
+            true,
+            Some("Entry::Ref64 + EncryptedNode"),
+            "native",
+            true,
+            Some("EncryptedManifest / new_encrypted"),
+            "native",
+            None,
+            None,
+            "Both; harness exercises ref32 only.",
+        ),
+        (
+            20,
+            "recanonicalise / history-independence",
+            true,
+            Some("recanonicalize(); apply==rebuild (I6)"),
+            "native",
+            false,
+            None,
+            "unsupported",
+            Some("cannot verify; obfuscation-key randomisation defeats dedup"),
+            None,
+            "1.0 proves dedup-stability (dedup_ratio_second_build); 0.2 cannot.",
+        ),
+    ];
+    ROWS.into_iter().map(cap).collect()
+}
+
+fn caveats() -> Vec<String> {
+    vec![
+        "hops->wall-clock latency is a stated model (hops x {25,50,75}ms, sequential, no pipelining/caching); FETCH COUNT is the hardware-independent truth, wall-ms illustrative only (derived_from_hops:true).".to_string(),
+        "Single-key update looks cheaper on 0.2 in isolation but 1.0 wins the amortised/batch path and is history-independent; never read single-update without the batch_sweep beside it.".to_string(),
+        "floor native hops are O(depth) but with a large N-growing constant (rightmost-spine fallback descent), far higher than a point get; shown as their own series.".to_string(),
+        "Listing multiplier_fair uses walk_from on identical prefixes (apples-to-apples); fallback_02_full_entries is the pessimal whole-map walk kept for reference.".to_string(),
+        "peak_rss_bytes is cumulative process VmHWM (monotone, dirty across cells); use peak_live_store_bytes for per-cell memory.".to_string(),
+        "0.2 at N=1e6 is ran:false (O(N)-RAM full-trie build outside budget); every 1e6 multiplier is null with reason. The absence IS the build-scale-ceiling finding.".to_string(),
+        "build wall_ns is a single cold pass (includes RSS sampling); criterion_ns_per_op is a warm multi-iter mean present only for some cells; cpu_loglog is fit over wall_ns and is indicative, not a precise asymptote.".to_string(),
+        "Corpus dependence is large; never quote a headline number without its corpus (uniform is the zero-prefix-sharing control).".to_string(),
+        "Value/metadata model is synthetic (ref32 = sha256(b\"val\"||key)); value-layer figures describe manifest structure, not real payload entropy; inline study not exercised.".to_string(),
+        "0.2 entries() DFS order is not a guaranteed ordered-iter API; any order is incidental and unseekable (ordered_guaranteed:false).".to_string(),
+        "cpu_loglog fits use few points (2-4 scales); treat slopes as indicative with the reported r2 and n_points.".to_string(),
+    ]
+}
+
 fn main() -> Result<(), Box<dyn Error>> {
     let args = parse_args();
     let c = cfg();
@@ -146,14 +685,6 @@ fn main() -> Result<(), Box<dyn Error>> {
             CorpusBlock { scales: scales_map },
         );
     }
-    formats.insert(
-        F10.to_string(),
-        FormatBlock {
-            crate_name: "nectar-manifest".to_string(),
-            registry: "StandardChunkSet".to_string(),
-            corpora: corpora10,
-        },
-    );
 
     // --- mantaray 0.2 ---
     let mut corpora02: BTreeMap<String, CorpusBlock> = BTreeMap::new();
@@ -183,6 +714,21 @@ fn main() -> Result<(), Box<dyn Error>> {
             CorpusBlock { scales: scales_map },
         );
     }
+    // Cross-fill 1.0-only op fallback costs + multipliers from the matching 0.2
+    // cell (both must have run), and fit CPU log-log slopes per (format,corpus).
+    cross_fill(&mut corpora10, &corpora02);
+    fit_loglog(&mut corpora10);
+    fit_loglog(&mut corpora02);
+    let headlines = build_headlines(&corpora10, &corpora02);
+
+    formats.insert(
+        F10.to_string(),
+        FormatBlock {
+            crate_name: "nectar-manifest".to_string(),
+            registry: "StandardChunkSet".to_string(),
+            corpora: corpora10,
+        },
+    );
     formats.insert(
         F02.to_string(),
         FormatBlock {
@@ -196,17 +742,27 @@ fn main() -> Result<(), Box<dyn Error>> {
         generated: now_iso(),
         git_branch: git(&["rev-parse", "--abbrev-ref", "HEAD"]),
         git_commit: git(&["rev-parse", "HEAD"]),
-        harness_version: "1".to_string(),
+        harness_version: "2".to_string(),
         seed_master: format!("0x{:016x}", corpus::MASTER_SEED),
         rtt_ms: c.rtt_ms,
+        rtt_ms_set: vec![25, 50, 75],
+        batch_k_sweep: vec![1, 10, 100, 1_000, 10_000],
+        range_windows: vec![0.001, 0.01, 0.10, 1.0],
+        value_read_corpus: "not_exercised (synthetic ref32 values)".to_string(),
         chunk_body_size: 4096,
         criterion_iters_note: "means from target/criterion/*/new/estimates.json".to_string(),
         sample_keys: c.sample_keys as u32,
         update_sample: c.update_sample as u32,
         batch_ops: c.batch_ops as u32,
+        caveats: caveats(),
     };
 
-    let doc = Document { meta, formats };
+    let doc = Document {
+        meta,
+        capability_matrix: capability_matrix(),
+        headlines,
+        formats,
+    };
     let json = serde_json::to_string_pretty(&doc)?;
     if let Some(parent) = args.out.parent() {
         std::fs::create_dir_all(parent)?;

--- a/crates/manifest-sim/src/bin/manifest_sim.rs
+++ b/crates/manifest-sim/src/bin/manifest_sim.rs
@@ -1,0 +1,217 @@
+//! Drive the harness across every `(format, corpus, scale)` and write one JSON
+//! result document. Every number is measured; unruns are `ran:false` + reason.
+
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use nectar_manifest_sim::corpus::{self, Corpus};
+use nectar_manifest_sim::criterion_fold;
+use nectar_manifest_sim::measure::{self, Cfg};
+use nectar_manifest_sim::results::{Cell, CorpusBlock, Document, FormatBlock, Meta};
+
+const DEFAULT_OUT: &str = "/home/mfw78/.claude/jobs/ba6b8d73/tmp/manifest-sim-results.json";
+const F10: &str = "mantaray_1_0";
+const F02: &str = "mantaray_0_2";
+
+struct Args {
+    out: PathBuf,
+    criterion_base: PathBuf,
+    scales: Vec<u64>,
+    max_02_scale: u64,
+}
+
+fn parse_args() -> Args {
+    let mut out = PathBuf::from(DEFAULT_OUT);
+    let mut criterion_base = PathBuf::from("target");
+    let mut scales = vec![1_000u64, 10_000, 100_000, 1_000_000];
+    let mut max_02_scale = 100_000u64;
+    let mut it = std::env::args().skip(1);
+    while let Some(a) = it.next() {
+        match a.as_str() {
+            "--out" => {
+                if let Some(v) = it.next() {
+                    out = PathBuf::from(v);
+                }
+            }
+            "--criterion-base" => {
+                if let Some(v) = it.next() {
+                    criterion_base = PathBuf::from(v);
+                }
+            }
+            "--scales" => {
+                if let Some(v) = it.next() {
+                    scales = v.split(',').filter_map(|s| s.trim().parse().ok()).collect();
+                }
+            }
+            "--max-02-scale" => {
+                if let Some(v) = it.next()
+                    && let Ok(n) = v.parse()
+                {
+                    max_02_scale = n;
+                }
+            }
+            _ => {}
+        }
+    }
+    Args {
+        out,
+        criterion_base,
+        scales,
+        max_02_scale,
+    }
+}
+
+fn git(args: &[&str]) -> String {
+    Command::new("git")
+        .args(args)
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_default()
+}
+
+fn now_iso() -> String {
+    // Wall-clock via `date -u`; harness metadata only.
+    Command::new("date")
+        .args(["-u", "+%Y-%m-%dT%H:%M:%SZ"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_default()
+}
+
+fn cfg() -> Cfg {
+    Cfg {
+        sample_keys: 10_000,
+        update_sample: 48,
+        batch_ops: 10_000,
+        rtt_ms: 25,
+    }
+}
+
+fn fold_into(cell: &mut Cell, base: &Path, format: &str, corpus_name: &str, scale: u64) {
+    if let Some(b) = &mut cell.build
+        && let Some(e) = criterion_fold::load(base, "build", format, corpus_name, scale)
+    {
+        b.criterion_ns_per_op = Some(e.mean_ns);
+        b.criterion_stddev_ns = Some(e.stddev_ns);
+    }
+    if let Some(g) = &mut cell.get
+        && let Some(e) = criterion_fold::load(base, "get", format, corpus_name, scale)
+    {
+        g.criterion_ns_per_op = Some(e.mean_ns);
+    }
+    if let Some(u) = &mut cell.update
+        && let Some(s) = &mut u.single
+        && let Some(e) = criterion_fold::load(base, "apply", format, corpus_name, scale)
+    {
+        s.criterion_ns_per_op = Some(e.mean_ns);
+    }
+}
+
+fn skipped_cell(reason: &str, n: u64, encoding: &str) -> Cell {
+    Cell {
+        ran: false,
+        reason: Some(reason.to_string()),
+        n_keys: Some(n),
+        key_encoding: Some(encoding.to_string()),
+        ..Cell::default()
+    }
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let args = parse_args();
+    let c = cfg();
+
+    let mut formats: BTreeMap<String, FormatBlock> = BTreeMap::new();
+
+    // --- mantaray 1.0 ---
+    let mut corpora10: BTreeMap<String, CorpusBlock> = BTreeMap::new();
+    for corpus in Corpus::all() {
+        let mut scales_map: BTreeMap<String, Cell> = BTreeMap::new();
+        for &scale in &args.scales {
+            let n = scale as usize;
+            eprintln!("[1.0] {} n={}", corpus.name(), n);
+            let keys = corpus::generate(corpus, n);
+            let mut cell = measure::measure_10(corpus, &keys, c)?;
+            fold_into(&mut cell, &args.criterion_base, F10, corpus.name(), scale);
+            scales_map.insert(scale.to_string(), cell);
+        }
+        corpora10.insert(
+            corpus.name().to_string(),
+            CorpusBlock { scales: scales_map },
+        );
+    }
+    formats.insert(
+        F10.to_string(),
+        FormatBlock {
+            crate_name: "nectar-manifest".to_string(),
+            registry: "StandardChunkSet".to_string(),
+            corpora: corpora10,
+        },
+    );
+
+    // --- mantaray 0.2 ---
+    let mut corpora02: BTreeMap<String, CorpusBlock> = BTreeMap::new();
+    for corpus in Corpus::all() {
+        let mut scales_map: BTreeMap<String, Cell> = BTreeMap::new();
+        for &scale in &args.scales {
+            let n = scale as usize;
+            if scale > args.max_02_scale {
+                scales_map.insert(
+                    scale.to_string(),
+                    skipped_cell(
+                        "0.2 build not run: O(N)-RAM full-trie build outside harness wall-clock budget at this scale",
+                        scale,
+                        corpus.key_encoding(),
+                    ),
+                );
+                continue;
+            }
+            eprintln!("[0.2] {} n={}", corpus.name(), n);
+            let keys = corpus::generate(corpus, n);
+            let mut cell = measure::measure_02(corpus, &keys, c)?;
+            fold_into(&mut cell, &args.criterion_base, F02, corpus.name(), scale);
+            scales_map.insert(scale.to_string(), cell);
+        }
+        corpora02.insert(
+            corpus.name().to_string(),
+            CorpusBlock { scales: scales_map },
+        );
+    }
+    formats.insert(
+        F02.to_string(),
+        FormatBlock {
+            crate_name: "nectar-mantaray".to_string(),
+            registry: "AnyChunkSet<4096>".to_string(),
+            corpora: corpora02,
+        },
+    );
+
+    let meta = Meta {
+        generated: now_iso(),
+        git_branch: git(&["rev-parse", "--abbrev-ref", "HEAD"]),
+        git_commit: git(&["rev-parse", "HEAD"]),
+        harness_version: "1".to_string(),
+        seed_master: format!("0x{:016x}", corpus::MASTER_SEED),
+        rtt_ms: c.rtt_ms,
+        chunk_body_size: 4096,
+        criterion_iters_note: "means from target/criterion/*/new/estimates.json".to_string(),
+        sample_keys: c.sample_keys as u32,
+        update_sample: c.update_sample as u32,
+        batch_ops: c.batch_ops as u32,
+    };
+
+    let doc = Document { meta, formats };
+    let json = serde_json::to_string_pretty(&doc)?;
+    if let Some(parent) = args.out.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&args.out, json.as_bytes())?;
+    eprintln!("wrote {} ({} bytes)", args.out.display(), json.len());
+    Ok(())
+}

--- a/crates/manifest-sim/src/corpus.rs
+++ b/crates/manifest-sim/src/corpus.rs
@@ -1,0 +1,327 @@
+//! Deterministic, seeded corpus generators shaped like the calibration traces.
+//!
+//! Master seed `0x6d616e7472617931`. Per-corpus stream seed is
+//! `sha256(master_le || corpus_name)`; a per-index block is
+//! `sha256(stream_seed || u64le(i))`, extended with a counter when a single
+//! index needs more than 32 bytes. Keys are generated then sorted, so the
+//! published set is order-independent. Values are ref32 addresses derived as
+//! `sha256(b"val" || key_bytes)`.
+//!
+//! Each corpus yields a logical key that both formats express: 1.0 takes raw
+//! key bytes; 0.2 needs a UTF-8 `&str`, so uniform binary keys are lowercase
+//! hex (the ACT hex pattern) while path corpora are byte-identical in both.
+
+use std::collections::BTreeSet;
+
+use sha2::{Digest, Sha256};
+
+/// Master seed, little-endian.
+pub const MASTER_SEED: u64 = 0x6d61_6e74_7261_7931;
+
+/// A generated key with both format encodings and optional content type.
+#[derive(Clone, Debug)]
+pub struct GenKey {
+    /// Raw key bytes fed to mantaray 1.0.
+    pub raw: Vec<u8>,
+    /// UTF-8 path fed to mantaray 0.2 (hex of `raw` for the uniform corpus).
+    pub path: String,
+    /// Content-type metadata value, when the corpus carries it.
+    pub content_type: Option<&'static str>,
+}
+
+impl GenKey {
+    /// Whether the 0.2 path is a byte-identical view of the 1.0 raw key.
+    #[must_use]
+    pub fn encodings_match(&self) -> bool {
+        self.raw.as_slice() == self.path.as_bytes()
+    }
+}
+
+/// The four corpora.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Corpus {
+    /// Zero-prefix-sharing control: 32 raw bytes per key.
+    Uniform,
+    /// Deep '/'-separated article paths with heavy prefix sharing.
+    Kiwix,
+    /// Full tile pyramid `z/x/y`.
+    OsmPyramid,
+    /// Bounding-box tile region `z/x/y` (contiguous runs).
+    OsmBbox,
+}
+
+impl Corpus {
+    /// The JSON key for this corpus.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Uniform => "uniform",
+            Self::Kiwix => "kiwix",
+            Self::OsmPyramid => "osm_pyramid",
+            Self::OsmBbox => "osm_bbox",
+        }
+    }
+
+    /// Whether the 0.2 key encoding is `hex` (uniform) or `raw` (paths).
+    #[must_use]
+    pub const fn key_encoding(self) -> &'static str {
+        match self {
+            Self::Uniform => "hex",
+            _ => "raw",
+        }
+    }
+
+    /// All four corpora.
+    #[must_use]
+    pub const fn all() -> [Self; 4] {
+        [Self::Uniform, Self::Kiwix, Self::OsmPyramid, Self::OsmBbox]
+    }
+}
+
+fn sha256(parts: &[&[u8]]) -> [u8; 32] {
+    let mut h = Sha256::new();
+    for p in parts {
+        h.update(p);
+    }
+    h.finalize().into()
+}
+
+/// Per-corpus stream seed.
+fn stream_seed(corpus: Corpus) -> [u8; 32] {
+    sha256(&[&MASTER_SEED.to_le_bytes(), corpus.name().as_bytes()])
+}
+
+/// A deterministic byte stream for index `i`: concatenated sha256 blocks so a
+/// single index can furnish more than 32 bytes of entropy.
+struct IdxStream {
+    seed: [u8; 32],
+    idx: u64,
+    block: [u8; 32],
+    ctr: u32,
+    pos: usize,
+}
+
+impl IdxStream {
+    fn new(seed: [u8; 32], idx: u64) -> Self {
+        let block = sha256(&[&seed, &idx.to_le_bytes(), &0u32.to_le_bytes()]);
+        Self {
+            seed,
+            idx,
+            block,
+            ctr: 0,
+            pos: 0,
+        }
+    }
+
+    fn next_byte(&mut self) -> u8 {
+        if self.pos == 32 {
+            self.ctr = self.ctr.wrapping_add(1);
+            self.block = sha256(&[&self.seed, &self.idx.to_le_bytes(), &self.ctr.to_le_bytes()]);
+            self.pos = 0;
+        }
+        let b = self.block[self.pos];
+        self.pos += 1;
+        b
+    }
+}
+
+/// A tagged deterministic address over a key's bytes: `sha256(tag || key)`.
+#[must_use]
+pub fn tagged_addr(tag: &[u8], key_bytes: &[u8]) -> [u8; 32] {
+    sha256(&[tag, key_bytes])
+}
+
+/// The ref32 value address for a key's bytes: `sha256(b"val" || key)`.
+#[must_use]
+pub fn value_addr(key_bytes: &[u8]) -> [u8; 32] {
+    tagged_addr(b"val", key_bytes)
+}
+
+fn to_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        s.push(HEX[usize::from(b >> 4)] as char);
+        s.push(HEX[usize::from(b & 0x0f)] as char);
+    }
+    s
+}
+
+/// Generate exactly `n` keys of `corpus`, sorted by raw bytes.
+#[must_use]
+pub fn generate(corpus: Corpus, n: usize) -> Vec<GenKey> {
+    match corpus {
+        Corpus::Uniform => uniform(n),
+        Corpus::Kiwix => kiwix(n),
+        Corpus::OsmPyramid => osm_pyramid(n),
+        Corpus::OsmBbox => osm_bbox(n),
+    }
+}
+
+fn uniform(n: usize) -> Vec<GenKey> {
+    let seed = stream_seed(Corpus::Uniform);
+    let mut set: BTreeSet<[u8; 32]> = BTreeSet::new();
+    let mut i: u64 = 0;
+    while set.len() < n {
+        let block = sha256(&[&seed, &i.to_le_bytes()]);
+        set.insert(block);
+        i += 1;
+    }
+    set.into_iter()
+        .take(n)
+        .map(|raw| GenKey {
+            path: to_hex(&raw),
+            raw: raw.to_vec(),
+            content_type: None,
+        })
+        .collect()
+}
+
+const KIWIX_ALPHABET: &[u8; 36] = b"abcdefghijklmnopqrstuvwxyz0123456789";
+const KIWIX_NAMESPACES: [&str; 4] = ["A/", "M/", "-/", "I/"];
+const KIWIX_EXTS: [&str; 3] = [".html", ".png", ".css"];
+const KIWIX_MIMES: [&str; 3] = ["text/html", "image/png", "text/css"];
+
+fn kiwix(n: usize) -> Vec<GenKey> {
+    let seed = stream_seed(Corpus::Kiwix);
+    // Order-of-emission list for prefix reuse, then dedup+sort at the end.
+    let mut emitted: Vec<(String, &'static str)> = Vec::with_capacity(n);
+    let mut seen: BTreeSet<String> = BTreeSet::new();
+    let mut i: u64 = 0;
+    while seen.len() < n {
+        let mut s = IdxStream::new(seed, i);
+        i += 1;
+        let b0 = s.next_byte();
+        let b1 = s.next_byte();
+        let b2 = s.next_byte();
+
+        // Namespace by Zipf-ish threshold on b0 (70/15/10/5).
+        let ns = if b0 < 179 {
+            KIWIX_NAMESPACES[0]
+        } else if b0 < 217 {
+            KIWIX_NAMESPACES[1]
+        } else if b0 < 243 {
+            KIWIX_NAMESPACES[2]
+        } else {
+            KIWIX_NAMESPACES[3]
+        };
+
+        let mut path = String::new();
+        // Prefix reuse (prob 0.6) to force shared LCP. The reused span is
+        // trimmed back to a '/' directory boundary so a reused prefix is always
+        // a well-formed directory path: this preserves heavy prefix sharing
+        // while keeping every full key terminal (ends in an extension, never a
+        // '/'), so no key is ever a strict prefix of another. That keeps the
+        // corpus faithful to real hierarchical article paths and avoids the
+        // "file.png/dir" splice artifact.
+        let mut reused = false;
+        if b1 < 154 && !emitted.is_empty() {
+            let pick = (usize::from(b2) << 8 | usize::from(s.next_byte())) % emitted.len();
+            let k = 4 + usize::from(s.next_byte()) % 20;
+            let src = &emitted[pick].0;
+            let take = k.min(src.len());
+            // Trim back to the last '/' within the first `take` bytes.
+            if let Some(pos) = src.as_bytes()[..take].iter().rposition(|&c| c == b'/') {
+                path.push_str(&src[..=pos]);
+                reused = true;
+            }
+        }
+        if !reused {
+            path.push_str(ns);
+        }
+
+        let segs = 1 + usize::from(s.next_byte()) % 3;
+        for seg in 0..segs {
+            if !path.is_empty() && !path.ends_with('/') {
+                path.push('/');
+            }
+            let len = 3 + usize::from(s.next_byte()) % 22;
+            for _ in 0..len {
+                let c = KIWIX_ALPHABET[usize::from(s.next_byte()) % 36];
+                path.push(c as char);
+            }
+            let _ = seg;
+        }
+        let ext_pick = usize::from(s.next_byte()) % 3;
+        path.push_str(KIWIX_EXTS[ext_pick]);
+        let mime = KIWIX_MIMES[ext_pick];
+
+        if seen.insert(path.clone()) {
+            emitted.push((path, mime));
+        }
+    }
+
+    let mut out: Vec<GenKey> = emitted
+        .into_iter()
+        .map(|(path, mime)| GenKey {
+            raw: path.clone().into_bytes(),
+            path,
+            content_type: Some(mime),
+        })
+        .collect();
+    out.sort_by(|a, b| a.raw.cmp(&b.raw));
+    out
+}
+
+fn ascii_key(z: u32, x: u64, y: u64) -> GenKey {
+    let path = format!("{z}/{x}/{y}");
+    GenKey {
+        raw: path.clone().into_bytes(),
+        path,
+        content_type: None,
+    }
+}
+
+fn osm_pyramid(n: usize) -> Vec<GenKey> {
+    let mut out: Vec<GenKey> = Vec::with_capacity(n);
+    let mut z: u32 = 0;
+    while out.len() < n {
+        let side: u64 = 1u64 << z;
+        for x in 0..side {
+            for y in 0..side {
+                if out.len() == n {
+                    break;
+                }
+                out.push(ascii_key(z, x, y));
+            }
+            if out.len() == n {
+                break;
+            }
+        }
+        z += 1;
+        if z > 40 {
+            break;
+        }
+    }
+    out.sort_by(|a, b| a.raw.cmp(&b.raw));
+    out
+}
+
+fn osm_bbox(n: usize) -> Vec<GenKey> {
+    // Germany-like contiguous window: x in [0.51,0.55], y in [0.33,0.40].
+    let mut out: Vec<GenKey> = Vec::with_capacity(n);
+    for z in 0..=15u32 {
+        let side: f64 = (1u64 << z) as f64;
+        let x_lo = (0.51 * side) as u64;
+        let x_hi = (0.55 * side).ceil() as u64;
+        let y_lo = (0.33 * side) as u64;
+        let y_hi = (0.40 * side).ceil() as u64;
+        for x in x_lo..x_hi.max(x_lo + 1).min(1u64 << z) {
+            for y in y_lo..y_hi.max(y_lo + 1).min(1u64 << z) {
+                if out.len() == n {
+                    break;
+                }
+                out.push(ascii_key(z, x, y));
+            }
+            if out.len() == n {
+                break;
+            }
+        }
+        if out.len() == n {
+            break;
+        }
+    }
+    out.sort_by(|a, b| a.raw.cmp(&b.raw));
+    out.truncate(n);
+    out
+}

--- a/crates/manifest-sim/src/criterion_fold.rs
+++ b/crates/manifest-sim/src/criterion_fold.rs
@@ -1,0 +1,41 @@
+//! Read criterion's `estimates.json` and fold mean/stddev ns-per-op into the
+//! result cells. Criterion writes
+//! `target/criterion/<group>/<id>/new/estimates.json` where the flat id is
+//! `<format>__<corpus>__<scale>`; a missing file means that timed cell was not
+//! benched and stays null.
+
+use std::path::Path;
+
+/// The mean point estimate (ns) and std-dev point estimate (ns) for a timed
+/// benchmark, if criterion produced one.
+#[derive(Clone, Copy, Debug)]
+pub struct Estimate {
+    pub mean_ns: f64,
+    pub stddev_ns: f64,
+}
+
+/// The flat benchmark id shared by the bench target and the fold reader.
+#[must_use]
+pub fn bench_id(format: &str, corpus: &str, scale: u64) -> String {
+    format!("{format}__{corpus}__{scale}")
+}
+
+/// Load an estimate for a `(group, format, corpus, scale)` benchmark id.
+#[must_use]
+pub fn load(base: &Path, group: &str, format: &str, corpus: &str, scale: u64) -> Option<Estimate> {
+    let path = base
+        .join("criterion")
+        .join(group)
+        .join(bench_id(format, corpus, scale))
+        .join("new")
+        .join("estimates.json");
+    let text = std::fs::read_to_string(&path).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&text).ok()?;
+    let mean_ns = value.get("mean")?.get("point_estimate")?.as_f64()?;
+    let stddev_ns = value
+        .get("std_dev")
+        .and_then(|v| v.get("point_estimate"))
+        .and_then(serde_json::Value::as_f64)
+        .unwrap_or(0.0);
+    Some(Estimate { mean_ns, stddev_ns })
+}

--- a/crates/manifest-sim/src/lib.rs
+++ b/crates/manifest-sim/src/lib.rs
@@ -1,0 +1,13 @@
+//! Empirical performance harness: mantaray 1.0 (`nectar-manifest`) vs mantaray
+//! 0.2 (`nectar-mantaray`), both run as plain (ref32) readers+writers over one
+//! shared instrumented in-memory chunk store.
+//!
+//! The public surface is the corpus generators, the `CountingStore`, the
+//! per-cell measurement functions and the result schema; the bin drives them
+//! across every `(format, corpus, scale)` and writes one JSON document.
+
+pub mod corpus;
+pub mod criterion_fold;
+pub mod measure;
+pub mod results;
+pub mod store;

--- a/crates/manifest-sim/src/measure.rs
+++ b/crates/manifest-sim/src/measure.rs
@@ -16,14 +16,24 @@ use nectar_primitives::{AnyChunkSet, ChunkAddress, ChunkRef, StandardChunkSet};
 
 use crate::corpus::{Corpus, GenKey, tagged_addr, value_addr};
 use crate::results::{
-    BatchUpdate, Build, Cell, Depth, Floor, Get, Listing, LoadLatency, OpCost, Range, SingleUpdate,
-    Storage, Update,
+    BatchPoint, BatchUpdate, Build, Cdf, Ceiling, Cell, Depth, Floor, Get, Histogram, IterFull,
+    KfCount, LatQuad, Listing, LoadLatency, OpCost, Range, RangeWindow, SingleUpdate, Storage,
+    SubtreeDelete, Update, ValueRead, WallLatency,
 };
 use crate::store::CountingStore;
 
 type Err = Box<dyn Error>;
 
 const BODY: f64 = 4096.0;
+
+/// RTT values (ms) for the hop x RTT illustrative wall-clock model.
+const RTT_SET: [u32; 3] = [25, 50, 75];
+/// Batch-size sweep for the write-amplification amortisation curve.
+const BATCH_KS: [usize; 5] = [1, 10, 100, 1_000, 10_000];
+/// Range-window widths (fraction of the sorted key domain) for the sweep.
+const RANGE_WS: [f64; 4] = [0.001, 0.01, 0.10, 1.0];
+/// A key that sorts strictly above every corpus key (ceiling upper bound).
+const MAX_KEY: [u8; 48] = [0xff; 48];
 
 /// Config knobs shared across cells.
 #[derive(Clone, Copy, Debug)]
@@ -52,6 +62,46 @@ fn pct(sorted: &[u64], p: f64) -> u64 {
     sorted.get(idx).copied().unwrap_or(0)
 }
 
+/// Discrete PMF of a small-integer sample (hops are 1..~150).
+fn histogram(values: &[u64]) -> Histogram {
+    let mut h: Histogram = Histogram::new();
+    for &v in values {
+        *h.entry(v).or_insert(0) += 1;
+    }
+    h
+}
+
+fn cdf(sorted: &[u64]) -> Cdf {
+    Cdf {
+        p50: pct(sorted, 0.50),
+        p90: pct(sorted, 0.90),
+        p99: pct(sorted, 0.99),
+        max: sorted.last().copied().unwrap_or(0),
+    }
+}
+
+/// The hop x RTT illustrative wall-clock model, one quad per RTT.
+fn wall_latency(sorted: &[u64]) -> WallLatency {
+    let c = cdf(sorted);
+    let mut by_rtt = std::collections::BTreeMap::new();
+    for rtt in RTT_SET {
+        let r = f64::from(rtt);
+        by_rtt.insert(
+            rtt.to_string(),
+            LatQuad {
+                p50: c.p50 as f64 * r,
+                p90: c.p90 as f64 * r,
+                p99: c.p99 as f64 * r,
+                max: c.max as f64 * r,
+            },
+        );
+    }
+    WallLatency {
+        by_rtt_ms: by_rtt,
+        model: "hops * rtt, sequential fetch, no pipelining or caching".to_string(),
+    }
+}
+
 fn depth_from(hops: &mut [u64]) -> Depth {
     hops.sort_unstable();
     Depth {
@@ -59,6 +109,8 @@ fn depth_from(hops: &mut [u64]) -> Depth {
         mean: Some(mean(hops)),
         p95: Some(pct(hops, 0.95)),
         max: hops.last().copied(),
+        histogram: Some(histogram(hops)),
+        fanout_mean: None,
     }
 }
 
@@ -81,6 +133,48 @@ fn get_block(hops: &[u64], rtt_ms: u32) -> Get {
             derived_from_hops: true,
         }),
         criterion_ns_per_op: None,
+        hops_histogram: Some(histogram(hops)),
+        hops_cdf: Some(cdf(&sorted)),
+        wall_latency_ms: Some(wall_latency(&sorted)),
+    }
+}
+
+/// Per-key `bytes/key`, `chunks/key`, embedding ratio.
+fn storage_block(snap_chunks: u64, live_bytes: u64, n: u64, embedded: Option<u64>) -> Storage {
+    let total_chunks = snap_chunks;
+    let bpk = if n == 0 {
+        0.0
+    } else {
+        live_bytes as f64 / n as f64
+    };
+    let cpk = if n == 0 {
+        0.0
+    } else {
+        total_chunks as f64 / n as f64
+    };
+    // 0.2 never embeds: caller passes None -> explicit 0.0, not null.
+    let emb = match embedded {
+        Some(e) => {
+            let denom = e + total_chunks;
+            if denom == 0 {
+                0.0
+            } else {
+                e as f64 / denom as f64
+            }
+        }
+        None => 0.0,
+    };
+    Storage {
+        total_chunks: Some(total_chunks),
+        total_payload_bytes: Some(live_bytes),
+        storage_utilisation: Some(if total_chunks == 0 {
+            0.0
+        } else {
+            live_bytes as f64 / (total_chunks as f64 * BODY)
+        }),
+        bytes_per_key: Some(bpk),
+        chunks_per_key: Some(cpk),
+        embedding_ratio: Some(emb),
     }
 }
 
@@ -166,6 +260,30 @@ pub fn measure_10(corpus: Corpus, keys: &[GenKey], cfg: Cfg) -> Result<Cell, Err
     let stats = built.stats();
     let snap = store.snapshot();
 
+    // Second identical build into the same store: by I6 no new distinct chunk
+    // should land. Capped to protect the 1e6 wall-clock budget.
+    let (dedup, dedup_reason) = if n <= 100_000 {
+        let first_distinct = snap.distinct_puts;
+        let before = store.snapshot().distinct_puts;
+        let mut b2 = Builder::<V1>::new();
+        for k in keys {
+            b2.insert(Key::from(k.raw.as_slice()), entry10(&k.raw), meta10(k));
+        }
+        let _ = block_on(b2.build(&store))?;
+        let after = store.snapshot().distinct_puts;
+        let ratio = if first_distinct == 0 {
+            0.0
+        } else {
+            (after - before) as f64 / first_distinct as f64
+        };
+        (Some(ratio), None)
+    } else {
+        (
+            None,
+            Some("second build skipped above 1e5 to bound wall-clock".to_string()),
+        )
+    };
+
     let build = Build {
         wall_ns: Some(build_ns),
         criterion_ns_per_op: None,
@@ -175,17 +293,18 @@ pub fn measure_10(corpus: Corpus, keys: &[GenKey], cfg: Cfg) -> Result<Cell, Err
         nodes_embedded: Some(stats.nodes_embedded() as u64),
         peak_rss_bytes: rss_after.or(rss_before),
         peak_live_store_bytes: Some(snap.peak_live_bytes),
+        builder_frontier_nodes: Some(stats.peak_open_nodes() as u64),
+        cpu_loglog: None,
+        dedup_ratio_second_build: dedup,
+        dedup_reason,
     };
     let total_chunks = snap.total_chunks;
-    let storage = Storage {
-        total_chunks: Some(total_chunks),
-        total_payload_bytes: Some(snap.live_bytes),
-        storage_utilisation: Some(if total_chunks == 0 {
-            0.0
-        } else {
-            snap.live_bytes as f64 / (total_chunks as f64 * BODY)
-        }),
-    };
+    let storage = storage_block(
+        total_chunks,
+        snap.live_bytes,
+        n as u64,
+        Some(stats.nodes_embedded() as u64),
+    );
 
     // --- get hops (== referenced chunk-path depth) over the sample ---
     let reader: Reader<&CountingStore<StandardChunkSet>, V1> = Reader::new(&store);
@@ -224,6 +343,9 @@ pub fn measure_10(corpus: Corpus, keys: &[GenKey], cfg: Cfg) -> Result<Cell, Err
         } else {
             fetch_total as f64 / keys_total as f64
         }),
+        fallback_02_full_entries: None,
+        fallback_02_walk_from: None,
+        multiplier_fair: None,
     };
 
     // --- floor (1.0 only) over the sample ---
@@ -241,37 +363,88 @@ pub fn measure_10(corpus: Corpus, keys: &[GenKey], cfg: Cfg) -> Result<Cell, Err
         hops_mean: Some(mean(&floor_hops)),
         hops_p95: Some(pct(&floor_hops, 0.95)),
         hops_max: floor_hops.last().copied(),
+        hops_histogram: Some(histogram(&floor_hops)),
+        fallback_02: None,
     };
 
-    // --- range (1.0 only): a fixed mid window ---
-    let (range, _) = if n >= 3 {
-        let lo = Key::from(keys[n * 2 / 5].raw.as_slice());
-        let hi = Key::from(keys[n * 3 / 5].raw.as_slice());
+    // --- ceiling (neither format names it): 1.0 emulates by seek, so measure
+    //     the range(key, MAX).next() hop cost per sampled key ---
+    let hi_all = Key::from(MAX_KEY.as_slice());
+    let mut ceil_hops: Vec<u64> = Vec::with_capacity(idxs.len());
+    for &i in &idxs {
+        let key = Key::from(keys[i].raw.as_slice());
+        let before = store.gets();
+        let mut cursor = block_on(reader.range(&root, &key, &hi_all))?;
+        let _ = block_on(cursor.next())?;
+        ceil_hops.push(store.gets() - before);
+    }
+    ceil_hops.sort_unstable();
+    let ceiling = Ceiling {
+        supported: true,
+        class: "seek_emulated".to_string(),
+        native_seek_hops_mean: Some(mean(&ceil_hops)),
+        native_seek_hops_max: ceil_hops.last().copied(),
+        fallback_02: None,
+    };
+
+    // --- range (1.0 only): selectivity sweep of centred windows ---
+    let mut windows: Vec<RangeWindow> = Vec::with_capacity(RANGE_WS.len());
+    for &w in &RANGE_WS {
+        let (lo_i, hi_i) = window_indices(n, w);
+        let lo = Key::from(keys[lo_i].raw.as_slice());
+        let hi = Key::from(keys[hi_i].raw.as_slice());
         let before = store.gets();
         let mut cursor = block_on(reader.range(&root, &lo, &hi))?;
         let mut count = 0u64;
         while let Some(_pair) = block_on(cursor.next())? {
             count += 1;
         }
-        (
-            Range {
-                supported: true,
-                reason: None,
-                fetch_count: Some(store.gets() - before),
-                keys_returned: Some(count),
-            },
-            (),
-        )
-    } else {
-        (
-            Range {
-                supported: true,
-                reason: None,
-                fetch_count: Some(0),
-                keys_returned: Some(0),
-            },
-            (),
-        )
+        windows.push(RangeWindow {
+            w,
+            fetch_count: Some(store.gets() - before),
+            keys_returned: Some(count),
+            fallback_02_fetches: None,
+            multiplier: None,
+            reason_if_null: None,
+        });
+    }
+    let range = Range {
+        supported: true,
+        reason: None,
+        windows,
+    };
+
+    // --- ordered full iter: fetches to first key, then to drain all ---
+    let before = store.gets();
+    let mut it = block_on(reader.iter(&root))?;
+    let _first = block_on(it.next())?;
+    let to_first = store.gets() - before;
+    let mut all = to_first;
+    loop {
+        let g0 = store.gets();
+        if block_on(it.next())?.is_none() {
+            break;
+        }
+        all += store.gets() - g0;
+    }
+    let iter_full = IterFull {
+        native_fetch_to_first_key: Some(to_first),
+        native_fetch_all: Some(all),
+        fallback_02_materialise_fetches: None,
+        ordered_guaranteed: true,
+    };
+
+    // --- value read: this harness binds ref32 values that are never stored as
+    //     content chunks, so a read-through / inline study is not exercised ---
+    let value_read = ValueRead {
+        inline_fraction: None,
+        fetches_native_mean: None,
+        fetches_02_mean: None,
+        chunks_saved_by_inline: None,
+        reason: Some(
+            "values are synthetic ref32 addresses, not stored content chunks; inline read-through not exercised"
+                .to_string(),
+        ),
     };
 
     // --- single-key update / insert / delete (apply, 1-op changeset) ---
@@ -333,6 +506,49 @@ pub fn measure_10(corpus: Corpus, keys: &[GenKey], cfg: Cfg) -> Result<Cell, Err
         criterion_ns_per_op: None,
     };
 
+    // --- batch-size sweep: one changeset per K, same mix ---
+    let mut batch_sweep: Vec<BatchPoint> = Vec::with_capacity(BATCH_KS.len());
+    let mix_label = if all_update { "100/0/0" } else { "80/10/10" };
+    for &k in &BATCH_KS {
+        let kk = n.min(k);
+        let mut cs = Changeset::<V1>::new();
+        for (i, key) in keys.iter().take(kk).enumerate() {
+            let slot = i % 10;
+            if all_update || slot < 8 {
+                cs.put(
+                    Key::from(key.raw.as_slice()),
+                    alt_entry10(&key.raw),
+                    meta10(key),
+                );
+            } else if slot == 8 {
+                let (iraw, _ip) = insert_key(2_000_000 + i);
+                cs.put(Key::from(iraw.as_slice()), entry10(&iraw), None);
+            } else {
+                cs.remove(Key::from(key.raw.as_slice()));
+            }
+        }
+        let before_p = store.puts();
+        let t = Instant::now();
+        let _ = block_on(apply(&store, &root, &cs))?;
+        let ns = t.elapsed().as_nanos() as u64;
+        let chunks = store.puts() - before_p;
+        batch_sweep.push(BatchPoint {
+            k: kk as u64,
+            mix: mix_label.to_string(),
+            chunks_rewritten: chunks,
+            wall_ns: ns,
+            write_amplification: if kk == 0 {
+                0.0
+            } else {
+                chunks as f64 / kk as f64
+            },
+            ns_per_op: if kk == 0 { 0.0 } else { ns as f64 / kk as f64 },
+        });
+    }
+
+    // --- subtree delete: remove every key under one listing prefix ---
+    let subtree_delete = subtree_delete_10(&store, &reader, &root, corpus, keys)?;
+
     let update = Update {
         single: Some(SingleUpdate {
             update: Some(op_cost(&upd)),
@@ -341,6 +557,8 @@ pub fn measure_10(corpus: Corpus, keys: &[GenKey], cfg: Cfg) -> Result<Cell, Err
             criterion_ns_per_op: None,
         }),
         batch: Some(batch),
+        batch_sweep,
+        subtree_delete: Some(subtree_delete),
     };
 
     Ok(Cell {
@@ -354,8 +572,63 @@ pub fn measure_10(corpus: Corpus, keys: &[GenKey], cfg: Cfg) -> Result<Cell, Err
         get: Some(get),
         listing: Some(listing),
         floor: Some(floor),
+        ceiling: Some(ceiling),
         range: Some(range),
+        iter_full: Some(iter_full),
+        value_read: Some(value_read),
         update: Some(update),
+        full_entries_walk_fetches: None,
+    })
+}
+
+/// The `[lo, hi)` sorted-key indices of a centred window of width `w`.
+fn window_indices(n: usize, w: f64) -> (usize, usize) {
+    if n == 0 {
+        return (0, 0);
+    }
+    let width = ((n as f64) * w).round() as usize;
+    let width = width.clamp(1, n);
+    let lo = (n - width) / 2;
+    let hi = (lo + width).min(n - 1);
+    (lo, hi)
+}
+
+/// Delete every key under the first listing prefix in one changeset.
+fn subtree_delete_10(
+    store: &CountingStore<StandardChunkSet>,
+    reader: &Reader<&CountingStore<StandardChunkSet>, V1>,
+    root: &ChunkAddress,
+    corpus: Corpus,
+    keys: &[GenKey],
+) -> Result<SubtreeDelete, Err> {
+    let prefixes = listing_prefixes(corpus, keys);
+    let Some(prefix) = prefixes.first() else {
+        return Ok(SubtreeDelete {
+            prefix_utf8: None,
+            keys_deleted: 0,
+            chunks_rewritten: 0,
+            wall_ns: 0,
+            reason: Some("no prefix available".to_string()),
+        });
+    };
+    let pk = Key::from(prefix.as_slice());
+    let mut cs = Changeset::<V1>::new();
+    let mut deleted = 0u64;
+    let mut cursor = block_on(reader.prefix(root, &pk))?;
+    while let Some((key, _entry)) = block_on(cursor.next())? {
+        cs.remove(key);
+        deleted += 1;
+    }
+    let before_p = store.puts();
+    let t = Instant::now();
+    let _ = block_on(apply(store, root, &cs))?;
+    let ns = t.elapsed().as_nanos() as u64;
+    Ok(SubtreeDelete {
+        prefix_utf8: String::from_utf8(prefix.clone()).ok(),
+        keys_deleted: deleted,
+        chunks_rewritten: store.puts() - before_p,
+        wall_ns: ns,
+        reason: None,
     })
 }
 
@@ -434,6 +707,31 @@ pub fn measure_02(corpus: Corpus, keys: &[GenKey], cfg: Cfg) -> Result<Cell, Err
     let rss_after = peak_rss_bytes();
     let snap = store.snapshot();
 
+    // Second identical build: 0.2 obfuscation randomisation may defeat dedup,
+    // so measure how many new distinct chunks a re-save produces.
+    let (dedup, dedup_reason) = if n <= 100_000 {
+        let first_distinct = snap.distinct_puts;
+        let before = store.snapshot().distinct_puts;
+        let mut m2: PlainManifest<&Store02> = Manifest::new(&store);
+        for k in keys {
+            let r = ref32(value_addr(k.path.as_bytes()));
+            block_on(m2.add(&k.path, r))?;
+        }
+        let _ = block_on(m2.save())?;
+        let after = store.snapshot().distinct_puts;
+        let ratio = if first_distinct == 0 {
+            0.0
+        } else {
+            (after - before) as f64 / first_distinct as f64
+        };
+        (Some(ratio), None)
+    } else {
+        (
+            None,
+            Some("second build skipped above 1e5 to bound wall-clock".to_string()),
+        )
+    };
+
     let build = Build {
         wall_ns: Some(build_ns),
         criterion_ns_per_op: None,
@@ -443,17 +741,15 @@ pub fn measure_02(corpus: Corpus, keys: &[GenKey], cfg: Cfg) -> Result<Cell, Err
         nodes_embedded: None,
         peak_rss_bytes: rss_after.or(rss_before),
         peak_live_store_bytes: Some(snap.peak_live_bytes),
+        // 0.2 holds the whole mutable trie in RAM at save: frontier = O(N).
+        builder_frontier_nodes: Some(snap.distinct_puts),
+        cpu_loglog: None,
+        dedup_ratio_second_build: dedup,
+        dedup_reason,
     };
     let total_chunks = snap.total_chunks;
-    let storage = Storage {
-        total_chunks: Some(total_chunks),
-        total_payload_bytes: Some(snap.live_bytes),
-        storage_utilisation: Some(if total_chunks == 0 {
-            0.0
-        } else {
-            snap.live_bytes as f64 / (total_chunks as f64 * BODY)
-        }),
-    };
+    // 0.2 never embeds children: pass None so embedding_ratio is explicit 0.0.
+    let storage = storage_block(total_chunks, snap.live_bytes, n as u64, None);
 
     // --- get hops over the sample (fresh open, no trie caching) ---
     let reader: PlainManifest<&Store02> = Manifest::open(root, &store);
@@ -466,37 +762,120 @@ pub fn measure_02(corpus: Corpus, keys: &[GenKey], cfg: Cfg) -> Result<Cell, Err
     }
     let get = get_block(&hops, cfg.rtt_ms);
     let mut depth_src = hops.clone();
-    let tree_depth = depth_from(&mut depth_src);
+    let mut tree_depth = depth_from(&mut depth_src);
 
-    // --- listing: full entries() walk fallback (no ordered prefix API) ---
+    // Fanout: mean live children over internal (forked) nodes, via a full walk.
+    let mut fork_sum = 0u64;
+    let mut internal = 0u64;
+    let mut mw: PlainManifest<&Store02> = Manifest::open(root, &store);
+    block_on(mw.walk(&mut |_path, node| {
+        let f = node.forks().len() as u64;
+        if f > 0 {
+            fork_sum += f;
+            internal += 1;
+        }
+        Ok(())
+    }))?;
+    tree_depth.fanout_mean = Some(if internal == 0 {
+        0.0
+    } else {
+        fork_sum as f64 / internal as f64
+    });
+
+    // --- listing: pessimal full entries() walk, plus the FAIR walk_from on the
+    //     same prefixes a 1.0 caller would list ---
     let before = store.gets();
     let entries = block_on(reader.entries())?;
     let walk_fetches = store.gets() - before;
     let keys_returned = entries.len() as u64;
-    let listing = Listing {
-        method: "full_walk_fallback".to_string(),
-        fetch_count: Some(walk_fetches),
-        keys_returned: Some(keys_returned),
-        fetches_per_key: Some(if keys_returned == 0 {
+    let full_entries = KfCount {
+        fetches: walk_fetches,
+        keys_returned,
+        fetches_per_key: if keys_returned == 0 {
             0.0
         } else {
             walk_fetches as f64 / keys_returned as f64
-        }),
+        },
+    };
+    // Fair fallback: walk_from(prefix) over the same logical prefixes as 1.0.
+    // walk_from only resolves an EXACT node-boundary path; a prefix that lands
+    // mid-edge raises NoForkFound. That is itself a 0.2 limitation, so such a
+    // prefix contributes nothing and is skipped rather than aborting the run.
+    let mut wf_fetches = 0u64;
+    let mut wf_keys = 0u64;
+    let mut wf_resolved = 0u64;
+    for pstr in listing_prefixes_02(corpus, keys) {
+        let before = store.gets();
+        let mut leaves = 0u64;
+        let mut mwf: PlainManifest<&Store02> = Manifest::open(root, &store);
+        let r = block_on(mwf.walk_from(&pstr, &mut |_p, node| {
+            if node.is_value() {
+                leaves += 1;
+            }
+            Ok(())
+        }));
+        if r.is_ok() {
+            wf_fetches += store.gets() - before;
+            wf_keys += leaves;
+            wf_resolved += 1;
+        }
+    }
+    let walk_from_opt = (wf_resolved > 0).then(|| KfCount {
+        fetches: wf_fetches,
+        keys_returned: wf_keys,
+        fetches_per_key: if wf_keys == 0 {
+            0.0
+        } else {
+            wf_fetches as f64 / wf_keys as f64
+        },
+    });
+    let listing = Listing {
+        method: "walk_from_fair + full_entries_pessimal".to_string(),
+        fetch_count: Some(wf_fetches),
+        keys_returned: Some(wf_keys),
+        fetches_per_key: walk_from_opt.as_ref().map(|k| k.fetches_per_key),
+        fallback_02_full_entries: Some(full_entries),
+        fallback_02_walk_from: walk_from_opt,
+        multiplier_fair: None,
     };
 
-    // floor / range: unsupported.
+    // floor / ceiling / range: no ordered/seekable API; the real 0.2 emulation
+    // is the full entries() walk (O(N)), whose fetch count == walk_fetches.
     let floor = Floor {
         supported: false,
-        reason: Some("no ordered API".to_string()),
+        reason: Some("no ordered/seekable API; emulated by full entries() walk".to_string()),
         hops_mean: None,
         hops_p95: None,
         hops_max: None,
+        hops_histogram: None,
+        fallback_02: None,
+    };
+    let ceiling = Ceiling {
+        supported: false,
+        class: "unsupported".to_string(),
+        native_seek_hops_mean: None,
+        native_seek_hops_max: None,
+        fallback_02: None,
     };
     let range = Range {
         supported: false,
-        reason: Some("no ordered API".to_string()),
-        fetch_count: None,
-        keys_returned: None,
+        reason: Some("no ordered/seekable API; emulated by full entries() walk".to_string()),
+        windows: Vec::new(),
+    };
+    let iter_full = IterFull {
+        native_fetch_to_first_key: None,
+        native_fetch_all: None,
+        fallback_02_materialise_fetches: Some(walk_fetches),
+        // entries() DFS order is undocumented and entries_concurrent is
+        // explicitly unordered: no ordered-iter guarantee.
+        ordered_guaranteed: false,
+    };
+    let value_read = ValueRead {
+        inline_fraction: None,
+        fetches_native_mean: None,
+        fetches_02_mean: None,
+        chunks_saved_by_inline: None,
+        reason: Some("no inline entries in 0.2; values are references".to_string()),
     };
 
     // --- single-key update / insert / delete: add/remove + save ---
@@ -556,6 +935,51 @@ pub fn measure_02(corpus: Corpus, keys: &[GenKey], cfg: Cfg) -> Result<Cell, Err
         criterion_ns_per_op: None,
     };
 
+    // --- batch-size sweep: K mutations + one save per K ---
+    let mut batch_sweep: Vec<BatchPoint> = Vec::with_capacity(BATCH_KS.len());
+    let mix_label = if all_update {
+        "100/0/0 (adds+save)"
+    } else {
+        "80/10/10 (adds+save)"
+    };
+    for &k in &BATCH_KS {
+        let kk = n.min(k);
+        let mut ms: PlainManifest<&Store02> = Manifest::open(root, &store);
+        let before_p = store.puts();
+        let t = Instant::now();
+        for (i, key) in keys.iter().take(kk).enumerate() {
+            let slot = i % 10;
+            if all_update || slot < 8 {
+                let r = ref32(tagged_addr(b"upd", key.path.as_bytes()));
+                block_on(ms.add(&key.path, r))?;
+            } else if slot == 8 {
+                let (_ir, ip) = insert_key(2_000_000 + i);
+                let r = ref32(value_addr(ip.as_bytes()));
+                block_on(ms.add(&ip, r))?;
+            } else {
+                block_on(ms.remove(&key.path))?;
+            }
+        }
+        let _ = block_on(ms.save())?;
+        let ns = t.elapsed().as_nanos() as u64;
+        let chunks = store.puts() - before_p;
+        batch_sweep.push(BatchPoint {
+            k: kk as u64,
+            mix: mix_label.to_string(),
+            chunks_rewritten: chunks,
+            wall_ns: ns,
+            write_amplification: if kk == 0 {
+                0.0
+            } else {
+                chunks as f64 / kk as f64
+            },
+            ns_per_op: if kk == 0 { 0.0 } else { ns as f64 / kk as f64 },
+        });
+    }
+
+    // --- subtree delete: remove every key under one listing prefix + save ---
+    let subtree_delete = subtree_delete_02(&store, root, corpus, keys)?;
+
     let update = Update {
         single: Some(SingleUpdate {
             update: Some(op_cost(&upd)),
@@ -564,6 +988,8 @@ pub fn measure_02(corpus: Corpus, keys: &[GenKey], cfg: Cfg) -> Result<Cell, Err
             criterion_ns_per_op: None,
         }),
         batch: Some(batch),
+        batch_sweep,
+        subtree_delete: Some(subtree_delete),
     };
 
     Ok(Cell {
@@ -577,8 +1003,73 @@ pub fn measure_02(corpus: Corpus, keys: &[GenKey], cfg: Cfg) -> Result<Cell, Err
         get: Some(get),
         listing: Some(listing),
         floor: Some(floor),
+        ceiling: Some(ceiling),
         range: Some(range),
+        iter_full: Some(iter_full),
+        value_read: Some(value_read),
         update: Some(update),
+        full_entries_walk_fetches: Some(walk_fetches),
+    })
+}
+
+/// 0.2 listing prefixes matching the 1.0 logical prefixes: for uniform (hex
+/// paths) the 1-raw-byte prefix maps to its 2-hex-char string; path corpora
+/// are byte-identical.
+fn listing_prefixes_02(corpus: Corpus, keys: &[GenKey]) -> Vec<String> {
+    listing_prefixes(corpus, keys)
+        .into_iter()
+        .filter_map(|p| match corpus {
+            Corpus::Uniform => Some(bytes_to_hex(&p)),
+            _ => String::from_utf8(p).ok(),
+        })
+        .collect()
+}
+
+fn bytes_to_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        s.push(HEX[usize::from(b >> 4)] as char);
+        s.push(HEX[usize::from(b & 0x0f)] as char);
+    }
+    s
+}
+
+/// Delete every 0.2 key under the first listing prefix, one save.
+fn subtree_delete_02(
+    store: &Store02,
+    root: ChunkAddress,
+    corpus: Corpus,
+    keys: &[GenKey],
+) -> Result<SubtreeDelete, Err> {
+    let Some(prefix) = listing_prefixes_02(corpus, keys).into_iter().next() else {
+        return Ok(SubtreeDelete {
+            prefix_utf8: None,
+            keys_deleted: 0,
+            chunks_rewritten: 0,
+            wall_ns: 0,
+            reason: Some("no prefix available".to_string()),
+        });
+    };
+    let victims: Vec<&str> = keys
+        .iter()
+        .map(|k| k.path.as_str())
+        .filter(|p| p.starts_with(&prefix))
+        .collect();
+    let mut mm: PlainManifest<&Store02> = Manifest::open(root, store);
+    let before_p = store.puts();
+    let t = Instant::now();
+    for p in &victims {
+        block_on(mm.remove(p))?;
+    }
+    let _ = block_on(mm.save())?;
+    let ns = t.elapsed().as_nanos() as u64;
+    Ok(SubtreeDelete {
+        prefix_utf8: Some(prefix),
+        keys_deleted: victims.len() as u64,
+        chunks_rewritten: store.puts() - before_p,
+        wall_ns: ns,
+        reason: None,
     })
 }
 

--- a/crates/manifest-sim/src/measure.rs
+++ b/crates/manifest-sim/src/measure.rs
@@ -1,0 +1,602 @@
+//! Metric collection for one `(format, corpus, scale)` cell.
+//!
+//! Every number here comes from executing the real builder/reader/apply path
+//! over the shared `CountingStore`; nulls are only ever produced by a
+//! capability gap, never by estimate.
+
+use std::error::Error;
+use std::time::Instant;
+
+use bytes::Bytes;
+use futures::executor::block_on;
+
+use nectar_manifest::{Builder, Changeset, Entry, Key, KeyId, Metadata, Reader, V1, apply};
+use nectar_mantaray::{Manifest, PlainManifest};
+use nectar_primitives::{AnyChunkSet, ChunkAddress, ChunkRef, StandardChunkSet};
+
+use crate::corpus::{Corpus, GenKey, tagged_addr, value_addr};
+use crate::results::{
+    BatchUpdate, Build, Cell, Depth, Floor, Get, Listing, LoadLatency, OpCost, Range, SingleUpdate,
+    Storage, Update,
+};
+use crate::store::CountingStore;
+
+type Err = Box<dyn Error>;
+
+const BODY: f64 = 4096.0;
+
+/// Config knobs shared across cells.
+#[derive(Clone, Copy, Debug)]
+pub struct Cfg {
+    pub sample_keys: usize,
+    pub update_sample: usize,
+    pub batch_ops: usize,
+    pub rtt_ms: u32,
+}
+
+// ---- small stats helpers -------------------------------------------------
+
+fn mean(v: &[u64]) -> f64 {
+    if v.is_empty() {
+        return 0.0;
+    }
+    let sum: u128 = v.iter().map(|&x| u128::from(x)).sum();
+    sum as f64 / v.len() as f64
+}
+
+fn pct(sorted: &[u64], p: f64) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let idx = ((sorted.len() - 1) as f64 * p).round() as usize;
+    sorted.get(idx).copied().unwrap_or(0)
+}
+
+fn depth_from(hops: &mut [u64]) -> Depth {
+    hops.sort_unstable();
+    Depth {
+        min: hops.first().copied(),
+        mean: Some(mean(hops)),
+        p95: Some(pct(hops, 0.95)),
+        max: hops.last().copied(),
+    }
+}
+
+fn get_block(hops: &[u64], rtt_ms: u32) -> Get {
+    let mut sorted = hops.to_vec();
+    sorted.sort_unstable();
+    let m = mean(hops);
+    let p95 = pct(&sorted, 0.95);
+    let mx = sorted.last().copied().unwrap_or(0);
+    let rtt = f64::from(rtt_ms);
+    Get {
+        sampled_keys: Some(hops.len() as u64),
+        hops_mean: Some(m),
+        hops_p95: Some(p95),
+        hops_max: Some(mx),
+        load_latency_ms: Some(LoadLatency {
+            mean: Some(m * rtt),
+            p95: Some(p95 as f64 * rtt),
+            max: Some(mx as f64 * rtt),
+            derived_from_hops: true,
+        }),
+        criterion_ns_per_op: None,
+    }
+}
+
+/// Deterministic evenly-spaced sample of `count` indices in `0..n`.
+fn sample_indices(n: usize, count: usize) -> Vec<usize> {
+    if n == 0 {
+        return Vec::new();
+    }
+    if n <= count {
+        return (0..n).collect();
+    }
+    let stride = n / count;
+    (0..count).map(|j| (j * stride).min(n - 1)).collect()
+}
+
+/// Peak resident set of the process, sampled from `/proc/self/status` VmHWM.
+/// Cumulative over the process lifetime, so it is a floor on the current
+/// build's peak, not a clean per-cell figure (see `peak_live_store_bytes`).
+fn peak_rss_bytes() -> Option<u64> {
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("VmHWM:") {
+            let kb: u64 = rest.trim().trim_end_matches(" kB").trim().parse().ok()?;
+            return Some(kb.saturating_mul(1024));
+        }
+    }
+    None
+}
+
+// ---- value / key builders ------------------------------------------------
+
+fn ref32(addr: [u8; 32]) -> ChunkRef {
+    ChunkRef::new(ChunkAddress::new(addr))
+}
+
+fn entry10(bytes: &[u8]) -> Entry<V1> {
+    Entry::from(ref32(value_addr(bytes)))
+}
+
+fn alt_entry10(bytes: &[u8]) -> Entry<V1> {
+    Entry::from(ref32(tagged_addr(b"upd", bytes)))
+}
+
+fn meta10(k: &GenKey) -> Option<Metadata<V1>> {
+    k.content_type.map(|ct| {
+        Metadata::<V1>::new(KeyId::ContentType, Bytes::from_static(ct.as_bytes()))
+            .expect("content-type fits the metadata bound")
+    })
+}
+
+/// A synthetic insert key in a namespace disjoint from every corpus key
+/// (uniform hex is `0-9a-f`, kiwix starts `A/M/-/I`, osm starts with a digit),
+/// so an insert adds a fresh branch and never nests under an existing key.
+fn insert_key(tag: usize) -> (Vec<u8>, String) {
+    let path = format!("~~ins~~{tag}");
+    let mut raw = vec![0xffu8, 0xff, 0xff];
+    raw.extend_from_slice(&(tag as u64).to_le_bytes());
+    (raw, path)
+}
+
+// ========================================================================
+// mantaray 1.0
+// ========================================================================
+
+/// Measure one 1.0 cell. `store` is fresh; only manifest node chunks land in
+/// it (values are bare ref32, never split), so `total_chunks` is exactly the
+/// resident node count.
+pub fn measure_10(corpus: Corpus, keys: &[GenKey], cfg: Cfg) -> Result<Cell, Err> {
+    let store = CountingStore::<StandardChunkSet>::new();
+    let n = keys.len();
+
+    // --- build ---
+    let mut builder = Builder::<V1>::new();
+    for k in keys {
+        builder.insert(Key::from(k.raw.as_slice()), entry10(&k.raw), meta10(k));
+    }
+    let rss_before = peak_rss_bytes();
+    let t = Instant::now();
+    let built = block_on(builder.build(&store))?;
+    let build_ns = t.elapsed().as_nanos() as u64;
+    let rss_after = peak_rss_bytes();
+    let root = *built.root();
+    let stats = built.stats();
+    let snap = store.snapshot();
+
+    let build = Build {
+        wall_ns: Some(build_ns),
+        criterion_ns_per_op: None,
+        criterion_stddev_ns: None,
+        peak_open_nodes: Some(stats.peak_open_nodes() as u64),
+        nodes_written: Some(stats.nodes_written() as u64),
+        nodes_embedded: Some(stats.nodes_embedded() as u64),
+        peak_rss_bytes: rss_after.or(rss_before),
+        peak_live_store_bytes: Some(snap.peak_live_bytes),
+    };
+    let total_chunks = snap.total_chunks;
+    let storage = Storage {
+        total_chunks: Some(total_chunks),
+        total_payload_bytes: Some(snap.live_bytes),
+        storage_utilisation: Some(if total_chunks == 0 {
+            0.0
+        } else {
+            snap.live_bytes as f64 / (total_chunks as f64 * BODY)
+        }),
+    };
+
+    // --- get hops (== referenced chunk-path depth) over the sample ---
+    let reader: Reader<&CountingStore<StandardChunkSet>, V1> = Reader::new(&store);
+    let idxs = sample_indices(n, cfg.sample_keys);
+    let mut hops: Vec<u64> = Vec::with_capacity(idxs.len());
+    for &i in &idxs {
+        let key = Key::from(keys[i].raw.as_slice());
+        let before = store.gets();
+        let _ = block_on(reader.get(&root, &key))?;
+        hops.push(store.gets() - before);
+    }
+    let get = get_block(&hops, cfg.rtt_ms);
+    let mut depth_src = hops.clone();
+    let tree_depth = depth_from(&mut depth_src);
+
+    // --- prefix listing (folder view) over a fixed set of prefixes ---
+    let mut fetch_total = 0u64;
+    let mut keys_total = 0u64;
+    for p in listing_prefixes(corpus, keys) {
+        let pk = Key::from(p.as_slice());
+        let before = store.gets();
+        let mut cursor = block_on(reader.prefix(&root, &pk))?;
+        let mut count = 0u64;
+        while let Some(_pair) = block_on(cursor.next())? {
+            count += 1;
+        }
+        fetch_total += store.gets() - before;
+        keys_total += count;
+    }
+    let listing = Listing {
+        method: "prefix".to_string(),
+        fetch_count: Some(fetch_total),
+        keys_returned: Some(keys_total),
+        fetches_per_key: Some(if keys_total == 0 {
+            0.0
+        } else {
+            fetch_total as f64 / keys_total as f64
+        }),
+    };
+
+    // --- floor (1.0 only) over the sample ---
+    let mut floor_hops: Vec<u64> = Vec::with_capacity(idxs.len());
+    for &i in &idxs {
+        let key = Key::from(keys[i].raw.as_slice());
+        let before = store.gets();
+        let _ = block_on(reader.floor(&root, &key))?;
+        floor_hops.push(store.gets() - before);
+    }
+    floor_hops.sort_unstable();
+    let floor = Floor {
+        supported: true,
+        reason: None,
+        hops_mean: Some(mean(&floor_hops)),
+        hops_p95: Some(pct(&floor_hops, 0.95)),
+        hops_max: floor_hops.last().copied(),
+    };
+
+    // --- range (1.0 only): a fixed mid window ---
+    let (range, _) = if n >= 3 {
+        let lo = Key::from(keys[n * 2 / 5].raw.as_slice());
+        let hi = Key::from(keys[n * 3 / 5].raw.as_slice());
+        let before = store.gets();
+        let mut cursor = block_on(reader.range(&root, &lo, &hi))?;
+        let mut count = 0u64;
+        while let Some(_pair) = block_on(cursor.next())? {
+            count += 1;
+        }
+        (
+            Range {
+                supported: true,
+                reason: None,
+                fetch_count: Some(store.gets() - before),
+                keys_returned: Some(count),
+            },
+            (),
+        )
+    } else {
+        (
+            Range {
+                supported: true,
+                reason: None,
+                fetch_count: Some(0),
+                keys_returned: Some(0),
+            },
+            (),
+        )
+    };
+
+    // --- single-key update / insert / delete (apply, 1-op changeset) ---
+    let usample = sample_indices(n, cfg.update_sample);
+    let mut upd = (Vec::new(), Vec::new());
+    let mut ins = (Vec::new(), Vec::new());
+    let mut del = (Vec::new(), Vec::new());
+    for (tag, &i) in usample.iter().enumerate() {
+        let k = &keys[i];
+        // update
+        let mut cs = Changeset::<V1>::new();
+        cs.put(Key::from(k.raw.as_slice()), alt_entry10(&k.raw), meta10(k));
+        apply_measure(&store, &root, &cs, &mut upd)?;
+        // insert
+        let (iraw, _ipath) = insert_key(tag);
+        let mut cs = Changeset::<V1>::new();
+        cs.put(Key::from(iraw.as_slice()), entry10(&iraw), None);
+        apply_measure(&store, &root, &cs, &mut ins)?;
+        // delete
+        let mut cs = Changeset::<V1>::new();
+        cs.remove(Key::from(k.raw.as_slice()));
+        apply_measure(&store, &root, &cs, &mut del)?;
+    }
+
+    // --- batch apply (one changeset) ---
+    let kops = n.min(cfg.batch_ops);
+    let mut cs = Changeset::<V1>::new();
+    let all_update = matches!(corpus, Corpus::OsmPyramid | Corpus::OsmBbox);
+    for (i, k) in keys.iter().take(kops).enumerate() {
+        let slot = i % 10;
+        if all_update || slot < 8 {
+            cs.put(Key::from(k.raw.as_slice()), alt_entry10(&k.raw), meta10(k));
+        } else if slot == 8 {
+            let (iraw, _ip) = insert_key(1_000_000 + i);
+            cs.put(Key::from(iraw.as_slice()), entry10(&iraw), None);
+        } else {
+            cs.remove(Key::from(k.raw.as_slice()));
+        }
+    }
+    let before_p = store.puts();
+    let t = Instant::now();
+    let _new_root = block_on(apply(&store, &root, &cs))?;
+    let batch_ns = t.elapsed().as_nanos() as u64;
+    let batch_chunks = store.puts() - before_p;
+    let batch = BatchUpdate {
+        k_ops: Some(kops as u64),
+        mix: if all_update {
+            "100/0/0".to_string()
+        } else {
+            "80/10/10".to_string()
+        },
+        chunks_rewritten: Some(batch_chunks),
+        wall_ns: Some(batch_ns),
+        write_amplification: Some(if kops == 0 {
+            0.0
+        } else {
+            batch_chunks as f64 / kops as f64
+        }),
+        criterion_ns_per_op: None,
+    };
+
+    let update = Update {
+        single: Some(SingleUpdate {
+            update: Some(op_cost(&upd)),
+            insert: Some(op_cost(&ins)),
+            delete: Some(op_cost(&del)),
+            criterion_ns_per_op: None,
+        }),
+        batch: Some(batch),
+    };
+
+    Ok(Cell {
+        ran: true,
+        reason: None,
+        n_keys: Some(n as u64),
+        key_encoding: Some("raw".to_string()),
+        build: Some(build),
+        storage: Some(storage),
+        tree_depth: Some(tree_depth),
+        get: Some(get),
+        listing: Some(listing),
+        floor: Some(floor),
+        range: Some(range),
+        update: Some(update),
+    })
+}
+
+fn apply_measure(
+    store: &CountingStore<StandardChunkSet>,
+    root: &ChunkAddress,
+    cs: &Changeset<V1>,
+    acc: &mut (Vec<u64>, Vec<u64>),
+) -> Result<(), Err> {
+    let before = store.puts();
+    let t = Instant::now();
+    let _ = block_on(apply(store, root, cs))?;
+    acc.0.push(store.puts() - before);
+    acc.1.push(t.elapsed().as_nanos() as u64);
+    Ok(())
+}
+
+fn op_cost(acc: &(Vec<u64>, Vec<u64>)) -> OpCost {
+    OpCost {
+        chunks_rewritten_mean: Some(mean(&acc.0)),
+        wall_ns: Some(mean(&acc.1).round() as u64),
+    }
+}
+
+fn listing_prefixes(corpus: Corpus, keys: &[GenKey]) -> Vec<Vec<u8>> {
+    let n = keys.len();
+    if n == 0 {
+        return Vec::new();
+    }
+    let mut out: Vec<Vec<u8>> = Vec::new();
+    for j in 0..8 {
+        let idx = (j * n / 8).min(n - 1);
+        let raw = &keys[idx].raw;
+        let p: Vec<u8> = match corpus {
+            Corpus::Uniform => raw.iter().take(1).copied().collect(),
+            _ => match raw.iter().rposition(|&b| b == b'/') {
+                Some(pos) => raw[..=pos].to_vec(),
+                None => raw.iter().take(1).copied().collect(),
+            },
+        };
+        if !out.contains(&p) {
+            out.push(p);
+        }
+    }
+    out
+}
+
+// ========================================================================
+// mantaray 0.2
+// ========================================================================
+
+type Store02 = CountingStore<AnyChunkSet<4096>>;
+
+/// Measure one 0.2 cell as a full reader+writer over the plain (ref32) trie.
+pub fn measure_02(corpus: Corpus, keys: &[GenKey], cfg: Cfg) -> Result<Cell, Err> {
+    let store = Store02::new();
+    let n = keys.len();
+
+    // --- build: add-loop then one save ---
+    let mut m: PlainManifest<&Store02> = Manifest::new(&store);
+    let rss_before = peak_rss_bytes();
+    let t = Instant::now();
+    for k in keys {
+        let r = ref32(value_addr(k.path.as_bytes()));
+        match k.content_type {
+            Some(ct) => {
+                let mut md = std::collections::BTreeMap::new();
+                md.insert("content-type".to_string(), ct.to_string());
+                block_on(m.add_with_metadata(&k.path, r, md))?;
+            }
+            None => block_on(m.add(&k.path, r))?,
+        }
+    }
+    let root = block_on(m.save())?;
+    let build_ns = t.elapsed().as_nanos() as u64;
+    let rss_after = peak_rss_bytes();
+    let snap = store.snapshot();
+
+    let build = Build {
+        wall_ns: Some(build_ns),
+        criterion_ns_per_op: None,
+        criterion_stddev_ns: None,
+        peak_open_nodes: None,
+        nodes_written: Some(snap.distinct_puts),
+        nodes_embedded: None,
+        peak_rss_bytes: rss_after.or(rss_before),
+        peak_live_store_bytes: Some(snap.peak_live_bytes),
+    };
+    let total_chunks = snap.total_chunks;
+    let storage = Storage {
+        total_chunks: Some(total_chunks),
+        total_payload_bytes: Some(snap.live_bytes),
+        storage_utilisation: Some(if total_chunks == 0 {
+            0.0
+        } else {
+            snap.live_bytes as f64 / (total_chunks as f64 * BODY)
+        }),
+    };
+
+    // --- get hops over the sample (fresh open, no trie caching) ---
+    let reader: PlainManifest<&Store02> = Manifest::open(root, &store);
+    let idxs = sample_indices(n, cfg.sample_keys);
+    let mut hops: Vec<u64> = Vec::with_capacity(idxs.len());
+    for &i in &idxs {
+        let before = store.gets();
+        let _ = block_on(reader.get(&keys[i].path))?;
+        hops.push(store.gets() - before);
+    }
+    let get = get_block(&hops, cfg.rtt_ms);
+    let mut depth_src = hops.clone();
+    let tree_depth = depth_from(&mut depth_src);
+
+    // --- listing: full entries() walk fallback (no ordered prefix API) ---
+    let before = store.gets();
+    let entries = block_on(reader.entries())?;
+    let walk_fetches = store.gets() - before;
+    let keys_returned = entries.len() as u64;
+    let listing = Listing {
+        method: "full_walk_fallback".to_string(),
+        fetch_count: Some(walk_fetches),
+        keys_returned: Some(keys_returned),
+        fetches_per_key: Some(if keys_returned == 0 {
+            0.0
+        } else {
+            walk_fetches as f64 / keys_returned as f64
+        }),
+    };
+
+    // floor / range: unsupported.
+    let floor = Floor {
+        supported: false,
+        reason: Some("no ordered API".to_string()),
+        hops_mean: None,
+        hops_p95: None,
+        hops_max: None,
+    };
+    let range = Range {
+        supported: false,
+        reason: Some("no ordered API".to_string()),
+        fetch_count: None,
+        keys_returned: None,
+    };
+
+    // --- single-key update / insert / delete: add/remove + save ---
+    let usample = sample_indices(n, cfg.update_sample);
+    let mut upd = (Vec::new(), Vec::new());
+    let mut ins = (Vec::new(), Vec::new());
+    let mut del = (Vec::new(), Vec::new());
+    for (tag, &i) in usample.iter().enumerate() {
+        let k = &keys[i];
+        // update
+        let r = ref32(tagged_addr(b"upd", k.path.as_bytes()));
+        save_measure(&store, root, &mut upd, |mm| block_on(mm.add(&k.path, r)))?;
+        // insert
+        let (_iraw, ipath) = insert_key(tag);
+        let ir = ref32(value_addr(ipath.as_bytes()));
+        save_measure(&store, root, &mut ins, |mm| block_on(mm.add(&ipath, ir)))?;
+        // delete
+        save_measure(&store, root, &mut del, |mm| block_on(mm.remove(&k.path)))?;
+    }
+
+    // --- batch: {K adds/removes} + one save ---
+    let kops = n.min(cfg.batch_ops);
+    let all_update = matches!(corpus, Corpus::OsmPyramid | Corpus::OsmBbox);
+    let mut mb: PlainManifest<&Store02> = Manifest::open(root, &store);
+    let before_p = store.puts();
+    let t = Instant::now();
+    for (i, k) in keys.iter().take(kops).enumerate() {
+        let slot = i % 10;
+        if all_update || slot < 8 {
+            let r = ref32(tagged_addr(b"upd", k.path.as_bytes()));
+            block_on(mb.add(&k.path, r))?;
+        } else if slot == 8 {
+            let (_ir, ip) = insert_key(1_000_000 + i);
+            let r = ref32(value_addr(ip.as_bytes()));
+            block_on(mb.add(&ip, r))?;
+        } else {
+            block_on(mb.remove(&k.path))?;
+        }
+    }
+    let _ = block_on(mb.save())?;
+    let batch_ns = t.elapsed().as_nanos() as u64;
+    let batch_chunks = store.puts() - before_p;
+    let batch = BatchUpdate {
+        k_ops: Some(kops as u64),
+        mix: if all_update {
+            "100/0/0 (adds+save)".to_string()
+        } else {
+            "80/10/10 (adds+save)".to_string()
+        },
+        chunks_rewritten: Some(batch_chunks),
+        wall_ns: Some(batch_ns),
+        write_amplification: Some(if kops == 0 {
+            0.0
+        } else {
+            batch_chunks as f64 / kops as f64
+        }),
+        criterion_ns_per_op: None,
+    };
+
+    let update = Update {
+        single: Some(SingleUpdate {
+            update: Some(op_cost(&upd)),
+            insert: Some(op_cost(&ins)),
+            delete: Some(op_cost(&del)),
+            criterion_ns_per_op: None,
+        }),
+        batch: Some(batch),
+    };
+
+    Ok(Cell {
+        ran: true,
+        reason: None,
+        n_keys: Some(n as u64),
+        key_encoding: Some(corpus.key_encoding().to_string()),
+        build: Some(build),
+        storage: Some(storage),
+        tree_depth: Some(tree_depth),
+        get: Some(get),
+        listing: Some(listing),
+        floor: Some(floor),
+        range: Some(range),
+        update: Some(update),
+    })
+}
+
+fn save_measure<Fn>(
+    store: &Store02,
+    root: ChunkAddress,
+    acc: &mut (Vec<u64>, Vec<u64>),
+    mutate: Fn,
+) -> Result<(), Err>
+where
+    Fn: FnOnce(&mut PlainManifest<&Store02>) -> Result<(), nectar_mantaray::MantarayError>,
+{
+    let mut mm: PlainManifest<&Store02> = Manifest::open(root, store);
+    let before = store.puts();
+    let t = Instant::now();
+    mutate(&mut mm)?;
+    let _ = block_on(mm.save())?;
+    acc.0.push(store.puts() - before);
+    acc.1.push(t.elapsed().as_nanos() as u64);
+    Ok(())
+}

--- a/crates/manifest-sim/src/results.rs
+++ b/crates/manifest-sim/src/results.rs
@@ -2,16 +2,26 @@
 //!
 //! Every numeric field is `Option`; a `None` serializes to JSON `null` and is
 //! only ever set by a real measurement or left null with a reason. No field is
-//! back-filled by estimate.
+//! back-filled by estimate. The top-level `capability_matrix` and `headlines`
+//! are the machine-readable op x format matrix and the cross-cell multiplier
+//! summary; both are populated only from executed cells (headlines) or from
+//! fixed API facts verified on the source tree (the matrix rows).
 
 use std::collections::BTreeMap;
 
 use serde::Serialize;
 
+/// A discrete PMF: value -> frequency, serialized with stringised integer keys.
+pub type Histogram = BTreeMap<u64, u64>;
+
 /// The whole result document.
 #[derive(Debug, Serialize)]
 pub struct Document {
     pub meta: Meta,
+    /// Exhaustive op x format capability matrix (fixed API facts).
+    pub capability_matrix: Vec<CapabilityRow>,
+    /// Cross-cell headline multipliers, computed from executed cells only.
+    pub headlines: Headlines,
     pub formats: BTreeMap<String, FormatBlock>,
 }
 
@@ -24,11 +34,54 @@ pub struct Meta {
     pub harness_version: String,
     pub seed_master: String,
     pub rtt_ms: u32,
+    pub rtt_ms_set: Vec<u32>,
+    pub batch_k_sweep: Vec<u64>,
+    pub range_windows: Vec<f64>,
+    pub value_read_corpus: String,
     pub chunk_body_size: u32,
     pub criterion_iters_note: String,
     pub sample_keys: u32,
     pub update_sample: u32,
     pub batch_ops: u32,
+    /// Honest caveats embedded so numbers are never read out of context.
+    pub caveats: Vec<String>,
+}
+
+/// One row of the capability matrix (fixed API facts, not a measurement).
+#[derive(Debug, Clone, Serialize)]
+pub struct CapabilityRow {
+    pub n: u32,
+    pub op: String,
+    pub v1_supported: bool,
+    pub v1_api: Option<String>,
+    pub v1_class: String,
+    pub v02_supported: bool,
+    pub v02_api: Option<String>,
+    pub v02_class: String,
+    pub v02_fallback: Option<String>,
+    pub v02_asymptote: Option<String>,
+    pub notes: String,
+}
+
+/// Cross-cell headline multipliers, all derived from executed cells only.
+#[derive(Debug, Default, Serialize)]
+pub struct Headlines {
+    pub notes: String,
+    pub entries: Vec<Headline>,
+}
+
+/// One headline multiplier at a `(corpus, scale)` where both sides ran.
+#[derive(Debug, Serialize)]
+pub struct Headline {
+    pub metric: String,
+    pub corpus: String,
+    pub scale: u64,
+    pub native: f64,
+    pub native_unit: String,
+    pub fallback: Option<f64>,
+    pub fallback_unit: String,
+    pub multiplier: Option<f64>,
+    pub reason_if_null: Option<String>,
 }
 
 /// One format's corpora.
@@ -59,8 +112,14 @@ pub struct Cell {
     pub get: Option<Get>,
     pub listing: Option<Listing>,
     pub floor: Option<Floor>,
+    pub ceiling: Option<Ceiling>,
     pub range: Option<Range>,
+    pub iter_full: Option<IterFull>,
+    pub value_read: Option<ValueRead>,
     pub update: Option<Update>,
+    /// The full O(N) entries-walk fetch count (0.2 only), used by the bin to
+    /// cross-fill floor/ceiling/range fallback multipliers into the 1.0 cell.
+    pub full_entries_walk_fetches: Option<u64>,
 }
 
 #[derive(Debug, Default, Serialize)]
@@ -73,6 +132,22 @@ pub struct Build {
     pub nodes_embedded: Option<u64>,
     pub peak_rss_bytes: Option<u64>,
     pub peak_live_store_bytes: Option<u64>,
+    /// 1.0 = peak_open_nodes (O(depth) frontier); 0.2 = nodes_written (O(N)).
+    pub builder_frontier_nodes: Option<u64>,
+    /// Least-squares fit of log(ns) vs log(N); filled in the bin.
+    pub cpu_loglog: Option<LogLog>,
+    /// distinct puts of a second identical build / distinct puts of the first.
+    pub dedup_ratio_second_build: Option<f64>,
+    pub dedup_reason: Option<String>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct LogLog {
+    pub slope: f64,
+    pub intercept: f64,
+    pub r2: f64,
+    pub n_points: u32,
+    pub basis: String,
 }
 
 #[derive(Debug, Default, Serialize)]
@@ -80,6 +155,10 @@ pub struct Storage {
     pub total_chunks: Option<u64>,
     pub total_payload_bytes: Option<u64>,
     pub storage_utilisation: Option<f64>,
+    pub bytes_per_key: Option<f64>,
+    pub chunks_per_key: Option<f64>,
+    /// embedded/(embedded+written); 0.2 has no embedding so this is 0.0.
+    pub embedding_ratio: Option<f64>,
 }
 
 #[derive(Debug, Default, Serialize)]
@@ -88,6 +167,8 @@ pub struct Depth {
     pub mean: Option<f64>,
     pub p95: Option<u64>,
     pub max: Option<u64>,
+    pub histogram: Option<Histogram>,
+    pub fanout_mean: Option<f64>,
 }
 
 #[derive(Debug, Default, Serialize)]
@@ -98,6 +179,9 @@ pub struct Get {
     pub hops_max: Option<u64>,
     pub load_latency_ms: Option<LoadLatency>,
     pub criterion_ns_per_op: Option<f64>,
+    pub hops_histogram: Option<Histogram>,
+    pub hops_cdf: Option<Cdf>,
+    pub wall_latency_ms: Option<WallLatency>,
 }
 
 #[derive(Debug, Default, Serialize)]
@@ -109,11 +193,47 @@ pub struct LoadLatency {
 }
 
 #[derive(Debug, Default, Serialize)]
+pub struct Cdf {
+    pub p50: u64,
+    pub p90: u64,
+    pub p99: u64,
+    pub max: u64,
+}
+
+/// Multi-RTT hop x RTT model. Never a measurement: the `model` string states so.
+#[derive(Debug, Serialize)]
+pub struct WallLatency {
+    pub by_rtt_ms: BTreeMap<String, LatQuad>,
+    pub model: String,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct LatQuad {
+    pub p50: f64,
+    pub p90: f64,
+    pub p99: f64,
+    pub max: f64,
+}
+
+#[derive(Debug, Default, Serialize)]
 pub struct Listing {
     pub method: String,
     pub fetch_count: Option<u64>,
     pub keys_returned: Option<u64>,
     pub fetches_per_key: Option<f64>,
+    /// 0.2 pessimal fallback: a full entries() walk over ALL keys.
+    pub fallback_02_full_entries: Option<KfCount>,
+    /// 0.2 fair fallback: walk_from(prefix) on the SAME prefixes as 1.0.
+    pub fallback_02_walk_from: Option<KfCount>,
+    /// 0.2 fair fetch / 1.0 fetch on identical prefixes; filled in the bin.
+    pub multiplier_fair: Option<f64>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct KfCount {
+    pub fetches: u64,
+    pub keys_returned: u64,
+    pub fetches_per_key: f64,
 }
 
 #[derive(Debug, Default, Serialize)]
@@ -123,20 +243,69 @@ pub struct Floor {
     pub hops_mean: Option<f64>,
     pub hops_p95: Option<u64>,
     pub hops_max: Option<u64>,
+    pub hops_histogram: Option<Histogram>,
+    pub fallback_02: Option<Fallback>,
+}
+
+/// A 0.2 emulation cost and its multiplier vs a native cost; filled in the bin
+/// for the matching `(corpus, scale)` where both sides ran.
+#[derive(Debug, Default, Serialize)]
+pub struct Fallback {
+    pub method: String,
+    pub fetches: Option<u64>,
+    pub multiplier: Option<f64>,
+    pub reason_if_null: Option<String>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct Ceiling {
+    pub supported: bool,
+    pub class: String,
+    pub native_seek_hops_mean: Option<f64>,
+    pub native_seek_hops_max: Option<u64>,
+    pub fallback_02: Option<Fallback>,
 }
 
 #[derive(Debug, Default, Serialize)]
 pub struct Range {
     pub supported: bool,
     pub reason: Option<String>,
+    pub windows: Vec<RangeWindow>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct RangeWindow {
+    pub w: f64,
     pub fetch_count: Option<u64>,
     pub keys_returned: Option<u64>,
+    pub fallback_02_fetches: Option<u64>,
+    pub multiplier: Option<f64>,
+    pub reason_if_null: Option<String>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct IterFull {
+    pub native_fetch_to_first_key: Option<u64>,
+    pub native_fetch_all: Option<u64>,
+    pub fallback_02_materialise_fetches: Option<u64>,
+    pub ordered_guaranteed: bool,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct ValueRead {
+    pub inline_fraction: Option<f64>,
+    pub fetches_native_mean: Option<f64>,
+    pub fetches_02_mean: Option<f64>,
+    pub chunks_saved_by_inline: Option<u64>,
+    pub reason: Option<String>,
 }
 
 #[derive(Debug, Default, Serialize)]
 pub struct Update {
     pub single: Option<SingleUpdate>,
     pub batch: Option<BatchUpdate>,
+    pub batch_sweep: Vec<BatchPoint>,
+    pub subtree_delete: Option<SubtreeDelete>,
 }
 
 #[derive(Debug, Default, Serialize)]
@@ -161,4 +330,23 @@ pub struct BatchUpdate {
     pub wall_ns: Option<u64>,
     pub write_amplification: Option<f64>,
     pub criterion_ns_per_op: Option<f64>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct BatchPoint {
+    pub k: u64,
+    pub mix: String,
+    pub chunks_rewritten: u64,
+    pub wall_ns: u64,
+    pub write_amplification: f64,
+    pub ns_per_op: f64,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct SubtreeDelete {
+    pub prefix_utf8: Option<String>,
+    pub keys_deleted: u64,
+    pub chunks_rewritten: u64,
+    pub wall_ns: u64,
+    pub reason: Option<String>,
 }

--- a/crates/manifest-sim/src/results.rs
+++ b/crates/manifest-sim/src/results.rs
@@ -1,0 +1,164 @@
+//! Serializable result schema: `format -> corpus -> scale -> cell`.
+//!
+//! Every numeric field is `Option`; a `None` serializes to JSON `null` and is
+//! only ever set by a real measurement or left null with a reason. No field is
+//! back-filled by estimate.
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+
+/// The whole result document.
+#[derive(Debug, Serialize)]
+pub struct Document {
+    pub meta: Meta,
+    pub formats: BTreeMap<String, FormatBlock>,
+}
+
+/// Run-level metadata.
+#[derive(Debug, Serialize)]
+pub struct Meta {
+    pub generated: String,
+    pub git_branch: String,
+    pub git_commit: String,
+    pub harness_version: String,
+    pub seed_master: String,
+    pub rtt_ms: u32,
+    pub chunk_body_size: u32,
+    pub criterion_iters_note: String,
+    pub sample_keys: u32,
+    pub update_sample: u32,
+    pub batch_ops: u32,
+}
+
+/// One format's corpora.
+#[derive(Debug, Serialize)]
+pub struct FormatBlock {
+    #[serde(rename = "crate")]
+    pub crate_name: String,
+    pub registry: String,
+    pub corpora: BTreeMap<String, CorpusBlock>,
+}
+
+/// One corpus' scales.
+#[derive(Debug, Serialize)]
+pub struct CorpusBlock {
+    pub scales: BTreeMap<String, Cell>,
+}
+
+/// One measured `(format, corpus, scale)` cell.
+#[derive(Debug, Default, Serialize)]
+pub struct Cell {
+    pub ran: bool,
+    pub reason: Option<String>,
+    pub n_keys: Option<u64>,
+    pub key_encoding: Option<String>,
+    pub build: Option<Build>,
+    pub storage: Option<Storage>,
+    pub tree_depth: Option<Depth>,
+    pub get: Option<Get>,
+    pub listing: Option<Listing>,
+    pub floor: Option<Floor>,
+    pub range: Option<Range>,
+    pub update: Option<Update>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct Build {
+    pub wall_ns: Option<u64>,
+    pub criterion_ns_per_op: Option<f64>,
+    pub criterion_stddev_ns: Option<f64>,
+    pub peak_open_nodes: Option<u64>,
+    pub nodes_written: Option<u64>,
+    pub nodes_embedded: Option<u64>,
+    pub peak_rss_bytes: Option<u64>,
+    pub peak_live_store_bytes: Option<u64>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct Storage {
+    pub total_chunks: Option<u64>,
+    pub total_payload_bytes: Option<u64>,
+    pub storage_utilisation: Option<f64>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct Depth {
+    pub min: Option<u64>,
+    pub mean: Option<f64>,
+    pub p95: Option<u64>,
+    pub max: Option<u64>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct Get {
+    pub sampled_keys: Option<u64>,
+    pub hops_mean: Option<f64>,
+    pub hops_p95: Option<u64>,
+    pub hops_max: Option<u64>,
+    pub load_latency_ms: Option<LoadLatency>,
+    pub criterion_ns_per_op: Option<f64>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct LoadLatency {
+    pub mean: Option<f64>,
+    pub p95: Option<f64>,
+    pub max: Option<f64>,
+    pub derived_from_hops: bool,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct Listing {
+    pub method: String,
+    pub fetch_count: Option<u64>,
+    pub keys_returned: Option<u64>,
+    pub fetches_per_key: Option<f64>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct Floor {
+    pub supported: bool,
+    pub reason: Option<String>,
+    pub hops_mean: Option<f64>,
+    pub hops_p95: Option<u64>,
+    pub hops_max: Option<u64>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct Range {
+    pub supported: bool,
+    pub reason: Option<String>,
+    pub fetch_count: Option<u64>,
+    pub keys_returned: Option<u64>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct Update {
+    pub single: Option<SingleUpdate>,
+    pub batch: Option<BatchUpdate>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct SingleUpdate {
+    pub update: Option<OpCost>,
+    pub insert: Option<OpCost>,
+    pub delete: Option<OpCost>,
+    pub criterion_ns_per_op: Option<f64>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct OpCost {
+    pub chunks_rewritten_mean: Option<f64>,
+    pub wall_ns: Option<u64>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct BatchUpdate {
+    pub k_ops: Option<u64>,
+    pub mix: String,
+    pub chunks_rewritten: Option<u64>,
+    pub wall_ns: Option<u64>,
+    pub write_amplification: Option<f64>,
+    pub criterion_ns_per_op: Option<f64>,
+}

--- a/crates/manifest-sim/src/store.rs
+++ b/crates/manifest-sim/src/store.rs
@@ -1,0 +1,146 @@
+//! Shared instrumented in-memory chunk store.
+//!
+//! One wrapper type satisfies both formats: it is generic over the chunk
+//! registry, so `CountingStore<StandardChunkSet>` backs mantaray 1.0 and
+//! `CountingStore<AnyChunkSet<4096>>` backs mantaray 0.2. Both hold 4096-byte
+//! content-chunk bodies, so every byte and chunk metric is directly
+//! comparable across formats.
+//!
+//! Counters are atomic so the store stays `Sync` (satisfies `MaybeSync`) and
+//! a caller snapshots gets/puts around a single operation to read off hops and
+//! chunks-rewritten by difference.
+
+use std::sync::atomic::{AtomicU64, Ordering::SeqCst};
+
+use nectar_primitives::ChunkOps;
+use nectar_primitives::chunk::{Chunk, ChunkAddress, ChunkRegistry, StandardChunkSet, Verified};
+use nectar_primitives::store::{ChunkGet, ChunkHas, ChunkPut, MemoryStore};
+
+/// A point-in-time read of every counter plus the resident chunk count.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Counters {
+    /// Total `get()` calls; the delta around one operation is that operation's
+    /// hop count.
+    pub gets: u64,
+    /// Total `put()` calls, counting rewrites of an already-resident address.
+    pub puts: u64,
+    /// Sum of payload bytes over every `put()`.
+    pub put_bytes: u64,
+    /// Payload bytes currently resident (grows only on a not-yet-present
+    /// address).
+    pub live_bytes: u64,
+    /// Peak of `live_bytes` observed so far.
+    pub peak_live_bytes: u64,
+    /// Puts of an address that was not already resident.
+    pub distinct_puts: u64,
+    /// Distinct resident addresses (`inner.len()`).
+    pub total_chunks: u64,
+}
+
+/// In-memory chunk store that counts gets, puts and byte residency.
+#[derive(Debug)]
+pub struct CountingStore<R: ChunkRegistry = StandardChunkSet> {
+    inner: MemoryStore<R>,
+    gets: AtomicU64,
+    puts: AtomicU64,
+    put_bytes: AtomicU64,
+    live_bytes: AtomicU64,
+    peak_live_bytes: AtomicU64,
+    distinct_puts: AtomicU64,
+}
+
+impl<R: ChunkRegistry> Default for CountingStore<R> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<R: ChunkRegistry> CountingStore<R> {
+    /// An empty counting store.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            inner: MemoryStore::new(),
+            gets: AtomicU64::new(0),
+            puts: AtomicU64::new(0),
+            put_bytes: AtomicU64::new(0),
+            live_bytes: AtomicU64::new(0),
+            peak_live_bytes: AtomicU64::new(0),
+            distinct_puts: AtomicU64::new(0),
+        }
+    }
+
+    /// Read every counter and the resident chunk count.
+    #[must_use]
+    pub fn snapshot(&self) -> Counters {
+        Counters {
+            gets: self.gets.load(SeqCst),
+            puts: self.puts.load(SeqCst),
+            put_bytes: self.put_bytes.load(SeqCst),
+            live_bytes: self.live_bytes.load(SeqCst),
+            peak_live_bytes: self.peak_live_bytes.load(SeqCst),
+            distinct_puts: self.distinct_puts.load(SeqCst),
+            total_chunks: self.inner.len() as u64,
+        }
+    }
+
+    /// Zero the flow counters (gets/puts/put_bytes) while keeping stored chunks
+    /// and residency figures.
+    pub fn reset_flow(&self) {
+        self.gets.store(0, SeqCst);
+        self.puts.store(0, SeqCst);
+        self.put_bytes.store(0, SeqCst);
+    }
+
+    /// Distinct resident addresses.
+    #[must_use]
+    pub fn total_chunks(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Gets observed so far.
+    #[must_use]
+    pub fn gets(&self) -> u64 {
+        self.gets.load(SeqCst)
+    }
+
+    /// Puts observed so far.
+    #[must_use]
+    pub fn puts(&self) -> u64 {
+        self.puts.load(SeqCst)
+    }
+}
+
+impl<R: ChunkRegistry> ChunkPut<R> for CountingStore<R> {
+    type Error = std::convert::Infallible;
+
+    async fn put(&self, chunk: Chunk<Verified, R>) -> Result<(), Self::Error> {
+        let n = chunk.envelope().data().len() as u64;
+        let addr = *chunk.address();
+        let is_new = !ChunkHas::has(&self.inner, &addr).await;
+        self.puts.fetch_add(1, SeqCst);
+        self.put_bytes.fetch_add(n, SeqCst);
+        if is_new {
+            self.distinct_puts.fetch_add(1, SeqCst);
+            let lb = self.live_bytes.fetch_add(n, SeqCst) + n;
+            self.peak_live_bytes.fetch_max(lb, SeqCst);
+        }
+        ChunkPut::put(&self.inner, chunk).await
+    }
+}
+
+impl<R: ChunkRegistry> ChunkGet<R> for CountingStore<R> {
+    type Trust = Verified;
+    type Error = <MemoryStore<R> as ChunkGet<R>>::Error;
+
+    async fn get(&self, address: &ChunkAddress) -> Result<Chunk<Verified, R>, Self::Error> {
+        self.gets.fetch_add(1, SeqCst);
+        ChunkGet::get(&self.inner, address).await
+    }
+}
+
+impl<R: ChunkRegistry> ChunkHas for CountingStore<R> {
+    async fn has(&self, address: &ChunkAddress) -> bool {
+        ChunkHas::has(&self.inner, address).await
+    }
+}


### PR DESCRIPTION
## v2: full operation surface + capability matrix + ordered-op value analysis

Extends the harness from the core build/get/apply cells to the exhaustive
op x format surface (head `e1226cb`):

- Top-level machine-readable `capability_matrix` (20 ops x 1.0/0.2) and a
  `headlines` summary of cross-cell native-vs-0.2-fallback multipliers.
- Distributions: get/floor hop histograms + p50/p90/p99 CDF + multi-RTT
  (25/50/75ms) `hops x RTT` illustrative wall-clock model (fetch count is the
  hardware-independent truth).
- Ordered-op value analysis measured natively AND via the real 0.2 emulation
  on the same keys: floor (kiwix 1e5 ~7,150x), ceiling (seek-emulated), range
  selectivity sweep (W 0.1%..100%, multiplier explodes 16,000x -> 86x), fair
  `walk_from` folder listing (~32x), ordered iter.
- Storage per-key + `embedding_ratio` (0.861); second-build dedup ratio (I6 =>
  0.0); builder frontier O(depth) vs O(N); CPU log-log slope; batch-size
  write-amp sweep K 1..10000; subtree-delete collapse cost.
- Every new field is Option, null-with-reason where a capability is absent or
  0.2 was not run at 1e6; honest caveats embedded in `meta.caveats`. Benches
  loop all four corpora over the existing core groups only.

---

## What

Adds `crates/manifest-sim` (`nectar-manifest-sim`): an empirical performance
harness that measures **mantaray 1.0** (`nectar-manifest`) against **mantaray
0.2** (`nectar-mantaray`), both run as plain (ref32) readers+writers over one
shared instrumented in-memory chunk store, plus criterion benches for
build/get/apply. The bin writes one nested JSON document
(`format -> corpus -> scale -> cell`) of measured metrics.

- **CountingStore**: one registry-generic wrapper counts gets/puts/byte
  residency; instantiates as `StandardChunkSet` for 1.0 and `AnyChunkSet<4096>`
  for 0.2, both 4096-byte content bodies, so chunk/byte/util metrics compare
  directly.
- **Corpora**: deterministic, seeded generators (uniform control, kiwix-like
  article paths, osm pyramid + bbox tile keys) from master seed
  `0x6d616e7472617931`. Uniform binary keys are hex-encoded for 0.2 (the ACT
  hex pattern), flagged `key_encoding: "hex"`; path corpora are byte-identical
  in both APIs.
- **Metrics per cell**: build wall + peak buffers, total chunks + utilisation,
  tree depth, get-hops (+ RTT-derived load latency), prefix listing, floor/range
  (1.0-only), single (update/insert/delete) and K=10000 batch update write-amp,
  with criterion ns/op folded in.

## Why

Quantifies the 1.0 design (child embedding + content-defined segmentation +
compacted radix trie) versus 0.2's one-chunk-per-node trie on a defensible,
byte-for-byte comparison. Headline measured results (kiwix, plain, ref32):

| scale | format | chunks | utilisation | get hops (mean/p95) |
|-------|--------|--------|-------------|---------------------|
| 1e5   | 1.0    | 5,305  | 0.39        | 4.20 / 4            |
| 1e5   | 0.2    | 182,506| 0.051       | 6.39 / 8            |
| 1e6   | 1.0    | 49,234 | 0.41        | 5.25 / 6            |

0.2 utilisation lands at ~4.7-5.1% across corpora, matching the spec 9.2
baseline; 1.0 batch-apply write-amplification is <1 (one merged rebuild) versus
0.2's ~1-3 (touched-path union re-save).

## Testing

- `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -D warnings`: clean.
- Ran the harness (release) across N in {1e3, 1e4, 1e5, 1e6} for 1.0 and
  {1e3, 1e4, 1e5} for 0.2 (1e6 recorded `ran:false` + reason: O(N)-RAM
  whole-trie build outside the wall-clock budget).
- Ran the criterion build/get/apply benches for both formats and folded their
  ns/op into the JSON. Every quantitative figure is measured; capability gaps
  (0.2 floor/range = "no ordered API"; 0.2 listing = full-walk fallback;
  1.0-only `peak_open_nodes`/`nodes_embedded`) are null-with-reason, never
  estimated.

## AI-assistance

Authored with AI assistance (Claude Code); all code, corpora, measurements and
numbers were executed and reviewed by the author. No figure is fabricated or
extrapolated.

---

Refs #264

Note: this is a **stacked PR** on top of `s264/72-closing-fixes`; CI will not
run until the base merges and this retargets to `develop`.

