### PR TITLE
feat(manifest): serve a prefix as a subtree root reference

### DIFF
--- a/crates/manifest/src/folder.rs
+++ b/crates/manifest/src/folder.rs
@@ -72,6 +72,10 @@ pub struct Listing<'a, S, F: Format = V1> {
     root: ChunkAddress,
     /// The exclusive bound of the directory's prefix range.
     end: Option<Bytes>,
+    /// Key bytes the cursor walks below; prepended to each cursor key to
+    /// recover the full key. Empty unless the listing delegated to a subtree
+    /// root, where the cursor walks the subtree's own key space.
+    base: Bytes,
     /// Key bytes consumed by the directory prefix; a child's segment starts
     /// here.
     dir_len: usize,
@@ -99,23 +103,26 @@ where
             let Some((key, entry)) = self.cursor.next().await? else {
                 return Ok(None);
             };
-            let bytes = key.as_bytes();
+            let full = self.full_key(key);
+            let bytes = full.as_bytes();
             let suffix = bytes.get(self.dir_len..).unwrap_or(&[]);
             // The directory path itself is not one of its own children.
             if suffix.is_empty() {
                 continue;
             }
             match suffix.iter().position(|&byte| byte == F::SEPARATOR) {
-                None => return Ok(Some(DirEntry::File { key, entry })),
+                None => return Ok(Some(DirEntry::File { key: full, entry })),
                 Some(cut) => {
                     let through = self.dir_len.saturating_add(cut).saturating_add(1);
                     let dir = bytes.get(..through).unwrap_or(bytes);
                     let dir_key = Key::from(dir);
                     match successor(dir) {
                         Some(start) => {
+                            // The cursor walks below `base`, so a reseek strips
+                            // the shared base the delegated subtree omits.
+                            let rel = start.get(self.base.len()..).unwrap_or(&[]);
                             self.cursor =
-                                Cursor::seek(self.store, &self.root, &start, self.end.clone())
-                                    .await?;
+                                Cursor::seek(self.store, &self.root, rel, self.end.clone()).await?;
                         }
                         None => self.done = true,
                     }
@@ -123,6 +130,19 @@ where
                 }
             }
         }
+    }
+
+    /// The full key of a cursor step: the delegated base followed by the cursor
+    /// key, which is the cursor key itself when the walk is rooted at the
+    /// manifest and no base was stripped.
+    fn full_key(&self, key: Key) -> Key {
+        if self.base.is_empty() {
+            return key;
+        }
+        let mut bytes = Vec::with_capacity(self.base.len().saturating_add(key.len()));
+        bytes.extend_from_slice(&self.base);
+        bytes.extend_from_slice(key.as_bytes());
+        Key::from(bytes)
     }
 }
 
@@ -219,12 +239,33 @@ where
         dir: &Key,
     ) -> Result<Listing<'_, S, F>, ReaderError> {
         let prefix = dir.as_bytes();
