### PR TITLE
feat(manifest-proof): add inclusion/exclusion proof crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2071,6 +2071,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nectar-manifest-proof"
+version = "0.4.0"
+dependencies = [
+ "alloy-primitives",
+ "bytes",
+ "futures",
+ "nectar-manifest",
+ "nectar-primitives",
+ "proptest",
+ "thiserror",
+]
+
+[[package]]
 name = "nectar-mantaray"
 version = "0.4.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ check.all_targets = true
 # nectar crates
 nectar-contracts = { version = "0.4.0", path = "crates/contracts" }
 nectar-manifest = { version = "0.4.0", path = "crates/manifest" }
+nectar-manifest-proof = { version = "0.4.0", path = "crates/manifest-proof" }
 nectar-mantaray = { version = "0.4.0", path = "crates/mantaray" }
 nectar-primitives = { version = "0.4.0", path = "crates/primitives" }
 nectar-swarms = { version = "0.4.0", path = "crates/swarms" }

--- a/crates/manifest-proof/Cargo.toml
+++ b/crates/manifest-proof/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "nectar-manifest-proof"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+description = "Inclusion and exclusion proofs over a mantaray 1.0 manifest, verified against a trusted root"
+documentation = "https://docs.rs/nectar-manifest-proof"
+readme = "README.md"
+keywords = ["swarm", "ethereum", "manifest", "mantaray", "proof"]
+categories = ["data-structures", "cryptography"]
+
+[lints]
+workspace = true
+
+[dependencies]
+alloy-primitives = { workspace = true }
+nectar-manifest = { workspace = true }
+nectar-primitives = { workspace = true }
+thiserror.workspace = true
+
+[dev-dependencies]
+bytes.workspace = true
+futures.workspace = true
+proptest.workspace = true
+
+[features]
+default = [ "std" ]
+std = [
+	"alloy-primitives/std",
+	"nectar-manifest/std",
+	"nectar-primitives/std",
+	"thiserror/std",
+]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/manifest-proof/README.md
+++ b/crates/manifest-proof/README.md
@@ -1,0 +1,15 @@
+# nectar-manifest-proof
+
+Inclusion and exclusion proofs over a mantaray 1.0 manifest, authenticated
+against a trusted root address.
+
+A proof is the authenticated descent path for a key under a root: an ordered
+chain of nodes, each authenticated against the reference the node before it
+yielded. Inclusion terminates at the key's entry; exclusion terminates where the
+descent provably cannot reach the key. Two granularities carry the same
+authentication: full-chunk (whole node bytes, re-BMT by the verifier) and
+BMT-segment (only the leading segments the descent reads, each behind its
+sibling path). `verify` replays the descent over the authenticated bytes and
+reports the verdict, so a proof cannot assert what its bytes do not.
+
+Part of the verifiable-manifests set under the mantaray 1.0 epic.

