### PR TITLE
feat(manifest-proof): range-completeness and state-transition proofs

### DIFF
--- a/crates/manifest-proof/src/error.rs
+++ b/crates/manifest-proof/src/error.rs
@@ -1,6 +1,6 @@
 //! Prove- and verify-side failures.
 
-use nectar_manifest::EncodeError;
+use nectar_manifest::{DecodeError, EncodeError};
 use nectar_primitives::{ChunkAddress, PrimitivesError};
 
 use crate::descent::DescentError;
@@ -64,4 +64,14 @@ pub enum VerifyError {
     /// encrypted subtree.
     #[error("proof path does not match the descent")]
     Malformed,
+    /// A frontier node the range walk needed was not carried in the proof; the
+    /// listing cannot be complete without it.
+    #[error("range node {0} absent from the proof")]
+    NodeAbsent(ChunkAddress),
+    /// A carried frontier node did not decode as a manifest node.
+    #[error(transparent)]
+    Decode(#[from] DecodeError),
+    /// The range spans an encrypted subtree the plain walk cannot enumerate.
+    #[error("range reaches an encrypted subtree")]
+    Encrypted,
 }

--- a/crates/manifest-proof/src/lib.rs
+++ b/crates/manifest-proof/src/lib.rs
@@ -22,6 +22,13 @@
 //! [`verify`] replays the descent over the authenticated bytes and reports what
 //! it finds, so a proof asserts no verdict its bytes do not.
 //!
+//! Two compositions ride the single-key primitives. A
+//! [range-completeness](prove_range_complete) proof attests a listing is every
+//! key in `[lo, hi)`, authenticating the frontier of nodes the range spans so an
+//! omitted key has no witness. A [state-transition](prove_transition) proof
+//! attests one key changed between two roots - an insertion, or its deletion and
+//! update duals - as its state under each root.
+//!
 //! The model is generic over [`Format`](nectar_manifest::Format) and defaults to
 //! the frozen `V1` plaintext layout.
 
@@ -42,10 +49,16 @@ mod descent;
 mod error;
 mod proof;
 mod prove;
+mod range;
+mod transition;
 mod verify;
 
 pub use descent::DescentError;
 pub use error::{ProveError, VerifyError};
 pub use proof::{ForkPathProof, Granularity, PathStep, Verdict};
 pub use prove::{NodeSource, prove_exclusion, prove_inclusion};
+pub use range::{RangeProof, prove_range_complete, verify_range};
+pub use transition::{
+    Transition, TransitionProof, prove_deletion, prove_transition, prove_update, verify_transition,
+};
 pub use verify::verify;

--- a/crates/manifest-proof/src/range.rs
+++ b/crates/manifest-proof/src/range.rs
@@ -1,0 +1,312 @@
+//! Range-completeness: prove a listing is every key in a half-open range.
+//!
+//! A single-key proof authenticates one descent; a complete listing needs the
+//! whole frontier. This proof ships every trie node whose subtree overlaps
+//! `[lo, hi)`, each self-authenticated by content address and chained from the
+//! trusted root, and the verifier re-walks that frontier: it emits each present
+//! key in order and, at every referenced child that overlaps the range, demands
+//! the node that continues it. A withheld node leaves an overlapping edge with
+//! no witness, so a listing that omits a key cannot verify, and the gaps are
+//! provably empty without a per-gap exclusion proof.
+//!
+//! The walk needs the whole fork table of each frontier node, so this proof is
+//! chunk-granularity throughout; the segment form authenticates a single edge,
+//! not a table. Enumeration mirrors the ordered reader (spec 8): a value rides
+//! in its fork record, embedded children fold in place, and a referenced child
+//! is a hop, so the emitted order is the trie's total key order.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use nectar_manifest::{Child, Entry, ForkTable, Format, Key, Node};
+use nectar_primitives::{ChunkAddress, ChunkOps, ContentChunk, DEFAULT_BODY_SIZE};
+
+use crate::error::{ProveError, VerifyError};
+use crate::prove::NodeSource;
+
+/// A complete authenticated listing over a key range: the frontier of trie
+/// nodes whose subtrees overlap the range, each addressed by its content hash.
+///
+/// Carries no key list of its own; [`verify_range`] re-derives the listing from
+/// the authenticated nodes, so the proof cannot assert a key its nodes omit.
+#[derive(Clone, Debug)]
+pub struct RangeProof {
+    nodes: Vec<Vec<u8>>,
+}
+
+impl RangeProof {
+    /// Assemble a proof from its frontier node payloads.
+    #[must_use]
+    pub const fn new(nodes: Vec<Vec<u8>>) -> Self {
+        Self { nodes }
+    }
+
+    /// The frontier node payloads, each a content-addressed chunk.
+    #[must_use]
+    pub fn nodes(&self) -> &[Vec<u8>] {
+        &self.nodes
+    }
+
+    /// The number of frontier nodes carried.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Whether the proof carries no nodes; never true for one `verify` accepts,
+    /// which always authenticates at least the root.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+}
+
+/// One resolved position in a node's ordered contents, keyed by its full key.
+enum Item<F: Format> {
+    /// A key terminates here with this value.
+    Value(Vec<u8>, Entry<F>),
+    /// The trie continues into a referenced child at this key prefix.
+    Ref(Vec<u8>, ChunkAddress),
+    /// The trie continues into an encrypted child the plain walk cannot open.
+    Encrypted(Vec<u8>),
+}
+
+/// Prove that the keys with `lo <= key < hi` are exactly the listing a
+/// [`verify_range`] of this proof yields, under `root`.
+///
+/// Collects every frontier node the range walk reaches; errors with
+/// [`ProveError::Encrypted`] when the range spans an encrypted subtree the
+/// plain prover cannot enumerate.
+pub fn prove_range_complete<F, S>(
+    source: &S,
+    root: &ChunkAddress,
+    lo: &Key,
+    hi: &Key,
+) -> Result<RangeProof, ProveError>
+where
+    F: Format,
+    S: NodeSource<F>,
+{
+    let mut collector = Collector {
+        source,
+        lo: lo.as_bytes(),
+        hi: hi.as_bytes(),
+        nodes: Vec::new(),
+        seen: BTreeSet::new(),
+    };
+    collector.collect(root, &[], true)?;
+    Ok(RangeProof::new(collector.nodes))
+}
+
+/// Verify `proof` over `[lo, hi)` under `root`, returning the authenticated
+/// complete listing in ascending key order.
+///
+/// Every referenced child whose subtree overlaps the range must be carried, so
+/// an accepted listing is provably total: a returned `Ok` is the whole range,
+/// not a prefix of it.
+pub fn verify_range<F: Format>(
+    root: &ChunkAddress,
+    lo: &Key,
+    hi: &Key,
+    proof: &RangeProof,
+) -> Result<Vec<(Key, Entry<F>)>, VerifyError> {
+    let mut map: BTreeMap<ChunkAddress, Node<F>> = BTreeMap::new();
+    for payload in proof.nodes() {
+        let chunk =
+            ContentChunk::<DEFAULT_BODY_SIZE>::new(payload.clone()).map_err(VerifyError::Seal)?;
+        let address = *chunk.address();
+        let node = Node::<F>::decode(payload).map_err(VerifyError::Decode)?;
+        map.insert(address, node);
+    }
+    let mut walker = Walker {
+        map: &map,
+        lo: lo.as_bytes(),
+        hi: hi.as_bytes(),
+        out: Vec::new(),
+    };
+    walker.walk(root, &[], true)?;
+    Ok(walker.out)
+}
+
+/// The prove-side frontier walk state: the node source, the range bounds and the
+/// nodes gathered so far, keyed to skip a subtree reached twice.
+struct Collector<'a, S> {
+    source: &'a S,
+    lo: &'a [u8],
+    hi: &'a [u8],
+    nodes: Vec<Vec<u8>>,
+    seen: BTreeSet<ChunkAddress>,
+}
+
+impl<S> Collector<'_, S> {
+    /// Descend from `address`, pushing its node and following every referenced
+    /// child whose subtree overlaps the range.
+    fn collect<F>(
+        &mut self,
+        address: &ChunkAddress,
+        base: &[u8],
+        is_root: bool,
+    ) -> Result<(), ProveError>
+    where
+        F: Format,
+        S: NodeSource<F>,
+    {
+        if !self.seen.insert(*address) {
+            return Ok(());
+        }
+        let node = self
+            .source
+            .node(address)
+            .ok_or(ProveError::NodeMissing(*address))?;
+        self.nodes.push(node.encode()?);
+        let mut items = Vec::new();
+        items_of(&node, base, is_root, &mut items);
+        for item in &items {
+            match item {
+                Item::Ref(prefix, child) if overlaps(prefix, self.lo, self.hi) => {
+                    self.collect::<F>(child, prefix, false)?;
+                }
+                Item::Encrypted(prefix) if overlaps(prefix, self.lo, self.hi) => {
+                    return Err(ProveError::Encrypted);
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+}
+
+/// The verify-side frontier walk state: the authenticated node map keyed by
+/// content address, the range bounds and the listing built so far.
+struct Walker<'a, F: Format> {
+    map: &'a BTreeMap<ChunkAddress, Node<F>>,
+    lo: &'a [u8],
+    hi: &'a [u8],
+    out: Vec<(Key, Entry<F>)>,
+}
+
+impl<F: Format> Walker<'_, F> {
+    /// Walk from `address`, emitting each in-range key and demanding a node for
+    /// every overlapping referenced child.
+    fn walk(
+        &mut self,
+        address: &ChunkAddress,
+        base: &[u8],
+        is_root: bool,
+    ) -> Result<(), VerifyError> {
+        let node = self
+            .map
+            .get(address)
+            .ok_or(VerifyError::NodeAbsent(*address))?;
+        let mut items = Vec::new();
+        items_of(node, base, is_root, &mut items);
+        for item in items {
+            match item {
+                Item::Value(key, entry) => {
+                    if in_range(&key, self.lo, self.hi) {
+                        self.out.push((Key::from(key), entry));
+                    }
+                }
+                Item::Ref(prefix, child) => {
+                    if overlaps(&prefix, self.lo, self.hi) {
+                        self.walk(&child, &prefix, false)?;
+                    }
+                }
+                Item::Encrypted(prefix) => {
+                    if overlaps(&prefix, self.lo, self.hi) {
+                        return Err(VerifyError::Encrypted);
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// A node's ordered contents as full-key items. The root's own value is the
+/// empty-key extension, the least key, and leads the list; a fork child node
+/// carries no such value of its own.
+fn items_of<F: Format>(node: &Node<F>, base: &[u8], is_root: bool, out: &mut Vec<Item<F>>) {
+    if is_root && let Some(entry) = node.entry() {
+        out.push(Item::Value(base.to_vec(), entry.clone()));
+    }
+    let mut prefix = base.to_vec();
+    table_items(node.forks(), &mut prefix, out);
+}
+
+/// Append each fork's value and continuation in wire order, folding embedded
+/// children in place so a whole node flattens without a fetch.
+fn table_items<F: Format>(table: &ForkTable<F>, prefix: &mut Vec<u8>, out: &mut Vec<Item<F>>) {
+    for (first, record) in table.iter() {
+        let mark = prefix.len();
+        prefix.push(first);
+        prefix.extend_from_slice(record.tail().as_bytes());
+        if let Some(entry) = record.entry() {
+            out.push(Item::Value(prefix.clone(), entry.clone()));
+        }
+        match record.child() {
+            Some(Child::Embedded(inner)) => table_items(inner, prefix, out),
+            Some(Child::Ref32(reference)) => {
+                out.push(Item::Ref(prefix.clone(), *reference.address()));
+            }
+            Some(Child::Ref64(_)) => out.push(Item::Encrypted(prefix.clone())),
+            None => {}
+        }
+        prefix.truncate(mark);
+    }
+}
+
+/// Whether the subtree under `prefix` can hold a key in `[lo, hi)`: its keys span
+/// `[prefix, successor(prefix))`, so it overlaps unless it sits wholly at or past
+/// `hi` or wholly below `lo`.
+fn overlaps(prefix: &[u8], lo: &[u8], hi: &[u8]) -> bool {
+    prefix < hi && successor(prefix).is_none_or(|end| end.as_slice() > lo)
+}
+
+/// Whether `key` falls in the half-open range `[lo, hi)`.
+fn in_range(key: &[u8], lo: &[u8], hi: &[u8]) -> bool {
+    lo <= key && key < hi
+}
+
+/// The least byte string strictly greater than every string starting with
+/// `prefix`: increment the last sub-`0xFF` byte after dropping the trailing
+/// `0xFF` run. `None` when the prefix is empty or all `0xFF`, i.e. unbounded.
+fn successor(prefix: &[u8]) -> Option<Vec<u8>> {
+    let mut bytes = prefix.to_vec();
+    loop {
+        match bytes.last() {
+            None => return None,
+            Some(&0xFF) => {
+                bytes.pop();
+            }
+            Some(&last) => {
+                if let Some(slot) = bytes.last_mut() {
+                    *slot = last.saturating_add(1);
+                }
+                return Some(bytes);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn successor_bounds_the_prefix_subtree() {
+        assert_eq!(successor(b"ab").as_deref(), Some(&b"ac"[..]));
+        assert_eq!(successor(b"a\xff").as_deref(), Some(&b"b"[..]));
+        assert_eq!(successor(b"\xff\xff"), None);
+        assert_eq!(successor(b""), None);
+    }
+
+    #[test]
+    fn overlap_and_range_are_half_open() {
+        assert!(overlaps(b"a", b"a", b"b"));
+        assert!(!overlaps(b"b", b"a", b"b"));
+        assert!(!overlaps(b"\x00", b"a", b"b"));
+        assert!(in_range(b"a", b"a", b"b"));
+        assert!(!in_range(b"b", b"a", b"b"));
+        assert!(!in_range(b"\x00", b"a", b"b"));
+    }
+}

--- a/crates/manifest-proof/src/transition.rs
+++ b/crates/manifest-proof/src/transition.rs
@@ -1,0 +1,164 @@
+//! State-transition proofs: what happened to one key between two roots.
+//!
+//! Each is two single-key proofs read against different roots: the key's state
+//! under `root_before` and under `root_after`. An insertion is exclusion then
+//! inclusion (absent, then present); its duals swap the halves - deletion is
+//! inclusion then exclusion, an update is inclusion under both roots with a
+//! changed value. The verifier confirms both halves and the shape, so a claim
+//! that no change happened, or the wrong one, fails to authenticate.
+
+use nectar_manifest::{Entry, Format, Key, V1};
+use nectar_primitives::ChunkAddress;
+
+use crate::error::{ProveError, VerifyError};
+use crate::proof::{ForkPathProof, Granularity, Verdict};
+use crate::prove::{NodeSource, prove_exclusion, prove_inclusion};
+use crate::verify::verify;
+
+/// Which state change a [`TransitionProof`] attests.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Kind {
+    /// Absent under the first root, present under the second.
+    Insertion,
+    /// Present under the first root, absent under the second.
+    Deletion,
+    /// Present under both roots with a changed value.
+    Update,
+}
+
+/// The change a verified [`TransitionProof`] establishes for a key between two
+/// roots.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Transition<F: Format = V1> {
+    /// The key was inserted with this value.
+    Insertion(Entry<F>),
+    /// The key holding this value was deleted.
+    Deletion(Entry<F>),
+    /// The key's value changed.
+    Update {
+        /// The value under the first root.
+        before: Entry<F>,
+        /// The value under the second root.
+        after: Entry<F>,
+    },
+}
+
+/// A proof that one key changed state between two roots: its authenticated state
+/// under each, plus the shape they must form.
+///
+/// Carries no outcome of its own; [`verify_transition`] reads both halves and
+/// rejects any pair that does not form the attested shape.
+#[derive(Clone, Debug)]
+pub struct TransitionProof {
+    before: ForkPathProof,
+    after: ForkPathProof,
+    kind: Kind,
+}
+
+/// Prove that `key` was inserted between `root_before` and `root_after`: absent
+/// under the first root, present under the second.
+///
+/// Errors when the shape does not hold - the key is present under the first
+/// root, or absent under the second - so a false insertion is unrepresentable.
+pub fn prove_transition<F, B, A>(
+    before_source: &B,
+    root_before: &ChunkAddress,
+    after_source: &A,
+    root_after: &ChunkAddress,
+    key: &Key,
+    granularity: Granularity,
+) -> Result<TransitionProof, ProveError>
+where
+    F: Format,
+    B: NodeSource<F>,
+    A: NodeSource<F>,
+{
+    let before = prove_exclusion::<F, B>(before_source, root_before, key, granularity)?;
+    let after = prove_inclusion::<F, A>(after_source, root_after, key, granularity)?;
+    Ok(TransitionProof {
+        before,
+        after,
+        kind: Kind::Insertion,
+    })
+}
+
+/// Prove that `key` was deleted between `root_before` and `root_after`: present
+/// under the first root, absent under the second. The dual of an insertion.
+pub fn prove_deletion<F, B, A>(
+    before_source: &B,
+    root_before: &ChunkAddress,
+    after_source: &A,
+    root_after: &ChunkAddress,
+    key: &Key,
+    granularity: Granularity,
+) -> Result<TransitionProof, ProveError>
+where
+    F: Format,
+    B: NodeSource<F>,
+    A: NodeSource<F>,
+{
+    let before = prove_inclusion::<F, B>(before_source, root_before, key, granularity)?;
+    let after = prove_exclusion::<F, A>(after_source, root_after, key, granularity)?;
+    Ok(TransitionProof {
+        before,
+        after,
+        kind: Kind::Deletion,
+    })
+}
+
+/// Prove that `key`'s value changed between `root_before` and `root_after`:
+/// present under both roots. The verifier rejects a proof whose two values are
+/// equal, so a no-op is not a transition.
+pub fn prove_update<F, B, A>(
+    before_source: &B,
+    root_before: &ChunkAddress,
+    after_source: &A,
+    root_after: &ChunkAddress,
+    key: &Key,
+    granularity: Granularity,
+) -> Result<TransitionProof, ProveError>
+where
+    F: Format,
+    B: NodeSource<F>,
+    A: NodeSource<F>,
+{
+    let before = prove_inclusion::<F, B>(before_source, root_before, key, granularity)?;
+    let after = prove_inclusion::<F, A>(after_source, root_after, key, granularity)?;
+    Ok(TransitionProof {
+        before,
+        after,
+        kind: Kind::Update,
+    })
+}
+
+/// Verify `proof` for `key` across `root_before` and `root_after`, returning the
+/// authenticated change.
+///
+/// Both halves are re-verified against their own root and the pair must form the
+/// attested shape, so a wrong root, a tampered half, or a mislabelled change
+/// fails rather than mis-verifying.
+pub fn verify_transition<F: Format>(
+    root_before: &ChunkAddress,
+    root_after: &ChunkAddress,
+    key: &Key,
+    proof: &TransitionProof,
+) -> Result<Transition<F>, VerifyError> {
+    let before = verify::<F>(root_before, key, &proof.before)?;
+    let after = verify::<F>(root_after, key, &proof.after)?;
+    match proof.kind {
+        Kind::Insertion => match (before, after) {
+            (Verdict::Absent, Verdict::Present(value)) => Ok(Transition::Insertion(value)),
+            _ => Err(VerifyError::Malformed),
+        },
+        Kind::Deletion => match (before, after) {
+            (Verdict::Present(value), Verdict::Absent) => Ok(Transition::Deletion(value)),
+            _ => Err(VerifyError::Malformed),
+        },
+        Kind::Update => match (before, after) {
+            (Verdict::Present(before), Verdict::Present(after)) if before != after => {
+                Ok(Transition::Update { before, after })
+            }
+            _ => Err(VerifyError::Malformed),
+        },
+    }
+}

--- a/crates/manifest-proof/tests/compositions.rs
+++ b/crates/manifest-proof/tests/compositions.rs
@@ -199,6 +199,95 @@ fn a_tampered_frontier_node_is_rejected() -> TestResult {
     Ok(())
 }
 
+#[test]
+fn boundary_windows_over_a_multi_node_frontier_match_the_reader() -> TestResult {
+    // Two spilled letter-subtrees give the root two referenced children, so a
+    // window whose bound falls inside one subtree exercises the overlap test at
+    // a real referenced edge rather than only over the whole-map frontier.
+    let mut pairs: Vec<(Vec<u8>, u8)> = Vec::new();
+    for i in 0u8..60 {
+        pairs.push((vec![b'a', i], i));
+    }
+    for i in 0u8..60 {
+        pairs.push((vec![b'b', i], 100u8.wrapping_add(i)));
+    }
+    let (store, root, map) = build(&pairs).ok_or("unexpected spill")?;
+    let src = source(&map);
+
+    let full = prove_range_complete::<V1, _>(
+        &src,
+        &root,
+        &Key::from(&b""[..]),
+        &Key::from(&b"\xff\xff"[..]),
+    )?;
+    ensure(
+        full.len() >= 3,
+        "two spilled subtrees must give a root plus two child nodes",
+    )?;
+
+    // Bounds that cut through a subtree, span both, or land in the empty gap
+    // between them: each descends a referenced child on the boundary.
+    for (lo, hi) in [
+        (&b""[..], &b"b\x10"[..]),
+        (&b"a\x14"[..], &b"c"[..]),
+        (&b"a\x30"[..], &b"b\x05"[..]),
+        (&b"a\xff"[..], &b"b\x00"[..]),
+        (&b""[..], &b"a\x00"[..]),
+    ] {
+        let lo = Key::from(lo);
+        let hi = Key::from(hi);
+        let want = oracle(&store, &root, &lo, &hi)?;
+        let proof = prove_range_complete::<V1, _>(&src, &root, &lo, &hi)?;
+        let got = verify_range::<V1>(&root, &lo, &hi, &proof)?;
+        ensure_eq(&got, &want, "boundary window listing")?;
+    }
+    Ok(())
+}
+
+#[test]
+fn adversarial_frontier_bytes_are_rejected_not_panicked() -> TestResult {
+    // verify_range decodes untrusted node bytes; truncated or malformed payloads
+    // must return an error, never panic or index out of bounds.
+    let root = ChunkAddress::new([7u8; 32]);
+    let lo = Key::from(&b""[..]);
+    let hi = Key::from(&b"\xff\xff"[..]);
+    let cases: Vec<Vec<u8>> = vec![
+        vec![],
+        vec![0],
+        vec![0x9a, 0x01],
+        vec![0x9a, 0x01, 0x00],
+        vec![0x40],
+        vec![0x20],
+        vec![1, 2, 3, 4, 5, 6, 7, 8],
+        vec![0xff; 5000],
+    ];
+    for bytes in &cases {
+        let proof = RangeProof::new(vec![bytes.clone()]);
+        ensure(
+            verify_range::<V1>(&root, &lo, &hi, &proof).is_err(),
+            "adversarial frontier bytes must be rejected",
+        )?;
+    }
+    Ok(())
+}
+
+#[test]
+fn a_range_with_lo_above_hi_lists_nothing() -> TestResult {
+    let pairs = vec![
+        (b"a".to_vec(), 0x01),
+        (b"b".to_vec(), 0x02),
+        (b"c".to_vec(), 0x03),
+    ];
+    let (_store, root, map) = build(&pairs).ok_or("unexpected spill")?;
+    let src = source(&map);
+    let lo = Key::from(&b"z"[..]);
+    let hi = Key::from(&b"a"[..]);
+    let proof = prove_range_complete::<V1, _>(&src, &root, &lo, &hi)?;
+    let got = verify_range::<V1>(&root, &lo, &hi, &proof)?;
+    ensure(got.is_empty(), "a range with lo above hi lists nothing")?;
+    Ok(())
+}
+
 /// The two roots of a manifest with `key` inserted, plus their node sources.
 fn before_after(
     base: &[(Vec<u8>, u8)],

--- a/crates/manifest-proof/tests/compositions.rs
+++ b/crates/manifest-proof/tests/compositions.rs
@@ -1,0 +1,308 @@
+//! Range-completeness and state-transition properties, checked against the
+//! streaming reader as the oracle. Tests report failures as errors rather than
+//! panicking, so the runtime-safety lints hold in test code too.
+
+use std::collections::BTreeMap;
+use std::error::Error;
+
+use futures::executor::block_on;
+use nectar_manifest::{Builder, Child, Entry, ForkTable, Key, Node, Reader, V1};
+use nectar_manifest_proof::{
+    Granularity, RangeProof, Transition, prove_deletion, prove_range_complete, prove_transition,
+    prove_update, verify_range, verify_transition,
+};
+use nectar_primitives::store::{ChunkGet, MemoryStore};
+use nectar_primitives::{ChunkAddress, ChunkOps, ChunkRef};
+
+type TestResult = Result<(), Box<dyn Error>>;
+type Map = BTreeMap<ChunkAddress, Node<V1>>;
+
+/// A fallible assertion.
+fn ensure(cond: bool, what: &str) -> TestResult {
+    if cond { Ok(()) } else { Err(what.into()) }
+}
+
+/// A fallible equality assertion.
+fn ensure_eq<T: PartialEq + core::fmt::Debug>(left: &T, right: &T, what: &str) -> TestResult {
+    if left == right {
+        Ok(())
+    } else {
+        Err(format!("{what}: {left:?} != {right:?}").into())
+    }
+}
+
+/// A ref32 entry keyed on a value byte, distinct per value so equality is
+/// meaningful.
+fn entry(byte: u8) -> Entry {
+    ChunkRef::new(ChunkAddress::new([byte; 32])).into()
+}
+
+/// Build a manifest from `pairs` into a fresh store and return its root plus a
+/// map of every plain node reachable from the root. `None` when a node spilled
+/// (out of scope here).
+fn build(pairs: &[(Vec<u8>, u8)]) -> Option<(MemoryStore, ChunkAddress, Map)> {
+    let store = MemoryStore::default();
+    let mut builder = Builder::<V1>::new();
+    for (key, value) in pairs {
+        builder.insert(Key::from(key.as_slice()), entry(*value), None);
+    }
+    let built = block_on(builder.build(&store)).ok()?;
+    let root = *built.root();
+    let mut map = Map::new();
+    collect(&store, &root, &mut map)?;
+    Some((store, root, map))
+}
+
+/// Fetch and decode the node at `address`, recording it and every plain child it
+/// references. `None` on a spilled node.
+fn collect(store: &MemoryStore, address: &ChunkAddress, map: &mut Map) -> Option<()> {
+    if map.contains_key(address) {
+        return Some(());
+    }
+    let chunk = block_on(ChunkGet::get(store, address)).ok()?;
+    let node = Node::<V1>::decode(chunk.envelope().data()).ok()?;
+    map.insert(*address, node.clone());
+    let mut children = Vec::new();
+    gather(node.forks(), &mut children);
+    for child in children {
+        collect(store, &child, map)?;
+    }
+    Some(())
+}
+
+/// Append every referenced child address under `table`, descending embedded
+/// tables in place.
+fn gather(table: &ForkTable<V1>, out: &mut Vec<ChunkAddress>) {
+    for (_, record) in table.iter() {
+        match record.child() {
+            Some(Child::Ref32(reference)) => out.push(*reference.address()),
+            Some(Child::Embedded(inner)) => gather(inner, out),
+            _ => {}
+        }
+    }
+}
+
+/// A source closure over a node map.
+fn source(map: &Map) -> impl Fn(&ChunkAddress) -> Option<Node<V1>> + '_ {
+    move |address: &ChunkAddress| map.get(address).cloned()
+}
+
+/// The reader's listing for `[lo, hi)`, the oracle a range proof must match.
+fn oracle(
+    store: &MemoryStore,
+    root: &ChunkAddress,
+    lo: &Key,
+    hi: &Key,
+) -> Result<Vec<(Key, Entry)>, Box<dyn Error>> {
+    let reader: Reader<_> = Reader::new(store);
+    let mut cursor = block_on(reader.range(root, lo, hi))?;
+    let mut out = Vec::new();
+    while let Some(pair) = block_on(cursor.next())? {
+        out.push(pair);
+    }
+    Ok(out)
+}
+
+#[test]
+fn a_range_proof_lists_every_key_and_matches_the_reader() -> TestResult {
+    let pairs = vec![
+        (b"about".to_vec(), 0xD4),
+        (b"about/team".to_vec(), 0xE5),
+        (b"img/icon.svg".to_vec(), 0xC3),
+        (b"img/logo.png".to_vec(), 0xB2),
+        (b"index.html".to_vec(), 0xA1),
+    ];
+    let (store, root, map) = build(&pairs).ok_or("unexpected spill")?;
+    let src = source(&map);
+
+    // A spread of half-open windows, including empty and whole-map bounds.
+    for (lo, hi) in [
+        (&b""[..], &b"\xff\xff"[..]),
+        (&b"about"[..], &b"index.html"[..]),
+        (&b"img/"[..], &b"img/\xff"[..]),
+        (&b"about/team"[..], &b"about/team"[..]),
+        (&b"z"[..], &b"zz"[..]),
+    ] {
+        let lo = Key::from(lo);
+        let hi = Key::from(hi);
+        let want = oracle(&store, &root, &lo, &hi)?;
+        let proof = prove_range_complete::<V1, _>(&src, &root, &lo, &hi)?;
+        let got = verify_range::<V1>(&root, &lo, &hi, &proof)?;
+        ensure_eq(&got, &want, "range listing")?;
+    }
+    Ok(())
+}
+
+#[test]
+fn an_omitted_frontier_node_is_rejected() -> TestResult {
+    // Enough keys under a shared first byte that the shared subtree spills into
+    // its own chunk, so the frontier has more than the root and a referenced
+    // child node can be withheld.
+    let pairs: Vec<(Vec<u8>, u8)> = (0u8..55).map(|i| (vec![b'a', i], i)).collect();
+    let (store, root, map) = build(&pairs).ok_or("unexpected spill")?;
+    let src = source(&map);
+    let lo = Key::from(&b""[..]);
+    let hi = Key::from(&b"\xff\xff"[..]);
+
+    let proof = prove_range_complete::<V1, _>(&src, &root, &lo, &hi)?;
+    ensure(
+        proof.len() >= 2,
+        "a referenced child must yield a multi-node frontier",
+    )?;
+    // The intact proof lists every key.
+    let want = oracle(&store, &root, &lo, &hi)?;
+    ensure_eq(
+        &verify_range::<V1>(&root, &lo, &hi, &proof)?,
+        &want,
+        "intact range listing",
+    )?;
+
+    // Dropping any non-root frontier node leaves an in-range edge with no
+    // witness, so the listing can no longer be shown complete.
+    for drop in 1..proof.len() {
+        let kept: Vec<Vec<u8>> = proof
+            .nodes()
+            .iter()
+            .enumerate()
+            .filter(|&(i, _)| i != drop)
+            .map(|(_, node)| node.clone())
+            .collect();
+        ensure(
+            verify_range::<V1>(&root, &lo, &hi, &RangeProof::new(kept)).is_err(),
+            "an omitted frontier node must be rejected",
+        )?;
+    }
+    Ok(())
+}
+
+#[test]
+fn a_tampered_frontier_node_is_rejected() -> TestResult {
+    let pairs = vec![(b"alpha".to_vec(), 0x11), (b"beta".to_vec(), 0x22)];
+    let (_store, root, map) = build(&pairs).ok_or("unexpected spill")?;
+    let src = source(&map);
+    let lo = Key::from(&b""[..]);
+    let hi = Key::from(&b"\xff"[..]);
+
+    let proof = prove_range_complete::<V1, _>(&src, &root, &lo, &hi)?;
+    let mut nodes: Vec<Vec<u8>> = proof.nodes().to_vec();
+    // Flip a byte in the root node: its content address no longer matches the
+    // trusted root, so the walk cannot start.
+    if let Some(node) = nodes.first_mut()
+        && let Some(byte) = node.last_mut()
+    {
+        *byte ^= 0xFF;
+    }
+    ensure(
+        verify_range::<V1>(&root, &lo, &hi, &RangeProof::new(nodes)).is_err(),
+        "a tampered frontier node must be rejected",
+    )?;
+    Ok(())
+}
+
+/// The two roots of a manifest with `key` inserted, plus their node sources.
+fn before_after(
+    base: &[(Vec<u8>, u8)],
+    key: &[u8],
+    value: u8,
+) -> Option<(ChunkAddress, Map, ChunkAddress, Map)> {
+    let (_s1, root_before, map_before) = build(base)?;
+    let mut after = base.to_vec();
+    after.push((key.to_vec(), value));
+    let (_s2, root_after, map_after) = build(&after)?;
+    Some((root_before, map_before, root_after, map_after))
+}
+
+#[test]
+fn an_insertion_transition_verifies_and_a_false_one_is_rejected() -> TestResult {
+    let base = vec![(b"a".to_vec(), 0x01), (b"c".to_vec(), 0x03)];
+    let key = Key::from(&b"b"[..]);
+    let (r1, m1, r2, m2) = before_after(&base, b"b", 0x02).ok_or("unexpected spill")?;
+    let (s1, s2) = (source(&m1), source(&m2));
+
+    for granularity in [Granularity::Chunk, Granularity::Segment] {
+        let proof = prove_transition::<V1, _, _>(&s1, &r1, &s2, &r2, &key, granularity)?;
+        ensure_eq(
+            &verify_transition::<V1>(&r1, &r2, &key, &proof)?,
+            &Transition::Insertion(entry(0x02)),
+            "insertion",
+        )?;
+        // Swapping the roots claims the key was inserted the other way: it is
+        // present under r2 and absent under r1, so neither half fits the shape.
+        ensure(
+            verify_transition::<V1>(&r2, &r1, &key, &proof).is_err(),
+            "a reversed-root insertion must be rejected",
+        )?;
+    }
+
+    // A key already present under the first root has no insertion: the exclusion
+    // half cannot be built at all.
+    let present = Key::from(&b"a"[..]);
+    ensure(
+        prove_transition::<V1, _, _>(&s1, &r1, &s2, &r2, &present, Granularity::Chunk).is_err(),
+        "a present key must not admit an insertion proof",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn deletion_and_update_duals_verify() -> TestResult {
+    let base = vec![(b"a".to_vec(), 0x01), (b"b".to_vec(), 0x02)];
+    let (_s0, root_with, map_with) = build(&base).ok_or("unexpected spill")?;
+    let without = vec![(b"a".to_vec(), 0x01)];
+    let (_s1, root_without, map_without) = build(&without).ok_or("unexpected spill")?;
+    let updated = vec![(b"a".to_vec(), 0x01), (b"b".to_vec(), 0x2B)];
+    let (_s2, root_updated, map_updated) = build(&updated).ok_or("unexpected spill")?;
+
+    let with = source(&map_with);
+    let missing = source(&map_without);
+    let changed = source(&map_updated);
+    let key = Key::from(&b"b"[..]);
+
+    // Deletion: present under the first root, absent under the second.
+    let deletion = prove_deletion::<V1, _, _>(
+        &with,
+        &root_with,
+        &missing,
+        &root_without,
+        &key,
+        Granularity::Segment,
+    )?;
+    ensure_eq(
+        &verify_transition::<V1>(&root_with, &root_without, &key, &deletion)?,
+        &Transition::Deletion(entry(0x02)),
+        "deletion",
+    )?;
+
+    // Update: present under both roots with a changed value.
+    let update = prove_update::<V1, _, _>(
+        &with,
+        &root_with,
+        &changed,
+        &root_updated,
+        &key,
+        Granularity::Chunk,
+    )?;
+    ensure_eq(
+        &verify_transition::<V1>(&root_with, &root_updated, &key, &update)?,
+        &Transition::Update {
+            before: entry(0x02),
+            after: entry(0x2B),
+        },
+        "update",
+    )?;
+
+    // An update whose value did not change is a no-op, not a transition.
+    let noop = prove_update::<V1, _, _>(
+        &with,
+        &root_with,
+        &with,
+        &root_with,
+        &key,
+        Granularity::Chunk,
+    )?;
+    ensure(
+        verify_transition::<V1>(&root_with, &root_with, &key, &noop).is_err(),
+        "an unchanged value must not verify as an update",
+    )?;
+    Ok(())
+}


### PR DESCRIPTION
## What

Implements #302 as two compositional proofs built on the #301 inclusion/exclusion primitives, scoped entirely to the `nectar-manifest-proof` crate:

- **Range-completeness** (`src/range.rs`): `RangeProof`, `prove_range_complete(source, root, lo, hi)`, `verify_range<F>(root, lo, hi, proof)` - an authenticated ascending listing over `[lo, hi)`. The proof ships the frontier of trie nodes whose subtrees overlap the range, each self-authenticated by content address and chained from the trusted root. `verify_range` re-walks the frontier in key order, mirroring the ordered reader's flatten (value in its fork record, embedded children folded in place, referenced children as hops), and demands a witness node at every referenced child whose `[prefix, successor(prefix))` overlaps the range. A withheld or tampered node leaves an in-range edge with no witness, which is rejected via the new `VerifyError::NodeAbsent`, `VerifyError::Decode` and `VerifyError::Encrypted` variants.
- **State transitions** (`src/transition.rs`): `TransitionProof`, `Transition`, `prove_transition`/`prove_deletion`/`prove_update`, `verify_transition` - each transition is two single-key proofs read against different roots (`root_before`, `root_after`). An insertion is exclusion-then-inclusion, a deletion is its dual, and an update is inclusion under both roots with a changed value. Proving enforces the claimed shape (e.g. a false insertion where the key is already present, or still absent, cannot be constructed), and verification confirms both halves plus the shape.

`src/lib.rs` re-exports the new public surface and extends the module-level docs; `src/error.rs` gains the three `VerifyError` variants above. `tests/compositions.rs` adds coverage for both proof kinds. Neither `fuzz/` nor `nectar-postage-usage` is touched.

## Why

#301 gives single-key inclusion/exclusion proofs but no way to authenticate a whole range as complete (no witheld keys) or to attest what changed between two states. Both compositions reuse the existing primitives rather than adding new authentication machinery: range-completeness needs only content-address authentication plus the trie's total order (no additional cryptographic assumptions), and transition proofs are two ordinary single-key proofs paired under a shape constraint.

Closes #302

## Testing

Verified independently on branch `s264/92-proof-compositions` (HEAD `0bbd0fe`) atop base `s264/90-proof-core`, cloned fresh and checked out via `FETCH_HEAD`. No changes were needed; nothing was committed or pushed as part of verification.

Battery run via `nix develop --command`:
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean, no warnings.
- Tests: `cargo-nextest` was not present in the dev shell, so `cargo test --workspace --all-features` was substituted as a faithful pass/fail equivalent. All suites green.

A red-team pass on the frontier re-walk confirmed that every ancestor prefix of an in-range key overlaps `[lo, hi)`, so withholding any node on its path triggers `NodeAbsent`; overlap/successor half-open logic and the root-only entry guard are correct; tampering is caught via the re-sealed BMT address. No panics were found on adversarial `verify_range` input (empty, truncated, oversized, or flag-poking payloads all return errors).

This is a stacked PR targeting `s264/90-proof-core`, not `main`.

## AI Assistance

Claude (Anthropic, Sonnet 5) was used for implementation, red-teaming and independent verification of this change, including the battery run and the composition of this PR description.