+        // When the directory's keys are exactly one referenced chunk reached at
+        // the prefix boundary, delegate the walk to that subtree root: it holds
+        // precisely the directory's keys, so the walk starts there and needs no
+        // upper bound. A boundary deeper than the prefix, or none, walks from
+        // the manifest root as before.
+        if let Some(found) = self.descend_subtree(root, prefix).await?
+            && found.base == prefix.len()
+        {
+            let subtree = *found.reference.address();
+            let cursor = Cursor::seek(self.store(), &subtree, &[], None).await?;
+            return Ok(Listing {
+                store: self.store(),
+                root: subtree,
+                end: None,
+                base: Bytes::copy_from_slice(prefix),
+                dir_len: prefix.len(),
+                done: false,
+                cursor,
+            });
+        }
         let end = successor(prefix);
         let cursor = Cursor::seek(self.store(), root, prefix, end.clone()).await?;
         Ok(Listing {
             store: self.store(),
             root: *root,
             end,
+            base: Bytes::new(),
             dir_len: prefix.len(),
             done: false,
             cursor,
@@ -435,6 +476,62 @@ mod tests {
         // Seeking past the subtree keeps the fetch count to the frontier, far
         // below the 64 leaves under it.
         assert!(store.gets() < 16, "fetched {} nodes", store.gets());
+    }
+
+    #[test]
+    fn list_delegates_a_referenced_subtree() {
+        use crate::bounded::Prefix;
+        use crate::fork::{Child, ForkTable};
+        use crate::node::Node;
+        use crate::store::NodePut;
+
+        let store = MemoryStore::default();
+        // A referenced "mg/" subtree holding a nested subdirectory and a file,
+        // so listing it delegates to the subtree root and still collapses and
+        // reseeks in the subtree's own key space.
+        let mut inner = ForkTable::new();
+        inner
+            .insert(
+                Prefix::try_from(&b"1"[..]).unwrap(),
+                entry(0x01).into(),
+                None,
+            )
+            .unwrap();
+        inner
+            .insert(
+                Prefix::try_from(&b"2"[..]).unwrap(),
+                entry(0x02).into(),
+                None,
+            )
+            .unwrap();
+        let mut leaf = ForkTable::new();
+        leaf.insert(
+            Prefix::try_from(&b"a/"[..]).unwrap(),
+            Child::Embedded(inner).into(),
+            None,
+        )
+        .unwrap();
+        leaf.insert(
+            Prefix::try_from(&b"logo.png"[..]).unwrap(),
+            entry(0xBB).into(),
+            None,
+        )
+        .unwrap();
+        let leaf_ref = block_on(store.put_node(&Node::new(None, leaf))).unwrap();
+
+        let mut forks: ForkTable = ForkTable::new();
+        forks
+            .insert(
+                Prefix::try_from(&b"mg/"[..]).unwrap(),
+                Child::Ref32(ChunkRef::new(leaf_ref)).into(),
+                None,
+            )
+            .unwrap();
+        let root = block_on(store.put_node(&Node::new(None, forks))).unwrap();
+
+        let reader: Reader<_> = Reader::new(&store);
+        let got = entries(block_on(reader.list(&root, &Key::from(&b"mg/"[..]))).unwrap());
+        assert_eq!(got, vec![dir(b"mg/a/"), file(b"mg/logo.png", 0xBB)]);
     }
 
     #[test]

--- a/crates/manifest/src/reader.rs
+++ b/crates/manifest/src/reader.rs
@@ -9,7 +9,7 @@
 use core::marker::PhantomData;
 
 use nectar_primitives::store::MaybeSync;
-use nectar_primitives::{ChunkAddress, ChunkOps};
+use nectar_primitives::{ChunkAddress, ChunkOps, ChunkRef};
 
 use crate::codec::{DecodedChunk, SegmentDir};
 use crate::fork::{Child, ForkTable};
@@ -115,6 +115,149 @@ where
                     is_root = false;
                 }
             }