--- a/crates/manifest-proof/src/descent.rs
+++ b/crates/manifest-proof/src/descent.rs
@@ -1,0 +1,267 @@
+//! Authenticated descent over a node's raw payload bytes.
+//!
+//! One engine drives both proof granularities: the verifier hands it the bytes
+//! it has authenticated for a node (a whole chunk, or a contiguous run of
+//! BMT-authenticated leading segments) and it re-derives the single next step
+//! the trie takes for the key. Embedded children live in the parent's bytes, so
+//! the walk crosses them without a step; only a referenced edge yields a hop.
+//!
+//! The parse restates just the node-body grammar the descent reads (preamble,
+//! flags, fork index, the followed record); soundness rests on canonicalness
+//! (spec 6.2): an authenticated node's fork set is complete and edges maximal,
+//! so the index entry for a byte is the whole story for that byte.
+
+use nectar_manifest::{Entry, Format, InlineValue};
+use nectar_primitives::wire::{Cursor, Underrun};
+use nectar_primitives::{ChunkAddress, ChunkRef, EncryptedChunkRef};
+
+/// Flags-byte facts of the node body grammar (spec 5.1). Restated here because
+/// they are wire structure, not a tunable the manifest crate exports.
+mod flag {
+    /// Bits 0-1: the entry presence and width discriminant.
+    pub(super) const ENTRY_MASK: u8 = 0b0000_0011;
+    /// Bits 2-3: the child presence and width discriminant.
+    pub(super) const CHILD_MASK: u8 = 0b0000_1100;
+    /// Bit 4: a metadata block follows.
+    pub(super) const HAS_META: u8 = 0b0001_0000;
+    /// Bit 5: the fork table is a segment directory.
+    pub(super) const SEGMENTED: u8 = 0b0010_0000;
+    /// Bit 6: the body is a segment, not a node.
+    pub(super) const SEGMENT: u8 = 0b0100_0000;
+}
+
+/// A two-bit reference/value width discriminant.
+#[derive(Clone, Copy)]
+enum Width {
+    /// Absent field.
+    None,
+    /// A plain 32-byte reference.
+    Ref32,
+    /// An encrypted 64-byte reference.
+    Ref64,
+    /// Length-prefixed inline bytes, or an embedded child body.
+    Inline,
+}
+
+/// The entry-position (bits 0-1) width of a flags byte.
+const fn entry_width(flags: u8) -> Width {
+    match flags & flag::ENTRY_MASK {
+        0b01 => Width::Ref32,
+        0b10 => Width::Ref64,
+        0b11 => Width::Inline,
+        _ => Width::None,
+    }
+}
+
+/// The child-position (bits 2-3) width of a flags byte.
+const fn child_width(flags: u8) -> Width {
+    match flags & flag::CHILD_MASK {
+        0b0100 => Width::Ref32,
+        0b1000 => Width::Ref64,
+        0b1100 => Width::Inline,
+        _ => Width::None,
+    }
+}
+
+/// A rejection while reading a node's authenticated bytes.
+#[non_exhaustive]
+#[derive(Debug, thiserror::Error)]
+pub enum DescentError {
+    /// The authenticated bytes ended inside a field the descent had to read;
+    /// for a segment proof this is a short segment run, not a malformed node.
+    #[error(transparent)]
+    Underrun(#[from] Underrun),
+    /// The payload does not open with this format's preamble.
+    #[error("not a mantaray 1.0 manifest")]
+    NotAManifest,
+    /// The node is a spilled segment or segment directory; a proof over a
+    /// spilled node is out of this crate's scope.
+    #[error("spilled node on the proof path")]
+    Spilled,
+    /// A fork prefix length of zero.
+    #[error("empty fork prefix")]
+    EmptyPrefix,
+    /// An inline value longer than the format admits.
+    #[error("inline value over the format bound")]
+    ValueTooLong,
+}
+
+/// Where the descent through one node lands for the key.
+#[derive(Debug)]
+pub(crate) enum Step<F: Format> {
+    /// The key terminates in this node with this value.
+    Found(Entry<F>),
+    /// The key continues into a referenced child at this address, with this
+    /// many key bytes consumed.
+    Follow(ChunkAddress, usize),
+    /// No authenticated continuation reaches the key from this node.
+    Absent,
+    /// The key funnels into an encrypted child; following it needs a key this
+    /// plain descent does not carry.
+    Encrypted,
+}
+
+/// A fresh cursor over `bytes` advanced past its first `offset` bytes.
+fn seek(bytes: &[u8], offset: usize) -> Result<Cursor<'_>, Underrun> {
+    let mut cur = Cursor::new(bytes);
+    let _ = cur.take_slice(offset)?;
+    Ok(cur)
+}
+
+/// The little-endian u16 the node grammar uses for every count, offset and
+/// length, widened for arithmetic.
+fn take_u16(cur: &mut Cursor<'_>) -> Result<usize, Underrun> {
+    cur.take::<[u8; 2]>()
+        .map(|b| usize::from(u16::from_le_bytes(b)))
+}
+
+/// The absolute offset a cursor over the whole buffer has reached.
+const fn offset(bytes: &[u8], cur: &Cursor<'_>) -> usize {
+    bytes.len().saturating_sub(cur.remaining().len())
+}
+
+/// Raise the high-water mark to `to`.
+fn bump(reached: &mut usize, to: usize) {
+    *reached = (*reached).max(to);
+}
+
+/// Read a width-tagged reference or value, advancing past it. Returns the value
+/// only when the caller may terminate on it; the bytes are consumed regardless
+/// so the cursor lands on whatever follows.
+fn take_value<F: Format>(
+    cur: &mut Cursor<'_>,
+    width: Width,
+) -> Result<Option<Entry<F>>, DescentError> {
+    Ok(match width {
+        Width::None => None,
+        Width::Ref32 => {
+            let bytes = cur.take::<[u8; ChunkRef::SIZE]>()?;
+            Some(Entry::Ref32(ChunkRef::new(ChunkAddress::new(bytes))))
+        }
+        Width::Ref64 => {
+            let bytes = cur.take::<[u8; EncryptedChunkRef::SIZE]>()?;
+            Some(Entry::Ref64(EncryptedChunkRef::from(bytes)))
+        }
+        Width::Inline => {
+            let len = usize::from(cur.take::<u8>()?);
+            let bytes = cur.take_slice(len)?;
+            let value = InlineValue::try_from(bytes).map_err(|_| DescentError::ValueTooLong)?;
+            Some(Entry::Inline(value))
+        }
+    })
+}
+
+/// Descend one node for `key` from key position `pos`, over bytes already
+/// authenticated against the node's address.
+///
+/// `reached` records the highest byte offset the descent read, so a prover can
+/// ship exactly the covering leading segments; a verifier passes a scratch it
+/// ignores.
+pub(crate) fn descend<F: Format>(
+    bytes: &[u8],
+    key: &[u8],
+    pos: usize,
+    reached: &mut usize,
+) -> Result<Step<F>, DescentError> {
+    let mut cur = Cursor::new(bytes);
+    if cur.take::<[u8; 2]>()? != F::PREAMBLE {
+        return Err(DescentError::NotAManifest);
+    }
+    let flags = cur.take::<u8>()?;
+    if flags & (flag::SEGMENT | flag::SEGMENTED) != 0 {
+        return Err(DescentError::Spilled);
+    }
+    // The root extension: an entry then a metadata block, each gated by the
+    // flags. A fork-child node carries none, so its flags leave both absent.
+    let root_entry = take_value::<F>(&mut cur, entry_width(flags))?;
+    if flags & flag::HAS_META != 0 {
+        let len = take_u16(&mut cur)?;
+        let _ = cur.take_slice(len)?;
+    }
+    let table_start = offset(bytes, &cur);
+    bump(reached, table_start);
+    // The empty key, or a key wholly consumed before this node, reads the
+    // node's own value.
+    if pos >= key.len() {
+        return Ok(root_entry.map_or(Step::Absent, Step::Found));
+    }
+    descend_table::<F>(bytes, table_start, key, pos, reached)
+}
+
+/// Walk `key` from `pos` down the fork table rooted at `table_start`, crossing
+/// embedded child tables in place and stopping at the first terminal, dead end,
+/// or referenced hop.
+fn descend_table<F: Format>(
+    bytes: &[u8],
+    table_start: usize,
+    key: &[u8],
+    pos: usize,
+    reached: &mut usize,
+) -> Result<Step<F>, DescentError> {
+    let Some(&byte) = key.get(pos) else {
+        return Ok(Step::Absent);
+    };
+    // The fork index: a count then `(first_byte, offset)` slots. Absence of a
+    // slot for `byte` is the compact gap that proves no fork continues the key.
+    let mut cur = seek(bytes, table_start)?;
+    let fcount = take_u16(&mut cur)?;
+    let mut record_off = None;
+    for _ in 0..fcount {
+        let first = cur.take::<u8>()?;
+        let off = take_u16(&mut cur)?;
+        if first == byte {
+            record_off = Some(off);
+        }
+    }
+    let records_start = offset(bytes, &cur);
+    bump(reached, records_start);
+    let Some(off) = record_off else {
+        return Ok(Step::Absent);
+    };
+
+    // The record for `byte`: flags, the tail behind its full-prefix length,
+    // then the flag-gated entry and child.
+    let mut rec = seek(bytes, records_start.saturating_add(off))?;
+    let flags = rec.take::<u8>()?;
+    let plen = usize::from(rec.take::<u8>()?);
+    let Some(tail_len) = plen.checked_sub(1) else {
+        return Err(DescentError::EmptyPrefix);
+    };
+    let tail = rec.take_slice(tail_len)?;
+    let start = pos.saturating_add(1);
+    let end = start.saturating_add(tail_len);
+    // The compacted edge must match byte for byte; a divergence proves the key
+    // leaves the trie here.
+    match key.get(start..end) {
+        Some(matched) if matched == tail => {}
+        _ => {
+            bump(reached, offset(bytes, &rec));
+            return Ok(Step::Absent);
+        }
+    }
+    let newpos = end;
+    let entry = take_value::<F>(&mut rec, entry_width(flags))?;
+    if newpos >= key.len() {
+        // The key ends at this fork: its own value, or nothing (a fork that
+        // only branches holds no value at its prefix).
+        bump(reached, offset(bytes, &rec));
+        return Ok(entry.map_or(Step::Absent, Step::Found));
+    }
+    let step = match child_width(flags) {
+        Width::None => Step::Absent,
+        Width::Ref32 => {
+            let address = ChunkAddress::new(rec.take::<[u8; ChunkRef::SIZE]>()?);
+            Step::Follow(address, newpos)
+        }
+        Width::Ref64 => Step::Encrypted,
+        Width::Inline => {
+            // An embedded child body: its length, a forced zero flags byte,
+            // then its own fork table, all in this node's bytes.
+            let _len = take_u16(&mut rec)?;
+            let body = offset(bytes, &rec);
+            return descend_table::<F>(bytes, body.saturating_add(1), key, newpos, reached);
+        }
+    };
+    bump(reached, offset(bytes, &rec));
+    Ok(step)
+}

