### PR TITLE
feat(manifest): weave order-statistic counts into the baseline wire grammar

### DIFF
--- a/crates/manifest/src/apply.rs
+++ b/crates/manifest/src/apply.rs
@@ -23,6 +23,7 @@ use nectar_primitives::store::{ChunkPut, MaybeSync};
 
 use crate::bounded::Prefix;
 use crate::builder::{BuildError, BuildStats, Item, build_table, emit_node, resolve};
+use crate::count::SubtreeCount;
 use crate::error::{ForkPrefixEmpty, PrefixTooLong};
 use crate::fork::{Child, ForkPayload, ForkRecord, ForkTable};
 use crate::format::{Format, V1};
@@ -335,13 +336,14 @@ where
     }
 
     if deeper.is_empty() {
-        // The child is untouched: reuse it verbatim.
+        // The child is untouched: reuse it verbatim, carrying its stored count.
         return finish(
             store,
             edge,
             new_entry,
             new_meta,
             existing.child().cloned(),
+            existing.child_count(),
             stats,
         )
         .await;
@@ -353,7 +355,7 @@ where
             if items.is_empty() {
                 // A deletion of an absent deeper key: the fork is unchanged bar
                 // its terminal value.
-                return finish(store, edge, new_entry, new_meta, None, stats).await;
+                return finish(store, edge, new_entry, new_meta, None, None, stats).await;
             }
             build_table(store, &items, plen, stats).await?
         }
@@ -394,7 +396,7 @@ where
     F: Format,
 {
     if table.is_empty() {
-        return finish(store, edge, entry, meta, None, stats).await;
+        return finish(store, edge, entry, meta, None, None, stats).await;
     }
     // Edge-compaction: a child-only fork over a single-fork child merges into
     // one edge, exactly as a from-scratch build would compact the shared run.
@@ -404,8 +406,10 @@ where
     {
         return compact(store, edge, first, record, stats).await;
     }
-    let child = resolve(store, table, stats).await?.into_child();
-    finish(store, edge, entry, meta, Some(child), stats).await
+    let resolved = resolve(store, table, stats).await?;
+    let count = resolved.child_count();
+    let child = resolved.into_child();
+    finish(store, edge, entry, meta, Some(child), count, stats).await
 }
 
 /// An insertion diverges within the edge: branch at the divergence, re-rooting
@@ -485,6 +489,7 @@ where
         remainder,
         existing.payload().clone(),
         existing.metadata().cloned(),
+        existing.child_count(),
     )
 }
 
@@ -500,6 +505,7 @@ async fn finish<S, F>(
     entry: Option<Entry<F>>,
     meta: Option<Metadata<F>>,
     child: Option<Child<F>>,
+    child_count: Option<SubtreeCount>,
     stats: &mut BuildStats,
 ) -> Result<Option<ForkRecord<F>>, ApplyError>
 where
@@ -516,7 +522,14 @@ where
     let has_entry = entry.is_some();
     ForkPayload::new(entry, child).map_or_else(
         || Ok(None),
-        |payload| make_fork(edge, payload, if has_entry { meta } else { None }),
+        |payload| {
+            make_fork(
+                edge,
+                payload,
+                if has_entry { meta } else { None },
+                child_count,
+            )
+        },
     )
 }
 
@@ -541,6 +554,7 @@ where
         &merged,
         record.payload().clone(),
         record.metadata().cloned(),
+        record.child_count(),
         stats,
     )
     .await
@@ -555,6 +569,7 @@ async fn chain<S, F>(
     prefix: &[u8],
     payload: ForkPayload<F>,
     meta: Option<Metadata<F>>,
+    child_count: Option<SubtreeCount>,
     stats: &mut BuildStats,
 ) -> Result<Option<ForkRecord<F>>, ApplyError>
 where
@@ -562,28 +577,40 @@ where
     F: Format,
 {
     if prefix.len() <= F::PLEN_MAX {
-        return make_fork(prefix, payload, meta);
+        return make_fork(prefix, payload, meta, child_count);
     }
     let head = prefix.get(..F::PLEN_MAX).ok_or(ApplyError::Internal)?;
     let rest = prefix.get(F::PLEN_MAX..).ok_or(ApplyError::Internal)?;
     let &first = rest.first().ok_or(ApplyError::Internal)?;
-    let inner = Box::pin(chain(store, rest, payload, meta, stats))
+    let inner = Box::pin(chain(store, rest, payload, meta, child_count, stats))
         .await?
         .ok_or(ApplyError::Internal)?;
     let mut table = ForkTable::new();
     table.insert_record(first, inner);
-    let child = resolve(store, table, stats).await?.into_child();
-    make_fork(head, ForkPayload::Child(child), None)
+    // The wrapping child-only fork routes the same subtree; its reference count
+    // is recomputed from the resolved table, not the terminal payload's.
+    let resolved = resolve(store, table, stats).await?;
+    let count = resolved.child_count();
+    let child = resolved.into_child();
+    make_fork(head, ForkPayload::Child(child), None, count)
 }
 
-/// A fork record for `edge` (its index byte plus tail) carrying `payload`.
+/// A fork record for `edge` (its index byte plus tail) carrying `payload`,
+/// stamping the referenced-child subtree count so it survives the rewrite.
 fn make_fork<F: Format>(
     edge: &[u8],
     payload: ForkPayload<F>,
     meta: Option<Metadata<F>>,
+    child_count: Option<SubtreeCount>,
 ) -> Result<Option<ForkRecord<F>>, ApplyError> {
     let tail = Prefix::try_from(edge.get(1..).ok_or(ApplyError::Internal)?)?;
-    Ok(Some(ForkRecord::from_tail_parts(tail, payload, meta)))
+    let mut record = ForkRecord::from_tail_parts(tail, payload, meta);
+    // The count rides only a referenced child; an embedded or leaf fork walks
+    // it in place, so a stray count never reaches the record.
+    if record.child().is_some_and(Child::is_reference) {
+        record.set_child_count(child_count);
+    }
+    Ok(Some(record))
 }
 
 /// The insertions of a change group as builder items, dropping deletions.