+        }
+    }
+
+    /// The reference of the single chunk that holds exactly the keys carrying
+    /// `prefix`, so a folder or prefix listing can be handed off in one
+    /// delegation rather than walked.
+    ///
+    /// The empty prefix selects the whole manifest and returns the root
+    /// reference. The result is `None` when no single chunk's key set is
+    /// exactly the prefix's: the prefix selects nothing, ends inside an embedded
+    /// child, or ends at a fork that also terminates a key. Descent into an
+    /// encrypted subtree surfaces as [`ReaderError::EncryptedChild`], since a
+    /// plain reference cannot carry it.
+    pub async fn subtree(
+        &self,
+        root: &ChunkAddress,
+        prefix: &Key,
+    ) -> Result<Option<ChunkRef>, ReaderError> {
+        Ok(self
+            .descend_subtree(root, prefix.as_bytes())
+            .await?
+            .map(|found| found.reference))
+    }
+
+    /// Descend `prefix` to the referenced chunk whose key set it is, tracking
+    /// the key bytes consumed to reach that chunk's root.
+    ///
+    /// Each referenced hop is one fetch, and the boundary chunk itself is never
+    /// fetched: its reference is the answer, so the cost is O(depth) fetches
+    /// down to the boundary and nothing below it.
+    pub(crate) async fn descend_subtree(
+        &self,
+        root: &ChunkAddress,
+        prefix: &[u8],
+    ) -> Result<Option<Subtree>, ReaderError> {
+        if prefix.is_empty() {
+            return Ok(Some(Subtree {
+                reference: ChunkRef::new(*root),
+                base: 0,
+            }));
+        }
+        let mut address = *root;
+        let mut base = 0usize;
+        loop {
+            let node = self.store.get_node::<F>(&address).await?;
+            match subtree_step(node.forks(), prefix, base) {
+                SubtreeStep::Absent => return Ok(None),
+                SubtreeStep::Encrypted => return Err(ReaderError::EncryptedChild),
+                SubtreeStep::Boundary(reference, base) => {
+                    return Ok(Some(Subtree { reference, base }));
+                }
+                SubtreeStep::Descend(next_address, next) => {
+                    address = next_address;
+                    base = next;
+                }
+            }
+        }
+    }
+}
+
+/// A prefix's subtree: the chunk holding exactly the prefix's keys, and the key
+/// bytes consumed to reach that chunk's root.
+pub(crate) struct Subtree {
+    /// The subtree chunk's reference.
+    pub(crate) reference: ChunkRef,
+    /// Key bytes consumed to reach the subtree chunk's root; at least the
+    /// prefix length, and equal to it when the prefix ends at the chunk root.
+    pub(crate) base: usize,
+}
+
+/// Where following `prefix` from `pos` through a chunk's embedded fork tables
+/// lands, stopping at the first boundary, referenced hop, or dead end.
+enum SubtreeStep {
+    /// No single chunk's key set is exactly the prefix's below here.
+    Absent,
+    /// The prefix funnels into an encrypted child the plain reader cannot open.
+    Encrypted,
+    /// The prefix's key set is exactly this referenced child's; its reference
+    /// and the key bytes consumed to reach the child's root.
+    Boundary(ChunkRef, usize),
+    /// The prefix continues past this edge into a referenced child at the given
+    /// address, with this many key bytes consumed.
+    Descend(ChunkAddress, usize),
+}
+
+/// Follow `prefix` from `pos` down a node's fork table and its embedded
+/// children, stopping where the prefix's key set is a lone referenced child,
+/// crosses a referenced edge, or has no single-chunk boundary.
+///
+/// Stays within one chunk: an embedded child lives in the parent's bytes, so
+/// the walk crosses embedded tables without a fetch and only a referenced edge
+/// bubbles up as a hop or a boundary.
+fn subtree_step<F: Format>(table: &ForkTable<F>, prefix: &[u8], pos: usize) -> SubtreeStep {
+    let mut table = table;
+    let mut pos = pos;
+    loop {
+        let Some(&byte) = prefix.get(pos) else {
+            return SubtreeStep::Absent;
+        };
+        let Some(record) = table.get(byte) else {
+            return SubtreeStep::Absent;
+        };
+        let tail = record.tail().as_bytes();
+        let Some(start) = pos.checked_add(1) else {
+            return SubtreeStep::Absent;
+        };
+        let Some(end) = start.checked_add(tail.len()) else {
+            return SubtreeStep::Absent;
+        };
+        // The prefix bytes past the fork byte, up to whatever the prefix holds.
+        let rest = prefix.get(start..).unwrap_or(&[]);
+        if prefix.len() <= end {
+            // The prefix ends at or within this edge: a boundary only when the
+            // fork is a lone reference whose child holds exactly its key set.
+            match tail.get(..rest.len()) {
+                Some(head) if head == rest => {}
+                _ => return SubtreeStep::Absent,
+            }
+            if record.entry().is_some() {
+                return SubtreeStep::Absent;
+            }
+            return match record.child() {
+                Some(Child::Ref32(reference)) => SubtreeStep::Boundary(*reference, end),
+                Some(Child::Ref64(_)) => SubtreeStep::Encrypted,
+                Some(Child::Embedded(_)) | None => SubtreeStep::Absent,
+            };
+        }
+        // The prefix passes the edge end: the whole edge must match, then the
+        // walk continues into the child.
+        match prefix.get(start..end) {
+            Some(matched) if matched == tail => {}
+            _ => return SubtreeStep::Absent,
+        }
+        match record.child() {
+            Some(Child::Embedded(inner)) => {
+                table = inner;
+                pos = end;
+            }
+            Some(Child::Ref32(reference)) => {
+                return SubtreeStep::Descend(*reference.address(), end);
+            }
+            Some(Child::Ref64(_)) => return SubtreeStep::Encrypted,
+            None => return SubtreeStep::Absent,
         }
     }
 }