--- a/crates/manifest-proof/src/error.rs
+++ b/crates/manifest-proof/src/error.rs
@@ -1,0 +1,67 @@
+//! Prove- and verify-side failures.
+
+use nectar_manifest::EncodeError;
+use nectar_primitives::{ChunkAddress, PrimitivesError};
+
+use crate::descent::DescentError;
+
+/// A proof-generation failure.
+#[non_exhaustive]
+#[derive(Debug, thiserror::Error)]
+pub enum ProveError {
+    /// A node the descent needed was not in the source.
+    #[error("node {0} not found")]
+    NodeMissing(ChunkAddress),
+    /// A node on the path could not be re-encoded to a single chunk; a spilled
+    /// node has no one-chunk form and is out of scope here.
+    #[error(transparent)]
+    Encode(#[from] EncodeError),
+    /// Reading a node's own bytes failed; a source node re-encoded to a
+    /// malformed image, which is a source bug.
+    #[error(transparent)]
+    Descent(#[from] DescentError),
+    /// Generating a BMT segment proof failed.
+    #[error("bmt segment proof")]
+    Bmt(#[source] PrimitivesError),
+    /// The descent funnelled into an encrypted subtree the plain prover cannot
+    /// open.
+    #[error("descent reached an encrypted subtree")]
+    Encrypted,
+    /// An inclusion proof was asked for an absent key.
+    #[error("key is absent")]
+    NotPresent,
+    /// An exclusion proof was asked for a present key.
+    #[error("key is present")]
+    NotAbsent,
+}
+
+/// A proof-verification failure. A rejected proof always fails here rather than
+/// returning a wrong verdict.
+#[non_exhaustive]
+#[derive(Debug, thiserror::Error)]
+pub enum VerifyError {
+    /// The proof carried no steps.
+    #[error("empty proof")]
+    Empty,
+    /// A node's authenticated bytes did not hash to the address handed down to
+    /// it: a tampered node, wrong value, or wrong root.
+    #[error("node bytes do not match the trusted address at step {0}")]
+    Unauthenticated(usize),
+    /// Sealing a chunk step's payload for re-hashing failed.
+    #[error("seal chunk step")]
+    Seal(#[source] PrimitivesError),
+    /// Verifying a BMT segment proof failed.
+    #[error("bmt segment proof")]
+    Bmt(#[source] PrimitivesError),
+    /// A segment step's segments were not a contiguous run from index zero.
+    #[error("segment proof indices are not contiguous from zero")]
+    SegmentGap,
+    /// Reading a node's authenticated bytes failed.
+    #[error(transparent)]
+    Descent(#[from] DescentError),
+    /// The path branched or terminated where the descent did not: a middle step
+    /// that terminates, a last step that continues, or a descent into an
+    /// encrypted subtree.
+    #[error("proof path does not match the descent")]
+    Malformed,
+}

--- a/crates/manifest-proof/src/lib.rs
+++ b/crates/manifest-proof/src/lib.rs
@@ -1,0 +1,51 @@
+//! Inclusion and exclusion proofs over a mantaray 1.0 manifest, authenticated
+//! against a trusted root address.
+//!
+//! A proof is the authenticated descent path for a key `K` under a root `R`: an
+//! ordered chain of nodes from `R` down, each authenticated against the
+//! reference the node before it yielded, so the whole path is a BMT hash chain
+//! anchored at the root. An [inclusion](prove_inclusion) proof terminates at the
+//! entry for `K`; an [exclusion](prove_exclusion) proof terminates where the
+//! descent provably cannot continue to `K` (no fork for the next byte, a
+//! compacted edge that diverges, or `K` exhausting with no terminal entry).
+//! Soundness rests on canonicalness (spec 6.2): an authenticated node's fork set
+//! is complete and its edges maximal, so local absence is global absence.
+//!
+//! Two granularities carry the same authentication (see [`Granularity`]): a
+//! full-chunk proof ships whole node bytes the verifier re-BMTs; a BMT-segment
+//! proof ships only the leading segments the descent reads, each behind its
+//! sibling path, the on-chain-cheap form. Both reuse the primitives BMT
+//! ([`Hasher`](nectar_primitives::Hasher)); this crate never re-hashes by hand.
+//!
+//! Embedding shortens proofs: an embedded child rides in its parent's bytes, so
+//! the descent crosses it with no extra step; only a referenced edge is a hop.
+//! [`verify`] replays the descent over the authenticated bytes and reports what
+//! it finds, so a proof asserts no verdict its bytes do not.
+//!
+//! The model is generic over [`Format`](nectar_manifest::Format) and defaults to
+//! the frozen `V1` plaintext layout.
+
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects,
+        clippy::panic
+    )
+)]
+
+mod descent;
+mod error;
+mod proof;
+mod prove;
+mod verify;
+
+pub use descent::DescentError;
+pub use error::{ProveError, VerifyError};
+pub use proof::{ForkPathProof, Granularity, PathStep, Verdict};
+pub use prove::{NodeSource, prove_exclusion, prove_inclusion};
+pub use verify::verify;

--- a/crates/manifest-proof/src/proof.rs
+++ b/crates/manifest-proof/src/proof.rs
@@ -1,0 +1,85 @@
+//! The proof data model: an ordered authenticated descent path.
+
+use nectar_manifest::{Entry, Format, V1};
+use nectar_primitives::Proof as SegmentProof;
+
+/// Which authentication granularity a proof step ships.
+///
+/// Both anchor every byte to the node's address; they trade proof size against
+/// verifier work.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Granularity {
+    /// Whole node bytes; the verifier re-BMTs each node (about 4 KB per node).
+    Chunk,
+    /// Only the leading BMT segments the descent reads, each behind its sibling
+    /// path; the on-chain-cheap form (about 32 bytes plus seven hashes per
+    /// covered segment).
+    Segment,
+}
+
+/// One authenticated node on the descent path.
+///
+/// Each step authenticates its node against the address handed down from the
+/// step before it (the trusted root for the first step), so a whole proof is a
+/// hash chain anchored at the root.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum PathStep {
+    /// The node's whole payload; its address is the BMT of these bytes.
+    Chunk {
+        /// The node payload the verifier re-BMTs.
+        payload: Vec<u8>,
+    },
+    /// A contiguous run of the node's leading BMT segments, from segment zero,
+    /// each with the sibling path authenticating it against the node address.
+    Segment {
+        /// The covering segments in ascending index from zero.
+        segments: Vec<SegmentProof>,
+    },
+}
+
+/// The authenticated descent path for a key under a root: the ordered nodes the
+/// descent visits, each authenticated against the previous node's reference.
+///
+/// A proof carries no verdict of its own; [`verify`](crate::verify) replays the
+/// descent over the authenticated bytes and reports what it finds, so a proof
+/// cannot assert a value its bytes do not.
+#[derive(Clone, Debug)]
+pub struct ForkPathProof {
+    steps: Vec<PathStep>,
+}
+
+impl ForkPathProof {
+    /// Assemble a proof from its ordered steps.
+    #[must_use]
+    pub const fn new(steps: Vec<PathStep>) -> Self {
+        Self { steps }
+    }
+
+    /// The ordered path steps, root first.
+    #[must_use]
+    pub fn steps(&self) -> &[PathStep] {
+        &self.steps
+    }
+
+    /// The number of authenticated nodes on the path.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.steps.len()
+    }
+
+    /// Whether the path has no steps; never true for a proof `verify` accepts.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.steps.is_empty()
+    }
+}
+
+/// The outcome a verified proof establishes for a key under a root.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Verdict<F: Format = V1> {
+    /// The key is present with this value.
+    Present(Entry<F>),
+    /// The key is provably absent.
+    Absent,
+}

