### PR TITLE
feat(manifest): bounded-concurrency read-ahead for ordered-scan cursors

### DIFF
--- a/crates/manifest/Cargo.toml
+++ b/crates/manifest/Cargo.toml
@@ -20,11 +20,11 @@ workspace = true
 [dependencies]
 alloy-primitives = { workspace = true }
 bytes.workspace = true
+futures.workspace = true
 nectar-primitives = { workspace = true }
 thiserror.workspace = true
 
 [dev-dependencies]
-futures.workspace = true
 proptest.workspace = true
 
 [features]

--- a/crates/manifest/src/format.rs
+++ b/crates/manifest/src/format.rs
@@ -77,6 +77,12 @@ pub trait Format:
     /// `usize`: the value exceeds a 32-bit `usize` on wasm32.
     const CUT_SCALE: u64;
 
+    /// Ordered-scan read-ahead window: the most trie-node fetches a cursor
+    /// keeps in flight at once while prefetching the covering frontier. A
+    /// reader tuning bounded by memory, not a wire parameter; the sliding
+    /// window keeps peak retained state O(depth) at this fetch count.
+    const READ_AHEAD: usize = 16;
+
     /// Domain-separation tag for the deterministic per-reference key
     /// derivation `keccak256(DERIVE_TAG || secret || plaintext)`. Frozen per
     /// version so encrypting the same plaintext under the same secret always

--- a/crates/manifest/src/scan.rs
+++ b/crates/manifest/src/scan.rs
@@ -6,10 +6,21 @@
 //! a reference points at. The only fetches are the trie nodes on the current
 //! path, so peak retained state is O(depth) and the value chunks are never
 //! pulled.
+//!
+//! The ordered cursor prefetches the covering frontier with bounded
+//! concurrency: it keeps up to [`Format::READ_AHEAD`] node fetches in flight in
+//! ascending-key order, so a scan pays O(depth) parallel rounds rather than one
+//! serial round trip per node. Chunks are immutable and content-addressed, so
+//! concurrent fetch needs no locking; the sliding window never materializes the
+//! whole frontier, so peak retained state stays O(depth) at the same fetch
+//! count a serial walk pays.
 
 use core::cmp::Ordering;
+use core::future::Future;
+use core::pin::Pin;
 
 use bytes::Bytes;
+use futures::stream::{FuturesUnordered, StreamExt};
 use nectar_primitives::ChunkAddress;
 use nectar_primitives::store::MaybeSync;
 
@@ -68,7 +79,34 @@ struct Frame<F: Format> {
     steps: Vec<Step<F>>,
     /// The next step to visit.
     index: usize,
+    /// Per-step prefetch tag, parallel to `steps`: the sequence id a referenced
+    /// child was launched under, once the read-ahead window scheduled it.
+    sched: Vec<Option<usize>>,
 }
+
+impl<F: Format> Frame<F> {
+    /// A frame over `steps`, resuming at `index`, with an empty prefetch tag.
+    fn new(base: Bytes, steps: Vec<Step<F>>, index: usize) -> Self {
+        let sched = vec![None; steps.len()];
+        Self {
+            base,
+            steps,
+            index,
+            sched,
+        }
+    }
+}
+
+/// A launched node fetch tagged with the sequence id it was scheduled under, so
+/// out-of-order completions route back to the descent that awaits them.
+type Fetched<F> = (usize, Result<Vec<Step<F>>, ReaderError>);
+
+/// An in-flight node fetch. Boxed to hold heterogeneous fetch futures in one
+/// queue; `Send` on native, unbounded on the single-threaded wasm executor.
+#[cfg(not(target_arch = "wasm32"))]
+type Fetch<'a, F> = Pin<Box<dyn Future<Output = Fetched<F>> + Send + 'a>>;
+#[cfg(target_arch = "wasm32")]
+type Fetch<'a, F> = Pin<Box<dyn Future<Output = Fetched<F>> + 'a>>;
 
 /// An ordered cursor over a manifest, yielding `(key, value)` in key order.
 ///