@@ -367,6 +510,128 @@ mod tests {
             block_on(reader.get(&root, &Key::from(&b"k"[..]))).unwrap(),
             Some(value),
         );
+    }
+
+    // A manifest whose "mg/" directory is a referenced subtree holding one key
+    // "mg/logo.png", with "index.html" embedded in the root under "i".
+    fn subtree_sample(store: &MemoryStore) -> (ChunkAddress, ChunkAddress) {
+        let mut leaf = ForkTable::new();
+        leaf.insert(prefix(b"logo.png"), entry(0xBB).into(), None)
+            .unwrap();
+        let leaf_ref = block_on(store.put_node(&Node::new(None, leaf))).unwrap();
+
+        let mut embedded = ForkTable::new();
+        embedded
+            .insert(prefix(b"ndex.html"), entry(0xAA).into(), None)
+            .unwrap();
+        let mut forks = ForkTable::new();
+        forks
+            .insert(prefix(b"i"), Child::Embedded(embedded).into(), None)
+            .unwrap();
+        forks
+            .insert(
+                prefix(b"mg/"),
+                Child::Ref32(ChunkRef::new(leaf_ref)).into(),
+                None,
+            )
+            .unwrap();
+        let root = block_on(store.put_node(&Node::new(None, forks))).unwrap();
+        (root, leaf_ref)
+    }
+
+    #[test]
+    fn subtree_of_the_empty_prefix_is_the_root() {
+        let store = MemoryStore::default();
+        let (root, _) = subtree_sample(&store);
+        let reader: Reader<_> = Reader::new(&store);
+        assert_eq!(
+            block_on(reader.subtree(&root, &Key::empty())).unwrap(),
+            Some(ChunkRef::new(root)),
+        );
+    }
+
+    #[test]
+    fn subtree_returns_the_referenced_child_covering_the_prefix() {
+        let store = MemoryStore::default();
+        let (root, leaf_ref) = subtree_sample(&store);
+        let reader: Reader<_> = Reader::new(&store);
+        // The prefix ends exactly at the referenced edge: the child is the
+        // subtree root, and its key set is exactly the "mg/" keys.
+        assert_eq!(
+            block_on(reader.subtree(&root, &Key::from(&b"mg/"[..]))).unwrap(),
+            Some(ChunkRef::new(leaf_ref)),
+        );
+        // A shorter prefix funnels into the same lone child with no branch or
+        // key between: still one node boundary, still the child.
+        assert_eq!(
+            block_on(reader.subtree(&root, &Key::from(&b"m"[..]))).unwrap(),
+            Some(ChunkRef::new(leaf_ref)),
+        );
+    }
+
+    #[test]
+    fn subtree_of_a_mid_edge_prefix_with_no_boundary_is_none() {
+        let store = MemoryStore::default();
+        let (root, _) = subtree_sample(&store);
+        let reader: Reader<_> = Reader::new(&store);
+        // "mg/logo" lands within the leaf's "logo.png" edge, which terminates a
+        // key rather than referencing a child: no chunk holds exactly its keys.
+        assert_eq!(
+            block_on(reader.subtree(&root, &Key::from(&b"mg/logo"[..]))).unwrap(),
+            None,
+        );
+    }
+
+    #[test]
+    fn subtree_of_an_embedded_prefix_is_none() {
+        let store = MemoryStore::default();
+        let (root, _) = subtree_sample(&store);
+        let reader: Reader<_> = Reader::new(&store);
+        // "index.html" lives embedded in the root chunk, with no chunk of its
+        // own to hand off.
+        assert_eq!(
+            block_on(reader.subtree(&root, &Key::from(&b"i"[..]))).unwrap(),
+            None,
+        );
+    }
+
+    #[test]
+    fn subtree_of_an_absent_prefix_is_none() {
+        let store = MemoryStore::default();
+        let (root, _) = subtree_sample(&store);
+        let reader: Reader<_> = Reader::new(&store);
+        assert_eq!(
+            block_on(reader.subtree(&root, &Key::from(&b"zzz"[..]))).unwrap(),
+            None,
+        );
+    }
+
+    #[test]
+    fn subtree_covers_exactly_the_prefix_key_set() {
+        let store = MemoryStore::default();
+        let (root, leaf_ref) = subtree_sample(&store);
+        let reader: Reader<_> = Reader::new(&store);
+        let sub = block_on(reader.subtree(&root, &Key::from(&b"mg/"[..])))
+            .unwrap()
+            .unwrap();
+        assert_eq!(sub.address(), &leaf_ref);
+
+        // The delegated subtree, walked from its own root, yields the same keys
+        // as the prefix range walked from the manifest root.
+        let mut delegated = Vec::new();
+        let mut cursor = block_on(reader.iter(sub.address())).unwrap();
+        while let Some((key, value)) = block_on(cursor.next()).unwrap() {
+            let mut full = b"mg/".to_vec();
+            full.extend_from_slice(key.as_bytes());
+            delegated.push((full, value));
+        }
+
+        let mut walked = Vec::new();
+        let mut cursor = block_on(reader.prefix(&root, &Key::from(&b"mg/"[..]))).unwrap();
+        while let Some((key, value)) = block_on(cursor.next()).unwrap() {
+            walked.push((key.as_bytes().to_vec(), value));
+        }
+        assert_eq!(delegated, walked);
     }
 
     #[test]