--- a/crates/manifest-proof/src/prove.rs
+++ b/crates/manifest-proof/src/prove.rs
@@ -1,0 +1,131 @@
+//! Proof generation: descend the manifest and record the authenticated path.
+
+use nectar_manifest::{Format, Key, Node, V1};
+use nectar_primitives::bmt::HASH_SIZE;
+use nectar_primitives::{ChunkAddress, Hasher, Prover};
+
+use crate::descent::{self, Step};
+use crate::error::ProveError;
+use crate::proof::{ForkPathProof, Granularity, PathStep};
+
+/// A read-only supply of manifest nodes by address, the tree a prover descends.
+///
+/// Implemented for any `Fn(&ChunkAddress) -> Option<Node<F>>`, so an in-memory
+/// map or a store adapter serves without a wrapper.
+pub trait NodeSource<F: Format = V1> {
+    /// The node stored at `address`, or `None` when the source lacks it.
+    fn node(&self, address: &ChunkAddress) -> Option<Node<F>>;
+}
+
+impl<F: Format, T: Fn(&ChunkAddress) -> Option<Node<F>>> NodeSource<F> for T {
+    fn node(&self, address: &ChunkAddress) -> Option<Node<F>> {
+        self(address)
+    }
+}
+
+/// Prove that `key` resolves to a value under `root`, at the given granularity.
+///
+/// Errors with [`ProveError::NotPresent`] when the key is absent, so the caller
+/// never mints an inclusion proof for a key that has none.
+pub fn prove_inclusion<F, S>(
+    source: &S,
+    root: &ChunkAddress,
+    key: &Key,
+    granularity: Granularity,
+) -> Result<ForkPathProof, ProveError>
+where
+    F: Format,
+    S: NodeSource<F>,
+{
+    let (steps, present) = build_path::<F, S>(source, root, key, granularity)?;
+    if present {
+        Ok(ForkPathProof::new(steps))
+    } else {
+        Err(ProveError::NotPresent)
+    }
+}
+
+/// Prove that `key` is absent under `root`, at the given granularity.
+///
+/// Errors with [`ProveError::NotAbsent`] when the key is present: an exclusion
+/// proof for a present key is unrepresentable, so absence is sound.
+pub fn prove_exclusion<F, S>(
+    source: &S,
+    root: &ChunkAddress,
+    key: &Key,
+    granularity: Granularity,
+) -> Result<ForkPathProof, ProveError>
+where
+    F: Format,
+    S: NodeSource<F>,
+{
+    let (steps, present) = build_path::<F, S>(source, root, key, granularity)?;
+    if present {
+        Err(ProveError::NotAbsent)
+    } else {
+        Ok(ForkPathProof::new(steps))
+    }
+}
+
+/// Descend from `root`, emitting one authenticated step per referenced hop and
+/// reporting whether the key terminated in a value.
+fn build_path<F, S>(
+    source: &S,
+    root: &ChunkAddress,
+    key: &Key,
+    granularity: Granularity,
+) -> Result<(Vec<PathStep>, bool), ProveError>
+where
+    F: Format,
+    S: NodeSource<F>,
+{
+    let key = key.as_bytes();
+    let mut steps = Vec::new();
+    let mut address = *root;
+    let mut pos = 0usize;
+    loop {
+        let node = source
+            .node(&address)
+            .ok_or(ProveError::NodeMissing(address))?;
+        let payload = node.encode()?;
+        let mut reached = 0usize;
+        let outcome = descent::descend::<F>(&payload, key, pos, &mut reached)?;
+        let step = match granularity {
+            Granularity::Chunk => PathStep::Chunk { payload },
+            Granularity::Segment => segment_step(&payload, reached)?,
+        };
+        steps.push(step);
+        match outcome {
+            Step::Found(_) => return Ok((steps, true)),
+            Step::Absent => return Ok((steps, false)),
+            Step::Encrypted => return Err(ProveError::Encrypted),
+            Step::Follow(next, next_pos) => {
+                address = next;
+                pos = next_pos;
+            }
+        }
+    }
+}
+
+/// Build a segment step covering the leading segments the descent read.
+fn segment_step(payload: &[u8], reached: usize) -> Result<PathStep, ProveError> {
+    let span = u64::try_from(payload.len()).unwrap_or(u64::MAX);
+    let count = last_segment(reached).saturating_add(1);
+    let mut hasher = Hasher::new();
+    hasher.set_span(span);
+    let mut segments = Vec::with_capacity(count);
+    for index in 0..count {
+        let proof = hasher
+            .generate_proof(payload, index)
+            .map_err(ProveError::Bmt)?;
+        segments.push(proof);
+    }
+    Ok(PathStep::Segment { segments })
+}
+
+/// The index of the segment holding the last byte the descent read.
+fn last_segment(reached: usize) -> usize {
+    reached
+        .checked_sub(1)
+        .map_or(0, |last| last.checked_div(HASH_SIZE).unwrap_or(0))
+}