@@ -76,12 +114,25 @@ struct Frame<F: Format> {
 /// hop on the current path, so a full walk peaks at O(depth) whatever the key
 /// count. An exclusive upper bound stops the walk without fetching subtrees
 /// that lie past it.
+///
+/// Referenced children ahead of the current position are prefetched with a
+/// sliding window of at most [`Format::READ_AHEAD`] fetches in flight, launched
+/// in ascending-key order and never past the upper bound, so the concurrent
+/// walk fetches exactly the nodes a serial walk would and returns them in the
+/// same order.
 #[derive(Debug)]
 pub struct Cursor<'a, S, F: Format = V1> {
     store: &'a S,
     stack: Vec<Frame<F>>,
     end: Option<Bytes>,
     done: bool,
+    /// Node fetches launched by the read-ahead window, awaiting completion.
+    inflight: FuturesUnordered<Fetch<'a, F>>,
+    /// Completions that arrived before the descent awaiting them; drained by
+    /// sequence id. Bounded with `inflight` by the window, so O(depth) overall.
+    ready: Vec<Fetched<F>>,
+    /// The next fetch sequence id to hand out.
+    next_seq: usize,
 }
 
 /// What visiting the top frame's next step resolves to, computed under a short
@@ -91,8 +142,9 @@ enum Advance<F: Format> {
     Pop,
     /// A key and its value at this position.
     Yield(Vec<u8>, Entry<F>),
-    /// Descend into the referenced child rooted at this key prefix.
-    Descend(Vec<u8>, ChunkAddress),
+    /// Descend into the referenced child rooted at this key prefix, awaiting the
+    /// prefetch launched under this sequence id when one was scheduled.
+    Descend(Vec<u8>, ChunkAddress, Option<usize>),
     /// An encrypted child blocks the walk at this key prefix.
     Encrypted(Vec<u8>),
 }
@@ -119,11 +171,7 @@ where
             let steps = flatten(&node, is_root);
             let remaining = start.get(base.len()..).unwrap_or(&[]);
             if remaining.is_empty() {
-                stack.push(Frame {
-                    base: Bytes::from(base),
-                    steps,
-                    index: 0,
-                });
+                stack.push(Frame::new(Bytes::from(base), steps, 0));
                 break;
             }
             let mut chosen = steps.len();
@@ -152,21 +200,17 @@ where
             }
             match deeper {
                 Some((i, child, suffix)) => {
-                    stack.push(Frame {
-                        base: Bytes::from(base.clone()),
+                    stack.push(Frame::new(
+                        Bytes::from(base.clone()),
                         steps,
-                        index: i.saturating_add(1),
-                    });
+                        i.saturating_add(1),
+                    ));
                     base.extend_from_slice(&suffix);
                     addr = child;
                     is_root = false;
                 }
                 None => {
-                    stack.push(Frame {
-                        base: Bytes::from(base),
-                        steps,
-                        index: chosen,
-                    });
+                    stack.push(Frame::new(Bytes::from(base), steps, chosen));
                     break;
                 }
             }
@@ -176,6 +220,9 @@ where
             stack,
             end,
             done: false,
+            inflight: FuturesUnordered::new(),
+            ready: Vec::new(),
+            next_seq: 0,
         })
     }
 
