### PR TITLE
feat(manifest): add V1Read read-optimized format profile

### DIFF
--- a/crates/manifest/src/format.rs
+++ b/crates/manifest/src/format.rs
@@ -8,6 +8,7 @@ use nectar_primitives::DEFAULT_BODY_SIZE;
 mod sealed {
     pub trait Sealed {}
     impl Sealed for super::V1 {}
+    impl Sealed for super::V1Read {}
 }
 
 /// Frozen layout parameters of one manifest wire format version, carried as
@@ -112,29 +113,93 @@ impl Format for V1 {
     const DERIVE_TAG: &'static [u8] = b"mantaray/1.0/key";
 }
 
-// Frozen cross-parameter facts, kept honest at compile time.
-const _: () = {
-    assert!(
-        V1::BUDGET + V1::PREAMBLE.len() == DEFAULT_BODY_SIZE,
-        "BUDGET must be the chunk body minus the preamble"
-    );
-    assert!(
-        V1::CAP_DIR < V1::CAP_FORK && V1::CAP_FORK < V1::BUDGET,
-        "segment capacities must sit below the body budget"
-    );
-    assert!(
-        V1::SEG_MIN <= V1::SEG_TARGET && V1::SEG_TARGET <= V1::CAP_DIR,
-        "cut suppression and target must fit the tightest capacity"
-    );
-    assert!(
-        V1::VINLINE_MAX <= V1::INLINE_MAX && V1::INLINE_MAX < V1::BUDGET,
-        "inline caps must nest below the body budget"
-    );
-    assert!(
-        V1::VINLINE_MAX <= 0xFF && V1::CKEY_MAX <= 0xFF && V1::META_MAX <= 0xFFFF,
-        "bounded lengths must fit their one- or two-byte wire length fields"
-    );
-};
+/// The read-optimized `tag_version 0x02` parameter set: the frozen `V1` layout
+/// with a heavier embedding budget.
+///
+/// A larger `INLINE_MAX` inlines heavier subtrees into their parent, so a
+/// range or listing window resolves through fewer referenced hops. The honest
+/// cost is single-update write-amplification: editing any key beneath an
+/// embedded subtree rewrites the larger parent chunk. A distinct wire version,
+/// so a manifest built here is byte-distinct from a `V1` one and only a
+/// `V1Read` reader accepts its heavier embeds; frozen `V1` is untouched. Every
+/// termination bound `V1` carries holds here, asserted below.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct V1Read;
+
+impl Format for V1Read {
+    const VERSION: u8 = 0x02;
+    const BUDGET: usize = V1::BUDGET;
+    const PLEN_MAX: usize = V1::PLEN_MAX;
+    const VINLINE_MAX: usize = V1::VINLINE_MAX;
+    const META_MAX: usize = V1::META_MAX;
+    const CKEY_MAX: usize = V1::CKEY_MAX;
+    const FORKS_MAX: usize = V1::FORKS_MAX;
+    // The one retuned parameter: a heavier embedding budget, still leaving the
+    // forced-cut margin a minimum-weight segment (asserted below).
+    const INLINE_MAX: usize = 2048;
+    const SEG_TARGET: usize = V1::SEG_TARGET;
+    const SEG_MIN: usize = V1::SEG_MIN;
+    const CAP_FORK: usize = V1::CAP_FORK;
+    const CAP_DIR: usize = V1::CAP_DIR;
+    const CUT_SCALE: u64 = V1::CUT_SCALE;
+    const DERIVE_TAG: &'static [u8] = V1::DERIVE_TAG;
+}
+
+// Frozen cross-parameter facts, kept honest at compile time. The bounds hold
+// for every profile: the heaviest fork record still fits a leaf segment alone,
+// so partitioning terminates and the OverBudget guard stays unreachable (spec
+// 5.4). Emitted as a const block per format so the checks evaluate at compile
+// time.
+macro_rules! assert_layout {
+    ($f:ty) => {
+        const _: () = {
+            assert!(
+                <$f>::BUDGET + <$f>::PREAMBLE.len() == DEFAULT_BODY_SIZE,
+                "BUDGET must be the chunk body minus the preamble"
+            );
+            assert!(
+                <$f>::CAP_DIR < <$f>::CAP_FORK && <$f>::CAP_FORK < <$f>::BUDGET,
+                "segment capacities must sit below the body budget"
+            );
+            assert!(
+                <$f>::SEG_MIN <= <$f>::SEG_TARGET && <$f>::SEG_TARGET <= <$f>::CAP_DIR,
+                "cut suppression and target must fit the tightest capacity"
+            );
+            assert!(
+                <$f>::VINLINE_MAX <= <$f>::INLINE_MAX && <$f>::INLINE_MAX < <$f>::BUDGET,
+                "inline caps must nest below the body budget"
+            );
+            assert!(
+                <$f>::VINLINE_MAX <= 0xFF && <$f>::CKEY_MAX <= 0xFF && <$f>::META_MAX <= 0xFFFF,
+                "bounded lengths must fit their one- or two-byte wire length fields"
+            );
+            // The worst-case Both fork record: an index slot, flags, plen, the
+            // longest tail, an inline value, an embedded child and two full
+            // metadata blocks (spec 5.4).
+            let worst = 3
+                + 1
+                + 1
+                + (<$f>::PLEN_MAX - 1)
+                + (1 + <$f>::VINLINE_MAX)
+                + (2 + <$f>::INLINE_MAX)
+                + (2 + <$f>::META_MAX);
+            // Any single record fits a leaf segment, so partitioning
+            // terminates, and the forced-cut margin still leaves room for a
+            // minimum-weight segment.
+            assert!(
+                worst <= <$f>::CAP_FORK,
+                "the worst fork record must fit a leaf segment alone"
+            );
+            assert!(
+                <$f>::CAP_FORK - worst >= <$f>::SEG_MIN,
+                "the forced-cut margin must leave a minimum-weight segment"
+            );
+        };
+    };
+}
+
+assert_layout!(V1);
+assert_layout!(V1Read);
 
 #[cfg(test)]
 mod tests {
@@ -173,6 +238,48 @@ mod tests {
     fn cut_scale_divides_the_hash_space_by_seg_target() {
         let product = u128::from(V1::CUT_SCALE) * u128::try_from(V1::SEG_TARGET).unwrap();
         assert_eq!(product, 1u128 << 64);
+    }
+
+    // The read profile is a distinct wire version carrying V1's layout with a
+    // heavier embedding budget; only INLINE_MAX and the version byte move.
+    #[test]
+    fn v1read_is_v1_with_a_heavier_embedding_budget() {
+        assert_eq!(V1Read::PREAMBLE, [0x6D, 0x02]);
+        assert_eq!(V1Read::VERSION, 0x02);
+        assert_ne!(V1Read::VERSION, V1::VERSION);
+        // A strictly larger embedding budget: the whole point of the profile.
+        const { assert!(V1Read::INLINE_MAX > V1::INLINE_MAX) };
+        assert_eq!(V1Read::INLINE_MAX, 2048);
+        // Every other layout parameter is inherited from V1 unchanged.
+        assert_eq!(V1Read::BUDGET, V1::BUDGET);
+        assert_eq!(V1Read::PLEN_MAX, V1::PLEN_MAX);
+        assert_eq!(V1Read::VINLINE_MAX, V1::VINLINE_MAX);
+        assert_eq!(V1Read::META_MAX, V1::META_MAX);
+        assert_eq!(V1Read::CKEY_MAX, V1::CKEY_MAX);
+        assert_eq!(V1Read::FORKS_MAX, V1::FORKS_MAX);
+        assert_eq!(V1Read::SEG_TARGET, V1::SEG_TARGET);
+        assert_eq!(V1Read::SEG_MIN, V1::SEG_MIN);
+        assert_eq!(V1Read::CAP_FORK, V1::CAP_FORK);
+        assert_eq!(V1Read::CAP_DIR, V1::CAP_DIR);
+        assert_eq!(V1Read::CUT_SCALE, V1::CUT_SCALE);
+        assert_eq!(V1Read::DERIVE_TAG, V1::DERIVE_TAG);
+    }
+
+    // The heavier budget keeps the termination bounds: the worst fork record
+    // still fits a leaf segment alone, and the forced-cut margin still leaves a
+    // minimum-weight segment (spec 5.4).
+    #[test]
+    fn the_read_profile_worst_fork_record_fits_a_segment_alone() {
+        let worst = 3
+            + 1
+            + 1
+            + (V1Read::PLEN_MAX - 1)
+            + (1 + V1Read::VINLINE_MAX)
+            + (2 + V1Read::INLINE_MAX)
+            + (2 + V1Read::META_MAX);
+        assert_eq!(worst, 3464);
+        assert!(worst <= V1Read::CAP_FORK);
+        assert!(V1Read::CAP_FORK - worst >= V1Read::SEG_MIN);
     }
 
     // The frozen bounds that make spill terminate and keep the OverBudget guard

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -6,7 +6,9 @@
 //! 0x01` parameter set, and public types default their format parameter to
 //! [`V1`]. Bounded newtypes ([`Prefix`], [`MetadataLen`], [`SegmentWeight`])
 //! check a format bound once at construction and carry it as a type
-//! invariant.
+//! invariant. [`V1Read`] is an opt-in read-optimized sibling: the same layout
+//! with a heavier embedding budget, trading single-update write-amplification
+//! for fewer chunks touched per range or listing window.
 //!
 //! The value model is [`Key`] (arbitrary bytes), [`Entry`] (a chunk
 //! reference or an inline value; absence is `Option` at the use site) and
@@ -107,7 +109,7 @@ pub use error::{
 };
 pub use folder::{DirEntry, Listing, Served, Website};
 pub use fork::{Child, ForkPayload, ForkRecord, ForkTable};
-pub use format::{Format, V1};
+pub use format::{Format, V1, V1Read};
 pub use meta::{CustomKey, KeyId, Metadata, MetadataKey};
 pub use node::{Node, RootExtension};
 pub use packing::{Directory, Domain, SegmentKind, cut, embed, h64, segment, spill};

--- a/crates/manifest/src/packing.rs
+++ b/crates/manifest/src/packing.rs
@@ -248,7 +248,7 @@ pub fn spill<F: Format>(forks: &[(Prefix<F>, SegmentWeight<F>)], domain: Domain)
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::format::V1;
+    use crate::format::{V1, V1Read};
 
     // The eight worked forks a..h with the spec's weights and hash-cut bits.
     const ROWS: [(u8, u64, bool); 8] = [
@@ -362,6 +362,25 @@ mod tests {
         ));
         assert!(!embed::<V1>(1, Domain::Plain, Domain::Encrypted));
         assert!(embed::<V1>(1, Domain::Encrypted, Domain::Encrypted));
+    }
+
+    // A subtree sized in the window between the two budgets is referenced under
+    // V1 but embedded under the read profile: the direct source of the read
+    // profile's fewer-fetches trade.
+    #[test]
+    fn the_read_profile_embeds_where_v1_references() {
+        for len in [V1::INLINE_MAX + 1, V1Read::INLINE_MAX] {
+            assert!(!embed::<V1>(len, Domain::Plain, Domain::Plain));
+            assert!(embed::<V1Read>(len, Domain::Plain, Domain::Plain));
+        }
+        // The read profile does not embed across the domain boundary either.
+        assert!(!embed::<V1Read>(1, Domain::Plain, Domain::Encrypted));
+        // Nor beyond its own, larger budget.
+        assert!(!embed::<V1Read>(
+            V1Read::INLINE_MAX + 1,
+            Domain::Plain,
+            Domain::Plain
+        ));
     }
 
     #[test]

--- a/crates/manifest/tests/read_profile.rs
+++ b/crates/manifest/tests/read_profile.rs
@@ -1,0 +1,144 @@
+//! The read-optimised profile through the public API: the whole build, read
+//! and apply path is generic over the format, and a heavier embedding budget
+//! inlines a subtree that V1 would reference, so the same key set resolves
+//! through fewer chunks under `V1Read`.
+
+use std::error::Error;
+
+use bytes::Bytes;
+use futures::executor::block_on;
+use nectar_manifest::{Builder, Changeset, Entry, Key, Reader, V1, V1Read, apply};
+use nectar_primitives::{ChunkAddress, ChunkRef, MemoryStore};
+
+type TestResult = Result<(), Box<dyn Error>>;
+
+fn ensure(cond: bool, what: &str) -> TestResult {
+    if cond { Ok(()) } else { Err(what.into()) }
+}
+
+fn ref_entry<F: nectar_manifest::Format>(fill: u8) -> Entry<F> {
+    Entry::from(ChunkRef::new(ChunkAddress::new([fill; 32])))
+}
+
+/// Keys sharing a single first byte and diverging at the second, so they hang
+/// off one root fork as a single sub-node. Forty-eight ref32 records size that
+/// sub-node body into the window between the two embedding budgets: V1
+/// references it, the read profile embeds it.
+fn windowed_keys() -> Vec<(Key, u8)> {
+    (0u8..48).map(|x| (Key::from(&[b'a', x][..]), x)).collect()
+}
+
+/// Build the windowed key set under `F`, returning the root and the number of
+/// distinct chunks the build stored.
+fn build_windowed<F: nectar_manifest::Format>() -> Result<(ChunkAddress, usize), Box<dyn Error>> {
+    let store = MemoryStore::default();
+    let mut builder = Builder::<F>::new();
+    for (key, fill) in windowed_keys() {
+        builder.insert(key, ref_entry::<F>(fill), None);
+    }
+    let built = block_on(builder.build(&store))?;
+    Ok((*built.root(), store.len()))
+}
+
+#[test]
+fn the_read_profile_stores_fewer_chunks_for_a_windowed_subtree() -> TestResult {
+    let (_, v1_chunks) = build_windowed::<V1>()?;
+    let (_, read_chunks) = build_windowed::<V1Read>()?;
+    // The sub-node is referenced under V1 (its own chunk) but embedded under
+    // the read profile (folded into the root), so the read build stores fewer.
+    ensure(
+        read_chunks < v1_chunks,
+        "read profile must store fewer chunks than V1 for the windowed subtree",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn the_read_profile_and_v1_produce_distinct_roots() -> TestResult {
+    let (v1_root, _) = build_windowed::<V1>()?;
+    let (read_root, _) = build_windowed::<V1Read>()?;
+    // A distinct wire version and a distinct shape: byte-distinct manifests.
+    ensure(
+        v1_root != read_root,
+        "the two profiles must root differently",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn build_then_read_round_trips_every_key_under_the_read_profile() -> TestResult {
+    let store = MemoryStore::default();
+    let mut builder = Builder::<V1Read>::new();
+    for (key, fill) in windowed_keys() {
+        builder.insert(key, ref_entry::<V1Read>(fill), None);
+    }
+    let root = *block_on(builder.build(&store))?.root();
+
+    let reader = Reader::<MemoryStore, V1Read>::new(store);
+    for (key, fill) in windowed_keys() {
+        let got = block_on(reader.get(&root, &key))?;
+        ensure(
+            got == Some(ref_entry::<V1Read>(fill)),
+            "read value mismatch",
+        )?;
+    }
+    // An absent key still reads as absent under the profile.
+    ensure(
+        block_on(reader.get(&root, &Key::from(&b"absent"[..])))?.is_none(),
+        "absent key must read as None",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn apply_matches_a_from_scratch_build_under_the_read_profile() -> TestResult {
+    let all = windowed_keys();
+    let split = 40usize;
+
+    // A base of the first keys, then a changeset staging the rest.
+    let store = MemoryStore::default();
+    let mut base = Builder::<V1Read>::new();
+    for (key, fill) in all.iter().take(split) {
+        base.insert(key.clone(), ref_entry::<V1Read>(*fill), None);
+    }
+    let base_root = *block_on(base.build(&store))?.root();
+
+    let mut changeset = Changeset::<V1Read>::new();
+    for (key, fill) in all.iter().skip(split) {
+        changeset.put(key.clone(), ref_entry::<V1Read>(*fill), None);
+    }
+    let applied = block_on(apply(&store, &base_root, &changeset))?;
+
+    // A from-scratch build of the merged key set lands on the same root, byte
+    // for byte: history independence holds under the read profile too.
+    let (scratch_root, _) = build_windowed::<V1Read>()?;
+    ensure(
+        applied == scratch_root,
+        "apply must match a from-scratch build under the read profile",
+    )?;
+
+    // The applied manifest reads back the full key set.
+    let reader = Reader::<MemoryStore, V1Read>::new(store);
+    for (key, fill) in &all {
+        let got = block_on(reader.get(&applied, key))?;
+        ensure(
+            got == Some(ref_entry::<V1Read>(*fill)),
+            "applied value mismatch",
+        )?;
+    }
+    Ok(())
+}
+
+#[test]
+fn an_inline_value_round_trips_under_the_read_profile() -> TestResult {
+    let store = MemoryStore::default();
+    let mut builder = Builder::<V1Read>::new();
+    let value = Entry::<V1Read>::inline(Bytes::from_static(b"<h1>hi</h1>"))?;
+    builder.insert(Key::from(&b"index.html"[..]), value.clone(), None);
+    let root = *block_on(builder.build(&store))?.root();
+
+    let reader = Reader::<MemoryStore, V1Read>::new(store);
+    let got = block_on(reader.get(&root, &Key::from(&b"index.html"[..])))?;
+    ensure(got == Some(value), "inline value must round-trip")?;
+    Ok(())
+}

--- a/crates/manifest/tests/read_profile.rs
+++ b/crates/manifest/tests/read_profile.rs
@@ -1,4 +1,4 @@
-//! The read-optimised profile through the public API: the whole build, read
+//! The read-optimized profile through the public API: the whole build, read
 //! and apply path is generic over the format, and a heavier embedding budget
 //! inlines a subtree that V1 would reference, so the same key set resolves
 //! through fewer chunks under `V1Read`.


### PR DESCRIPTION
## What

Adds `V1Read`, an opt-in read-optimized `Format` profile alongside the frozen `V1`, closing #295 (epic #264).

`V1Read` carries `V1`'s exact layout with one retuned associated const, `INLINE_MAX = 2048` (up from 1536), so subtrees whose flat body lands in the `(1536, 2048]` window embed into their parent rather than being referenced, cutting fetches per range/listing window.

It is a distinct wire version (`VERSION 0x02`, `PREAMBLE [0x6D, 0x02]`). `V1` (`tag_version 0x01`) is left byte-frozen; its freeze test and const asserts are untouched, just macro-refactored so the same layout checks run for both formats. Distinct-version is required, not optional: decode validates each embedded child length against `F::INLINE_MAX`, so a `V1` reader would reject `V1Read`'s heavier embeds; sharing version `0x01` would be incoherent.

Files touched:

- `crates/manifest/src/format.rs`: new `V1Read` struct and `Format` impl (sealed, `DERIVE_TAG`/`CUT_SCALE`/caps inherited from `V1`, only `INLINE_MAX` retuned); the frozen cross-parameter compile-time asserts are refactored into an `assert_layout!` macro and instantiated for both `V1` and `V1Read`, including the worst-fork-record termination bound.
- `crates/manifest/src/lib.rs`: `V1Read` re-exported alongside `Format`/`V1`, with a module-doc note on the trade-off (heavier embed budget vs single-update write-amplification).
- `crates/manifest/src/packing.rs`: packing changes needed for the new profile's embedding budget.
- `crates/manifest/tests/read_profile.rs`: new integration tests for the profile.

## Why

Per #295, range/listing workloads pay one fetch per referenced subtree hop. Raising the embedding budget for an opt-in profile lets more subtrees embed directly into their parent chunk, reducing fetches for these read-heavy access patterns, without touching the frozen `V1` wire format that existing consumers depend on.

## Testing

Independently re-cloned nectar at `s264/76-subtree-serve` and checked out `s264/78-read-profile` (HEAD `686f584`). Full battery via `nix develop` (nextest supplied ephemerally via `nix shell nixpkgs#cargo-nextest`, absent from the dev shell):

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean, no warnings.
- `cargo nextest run --workspace --all-features`: 902 tests, 902 passed, 1 skipped. Includes the new read-profile coverage: `format::tests::v1read_is_v1_with_a_heavier_embedding_budget`, `format::tests::the_read_profile_worst_fork_record_fits_a_segment_alone`, `packing::tests::the_read_profile_embeds_where_v1_references`, and the 5 integration tests in `tests/read_profile.rs` (fewer-chunks, distinct-roots, build-then-read round-trip, apply-matches-from-scratch, inline round-trip).

Adversarial review found no real bugs. Verified `V1` is byte-frozen (macro-refactored asserts are identical for `V1`; frozen-parameter test intact), so there is no wire-format drift. `V1Read` is a distinct version `0x02` that a `V1` reader rejects at the preamble, so there is no cross-profile misparse. Encode/decode are symmetric on the retuned `INLINE_MAX = 2048` (builder flat length equals embedded length equals validated length; no off-by-one). Decode is fully fallible via `Cursor` with no panic paths on truncated or adversarial input. Termination bounds hold: the worst fork record is 3464 bytes, within `CAP_FORK`, with margin for a minimum-weight segment.

This is a stacked PR targeting `s264/76-subtree-serve`; no CI beyond CLA runs until it is retargeted onto that base's resolution.

## AI assistance

Implemented and reviewed with Claude (Anthropic), per the org's AI assistance disclosure policy in nxm-rs/.github `CONTRIBUTING.md`.

Closes #295