--- a/crates/manifest-proof/src/verify.rs
+++ b/crates/manifest-proof/src/verify.rs
@@ -1,0 +1,115 @@
+//! Proof verification: replay the descent over authenticated bytes.
+//!
+//! Each step's bytes are authenticated against the address the step before it
+//! yielded, so the whole path is a hash chain from the trusted root. The
+//! verifier trusts no claim in the proof: it re-derives every hop and the
+//! terminal verdict from the authenticated bytes, so a tampered node, a wrong
+//! value, or a wrong root fails to authenticate rather than mis-verifying.
+
+use alloy_primitives::B256;
+use nectar_manifest::{Format, Key};
+use nectar_primitives::bmt::HASH_SIZE;
+use nectar_primitives::{
+    ChunkAddress, ChunkOps, ContentChunk, DEFAULT_BODY_SIZE, Proof as SegmentProof,
+};
+
+use crate::descent::{self, Step};
+use crate::error::VerifyError;
+use crate::proof::{ForkPathProof, PathStep, Verdict};
+
+/// Verify `proof` for `key` under `root`, returning the authenticated verdict.
+///
+/// Replaying the descent is the whole check: the returned verdict is whatever
+/// the authenticated nodes say, so a present key cannot yield `Absent` and a
+/// proof cannot assert a value its bytes do not carry.
+pub fn verify<F: Format>(
+    root: &ChunkAddress,
+    key: &Key,
+    proof: &ForkPathProof,
+) -> Result<Verdict<F>, VerifyError> {
+    let steps = proof.steps();
+    let Some(last) = steps.len().checked_sub(1) else {
+        return Err(VerifyError::Empty);
+    };
+    let key = key.as_bytes();
+    let mut trusted = *root;
+    let mut pos = 0usize;
+    for (index, step) in steps.iter().enumerate() {
+        match authenticated_step::<F>(step, &trusted, key, pos, index)? {
+            Step::Found(entry) => {
+                return if index == last {
+                    Ok(Verdict::Present(entry))
+                } else {
+                    Err(VerifyError::Malformed)
+                };
+            }
+            Step::Absent => {
+                return if index == last {
+                    Ok(Verdict::Absent)
+                } else {
+                    Err(VerifyError::Malformed)
+                };
+            }
+            Step::Encrypted => return Err(VerifyError::Malformed),
+            Step::Follow(next, next_pos) => {
+                if index == last {
+                    return Err(VerifyError::Malformed);
+                }
+                trusted = next;
+                pos = next_pos;
+            }
+        }
+    }
+    Err(VerifyError::Malformed)
+}
+
+/// Authenticate one node's bytes against `trusted`, then descend it for the key.
+fn authenticated_step<F: Format>(
+    step: &PathStep,
+    trusted: &ChunkAddress,
+    key: &[u8],
+    pos: usize,
+    index: usize,
+) -> Result<Step<F>, VerifyError> {
+    let mut scratch = 0usize;
+    match step {
+        PathStep::Chunk { payload } => {
+            let chunk = ContentChunk::<DEFAULT_BODY_SIZE>::new(payload.clone())
+                .map_err(VerifyError::Seal)?;
+            if chunk.address() != trusted {
+                return Err(VerifyError::Unauthenticated(index));
+            }
+            Ok(descent::descend::<F>(payload, key, pos, &mut scratch)?)
+        }
+        PathStep::Segment { segments } => {
+            let bytes = reassemble(segments, trusted, index)?;
+            Ok(descent::descend::<F>(&bytes, key, pos, &mut scratch)?)
+        }
+    }
+}
+
+/// Authenticate a contiguous leading run of segments against `trusted` and
+/// reassemble their bytes.
+fn reassemble(
+    segments: &[SegmentProof],
+    trusted: &ChunkAddress,
+    index: usize,
+) -> Result<Vec<u8>, VerifyError> {
+    let root = B256::from(*trusted);
+    let mut bytes = Vec::with_capacity(segments.len().saturating_mul(HASH_SIZE));
+    for (expected, proof) in segments.iter().enumerate() {
+        // The run must start at segment zero and leave no gap, so the
+        // reassembled prefix is anchored and contiguous.
+        if proof.segment_index != expected {
+            return Err(VerifyError::SegmentGap);
+        }
+        if !proof.verify(&root).map_err(VerifyError::Bmt)? {
+            return Err(VerifyError::Unauthenticated(index));
+        }
+        bytes.extend_from_slice(proof.segment.as_slice());
+    }
+    if bytes.is_empty() {
+        return Err(VerifyError::SegmentGap);
+    }
+    Ok(bytes)
+}