@@ -189,28 +236,33 @@ where
             return Ok(None);
         }
         loop {
+            self.schedule();
             let advance = match self.stack.last_mut() {
                 None => {
                     self.done = true;
                     return Ok(None);
                 }
-                Some(frame) => match frame.steps.get(frame.index) {
-                    None => Advance::Pop,
-                    Some(step) => {
-                        frame.index = frame.index.saturating_add(1);
-                        match step {
-                            Step::Value { suffix, entry } => {
-                                Advance::Yield(join(&frame.base, suffix), entry.clone())
-                            }
-                            Step::Ref { suffix, addr } => {
-                                Advance::Descend(join(&frame.base, suffix), *addr)
-                            }
-                            Step::Encrypted { suffix } => {
-                                Advance::Encrypted(join(&frame.base, suffix))
+                Some(frame) => {
+                    let index = frame.index;
+                    match frame.steps.get(index) {
+                        None => Advance::Pop,
+                        Some(step) => {
+                            frame.index = index.saturating_add(1);
+                            match step {
+                                Step::Value { suffix, entry } => {
+                                    Advance::Yield(join(&frame.base, suffix), entry.clone())
+                                }
+                                Step::Ref { suffix, addr } => {
+                                    let seq = frame.sched.get(index).copied().flatten();
+                                    Advance::Descend(join(&frame.base, suffix), *addr, seq)
+                                }
+                                Step::Encrypted { suffix } => {
+                                    Advance::Encrypted(join(&frame.base, suffix))
+                                }
                             }
                         }
                     }
-                },
+                }
             };
             match advance {
                 Advance::Pop => {
@@ -223,18 +275,14 @@ where
                     }
                     return Ok(Some((Key::new(Bytes::from(key)), entry)));
                 }
-                Advance::Descend(child_base, addr) => {
+                Advance::Descend(child_base, addr, seq) => {
                     if self.past_end(&child_base) {
                         self.done = true;
                         return Ok(None);
                     }
-                    let node = self.store.get_node::<F>(&addr).await?;
-                    let steps = flatten(&node, false);
-                    self.stack.push(Frame {
-                        base: Bytes::from(child_base),
-                        steps,
-                        index: 0,
-                    });
+                    let steps = self.resolve(seq, &addr).await?;
+                    self.stack
+                        .push(Frame::new(Bytes::from(child_base), steps, 0));
                 }
                 Advance::Encrypted(child_base) => {
                     if self.past_end(&child_base) {
@@ -245,6 +293,87 @@ where
                 }
             }
         }
+    }
+
+    /// Fill the read-ahead window: launch node fetches for the referenced
+    /// children the walk will reach next, in ascending-key order, until at most
+    /// [`Format::READ_AHEAD`] fetches are in flight.
+    ///
+    /// Scheduling mirrors the walk's own termination, so it launches exactly the
+    /// nodes the walk fetches: it stops at the first step at or past the upper
+    /// bound and at the first encrypted child, and never relaunches a child
+    /// already tagged with a sequence id.
+    fn schedule(&mut self) {
+        let cap = F::READ_AHEAD;
+        let store = self.store;
+        // Deepest frame first: that is ascending-key order from the cursor, so
+        // the child needed soonest is always launched first and never starved.
+        'outer: for frame in self.stack.iter_mut().rev() {
+            let mut index = frame.index;
+            while let Some(step) = frame.steps.get(index) {
+                if self.inflight.len().saturating_add(self.ready.len()) >= cap {
+                    break 'outer;
+                }
+                let key = join(&frame.base, step.suffix());
+                if self
+                    .end
+                    .as_ref()
+                    .is_some_and(|end| key.as_slice() >= end.as_ref())
+                {
+                    // The walk stops at this bound; nothing beyond it is fetched.
+                    break 'outer;
+                }
+                match step {
+                    // The walk errors here; no deeper node is fetched.
+                    Step::Encrypted { .. } => break 'outer,
+                    Step::Ref { addr, .. } if !matches!(frame.sched.get(index), Some(Some(_))) => {
+                        let seq = self.next_seq;
+                        self.next_seq = self.next_seq.saturating_add(1);
+                        if let Some(slot) = frame.sched.get_mut(index) {
+                            *slot = Some(seq);
+                        }
+                        let addr = *addr;
+                        let fetch: Fetch<'a, F> = Box::pin(async move {
+                            let result = store
+                                .get_node::<F>(&addr)
+                                .await
+                                .map(|node| flatten(&node, false))
+                                .map_err(ReaderError::from);
+                            (seq, result)
+                        });
+                        self.inflight.push(fetch);
+                    }
+                    Step::Ref { .. } | Step::Value { .. } => {}
+                }
+                index = index.saturating_add(1);
+            }
+        }
+    }
+
+    /// The steps of the child reached by a descent: take the prefetch launched
+    /// under `seq`, driving in-flight fetches until it completes and buffering
+    /// any earlier-arriving completions. Falls back to a direct fetch when the
+    /// descent was not prefetched.
+    async fn resolve(
+        &mut self,
+        seq: Option<usize>,
+        addr: &ChunkAddress,
+    ) -> Result<Vec<Step<F>>, ReaderError> {
+        if let Some(seq) = seq {
+            loop {
+                if let Some(pos) = self.ready.iter().position(|(other, _)| *other == seq) {
+                    return self.ready.swap_remove(pos).1;
+                }
+                match self.inflight.next().await {
+                    Some((other, result)) if other == seq => return result,
+                    Some(pair) => self.ready.push(pair),
+                    // The launched fetch is unaccounted for; fetch directly.
+                    None => break,
+                }
+            }
+        }
+        let node = self.store.get_node::<F>(addr).await?;
+        Ok(flatten(&node, false))
     }
 
     /// Whether `key` has reached the exclusive upper bound. A referenced child

