### PR TITLE
feat(manifest): add O(depth) order-statistic queries (rank, select, count, paginate)

### DIFF
--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -94,6 +94,7 @@ mod fork;
 mod format;
 mod meta;
 mod node;
+mod order;
 mod packing;
 mod reader;
 mod scan;

--- a/crates/manifest/src/order.rs
+++ b/crates/manifest/src/order.rs
@@ -1,0 +1,676 @@
+//! Order-statistic queries: rank, select, count and rank-directed pagination
+//! in O(depth), not O(window).
+//!
+//! Every fork's subtree carries its distinct key-count on the wire (spec 5.6):
+//! a referenced child's count is the stored annotation, an embedded child's is
+//! summed in the parent buffer, and a spilled node's segment descriptors carry a
+//! per-segment sum. A rank or index descent therefore skips a whole subtree by
+//! reading its count and routes a spilled node's segments by `seg_count`, so it
+//! fetches one node per referenced hop on the path and never the window it steps
+//! over.
+
+use bytes::Bytes;
+use nectar_primitives::store::MaybeSync;
+use nectar_primitives::{ChunkAddress, ChunkOps};
+
+use crate::codec::{DecodeError, DecodedChunk, SegDesc, SegmentDir};
+use crate::fork::{Child, ForkTable};
+use crate::format::Format;
+use crate::node::{Node, RootExtension};
+use crate::reader::{Reader, ReaderError};
+use crate::scan::{Cursor, successor};
+use crate::store::{NodeGet, StoreError};
+use crate::value::{Entry, Key};
+
+/// One flattened position of a chunk's fork table, in ascending key order, with
+/// the count of the keys it stands for. A value stands for itself; a referenced
+/// or encrypted child stands for its whole subtree, counted without a fetch.
+enum Ranked<F: Format> {
+    /// A key terminates here with this value; it counts once.
+    Value {
+        /// Key bytes below the chunk root.
+        suffix: Vec<u8>,
+        /// The bound value.
+        entry: Entry<F>,
+    },
+    /// The trie continues into a referenced child holding `count` keys.
+    Ref {
+        /// Key bytes below the chunk root leading to the child.
+        suffix: Vec<u8>,
+        /// The child chunk address.
+        addr: ChunkAddress,
+        /// The child subtree's distinct key-count.
+        count: u64,
+    },
+    /// An encrypted child the plain reader cannot open, holding `count` keys.
+    /// Its count still routes a rank past it; only a descent into it fails.
+    Encrypted {
+        /// Key bytes below the chunk root leading to the child.
+        suffix: Vec<u8>,
+        /// The child subtree's distinct key-count.
+        count: u64,
+    },
+}
+
+impl<F: Format> Ranked<F> {
+    /// The key bytes below the chunk root.
+    fn suffix(&self) -> &[u8] {
+        match self {
+            Self::Value { suffix, .. }
+            | Self::Ref { suffix, .. }
+            | Self::Encrypted { suffix, .. } => suffix,
+        }
+    }
+
+    /// The number of keys this position stands for.
+    const fn count(&self) -> u64 {
+        match self {
+            Self::Value { .. } => 1,
+            Self::Ref { count, .. } | Self::Encrypted { count, .. } => *count,
+        }
+    }
+}
+
+/// Flatten a chunk's fork table into ascending-key ranked positions, recursing
+/// embedded children in the parent buffer so only referenced hops leave a step.
+///
+/// A referenced child's count is the stored annotation; an embedded child is
+/// expanded in place, so the positions of one chunk carry no fetch between them.
+fn ranked<F: Format>(table: &ForkTable<F>) -> Vec<Ranked<F>> {
+    let mut steps = Vec::new();
+    let mut prefix = Vec::new();
+    ranked_table(table, &mut prefix, &mut steps);
+    steps
+}
+
+/// Walk a fork table in wire order, appending each terminal and referenced child
+/// as a ranked position and recursing embedded children in place.
+fn ranked_table<F: Format>(table: &ForkTable<F>, prefix: &mut Vec<u8>, steps: &mut Vec<Ranked<F>>) {
+    for (first, record) in table.iter() {
+        let mark = prefix.len();
+        prefix.push(first);
+        prefix.extend_from_slice(record.tail().as_bytes());
+        if let Some(entry) = record.entry() {
+            steps.push(Ranked::Value {
+                suffix: prefix.clone(),
+                entry: entry.clone(),
+            });
+        }
+        match record.child() {
+            Some(Child::Embedded(inner)) => ranked_table(inner, prefix, steps),
+            Some(Child::Ref32(reference)) => steps.push(Ranked::Ref {
+                suffix: prefix.clone(),
+                addr: *reference.address(),
+                count: record.child_count().unwrap_or_default().get(),
+            }),
+            Some(Child::Ref64(_)) => steps.push(Ranked::Encrypted {
+                suffix: prefix.clone(),
+                count: record.child_count().unwrap_or_default().get(),
+            }),
+            None => {}
+        }
+        prefix.truncate(mark);
+    }
+}
+
+/// The on-path contents of one node: its fork-table positions and the keys in
+/// the segments strictly before them. A spilled node contributes only the
+/// covering leaf's positions; `Before` means the target precedes every fork.
+enum OnPath<F: Format> {
+    /// The target precedes every fork in the node; nothing at or below it.
+    Before,
+    /// The covering fragment's positions and the count skipped before them.
+    Fragment {
+        /// Keys in the segments strictly before the covering fragment.
+        before: u64,
+        /// The covering fragment's ranked positions.
+        steps: Vec<Ranked<F>>,
+    },
+}
+
+/// The empty-key value a decoded root carries: its root extension entry.
+fn root_entry<F: Format>(decoded: &DecodedChunk<F>) -> Option<Entry<F>> {
+    match decoded {
+        DecodedChunk::Node(node) => node.entry().cloned(),
+        DecodedChunk::Segmented(root, _) => root.as_ref().and_then(RootExtension::entry).cloned(),
+        DecodedChunk::Leaf(_) | DecodedChunk::Directory(_) => None,
+    }
+}
+
+/// The descriptor covering `byte`: the one with the greatest first key not past
+/// it, and the summed count of every descriptor before it. `None` when `byte`
+/// precedes the first descriptor.
+fn covering(dir: &SegmentDir, byte: u8) -> Option<(u64, &SegDesc)> {
+    let mut before = 0u64;
+    let mut cover: Option<&SegDesc> = None;
+    for desc in &dir.descriptors {
+        if desc.first_key > byte {
+            break;
+        }
+        if let Some(prior) = cover {
+            before = before.saturating_add(prior.seg_count.get());
+        }
+        cover = Some(desc);
+    }
+    cover.map(|desc| (before, desc))
+}
+
+/// Where an index falls across a directory's descriptors: the residual index
+/// into the covering descriptor and the descriptor itself, subtracting the
+/// skipped segments' counts. `None` when the index runs past the node's total.
+fn covering_index(dir: &SegmentDir, index: u64) -> Option<(u64, &SegDesc)> {
+    let mut index = index;
+    for desc in &dir.descriptors {
+        let count = desc.seg_count.get();
+        if index < count {
+            return Some((index, desc));
+        }
+        index = index.saturating_sub(count);
+    }
+    None
+}
+
+impl<S, F> Reader<S, F>
+where
+    S: NodeGet + MaybeSync,
+    F: Format,
+{
+    /// The number of keys with `lo <= key < hi`, computed as `rank(hi) -
+    /// rank(lo)` in two O(depth) descents, so a window's size never fetches it.
+    pub async fn count(&self, root: &ChunkAddress, lo: &Key, hi: &Key) -> Result<u64, ReaderError> {
+        let high = self.rank(root, hi).await?;
+        let low = self.rank(root, lo).await?;
+        Ok(high.saturating_sub(low))
+    }
+
+    /// The number of keys strictly less than `key`: its position in ascending
+    /// key order.
+    ///
+    /// Descends one referenced hop per level, adding the whole-subtree count of
+    /// every fork and segment strictly before the target and recursing only the
+    /// one child on its path. An encrypted subtree on the path cannot be opened;
+    /// one merely before the target routes by its stored count.
+    pub async fn rank(&self, root: &ChunkAddress, key: &Key) -> Result<u64, ReaderError> {
+        let target = key.as_bytes();
+        let mut address = *root;
+        let mut consumed = 0usize;
+        let mut acc = 0u64;
+        let mut is_root = true;
+        loop {
+            let decoded = decode_at::<S, F>(self.store(), &address).await?;
+            if is_root && !target.is_empty() && root_entry(&decoded).is_some() {
+                acc = acc.saturating_add(1);
+            }
+            let Some(remaining) = target.get(consumed..).filter(|rest| !rest.is_empty()) else {
+                return Ok(acc);
+            };
+            let steps = match on_path(self.store(), &decoded, remaining).await? {
+                OnPath::Before => return Ok(acc),
+                OnPath::Fragment { before, steps } => {
+                    acc = acc.saturating_add(before);
+                    steps
+                }
+            };
+            match rank_fragment(&steps, remaining) {
+                Step::Here(count) => return Ok(acc.saturating_add(count)),
+                Step::Encrypted => return Err(ReaderError::EncryptedChild),
+                Step::Cross {
+                    addr,
+                    matched,
+                    before,
+                } => {
+                    acc = acc.saturating_add(before);
+                    consumed = consumed.saturating_add(matched);
+                    address = addr;
+                    is_root = false;
+                }
+            }
+        }
+    }
+
+    /// The key and value at position `index` in ascending key order, or `None`
+    /// when `index` is at or past the key count.
+    ///
+    /// Descends one referenced hop per level, skipping any subtree whose count
+    /// the index clears and routing a spilled node's segments by `seg_count`, so
+    /// the offset costs O(depth), never O(index).
+    pub async fn select(
+        &self,
+        root: &ChunkAddress,
+        index: u64,
+    ) -> Result<Option<(Key, Entry<F>)>, ReaderError> {
+        let mut address = *root;
+        let mut index = index;
+        let mut path: Vec<u8> = Vec::new();
+        let mut is_root = true;
+        loop {
+            let decoded = decode_at::<S, F>(self.store(), &address).await?;
+            if is_root && let Some(entry) = root_entry(&decoded) {
+                if index == 0 {
+                    return Ok(Some((Key::new(Bytes::from(path)), entry)));
+                }
+                index = index.saturating_sub(1);
+            }
+            let Some(steps) = index_path(self.store(), &decoded, &mut index).await? else {
+                return Ok(None);
+            };
+            match select_fragment(steps, &mut index) {
+                Some(Reach::Found { suffix, entry }) => {
+                    path.extend_from_slice(&suffix);
+                    return Ok(Some((Key::new(Bytes::from(path)), entry)));
+                }
+                Some(Reach::Encrypted) => return Err(ReaderError::EncryptedChild),
+                Some(Reach::Cross { addr, suffix }) => {
+                    path.extend_from_slice(&suffix);
+                    address = addr;
+                    is_root = false;
+                }
+                None => return Ok(None),
+            }
+        }
+    }
+
+    /// A cursor over the keys with `lo <= key < hi`, positioned `offset` keys in
+    /// and yielding at most `limit`.
+    ///
+    /// The offset is a rank-directed seek, so paging deep into a listing costs
+    /// O(depth), not O(offset); the yielded slice equals `range(lo, hi)` skipped
+    /// `offset` and taken `limit`.
+    pub async fn paginate(
+        &self,
+        root: &ChunkAddress,
+        lo: &Key,
+        hi: &Key,
+        offset: u64,
+        limit: usize,
+    ) -> Result<Cursor<'_, S, F>, ReaderError> {
+        let end = Some(Bytes::copy_from_slice(hi.as_bytes()));
+        let start = self.rank(root, lo).await?.saturating_add(offset);
+        self.page(root, start, end, limit).await
+    }
+
+    /// A cursor over the keys carrying `prefix`, positioned `offset` keys in and
+    /// yielding at most `limit`; the empty prefix pages the whole manifest.
+    ///
+    /// The offset is a rank-directed seek, so it costs O(depth), not O(offset);
+    /// the yielded slice equals `prefix(prefix)` skipped `offset` and taken
+    /// `limit`.
+    pub async fn paginate_prefix(
+        &self,
+        root: &ChunkAddress,
+        prefix: &Key,
+        offset: u64,
+        limit: usize,
+    ) -> Result<Cursor<'_, S, F>, ReaderError> {
+        let end = successor(prefix.as_bytes());
+        let start = self.rank(root, prefix).await?.saturating_add(offset);
+        self.page(root, start, end, limit).await
+    }
+
+    /// Position a bounded cursor at the key of absolute rank `start`: select that
+    /// key, then seek to it under `end`, capped at `limit`. An out-of-range start
+    /// yields an exhausted cursor.
+    async fn page(
+        &self,
+        root: &ChunkAddress,
+        start: u64,
+        end: Option<Bytes>,
+        limit: usize,
+    ) -> Result<Cursor<'_, S, F>, ReaderError> {
+        match self.select(root, start).await? {
+            None => Ok(Cursor::exhausted(self.store())),
+            Some((key, _)) => Ok(Cursor::seek(self.store(), root, key.as_bytes(), end)
+                .await?
+                .with_limit(limit)),
+        }
+    }
+}
+
+/// Fetch and decode the chunk at `address` without materializing a spilled
+/// node's segments: the descent routes them itself by `seg_count`.
+async fn decode_at<S, F>(store: &S, address: &ChunkAddress) -> Result<DecodedChunk<F>, ReaderError>
+where
+    S: NodeGet + MaybeSync,
+    F: Format,
+{
+    let chunk = store.get(address).await.map_err(StoreError::store)?;
+    Node::<F>::decode_chunk(chunk.envelope().data())
+        .map_err(|error| ReaderError::Store(StoreError::Decode(error)))
+}
+
+/// Resolve the ranked positions on the target's path through a decoded chunk,
+/// routing a spilled node's segments by `seg_count` so only the covering one is
+/// fetched. `remaining` is the target key from this node's root, never empty.
+async fn on_path<S, F>(
+    store: &S,
+    decoded: &DecodedChunk<F>,
+    remaining: &[u8],
+) -> Result<OnPath<F>, ReaderError>
+where
+    S: NodeGet + MaybeSync,
+    F: Format,
+{
+    match decoded {
+        DecodedChunk::Node(node) => Ok(OnPath::Fragment {
+            before: 0,
+            steps: ranked(node.forks()),
+        }),
+        DecodedChunk::Segmented(_, dir) => route_key(store, dir, remaining).await,
+        DecodedChunk::Leaf(_) | DecodedChunk::Directory(_) => Err(segment_context()),
+    }
+}
+
+/// Route a spilled node's directory to the leaf fragment covering `remaining`,
+/// summing the counts of the segments strictly before it. Descends at most the
+/// two directory levels the frozen bounds allow (spec 5.4).
+async fn route_key<S, F>(
+    store: &S,
+    dir: &SegmentDir,
+    remaining: &[u8],
+) -> Result<OnPath<F>, ReaderError>
+where
+    S: NodeGet + MaybeSync,
+    F: Format,
+{
+    let Some(&byte) = remaining.first() else {
+        return Ok(OnPath::Before);
+    };
+    let mut before = 0u64;
+    let mut current = match covering(dir, byte) {
+        Some((skip, desc)) => {
+            before = before.saturating_add(skip);
+            desc.clone()
+        }
+        None => return Ok(OnPath::Before),
+    };
+    for _ in 0..2 {
+        if current.key.is_some() {
+            return Err(ReaderError::EncryptedChild);
+        }
+        match decode_at::<S, F>(store, &current.address).await? {
+            DecodedChunk::Leaf(table) => {
+                return Ok(OnPath::Fragment {
+                    before,
+                    steps: ranked(&table),
+                });
+            }
+            DecodedChunk::Directory(inner) => match covering(&inner, byte) {
+                Some((skip, desc)) => {
+                    before = before.saturating_add(skip);
+                    current = desc.clone();
+                }
+                None => return Ok(OnPath::Before),
+            },
+            _ => return Err(segment_context()),
+        }
+    }
+    Err(segment_context())
+}
+
+/// Route a decoded chunk to the ranked positions holding the `index`th key,
+/// subtracting a spilled node's skipped-segment counts from `index`. `None` when
+/// the index runs past the node's total.
+async fn index_path<S, F>(
+    store: &S,
+    decoded: &DecodedChunk<F>,
+    index: &mut u64,
+) -> Result<Option<Vec<Ranked<F>>>, ReaderError>
+where
+    S: NodeGet + MaybeSync,
+    F: Format,
+{
+    match decoded {
+        DecodedChunk::Node(node) => Ok(Some(ranked(node.forks()))),
+        DecodedChunk::Segmented(_, dir) => {
+            let mut dir = dir.clone();
+            for _ in 0..2 {
+                let Some((residual, desc)) = covering_index(&dir, *index) else {
+                    return Ok(None);
+                };
+                *index = residual;
+                if desc.key.is_some() {
+                    return Err(ReaderError::EncryptedChild);
+                }
+                match decode_at::<S, F>(store, &desc.address).await? {
+                    DecodedChunk::Leaf(table) => return Ok(Some(ranked(&table))),
+                    DecodedChunk::Directory(inner) => dir = inner,
+                    _ => return Err(segment_context()),
+                }
+            }
+            Err(segment_context())
+        }
+        DecodedChunk::Leaf(_) | DecodedChunk::Directory(_) => Err(segment_context()),
+    }
+}
+
+/// A malformed-segment decode error: a reference named a node but a bare segment
+/// decoded, or a directory nested past its bound.
+const fn segment_context() -> ReaderError {
+    ReaderError::Store(StoreError::Decode(DecodeError::SegmentContext))
+}
+
+/// The outcome of ranking `remaining` through one chunk's fork-table fragment.
+enum Step {
+    /// The rank resolves here, adding this many in-fragment keys before it.
+    Here(u64),
+    /// The target descends into a referenced child at `addr`, `matched` key
+    /// bytes below the fragment root, with this many in-fragment keys before it.
+    Cross {
+        addr: ChunkAddress,
+        matched: usize,
+        before: u64,
+    },
+    /// The target descends into an encrypted child that cannot be opened.
+    Encrypted,
+}
+
+/// Count the keys strictly before `remaining` within one fragment's positions,
+/// stopping where the target descends into a referenced child.
+///
+/// A position wholly before the target adds its whole-subtree count; the one the
+/// target funnels into is recursed, not counted; the rest are past the target.
+fn rank_fragment<F: Format>(steps: &[Ranked<F>], remaining: &[u8]) -> Step {
+    let mut before = 0u64;
+    for step in steps {
+        let suffix = step.suffix();
+        if suffix >= remaining {
+            return Step::Here(before);
+        }
+        // `suffix < remaining`: a prefix of it means the target descends here.
+        let descends = remaining.starts_with(suffix);
+        match step {
+            Ranked::Value { .. } => before = before.saturating_add(1),
+            Ranked::Ref { addr, count, .. } => {
+                if descends {
+                    return Step::Cross {
+                        addr: *addr,
+                        matched: suffix.len(),
+                        before,
+                    };
+                }
+                before = before.saturating_add(*count);
+            }
+            Ranked::Encrypted { count, .. } => {
+                if descends {
+                    return Step::Encrypted;
+                }
+                before = before.saturating_add(*count);
+            }
+        }
+    }
+    Step::Here(before)
+}
+
+/// Where an index lands within one fragment's positions.
+enum Reach<F: Format> {
+    /// The index is this fragment's value at `suffix`.
+    Found { suffix: Vec<u8>, entry: Entry<F> },
+    /// The index falls inside the referenced child at `addr`, `suffix` below the
+    /// fragment root; the residual index stays in the caller's counter.
+    Cross { addr: ChunkAddress, suffix: Vec<u8> },
+    /// The index falls inside an encrypted child that cannot be opened.
+    Encrypted,
+}
+
+/// Resolve `index` within one fragment's positions, subtracting the counts of
+/// the positions before it. `None` when the index runs past the fragment total.
+fn select_fragment<F: Format>(steps: Vec<Ranked<F>>, index: &mut u64) -> Option<Reach<F>> {
+    for step in steps {
+        let count = step.count();
+        if *index < count {
+            return Some(match step {
+                Ranked::Value { suffix, entry } => Reach::Found { suffix, entry },
+                Ranked::Ref { suffix, addr, .. } => Reach::Cross { addr, suffix },
+                Ranked::Encrypted { .. } => Reach::Encrypted,
+            });
+        }
+        *index = index.saturating_sub(count);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::executor::block_on;
+    use nectar_primitives::store::MemoryStore;
+    use nectar_primitives::{ChunkAddress, ChunkRef, EncryptedChunkRef, EncryptionKey};
+
+    use crate::bounded::Prefix;
+    use crate::count::SubtreeCount;
+    use crate::fork::{Child, ForkTable};
+    use crate::format::V1;
+    use crate::node::{Node, RootExtension};
+    use crate::store::NodePut;
+    use crate::value::{Entry, Key};
+
+    use super::*;
+
+    fn entry(byte: u8) -> Entry<V1> {
+        ChunkRef::new(ChunkAddress::new([byte; 32])).into()
+    }
+
+    fn prefix(bytes: &[u8]) -> Prefix<V1> {
+        Prefix::try_from(bytes).unwrap()
+    }
+
+    #[test]
+    fn the_root_entry_is_index_zero_and_lifts_every_rank() {
+        let store = MemoryStore::default();
+        let root_ext = RootExtension::new(Some(entry(9)), None);
+        let mut forks = ForkTable::new();
+        forks.insert(prefix(b"k"), entry(1).into(), None).unwrap();
+        let root = block_on(store.put_node(&Node::<V1>::new(root_ext, forks))).unwrap();
+        let reader = Reader::<&MemoryStore, V1>::new(&store);
+
+        // The empty key leads iteration at index 0; "k" follows at index 1.
+        assert_eq!(
+            block_on(reader.select(&root, 0)).unwrap(),
+            Some((Key::empty(), entry(9)))
+        );
+        assert_eq!(
+            block_on(reader.select(&root, 1)).unwrap(),
+            Some((Key::from(&b"k"[..]), entry(1)))
+        );
+        assert_eq!(block_on(reader.select(&root, 2)).unwrap(), None);
+
+        // Nothing is strictly before the empty key; the root entry sits before
+        // every other key, so it lifts their ranks by one.
+        assert_eq!(block_on(reader.rank(&root, &Key::empty())).unwrap(), 0);
+        assert_eq!(
+            block_on(reader.rank(&root, &Key::from(&b"k"[..]))).unwrap(),
+            1
+        );
+        assert_eq!(
+            block_on(reader.rank(&root, &Key::from(&b"z"[..]))).unwrap(),
+            2
+        );
+        assert_eq!(
+            block_on(reader.count(&root, &Key::empty(), &Key::from(&b"z"[..]))).unwrap(),
+            2
+        );
+    }
+
+    // A root holding "a" and "z" as plain values with an encrypted five-key
+    // subtree wedged between them under "m"; the count rides the fork record.
+    fn with_encrypted(store: &MemoryStore) -> ChunkAddress {
+        let mut forks = ForkTable::new();
+        forks
+            .insert(prefix(b"a"), entry(0xA1).into(), None)
+            .unwrap();
+        forks
+            .insert(
+                prefix(b"m"),
+                Child::Ref64(EncryptedChunkRef::new(
+                    ChunkAddress::new([0x4D; 32]),
+                    EncryptionKey::from([0xC7; 32]),
+                ))
+                .into(),
+                None,
+            )
+            .unwrap();
+        forks
+            .get_mut(b'm')
+            .unwrap()
+            .set_child_count(Some(SubtreeCount::new(5)));
+        forks
+            .insert(prefix(b"z"), entry(0x2C).into(), None)
+            .unwrap();
+        block_on(store.put_node(&Node::<V1>::new(None, forks))).unwrap()
+    }
+
+    #[test]
+    fn an_encrypted_subtree_is_counted_without_being_opened() {
+        let store = MemoryStore::default();
+        let root = with_encrypted(&store);
+        let reader = Reader::<&MemoryStore, V1>::new(&store);
+
+        // Ranking past the encrypted subtree adds its stored count: "a", then its
+        // five keys, all strictly before "z".
+        assert_eq!(
+            block_on(reader.rank(&root, &Key::from(&b"z"[..]))).unwrap(),
+            6
+        );
+        // A key at the encrypted prefix does not descend; its keys are longer.
+        assert_eq!(
+            block_on(reader.rank(&root, &Key::from(&b"m"[..]))).unwrap(),
+            1
+        );
+        // Selecting the key just past the subtree skips all five by count.
+        assert_eq!(
+            block_on(reader.select(&root, 6)).unwrap(),
+            Some((Key::from(&b"z"[..]), entry(0x2C)))
+        );
+    }
+
+    #[test]
+    fn descending_into_an_encrypted_subtree_is_an_error() {
+        let store = MemoryStore::default();
+        let root = with_encrypted(&store);
+        let reader = Reader::<&MemoryStore, V1>::new(&store);
+
+        // A rank whose key funnels into the encrypted subtree cannot be answered.
+        assert!(matches!(
+            block_on(reader.rank(&root, &Key::from(&b"mx"[..]))),
+            Err(ReaderError::EncryptedChild)
+        ));
+        // An index landing inside the encrypted subtree cannot be opened.
+        assert!(matches!(
+            block_on(reader.select(&root, 3)),
+            Err(ReaderError::EncryptedChild)
+        ));
+    }
+
+    #[test]
+    fn an_empty_manifest_has_no_keys() {
+        let store = MemoryStore::default();
+        let root = block_on(store.put_node(&Node::<V1>::empty())).unwrap();
+        let reader = Reader::<&MemoryStore, V1>::new(&store);
+        assert_eq!(
+            block_on(reader.rank(&root, &Key::from(&b"x"[..]))).unwrap(),
+            0
+        );
+        assert_eq!(block_on(reader.select(&root, 0)).unwrap(), None);
+        let mut cursor = block_on(reader.paginate_prefix(&root, &Key::empty(), 0, 10)).unwrap();
+        assert!(block_on(cursor.next()).unwrap().is_none());
+    }
+}

--- a/crates/manifest/src/scan.rs
+++ b/crates/manifest/src/scan.rs
@@ -133,6 +133,8 @@ pub struct Cursor<'a, S, F: Format = V1> {
     ready: Vec<Fetched<F>>,
     /// The next fetch sequence id to hand out.
     next_seq: usize,
+    /// Remaining yields a paginated cursor may return; `None` is unbounded.
+    remaining: Option<usize>,
 }
 
 /// What visiting the top frame's next step resolves to, computed under a short