--- a/crates/manifest-proof/tests/roundtrip.rs
+++ b/crates/manifest-proof/tests/roundtrip.rs
@@ -216,6 +216,60 @@ fn a_tampered_proof_and_a_wrong_root_are_rejected() -> TestResult {
     Ok(())
 }
 
+#[test]
+fn a_referenced_child_yields_a_multi_step_path() -> TestResult {
+    // Keys sharing a leading byte, enough of them that the shared subtree
+    // exceeds the embedding bound and is stored as its own chunk: the descent
+    // then crosses a referenced hop, so the follow loop and the verifier's
+    // node-to-node authentication chain run past a single node.
+    let pairs: Vec<(Vec<u8>, u8)> = (0u8..55).map(|i| (vec![b'a', i], i)).collect();
+    let (store, root, map) = build(&pairs).ok_or("unexpected spill")?;
+
+    let present = Key::from(&[b'a', 5][..]);
+    let src = source(&map);
+    let proof = prove_inclusion(&src, &root, &present, Granularity::Chunk)?;
+    ensure(
+        proof.len() >= 2,
+        "a referenced child must yield a path of at least two nodes",
+    )?;
+
+    // The reader agrees across the two-node descent for the present key and for
+    // absent keys that only diverge inside the referenced child: a missing
+    // second byte, and a key that outlives the child's terminal.
+    check_key(&store, &root, &map, &present)?;
+    check_key(&store, &root, &map, &Key::from(&[b'a', 200][..]))?;
+    check_key(&store, &root, &map, &Key::from(&[b'a', 5, 0][..]))?;
+
+    // Tampering the intermediate node breaks the chain before the terminal node
+    // is reached, at either granularity.
+    for granularity in [Granularity::Chunk, Granularity::Segment] {
+        let proof = prove_inclusion(&src, &root, &present, granularity)?;
+        let mut steps: Vec<PathStep> = proof.steps().to_vec();
+        match steps.first_mut() {
+            Some(PathStep::Chunk { payload }) => {
+                if let Some(byte) = payload.last_mut() {
+                    *byte ^= 0xFF;
+                }
+            }
+            Some(PathStep::Segment { segments }) => {
+                if let Some(seg) = segments.first_mut() {
+                    let mut bytes = seg.segment.0;
+                    if let Some(byte) = bytes.first_mut() {
+                        *byte ^= 0xFF;
+                    }
+                    seg.segment = B256::from(bytes);
+                }
+            }
+            _ => {}
+        }
+        ensure(
+            verify::<V1>(&root, &present, &ForkPathProof::new(steps)).is_err(),
+            "a tampered intermediate node is rejected",
+        )?;
+    }
+    Ok(())
+}
+
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(48))]
 