--- a/crates/manifest/tests/scan.rs
+++ b/crates/manifest/tests/scan.rs
@@ -355,6 +355,60 @@ proptest! {
 }
 
 #[test]
+fn read_ahead_never_fetches_past_the_upper_bound() -> TestResult {
+    let memory = MemoryStore::default();
+    let (root, oracle) = wide_build(&memory)?;
+    // The root fans out into one referenced child per leading byte, so there are
+    // more sibling subtrees than the window: an unbounded prefetch would pull
+    // whole subtrees the bounded walk never visits.
+    let siblings = memory.len().saturating_sub(1);
+    ensure(
+        siblings > V1::READ_AHEAD,
+        "more sibling subtrees than the window",
+    )?;
+
+    // A gated store is essential here: its fetches park on the first poll, so a
+    // future the window launches past the bound genuinely starts (and is
+    // counted), the way a real async store would. An immediately-ready store
+    // hides the over-fetch, because the awaited fetch completes before the
+    // executor ever polls the surplus futures.
+    let store = GatedStore {
+        inner: memory,
+        ..Default::default()
+    };
+    let reader: Reader<_> = Reader::new(&store);
+
+    // A range over the single leading byte 0x00: its subtree is in range; every
+    // sibling at 0x01.. is at or past the exclusive bound. Read-ahead must stop
+    // at the bound, so only the root and that one subtree are ever fetched.
+    let lo = Key::from(&[0u8][..]);
+    let hi = Key::from(&[1u8][..]);
+    let got: Rows = {
+        let mut cursor = block_on(reader.range(&root, &lo, &hi)).map_err(|e| e.to_string())?;
+        let mut out = Vec::new();
+        while let Some((key, value)) = block_on(cursor.next()).map_err(|e| e.to_string())? {
+            out.push((key.as_bytes().to_vec(), value));
+        }
+        out
+    };
+    let expected: Rows = oracle
+        .iter()
+        .filter(|(k, _)| k.as_slice() >= lo.as_bytes() && k.as_slice() < hi.as_bytes())
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+    ensure(!expected.is_empty(), "the range covers the first subtree")?;
+    ensure_eq(got, expected, "bounded read-ahead matches the range oracle")?;
+
+    // Exactly the root and the one in-range subtree: no sibling past the bound is
+    // prefetched, so the window respects the range at the serial fetch count.
+    ensure_eq(
+        store.gets.load(Ordering::Relaxed),
+        2,
+        "root and the one in-range subtree only",
+    )
+}
+
+#[test]
 fn floor_matches_the_oracle() -> TestResult {
     let store = MemoryStore::default();
     let (root, oracle) = build(&store)?;

--- a/crates/manifest/tests/scan.rs
+++ b/crates/manifest/tests/scan.rs
@@ -2,15 +2,19 @@
 //! that iteration fetches trie nodes on the frontier only, never a value chunk,
 //! and a std map oracles the key order of iteration, ranges, prefixes and floor.
 
+use core::future::Future;
+use core::pin::Pin;
+use core::task::{Context, Poll};
 use std::collections::BTreeMap;
 use std::error::Error;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use bytes::Bytes;
 use futures::executor::block_on;
-use nectar_manifest::{Builder, Cursor, Entry, Key, Reader};
+use nectar_manifest::{Builder, Cursor, Entry, Format, Key, Reader, V1};
 use nectar_primitives::store::{ChunkGet, MemoryStore};
 use nectar_primitives::{Chunk, ChunkAddress, StandardChunkSet, Verified};
+use proptest::prelude::*;
 
 type TestResult = Result<(), Box<dyn Error>>;
 
@@ -191,6 +195,163 @@ fn prefix_matches_the_oracle() -> TestResult {
         ensure_eq(got, expected, "prefix matches the oracle")?;
     }
     Ok(())
+}
+
+/// A future that yields once: `Pending` on the first poll, `Ready` after. It
+/// forces the executor to poll the other in-flight fetches before any completes,
+/// so the gated store below witnesses their true overlap.
+#[derive(Debug)]
+struct YieldOnce(bool);
+
+impl Future for YieldOnce {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        if self.0 {
+            Poll::Ready(())
+        } else {
+            self.0 = true;
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        }
+    }
+}
+
+/// A trusted store that records the peak number of concurrent `get` calls and
+/// the total, so a test reads off both the in-flight bound and the fetch count.
+/// Each `get` yields once while counted, so concurrent fetches genuinely overlap
+/// under the single-threaded test executor.
+#[derive(Debug, Default)]
+struct GatedStore {
+    inner: MemoryStore,
+    inflight: AtomicUsize,
+    peak: AtomicUsize,
+    gets: AtomicUsize,
+}
+
+impl ChunkGet<StandardChunkSet> for GatedStore {
+    type Trust = Verified;
+    type Error = <MemoryStore as ChunkGet>::Error;
+
+    async fn get(
+        &self,
+        address: &ChunkAddress,
+    ) -> Result<Chunk<Verified, StandardChunkSet>, Self::Error> {
+        self.gets.fetch_add(1, Ordering::Relaxed);
+        let now = self
+            .inflight
+            .fetch_add(1, Ordering::Relaxed)
+            .saturating_add(1);
+        self.peak.fetch_max(now, Ordering::Relaxed);
+        YieldOnce(false).await;
+        let chunk = ChunkGet::get(&self.inner, address).await;
+        self.inflight.fetch_sub(1, Ordering::Relaxed);
+        chunk
+    }
+}
+
+/// Build a wide manifest whose first-byte subtrees each outgrow the inline bound
+/// and become referenced children, so the root fans out into many sibling nodes
+/// a scan must fetch. Returns the root and an ordered oracle.
+fn wide_build(store: &MemoryStore) -> Result<(ChunkAddress, Oracle), Box<dyn Error>> {
+    let mut builder = Builder::new();
+    let mut oracle = Oracle::new();
+    for a in 0u8..48 {
+        for b in 0u8..96 {
+            let key = vec![a, b];
+            let value = Entry::inline(Bytes::from(vec![a ^ b; 32])).map_err(|e| e.to_string())?;
+            builder.insert(Key::from(key.clone()), value.clone(), None);
+            oracle.insert(key, value);
+        }
+    }
+    let built = block_on(builder.build(store)).map_err(|e| e.to_string())?;
+    Ok((*built.root(), oracle))
+}
+
+#[test]
+fn read_ahead_bounds_in_flight_and_matches_the_oracle() -> TestResult {
+    let memory = MemoryStore::default();
+    let (root, oracle) = wide_build(&memory)?;
+    // The root fans out into referenced children, so the walk crosses many
+    // sibling hops rather than reading one embedded root.
+    let nodes = memory.len();
+    ensure(nodes > 8, "manifest fans out into many referenced children")?;
+
+    let store = GatedStore {
+        inner: memory,
+        ..Default::default()
+    };
+    let reader: Reader<_> = Reader::new(&store);
+
+    let got: Rows = {
+        let mut cursor = block_on(reader.iter(&root)).map_err(|e| e.to_string())?;
+        let mut out = Vec::new();
+        while let Some((key, value)) = block_on(cursor.next()).map_err(|e| e.to_string())? {
+            out.push((key.as_bytes().to_vec(), value));
+        }
+        out
+    };
+    let expected: Rows = oracle.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+    ensure_eq(got, expected, "read-ahead iteration matches the oracle")?;
+
+    // The concurrent walk fetches exactly the trie nodes a serial walk would,
+    // once each: read-ahead cuts round trips, not fetch count.
+    ensure_eq(
+        store.gets.load(Ordering::Relaxed),
+        nodes,
+        "one fetch per trie node",
+    )?;
+
+    let peak = store.peak.load(Ordering::Relaxed);
+    let cap = V1::READ_AHEAD;
+    // The window overlapped fetches: read-ahead is genuinely concurrent.
+    ensure(peak > 1, "read-ahead ran fetches concurrently")?;
+    // Peak in-flight never exceeds the cap: the window is bounded, not O(width).
+    ensure(
+        peak <= cap,
+        &format!("peak in-flight {peak} exceeded the read-ahead cap {cap}"),
+    )
+}
+
+proptest! {
+    // The concurrent cursor returns byte-identical key/value sequences to the
+    // ordered oracle over arbitrary key sets: read-ahead reorders fetches, never
+    // results.
+    #[test]
+    fn read_ahead_iteration_matches_any_ordered_oracle(
+        pairs in prop::collection::vec(
+            (prop::collection::vec(any::<u8>(), 1..6), any::<u8>()),
+            0..300,
+        ),
+    ) {
+        let mut oracle = Oracle::new();
+        for (key, fill) in pairs {
+            let value = Entry::inline(Bytes::from(vec![fill; 32]))
+                .map_err(|e| TestCaseError::fail(e.to_string()))?;
+            oracle.insert(key, value);
+        }
+        let store = MemoryStore::default();
+        let mut builder = Builder::new();
+        for (key, value) in &oracle {
+            builder.insert(Key::from(key.clone()), value.clone(), None);
+        }
+        let built = block_on(builder.build(&store))
+            .map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let reader: Reader<_> = Reader::new(&store);
+        let got: Rows = {
+            let mut cursor = block_on(reader.iter(built.root()))
+                .map_err(|e| TestCaseError::fail(e.to_string()))?;
+            let mut out = Vec::new();
+            while let Some((key, value)) = block_on(cursor.next())
+                .map_err(|e| TestCaseError::fail(e.to_string()))?
+            {
+                out.push((key.as_bytes().to_vec(), value));
+            }
+            out
+        };
+        let expected: Rows = oracle.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+        prop_assert_eq!(got, expected);
+    }
 }
 
 #[test]