@@ -620,12 +647,90 @@ mod tests {
     use nectar_primitives::{ChunkAddress, ChunkRef};
 
     use crate::builder::Builder;
+    use crate::format::V1;
     use crate::meta::{KeyId, Metadata};
 
     use super::*;
 
     fn entry(byte: u8) -> Entry {
         ChunkRef::new(ChunkAddress::new([byte; 32])).into()
+    }
+
+    // Walk the counted tree, asserting every stored referenced-child count
+    // equals the walked subtree size, and return the subtree's key count.
+    fn walk_counts(store: &MemoryStore, table: &ForkTable<V1>) -> u64 {
+        let mut total = 0u64;
+        for (_, record) in table.iter() {
+            let child = match record.child() {
+                None => 0,
+                Some(Child::Embedded(inner)) => walk_counts(store, inner),
+                Some(Child::Ref32(reference)) => {
+                    let node = block_on(store.get_node::<V1>(reference.address())).unwrap();
+                    let actual = walk_counts(store, node.forks());
+                    assert_eq!(
+                        record.child_count(),
+                        Some(SubtreeCount::new(actual)),
+                        "stored count must equal the walked subtree size"
+                    );
+                    actual
+                }
+                Some(Child::Ref64(_)) => unreachable!("a plaintext build has no encrypted child"),
+            };
+            total += u64::from(record.entry().is_some()) + child;
+        }
+        total
+    }
+
+    #[test]
+    fn counted_child_counts_match_a_full_walk_oracle() {
+        let store = MemoryStore::default();
+        let mut builder = Builder::<V1>::new();
+        let mut expected = 0u64;
+        // Many wide sub-trees, each referenced (over the embedding budget), under
+        // enough root forks to spill the root into a segment directory: exercises
+        // referenced-child counts and the segment path at once.
+        for p in 0u8..128 {
+            for x in 0u8..44 {
+                builder.insert(Key::from(&[p, x][..]), entry(x), None);
+                expected += 1;
+            }
+        }
+        let root = *block_on(builder.build(&store)).unwrap().root();
+        let node = block_on(store.get_node::<V1>(&root)).unwrap();
+        let total = u64::from(node.entry().is_some()) + walk_counts(&store, node.forks());
+        assert_eq!(total, expected);
+    }
+
+    #[test]
+    fn counted_apply_matches_a_rebuild_and_preserves_counts() {
+        let store = MemoryStore::default();
+        // A base that references a wide sub-tree under "a", then a changeset that
+        // deepens it: apply must reproduce the from-scratch counted root.
+        let mut base = Builder::<V1>::new();
+        for x in 0u8..40 {
+            base.insert(Key::from(&[b'a', x][..]), entry(x), None);
+        }
+        let base_root = *block_on(base.build(&store)).unwrap().root();
+
+        let mut cs = Changeset::<V1>::new();
+        for x in 40u8..64 {
+            cs.put(Key::from(&[b'a', x][..]), entry(x), None);
+        }
+        let applied = block_on(apply(&store, &base_root, &cs)).unwrap();
+
+        let mut scratch = Builder::<V1>::new();
+        for x in 0u8..64 {
+            scratch.insert(Key::from(&[b'a', x][..]), entry(x), None);
+        }
+        let scratch_root = *block_on(scratch.build(&MemoryStore::default()))
+            .unwrap()
+            .root();
+        assert_eq!(applied, scratch_root, "apply must match a counted rebuild");
+
+        // The applied tree's stored counts still equal the walked subtree sizes.
+        let node = block_on(store.get_node::<V1>(&applied)).unwrap();
+        let total = u64::from(node.entry().is_some()) + walk_counts(&store, node.forks());
+        assert_eq!(total, 64);
     }
 
     // Build a manifest from `keys` and return its root.

--- a/crates/manifest/src/builder.rs
+++ b/crates/manifest/src/builder.rs
@@ -19,8 +19,9 @@ use nectar_primitives::{
 use crate::bounded::{Prefix, SegmentWeight};
 use crate::codec::{
     SegmentDir, body_len, encode_dir_segment, encode_leaf_segment, encode_segmented_node,
-    record_weight,
+    fork_count, record_weight, table_count,
 };
+use crate::count::SubtreeCount;
 use crate::error::{ForkPrefixEmpty, PrefixTooLong, WeightOverBudget};
 use crate::fork::{Child, ForkPayload, ForkRecord, ForkTable};
 use crate::format::{Format, V1};
@@ -257,8 +258,9 @@ pub(crate) struct Item<F: Format> {
 pub(crate) enum Resolved<F: Format> {
     /// Small enough to inline into the parent's chunk.
     Embedded(ForkTable<F>),
-    /// Spilled to a chunk of its own.
-    Reference(ChunkRef),
+    /// Spilled to a chunk of its own, carrying its subtree count so the
+    /// parent fork stamps it on the reference.
+    Reference(ChunkRef, Option<SubtreeCount>),
 }
 
 impl<F: Format> Resolved<F> {
@@ -266,7 +268,16 @@ impl<F: Format> Resolved<F> {
     pub(crate) fn into_child(self) -> Child<F> {
         match self {
             Self::Embedded(table) => Child::Embedded(table),
-            Self::Reference(reference) => Child::Ref32(reference),
+            Self::Reference(reference, _) => Child::Ref32(reference),
+        }
+    }
+
+    /// The subtree count to stamp on the parent fork: present only for a
+    /// referenced child.
+    pub(crate) const fn child_count(&self) -> Option<SubtreeCount> {
+        match self {
+            Self::Embedded(_) => None,
+            Self::Reference(_, count) => *count,
         }
     }
 }
@@ -309,18 +320,19 @@ impl<'a, F: Format> Frame<'a, F> {
         }
     }
 
-    /// Close the open fork with its resolved child.
+    /// Close the open fork with its resolved child, stamping the referenced
+    /// child's subtree count onto the record.
     fn attach(&mut self, resolved: Resolved<F>) -> Result<(), BuildError> {
         let open = self.open.take().ok_or(BuildError::Internal)?;
-        let child = match resolved {
-            Resolved::Embedded(table) => Child::Embedded(table),
-            Resolved::Reference(reference) => Child::Ref32(reference),
-        };
+        let count = resolved.child_count();
+        let child = resolved.into_child();
         let payload = match open.entry {
             Some(entry) => ForkPayload::Both { entry, child },
             None => ForkPayload::Child(child),
         };
-        self.table.insert(open.prefix, payload, open.meta)?;
+        let (first, mut record) = ForkRecord::new(open.prefix, payload, open.meta)?;
+        record.set_child_count(count);
+        self.table.insert_record(first, record);
         Ok(())
     }
 
@@ -449,9 +461,12 @@ where
         stats.nodes_embedded = stats.nodes_embedded.saturating_add(1);
         return Ok(Resolved::Embedded(table));
     }
+    // The spilled subtree's count is the in-buffer sum of its fork counts, read
+    // before the table is consumed; the parent stamps it on the reference.
+    let count = Some(SubtreeCount::new(table_count(&table)));
     let node = Node::new(None, table);
     let address = emit_node(store, &node, stats).await?;
-    Ok(Resolved::Reference(ChunkRef::new(address)))
+    Ok(Resolved::Reference(ChunkRef::new(address), count))
 }
 
 /// Publish `node` as one chunk, or, when its flat body overruns the format
@@ -501,7 +516,8 @@ where
     }
 
     let directory = spill::<F>(&items, Domain::Plain);