--- a/crates/manifest/src/reader.rs
+++ b/crates/manifest/src/reader.rs
@@ -391,7 +391,7 @@ mod tests {
     use bytes::Bytes;
     use futures::executor::block_on;
     use nectar_primitives::store::MemoryStore;
-    use nectar_primitives::{ChunkAddress, ChunkRef};
+    use nectar_primitives::{ChunkAddress, ChunkRef, EncryptedChunkRef, EncryptionKey};
 
     use crate::bounded::Prefix;
     use crate::fork::{Child, ForkPayload, ForkTable};
@@ -604,6 +604,37 @@ mod tests {
             block_on(reader.subtree(&root, &Key::from(&b"zzz"[..]))).unwrap(),
             None,
         );
+    }
+
+    #[test]
+    fn subtree_through_an_encrypted_child_is_an_error() {
+        let store = MemoryStore::default();
+        // A "sec/" directory referenced through an encrypted (ref64) child: the
+        // plain reader cannot open it, and a 32-byte reference cannot carry it.
+        let mut forks = ForkTable::new();
+        forks
+            .insert(
+                prefix(b"sec/"),
+                Child::Ref64(EncryptedChunkRef::new(
+                    ChunkAddress::new([0x5E; 32]),
+                    EncryptionKey::from([0xA1; 32]),
+                ))
+                .into(),
+                None,
+            )
+            .unwrap();
+        let root = block_on(store.put_node(&Node::new(None, forks))).unwrap();
+        let reader: Reader<_> = Reader::new(&store);
+        // The boundary lands exactly on the encrypted edge.
+        assert!(matches!(
+            block_on(reader.subtree(&root, &Key::from(&b"sec/"[..]))),
+            Err(ReaderError::EncryptedChild),
+        ));
+        // A shorter prefix funnelling into the same encrypted child errs alike.
+        assert!(matches!(
+            block_on(reader.subtree(&root, &Key::from(&b"s"[..]))),
+            Err(ReaderError::EncryptedChild),
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds `Reader::subtree(root, prefix) -> Result<Option<ChunkRef>, ReaderError>` in `crates/manifest/src/reader.rs`: reader-side support for serving a prefix (folder) as a subtree root reference, so a client can delegate to the single chunk holding exactly a prefix's keys instead of walking it. No format, invariant, or error-variant change; `ReaderError::EncryptedChild` is a pre-existing variant, reused for descent into an encrypted subtree, since a 32-byte `ChunkRef` cannot carry a 64-byte encrypted reference.

Semantics, documented precisely in rustdoc:

- The empty prefix returns the root reference.
- A prefix that ends within an embedded child, at a fork that also terminates a key, or that selects nothing returns `None`.
- A mid-edge prefix that still funnels into one lone referenced child returns that child, because there is a node boundary even though the prefix does not land exactly on it.
- Descent into an encrypted subtree surfaces as `ReaderError::EncryptedChild`.

Descent is implemented via a new `descend_subtree` helper plus a pure `subtree_step` walker over embedded fork tables (`crates/manifest/src/reader.rs`), using `store.get_node` so spilled/segmented nodes are transparently materialized. Each referenced hop costs one fetch, and the boundary chunk itself is never fetched, so the cost is O(depth) down to the boundary.

`crates/manifest/src/folder.rs`'s directory listing now uses `descend_subtree` to delegate: when a directory's keys are exactly one referenced chunk reached at the prefix boundary, the `Listing` walk starts at that subtree root directly, with no upper bound needed, instead of walking the whole manifest with a prefix/end bound. Listing tracks the delegated `base` so reseeks and returned keys still reconstruct the full key correctly.

## Why

Closes #294

Serving a prefix as a subtree root reference lets a folder or prefix listing be handed off in one delegation rather than walked node by node from the manifest root, which is the piece this issue asks for on the reader side.

## Testing

Adversarial review found no correctness bug in the subtree logic. Verified against the hunt list: `subtree_step`/`descend_subtree` use only fallible byte access (`.get()`, `checked_add`, no slicing or `unwrap`), so a truncated or adversarial fork table cannot panic; descent cannot loop forever on a cyclic manifest because `base` strictly increases each hop and is bounded by `prefix.len()`; the boundary/base offset arithmetic (`end = pos + 1 + tail.len()`, the mid-edge `tail.get(..rest.len())` match, entry-present implies `Absent`) is sound; delegation in `folder.rs` is correctly restricted to `base == prefix.len()`.

Independent verification at tip `0a4dade` (2 commits atop `s264/74-parallel-cursor`: `fd4c272` feat, `0a4dade` test). Changed files are `crates/manifest/src/reader.rs` and `crates/manifest/src/folder.rs` only, confirming the change is reader-side with no format, invariant, or new error-variant surface.

Full battery, all via `nix develop --command` (`cargo-nextest` supplied ephemerally via `nix-shell -p cargo-nextest`):

- `cargo fmt --all -- --check`: pass
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: pass
- `cargo nextest run --workspace --all-features`: pass, 894 run, 894 passed, 1 skipped
- `cargo test --doc --workspace`: pass

Wasm and fuzz targets were correctly skipped: neither `nectar-postage-usage` nor `fuzz/` is in the diff.

This is a stacked PR targeting `s264/74-parallel-cursor`, not `main`; no CI beyond CLA runs until it is retargeted.

## AI assistance

Implemented and red-teamed with Claude (Anthropic), per the project's AI assistance disclosure in [nxm-rs/.github CONTRIBUTING.md](https://github.com/nxm-rs/.github/blob/main/CONTRIBUTING.md).

Closes #294