@@ -223,7 +225,30 @@ where
             inflight: FuturesUnordered::new(),
             ready: Vec::new(),
             next_seq: 0,
+            remaining: None,
         })
+    }
+
+    /// An already-exhausted cursor: yields nothing. Used when a paginated seek
+    /// starts past the last key.
+    pub(crate) fn exhausted(store: &'a S) -> Self {
+        Self {
+            store,
+            stack: Vec::new(),
+            end: None,
+            done: true,
+            inflight: FuturesUnordered::new(),
+            ready: Vec::new(),
+            next_seq: 0,
+            remaining: None,
+        }
+    }
+
+    /// Cap this cursor at `limit` yields, for a paginated page of a listing.
+    #[must_use]
+    pub(crate) const fn with_limit(mut self, limit: usize) -> Self {
+        self.remaining = Some(limit);
+        self
     }
 
     /// The next `(key, value)` in key order, or `None` at the end of the walk.
@@ -233,6 +258,10 @@ where
     /// fetch per key.
     pub async fn next(&mut self) -> Result<Option<(Key, Entry<F>)>, ReaderError> {
         if self.done {
+            return Ok(None);
+        }
+        if self.remaining == Some(0) {
+            self.done = true;
             return Ok(None);
         }
         loop {
@@ -272,6 +301,9 @@ where
                     if self.past_end(&key) {
                         self.done = true;
                         return Ok(None);
+                    }
+                    if let Some(left) = self.remaining {
+                        self.remaining = Some(left.saturating_sub(1));
                     }
                     return Ok(Some((Key::new(Bytes::from(key)), entry)));
                 }

--- a/crates/manifest/tests/order.rs
+++ b/crates/manifest/tests/order.rs
@@ -1,0 +1,361 @@
+//! Order-statistic conformance: rank, select and count
+//! agree with a full-walk oracle across corpora and shuffled builds; paginate
+//! returns the same slice as `iter().skip(offset).take(limit)`; and the offset
+//! seek costs O(depth), not O(offset), witnessed through a fetch-counting store.
+
+use std::error::Error;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use futures::executor::block_on;
+use nectar_manifest::{Builder, Entry, Key, Reader, V1};
+use nectar_primitives::store::{ChunkGet, MemoryStore};
+use nectar_primitives::{Chunk, ChunkAddress, ChunkRef, StandardChunkSet, Verified};
+
+type TestResult = Result<(), Box<dyn Error>>;
+
+/// A key set paired with the value each key carries.
+type KeySet = Vec<(Key, u8)>;
+
+/// The `(key, value)` pairs a walk yields, in key order.
+type Pairs = Vec<(Key, Entry<V1>)>;
+
+fn ensure(cond: bool, what: String) -> TestResult {
+    if cond { Ok(()) } else { Err(what.into()) }
+}
+
+fn entry(fill: u8) -> Entry<V1> {
+    Entry::from(ChunkRef::new(ChunkAddress::new([fill; 32])))
+}
+
+/// A store that counts every `get`, so a test reads how many nodes a query
+/// fetched.
+#[derive(Debug, Default)]
+struct CountingStore {
+    inner: MemoryStore,
+    gets: AtomicUsize,
+}
+
+impl CountingStore {
+    fn reset(&self) {
+        self.gets.store(0, Ordering::Relaxed);
+    }
+
+    fn gets(&self) -> usize {
+        self.gets.load(Ordering::Relaxed)
+    }
+}
+
+impl ChunkGet<StandardChunkSet> for CountingStore {
+    type Trust = Verified;
+    type Error = <MemoryStore as ChunkGet>::Error;
+
+    async fn get(
+        &self,
+        address: &ChunkAddress,
+    ) -> Result<Chunk<Verified, StandardChunkSet>, Self::Error> {
+        self.gets.fetch_add(1, Ordering::Relaxed);
+        ChunkGet::get(&self.inner, address).await
+    }
+}
+
+/// Every `radix`-ary key of length `len`, ascending, each valued on its last
+/// byte. A multi-byte alphabet fans the trie into referenced children and, at a
+/// full first-byte spread, spills interior nodes across segments.
+fn radix_keys(radix: u8, len: usize) -> KeySet {
+    let mut out = Vec::new();
+    let mut key = Vec::new();
+    fill(radix, len, &mut key, &mut out);
+    out
+}
+
+fn fill(radix: u8, remaining: usize, key: &mut Vec<u8>, out: &mut KeySet) {
+    match remaining {
+        0 => out.push((Key::from(key.as_slice()), key.last().copied().unwrap_or(0))),
+        _ => {
+            for digit in 0..radix {
+                key.push(digit);
+                fill(radix, remaining.saturating_sub(1), key, out);
+                key.pop();
+            }
+        }
+    }
+}
+
+/// A corpus whose root spills into a segment directory: a full 256 first-byte
+/// spread, each carrying a 50-key subtree too large to embed, so the root
+/// references 256 children and its own fork table overruns one chunk. Distinct
+/// values keep the children from collapsing, so the descent routes real
+/// segments. Order-statistic queries must route these by `seg_count`.
+fn wide_keys() -> KeySet {
+    let mut out = Vec::new();
+    for a in 0u16..256 {
+        for c in 0u8..50 {
+            let byte = u8::try_from(a).unwrap_or(0);
+            out.push((Key::from(&[byte, c][..]), byte.wrapping_add(c)));
+        }
+    }
+    out
+}
+
+fn build(store: &MemoryStore, keys: &[(Key, u8)]) -> Result<ChunkAddress, Box<dyn Error>> {
+    let mut builder = Builder::<V1>::new();
+    for (key, fill) in keys {
+        builder.insert(key.clone(), entry(*fill), None);
+    }
+    Ok(*block_on(builder.build(store))
+        .map_err(|e| e.to_string())?
+        .root())
+}
+
+/// The ground-truth ordering: every `(key, value)` a full walk yields.
+fn oracle(reader: &Reader<MemoryStore, V1>, root: &ChunkAddress) -> Result<Pairs, Box<dyn Error>> {
+    let mut out = Vec::new();
+    let mut cursor = block_on(reader.iter(root)).map_err(|e| e.to_string())?;
+    while let Some(pair) = block_on(cursor.next()).map_err(|e| e.to_string())? {
+        out.push(pair);
+    }
+    Ok(out)
+}
+
+#[test]
+fn rank_select_count_agree_with_a_full_walk_oracle() -> TestResult {
+    let store = MemoryStore::default();
+    let keys = radix_keys(12, 3);
+    let root = build(&store, &keys)?;
+    let reader = Reader::<MemoryStore, V1>::new(store);
+    let all = oracle(&reader, &root)?;
+    ensure(all.len() == keys.len(), "oracle lost keys".to_owned())?;
+
+    // select(i) is the i-th key; one past the end is None.
+    for (i, (key, value)) in all.iter().enumerate() {
+        let index = u64::try_from(i)?;
+        let got = block_on(reader.select(&root, index)).map_err(|e| e.to_string())?;
+        ensure(
+            got.as_ref() == Some(&(key.clone(), value.clone())),
+            format!("select({i}) mismatch"),
+        )?;
+    }
+    let end = u64::try_from(all.len())?;
+    ensure(
+        block_on(reader.select(&root, end))
+            .map_err(|e| e.to_string())?
+            .is_none(),
+        "select past the end must be None".to_owned(),
+    )?;
+
+    // rank(key) is the count of strictly-smaller keys, checked at present keys
+    // and at the absent points that bracket, precede and follow the key set.
+    let probes = [
+        Key::empty(),
+        Key::from(&[0u8][..]),
+        Key::from(&[3u8, 5][..]),
+        Key::from(&[3u8, 5, 5][..]),
+        Key::from(&[3u8, 5, 6][..]),
+        Key::from(&[6u8, 0, 0][..]),
+        Key::from(&[11u8, 11, 11][..]),
+        Key::from(&[12u8][..]),
+        Key::from(&[255u8][..]),
+    ];
+    for probe in &probes {
+        let expected = u64::try_from(all.iter().filter(|(k, _)| k < probe).count())?;
+        let got = block_on(reader.rank(&root, probe)).map_err(|e| e.to_string())?;
+        ensure(
+            got == expected,
+            format!("rank mismatch: {got} != {expected}"),
+        )?;
+    }
+
+    // count(lo, hi) is the size of the half-open window.
+    for (lo, hi) in [
+        (Key::from(&[0u8, 0, 0][..]), Key::from(&[3u8, 0, 0][..])),
+        (Key::from(&[3u8, 5, 5][..]), Key::from(&[7u8, 2, 2][..])),
+        (Key::empty(), Key::from(&[12u8][..])),
+        (Key::from(&[9u8][..]), Key::from(&[3u8][..])),
+    ] {
+        let expected = u64::try_from(all.iter().filter(|(k, _)| lo <= *k && *k < hi).count())?;
+        let got = block_on(reader.count(&root, &lo, &hi)).map_err(|e| e.to_string())?;
+        ensure(
+            got == expected,
+            format!("count mismatch: {got} != {expected}"),
+        )?;
+    }
+    Ok(())
+}
+
+#[test]
+fn spilled_node_order_statistics_agree_with_the_oracle() -> TestResult {
+    // A corpus whose root is a segmented node, so every query routes the root's
+    // segment directory by seg_count before descending a referenced child.
+    let store = MemoryStore::default();
+    let keys = wide_keys();
+    let root = build(&store, &keys)?;
+    let reader = Reader::<MemoryStore, V1>::new(store);
+    let all = oracle(&reader, &root)?;
+    ensure(all.len() == keys.len(), "oracle lost keys".to_owned())?;
+
+    // Sampled select and its inverse rank agree with the oracle across the whole
+    // spilled listing, including both ends.
+    let last = all.len().saturating_sub(1);
+    for i in (0..all.len()).step_by(311).chain([last]) {
+        let (key, value) = all.get(i).ok_or("oracle index out of range")?;
+        let index = u64::try_from(i)?;
+        let got = block_on(reader.select(&root, index)).map_err(|e| e.to_string())?;
+        ensure(
+            got.as_ref() == Some(&(key.clone(), value.clone())),
+            format!("spilled select({i}) mismatch"),
+        )?;
+        let rank = block_on(reader.rank(&root, key)).map_err(|e| e.to_string())?;
+        ensure(rank == index, format!("spilled rank at {i} mismatch"))?;
+    }
+
+    // Windows spanning several segments count exactly.
+    for (lo, hi) in [
+        (Key::from(&[0u8, 0][..]), Key::from(&[100u8, 0][..])),
+        (Key::from(&[40u8, 25][..]), Key::from(&[210u8, 10][..])),
+        (Key::empty(), Key::from(&[255u8, 255][..])),
+    ] {
+        let expected = u64::try_from(all.iter().filter(|(k, _)| lo <= *k && *k < hi).count())?;
+        let got = block_on(reader.count(&root, &lo, &hi)).map_err(|e| e.to_string())?;
+        ensure(
+            got == expected,
+            format!("spilled count mismatch: {got} != {expected}"),
+        )?;
+    }
+
+    // A page deep in the spilled listing is the matching oracle slice.
+    let mut got = Vec::new();
+    let mut cursor = block_on(reader.paginate_prefix(&root, &Key::empty(), 9000, 25))
+        .map_err(|e| e.to_string())?;
+    while let Some(pair) = block_on(cursor.next()).map_err(|e| e.to_string())? {
+        got.push(pair);
+    }
+    let want: Vec<_> = all.iter().skip(9000).take(25).cloned().collect();
+    ensure(got == want, "spilled paginate mismatch".to_owned())?;
+    Ok(())
+}
+
+#[test]
+fn order_statistics_are_stable_under_shuffled_build_order() -> TestResult {
+    let forward = radix_keys(10, 3);
+    let mut reversed = forward.clone();
+    reversed.reverse();
+
+    let a_store = MemoryStore::default();
+    let a = build(&a_store, &forward)?;
+    let b_store = MemoryStore::default();
+    let b = build(&b_store, &reversed)?;
+    ensure(a == b, "shuffled build must root identically".to_owned())?;
+
+    let reader = Reader::<MemoryStore, V1>::new(a_store);
+    // A shuffled build is the same tree, so every rank and select is unchanged.
+    for index in [0u64, 1, 250, 500, 999] {
+        let got = block_on(reader.select(&a, index)).map_err(|e| e.to_string())?;
+        let (key, _) = got.ok_or("select fell off the shuffled build")?;
+        let rank = block_on(reader.rank(&a, &key)).map_err(|e| e.to_string())?;
+        ensure(rank == index, format!("rank/select disagree at {index}"))?;
+    }
+    Ok(())
+}
+
+#[test]
+fn paginate_matches_iter_skip_take() -> TestResult {
+    let store = MemoryStore::default();
+    let keys = radix_keys(10, 3);
+    let root = build(&store, &keys)?;
+    let reader = Reader::<MemoryStore, V1>::new(store);
+    let all = oracle(&reader, &root)?;
+
+    // Whole-manifest pagination is exactly iter().skip(offset).take(limit).
+    for (offset, limit) in [(0u64, 7usize), (13, 20), (500, 33), (995, 50), (2000, 4)] {
+        let mut got = Vec::new();
+        let mut cursor = block_on(reader.paginate_prefix(&root, &Key::empty(), offset, limit))
+            .map_err(|e| e.to_string())?;
+        while let Some(pair) = block_on(cursor.next()).map_err(|e| e.to_string())? {
+            got.push(pair);
+        }
+        let start = usize::try_from(offset)?;
+        let want: Vec<_> = all.iter().skip(start).take(limit).cloned().collect();
+        ensure(
+            got == want,
+            format!("paginate_prefix({offset}, {limit}) mismatch"),
+        )?;
+    }
+
+    // Range pagination is the same over the range's own slice.
+    let lo = Key::from(&[3u8, 0, 0][..]);
+    let hi = Key::from(&[7u8, 0, 0][..]);
+    let window: Vec<_> = all
+        .iter()
+        .filter(|(k, _)| lo <= *k && *k < hi)
+        .cloned()
+        .collect();
+    for (offset, limit) in [(0u64, 10usize), (25, 40), (300, 12)] {
+        let mut got = Vec::new();
+        let mut cursor =
+            block_on(reader.paginate(&root, &lo, &hi, offset, limit)).map_err(|e| e.to_string())?;
+        while let Some(pair) = block_on(cursor.next()).map_err(|e| e.to_string())? {
+            got.push(pair);
+        }
+        let start = usize::try_from(offset)?;
+        let want: Vec<_> = window.iter().skip(start).take(limit).cloned().collect();
+        ensure(got == want, format!("paginate({offset}, {limit}) mismatch"))?;
+    }
+    Ok(())
+}
+
+#[test]
+fn the_offset_seek_costs_depth_not_offset() -> TestResult {
+    // A wide, spilled corpus: a full first-byte spread forces the root to spill
+    // into a segment directory, so the seek must route by seg_count.
+    let inner = MemoryStore::default();
+    let keys = wide_keys();
+    let root = build(&inner, &keys)?;
+    let store = CountingStore {
+        inner,
+        gets: AtomicUsize::new(0),
+    };
+    let reader = Reader::<CountingStore, V1>::new(store);
+    let total = u64::try_from(keys.len())?;
+
+    // Selecting near the start and deep into the listing fetches the same handful
+    // of nodes: a few directory and node hops per level, never the offset.
+    let mut costs = Vec::new();
+    for index in [0u64, total / 2, total.saturating_sub(1)] {
+        reader.store().reset();
+        let got = block_on(reader.select(&root, index)).map_err(|e| e.to_string())?;
+        ensure(got.is_some(), format!("select({index}) fell off"))?;
+        costs.push(reader.store().gets());
+    }
+    for cost in &costs {
+        ensure(
+            *cost <= 32,
+            format!("select fetched {cost} nodes, not O(depth)"),
+        )?;
+    }
+
+    // Paginating at a large offset fetches no more than at offset zero plus the
+    // page and its read-ahead: the offset itself is free.
+    reader.store().reset();
+    let mut head =
+        block_on(reader.paginate_prefix(&root, &Key::empty(), 0, 5)).map_err(|e| e.to_string())?;
+    while block_on(head.next()).map_err(|e| e.to_string())?.is_some() {}
+    let head_cost = reader.store().gets();
+
+    reader.store().reset();
+    let deep_offset = total.saturating_sub(5);
+    let mut deep = block_on(reader.paginate_prefix(&root, &Key::empty(), deep_offset, 5))
+        .map_err(|e| e.to_string())?;
+    while block_on(deep.next()).map_err(|e| e.to_string())?.is_some() {}
+    let deep_cost = reader.store().gets();
+
+    // The deep page pays for its own depth and window, not the offset it skipped.
+    ensure(
+        deep_cost <= head_cost.saturating_mul(2).saturating_add(32),
+        format!("deep page fetched {deep_cost} vs head {head_cost}: offset is not free"),
+    )?;
+    ensure(
+        u64::try_from(deep_cost)? < deep_offset,
+        format!("deep page fetched {deep_cost}, proportional to the offset"),
+    )?;
+    Ok(())
+}


### PR DESCRIPTION
## What

Adds O(depth) order-statistic query methods to the manifest reader, generic
over any `Format` rather than gated on a separate counted-profile marker
trait, since counts are now carried by the baseline wire itself (#307). A `V1`
manifest exposes these methods the same as `V1Read`; there is no longer a
`Counted` sealed trait to implement.

New file `crates/manifest/src/order.rs` (676 lines) adds:

- `Reader::rank(root, key)` returning the count of keys strictly less than
  `key`.
- `Reader::select(root, index)` returning the key/entry at a given position.
- `Reader::count(root, lo, hi)`, computed as `rank(hi) - rank(lo)`.
- `Reader::paginate(root, lo, hi, offset, limit)` and
  `Reader::paginate_prefix(root, prefix, offset, limit)`, which seek by rank
  and then walk.

The descent accumulates the whole-subtree count of every fork it steps over:
referenced children contribute their stored `child_count`, embedded children
are recursed within the parent buffer. For a spilled (`Segmented`) node, the
segment directory is routed by `seg_count` so only the covering leaf/dir
segment is fetched.

`crates/manifest/src/lib.rs` gains the `order` module. `crates/manifest/src/scan.rs`
gains 32 lines supporting the above. `crates/manifest/tests/order.rs` (361
lines, new) adds integration coverage for rank/select/count/paginate/paginate_prefix,
run entirely over `V1`.

## Why

Second half of #296, closed by #307.

Epic #264 Phase 2 requires order-statistic queries (rank/select/count/paginate)
over manifests so consumers can page through entries by position without an
O(window) scan. Since #307 makes every manifest counted at the wire level,
these queries are simply generic over `Format` and available to every reader,
with no capability split to reason about between profiles.

## Testing

Full battery run via `nix develop`:

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`:
  clean, including strict restriction lints.
- `cargo nextest run --workspace --locked`: 837 tests run, 837 passed, 1
  skipped, including the new `tests/order.rs` integration tests and doc tests.

`nectar-postage-usage` and `fuzz/` are untouched by this change, so the wasm
and cargo-fuzz gates do not apply here.

## AI Assistance

Claude (Anthropic) was used for implementation, red-team review, and independent verification testing, per the process in [nxm-rs/.github CONTRIBUTING.md](https://github.com/nxm-rs/.github/blob/main/CONTRIBUTING.md).