-    let mut leaf_descs: Vec<(u8, ChunkAddress)> = Vec::with_capacity(directory.leaves().len());
+    let mut leaf_descs: Vec<(u8, ChunkAddress, SubtreeCount)> =
+        Vec::with_capacity(directory.leaves().len());
     for range in directory.leaves() {
         let slice = forks.get(range.clone()).ok_or(BuildError::Internal)?;
         let &(first_key, _) = slice.first().ok_or(BuildError::Internal)?;
@@ -509,29 +525,41 @@ where
         for (byte, record) in slice {
             leaf.insert_record(*byte, (*record).clone());
         }
+        // The descriptor routes the segment's whole subtree count: the sum of
+        // its covered forks' counts, so a reader descends by rank without a
+        // fetch.
+        let seg_count = descriptor_count(slice.iter().map(|(_, record)| fork_count(record)));
         let address = put_payload(store, encode_leaf_segment(&leaf), stats).await?;
-        leaf_descs.push((first_key, address));
+        leaf_descs.push((first_key, address, seg_count));
     }
 
     let top = if directory.dirs().len() <= 1 {
         SegmentDir::plain(leaf_descs)
     } else {
-        let mut dir_descs: Vec<(u8, ChunkAddress)> = Vec::with_capacity(directory.dirs().len());
+        let mut dir_descs: Vec<(u8, ChunkAddress, SubtreeCount)> =
+            Vec::with_capacity(directory.dirs().len());
         for range in directory.dirs() {
             let group = leaf_descs.get(range.clone()).ok_or(BuildError::Internal)?;
-            let &(first_key, _) = group.first().ok_or(BuildError::Internal)?;
+            let &(first_key, _, _) = group.first().ok_or(BuildError::Internal)?;
+            let seg_count = descriptor_count(group.iter().map(|(_, _, count)| count.get()));
             let address = put_payload(
                 store,
                 encode_dir_segment::<F>(&SegmentDir::plain(group.to_vec())),
                 stats,
             )
             .await?;
-            dir_descs.push((first_key, address));
+            dir_descs.push((first_key, address, seg_count));
         }
         SegmentDir::plain(dir_descs)
     };
 
     put_payload(store, encode_segmented_node::<F>(node.root(), &top), stats).await
+}
+
+/// The subtree count a segment descriptor routes: the sum of the covered
+/// forks' (or nested descriptors') counts.
+fn descriptor_count(counts: impl Iterator<Item = u64>) -> SubtreeCount {
+    SubtreeCount::new(counts.fold(0, u64::saturating_add))
 }
 
 /// Seal a ready payload into a content chunk, store it, and count it.

--- a/crates/manifest/src/codec.rs
+++ b/crates/manifest/src/codec.rs
@@ -15,6 +15,7 @@ use nectar_primitives::wire::{Cursor, FromCursor, ToWriter, Underrun, Writer};
 use nectar_primitives::{ChunkAddress, ChunkRef, EncryptedChunkRef, EncryptionKey};
 
 use crate::bounded::{MetadataLen, Prefix};
+use crate::count::{CountError, SubtreeCount};
 use crate::error::{CustomKeyError, ForkPrefixEmpty, MetadataTooLong, PrefixTooLong, ValueTooLong};
 use crate::fork::{Child, ForkPayload, ForkRecord, ForkTable};
 use crate::format::Format;
@@ -256,6 +257,10 @@ pub enum DecodeError {
     /// segments are plumbing, never a node a fork points at (spec 5.3).
     #[error("segment reached out of directory context")]
     SegmentContext,
+    /// A counted-grammar subtree count was malformed: overlong, over-wide, or
+    /// short.
+    #[error(transparent)]
+    Count(#[from] CountError),
 }
 
 /// Rejections from [`Node::encode`]: the in-memory tree cannot form a legal
@@ -314,7 +319,7 @@ fn embedded_len<F: Format>(table: &ForkTable<F>) -> usize {
     size_of::<u8>().saturating_add(table_len(table))
 }
 
-/// Exact encoded bytes of one fork record.
+/// Exact encoded bytes of one fork record, including any trailing count.
 fn record_len<F: Format>(record: &ForkRecord<F>) -> usize {
     let mut len = size_of::<u8>() // fflags
         .saturating_add(size_of::<u8>()) // plen
@@ -328,7 +333,40 @@ fn record_len<F: Format>(record: &ForkRecord<F>) -> usize {
     if let Some(metadata) = record.metadata() {
         len = len.saturating_add(meta_len(metadata));
     }
-    len
+    len.saturating_add(child_count_len(record))
+}
+
+/// The trailing count bytes a fork record carries: a referenced child's
+/// `child_count`; an embedded or leaf fork carries none.
+fn child_count_len<F: Format>(record: &ForkRecord<F>) -> usize {
+    if record.child().is_some_and(Child::is_reference) {
+        record.child_count().unwrap_or_default().wire_len()
+    } else {
+        0
+    }
+}
+
+/// The subtree key-count of one fork: its terminal key, plus its child's count.
+/// A referenced child's count is the stored annotation; an embedded child's is
+/// walked in place, so a node's total is the in-buffer sum of its fork counts.
+pub(crate) fn fork_count<F: Format>(record: &ForkRecord<F>) -> u64 {
+    let entry = u64::from(record.entry().is_some());
+    let child = match record.child() {
+        None => 0,
+        Some(Child::Embedded(table)) => table_count(table),
+        Some(Child::Ref32(_) | Child::Ref64(_)) => {
+            record.child_count().map_or(0, SubtreeCount::get)
+        }
+    };
+    entry.saturating_add(child)
+}
+
+/// The subtree key-count of a fork table: the sum of its forks' counts.
+pub(crate) fn table_count<F: Format>(table: &ForkTable<F>) -> u64 {
+    table
+        .iter()
+        .map(|(_, record)| fork_count(record))
+        .fold(0, u64::saturating_add)
 }
 
 /// Exact encoded bytes of a fork table: count, index, records.
@@ -616,14 +654,21 @@ impl<F: Format> FromCursor for ForkRecord<F> {
         } else {
             None
         };
+        let referenced_child = matches!(child_fmt, WireFmt::Ref32 | WireFmt::Ref64);
         let payload = ForkPayload::new(entry, child).ok_or(DecodeError::ForkFlags(flags))?;
-        Ok(Self::from_tail_parts(tail, payload, metadata))
+        let mut record = Self::from_tail_parts(tail, payload, metadata);
+        // The trailing count rides only a referenced child; an embedded or
+        // leaf fork recomputes it in place.
+        if referenced_child {
+            record.set_child_count(Some(cur.take::<SubtreeCount>()?));
+        }
+        Ok(record)
     }
 }
 
 impl<F: Format> ToWriter for ForkRecord<F> {
     /// Emits the flags, the tail behind its count, then the flag-gated
-    /// fields.
+    /// fields, and last the trailing referenced-child count.
     fn put_into(&self, w: &mut Writer<'_>) {
         w.put(&fork_flag_bits(self));
         w.put(self.tail());
@@ -635,6 +680,9 @@ impl<F: Format> ToWriter for ForkRecord<F> {
         }
         if let Some(metadata) = self.metadata() {
             w.put(metadata);
+        }
+        if self.child().is_some_and(Child::is_reference) {
+            w.put(&self.child_count().unwrap_or_default());
         }
     }
 }