--- a/crates/manifest-proof/tests/roundtrip.rs
+++ b/crates/manifest-proof/tests/roundtrip.rs
@@ -1,0 +1,246 @@
+//! Round-trip, tamper-rejection and exclusion-soundness properties, checked
+//! against the streaming reader as the oracle. Tests report failures as errors
+//! rather than panicking, so the runtime-safety lints hold in test code too.
+
+use std::collections::BTreeMap;
+use std::error::Error;
+
+use alloy_primitives::B256;
+use futures::executor::block_on;
+use nectar_manifest::{Builder, Child, Entry, ForkTable, Key, Node, Reader, V1};
+use nectar_manifest_proof::{
+    ForkPathProof, Granularity, PathStep, Verdict, prove_exclusion, prove_inclusion, verify,
+};
+use nectar_primitives::store::{ChunkGet, MemoryStore};
+use nectar_primitives::{ChunkAddress, ChunkOps, ChunkRef};
+use proptest::prelude::*;
+
+type TestResult = Result<(), Box<dyn Error>>;
+type Map = BTreeMap<ChunkAddress, Node<V1>>;
+
+/// A fallible assertion.
+fn ensure(cond: bool, what: &str) -> TestResult {
+    if cond { Ok(()) } else { Err(what.into()) }
+}
+
+/// A fallible equality assertion.
+fn ensure_eq<T: PartialEq + core::fmt::Debug>(left: &T, right: &T, what: &str) -> TestResult {
+    if left == right {
+        Ok(())
+    } else {
+        Err(format!("{what}: {left:?} != {right:?}").into())
+    }
+}
+
+/// A ref32 entry keyed on a value byte, distinct per value so equality is
+/// meaningful.
+fn entry(byte: u8) -> Entry {
+    ChunkRef::new(ChunkAddress::new([byte; 32])).into()
+}
+
+/// Build a manifest from `pairs` into a fresh store and return its root plus a
+/// map of every plain node reachable from the root. Returns `None` when a node
+/// spilled (out of scope here), so a case can skip it.
+fn build(pairs: &[(Vec<u8>, u8)]) -> Option<(MemoryStore, ChunkAddress, Map)> {
+    let store = MemoryStore::default();
+    let mut builder = Builder::<V1>::new();
+    for (key, value) in pairs {
+        builder.insert(Key::from(key.as_slice()), entry(*value), None);
+    }
+    let built = block_on(builder.build(&store)).ok()?;
+    let root = *built.root();
+    let mut map = Map::new();
+    collect(&store, &root, &mut map)?;
+    Some((store, root, map))
+}
+
+/// Fetch and decode the node at `address`, recording it and every plain child
+/// it references. Returns `None` on a spilled node.
+fn collect(store: &MemoryStore, address: &ChunkAddress, map: &mut Map) -> Option<()> {
+    if map.contains_key(address) {
+        return Some(());
+    }
+    let chunk = block_on(ChunkGet::get(store, address)).ok()?;
+    let node = Node::<V1>::decode(chunk.envelope().data()).ok()?;
+    map.insert(*address, node.clone());
+    let mut children = Vec::new();
+    gather(node.forks(), &mut children);
+    for child in children {
+        collect(store, &child, map)?;
+    }
+    Some(())
+}
+
+/// Append every referenced child address under `table`, descending embedded
+/// tables in place.
+fn gather(table: &ForkTable<V1>, out: &mut Vec<ChunkAddress>) {
+    for (_, record) in table.iter() {
+        match record.child() {
+            Some(Child::Ref32(reference)) => out.push(*reference.address()),
+            Some(Child::Embedded(inner)) => gather(inner, out),
+            _ => {}
+        }
+    }
+}
+
+/// The reader's answer for `key`, the oracle a proof must agree with.
+fn oracle(
+    store: &MemoryStore,
+    root: &ChunkAddress,
+    key: &Key,
+) -> Result<Option<Entry>, Box<dyn Error>> {
+    let reader: Reader<_> = Reader::new(store);
+    Ok(block_on(reader.get(root, key))?)
+}
+
+/// A source closure over a node map.
+fn source(map: &Map) -> impl Fn(&ChunkAddress) -> Option<Node<V1>> + '_ {
+    move |address: &ChunkAddress| map.get(address).cloned()
+}
+
+/// Prove and verify `key` at both granularities, asserting each verdict matches
+/// the oracle and that the opposite proof is refused.
+fn check_key(store: &MemoryStore, root: &ChunkAddress, map: &Map, key: &Key) -> TestResult {
+    let want = oracle(store, root, key)?;
+    let src = source(map);
+    for granularity in [Granularity::Chunk, Granularity::Segment] {
+        match &want {
+            Some(value) => {
+                let proof = prove_inclusion(&src, root, key, granularity)?;
+                ensure_eq(
+                    &verify(root, key, &proof)?,
+                    &Verdict::Present(value.clone()),
+                    "inclusion verdict",
+                )?;
+                ensure(
+                    prove_exclusion(&src, root, key, granularity).is_err(),
+                    "a present key must not admit an exclusion proof",
+                )?;
+            }
+            None => {
+                let proof = prove_exclusion(&src, root, key, granularity)?;
+                ensure_eq(
+                    &verify::<V1>(root, key, &proof)?,
+                    &Verdict::Absent,
+                    "exclusion verdict",
+                )?;
+                ensure(
+                    prove_inclusion(&src, root, key, granularity).is_err(),
+                    "an absent key must not admit an inclusion proof",
+                )?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Flip a byte inside the proof so no node authenticates, whatever the
+/// granularity.
+fn tamper(proof: &ForkPathProof) -> ForkPathProof {
+    let mut steps: Vec<PathStep> = proof.steps().to_vec();
+    if let Some(last) = steps.last_mut() {
+        match last {
+            PathStep::Chunk { payload } => {
+                if let Some(byte) = payload.last_mut() {
+                    *byte ^= 0xFF;
+                }
+            }
+            PathStep::Segment { segments } => {
+                if let Some(seg) = segments.first_mut() {
+                    let mut bytes = seg.segment.0;
+                    if let Some(byte) = bytes.first_mut() {
+                        *byte ^= 0xFF;
+                    }
+                    seg.segment = B256::from(bytes);
+                }
+            }
+            _ => {}
+        }
+    }
+    ForkPathProof::new(steps)
+}
+
+#[test]
+fn present_and_absent_keys_round_trip_at_both_granularities() -> TestResult {
+    let pairs = vec![
+        (b"index.html".to_vec(), 0xA1),
+        (b"img/logo.png".to_vec(), 0xB2),
+        (b"img/icon.svg".to_vec(), 0xC3),
+        (b"about".to_vec(), 0xD4),
+        (b"about/team".to_vec(), 0xE5),
+    ];
+    let (store, root, map) = build(&pairs).ok_or("unexpected spill")?;
+
+    for (key, _) in &pairs {
+        check_key(&store, &root, &map, &Key::from(key.as_slice()))?;
+    }
+    // Absent keys covering each exclusion shape: no fork, a key ending inside an
+    // edge, a diverging edge, the empty key, and a lone branch byte.
+    for absent in [
+        &b"missing"[..],
+        &b"img/logo"[..],
+        &b"index.htmlx"[..],
+        &b""[..],
+        &b"i"[..],
+    ] {
+        check_key(&store, &root, &map, &Key::from(absent))?;
+    }
+    Ok(())
+}
+
+#[test]
+fn a_tampered_proof_and_a_wrong_root_are_rejected() -> TestResult {
+    let pairs = vec![(b"alpha".to_vec(), 0x11), (b"alpha/beta".to_vec(), 0x22)];
+    let (_store, root, map) = build(&pairs).ok_or("unexpected spill")?;
+    let src = source(&map);
+    let key = Key::from(&b"alpha/beta"[..]);
+
+    for granularity in [Granularity::Chunk, Granularity::Segment] {
+        let proof = prove_inclusion(&src, &root, &key, granularity)?;
+        ensure(
+            matches!(verify::<V1>(&root, &key, &proof), Ok(Verdict::Present(_))),
+            "the intact proof verifies present",
+        )?;
+        // Tampered bytes fail to authenticate.
+        ensure(
+            verify::<V1>(&root, &key, &tamper(&proof)).is_err(),
+            "a tampered proof is rejected",
+        )?;
+        // A wrong root breaks the very first hop.
+        let wrong = ChunkAddress::new([0x99; 32]);
+        ensure(
+            verify::<V1>(&wrong, &key, &proof).is_err(),
+            "a wrong root is rejected",
+        )?;
+    }
+    Ok(())
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(48))]
+
+    #[test]
+    fn proofs_agree_with_the_reader(
+        pairs in proptest::collection::vec(
+            (proptest::collection::vec(any::<u8>(), 1..6), any::<u8>()),
+            1..24,
+        ),
+    ) {
+        let dedup: BTreeMap<Vec<u8>, u8> = pairs.into_iter().collect();
+        let pairs: Vec<(Vec<u8>, u8)> = dedup.into_iter().collect();
+        if let Some((store, root, map)) = build(&pairs) {
+            let run = || -> TestResult {
+                for (key, _) in &pairs {
+                    check_key(&store, &root, &map, &Key::from(key.as_slice()))?;
+                    // An absent probe derived from each present key.
+                    let mut extended = key.clone();
+                    extended.push(0x00);
+                    check_key(&store, &root, &map, &Key::from(extended.as_slice()))?;
+                }
+                check_key(&store, &root, &map, &Key::from(&b"\xff\xff\xff"[..]))?;
+                Ok(())
+            };
+            run().map_err(|e| TestCaseError::fail(e.to_string()))?;
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds a new workspace crate, `nectar-manifest-proof`, providing a proof generator and verifier for inclusion and exclusion proofs over a mantaray 1.0 manifest, authenticated against a trusted root (BMT) address.

A `ForkPathProof` is an ordered chain of authenticated nodes from root to terminal.
Each step authenticates its node against the reference the previous node yielded, so the whole path forms a BMT hash chain anchored at the root.

`prove_inclusion` terminates at the target key's entry.
`prove_exclusion` terminates at the point where the descent provably cannot continue to the key, whether that is the absence of a fork for the next byte, a diverging compacted edge, or the key exhausting with no terminal entry present.

`verify(root, key, proof) -> Verdict::{Present(Entry) | Absent}` independently replays the descent over the authenticated bytes in the proof and returns whatever that replay yields, so a tampered proof, a wrong value, or a wrong root fails authentication rather than being mis-verified as present or absent.

New crate layout: `Cargo.toml`, `README.md`, `src/{lib,error,proof,descent,prove,verify}.rs`, `tests/roundtrip.rs`, plus `Cargo.toml`/`Cargo.lock` workspace wiring.

## Why

Closes #301

Manifest consumers need a way to prove and independently verify presence or absence of a key in a mantaray 1.0 manifest without trusting the party that produced the proof, given only the manifest's BMT root.

## Testing

Full battery run via `nix develop --command` (`cargo-nextest` supplied ephemerally via `nix shell nixpkgs#cargo-nextest`):

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean, new crate compiles with no warnings.
- `cargo nextest run --workspace --all-features`: 937 passed, 0 failed, 1 skipped. The crate's proptest oracle test (`proofs_agree_with_the_reader`) runs approximately 60s and is flagged slow but passes.
- `cargo test --doc --workspace`.

An independent adversarial review found the descent parser to be byte-for-byte compatible with the manifest wire codec (verified field-by-field, including embedded children, ref64, and the V1Counted trailing-count layout), the multi-step authentication chain and gap-proof coverage to be sound, and confirmed empirically that truncated or adversarial input (oversized/garbage/empty proofs, intermediate-step tamper on a real two-node proof) cannot panic, owing to consistent use of a checked cursor and saturating/checked arithmetic. No correctness or soundness bugs were found.

This is a stacked PR targeting `s264/82-counted-reader`; no independent CI runs against this base until the stack is retargeted onto the trunk.

## AI Assistance

Claude (Anthropic) was used for code generation of the crate implementation and tests, for the independent adversarial review, and for this PR description.