### PR DESCRIPTION
Closes #293

## What

Adds bounded-concurrency read-ahead to the ordered-read `Cursor` in `crates/manifest/src/scan.rs`.

The serial cursor fetched one trie node per `next()`, awaited inline, so `range`/`prefix`/`iter` cost one RTT per node on the covering frontier. The rewritten cursor keeps a sliding window of at most `Format::READ_AHEAD` node fetches in flight via a `FuturesUnordered` pipeline: a `schedule()` pass launches the referenced children the walk will reach next, in strict ascending-key (DFS) order, deepest-frame-first, so the soonest-needed node is always launched first and there is no head-of-line stall. `resolve()` takes the completion tagged with the descent's sequence id, buffering earlier-arriving completions.

Scheduling mirrors the walk's own termination exactly: it stops at the first step at/past the exclusive upper bound and at the first encrypted child, so it launches precisely the nodes a serial walk fetches, no more and no less.

`Format::READ_AHEAD` is a new associated const (default `16`) documenting the window size; it is a reader-side tuning knob, not a wire parameter. `futures` moves from a dev-dependency to a real dependency of `nectar-manifest` to support the pipeline.

## Why

Ordered scans (`range`, `prefix`, `iter`) previously paid one network round trip per trie node on the frontier, serialized. Pipelining independent node fetches up to a bounded window removes that serialization without changing what gets fetched or the order results are yielded in.

## Testing

Verified independently against tip `22a5d62`, rebased on `s264/72-closing-fixes`:

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean, no warnings.
- `cargo nextest run --workspace --all-features`: 886 passed, 1 skipped.
- New tests added in `crates/manifest/tests/scan.rs`: a `GatedStore` instrument to observe in-flight fetch counts, a proptest comparing concurrent-cursor output against the serial walk, and a bound test (`read_ahead_bounds_in_flight_and_matches_serial_output` and a follow-up guard test) confirming the read-ahead window never schedules past the range's exclusive upper bound. All green in isolation and as part of the full suite.

Reviewed for correctness: `resolve()` always returns `flatten(get_node(addr))` with a stable seq<->addr binding, walk ordering/bounds are unchanged, and `schedule()` only chooses what to prefetch, so concurrent-cursor output is provably identical to the serial walk. New code is panic-free on adversarial input (only `.get()`/`saturating_add`, no indexing). The peak `inflight + ready <= cap` memory bound holds.

This PR targets `s264/72-closing-fixes` as part of the s264 stacked train; no CI beyond CLA runs until it is retargeted.

AI Assistance: Claude (Anthropic) used for implementation, red-team review, and independent verification testing of this change.