@@ -842,6 +890,9 @@ pub(crate) struct SegDesc {
     pub(crate) address: ChunkAddress,
     /// The child's decryption key, present iff the directory is wide.
     pub(crate) key: Option<EncryptionKey>,
+    /// The sum of the covered forks' subtree counts, so a spilled node routes a
+    /// whole segment by rank without fetching it.
+    pub(crate) seg_count: SubtreeCount,
 }
 
 /// A decoded segment directory: uniform-width descriptors in ascending key
@@ -856,16 +907,18 @@ pub(crate) struct SegmentDir {
 }
 
 impl SegmentDir {
-    /// A plaintext directory over `(first_key, address)` descriptors.
-    pub(crate) fn plain(descriptors: Vec<(u8, ChunkAddress)>) -> Self {
+    /// A plaintext directory over `(first_key, address)` descriptors, with the
+    /// subtree count each descriptor routes.
+    pub(crate) fn plain(descriptors: Vec<(u8, ChunkAddress, SubtreeCount)>) -> Self {
         Self {
             wide: false,
             descriptors: descriptors
                 .into_iter()
-                .map(|(first_key, address)| SegDesc {
+                .map(|(first_key, address, seg_count)| SegDesc {
                     first_key,
                     address,
                     key: None,
+                    seg_count,
                 })
                 .collect(),
         }
@@ -907,7 +960,7 @@ impl<F: Format> DecodedChunk<F> {
 }
 
 /// Emit a segment directory body: sflags, count, the ascending keys, then the
-/// uniform-width references.
+/// uniform-width references, each trailed by its `seg_count`.
 fn put_segment_dir(w: &mut Writer<'_>, dir: &SegmentDir) {
     w.put(&(if dir.wide { WIDE_REFS } else { 0u8 }));
     w.put(&U16Le::of(dir.descriptors.len()));
@@ -919,6 +972,7 @@ fn put_segment_dir(w: &mut Writer<'_>, dir: &SegmentDir) {
         if let Some(key) = &desc.key {
             w.put(key.as_bytes());
         }
+        w.put(&desc.seg_count);
     }
 }
 
@@ -1001,10 +1055,12 @@ fn take_segment_dir<F: Format>(cur: &mut Cursor<'_>) -> Result<SegmentDir, Decod
         } else {
             None
         };
+        let seg_count = cur.take::<SubtreeCount>()?;
         descriptors.push(SegDesc {
             first_key,
             address,
             key,
+            seg_count,
         });
     }
     Ok(SegmentDir { wide, descriptors })
@@ -1743,7 +1799,10 @@ mod tests {
         ));
         assert_eq!(recanonicalize::<V1>(&leaf).unwrap(), leaf);
 
-        let dir = SegmentDir::plain(vec![(b'a', addr(1)), (b'c', addr(2))]);
+        let dir = SegmentDir::plain(vec![
+            (b'a', addr(1), SubtreeCount::default()),
+            (b'c', addr(2), SubtreeCount::default()),
+        ]);
         let directory = encode_dir_segment::<V1>(&dir);
         assert!(matches!(
             Node::<V1>::decode_chunk(&directory).unwrap(),
@@ -1758,6 +1817,91 @@ mod tests {
             DecodedChunk::Segmented(Some(_), _)
         ));
         assert_eq!(recanonicalize::<V1>(&segmented).unwrap(), segmented);
+    }
+
+    // A node carrying one referenced-child fork: the child count rides as a
+    // trailing uleb128 after the reference.
+    #[test]
+    fn counted_referenced_child_carries_a_trailing_count() {
+        let mut forks: ForkTable<V1> = ForkTable::new();
+        forks
+            .insert(
+                Prefix::try_from(&b"a"[..]).unwrap(),
+                Child::Ref32(ChunkRef::new(addr(0x11))).into(),
+                None,
+            )
+            .unwrap();
+        forks
+            .get_mut(b'a')
+            .unwrap()
+            .set_child_count(Some(SubtreeCount::new(5)));
+        let node = Node::new(None, forks);
+
+        let mut expected = vec![0x6D, 0x01, 0x00, 0x01, 0x00, b'a', 0x00, 0x00, 0x04, 0x01];
+        expected.extend_from_slice(&[0x11; 32]);
+        expected.push(0x05);
+        let payload = node.encode().unwrap();
+        assert_eq!(payload, expected);
+        assert_eq!(node.encoded_len(), payload.len());
+
+        let decoded = Node::<V1>::decode(&payload).unwrap();
+        assert_eq!(decoded, node);
+        assert_eq!(
+            decoded.forks().get(b'a').unwrap().child_count(),
+            Some(SubtreeCount::new(5))
+        );
+        assert_eq!(fork_count(decoded.forks().get(b'a').unwrap()), 5);
+    }
+
+    // A non-canonical (overlong) child count is rejected: canonical minimal
+    // length only.
+    #[test]
+    fn an_overlong_count_rejects() {
+        let mut image = vec![0x6D, 0x01, 0x00, 0x01, 0x00, b'a', 0x00, 0x00, 0x04, 0x01];
+        image.extend_from_slice(&[0x11; 32]);
+        // 0x80 0x00 encodes zero in two bytes: a non-minimal run.
+        image.extend_from_slice(&[0x80, 0x00]);
+        assert!(matches!(
+            Node::<V1>::decode(&image),
+            Err(DecodeError::Count(CountError::Overlong))
+        ));
+    }
+
+    // A segment directory carries a seg_count after every descriptor, and the
+    // whole segment chunk set round-trips through recanonicalize.
+    #[test]
+    fn counted_segments_carry_seg_counts_and_round_trip() {
+        let mut leaf: ForkTable<V1> = ForkTable::new();
+        leaf.insert(
+            Prefix::<V1>::try_from(&b"ab"[..]).unwrap(),
+            Entry::from(ref32(1)).into(),
+            None,
+        )
+        .unwrap();
+        leaf.insert(
+            Prefix::<V1>::try_from(&b"cd"[..]).unwrap(),
+            Entry::from(ref32(2)).into(),
+            None,
+        )
+        .unwrap();
+        let leaf_chunk = encode_leaf_segment::<V1>(&leaf);
+        assert_eq!(recanonicalize::<V1>(&leaf_chunk).unwrap(), leaf_chunk);
+
+        let dir = SegmentDir::plain(vec![
+            (b'a', addr(1), SubtreeCount::new(3)),
+            (b'c', addr(2), SubtreeCount::new(4)),
+        ]);
+        let dir_chunk = encode_dir_segment::<V1>(&dir);
+        // The descriptor's seg_count follows its address: ...addr(32) 03, addr(32) 04.
+        assert_eq!(dir_chunk.last(), Some(&0x04));
+        match Node::<V1>::decode_chunk(&dir_chunk).unwrap() {
+            DecodedChunk::Directory(decoded) => {
+                assert_eq!(decoded.descriptors[0].seg_count, SubtreeCount::new(3));
+                assert_eq!(decoded.descriptors[1].seg_count, SubtreeCount::new(4));
+            }
+            _ => panic!("expected a directory"),
+        }
+        assert_eq!(recanonicalize::<V1>(&dir_chunk).unwrap(), dir_chunk);
     }
 
     #[test]

--- a/crates/manifest/src/count.rs
+++ b/crates/manifest/src/count.rs
@@ -1,0 +1,178 @@
+//! Order-statistic subtree key-count carried by the node grammar.
+//!
+//! The count is a pure function of the key set: `subtree_count(f) =
+//! (f.entry?1:0) + child_count(f)`, so canonical bytes and dedup hold
+//! unchanged. It rides the wire as a canonical (minimal-length) uleb128; the
+//! decoder rejects an overlong encoding and caps the read length, so the only
+//! fallible byte access is the cursor.
+
+use nectar_primitives::wire::{Cursor, FromCursor, ToWriter, Underrun, Writer};
+
+/// The greatest number of uleb128 bytes a `u64` count occupies: `ceil(64 / 7)`.
+/// The decoder reads at most this many bytes before rejecting, so a hostile
+/// image cannot drive an unbounded read.
+pub(crate) const MAX_WIRE_BYTES: usize = 10;
+
+/// A subtree's distinct key-count: the order-statistic annotation a
+/// referenced-child fork or segment descriptor carries.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SubtreeCount(u64);
+
+impl SubtreeCount {
+    /// The count as a `u64`.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+
+    /// The count from a `u64`.
+    #[must_use]
+    pub const fn new(count: u64) -> Self {
+        Self(count)
+    }
+
+    /// The canonical uleb128 byte length of this count.
+    pub(crate) const fn wire_len(self) -> usize {
+        let mut value = self.0;
+        let mut len: usize = 1;
+        while value >= 0x80 {
+            value >>= 7;
+            len = len.saturating_add(1);
+        }
+        len
+    }
+}
+
+/// A rejection reading a subtree count: a short read, an overlong (non-minimal)
+/// encoding, or a run wider than a `u64`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum CountError {
+    /// The buffer ended inside the count.
+    #[error(transparent)]
+    Underrun(#[from] Underrun),
+    /// A non-minimal encoding: a multi-byte run ending in a zero payload byte.
+    #[error("non-canonical subtree count encoding")]
+    Overlong,
+    /// The count did not terminate within a `u64`'s worth of bytes.
+    #[error("subtree count exceeds the wire bound")]
+    TooWide,
+}
+
+impl FromCursor for SubtreeCount {
+    type Error = CountError;
+
+    /// Reads a canonical uleb128 count, rejecting an overlong or over-wide run.
+    fn take_from(cur: &mut Cursor<'_>) -> Result<Self, CountError> {
+        let mut value: u64 = 0;
+        for index in 0..MAX_WIRE_BYTES {
+            let byte = cur.take::<u8>()?;
+            let low = u64::from(byte & 0x7F);
+            let shift = u32::try_from(index.saturating_mul(7)).map_err(|_| CountError::TooWide)?;
+            // A payload that shifts past the u64, or whose bits do not survive
+            // the round-trip, is over-wide: the high byte carries only the bits
+            // that fit.
+            let shifted = low.checked_shl(shift).ok_or(CountError::TooWide)?;
+            if shifted.checked_shr(shift) != Some(low) {
+                return Err(CountError::TooWide);
+            }
+            value |= shifted;
+            if byte & 0x80 == 0 {
+                // Minimal-length: a multi-byte run never ends in a zero payload.
+                if index > 0 && byte == 0 {
+                    return Err(CountError::Overlong);
+                }
+                return Ok(Self(value));
+            }
+        }
+        Err(CountError::TooWide)
+    }
+}
+
+impl ToWriter for SubtreeCount {
+    /// Emits the canonical minimal-length uleb128 encoding.
+    fn put_into(&self, w: &mut Writer<'_>) {
+        let mut value = self.0;
+        loop {
+            let byte = u8::try_from(value & 0x7F).unwrap_or(0);
+            value >>= 7;
+            if value == 0 {
+                w.put(&byte);
+                return;
+            }
+            w.put(&(byte | 0x80));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn encode(value: u64) -> Vec<u8> {
+        let mut buf = Vec::new();
+        Writer::new(&mut buf).put(&SubtreeCount::new(value));
+        buf
+    }
+
+    fn decode(bytes: &[u8]) -> Result<SubtreeCount, CountError> {
+        let mut cur = Cursor::new(bytes);
+        cur.take::<SubtreeCount>()
+    }
+
+    #[test]
+    fn canonical_encodings_round_trip() {
+        for value in [
+            0u64,
+            1,
+            0x7F,
+            0x80,
+            0x3FFF,
+            0x4000,
+            u64::from(u32::MAX),
+            u64::MAX,
+        ] {
+            let bytes = encode(value);
+            assert_eq!(bytes.len(), SubtreeCount::new(value).wire_len());
+            assert_eq!(decode(&bytes).unwrap().get(), value);
+        }
+    }
+
+    #[test]
+    fn low_values_are_single_byte() {
+        assert_eq!(encode(0), [0x00]);
+        assert_eq!(encode(1), [0x01]);
+        assert_eq!(encode(0x7F), [0x7F]);
+        assert_eq!(encode(0x80), [0x80, 0x01]);
+    }
+
+    #[test]
+    fn overlong_encodings_reject() {
+        // Zero in two bytes, and one in two bytes: both end in a zero payload.
+        assert_eq!(decode(&[0x80, 0x00]), Err(CountError::Overlong));
+        assert_eq!(decode(&[0x81, 0x00]), Err(CountError::Overlong));
+        assert_eq!(decode(&[0xFF, 0x00]), Err(CountError::Overlong));
+    }
+
+    #[test]
+    fn over_wide_runs_reject() {
+        // Eleven continuation bytes never terminate within a u64.
+        assert_eq!(decode(&[0x80; 11]), Err(CountError::TooWide));
+        // A tenth byte carrying more than the top bit overflows the u64.
+        assert_eq!(
+            decode(&[0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02]),
+            Err(CountError::TooWide)
+        );
+    }
+
+    #[test]
+    fn a_truncated_run_underruns() {
+        assert!(matches!(decode(&[0x80]), Err(CountError::Underrun(_))));
+        assert!(matches!(decode(&[]), Err(CountError::Underrun(_))));
+    }
+
+    #[test]
+    fn u64_max_is_ten_bytes() {
+        assert_eq!(SubtreeCount::new(u64::MAX).wire_len(), MAX_WIRE_BYTES);
+        assert_eq!(encode(u64::MAX).len(), MAX_WIRE_BYTES);
+    }
+}

--- a/crates/manifest/src/fork.rs
+++ b/crates/manifest/src/fork.rs
@@ -10,6 +10,7 @@ use std::collections::BTreeMap;
 use nectar_primitives::{ChunkAddress, ChunkRef, EncryptedChunkRef};
 
 use crate::bounded::Prefix;
+use crate::count::SubtreeCount;
 use crate::error::ForkPrefixEmpty;
 use crate::format::{Format, V1};
 use crate::meta::Metadata;
@@ -139,6 +140,17 @@ pub struct ForkRecord<F: Format = V1> {
     tail: Prefix<F>,
     payload: ForkPayload<F>,
     metadata: Option<Metadata<F>>,
+    child_count: Option<SubtreeCount>,
+}
+
+/// The count a fresh record starts with: a referenced child always owns a
+/// wire count, zero until the builder or apply stamps the real subtree size;
+/// an embedded or absent child carries none, its count is walked in place.
+const fn initial_child_count<F: Format>(payload: &ForkPayload<F>) -> Option<SubtreeCount> {
+    match payload.child() {
+        Some(Child::Ref32(_) | Child::Ref64(_)) => Some(SubtreeCount::new(0)),
+        _ => None,
+    }
 }
 
 impl<F: Format> ForkRecord<F> {
@@ -151,12 +163,14 @@ impl<F: Format> ForkRecord<F> {
         metadata: Option<Metadata<F>>,
     ) -> Result<(u8, Self), ForkPrefixEmpty> {
         let (first, tail) = prefix.split_first().ok_or(ForkPrefixEmpty)?;
+        let child_count = initial_child_count(&payload);
         Ok((
             first,
             Self {
                 tail,
                 payload,
                 metadata,
+                child_count,
             },
         ))
     }
@@ -168,10 +182,12 @@ impl<F: Format> ForkRecord<F> {
         payload: ForkPayload<F>,
         metadata: Option<Metadata<F>>,
     ) -> Self {
+        let child_count = initial_child_count(&payload);
         Self {
             tail,
             payload,
             metadata,
+            child_count,
         }
     }
 
@@ -214,6 +230,19 @@ impl<F: Format> ForkRecord<F> {
     #[must_use]
     pub const fn metadata(&self) -> Option<&Metadata<F>> {
         self.metadata.as_ref()
+    }
+
+    /// The subtree key-count of a referenced child, carried on the wire and
+    /// reused verbatim when the subtree is spliced by address. `None` for an
+    /// embedded or absent child, whose count is walked in place.
+    pub(crate) const fn child_count(&self) -> Option<SubtreeCount> {
+        self.child_count
+    }
+
+    /// Set the referenced-child subtree count the builder and apply maintain
+    /// bottom-up.
+    pub(crate) const fn set_child_count(&mut self, count: Option<SubtreeCount>) {
+        self.child_count = count;
     }
 
     /// Mutable access to the fork's metadata slot.

--- a/crates/manifest/src/format.rs
+++ b/crates/manifest/src/format.rs
@@ -5,6 +5,8 @@ use core::hash::Hash;
 
 use nectar_primitives::DEFAULT_BODY_SIZE;
 
+use crate::count::MAX_WIRE_BYTES;
+
 mod sealed {
     pub trait Sealed {}
     impl Sealed for super::V1 {}
@@ -93,6 +95,12 @@ pub trait Format:
 }
 
 /// The frozen `tag_version 0x01` parameter set.
+///
+/// The node grammar carries order-statistic subtree counts: every
+/// referenced-child fork ends with a trailing `child_count` and every
+/// segment-directory descriptor carries a `seg_count`, so navigation by rank
+/// costs O(depth) instead of O(window). Each count is a pure function of the
+/// key set, so canonical bytes and bit-exact `apply` hold unchanged.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct V1;
 
@@ -175,14 +183,18 @@ macro_rules! assert_layout {
             );
             // The worst-case Both fork record: an index slot, flags, plen, the
             // longest tail, an inline value, an embedded child and two full
-            // metadata blocks (spec 5.4).
+            // metadata blocks (spec 5.4). A referenced child adds a trailing
+            // count; charge its worst-case width to the record even though the
+            // embedded worst case never carries one.
+            let count = MAX_WIRE_BYTES;
             let worst = 3
                 + 1
                 + 1
                 + (<$f>::PLEN_MAX - 1)
                 + (1 + <$f>::VINLINE_MAX)
                 + (2 + <$f>::INLINE_MAX)
-                + (2 + <$f>::META_MAX);
+                + (2 + <$f>::META_MAX)
+                + count;
             // Any single record fits a leaf segment, so partitioning
             // terminates, and the forced-cut margin still leaves room for a
             // minimum-weight segment.
@@ -200,6 +212,15 @@ macro_rules! assert_layout {
 
 assert_layout!(V1);
 assert_layout!(V1Read);
+
+// Wire-version registry: 0x01 V1, 0x02 V1Read. Readers dispatch on the
+// version byte, so every profile must own a distinct one; pinned at compile
+// time so a collision is a build error rather than a silent wire ambiguity.
+const _: () = {
+    assert!(V1::VERSION == 0x01);
+    assert!(V1Read::VERSION == 0x02);
+    assert!(V1::VERSION != V1Read::VERSION);
+};
 
 #[cfg(test)]
 mod tests {
@@ -265,9 +286,10 @@ mod tests {
         assert_eq!(V1Read::DERIVE_TAG, V1::DERIVE_TAG);
     }
 
-    // The heavier budget keeps the termination bounds: the worst fork record
-    // still fits a leaf segment alone, and the forced-cut margin still leaves a
-    // minimum-weight segment (spec 5.4).
+    // The heavier budget keeps the termination bounds: the worst fork record,
+    // with the worst-case trailing count charged, still fits a leaf segment
+    // alone, and the forced-cut margin still leaves a minimum-weight segment
+    // (spec 5.4).
     #[test]
     fn the_read_profile_worst_fork_record_fits_a_segment_alone() {
         let worst = 3
@@ -276,8 +298,9 @@ mod tests {
             + (V1Read::PLEN_MAX - 1)
             + (1 + V1Read::VINLINE_MAX)
             + (2 + V1Read::INLINE_MAX)
-            + (2 + V1Read::META_MAX);
-        assert_eq!(worst, 3464);
+            + (2 + V1Read::META_MAX)
+            + MAX_WIRE_BYTES;
+        assert_eq!(worst, 3474);
         assert!(worst <= V1Read::CAP_FORK);
         assert!(V1Read::CAP_FORK - worst >= V1Read::SEG_MIN);
     }
@@ -288,15 +311,17 @@ mod tests {
     #[test]
     fn the_worst_fork_record_fits_a_segment_alone() {
         // A Both fork at the worst case: index slot, flags, plen, the longest
-        // tail, an inline value, an embedded child and two full metadata blocks.
+        // tail, an inline value, an embedded child, two full metadata blocks
+        // and the worst-case trailing count.
         let worst = 3
             + 1
             + 1
             + (V1::PLEN_MAX - 1)
             + (1 + V1::VINLINE_MAX)
             + (2 + V1::INLINE_MAX)
-            + (2 + V1::META_MAX);
-        assert_eq!(worst, 2952);
+            + (2 + V1::META_MAX)
+            + MAX_WIRE_BYTES;
+        assert_eq!(worst, 2962);
         // Any single record fits a leaf segment, so partitioning terminates.
         assert!(worst <= V1::CAP_FORK);
         // The forced-cut margin leaves room for a minimum-weight segment, so

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -6,9 +6,12 @@
 //! 0x01` parameter set, and public types default their format parameter to
 //! [`V1`]. Bounded newtypes ([`Prefix`], [`MetadataLen`], [`SegmentWeight`])
 //! check a format bound once at construction and carry it as a type
-//! invariant. [`V1Read`] is an opt-in read-optimized sibling: the same layout
-//! with a heavier embedding budget, trading single-update write-amplification
-//! for fewer chunks touched per range or listing window.
+//! invariant. The node grammar weaves order-statistic [`SubtreeCount`]s into
+//! every referenced child and segment descriptor, so navigation by rank costs
+//! O(depth) instead of O(window). [`V1Read`] is an opt-in read-optimized
+//! sibling: the same layout with a heavier embedding budget, trading
+//! single-update write-amplification for fewer chunks touched per range or
+//! listing window.
 //!
 //! The value model is [`Key`] (arbitrary bytes), [`Entry`] (a chunk
 //! reference or an inline value; absence is `Option` at the use site) and
@@ -81,6 +84,7 @@ mod apply;
 mod bounded;
 mod builder;
 mod codec;
+mod count;
 mod dx;
 #[cfg(feature = "encryption")]
 mod encryption;
@@ -100,6 +104,7 @@ pub use apply::{ApplyError, Changeset, apply};
 pub use bounded::{MetadataLen, Prefix, SegmentWeight};
 pub use builder::{BuildError, BuildStats, Builder, Built, build_files};
 pub use codec::{DecodeError, EncodeError, recanonicalize};
+pub use count::{CountError, SubtreeCount};
 pub use dx::FetchError;
 #[cfg(feature = "encryption")]
 #[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]

--- a/crates/manifest/src/packing.rs
+++ b/crates/manifest/src/packing.rs
@@ -14,6 +14,7 @@ use alloy_primitives::keccak256;
 use nectar_primitives::{ChunkRef, EncryptedChunkRef};
 
 use crate::bounded::{Prefix, SegmentWeight};
+use crate::count::MAX_WIRE_BYTES;
 use crate::fork::Child;
 use crate::format::Format;
 use crate::value::Entry;
@@ -212,16 +213,20 @@ impl Directory {
 /// The packing weight of one directory fork: it routes a single first byte,
 /// with no tail, to one segment child, so its record is the flags and
 /// prefix-length bytes plus one reference of the domain's width, behind its
-/// fork-table index slot.
+/// fork-table index slot. A descriptor also trails a `seg_count`; its
+/// worst-case width is charged so a directory stays within one chunk by
+/// construction, as the leaf path charges the count on its records.
 const fn dir_entry_weight(domain: Domain) -> usize {
     let reference = match domain {
         Domain::Plain => ChunkRef::SIZE,
         Domain::Encrypted => EncryptedChunkRef::SIZE,
     };
+    let count = MAX_WIRE_BYTES;
     let slot = size_of::<u8>().saturating_add(size_of::<u16>());
     slot.saturating_add(size_of::<u8>()) // fflags
         .saturating_add(size_of::<u8>()) // plen (routes by the first byte)
         .saturating_add(reference)
+        .saturating_add(count)
 }
 
 /// Spill an oversized fork table into a <= depth-2 segment directory.
@@ -249,6 +254,19 @@ pub fn spill<F: Format>(forks: &[(Prefix<F>, SegmentWeight<F>)], domain: Domain)
 mod tests {
     use super::*;
     use crate::format::{V1, V1Read};
+
+    // The directory packing weight must cover the widest descriptor its segment
+    // chunk can actually carry, including the worst-case trailing seg_count,
+    // so a spilled directory stays within one chunk by construction.
+    #[test]
+    fn the_directory_weight_covers_the_widest_descriptor() {
+        // The on-wire descriptor: its first-key byte, the routed reference and
+        // a seg_count of up to MAX_WIRE_BYTES.
+        let widest = size_of::<u8>()
+            .saturating_add(ChunkRef::SIZE)
+            .saturating_add(MAX_WIRE_BYTES);
+        assert!(widest <= dir_entry_weight(Domain::Plain));
+    }
 
     // The eight worked forks a..h with the spec's weights and hash-cut bits.
     const ROWS: [(u8, u64, bool); 8] = [

--- a/crates/manifest/tests/counted.rs
+++ b/crates/manifest/tests/counted.rs
@@ -1,0 +1,112 @@
+//! Order-statistic counts through the public API: a manifest round-trips its
+//! keys, stays canonical under shuffled build order, and folds a changeset to
+//! the same root a from-scratch build produces, with counts maintained
+//! throughout.
+
+use std::error::Error;
+
+use bytes::Bytes;
+use futures::executor::block_on;
+use nectar_manifest::{Builder, Changeset, Entry, Key, Reader, V1, apply};
+use nectar_primitives::{ChunkAddress, ChunkRef, MemoryStore};
+
+type TestResult = Result<(), Box<dyn Error>>;
+
+fn ensure(cond: bool, what: &str) -> TestResult {
+    if cond { Ok(()) } else { Err(what.into()) }
+}
+
+fn ref_entry<F: nectar_manifest::Format>(fill: u8) -> Entry<F> {
+    Entry::from(ChunkRef::new(ChunkAddress::new([fill; 32])))
+}
+
+/// A key set wide and deep enough to reference sub-nodes and spill the root:
+/// many first-byte groups, each holding a windowed sub-tree of its own.
+fn keys() -> Vec<(Key, u8)> {
+    let mut out = Vec::new();
+    for p in 0u8..96 {
+        for x in 0u8..44 {
+            out.push((Key::from(&[p, x][..]), x));
+        }
+    }
+    out
+}
+
+fn build<F: nectar_manifest::Format>(order: &[(Key, u8)]) -> Result<ChunkAddress, Box<dyn Error>> {
+    let store = MemoryStore::default();
+    let mut builder = Builder::<F>::new();
+    for (key, fill) in order {
+        builder.insert(key.clone(), ref_entry::<F>(*fill), None);
+    }
+    Ok(*block_on(builder.build(&store))?.root())
+}
+
+#[test]
+fn counted_canonical_bytes_are_stable_under_shuffled_build_order() -> TestResult {
+    let forward = keys();
+    let mut reversed = forward.clone();
+    reversed.reverse();
+    let a = build::<V1>(&forward)?;
+    let b = build::<V1>(&reversed)?;
+    ensure(a == b, "counted root must not depend on insertion order")?;
+    Ok(())
+}
+
+#[test]
+fn build_then_read_round_trips_every_key() -> TestResult {
+    let store = MemoryStore::default();
+    let all = keys();
+    let mut builder = Builder::<V1>::new();
+    for (key, fill) in &all {
+        builder.insert(key.clone(), ref_entry::<V1>(*fill), None);
+    }
+    let root = *block_on(builder.build(&store))?.root();
+
+    let reader = Reader::<MemoryStore, V1>::new(store);
+    for (key, fill) in &all {
+        let got = block_on(reader.get(&root, key))?;
+        ensure(got == Some(ref_entry::<V1>(*fill)), "read value mismatch")?;
+    }
+    ensure(
+        block_on(reader.get(&root, &Key::from(&b"absent"[..])))?.is_none(),
+        "absent key must read as None",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn apply_matches_a_from_scratch_build() -> TestResult {
+    let all = keys();
+    let split = all.len() * 3 / 4;
+
+    let store = MemoryStore::default();
+    let mut base = Builder::<V1>::new();
+    for (key, fill) in all.iter().take(split) {
+        base.insert(key.clone(), ref_entry::<V1>(*fill), None);
+    }
+    let base_root = *block_on(base.build(&store))?.root();
+
+    let mut changeset = Changeset::<V1>::new();
+    for (key, fill) in all.iter().skip(split) {
+        changeset.put(key.clone(), ref_entry::<V1>(*fill), None);
+    }
+    let applied = block_on(apply(&store, &base_root, &changeset))?;
+
+    let scratch = build::<V1>(&all)?;
+    ensure(applied == scratch, "apply must match a from-scratch build")?;
+    Ok(())
+}
+
+#[test]
+fn an_inline_value_round_trips() -> TestResult {
+    let store = MemoryStore::default();
+    let mut builder = Builder::<V1>::new();
+    let value = Entry::<V1>::inline(Bytes::from_static(b"<h1>hi</h1>"))?;
+    builder.insert(Key::from(&b"index.html"[..]), value.clone(), None);
+    let root = *block_on(builder.build(&store))?.root();
+
+    let reader = Reader::<MemoryStore, V1>::new(store);
+    let got = block_on(reader.get(&root, &Key::from(&b"index.html"[..])))?;
+    ensure(got == Some(value), "inline value must round-trip")?;
+    Ok(())
+}


### PR DESCRIPTION
## What

Makes the frozen `tag_version 0x01` (`V1`) grammar itself carry order-statistic
subtree counts, scoped entirely to `crates/manifest`, for #296 (epic #264 Phase
2). There is no longer a separate counted profile: the baseline wire is
counted, `V1Read` (`0x02`) inherits it as before, and the earlier `V1Counted`
(`0x03`) profile is gone.

- `count.rs`: unchanged in role — a `SubtreeCount` newtype with a canonical
  minimal-length uleb128 codec over `wire::Cursor`/`Writer`. The decoder
  rejects overlong (non-minimal) encodings and over-wide runs via checked
  shifts, is bounded by a 10-byte (`MAX_WIRE_BYTES`) cap, and contains no
  slicing, `unwrap`, or `#[allow]`. A public `CountError` enum (`Underrun`,
  `Overlong`, `TooWide`) reports rejections.
- `format.rs`: the `Format` trait loses the `COUNTED` discriminant and
  `V1Counted` is deleted. `V1`'s fork-record termination bound is re-derived
  to add the worst-case varint count weight unconditionally, and `V1Read`
  inherits it by reusing `V1`'s layout constants as before; both are
  re-asserted via `assert_layout!`.
- `codec.rs`: fork records unconditionally gain a trailing `child_count`
  uleb128 when the child is referenced (`Ref32`/`Ref64`); it is omitted for
  embedded/leaf children. Segment-directory descriptors unconditionally gain
  an analogous `seg_count`. There is no longer a const-folded uncounted path.
- `apply.rs`, `builder.rs`, `fork.rs`, `packing.rs`: thread `SubtreeCount`
  through verbatim-reuse, chain, compact, reroot and split so `apply(root,
  delta)` reproduces manifests bit-exactly, since a subtree's count is a pure
  function of its key set (`(entry?1:0) + sum(child counts)`). Directory
  packing weight now charges the worst-case `seg_count` width per descriptor
  as well, so a directory routing many maximal counts cannot overrun its
  segment chunk.
- `tests/counted.rs`: integration coverage for the baseline (round-trip,
  canonicality under shuffled build order, apply-vs-rebuild). Renamed off the
  `_with_counts` naming this rework makes redundant, since counts are no
  longer an optional add-on: `build_then_read_round_trips_every_key`,
  `apply_matches_a_from_scratch_build`, `an_inline_value_round_trips`.
- Existing fixture/vector tests were regenerated against the new baseline
  bytes.

The `0x01` version byte keeps its value but changes wire meaning: uncounted
payloads written by an earlier unreleased build no longer decode.

## Why

Order-statistic subtree counts let a manifest answer "how many keys in this
subtree" and support rank-based navigation in O(depth) rather than O(window).
Carrying the count on the baseline wire instead of behind a separate profile
removes a whole axis of format proliferation (no `V1`-vs-`V1Counted` split to
keep in sync) without disturbing anything else `V1` guarantees: the count is a
pure function of the key set, so canonical bytes and bit-exact `apply` hold
exactly as before. `V1Read` (`0x02`) continues to be a distinct wire version
carrying this same counted baseline with a heavier embedding budget.

Closes #296

## Testing

Full workspace battery, clean at the branch tip via `nix develop`:

- `cargo fmt --all --check`: clean.
- `cargo nextest run -p nectar-manifest -p nectar-manifest-proof --locked`:
  234 tests run, 234 passed, 0 skipped.
- `cargo nextest run --workspace --locked`: 837 tests run, 837 passed, 1
  skipped.
- `cargo test --doc --workspace --locked`: clean.
- `cargo fuzz build` plus `manifest_node_decode` / `manifest_build_roundtrip`
  / `manifest_apply_rebuild` targets (10000 runs each) and all committed seed
  corpora replay clean.
- A stale-reference sweep at the tip (`V1Counted`, `Format::COUNTED`,
  `uncounted`, `never emitted`, `unemitted`, `under the counted grammar`,
  `tag_version 0x03`) returns zero hits across `crates/`, `contracts/`, and
  `fuzz/`.

## AI Assistance

This PR's implementation, red-teaming and this description were produced with assistance from Claude (Anthropic), per the process in [nxm-rs/.github CONTRIBUTING.md](https://github.com/nxm-rs/.github/blob/main/CONTRIBUTING.md).
