### PR TITLE
feat(manifest-proof): add authenticated rank, count, select and pagination proofs

### DIFF
--- a/crates/manifest-proof/src/counted.rs
+++ b/crates/manifest-proof/src/counted.rs
@@ -1,0 +1,998 @@
+//! Authenticated rank, count, select and pagination proofs over the counted
+//! node grammar.
+//!
+//! The node grammar carries every subtree's distinct key-count in the
+//! authenticated node bytes (spec 5.6), so an order-statistic answer is provable
+//! with the same O(depth) descent the reader walks: a [rank](prove_rank) or
+//! [select](prove_select) proof is the chain of nodes the descent visits, each
+//! authenticated against the reference the one before it yielded, and the
+//! verifier re-derives the answer from those bytes alone. A [count](prove_count)
+//! proof is two rank descents whose difference is the window size; a
+//! [page](prove_page) proof pins a listing slice by its absolute ranks.
+//!
+//! TRUST BOUNDARY - counted proofs assume an HONEST BUILDER. A referenced
+//! child's `child_count` is bound to its parent chunk's bytes but NOT to the
+//! child's real subtree: re-encoding a chunk reproduces the same count, it does
+//! not re-derive it from the child, and an inflated count stays internally
+//! consistent all the way to the root. So these proofs establish the count as
+//! COMMITTED BY THE ROOT - sound against an honest builder (a gateway, indexer
+//! or registry operator whose manifest you already rely on), NOT against an
+//! adversarial root that plants false counts on the subtrees a descent skips.
+//! The strictly trustless answers ride the count-independent inclusion,
+//! exclusion and range-completeness proofs, which are sound against adversarial
+//! roots by canonicalness.
+//!
+//! The residual trust is bounded where free: every hop the descent DOES take
+//! fetches the child, so the verifier cross-checks the parent-asserted
+//! `child_count` against the child's own derived total (the sum of its fork
+//! counts) and rejects an on-path inconsistency. Only the counts of the
+//! un-fetched siblings a descent skips remain purely author-asserted.
+
+use nectar_manifest::{Entry, Format, Key, SubtreeCount};
+use nectar_primitives::wire::Cursor;
+use nectar_primitives::{
+    ChunkAddress, ChunkOps, ChunkRef, ContentChunk, DEFAULT_BODY_SIZE, EncryptedChunkRef,
+};
+
+use crate::descent::{DescentError, Width, child_width, entry_width, flag, take_u16, take_value};
+use crate::error::{ProveError, VerifyError};
+use crate::prove::NodeSource;
+
+/// An authenticated chain of node payloads: the nodes one counted descent
+/// visits, root first, each addressed by the BMT of its bytes.
+///
+/// Carries no answer of its own; the verifier re-derives it from the
+/// authenticated bytes, so the chain cannot assert a count its nodes do not.
+#[derive(Clone, Debug)]
+pub struct CountedPath {
+    nodes: Vec<Vec<u8>>,
+}
+
+impl CountedPath {
+    /// Assemble a path from its ordered node payloads, root first.
+    #[must_use]
+    pub const fn new(nodes: Vec<Vec<u8>>) -> Self {
+        Self { nodes }
+    }
+
+    /// The node payloads in descent order, root first.
+    #[must_use]
+    pub fn nodes(&self) -> &[Vec<u8>] {
+        &self.nodes
+    }
+
+    /// The number of authenticated nodes on the path.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Whether the path carries no nodes; never true for one a verify accepts.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+}
+
+/// A proof of `rank(key)`: the authenticated descent path to the key's position.
+#[derive(Clone, Debug)]
+pub struct RankProof {
+    path: CountedPath,
+}
+
+impl RankProof {
+    /// Assemble a rank proof from its descent path.
+    #[must_use]
+    pub const fn new(path: CountedPath) -> Self {
+        Self { path }
+    }
+
+    /// The authenticated rank-descent path.
+    #[must_use]
+    pub const fn path(&self) -> &CountedPath {
+        &self.path
+    }
+}
+
+/// A proof of `count(lo, hi)`: the two rank descents whose difference is the
+/// number of keys in the half-open window.
+#[derive(Clone, Debug)]
+pub struct CountProof {
+    lo: CountedPath,
+    hi: CountedPath,
+}
+
+impl CountProof {
+    /// Assemble a count proof from the `lo` and `hi` rank descents.
+    #[must_use]
+    pub const fn new(lo: CountedPath, hi: CountedPath) -> Self {
+        Self { lo, hi }
+    }
+
+    /// The rank descent to the lower bound.
+    #[must_use]
+    pub const fn lo(&self) -> &CountedPath {
+        &self.lo
+    }
+
+    /// The rank descent to the upper bound.
+    #[must_use]
+    pub const fn hi(&self) -> &CountedPath {
+        &self.hi
+    }
+}
+
+/// A proof of `select(index)`: the authenticated descent to the key at a rank.
+#[derive(Clone, Debug)]
+pub struct SelectProof {
+    path: CountedPath,
+}
+
+impl SelectProof {
+    /// Assemble a select proof from its descent path.
+    #[must_use]
+    pub const fn new(path: CountedPath) -> Self {
+        Self { path }
+    }
+
+    /// The authenticated select-descent path.
+    #[must_use]
+    pub const fn path(&self) -> &CountedPath {
+        &self.path
+    }
+}
+
+/// A proof of one pagination slice: the rank descents bounding the window and a
+/// rank-pinned select descent for each returned key.
+///
+/// The upper bound is `None` for an unbounded prefix page (the empty or
+/// all-`0xFF` prefix), whose total is read from the authenticated root.
+#[derive(Clone, Debug)]
+pub struct PageProof {
+    lo: CountedPath,
+    hi: Option<CountedPath>,
+    entries: Vec<CountedPath>,
+}
+
+impl PageProof {
+    /// Assemble a page proof from its bound descents and per-key select
+    /// descents.
+    #[must_use]
+    pub const fn new(lo: CountedPath, hi: Option<CountedPath>, entries: Vec<CountedPath>) -> Self {
+        Self { lo, hi, entries }
+    }
+
+    /// The rank descent to the lower bound.
+    #[must_use]
+    pub const fn lo(&self) -> &CountedPath {
+        &self.lo
+    }
+
+    /// The rank descent to the upper bound, absent for an unbounded page.
+    #[must_use]
+    pub const fn hi(&self) -> Option<&CountedPath> {
+        self.hi.as_ref()
+    }
+
+    /// The rank-pinned select descents, one per returned key.
+    #[must_use]
+    pub fn entries(&self) -> &[CountedPath] {
+        &self.entries
+    }
+}
+
+/// One flattened fork-table position, in ascending key order, with the count of
+/// keys it stands for: a value counts once, a referenced or encrypted child for
+/// its whole author-asserted subtree.
+enum Pos<F: Format> {
+    /// A key terminates here with this value.
+    Value {
+        /// Key bytes below the node root.
+        suffix: Vec<u8>,
+        /// The bound value.
+        entry: Entry<F>,
+    },
+    /// A referenced child holding `count` keys.
+    Ref {
+        /// Key bytes below the node root leading to the child.
+        suffix: Vec<u8>,
+        /// The child chunk address.
+        addr: ChunkAddress,
+        /// The child subtree's asserted distinct key-count.
+        count: u64,
+    },
+    /// An encrypted child holding `count` keys; its count still routes a rank
+    /// past it, only a descent into it fails.
+    Encrypted {
+        /// Key bytes below the node root leading to the child.
+        suffix: Vec<u8>,
+        /// The child subtree's asserted distinct key-count.
+        count: u64,
+    },
+}
+
+impl<F: Format> Pos<F> {
+    /// The key bytes below the node root.
+    fn suffix(&self) -> &[u8] {
+        match self {
+            Self::Value { suffix, .. }
+            | Self::Ref { suffix, .. }
+            | Self::Encrypted { suffix, .. } => suffix,
+        }
+    }
+
+    /// The number of keys this position stands for.
+    const fn count(&self) -> u64 {
+        match self {
+            Self::Value { .. } => 1,
+            Self::Ref { count, .. } | Self::Encrypted { count, .. } => *count,
+        }
+    }
+}
+
+/// A node flattened to its root entry and ascending-key positions, embedded
+/// children folded in place so only referenced hops leave the buffer.
+struct Flat<F: Format> {
+    root_entry: Option<Entry<F>>,
+    positions: Vec<Pos<F>>,
+}
+
+impl<F: Format> Flat<F> {
+    /// The node's derived total: the summed counts of its positions. A
+    /// referenced child node carries no root entry, so this is exactly the count
+    /// its parent asserts for it, and the two must agree.
+    fn derived_total(&self) -> u64 {
+        self.positions
+            .iter()
+            .map(Pos::count)
+            .fold(0, u64::saturating_add)
+    }
+}
+
+/// Parse an authenticated node payload into its flattened positions, reading the
+/// trailing `child_count` on every referenced fork.
+///
+/// Rejects a spilled node: a proof over a segment directory is out of scope, the
+/// same bound the single-key descent keeps.
+fn flatten<F: Format>(bytes: &[u8]) -> Result<Flat<F>, DescentError> {
+    let mut cur = Cursor::new(bytes);
+    if cur.take::<[u8; 2]>()? != F::PREAMBLE {
+        return Err(DescentError::NotAManifest);
+    }
+    let flags = cur.take::<u8>()?;
+    if flags & (flag::SEGMENT | flag::SEGMENTED) != 0 {
+        return Err(DescentError::Spilled);
+    }
+    let root_entry = take_value::<F>(&mut cur, entry_width(flags))?;
+    if flags & flag::HAS_META != 0 {
+        let len = take_u16(&mut cur)?;
+        let _ = cur.take_slice(len)?;
+    }
+    let mut positions = Vec::new();
+    let mut prefix = Vec::new();
+    read_table::<F>(&mut cur, &mut prefix, &mut positions)?;
+    Ok(Flat {
+        root_entry,
+        positions,
+    })
+}
+
+/// Read a fork table at the cursor: the count, the index of first bytes, then
+/// each record parsed in place and appended as ascending-key positions.
+fn read_table<F: Format>(
+    cur: &mut Cursor<'_>,
+    prefix: &mut Vec<u8>,
+    positions: &mut Vec<Pos<F>>,
+) -> Result<(), DescentError> {
+    let fcount = take_u16(cur)?;
+    let mut firsts = Vec::with_capacity(fcount);
+    for _ in 0..fcount {
+        let first = cur.take::<u8>()?;
+        let _off = take_u16(cur)?;
+        firsts.push(first);
+    }
+    for first in firsts {
+        read_record::<F>(cur, first, prefix, positions)?;
+    }
+    Ok(())
+}
+
+/// Parse one fork record in wire order (flags, tail, entry, child, metadata,
+/// trailing count), appending its value and its child's positions.
+fn read_record<F: Format>(
+    cur: &mut Cursor<'_>,
+    first: u8,
+    prefix: &mut Vec<u8>,
+    positions: &mut Vec<Pos<F>>,
+) -> Result<(), DescentError> {
+    let flags = cur.take::<u8>()?;
+    let plen = usize::from(cur.take::<u8>()?);
+    let tail_len = plen.checked_sub(1).ok_or(DescentError::EmptyPrefix)?;
+    let tail = cur.take_slice(tail_len)?;
+    let mark = prefix.len();
+    prefix.push(first);
+    prefix.extend_from_slice(tail);
+
+    if let Some(entry) = take_value::<F>(cur, entry_width(flags))? {
+        positions.push(Pos::Value {
+            suffix: prefix.clone(),
+            entry,
+        });
+    }
+
+    // The child field. A referenced child defers its position until its trailing
+    // count is read; an embedded child folds its own positions in place now.
+    let width = child_width(flags);
+    let referenced = matches!(width, Width::Ref32 | Width::Ref64);
+    let deferred = match width {
+        Width::None => None,
+        Width::Ref32 => {
+            let raw = cur.take::<[u8; ChunkRef::SIZE]>()?;
+            Some(Deferred::Ref(ChunkAddress::new(raw)))
+        }
+        Width::Ref64 => {
+            let _raw = cur.take::<[u8; EncryptedChunkRef::SIZE]>()?;
+            Some(Deferred::Encrypted)
+        }
+        Width::Inline => {
+            let _len = take_u16(cur)?;
+            let _zero = cur.take::<u8>()?;
+            read_table::<F>(cur, prefix, positions)?;
+            None
+        }
+    };
+
+    if flags & flag::HAS_META != 0 {
+        let len = take_u16(cur)?;
+        let _ = cur.take_slice(len)?;
+    }
+    let count = if referenced {
+        cur.take::<SubtreeCount>()?.get()
+    } else {
+        0
+    };
+    match deferred {
+        Some(Deferred::Ref(addr)) => positions.push(Pos::Ref {
+            suffix: prefix.clone(),
+            addr,
+            count,
+        }),
+        Some(Deferred::Encrypted) => positions.push(Pos::Encrypted {
+            suffix: prefix.clone(),
+            count,
+        }),
+        None => {}
+    }
+    prefix.truncate(mark);
+    Ok(())
+}
+
+/// A referenced child parsed before its trailing count, held until the count is
+/// read so its position lands with the right count.
+enum Deferred {
+    /// A plain reference at this address.
+    Ref(ChunkAddress),
+    /// An encrypted reference the plain descent cannot open.
+    Encrypted,
+}
+
+/// Where ranking the target through one node's positions lands.
+enum RankStep {
+    /// The rank resolves in this node, with this many in-node keys before it.
+    Here(u64),
+    /// The target descends into a referenced child, `matched` key bytes below
+    /// the node root, with this many in-node keys strictly before it.
+    Cross {
+        /// The child chunk address.
+        addr: ChunkAddress,
+        /// Key bytes consumed reaching the child.
+        matched: usize,
+        /// In-node keys strictly before the target.
+        before: u64,
+        /// The child's asserted count, cross-checked against the child node.
+        count: u64,
+    },
+    /// The target descends into an encrypted child that cannot be opened.
+    Encrypted,
+}
+
+/// Count the keys strictly before `remaining` within one node's positions,
+/// stopping where the target descends into a referenced child.
+fn rank_step<F: Format>(positions: &[Pos<F>], remaining: &[u8]) -> RankStep {
+    let mut before = 0u64;
+    for pos in positions {
+        let suffix = pos.suffix();
+        if suffix >= remaining {
+            return RankStep::Here(before);
+        }
+        let descends = remaining.starts_with(suffix);
+        match pos {
+            Pos::Value { .. } => before = before.saturating_add(1),
+            Pos::Ref { addr, count, .. } => {
+                if descends {
+                    return RankStep::Cross {
+                        addr: *addr,
+                        matched: suffix.len(),
+                        before,
+                        count: *count,
+                    };
+                }
+                before = before.saturating_add(*count);
+            }
+            Pos::Encrypted { count, .. } => {
+                if descends {
+                    return RankStep::Encrypted;
+                }
+                before = before.saturating_add(*count);
+            }
+        }
+    }
+    RankStep::Here(before)
+}
+
+/// Where an absolute index lands within one node's positions.
+enum SelectStep<F: Format> {
+    /// The index is this node's value at `suffix`.
+    Found {
+        /// Key bytes below the node root.
+        suffix: Vec<u8>,
+        /// The resolved value.
+        entry: Entry<F>,
+    },
+    /// The index falls inside the referenced child at `addr`, `suffix` below the
+    /// node root, with `residual` its index within the child.
+    Cross {
+        /// The child chunk address.
+        addr: ChunkAddress,
+        /// Key bytes consumed reaching the child.
+        suffix: Vec<u8>,
+        /// The index within the child subtree.
+        residual: u64,
+        /// The child's asserted count, cross-checked against the child node.
+        count: u64,
+    },
+    /// The index falls inside an encrypted child that cannot be opened.
+    Encrypted,
+    /// The index runs past this node's total.
+    Past,
+}
+
+/// Resolve `index` within one node's positions, subtracting the counts of the
+/// positions before it.
+fn select_step<F: Format>(positions: Vec<Pos<F>>, index: u64) -> SelectStep<F> {
+    let mut index = index;
+    for pos in positions {
+        let count = pos.count();
+        if index < count {
+            return match pos {
+                Pos::Value { suffix, entry } => SelectStep::Found { suffix, entry },
+                Pos::Ref {
+                    suffix,
+                    addr,
+                    count,
+                } => SelectStep::Cross {
+                    addr,
+                    suffix,
+                    residual: index,
+                    count,
+                },
+                Pos::Encrypted { .. } => SelectStep::Encrypted,
+            };
+        }
+        index = index.saturating_sub(count);
+    }
+    SelectStep::Past
+}
+
+/// Authenticate a node payload against `trusted`, then flatten it. The seal
+/// re-BMTs the bytes, so a tampered node or wrong reference fails here.
+fn authenticated<F: Format>(
+    payload: &[u8],
+    trusted: &ChunkAddress,
+    index: usize,
+) -> Result<Flat<F>, VerifyError> {
+    let chunk =
+        ContentChunk::<DEFAULT_BODY_SIZE>::new(payload.to_vec()).map_err(VerifyError::Seal)?;
+    if chunk.address() != trusted {
+        return Err(VerifyError::Unauthenticated(index));
+    }
+    Ok(flatten::<F>(payload)?)
+}
+
+/// Descend the manifest for `key`, recording each visited node payload and
+/// accumulating the rank the descent proves.
+fn rank_walk<F, S>(
+    source: &S,
+    root: &ChunkAddress,
+    key: &Key,
+) -> Result<(Vec<Vec<u8>>, u64), ProveError>
+where
+    F: Format,
+    S: NodeSource<F>,
+{
+    let target = key.as_bytes();
+    let mut nodes = Vec::new();
+    let mut address = *root;
+    let mut consumed = 0usize;
+    let mut acc = 0u64;
+    let mut is_root = true;
+    loop {
+        let node = source
+            .node(&address)
+            .ok_or(ProveError::NodeMissing(address))?;
+        let payload = node.encode()?;
+        let flat = flatten::<F>(&payload)?;
+        nodes.push(payload);
+        if is_root && !target.is_empty() && flat.root_entry.is_some() {
+            acc = acc.saturating_add(1);
+        }
+        let Some(remaining) = target.get(consumed..).filter(|rest| !rest.is_empty()) else {
+            return Ok((nodes, acc));
+        };
+        match rank_step(&flat.positions, remaining) {
+            RankStep::Here(before) => return Ok((nodes, acc.saturating_add(before))),
+            RankStep::Encrypted => return Err(ProveError::Encrypted),
+            RankStep::Cross {
+                addr,
+                matched,
+                before,
+                ..
+            } => {
+                acc = acc.saturating_add(before);
+                consumed = consumed.saturating_add(matched);
+                address = addr;
+                is_root = false;
+            }
+        }
+    }
+}
+
+/// Replay a rank descent over authenticated bytes, cross-checking every on-path
+/// `child_count` against the child node's derived total.
+fn replay_rank<F: Format>(
+    root: &ChunkAddress,
+    key: &Key,
+    path: &CountedPath,
+) -> Result<u64, VerifyError> {
+    let target = key.as_bytes();
+    let mut acc = 0u64;
+    let mut consumed = 0usize;
+    let mut trusted = *root;
+    let mut is_root = true;
+    let mut expected: Option<u64> = None;
+    for (index, payload) in path.nodes().iter().enumerate() {
+        let flat = authenticated::<F>(payload, &trusted, index)?;
+        if let Some(want) = expected
+            && flat.derived_total() != want
+        {
+            return Err(VerifyError::CountMismatch);
+        }
+        if is_root && !target.is_empty() && flat.root_entry.is_some() {
+            acc = acc.saturating_add(1);
+        }
+        let Some(remaining) = target.get(consumed..).filter(|rest| !rest.is_empty()) else {
+            return Ok(acc);
+        };
+        match rank_step(&flat.positions, remaining) {
+            RankStep::Here(before) => return Ok(acc.saturating_add(before)),
+            RankStep::Encrypted => return Err(VerifyError::Encrypted),
+            RankStep::Cross {
+                addr,
+                matched,
+                before,
+                count,
+            } => {
+                acc = acc.saturating_add(before);
+                consumed = consumed.saturating_add(matched);
+                trusted = addr;
+                is_root = false;
+                expected = Some(count);
+            }
+        }
+    }
+    Err(VerifyError::Malformed)
+}
+
+/// Descend the manifest for absolute rank `index`, recording each visited node.
+/// `None` when the index runs past the manifest's key count.
+fn select_walk<F, S>(
+    source: &S,
+    root: &ChunkAddress,
+    index: u64,
+) -> Result<Option<Vec<Vec<u8>>>, ProveError>
+where
+    F: Format,
+    S: NodeSource<F>,
+{
+    let mut nodes = Vec::new();
+    let mut address = *root;
+    let mut index = index;
+    let mut is_root = true;
+    loop {
+        let node = source
+            .node(&address)
+            .ok_or(ProveError::NodeMissing(address))?;
+        let payload = node.encode()?;
+        let flat = flatten::<F>(&payload)?;
+        nodes.push(payload);
+        if is_root && flat.root_entry.is_some() {
+            if index == 0 {
+                return Ok(Some(nodes));
+            }
+            index = index.saturating_sub(1);
+        }
+        match select_step(flat.positions, index) {
+            SelectStep::Found { .. } => return Ok(Some(nodes)),
+            SelectStep::Encrypted => return Err(ProveError::Encrypted),
+            SelectStep::Past => return Ok(None),
+            SelectStep::Cross { addr, residual, .. } => {
+                index = residual;
+                address = addr;
+                is_root = false;
+            }
+        }
+    }
+}
+
+/// Replay a select descent over authenticated bytes, cross-checking every
+/// on-path `child_count` and returning the resolved key and value.
+fn replay_select<F: Format>(
+    root: &ChunkAddress,
+    index: u64,
+    path: &CountedPath,
+) -> Result<(Key, Entry<F>), VerifyError> {
+    let mut trusted = *root;
+    let mut index = index;
+    let mut key = Vec::new();
+    let mut is_root = true;
+    let mut expected: Option<u64> = None;
+    for (step, payload) in path.nodes().iter().enumerate() {
+        let flat = authenticated::<F>(payload, &trusted, step)?;
+        if let Some(want) = expected
+            && flat.derived_total() != want
+        {
+            return Err(VerifyError::CountMismatch);
+        }
+        if is_root && let Some(entry) = &flat.root_entry {
+            if index == 0 {
+                return Ok((Key::from(key.as_slice()), entry.clone()));
+            }
+            index = index.saturating_sub(1);
+        }
+        match select_step(flat.positions, index) {
+            SelectStep::Found { suffix, entry } => {
+                key.extend_from_slice(&suffix);
+                return Ok((Key::from(key.as_slice()), entry));
+            }
+            SelectStep::Encrypted => return Err(VerifyError::Encrypted),
+            SelectStep::Past => return Err(VerifyError::IndexOutOfRange),
+            SelectStep::Cross {
+                addr,
+                suffix,
+                residual,
+                count,
+            } => {
+                key.extend_from_slice(&suffix);
+                index = residual;
+                trusted = addr;
+                is_root = false;
+                expected = Some(count);
+            }
+        }
+    }
+    Err(VerifyError::Malformed)
+}
+
+/// The whole manifest's key count from the authenticated root: its derived total
+/// plus its own empty-key entry.
+fn whole_count<F: Format>(root: &ChunkAddress, path: &CountedPath) -> Result<u64, VerifyError> {
+    let payload = path.nodes().first().ok_or(VerifyError::Empty)?;
+    let flat = authenticated::<F>(payload, root, 0)?;
+    let entry = u64::from(flat.root_entry.is_some());
+    Ok(flat.derived_total().saturating_add(entry))
+}
+
+/// The least byte string strictly greater than every string starting with
+/// `prefix`. `None` when the prefix is empty or all `0xFF`, i.e. unbounded.
+fn successor(prefix: &[u8]) -> Option<Vec<u8>> {
+    let mut bytes = prefix.to_vec();
+    loop {
+        match bytes.last() {
+            None => return None,
+            Some(&0xFF) => {
+                bytes.pop();
+            }
+            Some(&last) => {
+                if let Some(slot) = bytes.last_mut() {
+                    *slot = last.saturating_add(1);
+                }
+                return Some(bytes);
+            }
+        }
+    }
+}
+
+/// Prove `rank(key)`: the number of keys strictly less than `key`, under `root`.
+///
+/// The proof is the O(depth) descent path; [`verify_rank`] re-derives the rank
+/// and cross-checks every on-path count. See the [module](self) trust boundary:
+/// the rank is sound relative to the committed root, under an honest builder.
+pub fn prove_rank<F, S>(source: &S, root: &ChunkAddress, key: &Key) -> Result<RankProof, ProveError>
+where
+    F: Format,
+    S: NodeSource<F>,
+{
+    let (nodes, _) = rank_walk::<F, S>(source, root, key)?;
+    Ok(RankProof::new(CountedPath::new(nodes)))
+}
+
+/// Verify a [`prove_rank`] proof, returning the authenticated rank.
+///
+/// Rejects an on-path count inconsistency ([`VerifyError::CountMismatch`]); the
+/// counts of skipped siblings stay author-asserted (see the [module](self)
+/// trust boundary).
+pub fn verify_rank<F: Format>(
+    root: &ChunkAddress,
+    key: &Key,
+    proof: &RankProof,
+) -> Result<u64, VerifyError> {
+    replay_rank::<F>(root, key, proof.path())
+}
+
+/// Prove `count(lo, hi)`: the number of keys with `lo <= key < hi`, under
+/// `root`, as the two rank descents whose difference is the window size.
+///
+/// See the [module](self) trust boundary: the count is sound relative to the
+/// committed root, under an honest builder.
+pub fn prove_count<F, S>(
+    source: &S,
+    root: &ChunkAddress,
+    lo: &Key,
+    hi: &Key,
+) -> Result<CountProof, ProveError>
+where
+    F: Format,
+    S: NodeSource<F>,
+{
+    let (lo_nodes, _) = rank_walk::<F, S>(source, root, lo)?;
+    let (hi_nodes, _) = rank_walk::<F, S>(source, root, hi)?;
+    Ok(CountProof::new(
+        CountedPath::new(lo_nodes),
+        CountedPath::new(hi_nodes),
+    ))
+}
+
+/// Verify a [`prove_count`] proof, returning `rank(hi) - rank(lo)`.
+///
+/// Both descents are cross-checked; an on-path inconsistency in either is
+/// rejected.
+pub fn verify_count<F: Format>(
+    root: &ChunkAddress,
+    lo: &Key,
+    hi: &Key,
+    proof: &CountProof,
+) -> Result<u64, VerifyError> {
+    let low = replay_rank::<F>(root, lo, proof.lo())?;
+    let high = replay_rank::<F>(root, hi, proof.hi())?;
+    Ok(high.saturating_sub(low))
+}
+
+/// Prove `select(index)`: the key and value at position `index` in ascending key
+/// order, under `root`.
+///
+/// Errors with [`ProveError::IndexOutOfRange`] when the index is at or past the
+/// key count. See the [module](self) trust boundary.
+pub fn prove_select<F, S>(
+    source: &S,
+    root: &ChunkAddress,
+    index: u64,
+) -> Result<SelectProof, ProveError>
+where
+    F: Format,
+    S: NodeSource<F>,
+{
+    select_walk::<F, S>(source, root, index)?.map_or(Err(ProveError::IndexOutOfRange), |nodes| {
+        Ok(SelectProof::new(CountedPath::new(nodes)))
+    })
+}
+
+/// Verify a [`prove_select`] proof, returning the authenticated key and value.
+///
+/// Rejects an on-path count inconsistency; the position is sound relative to the
+/// committed root, under an honest builder.
+pub fn verify_select<F: Format>(
+    root: &ChunkAddress,
+    index: u64,
+    proof: &SelectProof,
+) -> Result<(Key, Entry<F>), VerifyError> {
+    replay_select::<F>(root, index, proof.path())
+}
+
+/// Assemble a page proof over `[lo, hi)` (an unbounded upper bound when `hi` is
+/// `None`), skipping `offset` keys and returning at most `limit`.
+fn page_core<F, S>(
+    source: &S,
+    root: &ChunkAddress,
+    lo: &Key,
+    hi: Option<&Key>,
+    offset: u64,
+    limit: usize,
+) -> Result<PageProof, ProveError>
+where
+    F: Format,
+    S: NodeSource<F>,
+{
+    let (lo_nodes, rank_lo) = rank_walk::<F, S>(source, root, lo)?;
+    let (hi_path, rank_hi) = match hi {
+        Some(key) => {
+            let (nodes, rank) = rank_walk::<F, S>(source, root, key)?;
+            (Some(CountedPath::new(nodes)), rank)
+        }
+        None => (None, whole_count_prove::<F, S>(source, root)?),
+    };
+    let total = rank_hi.saturating_sub(rank_lo);
+    let take = u64::try_from(limit)
+        .unwrap_or(u64::MAX)
+        .min(total.saturating_sub(offset));
+    let start = rank_lo.saturating_add(offset);
+    let mut entries = Vec::new();
+    let mut i = 0u64;
+    while i < take {
+        match select_walk::<F, S>(source, root, start.saturating_add(i))? {
+            Some(nodes) => entries.push(CountedPath::new(nodes)),
+            None => break,
+        }
+        i = i.saturating_add(1);
+    }
+    Ok(PageProof::new(CountedPath::new(lo_nodes), hi_path, entries))
+}
+
+/// The whole manifest's key count, walked from the fetched root.
+fn whole_count_prove<F, S>(source: &S, root: &ChunkAddress) -> Result<u64, ProveError>
+where
+    F: Format,
+    S: NodeSource<F>,
+{
+    let node = source.node(root).ok_or(ProveError::NodeMissing(*root))?;
+    let payload = node.encode()?;
+    let flat = flatten::<F>(&payload)?;
+    let entry = u64::from(flat.root_entry.is_some());
+    Ok(flat.derived_total().saturating_add(entry))
+}
+
+/// Verify a page proof over `[lo, hi)`, returning the authenticated slice.
+fn verify_page_core<F: Format>(
+    root: &ChunkAddress,
+    lo: &Key,
+    hi: Option<&Key>,
+    offset: u64,
+    limit: usize,
+    proof: &PageProof,
+) -> Result<Vec<(Key, Entry<F>)>, VerifyError> {
+    let rank_lo = replay_rank::<F>(root, lo, proof.lo())?;
+    let rank_hi = match (hi, proof.hi()) {
+        (Some(key), Some(path)) => replay_rank::<F>(root, key, path)?,
+        (None, None) => whole_count::<F>(root, proof.lo())?,
+        _ => return Err(VerifyError::PageShape),
+    };
+    let total = rank_hi.saturating_sub(rank_lo);
+    let expected = u64::try_from(limit)
+        .unwrap_or(u64::MAX)
+        .min(total.saturating_sub(offset));
+    let entries = proof.entries();
+    if u64::try_from(entries.len()).unwrap_or(u64::MAX) != expected {
+        return Err(VerifyError::PageShape);
+    }
+    let start = rank_lo.saturating_add(offset);
+    let lo_bytes = lo.as_bytes();
+    let hi_bytes = hi.map(Key::as_bytes);
+    let mut out = Vec::new();
+    let mut previous: Option<Vec<u8>> = None;
+    for (i, path) in entries.iter().enumerate() {
+        let rank = start.saturating_add(u64::try_from(i).unwrap_or(u64::MAX));
+        let (key, entry) = replay_select::<F>(root, rank, path)?;
+        let bytes = key.as_bytes();
+        // Each key must sit in the window and strictly after the last: the slice
+        // is the ordered range page, not an unordered set.
+        if bytes < lo_bytes || hi_bytes.is_some_and(|hi| bytes >= hi) {
+            return Err(VerifyError::PageShape);
+        }
+        if previous.as_deref().is_some_and(|prev| bytes <= prev) {
+            return Err(VerifyError::PageShape);
+        }
+        previous = Some(bytes.to_vec());
+        out.push((key, entry));
+    }
+    Ok(out)
+}
+
+/// Prove a pagination slice over the half-open range `[lo, hi)`: skip `offset`
+/// keys and return at most `limit`.
+///
+/// The proof is the rank descents bounding the window plus a rank-pinned select
+/// descent for each returned key, so paging deep costs O(depth * limit). See the
+/// [module](self) trust boundary.
+pub fn prove_page<F, S>(
+    source: &S,
+    root: &ChunkAddress,
+    lo: &Key,
+    hi: &Key,
+    offset: u64,
+    limit: usize,
+) -> Result<PageProof, ProveError>
+where
+    F: Format,
+    S: NodeSource<F>,
+{
+    page_core::<F, S>(source, root, lo, Some(hi), offset, limit)
+}
+
+/// Verify a [`prove_page`] proof over `[lo, hi)`, returning the authenticated
+/// slice.
+///
+/// Rejects a slice whose length, ordering or bounds disagree with the proven
+/// window size ([`VerifyError::PageShape`]), or an on-path count inconsistency.
+pub fn verify_page<F: Format>(
+    root: &ChunkAddress,
+    lo: &Key,
+    hi: &Key,
+    offset: u64,
+    limit: usize,
+    proof: &PageProof,
+) -> Result<Vec<(Key, Entry<F>)>, VerifyError> {
+    verify_page_core::<F>(root, lo, Some(hi), offset, limit, proof)
+}
+
+/// Prove a pagination slice over the keys carrying `prefix`: skip `offset` keys
+/// and return at most `limit`. The empty prefix pages the whole manifest.
+///
+/// See the [module](self) trust boundary.
+pub fn prove_page_prefix<F, S>(
+    source: &S,
+    root: &ChunkAddress,
+    prefix: &Key,
+    offset: u64,
+    limit: usize,
+) -> Result<PageProof, ProveError>
+where
+    F: Format,
+    S: NodeSource<F>,
+{
+    successor(prefix.as_bytes()).map_or_else(
+        || page_core::<F, S>(source, root, prefix, None, offset, limit),
+        |bytes| {
+            page_core::<F, S>(
+                source,
+                root,
+                prefix,
+                Some(&Key::from(bytes.as_slice())),
+                offset,
+                limit,
+            )
+        },
+    )
+}
+
+/// Verify a [`prove_page_prefix`] proof over the keys carrying `prefix`,
+/// returning the authenticated slice.
+pub fn verify_page_prefix<F: Format>(
+    root: &ChunkAddress,
+    prefix: &Key,
+    offset: u64,
+    limit: usize,
+    proof: &PageProof,
+) -> Result<Vec<(Key, Entry<F>)>, VerifyError> {
+    successor(prefix.as_bytes()).map_or_else(
+        || verify_page_core::<F>(root, prefix, None, offset, limit, proof),
+        |bytes| {
+            verify_page_core::<F>(
+                root,
+                prefix,
+                Some(&Key::from(bytes.as_slice())),
+                offset,
+                limit,
+                proof,
+            )
+        },
+    )
+}

--- a/crates/manifest-proof/src/descent.rs
+++ b/crates/manifest-proof/src/descent.rs
@@ -11,28 +11,28 @@
 //! (spec 6.2): an authenticated node's fork set is complete and edges maximal,
 //! so the index entry for a byte is the whole story for that byte.
 
-use nectar_manifest::{Entry, Format, InlineValue};
+use nectar_manifest::{CountError, Entry, Format, InlineValue};
 use nectar_primitives::wire::{Cursor, Underrun};
 use nectar_primitives::{ChunkAddress, ChunkRef, EncryptedChunkRef};
 
 /// Flags-byte facts of the node body grammar (spec 5.1). Restated here because
 /// they are wire structure, not a tunable the manifest crate exports.
-mod flag {
+pub(crate) mod flag {
     /// Bits 0-1: the entry presence and width discriminant.
-    pub(super) const ENTRY_MASK: u8 = 0b0000_0011;
+    pub(crate) const ENTRY_MASK: u8 = 0b0000_0011;
     /// Bits 2-3: the child presence and width discriminant.
-    pub(super) const CHILD_MASK: u8 = 0b0000_1100;
+    pub(crate) const CHILD_MASK: u8 = 0b0000_1100;
     /// Bit 4: a metadata block follows.
-    pub(super) const HAS_META: u8 = 0b0001_0000;
+    pub(crate) const HAS_META: u8 = 0b0001_0000;
     /// Bit 5: the fork table is a segment directory.
-    pub(super) const SEGMENTED: u8 = 0b0010_0000;
+    pub(crate) const SEGMENTED: u8 = 0b0010_0000;
     /// Bit 6: the body is a segment, not a node.
-    pub(super) const SEGMENT: u8 = 0b0100_0000;
+    pub(crate) const SEGMENT: u8 = 0b0100_0000;
 }
 
 /// A two-bit reference/value width discriminant.
 #[derive(Clone, Copy)]
-enum Width {
+pub(crate) enum Width {
     /// Absent field.
     None,
     /// A plain 32-byte reference.
@@ -44,7 +44,7 @@ enum Width {
 }
 
 /// The entry-position (bits 0-1) width of a flags byte.
-const fn entry_width(flags: u8) -> Width {
+pub(crate) const fn entry_width(flags: u8) -> Width {
     match flags & flag::ENTRY_MASK {
         0b01 => Width::Ref32,
         0b10 => Width::Ref64,
@@ -54,7 +54,7 @@ const fn entry_width(flags: u8) -> Width {
 }
 
 /// The child-position (bits 2-3) width of a flags byte.
-const fn child_width(flags: u8) -> Width {
+pub(crate) const fn child_width(flags: u8) -> Width {
     match flags & flag::CHILD_MASK {
         0b0100 => Width::Ref32,
         0b1000 => Width::Ref64,
@@ -84,6 +84,9 @@ pub enum DescentError {
     /// An inline value longer than the format admits.
     #[error("inline value over the format bound")]
     ValueTooLong,
+    /// A malformed subtree count on a counted-profile fork or descriptor.
+    #[error(transparent)]
+    Count(#[from] CountError),
 }
 
 /// Where the descent through one node lands for the key.
@@ -110,7 +113,7 @@ fn seek(bytes: &[u8], offset: usize) -> Result<Cursor<'_>, Underrun> {
 
 /// The little-endian u16 the node grammar uses for every count, offset and
 /// length, widened for arithmetic.
-fn take_u16(cur: &mut Cursor<'_>) -> Result<usize, Underrun> {
+pub(crate) fn take_u16(cur: &mut Cursor<'_>) -> Result<usize, Underrun> {
     cur.take::<[u8; 2]>()
         .map(|b| usize::from(u16::from_le_bytes(b)))
 }
@@ -128,7 +131,7 @@ fn bump(reached: &mut usize, to: usize) {
 /// Read a width-tagged reference or value, advancing past it. Returns the value
 /// only when the caller may terminate on it; the bytes are consumed regardless
 /// so the cursor lands on whatever follows.
-fn take_value<F: Format>(
+pub(crate) fn take_value<F: Format>(
     cur: &mut Cursor<'_>,
     width: Width,
 ) -> Result<Option<Entry<F>>, DescentError> {

--- a/crates/manifest-proof/src/error.rs
+++ b/crates/manifest-proof/src/error.rs
@@ -33,6 +33,9 @@ pub enum ProveError {
     /// An exclusion proof was asked for a present key.
     #[error("key is present")]
     NotAbsent,
+    /// A select proof was asked for an index at or past the key count.
+    #[error("index is past the key count")]
+    IndexOutOfRange,
 }
 
 /// A proof-verification failure. A rejected proof always fails here rather than
@@ -74,4 +77,15 @@ pub enum VerifyError {
     /// The range spans an encrypted subtree the plain walk cannot enumerate.
     #[error("range reaches an encrypted subtree")]
     Encrypted,
+    /// A parent-asserted `child_count` did not equal the child node's derived
+    /// total: an on-path count inconsistency the counted proofs reject.
+    #[error("child_count does not match the child's derived total")]
+    CountMismatch,
+    /// A select or page descent resolved an index past the key count.
+    #[error("index is past the key count")]
+    IndexOutOfRange,
+    /// A page slice's length, ordering or bounds disagreed with the proven
+    /// window size.
+    #[error("page slice does not match the proven window")]
+    PageShape,
 }

--- a/crates/manifest-proof/src/lib.rs
+++ b/crates/manifest-proof/src/lib.rs
@@ -29,6 +29,16 @@
 //! attests one key changed between two roots - an insertion, or its deletion and
 //! update duals - as its state under each root.
 //!
+//! A further family rides the authenticated subtree counts the node grammar
+//! carries: [`prove_rank`],
+//! [`prove_count`], [`prove_select`] and [`prove_page`] answer order-statistic
+//! questions in O(depth). These assume an HONEST BUILDER: a referenced child's
+//! count is author-asserted, bound to its parent chunk but not to the child's
+//! real subtree, so a counted proof establishes the count as committed by the
+//! root, not against an adversarial root. The strictly trustless answers ride
+//! the count-independent inclusion, exclusion and range-completeness proofs. See
+//! the [`prove_count`] trust-boundary notes for the full statement.
+//!
 //! The model is generic over [`Format`](nectar_manifest::Format) and defaults to
 //! the frozen `V1` plaintext layout.
 
@@ -45,6 +55,7 @@
     )
 )]
 
+mod counted;
 mod descent;
 mod error;
 mod proof;
@@ -53,6 +64,11 @@ mod range;
 mod transition;
 mod verify;
 
+pub use counted::{
+    CountProof, CountedPath, PageProof, RankProof, SelectProof, prove_count, prove_page,
+    prove_page_prefix, prove_rank, prove_select, verify_count, verify_page, verify_page_prefix,
+    verify_rank, verify_select,
+};
 pub use descent::DescentError;
 pub use error::{ProveError, VerifyError};
 pub use proof::{ForkPathProof, Granularity, PathStep, Verdict};

--- a/crates/manifest-proof/tests/counted.rs
+++ b/crates/manifest-proof/tests/counted.rs
@@ -1,0 +1,513 @@
+//! Authenticated rank, count, select and pagination proofs, checked against
+//! the streaming reader as the oracle. Tests report
+//! failures as errors rather than panicking, so the runtime-safety lints hold in
+//! test code too.
+//!
+//! Counted proofs are honest-builder sound: the oracle here builds honest
+//! manifests, so a proof must agree with it, and a hand-inflated on-path count
+//! must be rejected by the cross-check.
+
+use std::collections::BTreeMap;
+use std::error::Error;
+
+use futures::executor::block_on;
+use nectar_manifest::{Builder, Child, Entry, ForkTable, Key, Node, Reader, V1};
+use nectar_manifest_proof::{
+    CountedPath, PageProof, RankProof, VerifyError, prove_count, prove_page, prove_page_prefix,
+    prove_rank, prove_select, verify_count, verify_page, verify_page_prefix, verify_rank,
+    verify_select,
+};
+use nectar_primitives::store::{ChunkGet, MemoryStore};
+use nectar_primitives::{ChunkAddress, ChunkOps, ChunkRef, ContentChunk, DEFAULT_BODY_SIZE};
+use proptest::prelude::*;
+
+type TestResult = Result<(), Box<dyn Error>>;
+type Map = BTreeMap<ChunkAddress, Node<V1>>;
+type Listing = Vec<(Key, Entry<V1>)>;
+
+/// A `usize` widened to the `u64` the rank API speaks, saturating rather than
+/// wrapping so the runtime-safety lints stay green in test code.
+fn as_u64(value: usize) -> u64 {
+    u64::try_from(value).unwrap_or(u64::MAX)
+}
+
+/// A fallible assertion.
+fn ensure(cond: bool, what: &str) -> TestResult {
+    if cond { Ok(()) } else { Err(what.into()) }
+}
+
+/// A fallible equality assertion.
+fn ensure_eq<T: PartialEq + core::fmt::Debug>(left: &T, right: &T, what: &str) -> TestResult {
+    if left == right {
+        Ok(())
+    } else {
+        Err(format!("{what}: {left:?} != {right:?}").into())
+    }
+}
+
+/// A ref32 entry keyed on a value byte, distinct per value so equality is
+/// meaningful.
+fn entry(byte: u8) -> Entry<V1> {
+    ChunkRef::new(ChunkAddress::new([byte; 32])).into()
+}
+
+/// Build a counted manifest from `pairs` into a fresh store and return its root
+/// plus a map of every plain node reachable from the root. `None` when a node
+/// spilled (out of scope here).
+fn build(pairs: &[(Vec<u8>, u8)]) -> Option<(MemoryStore, ChunkAddress, Map)> {
+    let store = MemoryStore::default();
+    let mut builder = Builder::<V1>::new();
+    for (key, value) in pairs {
+        builder.insert(Key::from(key.as_slice()), entry(*value), None);
+    }
+    let built = block_on(builder.build(&store)).ok()?;
+    let root = *built.root();
+    let mut map = Map::new();
+    collect(&store, &root, &mut map)?;
+    Some((store, root, map))
+}
+
+/// Fetch and decode the node at `address`, recording it and every plain child it
+/// references. `None` on a spilled node.
+fn collect(store: &MemoryStore, address: &ChunkAddress, map: &mut Map) -> Option<()> {
+    if map.contains_key(address) {
+        return Some(());
+    }
+    let chunk = block_on(ChunkGet::get(store, address)).ok()?;
+    let node = Node::<V1>::decode(chunk.envelope().data()).ok()?;
+    map.insert(*address, node.clone());
+    let mut children = Vec::new();
+    gather(node.forks(), &mut children);
+    for child in children {
+        collect(store, &child, map)?;
+    }
+    Some(())
+}
+
+/// Append every referenced child address under `table`, descending embedded
+/// tables in place.
+fn gather(table: &ForkTable<V1>, out: &mut Vec<ChunkAddress>) {
+    for (_, record) in table.iter() {
+        match record.child() {
+            Some(Child::Ref32(reference)) => out.push(*reference.address()),
+            Some(Child::Embedded(inner)) => gather(inner, out),
+            _ => {}
+        }
+    }
+}
+
+/// A source closure over a node map.
+fn source(map: &Map) -> impl Fn(&ChunkAddress) -> Option<Node<V1>> + '_ {
+    move |address: &ChunkAddress| map.get(address).cloned()
+}
+
+/// The reader over a store, the oracle every proof must agree with.
+const fn reader(store: &MemoryStore) -> Reader<&MemoryStore, V1> {
+    Reader::new(store)
+}
+
+/// The reader's whole ordered listing, the ground truth for select and page.
+fn listing(store: &MemoryStore, root: &ChunkAddress) -> Result<Listing, Box<dyn Error>> {
+    let reader = reader(store);
+    let mut cursor = block_on(reader.range(root, &Key::empty(), &Key::from(&[0xFFu8; 8][..])))?;
+    let mut out = Vec::new();
+    while let Some(pair) = block_on(cursor.next())? {
+        out.push(pair);
+    }
+    Ok(out)
+}
+
+/// Every rank probe verifies against the reader, and count over a window is the
+/// difference of the two.
+fn check_rank_and_count(
+    store: &MemoryStore,
+    root: &ChunkAddress,
+    map: &Map,
+    probes: &[&[u8]],
+) -> TestResult {
+    let reader = reader(store);
+    let src = source(map);
+    for probe in probes {
+        let key = Key::from(*probe);
+        let want = block_on(reader.rank(root, &key))?;
+        let proof = prove_rank::<V1, _>(&src, root, &key)?;
+        ensure_eq(&verify_rank::<V1>(root, &key, &proof)?, &want, "rank")?;
+    }
+    // Count over each ordered pair of probes matches rank(hi) - rank(lo).
+    for lo in probes {
+        for hi in probes {
+            let lo = Key::from(*lo);
+            let hi = Key::from(*hi);
+            let want = block_on(reader.count(root, &lo, &hi))?;
+            let proof = prove_count::<V1, _>(&src, root, &lo, &hi)?;
+            ensure_eq(&verify_count::<V1>(root, &lo, &hi, &proof)?, &want, "count")?;
+        }
+    }
+    Ok(())
+}
+
+/// Every in-range index selects the reader's key, and an out-of-range index is
+/// refused a proof.
+fn check_select(store: &MemoryStore, root: &ChunkAddress, map: &Map) -> TestResult {
+    let reader = reader(store);
+    let src = source(map);
+    let total = listing(store, root)?.len();
+    for index in 0..total {
+        let idx = as_u64(index);
+        let want = block_on(reader.select(root, idx))?.ok_or("reader select gap")?;
+        let proof = prove_select::<V1, _>(&src, root, idx)?;
+        ensure_eq(&verify_select::<V1>(root, idx, &proof)?, &want, "select")?;
+    }
+    // The first index past the last key has no proof.
+    ensure(
+        prove_select::<V1, _>(&src, root, as_u64(total)).is_err(),
+        "an out-of-range index must not admit a select proof",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn rank_count_and_select_agree_with_the_reader() -> TestResult {
+    let pairs = vec![
+        (b"about".to_vec(), 0xD4),
+        (b"about/team".to_vec(), 0xE5),
+        (b"img/icon.svg".to_vec(), 0xC3),
+        (b"img/logo.png".to_vec(), 0xB2),
+        (b"index.html".to_vec(), 0xA1),
+    ];
+    let (store, root, map) = build(&pairs).ok_or("unexpected spill")?;
+    check_rank_and_count(
+        &store,
+        &root,
+        &map,
+        &[
+            &b""[..],
+            &b"about"[..],
+            &b"about/team"[..],
+            &b"img/"[..],
+            &b"index.html"[..],
+            &b"zzz"[..],
+        ],
+    )?;
+    check_select(&store, &root, &map)?;
+    Ok(())
+}
+
+#[test]
+fn a_root_entry_leads_the_ordering() -> TestResult {
+    // An empty key rides in the root extension: it is select index zero and lifts
+    // every other rank by one.
+    let pairs = vec![
+        (b"".to_vec(), 0x99),
+        (b"a".to_vec(), 0x11),
+        (b"b".to_vec(), 0x22),
+    ];
+    let (store, root, map) = build(&pairs).ok_or("unexpected spill")?;
+    let reader = reader(&store);
+    let src = source(&map);
+
+    let proof = prove_select::<V1, _>(&src, &root, 0)?;
+    ensure_eq(
+        &verify_select::<V1>(&root, 0, &proof)?,
+        &(Key::empty(), entry(0x99)),
+        "root entry is index zero",
+    )?;
+    for key in [&b""[..], &b"a"[..], &b"b"[..], &b"c"[..]] {
+        let key = Key::from(key);
+        let proof = prove_rank::<V1, _>(&src, &root, &key)?;
+        ensure_eq(
+            &verify_rank::<V1>(&root, &key, &proof)?,
+            &block_on(reader.rank(&root, &key))?,
+            "rank with a root entry",
+        )?;
+    }
+    check_select(&store, &root, &map)?;
+    Ok(())
+}
+
+#[test]
+fn a_referenced_child_yields_a_multi_node_descent() -> TestResult {
+    // Keys under one leading byte, enough that the shared subtree spills to its
+    // own chunk, so a rank descent crosses a referenced hop.
+    let pairs: Vec<(Vec<u8>, u8)> = (0u8..55).map(|i| (vec![b'a', i], i)).collect();
+    let (store, root, map) = build(&pairs).ok_or("unexpected spill")?;
+    let src = source(&map);
+
+    let key = Key::from(&[b'a', 5][..]);
+    let proof = prove_rank::<V1, _>(&src, &root, &key)?;
+    ensure(
+        proof.path().len() >= 2,
+        "a referenced child must yield a path of at least two nodes",
+    )?;
+    let reader = reader(&store);
+    ensure_eq(
+        &verify_rank::<V1>(&root, &key, &proof)?,
+        &block_on(reader.rank(&root, &key))?,
+        "rank across a referenced hop",
+    )?;
+    check_select(&store, &root, &map)?;
+    Ok(())
+}
+
+/// The content address of a node payload.
+fn address_of(payload: &[u8]) -> Result<ChunkAddress, Box<dyn Error>> {
+    let chunk = ContentChunk::<DEFAULT_BODY_SIZE>::new(payload.to_vec())?;
+    Ok(*chunk.address())
+}
+
+#[test]
+fn an_on_path_count_inconsistency_is_rejected() -> TestResult {
+    // A root whose single fork references the whole subtree: its trailing
+    // child_count is the final payload byte. Inflating it past the child's real
+    // total and re-addressing the root leaves the referenced child unchanged, so
+    // the descent fetches it and the cross-check catches the lie.
+    let pairs: Vec<(Vec<u8>, u8)> = (0u8..55).map(|i| (vec![b'a', i], i)).collect();
+    let (_store, root, map) = build(&pairs).ok_or("unexpected spill")?;
+    let src = source(&map);
+    let key = Key::from(&[b'a', 5][..]);
+
+    let honest = prove_rank::<V1, _>(&src, &root, &key)?;
+    let mut nodes: Vec<Vec<u8>> = honest.path().nodes().to_vec();
+    ensure(nodes.len() >= 2, "the descent must reach the child")?;
+
+    // The honest child_count is 55 keys, a single trailing byte; bump it.
+    let root_bytes = nodes.first_mut().ok_or("no root node")?;
+    ensure_eq(
+        &root_bytes.last().copied(),
+        &Some(55u8),
+        "the trailing byte is the subtree count",
+    )?;
+    if let Some(byte) = root_bytes.last_mut() {
+        *byte = 100;
+    }
+    let inflated_root = address_of(root_bytes)?;
+    let tampered = RankProof::new(CountedPath::new(nodes));
+
+    ensure(
+        matches!(
+            verify_rank::<V1>(&inflated_root, &key, &tampered),
+            Err(VerifyError::CountMismatch)
+        ),
+        "an inflated on-path count must be rejected by the cross-check",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn a_tampered_or_wrong_root_rank_proof_is_rejected() -> TestResult {
+    let pairs: Vec<(Vec<u8>, u8)> = (0u8..55).map(|i| (vec![b'a', i], i)).collect();
+    let (_store, root, map) = build(&pairs).ok_or("unexpected spill")?;
+    let src = source(&map);
+    let key = Key::from(&[b'a', 5][..]);
+    let proof = prove_rank::<V1, _>(&src, &root, &key)?;
+
+    // A byte flipped in the intermediate node breaks its authentication.
+    let mut nodes: Vec<Vec<u8>> = proof.path().nodes().to_vec();
+    if let Some(child) = nodes.get_mut(1)
+        && let Some(byte) = child.last_mut()
+    {
+        *byte ^= 0xFF;
+    }
+    ensure(
+        verify_rank::<V1>(&root, &key, &RankProof::new(CountedPath::new(nodes))).is_err(),
+        "a tampered node must be rejected",
+    )?;
+    // A wrong root breaks the very first hop.
+    ensure(
+        verify_rank::<V1>(&ChunkAddress::new([0x99; 32]), &key, &proof).is_err(),
+        "a wrong root must be rejected",
+    )?;
+    Ok(())
+}
+
+/// Collect a reader page over `[lo, hi)`.
+fn page_oracle(
+    store: &MemoryStore,
+    root: &ChunkAddress,
+    lo: &Key,
+    hi: &Key,
+    offset: u64,
+    limit: usize,
+) -> Result<Listing, Box<dyn Error>> {
+    let reader = reader(store);
+    let mut cursor = block_on(reader.paginate(root, lo, hi, offset, limit))?;
+    let mut out = Vec::new();
+    while let Some(pair) = block_on(cursor.next())? {
+        out.push(pair);
+    }
+    Ok(out)
+}
+
+/// Collect a reader prefix page.
+fn prefix_oracle(
+    store: &MemoryStore,
+    root: &ChunkAddress,
+    prefix: &Key,
+    offset: u64,
+    limit: usize,
+) -> Result<Listing, Box<dyn Error>> {
+    let reader = reader(store);
+    let mut cursor = block_on(reader.paginate_prefix(root, prefix, offset, limit))?;
+    let mut out = Vec::new();
+    while let Some(pair) = block_on(cursor.next())? {
+        out.push(pair);
+    }
+    Ok(out)
+}
+
+#[test]
+fn page_proofs_match_the_true_slice() -> TestResult {
+    let pairs: Vec<(Vec<u8>, u8)> = (0u8..60)
+        .map(|i| (vec![b'a', i], i))
+        .chain((0u8..60).map(|i| (vec![b'b', i], 100u8.wrapping_add(i))))
+        .collect();
+    let (store, root, map) = build(&pairs).ok_or("unexpected spill")?;
+    let src = source(&map);
+
+    // Range pages: whole window and sub-windows, at several offsets and limits.
+    let lo = Key::from(&b""[..]);
+    let hi = Key::from(&[0xFFu8; 8][..]);
+    for (offset, limit) in [(0u64, 5usize), (10, 7), (50, 20), (119, 4), (200, 3)] {
+        let want = page_oracle(&store, &root, &lo, &hi, offset, limit)?;
+        let proof = prove_page::<V1, _>(&src, &root, &lo, &hi, offset, limit)?;
+        ensure_eq(
+            &verify_page::<V1>(&root, &lo, &hi, offset, limit, &proof)?,
+            &want,
+            "range page",
+        )?;
+    }
+
+    // A bounded sub-window that starts and ends inside the key set.
+    let sub_lo = Key::from(&[b'a', 10][..]);
+    let sub_hi = Key::from(&[b'b', 20][..]);
+    for (offset, limit) in [(0u64, 8usize), (30, 10), (70, 5)] {
+        let want = page_oracle(&store, &root, &sub_lo, &sub_hi, offset, limit)?;
+        let proof = prove_page::<V1, _>(&src, &root, &sub_lo, &sub_hi, offset, limit)?;
+        ensure_eq(
+            &verify_page::<V1>(&root, &sub_lo, &sub_hi, offset, limit, &proof)?,
+            &want,
+            "sub-window page",
+        )?;
+    }
+
+    // Prefix pages, including the whole-manifest empty prefix (unbounded above)
+    // and a single-letter prefix (bounded by its successor).
+    for prefix in [&b""[..], &b"a"[..], &b"b"[..]] {
+        let prefix = Key::from(prefix);
+        for (offset, limit) in [(0u64, 6usize), (25, 9), (100, 4)] {
+            let want = prefix_oracle(&store, &root, &prefix, offset, limit)?;
+            let proof = prove_page_prefix::<V1, _>(&src, &root, &prefix, offset, limit)?;
+            ensure_eq(
+                &verify_page_prefix::<V1>(&root, &prefix, offset, limit, &proof)?,
+                &want,
+                "prefix page",
+            )?;
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn a_page_with_a_dropped_entry_is_rejected() -> TestResult {
+    let pairs: Vec<(Vec<u8>, u8)> = (0u8..60).map(|i| (vec![b'a', i], i)).collect();
+    let (_store, root, map) = build(&pairs).ok_or("unexpected spill")?;
+    let src = source(&map);
+    let lo = Key::from(&b""[..]);
+    let hi = Key::from(&[0xFFu8; 8][..]);
+
+    let proof = prove_page::<V1, _>(&src, &root, &lo, &hi, 0, 6)?;
+    ensure(
+        proof.entries().len() == 6,
+        "the page proof carries one descent per returned key",
+    )?;
+    // Dropping a returned-key descent leaves fewer entries than the proven window
+    // demands, so the slice no longer matches its length.
+    let kept: Vec<CountedPath> = proof.entries().iter().skip(1).cloned().collect();
+    let short = PageProof::new(proof.lo().clone(), proof.hi().cloned(), kept);
+    ensure(
+        matches!(
+            verify_page::<V1>(&root, &lo, &hi, 0, 6, &short),
+            Err(VerifyError::PageShape)
+        ),
+        "a page missing a returned key must be rejected",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn adversarial_bytes_are_rejected_not_panicked() -> TestResult {
+    // A rank proof over untrusted node bytes must error, never panic or index out
+    // of bounds. Each payload is addressed honestly so authentication passes and
+    // the flattening parser itself faces the hostile bytes.
+    let key = Key::from(&b"anything"[..]);
+    let cases: Vec<Vec<u8>> = vec![
+        vec![],
+        vec![0x6D],
+        vec![0x6D, 0x01],
+        vec![0x6D, 0x01, 0x00],
+        vec![0x6D, 0x01, 0x40],
+        vec![0x6D, 0x01, 0x20],
+        vec![0x6D, 0x01, 0x00, 0x01, 0x00],
+        vec![0x6D, 0x01, 0x00, 0x01, 0x00, 0x61, 0x00, 0x00],
+        vec![0xFF; 4096],
+    ];
+    for bytes in &cases {
+        let root = address_of(bytes)?;
+        let proof = RankProof::new(CountedPath::new(vec![bytes.clone()]));
+        // Either the parse rejects the bytes, or it yields some rank without
+        // panicking; both are acceptable, a panic is not.
+        let _ = verify_rank::<V1>(&root, &key, &proof);
+    }
+    Ok(())
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(48))]
+
+    #[test]
+    fn counted_proofs_agree_with_the_reader(
+        pairs in proptest::collection::vec(
+            (proptest::collection::vec(any::<u8>(), 1..5), any::<u8>()),
+            1..24,
+        ),
+        offset in 0u64..8,
+        limit in 1usize..6,
+    ) {
+        let dedup: BTreeMap<Vec<u8>, u8> = pairs.into_iter().collect();
+        let pairs: Vec<(Vec<u8>, u8)> = dedup.into_iter().collect();
+        if let Some((store, root, map)) = build(&pairs) {
+            let run = || -> TestResult {
+                let src = source(&map);
+                let reader = reader(&store);
+                let keys = listing(&store, &root)?;
+                // Rank and select at every key and one probe past the end.
+                for (index, (key, value)) in keys.iter().enumerate() {
+                    let idx = as_u64(index);
+                    let rank_proof = prove_rank::<V1, _>(&src, &root, key)?;
+                    ensure_eq(
+                        &verify_rank::<V1>(&root, key, &rank_proof)?,
+                        &block_on(reader.rank(&root, key))?,
+                        "rank",
+                    )?;
+                    let select_proof = prove_select::<V1, _>(&src, &root, idx)?;
+                    ensure_eq(
+                        &verify_select::<V1>(&root, idx, &select_proof)?,
+                        &(key.clone(), value.clone()),
+                        "select",
+                    )?;
+                }
+                // A whole-manifest prefix page against the reader.
+                let prefix = Key::empty();
+                let want = prefix_oracle(&store, &root, &prefix, offset, limit)?;
+                let proof = prove_page_prefix::<V1, _>(&src, &root, &prefix, offset, limit)?;
+                ensure_eq(
+                    &verify_page_prefix::<V1>(&root, &prefix, offset, limit, &proof)?,
+                    &want,
+                    "prefix page",
+                )?;
+                Ok(())
+            };
+            run().map_err(|e| TestCaseError::fail(e.to_string()))?;
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds authenticated rank/count/select/pagination proofs over the baseline
counted wire grammar to `nectar-manifest-proof`. These proofs are generic
over `Format` (any manifest, since #307 makes every profile counted), not
scoped to a separate `0x03` profile as originally planned — that profile no
longer exists.

New module `crates/manifest-proof/src/counted.rs` (~1000 lines) provides:

- `prove_rank` / `verify_rank`
- `prove_count` / `verify_count`
- `prove_select` / `verify_select`
- `prove_page` / `verify_page` and `prove_page_prefix` / `verify_page_prefix`

with public types `RankProof`, `CountProof`, `SelectProof`, `PageProof` and
`CountedPath`, all re-exported from `lib.rs`.

A proof is the O(depth) chain of node payloads the count-descent visits, each
content-addressed and chained from the trusted root. Verification re-derives
the answer from the authenticated bytes alone, never trusting a claim carried
in the proof: the flatten parser matches the manifest codec's `ForkRecord`
wire order and reads the trailing `child_count` / `seg_count` via
`wire::Cursor`. `count` is computed as `rank(hi) - rank(lo)` (two rank
descents); `prove_page` carries both bound rank descents plus one rank-pinned
select descent per returned key, so the verifier pins every returned entry to
the counted commitment.

`descent.rs` gains the count-aware descent support these proofs walk, and
`error.rs` adds the new failure modes: `ProveError::IndexOutOfRange`, and
`VerifyError::CountMismatch`, `VerifyError::IndexOutOfRange`,
`VerifyError::PageShape`.

## Why

Closes #303

The count-independent inclusion/exclusion/range-completeness proofs already in
this crate cannot answer order-statistic questions (rank, count, select,
paginated listing) without an O(n) scan. Since the baseline wire now commits
subtree counts at every fork (#307), an O(depth) authenticated descent can
answer these directly over any manifest, not only a separate profile. As
documented in `lib.rs`, this family trusts an HONEST BUILDER: a referenced
child's count is author-asserted and bound to its parent chunk, but not
checked against the child's real subtree, so these proofs establish the count
as committed by the root rather than against an adversarial root. Every hop
the descent does fetch cross-checks the parent-asserted `child_count` against
the child's own derived total and rejects an on-path inconsistency; only the
counts of un-fetched siblings a descent skips remain purely author-asserted.
The strictly trustless answers continue to ride the existing count-independent
proofs.

## Testing

New `tests/counted.rs` (513 lines) covers the rank/count/select/page proof
and verify paths, alongside the existing `tests/compositions.rs` and
`tests/roundtrip.rs` suites.

Full battery run via `nix develop`:

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`:
  clean.
- `cargo nextest run -p nectar-manifest -p nectar-manifest-proof --locked`:
  234 tests run, 234 passed, 0 skipped.
- `cargo test --doc --workspace --locked`: clean.
- A stale-reference sweep at the tip (`counted grammar's trailing`, `counted
  profile`, `tag_version 0x03`) returns zero hits.

## AI Assistance

Implemented with Claude Sonnet 4.5 and adversarially reviewed with Claude Opus 4.5, per the process in [nxm-rs/.github CONTRIBUTING.md](https://github.com/nxm-rs/.github/blob/main/CONTRIBUTING.md). The red-team pass found no real bugs: the flatten parser was checked byte-for-byte against the manifest codec's `ForkRecord` wire order, adversarial input is `Cursor`-gated with no indexing, `unwrap` or `panic`, and the rank/count/select/page algorithms were checked against the independent reader oracle in `order.rs`.