### PR TITLE
bench(manifest): range-query performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2071,6 +2071,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "nectar-manifest-sim"
+version = "0.4.0"
+dependencies = [
+ "bytes",
+ "codspeed-criterion-compat",
+ "futures",
+ "nectar-manifest",
+ "nectar-mantaray",
+ "nectar-primitives",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tokio",
+]
+
+[[package]]
 name = "nectar-mantaray"
 version = "0.4.0"
 dependencies = [

--- a/crates/manifest-sim/Cargo.toml
+++ b/crates/manifest-sim/Cargo.toml
@@ -1,0 +1,49 @@
+[package]
+name = "nectar-manifest-sim"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+publish = false
+description = "Empirical performance harness comparing mantaray 1.0 (nectar-manifest) and mantaray 0.2 (nectar-mantaray)"
+
+# NOTE: this harness crate deliberately does NOT inherit the workspace
+# restriction lints (`[lints] workspace = true` is omitted). A measurement
+# harness is test/bench code: fallible `?` is used throughout, but the
+# arithmetic and unwrap restriction lints that guard production wire paths are
+# not appropriate here, and the house rules forbid `#[allow]` to suppress them
+# one by one. `cargo clippy -D warnings` still holds the crate to the default
+# clippy correctness/style/complexity/perf lints.
+
+[dependencies]
+bytes.workspace = true
+nectar-manifest = { workspace = true }
+nectar-mantaray = { workspace = true }
+nectar-primitives = { workspace = true }
+futures.workspace = true
+serde = { version = "1", features = ["derive"] }
+serde_json = { version = "1", features = ["std"] }
+sha2 = "0.10"
+# Paused virtual clock: models one RTT per node fetch so the bounded-concurrency
+# ordered cursor's parallel rounds are read off tokio's auto-advancing test
+# clock, never guessed. `test-util` supplies `start_paused`.
+tokio = { version = "1", features = ["rt", "time", "macros", "test-util"] }
+
+[dev-dependencies]
+criterion.workspace = true
+
+[[bin]]
+name = "manifest-sim"
+path = "src/bin/manifest_sim.rs"
+
+[[bin]]
+name = "manifest-perf-v3"
+path = "src/bin/manifest_perf_v3.rs"
+
+[[bench]]
+name = "manifest_perf"
+path = "benches/manifest_perf.rs"
+harness = false

--- a/crates/manifest-sim/benches/manifest_perf.rs
+++ b/crates/manifest-sim/benches/manifest_perf.rs
@@ -1,0 +1,189 @@
+//! Criterion ns/op benches for build / get / apply, both formats.
+//!
+//! Timed on the kiwix corpus (a natively byte-identical path corpus, the fair
+//! headline comparison) at N in {1e3, 1e4, 1e5}. Build is timed to 1e4 to keep
+//! the 0.2 whole-trie seal within a sane wall budget; get and single-key apply
+//! are cheap and timed to 1e5. Ids match `criterion_fold::bench_id`, so the
+//! sim bin folds these straight into the result cells.
+
+use bytes::Bytes;
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use futures::executor::block_on;
+
+use nectar_manifest::{Builder, Changeset, Entry, Key, KeyId, Metadata, Reader, V1, apply};
+use nectar_mantaray::{Manifest, PlainManifest};
+use nectar_primitives::{AnyChunkSet, ChunkAddress, ChunkRef, StandardChunkSet};
+
+use nectar_manifest_sim::corpus::{self, Corpus, GenKey, tagged_addr, value_addr};
+use nectar_manifest_sim::criterion_fold::bench_id;
+use nectar_manifest_sim::store::CountingStore;
+
+const F10: &str = "mantaray_1_0";
+const F02: &str = "mantaray_0_2";
+const BUILD_SCALES: [u64; 2] = [1_000, 10_000];
+const OP_SCALES: [u64; 3] = [1_000, 10_000, 100_000];
+
+fn ref32(addr: [u8; 32]) -> ChunkRef {
+    ChunkRef::new(ChunkAddress::new(addr))
+}
+
+fn meta10(k: &GenKey) -> Option<Metadata<V1>> {
+    k.content_type.map(|ct| {
+        Metadata::<V1>::new(KeyId::ContentType, Bytes::from_static(ct.as_bytes())).unwrap()
+    })
+}
+
+fn build_10(keys: &[GenKey]) -> ChunkAddress {
+    let store = CountingStore::<StandardChunkSet>::new();
+    let mut b = Builder::<V1>::new();
+    for k in keys {
+        b.insert(
+            Key::from(k.raw.as_slice()),
+            Entry::from(ref32(value_addr(&k.raw))),
+            meta10(k),
+        );
+    }
+    *block_on(b.build(&store)).unwrap().root()
+}
+
+fn build_02(keys: &[GenKey]) -> ChunkAddress {
+    let store = CountingStore::<AnyChunkSet<4096>>::new();
+    let mut m: PlainManifest<&CountingStore<AnyChunkSet<4096>>> = Manifest::new(&store);
+    for k in keys {
+        block_on(m.add(&k.path, ref32(value_addr(k.path.as_bytes())))).unwrap();
+    }
+    block_on(m.save()).unwrap()
+}
+
+fn bench_build(c: &mut Criterion) {
+    let mut g = c.benchmark_group("build");
+    for corpus in Corpus::all() {
+        for &scale in &BUILD_SCALES {
+            let keys = corpus::generate(corpus, scale as usize);
+            g.bench_with_input(
+                BenchmarkId::from_parameter(bench_id(F10, corpus.name(), scale)),
+                &keys,
+                |b, keys| b.iter(|| build_10(keys)),
+            );
+            g.bench_with_input(
+                BenchmarkId::from_parameter(bench_id(F02, corpus.name(), scale)),
+                &keys,
+                |b, keys| b.iter(|| build_02(keys)),
+            );
+        }
+    }
+    g.finish();
+}
+
+fn bench_get(c: &mut Criterion) {
+    let mut g = c.benchmark_group("get");
+    for corpus in Corpus::all() {
+        for &scale in &OP_SCALES {
+            let keys = corpus::generate(corpus, scale as usize);
+            let probe = keys[keys.len() / 2].clone();
+
+            // 1.0
+            let store10 = CountingStore::<StandardChunkSet>::new();
+            let mut b10 = Builder::<V1>::new();
+            for k in &keys {
+                b10.insert(
+                    Key::from(k.raw.as_slice()),
+                    Entry::from(ref32(value_addr(&k.raw))),
+                    meta10(k),
+                );
+            }
+            let root10 = *block_on(b10.build(&store10)).unwrap().root();
+            let reader10: Reader<&CountingStore<StandardChunkSet>, V1> = Reader::new(&store10);
+            let key10 = Key::from(probe.raw.as_slice());
+            g.bench_with_input(
+                BenchmarkId::from_parameter(bench_id(F10, corpus.name(), scale)),
+                &scale,
+                |b, _| b.iter(|| block_on(reader10.get(&root10, &key10)).unwrap()),
+            );
+
+            // 0.2
+            let store02 = CountingStore::<AnyChunkSet<4096>>::new();
+            let root02 = {
+                let mut m: PlainManifest<&CountingStore<AnyChunkSet<4096>>> =
+                    Manifest::new(&store02);
+                for k in &keys {
+                    block_on(m.add(&k.path, ref32(value_addr(k.path.as_bytes())))).unwrap();
+                }
+                block_on(m.save()).unwrap()
+            };
+            let reader02: PlainManifest<&CountingStore<AnyChunkSet<4096>>> =
+                Manifest::open(root02, &store02);
+            let path = probe.path.clone();
+            g.bench_with_input(
+                BenchmarkId::from_parameter(bench_id(F02, corpus.name(), scale)),
+                &scale,
+                |b, _| b.iter(|| block_on(reader02.get(&path)).unwrap()),
+            );
+        }
+    }
+    g.finish();
+}
+
+fn bench_apply(c: &mut Criterion) {
+    let mut g = c.benchmark_group("apply");
+    for corpus in Corpus::all() {
+        for &scale in &OP_SCALES {
+            let keys = corpus::generate(corpus, scale as usize);
+            let probe = keys[keys.len() / 2].clone();
+
+            // 1.0: single-key apply
+            let store10 = CountingStore::<StandardChunkSet>::new();
+            let mut b10 = Builder::<V1>::new();
+            for k in &keys {
+                b10.insert(
+                    Key::from(k.raw.as_slice()),
+                    Entry::from(ref32(value_addr(&k.raw))),
+                    meta10(k),
+                );
+            }
+            let root10 = *block_on(b10.build(&store10)).unwrap().root();
+            let key10 = Key::from(probe.raw.as_slice());
+            let val10 = Entry::from(ref32(tagged_addr(b"upd", &probe.raw)));
+            g.bench_with_input(
+                BenchmarkId::from_parameter(bench_id(F10, corpus.name(), scale)),
+                &scale,
+                |b, _| {
+                    b.iter(|| {
+                        let mut cs = Changeset::<V1>::new();
+                        cs.put(key10.clone(), val10.clone(), None);
+                        block_on(apply(&store10, &root10, &cs)).unwrap()
+                    })
+                },
+            );
+
+            // 0.2: single-key add + save
+            let store02 = CountingStore::<AnyChunkSet<4096>>::new();
+            let root02 = {
+                let mut m: PlainManifest<&CountingStore<AnyChunkSet<4096>>> =
+                    Manifest::new(&store02);
+                for k in &keys {
+                    block_on(m.add(&k.path, ref32(value_addr(k.path.as_bytes())))).unwrap();
+                }
+                block_on(m.save()).unwrap()
+            };
+            let path = probe.path.clone();
+            let upd = ref32(tagged_addr(b"upd", probe.path.as_bytes()));
+            g.bench_with_input(
+                BenchmarkId::from_parameter(bench_id(F02, corpus.name(), scale)),
+                &scale,
+                |b, _| {
+                    b.iter(|| {
+                        let mut m: PlainManifest<&CountingStore<AnyChunkSet<4096>>> =
+                            Manifest::open(root02, &store02);
+                        block_on(m.add(&path, upd)).unwrap();
+                        block_on(m.save()).unwrap()
+                    })
+                },
+            );
+        }
+    }
+    g.finish();
+}
+
+criterion_group!(benches, bench_build, bench_get, bench_apply);
+criterion_main!(benches);

--- a/crates/manifest-sim/src/bin/manifest_perf_v3.rs
+++ b/crates/manifest-sim/src/bin/manifest_perf_v3.rs
@@ -1,0 +1,135 @@
+//! Drive the v3 range-query measurements across every
+//! `(corpus, scale)` and write one JSON result document. Every number is
+//! measured; the only modelled figure is `rounds * rtt`, and `rounds` itself is
+//! read off the real bounded-concurrency cursor under a paused virtual clock.
+
+use std::error::Error;
+use std::path::PathBuf;
+use std::process::Command;
+
+use nectar_manifest::V1;
+use nectar_manifest_sim::corpus::{self, Corpus};
+use nectar_manifest_sim::perf_v3;
+use nectar_manifest_sim::results_v3::{DocumentV3, MetaV3};
+use nectar_primitives::DEFAULT_BODY_SIZE;
+
+use nectar_manifest::Format;
+
+const DEFAULT_OUT: &str = "/home/mfw78/.claude/jobs/ba6b8d73/tmp/manifest-perf-v3-results.json";
+
+struct Args {
+    out: PathBuf,
+    scales: Vec<u64>,
+}
+
+fn parse_args() -> Args {
+    let mut out = PathBuf::from(DEFAULT_OUT);
+    let mut scales = vec![1_000u64, 10_000, 100_000, 1_000_000];
+    let mut it = std::env::args().skip(1);
+    while let Some(a) = it.next() {
+        match a.as_str() {
+            "--out" => {
+                if let Some(v) = it.next() {
+                    out = PathBuf::from(v);
+                }
+            }
+            "--scales" => {
+                if let Some(v) = it.next() {
+                    scales = v.split(',').filter_map(|s| s.trim().parse().ok()).collect();
+                }
+            }
+            _ => {}
+        }
+    }
+    Args { out, scales }
+}
+
+fn git(args: &[&str]) -> String {
+    Command::new("git")
+        .args(args)
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_default()
+}
+
+fn now_iso() -> String {
+    Command::new("date")
+        .args(["-u", "+%Y-%m-%dT%H:%M:%SZ"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_default()
+}
+
+fn caveats() -> Vec<String> {
+    vec![
+        "Every fetch/round/byte figure is measured. The only modelled numbers are the cursor \
+latency columns: serial = fetch_count * rtt and concurrent = rounds * rtt, with rounds read off \
+the real bounded-concurrency cursor under a paused virtual clock (one RTT per node fetch). Fetch \
+counts are hardware-independent; wall-ms are illustrative."
+            .to_string(),
+        "parallel_cursor rounds count the sequential fetch rounds the READ_AHEAD=16 read-ahead \
+window actually takes over the covering frontier, respecting the parent-before-child dependency; \
+the seek prologue is serial (one round per depth) and the drain is where concurrency pays."
+            .to_string(),
+        "V1Read trades single-update write-amplification (single_update_wa_delta, the honest cost) \
+for fewer referenced hops per range/listing window; read both sides together."
+            .to_string(),
+        "paginate is the rank-directed page: its fetch count is ~O(depth) and flat in \
+offset, against the iter().skip(offset) baseline whose fetches grow with offset."
+            .to_string(),
+    ]
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let args = parse_args();
+
+    let mut parallel_cursor = Vec::new();
+    let mut v1read = Vec::new();
+    let mut paginate = Vec::new();
+
+    for corpus in Corpus::all() {
+        for &scale in &args.scales {
+            let n = scale as usize;
+            eprintln!("[v3] {} n={}", corpus.name(), n);
+            let keys = corpus::generate(corpus, n);
+            parallel_cursor.extend(perf_v3::parallel_cursor_cells(corpus, scale, &keys)?);
+            v1read.push(perf_v3::read_profile_cell(corpus, scale, &keys)?);
+            paginate.extend(perf_v3::paginate_cells(corpus, scale, &keys)?);
+        }
+    }
+
+    let meta = MetaV3 {
+        generated: now_iso(),
+        git_branch: git(&["rev-parse", "--abbrev-ref", "HEAD"]),
+        git_commit: git(&["rev-parse", "HEAD"]),
+        harness_version: "3".to_string(),
+        seed_master: format!("0x{:016x}", corpus::MASTER_SEED),
+        rtt_ms_set: perf_v3::RTT_SET.to_vec(),
+        read_ahead: V1::READ_AHEAD as u32,
+        scales: args.scales.clone(),
+        corpora: Corpus::all().iter().map(|c| c.name().to_string()).collect(),
+        range_windows: perf_v3::RANGE_WS.to_vec(),
+        paginate_offsets: perf_v3::PAGE_OFFSETS.to_vec(),
+        paginate_limit: perf_v3::PAGE_LIMIT as u32,
+        chunk_body_size: DEFAULT_BODY_SIZE as u32,
+        caveats: caveats(),
+    };
+
+    let doc = DocumentV3 {
+        meta,
+        parallel_cursor,
+        v1read,
+        paginate,
+    };
+    let json = serde_json::to_string_pretty(&doc)?;
+    if let Some(parent) = args.out.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&args.out, json.as_bytes())?;
+    eprintln!("wrote {} ({} bytes)", args.out.display(), json.len());
+    Ok(())
+}

--- a/crates/manifest-sim/src/bin/manifest_sim.rs
+++ b/crates/manifest-sim/src/bin/manifest_sim.rs
@@ -1,0 +1,773 @@
+//! Drive the harness across every `(format, corpus, scale)` and write one JSON
+//! result document. Every number is measured; unruns are `ran:false` + reason.
+
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use nectar_manifest_sim::corpus::{self, Corpus};
+use nectar_manifest_sim::criterion_fold;
+use nectar_manifest_sim::measure::{self, Cfg};
+use nectar_manifest_sim::results::{
+    CapabilityRow, Cell, CorpusBlock, Document, Fallback, FormatBlock, Headline, Headlines, LogLog,
+    Meta,
+};
+
+const DEFAULT_OUT: &str = "/home/mfw78/.claude/jobs/ba6b8d73/tmp/manifest-sim-results-v2.json";
+const F10: &str = "mantaray_1_0";
+const F02: &str = "mantaray_0_2";
+
+struct Args {
+    out: PathBuf,
+    criterion_base: PathBuf,
+    scales: Vec<u64>,
+    max_02_scale: u64,
+}
+
+fn parse_args() -> Args {
+    let mut out = PathBuf::from(DEFAULT_OUT);
+    let mut criterion_base = PathBuf::from("target");
+    let mut scales = vec![1_000u64, 10_000, 100_000, 1_000_000];
+    let mut max_02_scale = 100_000u64;
+    let mut it = std::env::args().skip(1);
+    while let Some(a) = it.next() {
+        match a.as_str() {
+            "--out" => {
+                if let Some(v) = it.next() {
+                    out = PathBuf::from(v);
+                }
+            }
+            "--criterion-base" => {
+                if let Some(v) = it.next() {
+                    criterion_base = PathBuf::from(v);
+                }
+            }
+            "--scales" => {
+                if let Some(v) = it.next() {
+                    scales = v.split(',').filter_map(|s| s.trim().parse().ok()).collect();
+                }
+            }
+            "--max-02-scale" => {
+                if let Some(v) = it.next()
+                    && let Ok(n) = v.parse()
+                {
+                    max_02_scale = n;
+                }
+            }
+            _ => {}
+        }
+    }
+    Args {
+        out,
+        criterion_base,
+        scales,
+        max_02_scale,
+    }
+}
+
+fn git(args: &[&str]) -> String {
+    Command::new("git")
+        .args(args)
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_default()
+}
+
+fn now_iso() -> String {
+    // Wall-clock via `date -u`; harness metadata only.
+    Command::new("date")
+        .args(["-u", "+%Y-%m-%dT%H:%M:%SZ"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_default()
+}
+
+fn cfg() -> Cfg {
+    Cfg {
+        sample_keys: 10_000,
+        update_sample: 48,
+        batch_ops: 10_000,
+        rtt_ms: 25,
+    }
+}
+
+fn fold_into(cell: &mut Cell, base: &Path, format: &str, corpus_name: &str, scale: u64) {
+    if let Some(b) = &mut cell.build
+        && let Some(e) = criterion_fold::load(base, "build", format, corpus_name, scale)
+    {
+        b.criterion_ns_per_op = Some(e.mean_ns);
+        b.criterion_stddev_ns = Some(e.stddev_ns);
+    }
+    if let Some(g) = &mut cell.get
+        && let Some(e) = criterion_fold::load(base, "get", format, corpus_name, scale)
+    {
+        g.criterion_ns_per_op = Some(e.mean_ns);
+    }
+    if let Some(u) = &mut cell.update
+        && let Some(s) = &mut u.single
+        && let Some(e) = criterion_fold::load(base, "apply", format, corpus_name, scale)
+    {
+        s.criterion_ns_per_op = Some(e.mean_ns);
+    }
+}
+
+fn skipped_cell(reason: &str, n: u64, encoding: &str) -> Cell {
+    Cell {
+        ran: false,
+        reason: Some(reason.to_string()),
+        n_keys: Some(n),
+        key_encoding: Some(encoding.to_string()),
+        ..Cell::default()
+    }
+}
+
+const NOT_RUN: &str = "0.2 not run at this scale";
+
+/// Fill 1.0-only op fallback costs + multipliers from the matching 0.2 cell.
+fn cross_fill(c10: &mut BTreeMap<String, CorpusBlock>, c02: &BTreeMap<String, CorpusBlock>) {
+    for (corpus, block) in c10.iter_mut() {
+        for (scale, cell) in block.scales.iter_mut() {
+            let peer = c02
+                .get(corpus)
+                .and_then(|b| b.scales.get(scale))
+                .filter(|c| c.ran);
+            let walk = peer.and_then(|c| c.full_entries_walk_fetches);
+            let peer_walk_from = peer
+                .and_then(|c| c.listing.as_ref())
+                .and_then(|l| l.fallback_02_walk_from.as_ref())
+                .map(|k| k.fetches);
+
+            // floor
+            if let Some(f) = cell.floor.as_mut() {
+                let native = f.hops_mean.unwrap_or(0.0);
+                f.fallback_02 = Some(match walk {
+                    Some(fetches) => Fallback {
+                        method: "entries() full walk + client scan".to_string(),
+                        fetches: Some(fetches),
+                        multiplier: (native > 0.0).then(|| fetches as f64 / native),
+                        reason_if_null: None,
+                    },
+                    None => Fallback {
+                        method: "entries() full walk + client scan".to_string(),
+                        fetches: None,
+                        multiplier: None,
+                        reason_if_null: Some(NOT_RUN.to_string()),
+                    },
+                });
+            }
+            // ceiling
+            if let Some(cl) = cell.ceiling.as_mut() {
+                let native = cl.native_seek_hops_mean.unwrap_or(0.0);
+                cl.fallback_02 = Some(match walk {
+                    Some(fetches) => Fallback {
+                        method: "entries() full walk + client scan".to_string(),
+                        fetches: Some(fetches),
+                        multiplier: (native > 0.0).then(|| fetches as f64 / native),
+                        reason_if_null: None,
+                    },
+                    None => Fallback {
+                        method: "entries() full walk + client scan".to_string(),
+                        fetches: None,
+                        multiplier: None,
+                        reason_if_null: Some(NOT_RUN.to_string()),
+                    },
+                });
+            }
+            // range windows
+            if let Some(r) = cell.range.as_mut() {
+                for win in r.windows.iter_mut() {
+                    match (walk, win.fetch_count) {
+                        (Some(w), Some(native)) if native > 0 => {
+                            win.fallback_02_fetches = Some(w);
+                            win.multiplier = Some(w as f64 / native as f64);
+                        }
+                        (None, _) => win.reason_if_null = Some(NOT_RUN.to_string()),
+                        _ => {}
+                    }
+                }
+            }
+            // listing fair multiplier
+            if let Some(l) = cell.listing.as_mut()
+                && let (Some(wf), Some(native)) = (peer_walk_from, l.fetch_count)
+                && native > 0
+            {
+                l.multiplier_fair = Some(wf as f64 / native as f64);
+            }
+        }
+    }
+}
+
+/// Least-squares fit of log(build wall_ns) vs log(N) per corpus, stored on every
+/// scale's cell. A single cold pass, so it is indicative not a precise
+/// asymptote (see caveats); r2 and n_points are reported for that reason.
+fn fit_loglog(corpora: &mut BTreeMap<String, CorpusBlock>) {
+    for block in corpora.values_mut() {
+        let mut pts: Vec<(f64, f64)> = Vec::new();
+        for cell in block.scales.values() {
+            if let (Some(n), Some(b)) = (cell.n_keys, cell.build.as_ref())
+                && let Some(ns) = b.wall_ns
+                && n > 0
+                && ns > 0
+            {
+                pts.push(((n as f64).ln(), (ns as f64).ln()));
+            }
+        }
+        if pts.len() < 2 {
+            continue;
+        }
+        let fit = least_squares(&pts);
+        for cell in block.scales.values_mut() {
+            if let Some(b) = cell.build.as_mut() {
+                b.cpu_loglog = Some(LogLog {
+                    slope: fit.0,
+                    intercept: fit.1,
+                    r2: fit.2,
+                    n_points: pts.len() as u32,
+                    basis: "build wall_ns, single cold pass".to_string(),
+                });
+            }
+        }
+    }
+}
+
+/// (slope, intercept, r2) of ys on xs.
+fn least_squares(pts: &[(f64, f64)]) -> (f64, f64, f64) {
+    let n = pts.len() as f64;
+    let mx = pts.iter().map(|p| p.0).sum::<f64>() / n;
+    let my = pts.iter().map(|p| p.1).sum::<f64>() / n;
+    let mut sxx = 0.0;
+    let mut sxy = 0.0;
+    let mut syy = 0.0;
+    for &(x, y) in pts {
+        sxx += (x - mx) * (x - mx);
+        sxy += (x - mx) * (y - my);
+        syy += (y - my) * (y - my);
+    }
+    let slope = if sxx == 0.0 { 0.0 } else { sxy / sxx };
+    let intercept = my - slope * mx;
+    let r2 = if sxx == 0.0 || syy == 0.0 {
+        0.0
+    } else {
+        (sxy * sxy) / (sxx * syy)
+    };
+    (slope, intercept, r2)
+}
+
+/// Cross-cell headline multipliers, derived from executed cells only.
+fn build_headlines(
+    c10: &BTreeMap<String, CorpusBlock>,
+    c02: &BTreeMap<String, CorpusBlock>,
+) -> Headlines {
+    let mut entries: Vec<Headline> = Vec::new();
+    for (corpus, block) in c10 {
+        for (scale, cell) in &block.scales {
+            let scale_n: u64 = scale.parse().unwrap_or(0);
+            // floor multiplier (native hops vs 0.2 full-walk fetches)
+            if let Some(f) = &cell.floor
+                && let Some(fb) = &f.fallback_02
+            {
+                entries.push(Headline {
+                    metric: "floor_multiplier".to_string(),
+                    corpus: corpus.clone(),
+                    scale: scale_n,
+                    native: f.hops_mean.unwrap_or(0.0),
+                    native_unit: "hops".to_string(),
+                    fallback: fb.fetches.map(|x| x as f64),
+                    fallback_unit: "fetches".to_string(),
+                    multiplier: fb.multiplier,
+                    reason_if_null: fb.reason_if_null.clone(),
+                });
+            }
+            // range @ 10% window
+            if let Some(r) = &cell.range
+                && let Some(w) = r.windows.iter().find(|w| (w.w - 0.10).abs() < 1e-9)
+            {
+                entries.push(Headline {
+                    metric: "range_multiplier_w0.10".to_string(),
+                    corpus: corpus.clone(),
+                    scale: scale_n,
+                    native: w.fetch_count.unwrap_or(0) as f64,
+                    native_unit: "fetches".to_string(),
+                    fallback: w.fallback_02_fetches.map(|x| x as f64),
+                    fallback_unit: "fetches".to_string(),
+                    multiplier: w.multiplier,
+                    reason_if_null: w.reason_if_null.clone(),
+                });
+            }
+            // listing fair multiplier
+            if let Some(l) = &cell.listing {
+                entries.push(Headline {
+                    metric: "listing_fair_multiplier".to_string(),
+                    corpus: corpus.clone(),
+                    scale: scale_n,
+                    native: l.fetch_count.unwrap_or(0) as f64,
+                    native_unit: "fetches".to_string(),
+                    fallback: l.fallback_02_walk_from.as_ref().map(|k| k.fetches as f64),
+                    fallback_unit: "fetches (walk_from)".to_string(),
+                    multiplier: l.multiplier_fair,
+                    reason_if_null: (l.multiplier_fair.is_none()).then(|| NOT_RUN.to_string()),
+                });
+            }
+            // build-scale ceiling: 1.0 frontier vs 0.2 (absent above cap)
+            if let Some(b) = &cell.build {
+                let peer_ran = c02
+                    .get(corpus)
+                    .and_then(|bl| bl.scales.get(scale))
+                    .is_some_and(|c| c.ran);
+                let peer_frontier = c02
+                    .get(corpus)
+                    .and_then(|bl| bl.scales.get(scale))
+                    .and_then(|c| c.build.as_ref())
+                    .and_then(|bb| bb.builder_frontier_nodes);
+                entries.push(Headline {
+                    metric: "build_frontier_nodes".to_string(),
+                    corpus: corpus.clone(),
+                    scale: scale_n,
+                    native: b.builder_frontier_nodes.unwrap_or(0) as f64,
+                    native_unit: "open nodes (O(depth))".to_string(),
+                    fallback: peer_frontier.map(|x| x as f64),
+                    fallback_unit: "resident nodes (O(N))".to_string(),
+                    multiplier: match (b.builder_frontier_nodes, peer_frontier) {
+                        (Some(nat), Some(pf)) if nat > 0 => Some(pf as f64 / nat as f64),
+                        _ => None,
+                    },
+                    reason_if_null: (!peer_ran).then(|| NOT_RUN.to_string()),
+                });
+            }
+        }
+    }
+    Headlines {
+        notes: "Every multiplier is native-vs-0.2-fallback at a scale where BOTH ran; where 0.2 did not run the fallback is null with reason. Units are store fetches (hardware-independent) or hop counts, never wall-clock.".to_string(),
+        entries,
+    }
+}
+
+/// One capability-matrix row as fixed data: see [`CapabilityRow`] for fields.
+type Row = (
+    u32,
+    &'static str,
+    bool,
+    Option<&'static str>,
+    &'static str,
+    bool,
+    Option<&'static str>,
+    &'static str,
+    Option<&'static str>,
+    Option<&'static str>,
+    &'static str,
+);
+
+fn cap(r: Row) -> CapabilityRow {
+    CapabilityRow {
+        n: r.0,
+        op: r.1.to_string(),
+        v1_supported: r.2,
+        v1_api: r.3.map(str::to_string),
+        v1_class: r.4.to_string(),
+        v02_supported: r.5,
+        v02_api: r.6.map(str::to_string),
+        v02_class: r.7.to_string(),
+        v02_fallback: r.8.map(str::to_string),
+        v02_asymptote: r.9.map(str::to_string),
+        notes: r.10.to_string(),
+    }
+}
+
+/// The exhaustive op x format capability matrix (fixed API facts verified on
+/// the source tree at build time).
+fn capability_matrix() -> Vec<CapabilityRow> {
+    const ROWS: [Row; 20] = [
+        (
+            1,
+            "build-from-scratch",
+            true,
+            Some("Builder::insert+build"),
+            "native",
+            true,
+            Some("Manifest::new+add*+save"),
+            "native",
+            None,
+            Some("O(N) RAM"),
+            "1.0 frontier O(depth) (peak_open_nodes ~6..11); 0.2 holds whole trie -> O(N) RAM, ran:false at 1e6.",
+        ),
+        (
+            2,
+            "build_files",
+            true,
+            Some("build_files(store, iter)"),
+            "native",
+            false,
+            None,
+            "fallback",
+            Some("hand-rolled BMT loop + add-loop + save"),
+            Some("O(N)"),
+            "1.0 one-call ingest; 0.2 dev writes the loop.",
+        ),
+        (
+            3,
+            "get",
+            true,
+            Some("Reader::get"),
+            "seek",
+            true,
+            Some("Manifest::get"),
+            "seek",
+            None,
+            Some("O(depth)"),
+            "Both O(depth) hop-counted descent.",
+        ),
+        (
+            4,
+            "has/contains",
+            true,
+            Some("get(...).is_some()"),
+            "seek",
+            true,
+            Some("get(...).is_some()"),
+            "seek",
+            None,
+            Some("O(depth)"),
+            "Neither ships a dedicated has; equal.",
+        ),
+        (
+            5,
+            "folder-exists",
+            true,
+            Some("prefix(p).next().is_some()"),
+            "seek",
+            true,
+            Some("Manifest::has_prefix"),
+            "seek",
+            None,
+            Some("O(depth)"),
+            "0.2 has the only named prefix-existence probe; cost equal.",
+        ),
+        (
+            6,
+            "floor",
+            true,
+            Some("Reader::floor"),
+            "seek",
+            false,
+            None,
+            "unsupported",
+            Some("entries() full walk + client scan"),
+            Some("O(N)"),
+            "HARD 0.2 gap; multiplier measured per cell (floor.fallback_02).",
+        ),
+        (
+            7,
+            "ceiling",
+            true,
+            Some("range(key, MAX).next()"),
+            "seek",
+            false,
+            None,
+            "unsupported",
+            Some("entries() full walk + client scan"),
+            Some("O(N)"),
+            "Soft gap in both (neither names it); 1.0 emulates by seek O(depth), 0.2 pays O(N).",
+        ),
+        (
+            8,
+            "range",
+            true,
+            Some("Reader::range / Cursor"),
+            "seek",
+            false,
+            None,
+            "unsupported",
+            Some("entries() full walk + filter"),
+            Some("O(N)"),
+            "HARD 0.2 gap; selectivity sweep in range.windows.",
+        ),
+        (
+            9,
+            "prefix-scan / listing",
+            true,
+            Some("prefix / folder::list"),
+            "native",
+            true,
+            Some("walk_from(prefix) or entries()"),
+            "partial",
+            Some("walk_from = O(subtree); entries = O(N); no ordered seek"),
+            Some("O(subtree)"),
+            "1.0 embeds children; fair multiplier in listing.multiplier_fair.",
+        ),
+        (
+            10,
+            "ordered iter (full)",
+            true,
+            Some("Cursor::iter"),
+            "native",
+            false,
+            Some("entries() (DFS, unguaranteed)"),
+            "partial",
+            Some("materialise all N then maybe sort"),
+            Some("O(N) mem"),
+            "1.0 first key after O(depth); 0.2 after loading everything; entries_concurrent unordered.",
+        ),
+        (
+            11,
+            "serve / website-view",
+            true,
+            Some("Reader::serve + website()"),
+            "native",
+            false,
+            Some("index_document/error_document"),
+            "partial",
+            Some("client re-implements exact->index->error via repeated get"),
+            Some("O(depth) per probe"),
+            "Site metadata in both; resolver is 1.0-only.",
+        ),
+        (
+            12,
+            "single-key insert",
+            true,
+            Some("apply(Changeset{put})"),
+            "native",
+            true,
+            Some("add+save"),
+            "native",
+            None,
+            None,
+            "1.0 CoW new root; 0.2 reseals touched spine.",
+        ),
+        (
+            13,
+            "single-key update",
+            true,
+            Some("apply(Changeset{put})"),
+            "native",
+            true,
+            Some("add(overwrite)+save"),
+            "native",
+            None,
+            None,
+            "1.0 rewrites more spine per isolated edit; batch reverses it.",
+        ),
+        (
+            14,
+            "single-key remove",
+            true,
+            Some("apply(Changeset{remove})"),
+            "native",
+            true,
+            Some("remove+save"),
+            "native",
+            None,
+            None,
+            "Plus collapse cost (update.subtree_delete).",
+        ),
+        (
+            15,
+            "batch apply(changeset)",
+            true,
+            Some("apply(store, root, Changeset)"),
+            "native",
+            false,
+            Some("K add/remove + one save"),
+            "fallback",
+            Some("O(K*depth) in-RAM mutations + reseal; no declarative delta"),
+            Some("O(K*depth)"),
+            "1.0 batch write-amp far lower; the amortisation story (update.batch_sweep).",
+        ),
+        (
+            16,
+            "metadata read/write",
+            true,
+            Some("Metadata<KeyId/CustomKey>"),
+            "native",
+            true,
+            Some("add_with_metadata (BTreeMap)"),
+            "native",
+            None,
+            None,
+            "0.2 arbitrary map -> dedup hazard; 1.0 typed TLV canonical.",
+        ),
+        (
+            17,
+            "inline values",
+            true,
+            Some("Entry::Inline (<=128B)"),
+            "native",
+            false,
+            None,
+            "unsupported",
+            Some("store a content chunk + 1 extra fetch/read"),
+            Some("O(1) extra"),
+            "HARD 1.0-only; not exercised here (synthetic ref32 values).",
+        ),
+        (
+            18,
+            "referenced values (ref32)",
+            true,
+            Some("Entry::Ref32"),
+            "native",
+            true,
+            Some("ChunkRef"),
+            "native",
+            None,
+            None,
+            "Both; the exercised value model.",
+        ),
+        (
+            19,
+            "encrypted refs (ref64)",
+            true,
+            Some("Entry::Ref64 + EncryptedNode"),
+            "native",
+            true,
+            Some("EncryptedManifest / new_encrypted"),
+            "native",
+            None,
+            None,
+            "Both; harness exercises ref32 only.",
+        ),
+        (
+            20,
+            "recanonicalise / history-independence",
+            true,
+            Some("recanonicalize(); apply==rebuild (I6)"),
+            "native",
+            false,
+            None,
+            "unsupported",
+            Some("cannot verify; obfuscation-key randomisation defeats dedup"),
+            None,
+            "1.0 proves dedup-stability (dedup_ratio_second_build); 0.2 cannot.",
+        ),
+    ];
+    ROWS.into_iter().map(cap).collect()
+}
+
+fn caveats() -> Vec<String> {
+    vec![
+        "hops->wall-clock latency is a stated model (hops x {25,50,75}ms, sequential, no pipelining/caching); FETCH COUNT is the hardware-independent truth, wall-ms illustrative only (derived_from_hops:true).".to_string(),
+        "Single-key update looks cheaper on 0.2 in isolation but 1.0 wins the amortised/batch path and is history-independent; never read single-update without the batch_sweep beside it.".to_string(),
+        "floor native hops are O(depth) but with a large N-growing constant (rightmost-spine fallback descent), far higher than a point get; shown as their own series.".to_string(),
+        "Listing multiplier_fair uses walk_from on identical prefixes (apples-to-apples); fallback_02_full_entries is the pessimal whole-map walk kept for reference.".to_string(),
+        "peak_rss_bytes is cumulative process VmHWM (monotone, dirty across cells); use peak_live_store_bytes for per-cell memory.".to_string(),
+        "0.2 at N=1e6 is ran:false (O(N)-RAM full-trie build outside budget); every 1e6 multiplier is null with reason. The absence IS the build-scale-ceiling finding.".to_string(),
+        "build wall_ns is a single cold pass (includes RSS sampling); criterion_ns_per_op is a warm multi-iter mean present only for some cells; cpu_loglog is fit over wall_ns and is indicative, not a precise asymptote.".to_string(),
+        "Corpus dependence is large; never quote a headline number without its corpus (uniform is the zero-prefix-sharing control).".to_string(),
+        "Value/metadata model is synthetic (ref32 = sha256(b\"val\"||key)); value-layer figures describe manifest structure, not real payload entropy; inline study not exercised.".to_string(),
+        "0.2 entries() DFS order is not a guaranteed ordered-iter API; any order is incidental and unseekable (ordered_guaranteed:false).".to_string(),
+        "cpu_loglog fits use few points (2-4 scales); treat slopes as indicative with the reported r2 and n_points.".to_string(),
+    ]
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let args = parse_args();
+    let c = cfg();
+
+    let mut formats: BTreeMap<String, FormatBlock> = BTreeMap::new();
+
+    // --- mantaray 1.0 ---
+    let mut corpora10: BTreeMap<String, CorpusBlock> = BTreeMap::new();
+    for corpus in Corpus::all() {
+        let mut scales_map: BTreeMap<String, Cell> = BTreeMap::new();
+        for &scale in &args.scales {
+            let n = scale as usize;
+            eprintln!("[1.0] {} n={}", corpus.name(), n);
+            let keys = corpus::generate(corpus, n);
+            let mut cell = measure::measure_10(corpus, &keys, c)?;
+            fold_into(&mut cell, &args.criterion_base, F10, corpus.name(), scale);
+            scales_map.insert(scale.to_string(), cell);
+        }
+        corpora10.insert(
+            corpus.name().to_string(),
+            CorpusBlock { scales: scales_map },
+        );
+    }
+
+    // --- mantaray 0.2 ---
+    let mut corpora02: BTreeMap<String, CorpusBlock> = BTreeMap::new();
+    for corpus in Corpus::all() {
+        let mut scales_map: BTreeMap<String, Cell> = BTreeMap::new();
+        for &scale in &args.scales {
+            let n = scale as usize;
+            if scale > args.max_02_scale {
+                scales_map.insert(
+                    scale.to_string(),
+                    skipped_cell(
+                        "0.2 build not run: O(N)-RAM full-trie build outside harness wall-clock budget at this scale",
+                        scale,
+                        corpus.key_encoding(),
+                    ),
+                );
+                continue;
+            }
+            eprintln!("[0.2] {} n={}", corpus.name(), n);
+            let keys = corpus::generate(corpus, n);
+            let mut cell = measure::measure_02(corpus, &keys, c)?;
+            fold_into(&mut cell, &args.criterion_base, F02, corpus.name(), scale);
+            scales_map.insert(scale.to_string(), cell);
+        }
+        corpora02.insert(
+            corpus.name().to_string(),
+            CorpusBlock { scales: scales_map },
+        );
+    }
+    // Cross-fill 1.0-only op fallback costs + multipliers from the matching 0.2
+    // cell (both must have run), and fit CPU log-log slopes per (format,corpus).
+    cross_fill(&mut corpora10, &corpora02);
+    fit_loglog(&mut corpora10);
+    fit_loglog(&mut corpora02);
+    let headlines = build_headlines(&corpora10, &corpora02);
+
+    formats.insert(
+        F10.to_string(),
+        FormatBlock {
+            crate_name: "nectar-manifest".to_string(),
+            registry: "StandardChunkSet".to_string(),
+            corpora: corpora10,
+        },
+    );
+    formats.insert(
+        F02.to_string(),
+        FormatBlock {
+            crate_name: "nectar-mantaray".to_string(),
+            registry: "AnyChunkSet<4096>".to_string(),
+            corpora: corpora02,
+        },
+    );
+
+    let meta = Meta {
+        generated: now_iso(),
+        git_branch: git(&["rev-parse", "--abbrev-ref", "HEAD"]),
+        git_commit: git(&["rev-parse", "HEAD"]),
+        harness_version: "2".to_string(),
+        seed_master: format!("0x{:016x}", corpus::MASTER_SEED),
+        rtt_ms: c.rtt_ms,
+        rtt_ms_set: vec![25, 50, 75],
+        batch_k_sweep: vec![1, 10, 100, 1_000, 10_000],
+        range_windows: vec![0.001, 0.01, 0.10, 1.0],
+        value_read_corpus: "not_exercised (synthetic ref32 values)".to_string(),
+        chunk_body_size: 4096,
+        criterion_iters_note: "means from target/criterion/*/new/estimates.json".to_string(),
+        sample_keys: c.sample_keys as u32,
+        update_sample: c.update_sample as u32,
+        batch_ops: c.batch_ops as u32,
+        caveats: caveats(),
+    };
+
+    let doc = Document {
+        meta,
+        capability_matrix: capability_matrix(),
+        headlines,
+        formats,
+    };
+    let json = serde_json::to_string_pretty(&doc)?;
+    if let Some(parent) = args.out.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&args.out, json.as_bytes())?;
+    eprintln!("wrote {} ({} bytes)", args.out.display(), json.len());
+    Ok(())
+}

--- a/crates/manifest-sim/src/corpus.rs
+++ b/crates/manifest-sim/src/corpus.rs
@@ -1,0 +1,327 @@
+//! Deterministic, seeded corpus generators shaped like the calibration traces.
+//!
+//! Master seed `0x6d616e7472617931`. Per-corpus stream seed is
+//! `sha256(master_le || corpus_name)`; a per-index block is
+//! `sha256(stream_seed || u64le(i))`, extended with a counter when a single
+//! index needs more than 32 bytes. Keys are generated then sorted, so the
+//! published set is order-independent. Values are ref32 addresses derived as
+//! `sha256(b"val" || key_bytes)`.
+//!
+//! Each corpus yields a logical key that both formats express: 1.0 takes raw
+//! key bytes; 0.2 needs a UTF-8 `&str`, so uniform binary keys are lowercase
+//! hex (the ACT hex pattern) while path corpora are byte-identical in both.
+
+use std::collections::BTreeSet;
+
+use sha2::{Digest, Sha256};
+
+/// Master seed, little-endian.
+pub const MASTER_SEED: u64 = 0x6d61_6e74_7261_7931;
+
+/// A generated key with both format encodings and optional content type.
+#[derive(Clone, Debug)]
+pub struct GenKey {
+    /// Raw key bytes fed to mantaray 1.0.
+    pub raw: Vec<u8>,
+    /// UTF-8 path fed to mantaray 0.2 (hex of `raw` for the uniform corpus).
+    pub path: String,
+    /// Content-type metadata value, when the corpus carries it.
+    pub content_type: Option<&'static str>,
+}
+
+impl GenKey {
+    /// Whether the 0.2 path is a byte-identical view of the 1.0 raw key.
+    #[must_use]
+    pub fn encodings_match(&self) -> bool {
+        self.raw.as_slice() == self.path.as_bytes()
+    }
+}
+
+/// The four corpora.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Corpus {
+    /// Zero-prefix-sharing control: 32 raw bytes per key.
+    Uniform,
+    /// Deep '/'-separated article paths with heavy prefix sharing.
+    Kiwix,
+    /// Full tile pyramid `z/x/y`.
+    OsmPyramid,
+    /// Bounding-box tile region `z/x/y` (contiguous runs).
+    OsmBbox,
+}
+
+impl Corpus {
+    /// The JSON key for this corpus.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Uniform => "uniform",
+            Self::Kiwix => "kiwix",
+            Self::OsmPyramid => "osm_pyramid",
+            Self::OsmBbox => "osm_bbox",
+        }
+    }
+
+    /// Whether the 0.2 key encoding is `hex` (uniform) or `raw` (paths).
+    #[must_use]
+    pub const fn key_encoding(self) -> &'static str {
+        match self {
+            Self::Uniform => "hex",
+            _ => "raw",
+        }
+    }
+
+    /// All four corpora.
+    #[must_use]
+    pub const fn all() -> [Self; 4] {
+        [Self::Uniform, Self::Kiwix, Self::OsmPyramid, Self::OsmBbox]
+    }
+}
+
+fn sha256(parts: &[&[u8]]) -> [u8; 32] {
+    let mut h = Sha256::new();
+    for p in parts {
+        h.update(p);
+    }
+    h.finalize().into()
+}
+
+/// Per-corpus stream seed.
+fn stream_seed(corpus: Corpus) -> [u8; 32] {
+    sha256(&[&MASTER_SEED.to_le_bytes(), corpus.name().as_bytes()])
+}
+
+/// A deterministic byte stream for index `i`: concatenated sha256 blocks so a
+/// single index can furnish more than 32 bytes of entropy.
+struct IdxStream {
+    seed: [u8; 32],
+    idx: u64,
+    block: [u8; 32],
+    ctr: u32,
+    pos: usize,
+}
+
+impl IdxStream {
+    fn new(seed: [u8; 32], idx: u64) -> Self {
+        let block = sha256(&[&seed, &idx.to_le_bytes(), &0u32.to_le_bytes()]);
+        Self {
+            seed,
+            idx,
+            block,
+            ctr: 0,
+            pos: 0,
+        }
+    }
+
+    fn next_byte(&mut self) -> u8 {
+        if self.pos == 32 {
+            self.ctr = self.ctr.wrapping_add(1);
+            self.block = sha256(&[&self.seed, &self.idx.to_le_bytes(), &self.ctr.to_le_bytes()]);
+            self.pos = 0;
+        }
+        let b = self.block[self.pos];
+        self.pos += 1;
+        b
+    }
+}
+
+/// A tagged deterministic address over a key's bytes: `sha256(tag || key)`.
+#[must_use]
+pub fn tagged_addr(tag: &[u8], key_bytes: &[u8]) -> [u8; 32] {
+    sha256(&[tag, key_bytes])
+}
+
+/// The ref32 value address for a key's bytes: `sha256(b"val" || key)`.
+#[must_use]
+pub fn value_addr(key_bytes: &[u8]) -> [u8; 32] {
+    tagged_addr(b"val", key_bytes)
+}
+
+fn to_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        s.push(HEX[usize::from(b >> 4)] as char);
+        s.push(HEX[usize::from(b & 0x0f)] as char);
+    }
+    s
+}
+
+/// Generate exactly `n` keys of `corpus`, sorted by raw bytes.
+#[must_use]
+pub fn generate(corpus: Corpus, n: usize) -> Vec<GenKey> {
+    match corpus {
+        Corpus::Uniform => uniform(n),
+        Corpus::Kiwix => kiwix(n),
+        Corpus::OsmPyramid => osm_pyramid(n),
+        Corpus::OsmBbox => osm_bbox(n),
+    }
+}
+
+fn uniform(n: usize) -> Vec<GenKey> {
+    let seed = stream_seed(Corpus::Uniform);
+    let mut set: BTreeSet<[u8; 32]> = BTreeSet::new();
+    let mut i: u64 = 0;
+    while set.len() < n {
+        let block = sha256(&[&seed, &i.to_le_bytes()]);
+        set.insert(block);
+        i += 1;
+    }
+    set.into_iter()
+        .take(n)
+        .map(|raw| GenKey {
+            path: to_hex(&raw),
+            raw: raw.to_vec(),
+            content_type: None,
+        })
+        .collect()
+}
+
+const KIWIX_ALPHABET: &[u8; 36] = b"abcdefghijklmnopqrstuvwxyz0123456789";
+const KIWIX_NAMESPACES: [&str; 4] = ["A/", "M/", "-/", "I/"];
+const KIWIX_EXTS: [&str; 3] = [".html", ".png", ".css"];
+const KIWIX_MIMES: [&str; 3] = ["text/html", "image/png", "text/css"];
+
+fn kiwix(n: usize) -> Vec<GenKey> {
+    let seed = stream_seed(Corpus::Kiwix);
+    // Order-of-emission list for prefix reuse, then dedup+sort at the end.
+    let mut emitted: Vec<(String, &'static str)> = Vec::with_capacity(n);
+    let mut seen: BTreeSet<String> = BTreeSet::new();
+    let mut i: u64 = 0;
+    while seen.len() < n {
+        let mut s = IdxStream::new(seed, i);
+        i += 1;
+        let b0 = s.next_byte();
+        let b1 = s.next_byte();
+        let b2 = s.next_byte();
+
+        // Namespace by Zipf-ish threshold on b0 (70/15/10/5).
+        let ns = if b0 < 179 {
+            KIWIX_NAMESPACES[0]
+        } else if b0 < 217 {
+            KIWIX_NAMESPACES[1]
+        } else if b0 < 243 {
+            KIWIX_NAMESPACES[2]
+        } else {
+            KIWIX_NAMESPACES[3]
+        };
+
+        let mut path = String::new();
+        // Prefix reuse (prob 0.6) to force shared LCP. The reused span is
+        // trimmed back to a '/' directory boundary so a reused prefix is always
+        // a well-formed directory path: this preserves heavy prefix sharing
+        // while keeping every full key terminal (ends in an extension, never a
+        // '/'), so no key is ever a strict prefix of another. That keeps the
+        // corpus faithful to real hierarchical article paths and avoids the
+        // "file.png/dir" splice artifact.
+        let mut reused = false;
+        if b1 < 154 && !emitted.is_empty() {
+            let pick = (usize::from(b2) << 8 | usize::from(s.next_byte())) % emitted.len();
+            let k = 4 + usize::from(s.next_byte()) % 20;
+            let src = &emitted[pick].0;
+            let take = k.min(src.len());
+            // Trim back to the last '/' within the first `take` bytes.
+            if let Some(pos) = src.as_bytes()[..take].iter().rposition(|&c| c == b'/') {
+                path.push_str(&src[..=pos]);
+                reused = true;
+            }
+        }
+        if !reused {
+            path.push_str(ns);
+        }
+
+        let segs = 1 + usize::from(s.next_byte()) % 3;
+        for seg in 0..segs {
+            if !path.is_empty() && !path.ends_with('/') {
+                path.push('/');
+            }
+            let len = 3 + usize::from(s.next_byte()) % 22;
+            for _ in 0..len {
+                let c = KIWIX_ALPHABET[usize::from(s.next_byte()) % 36];
+                path.push(c as char);
+            }
+            let _ = seg;
+        }
+        let ext_pick = usize::from(s.next_byte()) % 3;
+        path.push_str(KIWIX_EXTS[ext_pick]);
+        let mime = KIWIX_MIMES[ext_pick];
+
+        if seen.insert(path.clone()) {
+            emitted.push((path, mime));
+        }
+    }
+
+    let mut out: Vec<GenKey> = emitted
+        .into_iter()
+        .map(|(path, mime)| GenKey {
+            raw: path.clone().into_bytes(),
+            path,
+            content_type: Some(mime),
+        })
+        .collect();
+    out.sort_by(|a, b| a.raw.cmp(&b.raw));
+    out
+}
+
+fn ascii_key(z: u32, x: u64, y: u64) -> GenKey {
+    let path = format!("{z}/{x}/{y}");
+    GenKey {
+        raw: path.clone().into_bytes(),
+        path,
+        content_type: None,
+    }
+}
+
+fn osm_pyramid(n: usize) -> Vec<GenKey> {
+    let mut out: Vec<GenKey> = Vec::with_capacity(n);
+    let mut z: u32 = 0;
+    while out.len() < n {
+        let side: u64 = 1u64 << z;
+        for x in 0..side {
+            for y in 0..side {
+                if out.len() == n {
+                    break;
+                }
+                out.push(ascii_key(z, x, y));
+            }
+            if out.len() == n {
+                break;
+            }
+        }
+        z += 1;
+        if z > 40 {
+            break;
+        }
+    }
+    out.sort_by(|a, b| a.raw.cmp(&b.raw));
+    out
+}
+
+fn osm_bbox(n: usize) -> Vec<GenKey> {
+    // Germany-like contiguous window: x in [0.51,0.55], y in [0.33,0.40].
+    let mut out: Vec<GenKey> = Vec::with_capacity(n);
+    for z in 0..=15u32 {
+        let side: f64 = (1u64 << z) as f64;
+        let x_lo = (0.51 * side) as u64;
+        let x_hi = (0.55 * side).ceil() as u64;
+        let y_lo = (0.33 * side) as u64;
+        let y_hi = (0.40 * side).ceil() as u64;
+        for x in x_lo..x_hi.max(x_lo + 1).min(1u64 << z) {
+            for y in y_lo..y_hi.max(y_lo + 1).min(1u64 << z) {
+                if out.len() == n {
+                    break;
+                }
+                out.push(ascii_key(z, x, y));
+            }
+            if out.len() == n {
+                break;
+            }
+        }
+        if out.len() == n {
+            break;
+        }
+    }
+    out.sort_by(|a, b| a.raw.cmp(&b.raw));
+    out.truncate(n);
+    out
+}

--- a/crates/manifest-sim/src/criterion_fold.rs
+++ b/crates/manifest-sim/src/criterion_fold.rs
@@ -1,0 +1,41 @@
+//! Read criterion's `estimates.json` and fold mean/stddev ns-per-op into the
+//! result cells. Criterion writes
+//! `target/criterion/<group>/<id>/new/estimates.json` where the flat id is
+//! `<format>__<corpus>__<scale>`; a missing file means that timed cell was not
+//! benched and stays null.
+
+use std::path::Path;
+
+/// The mean point estimate (ns) and std-dev point estimate (ns) for a timed
+/// benchmark, if criterion produced one.
+#[derive(Clone, Copy, Debug)]
+pub struct Estimate {
+    pub mean_ns: f64,
+    pub stddev_ns: f64,
+}
+
+/// The flat benchmark id shared by the bench target and the fold reader.
+#[must_use]
+pub fn bench_id(format: &str, corpus: &str, scale: u64) -> String {
+    format!("{format}__{corpus}__{scale}")
+}
+
+/// Load an estimate for a `(group, format, corpus, scale)` benchmark id.
+#[must_use]
+pub fn load(base: &Path, group: &str, format: &str, corpus: &str, scale: u64) -> Option<Estimate> {
+    let path = base
+        .join("criterion")
+        .join(group)
+        .join(bench_id(format, corpus, scale))
+        .join("new")
+        .join("estimates.json");
+    let text = std::fs::read_to_string(&path).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&text).ok()?;
+    let mean_ns = value.get("mean")?.get("point_estimate")?.as_f64()?;
+    let stddev_ns = value
+        .get("std_dev")
+        .and_then(|v| v.get("point_estimate"))
+        .and_then(serde_json::Value::as_f64)
+        .unwrap_or(0.0);
+    Some(Estimate { mean_ns, stddev_ns })
+}

--- a/crates/manifest-sim/src/lib.rs
+++ b/crates/manifest-sim/src/lib.rs
@@ -1,0 +1,15 @@
+//! Empirical performance harness: mantaray 1.0 (`nectar-manifest`) vs mantaray
+//! 0.2 (`nectar-mantaray`), both run as plain (ref32) readers+writers over one
+//! shared instrumented in-memory chunk store.
+//!
+//! The public surface is the corpus generators, the `CountingStore`, the
+//! per-cell measurement functions and the result schema; the bin drives them
+//! across every `(format, corpus, scale)` and writes one JSON document.
+
+pub mod corpus;
+pub mod criterion_fold;
+pub mod measure;
+pub mod perf_v3;
+pub mod results;
+pub mod results_v3;
+pub mod store;

--- a/crates/manifest-sim/src/measure.rs
+++ b/crates/manifest-sim/src/measure.rs
@@ -1,0 +1,1093 @@
+//! Metric collection for one `(format, corpus, scale)` cell.
+//!
+//! Every number here comes from executing the real builder/reader/apply path
+//! over the shared `CountingStore`; nulls are only ever produced by a
+//! capability gap, never by estimate.
+
+use std::error::Error;
+use std::time::Instant;
+
+use bytes::Bytes;
+use futures::executor::block_on;
+
+use nectar_manifest::{Builder, Changeset, Entry, Key, KeyId, Metadata, Reader, V1, apply};
+use nectar_mantaray::{Manifest, PlainManifest};
+use nectar_primitives::{AnyChunkSet, ChunkAddress, ChunkRef, StandardChunkSet};
+
+use crate::corpus::{Corpus, GenKey, tagged_addr, value_addr};
+use crate::results::{
+    BatchPoint, BatchUpdate, Build, Cdf, Ceiling, Cell, Depth, Floor, Get, Histogram, IterFull,
+    KfCount, LatQuad, Listing, LoadLatency, OpCost, Range, RangeWindow, SingleUpdate, Storage,
+    SubtreeDelete, Update, ValueRead, WallLatency,
+};
+use crate::store::CountingStore;
+
+type Err = Box<dyn Error>;
+
+const BODY: f64 = 4096.0;
+
+/// RTT values (ms) for the hop x RTT illustrative wall-clock model.
+const RTT_SET: [u32; 3] = [25, 50, 75];
+/// Batch-size sweep for the write-amplification amortisation curve.
+const BATCH_KS: [usize; 5] = [1, 10, 100, 1_000, 10_000];
+/// Range-window widths (fraction of the sorted key domain) for the sweep.
+const RANGE_WS: [f64; 4] = [0.001, 0.01, 0.10, 1.0];
+/// A key that sorts strictly above every corpus key (ceiling upper bound).
+const MAX_KEY: [u8; 48] = [0xff; 48];
+
+/// Config knobs shared across cells.
+#[derive(Clone, Copy, Debug)]
+pub struct Cfg {
+    pub sample_keys: usize,
+    pub update_sample: usize,
+    pub batch_ops: usize,
+    pub rtt_ms: u32,
+}
+
+// ---- small stats helpers -------------------------------------------------
+
+fn mean(v: &[u64]) -> f64 {
+    if v.is_empty() {
+        return 0.0;
+    }
+    let sum: u128 = v.iter().map(|&x| u128::from(x)).sum();
+    sum as f64 / v.len() as f64
+}
+
+fn pct(sorted: &[u64], p: f64) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let idx = ((sorted.len() - 1) as f64 * p).round() as usize;
+    sorted.get(idx).copied().unwrap_or(0)
+}
+
+/// Discrete PMF of a small-integer sample (hops are 1..~150).
+fn histogram(values: &[u64]) -> Histogram {
+    let mut h: Histogram = Histogram::new();
+    for &v in values {
+        *h.entry(v).or_insert(0) += 1;
+    }
+    h
+}
+
+fn cdf(sorted: &[u64]) -> Cdf {
+    Cdf {
+        p50: pct(sorted, 0.50),
+        p90: pct(sorted, 0.90),
+        p99: pct(sorted, 0.99),
+        max: sorted.last().copied().unwrap_or(0),
+    }
+}
+
+/// The hop x RTT illustrative wall-clock model, one quad per RTT.
+fn wall_latency(sorted: &[u64]) -> WallLatency {
+    let c = cdf(sorted);
+    let mut by_rtt = std::collections::BTreeMap::new();
+    for rtt in RTT_SET {
+        let r = f64::from(rtt);
+        by_rtt.insert(
+            rtt.to_string(),
+            LatQuad {
+                p50: c.p50 as f64 * r,
+                p90: c.p90 as f64 * r,
+                p99: c.p99 as f64 * r,
+                max: c.max as f64 * r,
+            },
+        );
+    }
+    WallLatency {
+        by_rtt_ms: by_rtt,
+        model: "hops * rtt, sequential fetch, no pipelining or caching".to_string(),
+    }
+}
+
+fn depth_from(hops: &mut [u64]) -> Depth {
+    hops.sort_unstable();
+    Depth {
+        min: hops.first().copied(),
+        mean: Some(mean(hops)),
+        p95: Some(pct(hops, 0.95)),
+        max: hops.last().copied(),
+        histogram: Some(histogram(hops)),
+        fanout_mean: None,
+    }
+}
+
+fn get_block(hops: &[u64], rtt_ms: u32) -> Get {
+    let mut sorted = hops.to_vec();
+    sorted.sort_unstable();
+    let m = mean(hops);
+    let p95 = pct(&sorted, 0.95);
+    let mx = sorted.last().copied().unwrap_or(0);
+    let rtt = f64::from(rtt_ms);
+    Get {
+        sampled_keys: Some(hops.len() as u64),
+        hops_mean: Some(m),
+        hops_p95: Some(p95),
+        hops_max: Some(mx),
+        load_latency_ms: Some(LoadLatency {
+            mean: Some(m * rtt),
+            p95: Some(p95 as f64 * rtt),
+            max: Some(mx as f64 * rtt),
+            derived_from_hops: true,
+        }),
+        criterion_ns_per_op: None,
+        hops_histogram: Some(histogram(hops)),
+        hops_cdf: Some(cdf(&sorted)),
+        wall_latency_ms: Some(wall_latency(&sorted)),
+    }
+}
+
+/// Per-key `bytes/key`, `chunks/key`, embedding ratio.
+fn storage_block(snap_chunks: u64, live_bytes: u64, n: u64, embedded: Option<u64>) -> Storage {
+    let total_chunks = snap_chunks;
+    let bpk = if n == 0 {
+        0.0
+    } else {
+        live_bytes as f64 / n as f64
+    };
+    let cpk = if n == 0 {
+        0.0
+    } else {
+        total_chunks as f64 / n as f64
+    };
+    // 0.2 never embeds: caller passes None -> explicit 0.0, not null.
+    let emb = match embedded {
+        Some(e) => {
+            let denom = e + total_chunks;
+            if denom == 0 {
+                0.0
+            } else {
+                e as f64 / denom as f64
+            }
+        }
+        None => 0.0,
+    };
+    Storage {
+        total_chunks: Some(total_chunks),
+        total_payload_bytes: Some(live_bytes),
+        storage_utilisation: Some(if total_chunks == 0 {
+            0.0
+        } else {
+            live_bytes as f64 / (total_chunks as f64 * BODY)
+        }),
+        bytes_per_key: Some(bpk),
+        chunks_per_key: Some(cpk),
+        embedding_ratio: Some(emb),
+    }
+}
+
+/// Deterministic evenly-spaced sample of `count` indices in `0..n`.
+fn sample_indices(n: usize, count: usize) -> Vec<usize> {
+    if n == 0 {
+        return Vec::new();
+    }
+    if n <= count {
+        return (0..n).collect();
+    }
+    let stride = n / count;
+    (0..count).map(|j| (j * stride).min(n - 1)).collect()
+}
+
+/// Peak resident set of the process, sampled from `/proc/self/status` VmHWM.
+/// Cumulative over the process lifetime, so it is a floor on the current
+/// build's peak, not a clean per-cell figure (see `peak_live_store_bytes`).
+fn peak_rss_bytes() -> Option<u64> {
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("VmHWM:") {
+            let kb: u64 = rest.trim().trim_end_matches(" kB").trim().parse().ok()?;
+            return Some(kb.saturating_mul(1024));
+        }
+    }
+    None
+}
+
+// ---- value / key builders ------------------------------------------------
+
+fn ref32(addr: [u8; 32]) -> ChunkRef {
+    ChunkRef::new(ChunkAddress::new(addr))
+}
+
+fn entry10(bytes: &[u8]) -> Entry<V1> {
+    Entry::from(ref32(value_addr(bytes)))
+}
+
+fn alt_entry10(bytes: &[u8]) -> Entry<V1> {
+    Entry::from(ref32(tagged_addr(b"upd", bytes)))
+}
+
+fn meta10(k: &GenKey) -> Option<Metadata<V1>> {
+    k.content_type.map(|ct| {
+        Metadata::<V1>::new(KeyId::ContentType, Bytes::from_static(ct.as_bytes()))
+            .expect("content-type fits the metadata bound")
+    })
+}
+
+/// A synthetic insert key in a namespace disjoint from every corpus key
+/// (uniform hex is `0-9a-f`, kiwix starts `A/M/-/I`, osm starts with a digit),
+/// so an insert adds a fresh branch and never nests under an existing key.
+fn insert_key(tag: usize) -> (Vec<u8>, String) {
+    let path = format!("~~ins~~{tag}");
+    let mut raw = vec![0xffu8, 0xff, 0xff];
+    raw.extend_from_slice(&(tag as u64).to_le_bytes());
+    (raw, path)
+}
+
+// ========================================================================
+// mantaray 1.0
+// ========================================================================
+
+/// Measure one 1.0 cell. `store` is fresh; only manifest node chunks land in
+/// it (values are bare ref32, never split), so `total_chunks` is exactly the
+/// resident node count.
+pub fn measure_10(corpus: Corpus, keys: &[GenKey], cfg: Cfg) -> Result<Cell, Err> {
+    let store = CountingStore::<StandardChunkSet>::new();
+    let n = keys.len();
+
+    // --- build ---
+    let mut builder = Builder::<V1>::new();
+    for k in keys {
+        builder.insert(Key::from(k.raw.as_slice()), entry10(&k.raw), meta10(k));
+    }
+    let rss_before = peak_rss_bytes();
+    let t = Instant::now();
+    let built = block_on(builder.build(&store))?;
+    let build_ns = t.elapsed().as_nanos() as u64;
+    let rss_after = peak_rss_bytes();
+    let root = *built.root();
+    let stats = built.stats();
+    let snap = store.snapshot();
+
+    // Second identical build into the same store: by I6 no new distinct chunk
+    // should land. Capped to protect the 1e6 wall-clock budget.
+    let (dedup, dedup_reason) = if n <= 100_000 {
+        let first_distinct = snap.distinct_puts;
+        let before = store.snapshot().distinct_puts;
+        let mut b2 = Builder::<V1>::new();
+        for k in keys {
+            b2.insert(Key::from(k.raw.as_slice()), entry10(&k.raw), meta10(k));
+        }
+        let _ = block_on(b2.build(&store))?;
+        let after = store.snapshot().distinct_puts;
+        let ratio = if first_distinct == 0 {
+            0.0
+        } else {
+            (after - before) as f64 / first_distinct as f64
+        };
+        (Some(ratio), None)
+    } else {
+        (
+            None,
+            Some("second build skipped above 1e5 to bound wall-clock".to_string()),
+        )
+    };
+
+    let build = Build {
+        wall_ns: Some(build_ns),
+        criterion_ns_per_op: None,
+        criterion_stddev_ns: None,
+        peak_open_nodes: Some(stats.peak_open_nodes() as u64),
+        nodes_written: Some(stats.nodes_written() as u64),
+        nodes_embedded: Some(stats.nodes_embedded() as u64),
+        peak_rss_bytes: rss_after.or(rss_before),
+        peak_live_store_bytes: Some(snap.peak_live_bytes),
+        builder_frontier_nodes: Some(stats.peak_open_nodes() as u64),
+        cpu_loglog: None,
+        dedup_ratio_second_build: dedup,
+        dedup_reason,
+    };
+    let total_chunks = snap.total_chunks;
+    let storage = storage_block(
+        total_chunks,
+        snap.live_bytes,
+        n as u64,
+        Some(stats.nodes_embedded() as u64),
+    );
+
+    // --- get hops (== referenced chunk-path depth) over the sample ---
+    let reader: Reader<&CountingStore<StandardChunkSet>, V1> = Reader::new(&store);
+    let idxs = sample_indices(n, cfg.sample_keys);
+    let mut hops: Vec<u64> = Vec::with_capacity(idxs.len());
+    for &i in &idxs {
+        let key = Key::from(keys[i].raw.as_slice());
+        let before = store.gets();
+        let _ = block_on(reader.get(&root, &key))?;
+        hops.push(store.gets() - before);
+    }
+    let get = get_block(&hops, cfg.rtt_ms);
+    let mut depth_src = hops.clone();
+    let tree_depth = depth_from(&mut depth_src);
+
+    // --- prefix listing (folder view) over a fixed set of prefixes ---
+    let mut fetch_total = 0u64;
+    let mut keys_total = 0u64;
+    for p in listing_prefixes(corpus, keys) {
+        let pk = Key::from(p.as_slice());
+        let before = store.gets();
+        let mut cursor = block_on(reader.prefix(&root, &pk))?;
+        let mut count = 0u64;
+        while let Some(_pair) = block_on(cursor.next())? {
+            count += 1;
+        }
+        fetch_total += store.gets() - before;
+        keys_total += count;
+    }
+    let listing = Listing {
+        method: "prefix".to_string(),
+        fetch_count: Some(fetch_total),
+        keys_returned: Some(keys_total),
+        fetches_per_key: Some(if keys_total == 0 {
+            0.0
+        } else {
+            fetch_total as f64 / keys_total as f64
+        }),
+        fallback_02_full_entries: None,
+        fallback_02_walk_from: None,
+        multiplier_fair: None,
+    };
+
+    // --- floor (1.0 only) over the sample ---
+    let mut floor_hops: Vec<u64> = Vec::with_capacity(idxs.len());
+    for &i in &idxs {
+        let key = Key::from(keys[i].raw.as_slice());
+        let before = store.gets();
+        let _ = block_on(reader.floor(&root, &key))?;
+        floor_hops.push(store.gets() - before);
+    }
+    floor_hops.sort_unstable();
+    let floor = Floor {
+        supported: true,
+        reason: None,
+        hops_mean: Some(mean(&floor_hops)),
+        hops_p95: Some(pct(&floor_hops, 0.95)),
+        hops_max: floor_hops.last().copied(),
+        hops_histogram: Some(histogram(&floor_hops)),
+        fallback_02: None,
+    };
+
+    // --- ceiling (neither format names it): 1.0 emulates by seek, so measure
+    //     the range(key, MAX).next() hop cost per sampled key ---
+    let hi_all = Key::from(MAX_KEY.as_slice());
+    let mut ceil_hops: Vec<u64> = Vec::with_capacity(idxs.len());
+    for &i in &idxs {
+        let key = Key::from(keys[i].raw.as_slice());
+        let before = store.gets();
+        let mut cursor = block_on(reader.range(&root, &key, &hi_all))?;
+        let _ = block_on(cursor.next())?;
+        ceil_hops.push(store.gets() - before);
+    }
+    ceil_hops.sort_unstable();
+    let ceiling = Ceiling {
+        supported: true,
+        class: "seek_emulated".to_string(),
+        native_seek_hops_mean: Some(mean(&ceil_hops)),
+        native_seek_hops_max: ceil_hops.last().copied(),
+        fallback_02: None,
+    };
+
+    // --- range (1.0 only): selectivity sweep of centred windows ---
+    let mut windows: Vec<RangeWindow> = Vec::with_capacity(RANGE_WS.len());
+    for &w in &RANGE_WS {
+        let (lo_i, hi_i) = window_indices(n, w);
+        let lo = Key::from(keys[lo_i].raw.as_slice());
+        let hi = Key::from(keys[hi_i].raw.as_slice());
+        let before = store.gets();
+        let mut cursor = block_on(reader.range(&root, &lo, &hi))?;
+        let mut count = 0u64;
+        while let Some(_pair) = block_on(cursor.next())? {
+            count += 1;
+        }
+        windows.push(RangeWindow {
+            w,
+            fetch_count: Some(store.gets() - before),
+            keys_returned: Some(count),
+            fallback_02_fetches: None,
+            multiplier: None,
+            reason_if_null: None,
+        });
+    }
+    let range = Range {
+        supported: true,
+        reason: None,
+        windows,
+    };
+
+    // --- ordered full iter: fetches to first key, then to drain all ---
+    let before = store.gets();
+    let mut it = block_on(reader.iter(&root))?;
+    let _first = block_on(it.next())?;
+    let to_first = store.gets() - before;
+    let mut all = to_first;
+    loop {
+        let g0 = store.gets();
+        if block_on(it.next())?.is_none() {
+            break;
+        }
+        all += store.gets() - g0;
+    }
+    let iter_full = IterFull {
+        native_fetch_to_first_key: Some(to_first),
+        native_fetch_all: Some(all),
+        fallback_02_materialise_fetches: None,
+        ordered_guaranteed: true,
+    };
+
+    // --- value read: this harness binds ref32 values that are never stored as
+    //     content chunks, so a read-through / inline study is not exercised ---
+    let value_read = ValueRead {
+        inline_fraction: None,
+        fetches_native_mean: None,
+        fetches_02_mean: None,
+        chunks_saved_by_inline: None,
+        reason: Some(
+            "values are synthetic ref32 addresses, not stored content chunks; inline read-through not exercised"
+                .to_string(),
+        ),
+    };
+
+    // --- single-key update / insert / delete (apply, 1-op changeset) ---
+    let usample = sample_indices(n, cfg.update_sample);
+    let mut upd = (Vec::new(), Vec::new());
+    let mut ins = (Vec::new(), Vec::new());
+    let mut del = (Vec::new(), Vec::new());
+    for (tag, &i) in usample.iter().enumerate() {
+        let k = &keys[i];
+        // update
+        let mut cs = Changeset::<V1>::new();
+        cs.put(Key::from(k.raw.as_slice()), alt_entry10(&k.raw), meta10(k));
+        apply_measure(&store, &root, &cs, &mut upd)?;
+        // insert
+        let (iraw, _ipath) = insert_key(tag);
+        let mut cs = Changeset::<V1>::new();
+        cs.put(Key::from(iraw.as_slice()), entry10(&iraw), None);
+        apply_measure(&store, &root, &cs, &mut ins)?;
+        // delete
+        let mut cs = Changeset::<V1>::new();
+        cs.remove(Key::from(k.raw.as_slice()));
+        apply_measure(&store, &root, &cs, &mut del)?;
+    }
+
+    // --- batch apply (one changeset) ---
+    let kops = n.min(cfg.batch_ops);
+    let mut cs = Changeset::<V1>::new();
+    let all_update = matches!(corpus, Corpus::OsmPyramid | Corpus::OsmBbox);
+    for (i, k) in keys.iter().take(kops).enumerate() {
+        let slot = i % 10;
+        if all_update || slot < 8 {
+            cs.put(Key::from(k.raw.as_slice()), alt_entry10(&k.raw), meta10(k));
+        } else if slot == 8 {
+            let (iraw, _ip) = insert_key(1_000_000 + i);
+            cs.put(Key::from(iraw.as_slice()), entry10(&iraw), None);
+        } else {
+            cs.remove(Key::from(k.raw.as_slice()));
+        }
+    }
+    let before_p = store.puts();
+    let t = Instant::now();
+    let _new_root = block_on(apply(&store, &root, &cs))?;
+    let batch_ns = t.elapsed().as_nanos() as u64;
+    let batch_chunks = store.puts() - before_p;
+    let batch = BatchUpdate {
+        k_ops: Some(kops as u64),
+        mix: if all_update {
+            "100/0/0".to_string()
+        } else {
+            "80/10/10".to_string()
+        },
+        chunks_rewritten: Some(batch_chunks),
+        wall_ns: Some(batch_ns),
+        write_amplification: Some(if kops == 0 {
+            0.0
+        } else {
+            batch_chunks as f64 / kops as f64
+        }),
+        criterion_ns_per_op: None,
+    };
+
+    // --- batch-size sweep: one changeset per K, same mix ---
+    let mut batch_sweep: Vec<BatchPoint> = Vec::with_capacity(BATCH_KS.len());
+    let mix_label = if all_update { "100/0/0" } else { "80/10/10" };
+    for &k in &BATCH_KS {
+        let kk = n.min(k);
+        let mut cs = Changeset::<V1>::new();
+        for (i, key) in keys.iter().take(kk).enumerate() {
+            let slot = i % 10;
+            if all_update || slot < 8 {
+                cs.put(
+                    Key::from(key.raw.as_slice()),
+                    alt_entry10(&key.raw),
+                    meta10(key),
+                );
+            } else if slot == 8 {
+                let (iraw, _ip) = insert_key(2_000_000 + i);
+                cs.put(Key::from(iraw.as_slice()), entry10(&iraw), None);
+            } else {
+                cs.remove(Key::from(key.raw.as_slice()));
+            }
+        }
+        let before_p = store.puts();
+        let t = Instant::now();
+        let _ = block_on(apply(&store, &root, &cs))?;
+        let ns = t.elapsed().as_nanos() as u64;
+        let chunks = store.puts() - before_p;
+        batch_sweep.push(BatchPoint {
+            k: kk as u64,
+            mix: mix_label.to_string(),
+            chunks_rewritten: chunks,
+            wall_ns: ns,
+            write_amplification: if kk == 0 {
+                0.0
+            } else {
+                chunks as f64 / kk as f64
+            },
+            ns_per_op: if kk == 0 { 0.0 } else { ns as f64 / kk as f64 },
+        });
+    }
+
+    // --- subtree delete: remove every key under one listing prefix ---
+    let subtree_delete = subtree_delete_10(&store, &reader, &root, corpus, keys)?;
+
+    let update = Update {
+        single: Some(SingleUpdate {
+            update: Some(op_cost(&upd)),
+            insert: Some(op_cost(&ins)),
+            delete: Some(op_cost(&del)),
+            criterion_ns_per_op: None,
+        }),
+        batch: Some(batch),
+        batch_sweep,
+        subtree_delete: Some(subtree_delete),
+    };
+
+    Ok(Cell {
+        ran: true,
+        reason: None,
+        n_keys: Some(n as u64),
+        key_encoding: Some("raw".to_string()),
+        build: Some(build),
+        storage: Some(storage),
+        tree_depth: Some(tree_depth),
+        get: Some(get),
+        listing: Some(listing),
+        floor: Some(floor),
+        ceiling: Some(ceiling),
+        range: Some(range),
+        iter_full: Some(iter_full),
+        value_read: Some(value_read),
+        update: Some(update),
+        full_entries_walk_fetches: None,
+    })
+}
+
+/// The `[lo, hi)` sorted-key indices of a centred window of width `w`.
+fn window_indices(n: usize, w: f64) -> (usize, usize) {
+    if n == 0 {
+        return (0, 0);
+    }
+    let width = ((n as f64) * w).round() as usize;
+    let width = width.clamp(1, n);
+    let lo = (n - width) / 2;
+    let hi = (lo + width).min(n - 1);
+    (lo, hi)
+}
+
+/// Delete every key under the first listing prefix in one changeset.
+fn subtree_delete_10(
+    store: &CountingStore<StandardChunkSet>,
+    reader: &Reader<&CountingStore<StandardChunkSet>, V1>,
+    root: &ChunkAddress,
+    corpus: Corpus,
+    keys: &[GenKey],
+) -> Result<SubtreeDelete, Err> {
+    let prefixes = listing_prefixes(corpus, keys);
+    let Some(prefix) = prefixes.first() else {
+        return Ok(SubtreeDelete {
+            prefix_utf8: None,
+            keys_deleted: 0,
+            chunks_rewritten: 0,
+            wall_ns: 0,
+            reason: Some("no prefix available".to_string()),
+        });
+    };
+    let pk = Key::from(prefix.as_slice());
+    let mut cs = Changeset::<V1>::new();
+    let mut deleted = 0u64;
+    let mut cursor = block_on(reader.prefix(root, &pk))?;
+    while let Some((key, _entry)) = block_on(cursor.next())? {
+        cs.remove(key);
+        deleted += 1;
+    }
+    let before_p = store.puts();
+    let t = Instant::now();
+    let _ = block_on(apply(store, root, &cs))?;
+    let ns = t.elapsed().as_nanos() as u64;
+    Ok(SubtreeDelete {
+        prefix_utf8: String::from_utf8(prefix.clone()).ok(),
+        keys_deleted: deleted,
+        chunks_rewritten: store.puts() - before_p,
+        wall_ns: ns,
+        reason: None,
+    })
+}
+
+fn apply_measure(
+    store: &CountingStore<StandardChunkSet>,
+    root: &ChunkAddress,
+    cs: &Changeset<V1>,
+    acc: &mut (Vec<u64>, Vec<u64>),
+) -> Result<(), Err> {
+    let before = store.puts();
+    let t = Instant::now();
+    let _ = block_on(apply(store, root, cs))?;
+    acc.0.push(store.puts() - before);
+    acc.1.push(t.elapsed().as_nanos() as u64);
+    Ok(())
+}
+
+fn op_cost(acc: &(Vec<u64>, Vec<u64>)) -> OpCost {
+    OpCost {
+        chunks_rewritten_mean: Some(mean(&acc.0)),
+        wall_ns: Some(mean(&acc.1).round() as u64),
+    }
+}
+
+fn listing_prefixes(corpus: Corpus, keys: &[GenKey]) -> Vec<Vec<u8>> {
+    let n = keys.len();
+    if n == 0 {
+        return Vec::new();
+    }
+    let mut out: Vec<Vec<u8>> = Vec::new();
+    for j in 0..8 {
+        let idx = (j * n / 8).min(n - 1);
+        let raw = &keys[idx].raw;
+        let p: Vec<u8> = match corpus {
+            Corpus::Uniform => raw.iter().take(1).copied().collect(),
+            _ => match raw.iter().rposition(|&b| b == b'/') {
+                Some(pos) => raw[..=pos].to_vec(),
+                None => raw.iter().take(1).copied().collect(),
+            },
+        };
+        if !out.contains(&p) {
+            out.push(p);
+        }
+    }
+    out
+}
+
+// ========================================================================
+// mantaray 0.2
+// ========================================================================
+
+type Store02 = CountingStore<AnyChunkSet<4096>>;
+
+/// Measure one 0.2 cell as a full reader+writer over the plain (ref32) trie.
+pub fn measure_02(corpus: Corpus, keys: &[GenKey], cfg: Cfg) -> Result<Cell, Err> {
+    let store = Store02::new();
+    let n = keys.len();
+
+    // --- build: add-loop then one save ---
+    let mut m: PlainManifest<&Store02> = Manifest::new(&store);
+    let rss_before = peak_rss_bytes();
+    let t = Instant::now();
+    for k in keys {
+        let r = ref32(value_addr(k.path.as_bytes()));
+        match k.content_type {
+            Some(ct) => {
+                let mut md = std::collections::BTreeMap::new();
+                md.insert("content-type".to_string(), ct.to_string());
+                block_on(m.add_with_metadata(&k.path, r, md))?;
+            }
+            None => block_on(m.add(&k.path, r))?,
+        }
+    }
+    let root = block_on(m.save())?;
+    let build_ns = t.elapsed().as_nanos() as u64;
+    let rss_after = peak_rss_bytes();
+    let snap = store.snapshot();
+
+    // Second identical build: 0.2 obfuscation randomisation may defeat dedup,
+    // so measure how many new distinct chunks a re-save produces.
+    let (dedup, dedup_reason) = if n <= 100_000 {
+        let first_distinct = snap.distinct_puts;
+        let before = store.snapshot().distinct_puts;
+        let mut m2: PlainManifest<&Store02> = Manifest::new(&store);
+        for k in keys {
+            let r = ref32(value_addr(k.path.as_bytes()));
+            block_on(m2.add(&k.path, r))?;
+        }
+        let _ = block_on(m2.save())?;
+        let after = store.snapshot().distinct_puts;
+        let ratio = if first_distinct == 0 {
+            0.0
+        } else {
+            (after - before) as f64 / first_distinct as f64
+        };
+        (Some(ratio), None)
+    } else {
+        (
+            None,
+            Some("second build skipped above 1e5 to bound wall-clock".to_string()),
+        )
+    };
+
+    let build = Build {
+        wall_ns: Some(build_ns),
+        criterion_ns_per_op: None,
+        criterion_stddev_ns: None,
+        peak_open_nodes: None,
+        nodes_written: Some(snap.distinct_puts),
+        nodes_embedded: None,
+        peak_rss_bytes: rss_after.or(rss_before),
+        peak_live_store_bytes: Some(snap.peak_live_bytes),
+        // 0.2 holds the whole mutable trie in RAM at save: frontier = O(N).
+        builder_frontier_nodes: Some(snap.distinct_puts),
+        cpu_loglog: None,
+        dedup_ratio_second_build: dedup,
+        dedup_reason,
+    };
+    let total_chunks = snap.total_chunks;
+    // 0.2 never embeds children: pass None so embedding_ratio is explicit 0.0.
+    let storage = storage_block(total_chunks, snap.live_bytes, n as u64, None);
+
+    // --- get hops over the sample (fresh open, no trie caching) ---
+    let reader: PlainManifest<&Store02> = Manifest::open(root, &store);
+    let idxs = sample_indices(n, cfg.sample_keys);
+    let mut hops: Vec<u64> = Vec::with_capacity(idxs.len());
+    for &i in &idxs {
+        let before = store.gets();
+        let _ = block_on(reader.get(&keys[i].path))?;
+        hops.push(store.gets() - before);
+    }
+    let get = get_block(&hops, cfg.rtt_ms);
+    let mut depth_src = hops.clone();
+    let mut tree_depth = depth_from(&mut depth_src);
+
+    // Fanout: mean live children over internal (forked) nodes, via a full walk.
+    let mut fork_sum = 0u64;
+    let mut internal = 0u64;
+    let mut mw: PlainManifest<&Store02> = Manifest::open(root, &store);
+    block_on(mw.walk(&mut |_path, node| {
+        let f = node.forks().len() as u64;
+        if f > 0 {
+            fork_sum += f;
+            internal += 1;
+        }
+        Ok(())
+    }))?;
+    tree_depth.fanout_mean = Some(if internal == 0 {
+        0.0
+    } else {
+        fork_sum as f64 / internal as f64
+    });
+
+    // --- listing: pessimal full entries() walk, plus the FAIR walk_from on the
+    //     same prefixes a 1.0 caller would list ---
+    let before = store.gets();
+    let entries = block_on(reader.entries())?;
+    let walk_fetches = store.gets() - before;
+    let keys_returned = entries.len() as u64;
+    let full_entries = KfCount {
+        fetches: walk_fetches,
+        keys_returned,
+        fetches_per_key: if keys_returned == 0 {
+            0.0
+        } else {
+            walk_fetches as f64 / keys_returned as f64
+        },
+    };
+    // Fair fallback: walk_from(prefix) over the same logical prefixes as 1.0.
+    // walk_from only resolves an EXACT node-boundary path; a prefix that lands
+    // mid-edge raises NoForkFound. That is itself a 0.2 limitation, so such a
+    // prefix contributes nothing and is skipped rather than aborting the run.
+    let mut wf_fetches = 0u64;
+    let mut wf_keys = 0u64;
+    let mut wf_resolved = 0u64;
+    for pstr in listing_prefixes_02(corpus, keys) {
+        let before = store.gets();
+        let mut leaves = 0u64;
+        let mut mwf: PlainManifest<&Store02> = Manifest::open(root, &store);
+        let r = block_on(mwf.walk_from(&pstr, &mut |_p, node| {
+            if node.is_value() {
+                leaves += 1;
+            }
+            Ok(())
+        }));
+        if r.is_ok() {
+            wf_fetches += store.gets() - before;
+            wf_keys += leaves;
+            wf_resolved += 1;
+        }
+    }
+    let walk_from_opt = (wf_resolved > 0).then(|| KfCount {
+        fetches: wf_fetches,
+        keys_returned: wf_keys,
+        fetches_per_key: if wf_keys == 0 {
+            0.0
+        } else {
+            wf_fetches as f64 / wf_keys as f64
+        },
+    });
+    let listing = Listing {
+        method: "walk_from_fair + full_entries_pessimal".to_string(),
+        fetch_count: Some(wf_fetches),
+        keys_returned: Some(wf_keys),
+        fetches_per_key: walk_from_opt.as_ref().map(|k| k.fetches_per_key),
+        fallback_02_full_entries: Some(full_entries),
+        fallback_02_walk_from: walk_from_opt,
+        multiplier_fair: None,
+    };
+
+    // floor / ceiling / range: no ordered/seekable API; the real 0.2 emulation
+    // is the full entries() walk (O(N)), whose fetch count == walk_fetches.
+    let floor = Floor {
+        supported: false,
+        reason: Some("no ordered/seekable API; emulated by full entries() walk".to_string()),
+        hops_mean: None,
+        hops_p95: None,
+        hops_max: None,
+        hops_histogram: None,
+        fallback_02: None,
+    };
+    let ceiling = Ceiling {
+        supported: false,
+        class: "unsupported".to_string(),
+        native_seek_hops_mean: None,
+        native_seek_hops_max: None,
+        fallback_02: None,
+    };
+    let range = Range {
+        supported: false,
+        reason: Some("no ordered/seekable API; emulated by full entries() walk".to_string()),
+        windows: Vec::new(),
+    };
+    let iter_full = IterFull {
+        native_fetch_to_first_key: None,
+        native_fetch_all: None,
+        fallback_02_materialise_fetches: Some(walk_fetches),
+        // entries() DFS order is undocumented and entries_concurrent is
+        // explicitly unordered: no ordered-iter guarantee.
+        ordered_guaranteed: false,
+    };
+    let value_read = ValueRead {
+        inline_fraction: None,
+        fetches_native_mean: None,
+        fetches_02_mean: None,
+        chunks_saved_by_inline: None,
+        reason: Some("no inline entries in 0.2; values are references".to_string()),
+    };
+
+    // --- single-key update / insert / delete: add/remove + save ---
+    let usample = sample_indices(n, cfg.update_sample);
+    let mut upd = (Vec::new(), Vec::new());
+    let mut ins = (Vec::new(), Vec::new());
+    let mut del = (Vec::new(), Vec::new());
+    for (tag, &i) in usample.iter().enumerate() {
+        let k = &keys[i];
+        // update
+        let r = ref32(tagged_addr(b"upd", k.path.as_bytes()));
+        save_measure(&store, root, &mut upd, |mm| block_on(mm.add(&k.path, r)))?;
+        // insert
+        let (_iraw, ipath) = insert_key(tag);
+        let ir = ref32(value_addr(ipath.as_bytes()));
+        save_measure(&store, root, &mut ins, |mm| block_on(mm.add(&ipath, ir)))?;
+        // delete
+        save_measure(&store, root, &mut del, |mm| block_on(mm.remove(&k.path)))?;
+    }
+
+    // --- batch: {K adds/removes} + one save ---
+    let kops = n.min(cfg.batch_ops);
+    let all_update = matches!(corpus, Corpus::OsmPyramid | Corpus::OsmBbox);
+    let mut mb: PlainManifest<&Store02> = Manifest::open(root, &store);
+    let before_p = store.puts();
+    let t = Instant::now();
+    for (i, k) in keys.iter().take(kops).enumerate() {
+        let slot = i % 10;
+        if all_update || slot < 8 {
+            let r = ref32(tagged_addr(b"upd", k.path.as_bytes()));
+            block_on(mb.add(&k.path, r))?;
+        } else if slot == 8 {
+            let (_ir, ip) = insert_key(1_000_000 + i);
+            let r = ref32(value_addr(ip.as_bytes()));
+            block_on(mb.add(&ip, r))?;
+        } else {
+            block_on(mb.remove(&k.path))?;
+        }
+    }
+    let _ = block_on(mb.save())?;
+    let batch_ns = t.elapsed().as_nanos() as u64;
+    let batch_chunks = store.puts() - before_p;
+    let batch = BatchUpdate {
+        k_ops: Some(kops as u64),
+        mix: if all_update {
+            "100/0/0 (adds+save)".to_string()
+        } else {
+            "80/10/10 (adds+save)".to_string()
+        },
+        chunks_rewritten: Some(batch_chunks),
+        wall_ns: Some(batch_ns),
+        write_amplification: Some(if kops == 0 {
+            0.0
+        } else {
+            batch_chunks as f64 / kops as f64
+        }),
+        criterion_ns_per_op: None,
+    };
+
+    // --- batch-size sweep: K mutations + one save per K ---
+    let mut batch_sweep: Vec<BatchPoint> = Vec::with_capacity(BATCH_KS.len());
+    let mix_label = if all_update {
+        "100/0/0 (adds+save)"
+    } else {
+        "80/10/10 (adds+save)"
+    };
+    for &k in &BATCH_KS {
+        let kk = n.min(k);
+        let mut ms: PlainManifest<&Store02> = Manifest::open(root, &store);
+        let before_p = store.puts();
+        let t = Instant::now();
+        for (i, key) in keys.iter().take(kk).enumerate() {
+            let slot = i % 10;
+            if all_update || slot < 8 {
+                let r = ref32(tagged_addr(b"upd", key.path.as_bytes()));
+                block_on(ms.add(&key.path, r))?;
+            } else if slot == 8 {
+                let (_ir, ip) = insert_key(2_000_000 + i);
+                let r = ref32(value_addr(ip.as_bytes()));
+                block_on(ms.add(&ip, r))?;
+            } else {
+                block_on(ms.remove(&key.path))?;
+            }
+        }
+        let _ = block_on(ms.save())?;
+        let ns = t.elapsed().as_nanos() as u64;
+        let chunks = store.puts() - before_p;
+        batch_sweep.push(BatchPoint {
+            k: kk as u64,
+            mix: mix_label.to_string(),
+            chunks_rewritten: chunks,
+            wall_ns: ns,
+            write_amplification: if kk == 0 {
+                0.0
+            } else {
+                chunks as f64 / kk as f64
+            },
+            ns_per_op: if kk == 0 { 0.0 } else { ns as f64 / kk as f64 },
+        });
+    }
+
+    // --- subtree delete: remove every key under one listing prefix + save ---
+    let subtree_delete = subtree_delete_02(&store, root, corpus, keys)?;
+
+    let update = Update {
+        single: Some(SingleUpdate {
+            update: Some(op_cost(&upd)),
+            insert: Some(op_cost(&ins)),
+            delete: Some(op_cost(&del)),
+            criterion_ns_per_op: None,
+        }),
+        batch: Some(batch),
+        batch_sweep,
+        subtree_delete: Some(subtree_delete),
+    };
+
+    Ok(Cell {
+        ran: true,
+        reason: None,
+        n_keys: Some(n as u64),
+        key_encoding: Some(corpus.key_encoding().to_string()),
+        build: Some(build),
+        storage: Some(storage),
+        tree_depth: Some(tree_depth),
+        get: Some(get),
+        listing: Some(listing),
+        floor: Some(floor),
+        ceiling: Some(ceiling),
+        range: Some(range),
+        iter_full: Some(iter_full),
+        value_read: Some(value_read),
+        update: Some(update),
+        full_entries_walk_fetches: Some(walk_fetches),
+    })
+}
+
+/// 0.2 listing prefixes matching the 1.0 logical prefixes: for uniform (hex
+/// paths) the 1-raw-byte prefix maps to its 2-hex-char string; path corpora
+/// are byte-identical.
+fn listing_prefixes_02(corpus: Corpus, keys: &[GenKey]) -> Vec<String> {
+    listing_prefixes(corpus, keys)
+        .into_iter()
+        .filter_map(|p| match corpus {
+            Corpus::Uniform => Some(bytes_to_hex(&p)),
+            _ => String::from_utf8(p).ok(),
+        })
+        .collect()
+}
+
+fn bytes_to_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        s.push(HEX[usize::from(b >> 4)] as char);
+        s.push(HEX[usize::from(b & 0x0f)] as char);
+    }
+    s
+}
+
+/// Delete every 0.2 key under the first listing prefix, one save.
+fn subtree_delete_02(
+    store: &Store02,
+    root: ChunkAddress,
+    corpus: Corpus,
+    keys: &[GenKey],
+) -> Result<SubtreeDelete, Err> {
+    let Some(prefix) = listing_prefixes_02(corpus, keys).into_iter().next() else {
+        return Ok(SubtreeDelete {
+            prefix_utf8: None,
+            keys_deleted: 0,
+            chunks_rewritten: 0,
+            wall_ns: 0,
+            reason: Some("no prefix available".to_string()),
+        });
+    };
+    let victims: Vec<&str> = keys
+        .iter()
+        .map(|k| k.path.as_str())
+        .filter(|p| p.starts_with(&prefix))
+        .collect();
+    let mut mm: PlainManifest<&Store02> = Manifest::open(root, store);
+    let before_p = store.puts();
+    let t = Instant::now();
+    for p in &victims {
+        block_on(mm.remove(p))?;
+    }
+    let _ = block_on(mm.save())?;
+    let ns = t.elapsed().as_nanos() as u64;
+    Ok(SubtreeDelete {
+        prefix_utf8: Some(prefix),
+        keys_deleted: victims.len() as u64,
+        chunks_rewritten: store.puts() - before_p,
+        wall_ns: ns,
+        reason: None,
+    })
+}
+
+fn save_measure<Fn>(
+    store: &Store02,
+    root: ChunkAddress,
+    acc: &mut (Vec<u64>, Vec<u64>),
+    mutate: Fn,
+) -> Result<(), Err>
+where
+    Fn: FnOnce(&mut PlainManifest<&Store02>) -> Result<(), nectar_mantaray::MantarayError>,
+{
+    let mut mm: PlainManifest<&Store02> = Manifest::open(root, store);
+    let before = store.puts();
+    let t = Instant::now();
+    mutate(&mut mm)?;
+    let _ = block_on(mm.save())?;
+    acc.0.push(store.puts() - before);
+    acc.1.push(t.elapsed().as_nanos() as u64);
+    Ok(())
+}

--- a/crates/manifest-sim/src/perf_v3.rs
+++ b/crates/manifest-sim/src/perf_v3.rs
@@ -1,0 +1,450 @@
+//! Measurements for the v3 range-query performance run.
+//!
+//! Every figure is produced by executing a real reader or cursor over one of
+//! the shared corpora. The single modelled quantity is wall-clock latency, and
+//! it is always a MEASURED count times a stated RTT:
+//! the serial baseline is `fetch_count * rtt`, and the bounded-concurrent figure
+//! is `rounds * rtt` where `rounds` is read off the real cursor under a paused
+//! virtual clock. A capability gap is a `null` with a reason, never an estimate.
+
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::time::Duration;
+
+use bytes::Bytes;
+use futures::executor::block_on;
+
+use nectar_manifest::{
+    Builder, Changeset, Entry, Format, Key, KeyId, Metadata, Reader, V1, V1Read, apply,
+};
+use nectar_primitives::store::MemoryStore;
+use nectar_primitives::{ChunkAddress, ChunkRef, StandardChunkSet};
+
+use crate::corpus::{Corpus, GenKey, tagged_addr, value_addr};
+use crate::results_v3::{
+    CursorLatency, PaginateCell, ParallelCursorCell, ReadProfileCell, ReadProfileSide,
+};
+use crate::store::{CountingStore, LatencyStore};
+
+type Err = Box<dyn Error>;
+
+/// Range-window fractions of the key domain: 0.1% up to 100%.
+pub const RANGE_WS: [f64; 4] = [0.001, 0.01, 0.10, 1.0];
+/// RTT values (ms) for the serial-vs-concurrent latency model.
+pub const RTT_SET: [u32; 3] = [25, 50, 75];
+/// Rank offsets for the pagination sweep.
+pub const PAGE_OFFSETS: [u64; 5] = [0, 100, 1_000, 10_000, 100_000];
+/// Keys returned per pagination request.
+pub const PAGE_LIMIT: usize = 20;
+/// One virtual millisecond of modelled latency per node fetch.
+const RTT_UNIT: Duration = Duration::from_millis(1);
+/// A key sorting strictly above every corpus key: the open upper bound.
+const MAX_KEY: [u8; 48] = [0xff; 48];
+
+// ---- shared builders -----------------------------------------------------
+
+fn ref32(addr: [u8; 32]) -> ChunkRef {
+    ChunkRef::new(ChunkAddress::new(addr))
+}
+
+fn entry_for<F: Format>(bytes: &[u8]) -> Entry<F> {
+    Entry::<F>::from(ref32(value_addr(bytes)))
+}
+
+fn alt_entry_for<F: Format>(bytes: &[u8]) -> Entry<F> {
+    Entry::<F>::from(ref32(tagged_addr(b"upd", bytes)))
+}
+
+fn meta_for<F: Format>(k: &GenKey) -> Option<Metadata<F>> {
+    k.content_type.and_then(|ct| {
+        Metadata::<F>::new(KeyId::ContentType, Bytes::from_static(ct.as_bytes())).ok()
+    })
+}
+
+/// Build every key into a fresh in-memory store, returning the root.
+fn build_mem<F: Format>(keys: &[GenKey]) -> Result<(MemoryStore, ChunkAddress), Err> {
+    let store = MemoryStore::default();
+    let mut builder = Builder::<F>::new();
+    for k in keys {
+        builder.insert(
+            Key::from(k.raw.as_slice()),
+            entry_for::<F>(&k.raw),
+            meta_for::<F>(k),
+        );
+    }
+    let built = block_on(builder.build(&store))?;
+    let root = *built.root();
+    Ok((store, root))
+}
+
+/// Build every key into a fresh counting store, returning the root.
+fn build_counting<F: Format>(
+    keys: &[GenKey],
+) -> Result<(CountingStore<StandardChunkSet>, ChunkAddress), Err> {
+    let store = CountingStore::<StandardChunkSet>::new();
+    let mut builder = Builder::<F>::new();
+    for k in keys {
+        builder.insert(
+            Key::from(k.raw.as_slice()),
+            entry_for::<F>(&k.raw),
+            meta_for::<F>(k),
+        );
+    }
+    let built = block_on(builder.build(&store))?;
+    let root = *built.root();
+    Ok((store, root))
+}
+
+/// Deterministic evenly-spaced sample of `count` indices in `0..n`.
+fn sample_indices(n: usize, count: usize) -> Vec<usize> {
+    if n == 0 {
+        return Vec::new();
+    }
+    if n <= count {
+        return (0..n).collect();
+    }
+    let stride = n / count;
+    (0..count).map(|j| (j * stride).min(n - 1)).collect()
+}
+
+/// The `[lo, hi)` sorted-key indices of a centred window of width `w`.
+fn window_indices(n: usize, w: f64) -> (usize, usize) {
+    if n == 0 {
+        return (0, 0);
+    }
+    let width = ((n as f64) * w).round() as usize;
+    let width = width.clamp(1, n);
+    let lo = (n - width) / 2;
+    let hi = (lo + width).min(n - 1);
+    (lo, hi)
+}
+
+/// The `lo` and open `hi` keys of a centred window; a full window opens the
+/// upper bound past every key so the scan runs to the last.
+fn window_keys(keys: &[GenKey], w: f64) -> (Key, Key) {
+    let n = keys.len();
+    let (lo_i, hi_i) = window_indices(n, w);
+    let lo = keys
+        .get(lo_i)
+        .map_or_else(Key::empty, |k| Key::from(k.raw.as_slice()));
+    let hi = if w >= 1.0 {
+        Key::from(MAX_KEY.as_slice())
+    } else {
+        keys.get(hi_i).map_or_else(
+            || Key::from(MAX_KEY.as_slice()),
+            |k| Key::from(k.raw.as_slice()),
+        )
+    };
+    (lo, hi)
+}
+
+/// The first listing prefix of a path corpus (the bytes up to the first '/'),
+/// or a one-byte prefix for the uniform corpus.
+fn first_prefix(corpus: Corpus, keys: &[GenKey]) -> Option<Vec<u8>> {
+    let mid = keys.get(keys.len() / 2)?;
+    let raw = &mid.raw;
+    let p = match corpus {
+        Corpus::Uniform => raw.iter().take(1).copied().collect(),
+        _ => match raw.iter().rposition(|&b| b == b'/') {
+            Some(pos) => raw.get(..=pos).map(<[u8]>::to_vec).unwrap_or_default(),
+            None => raw.iter().take(1).copied().collect(),
+        },
+    };
+    Some(p)
+}
+
+// ---- #293 parallel cursor ------------------------------------------------
+
+/// Drain a range scan under a paused virtual clock, returning
+/// `(fetch_count, rounds, keys_returned)`. One virtual millisecond is charged
+/// per node fetch, so the elapsed virtual time is exactly `rounds` and the
+/// bounded-concurrency read-ahead collapses independent fetches into one round.
+fn range_rounds<F: Format>(
+    store: &MemoryStore,
+    root: &ChunkAddress,
+    lo: &Key,
+    hi: &Key,
+) -> Result<(u64, u64, u64), Err> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .start_paused(true)
+        .build()?;
+    let out: Result<(u64, u64, u64), nectar_manifest::ReaderError> = rt.block_on(async {
+        let latency = LatencyStore::<StandardChunkSet>::new(store, RTT_UNIT);
+        let reader = Reader::<&LatencyStore<StandardChunkSet>, F>::new(&latency);
+        let t0 = tokio::time::Instant::now();
+        let mut cursor = reader.range(root, lo, hi).await?;
+        let mut keys = 0u64;
+        while cursor.next().await?.is_some() {
+            keys = keys.saturating_add(1);
+        }
+        let rounds = t0.elapsed().as_millis() as u64;
+        Ok((latency.gets(), rounds, keys))
+    });
+    Ok(out?)
+}
+
+/// Drain a prefix scan under the paused virtual clock, as [`range_rounds`].
+fn prefix_rounds<F: Format>(
+    store: &MemoryStore,
+    root: &ChunkAddress,
+    prefix: &Key,
+) -> Result<(u64, u64, u64), Err> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .start_paused(true)
+        .build()?;
+    let out: Result<(u64, u64, u64), nectar_manifest::ReaderError> = rt.block_on(async {
+        let latency = LatencyStore::<StandardChunkSet>::new(store, RTT_UNIT);
+        let reader = Reader::<&LatencyStore<StandardChunkSet>, F>::new(&latency);
+        let t0 = tokio::time::Instant::now();
+        let mut cursor = reader.prefix(root, prefix).await?;
+        let mut keys = 0u64;
+        while cursor.next().await?.is_some() {
+            keys = keys.saturating_add(1);
+        }
+        let rounds = t0.elapsed().as_millis() as u64;
+        Ok((latency.gets(), rounds, keys))
+    });
+    Ok(out?)
+}
+
+/// The serial and bounded-concurrent latency at each RTT, and their speedup.
+fn cursor_latency(fetch_count: u64, rounds: u64) -> BTreeMap<String, CursorLatency> {
+    let mut by = BTreeMap::new();
+    for rtt in RTT_SET {
+        let r = f64::from(rtt);
+        let serial = fetch_count as f64 * r;
+        let concurrent = rounds as f64 * r;
+        by.insert(
+            rtt.to_string(),
+            CursorLatency {
+                serial_ms: serial,
+                concurrent_ms: concurrent,
+                speedup: (concurrent > 0.0).then(|| serial / concurrent),
+            },
+        );
+    }
+    by
+}
+
+const PC_MODEL: &str = "serial = fetch_count * rtt; concurrent = rounds * rtt; rounds measured from the real \
+bounded-concurrency cursor under a paused virtual clock (READ_AHEAD=16), one RTT charged per node \
+fetch; fetch_count is identical for both.";
+
+/// Parallel-cursor cells for one `(corpus, scale)`: a range sweep plus one
+/// prefix scan.
+pub fn parallel_cursor_cells(
+    corpus: Corpus,
+    scale: u64,
+    keys: &[GenKey],
+) -> Result<Vec<ParallelCursorCell>, Err> {
+    let (store, root) = build_mem::<V1>(keys)?;
+    let mut cells = Vec::new();
+    for &w in &RANGE_WS {
+        let (lo, hi) = window_keys(keys, w);
+        let (fetch_count, rounds, keys_returned) = range_rounds::<V1>(&store, &root, &lo, &hi)?;
+        cells.push(ParallelCursorCell {
+            corpus: corpus.name().to_string(),
+            scale,
+            op: "range".to_string(),
+            window: Some(w),
+            keys_returned,
+            fetch_count,
+            rounds,
+            read_ahead: V1::READ_AHEAD as u32,
+            by_rtt_ms: cursor_latency(fetch_count, rounds),
+            model: PC_MODEL.to_string(),
+        });
+    }
+    if let Some(prefix) = first_prefix(corpus, keys) {
+        let pk = Key::from(prefix.as_slice());
+        let (fetch_count, rounds, keys_returned) = prefix_rounds::<V1>(&store, &root, &pk)?;
+        cells.push(ParallelCursorCell {
+            corpus: corpus.name().to_string(),
+            scale,
+            op: "prefix".to_string(),
+            window: None,
+            keys_returned,
+            fetch_count,
+            rounds,
+            read_ahead: V1::READ_AHEAD as u32,
+            by_rtt_ms: cursor_latency(fetch_count, rounds),
+            model: PC_MODEL.to_string(),
+        });
+    }
+    Ok(cells)
+}
+
+// ---- #295 V1Read vs V1 ---------------------------------------------------
+
+/// Mean and max get-depth over a key sample, counted as store fetches per get.
+fn get_depth<F: Format>(
+    store: &CountingStore<StandardChunkSet>,
+    reader: &Reader<&CountingStore<StandardChunkSet>, F>,
+    root: &ChunkAddress,
+    keys: &[GenKey],
+    idxs: &[usize],
+) -> Result<(f64, u64), Err> {
+    let mut hops: Vec<u64> = Vec::with_capacity(idxs.len());
+    for &i in idxs {
+        if let Some(k) = keys.get(i) {
+            let before = store.gets();
+            let _ = block_on(reader.get(root, &Key::from(k.raw.as_slice())))?;
+            hops.push(store.gets().saturating_sub(before));
+        }
+    }
+    let sum: u128 = hops.iter().map(|&x| u128::from(x)).sum();
+    let mean = if hops.is_empty() {
+        0.0
+    } else {
+        sum as f64 / hops.len() as f64
+    };
+    let max = hops.iter().copied().max().unwrap_or(0);
+    Ok((mean, max))
+}
+
+/// Fetches to drain each range window, and mean single-update write-amp, for one
+/// format over one corpus.
+fn read_side<F: Format>(keys: &[GenKey]) -> Result<ReadProfileSide, Err> {
+    let (store, root) = build_counting::<F>(keys)?;
+    let reader = Reader::<&CountingStore<StandardChunkSet>, F>::new(&store);
+    let n = keys.len();
+    let idxs = sample_indices(n, 256);
+    let (depth_mean, depth_max) = get_depth::<F>(&store, &reader, &root, keys, &idxs)?;
+
+    let mut range_fetch = BTreeMap::new();
+    for &w in &RANGE_WS {
+        let (lo, hi) = window_keys(keys, w);
+        let before = store.gets();
+        let mut cursor = block_on(reader.range(&root, &lo, &hi))?;
+        while block_on(cursor.next())?.is_some() {}
+        range_fetch.insert(fmt_w(w), store.gets().saturating_sub(before));
+    }
+
+    // Single-key update write-amplification: one-op changesets over the sample.
+    let usample = sample_indices(n, 48);
+    let mut rewrites: Vec<u64> = Vec::with_capacity(usample.len());
+    for &i in &usample {
+        if let Some(k) = keys.get(i) {
+            let mut cs = Changeset::<F>::new();
+            cs.put(
+                Key::from(k.raw.as_slice()),
+                alt_entry_for::<F>(&k.raw),
+                meta_for::<F>(k),
+            );
+            let before = store.puts();
+            let _ = block_on(apply(&store, &root, &cs))?;
+            rewrites.push(store.puts().saturating_sub(before));
+        }
+    }
+    let sum: u128 = rewrites.iter().map(|&x| u128::from(x)).sum();
+    let wa_mean = if rewrites.is_empty() {
+        0.0
+    } else {
+        sum as f64 / rewrites.len() as f64
+    };
+
+    Ok(ReadProfileSide {
+        version_byte: F::VERSION,
+        inline_max: F::INLINE_MAX as u32,
+        tree_depth_mean: depth_mean,
+        tree_depth_max: depth_max,
+        range_fetch_by_window: range_fetch,
+        single_update_chunks_mean: wa_mean,
+    })
+}
+
+fn fmt_w(w: f64) -> String {
+    format!("{w}")
+}
+
+/// The V1Read-vs-V1 cell for one `(corpus, scale)`.
+pub fn read_profile_cell(
+    corpus: Corpus,
+    scale: u64,
+    keys: &[GenKey],
+) -> Result<ReadProfileCell, Err> {
+    let v1 = read_side::<V1>(keys)?;
+    let v1read = read_side::<V1Read>(keys)?;
+    let mut fetch_ratio = BTreeMap::new();
+    for &w in &RANGE_WS {
+        let key = fmt_w(w);
+        if let (Some(&a), Some(&b)) = (
+            v1read.range_fetch_by_window.get(&key),
+            v1.range_fetch_by_window.get(&key),
+        ) && b > 0
+        {
+            fetch_ratio.insert(key, a as f64 / b as f64);
+        }
+    }
+    let depth_ratio =
+        (v1.tree_depth_mean > 0.0).then(|| v1read.tree_depth_mean / v1.tree_depth_mean);
+    let delta = v1read.single_update_chunks_mean - v1.single_update_chunks_mean;
+    let ratio = (v1.single_update_chunks_mean > 0.0)
+        .then(|| v1read.single_update_chunks_mean / v1.single_update_chunks_mean);
+    Ok(ReadProfileCell {
+        corpus: corpus.name().to_string(),
+        scale,
+        v1,
+        v1read,
+        fetch_ratio_by_window: fetch_ratio,
+        depth_ratio,
+        single_update_wa_delta: delta,
+        single_update_wa_ratio: ratio,
+    })
+}
+
+// ---- #296/#303 paginate --------------------------------------------------
+
+/// The pagination sweep for one `(corpus, scale)`: rank-directed paginate.
+pub fn paginate_cells(
+    corpus: Corpus,
+    scale: u64,
+    keys: &[GenKey],
+) -> Result<Vec<PaginateCell>, Err> {
+    let (store, root) = build_counting::<V1>(keys)?;
+    let reader = Reader::<&CountingStore<StandardChunkSet>, V1>::new(&store);
+    let n = keys.len() as u64;
+    let empty = Key::empty();
+    let mut cells = Vec::new();
+    for &offset in &PAGE_OFFSETS {
+        if offset >= n {
+            continue;
+        }
+        // Rank-directed paginate: O(depth) regardless of offset.
+        let before = store.gets();
+        let mut cursor = block_on(reader.paginate_prefix(&root, &empty, offset, PAGE_LIMIT))?;
+        let mut returned = 0u64;
+        while block_on(cursor.next())?.is_some() {
+            returned = returned.saturating_add(1);
+        }
+        let paginate_fetch = store.gets().saturating_sub(before);
+
+        // Baseline: iter().skip(offset).take(limit); fetches grow with offset.
+        let before = store.gets();
+        let mut it = block_on(reader.iter(&root))?;
+        let mut seen = 0u64;
+        let target = offset.saturating_add(PAGE_LIMIT as u64);
+        while seen < target {
+            if block_on(it.next())?.is_none() {
+                break;
+            }
+            seen = seen.saturating_add(1);
+        }
+        let skip_fetch = store.gets().saturating_sub(before);
+
+        cells.push(PaginateCell {
+            corpus: corpus.name().to_string(),
+            scale,
+            offset,
+            limit: PAGE_LIMIT as u32,
+            keys_returned: returned,
+            paginate_fetch_count: paginate_fetch,
+            skip_baseline_fetch_count: skip_fetch,
+            skip_over_paginate: (paginate_fetch > 0)
+                .then(|| skip_fetch as f64 / paginate_fetch as f64),
+        });
+    }
+    Ok(cells)
+}

--- a/crates/manifest-sim/src/results.rs
+++ b/crates/manifest-sim/src/results.rs
@@ -1,0 +1,352 @@
+//! Serializable result schema: `format -> corpus -> scale -> cell`.
+//!
+//! Every numeric field is `Option`; a `None` serializes to JSON `null` and is
+//! only ever set by a real measurement or left null with a reason. No field is
+//! back-filled by estimate. The top-level `capability_matrix` and `headlines`
+//! are the machine-readable op x format matrix and the cross-cell multiplier
+//! summary; both are populated only from executed cells (headlines) or from
+//! fixed API facts verified on the source tree (the matrix rows).
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+
+/// A discrete PMF: value -> frequency, serialized with stringised integer keys.
+pub type Histogram = BTreeMap<u64, u64>;
+
+/// The whole result document.
+#[derive(Debug, Serialize)]
+pub struct Document {
+    pub meta: Meta,
+    /// Exhaustive op x format capability matrix (fixed API facts).
+    pub capability_matrix: Vec<CapabilityRow>,
+    /// Cross-cell headline multipliers, computed from executed cells only.
+    pub headlines: Headlines,
+    pub formats: BTreeMap<String, FormatBlock>,
+}
+
+/// Run-level metadata.
+#[derive(Debug, Serialize)]
+pub struct Meta {
+    pub generated: String,
+    pub git_branch: String,
+    pub git_commit: String,
+    pub harness_version: String,
+    pub seed_master: String,
+    pub rtt_ms: u32,
+    pub rtt_ms_set: Vec<u32>,
+    pub batch_k_sweep: Vec<u64>,
+    pub range_windows: Vec<f64>,
+    pub value_read_corpus: String,
+    pub chunk_body_size: u32,
+    pub criterion_iters_note: String,
+    pub sample_keys: u32,
+    pub update_sample: u32,
+    pub batch_ops: u32,
+    /// Honest caveats embedded so numbers are never read out of context.
+    pub caveats: Vec<String>,
+}
+
+/// One row of the capability matrix (fixed API facts, not a measurement).
+#[derive(Debug, Clone, Serialize)]
+pub struct CapabilityRow {
+    pub n: u32,
+    pub op: String,
+    pub v1_supported: bool,
+    pub v1_api: Option<String>,
+    pub v1_class: String,
+    pub v02_supported: bool,
+    pub v02_api: Option<String>,
+    pub v02_class: String,
+    pub v02_fallback: Option<String>,
+    pub v02_asymptote: Option<String>,
+    pub notes: String,
+}
+
+/// Cross-cell headline multipliers, all derived from executed cells only.
+#[derive(Debug, Default, Serialize)]
+pub struct Headlines {
+    pub notes: String,
+    pub entries: Vec<Headline>,
+}
+
+/// One headline multiplier at a `(corpus, scale)` where both sides ran.
+#[derive(Debug, Serialize)]
+pub struct Headline {
+    pub metric: String,
+    pub corpus: String,
+    pub scale: u64,
+    pub native: f64,
+    pub native_unit: String,
+    pub fallback: Option<f64>,
+    pub fallback_unit: String,
+    pub multiplier: Option<f64>,
+    pub reason_if_null: Option<String>,
+}
+
+/// One format's corpora.
+#[derive(Debug, Serialize)]
+pub struct FormatBlock {
+    #[serde(rename = "crate")]
+    pub crate_name: String,
+    pub registry: String,
+    pub corpora: BTreeMap<String, CorpusBlock>,
+}
+
+/// One corpus' scales.
+#[derive(Debug, Serialize)]
+pub struct CorpusBlock {
+    pub scales: BTreeMap<String, Cell>,
+}
+
+/// One measured `(format, corpus, scale)` cell.
+#[derive(Debug, Default, Serialize)]
+pub struct Cell {
+    pub ran: bool,
+    pub reason: Option<String>,
+    pub n_keys: Option<u64>,
+    pub key_encoding: Option<String>,
+    pub build: Option<Build>,
+    pub storage: Option<Storage>,
+    pub tree_depth: Option<Depth>,
+    pub get: Option<Get>,
+    pub listing: Option<Listing>,
+    pub floor: Option<Floor>,
+    pub ceiling: Option<Ceiling>,
+    pub range: Option<Range>,
+    pub iter_full: Option<IterFull>,
+    pub value_read: Option<ValueRead>,
+    pub update: Option<Update>,
+    /// The full O(N) entries-walk fetch count (0.2 only), used by the bin to
+    /// cross-fill floor/ceiling/range fallback multipliers into the 1.0 cell.
+    pub full_entries_walk_fetches: Option<u64>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct Build {
+    pub wall_ns: Option<u64>,
+    pub criterion_ns_per_op: Option<f64>,
+    pub criterion_stddev_ns: Option<f64>,
+    pub peak_open_nodes: Option<u64>,
+    pub nodes_written: Option<u64>,
+    pub nodes_embedded: Option<u64>,
+    pub peak_rss_bytes: Option<u64>,
+    pub peak_live_store_bytes: Option<u64>,
+    /// 1.0 = peak_open_nodes (O(depth) frontier); 0.2 = nodes_written (O(N)).
+    pub builder_frontier_nodes: Option<u64>,
+    /// Least-squares fit of log(ns) vs log(N); filled in the bin.
+    pub cpu_loglog: Option<LogLog>,
+    /// distinct puts of a second identical build / distinct puts of the first.
+    pub dedup_ratio_second_build: Option<f64>,
+    pub dedup_reason: Option<String>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct LogLog {
+    pub slope: f64,
+    pub intercept: f64,
+    pub r2: f64,
+    pub n_points: u32,
+    pub basis: String,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct Storage {
+    pub total_chunks: Option<u64>,
+    pub total_payload_bytes: Option<u64>,
+    pub storage_utilisation: Option<f64>,
+    pub bytes_per_key: Option<f64>,
+    pub chunks_per_key: Option<f64>,
+    /// embedded/(embedded+written); 0.2 has no embedding so this is 0.0.
+    pub embedding_ratio: Option<f64>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct Depth {
+    pub min: Option<u64>,
+    pub mean: Option<f64>,
+    pub p95: Option<u64>,
+    pub max: Option<u64>,
+    pub histogram: Option<Histogram>,
+    pub fanout_mean: Option<f64>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct Get {
+    pub sampled_keys: Option<u64>,
+    pub hops_mean: Option<f64>,
+    pub hops_p95: Option<u64>,
+    pub hops_max: Option<u64>,
+    pub load_latency_ms: Option<LoadLatency>,
+    pub criterion_ns_per_op: Option<f64>,
+    pub hops_histogram: Option<Histogram>,
+    pub hops_cdf: Option<Cdf>,
+    pub wall_latency_ms: Option<WallLatency>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct LoadLatency {
+    pub mean: Option<f64>,
+    pub p95: Option<f64>,
+    pub max: Option<f64>,
+    pub derived_from_hops: bool,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct Cdf {
+    pub p50: u64,
+    pub p90: u64,
+    pub p99: u64,
+    pub max: u64,
+}
+
+/// Multi-RTT hop x RTT model. Never a measurement: the `model` string states so.
+#[derive(Debug, Serialize)]
+pub struct WallLatency {
+    pub by_rtt_ms: BTreeMap<String, LatQuad>,
+    pub model: String,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct LatQuad {
+    pub p50: f64,
+    pub p90: f64,
+    pub p99: f64,
+    pub max: f64,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct Listing {
+    pub method: String,
+    pub fetch_count: Option<u64>,
+    pub keys_returned: Option<u64>,
+    pub fetches_per_key: Option<f64>,
+    /// 0.2 pessimal fallback: a full entries() walk over ALL keys.
+    pub fallback_02_full_entries: Option<KfCount>,
+    /// 0.2 fair fallback: walk_from(prefix) on the SAME prefixes as 1.0.
+    pub fallback_02_walk_from: Option<KfCount>,
+    /// 0.2 fair fetch / 1.0 fetch on identical prefixes; filled in the bin.
+    pub multiplier_fair: Option<f64>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct KfCount {
+    pub fetches: u64,
+    pub keys_returned: u64,
+    pub fetches_per_key: f64,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct Floor {
+    pub supported: bool,
+    pub reason: Option<String>,
+    pub hops_mean: Option<f64>,
+    pub hops_p95: Option<u64>,
+    pub hops_max: Option<u64>,
+    pub hops_histogram: Option<Histogram>,
+    pub fallback_02: Option<Fallback>,
+}
+
+/// A 0.2 emulation cost and its multiplier vs a native cost; filled in the bin
+/// for the matching `(corpus, scale)` where both sides ran.
+#[derive(Debug, Default, Serialize)]
+pub struct Fallback {
+    pub method: String,
+    pub fetches: Option<u64>,
+    pub multiplier: Option<f64>,
+    pub reason_if_null: Option<String>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct Ceiling {
+    pub supported: bool,
+    pub class: String,
+    pub native_seek_hops_mean: Option<f64>,
+    pub native_seek_hops_max: Option<u64>,
+    pub fallback_02: Option<Fallback>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct Range {
+    pub supported: bool,
+    pub reason: Option<String>,
+    pub windows: Vec<RangeWindow>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct RangeWindow {
+    pub w: f64,
+    pub fetch_count: Option<u64>,
+    pub keys_returned: Option<u64>,
+    pub fallback_02_fetches: Option<u64>,
+    pub multiplier: Option<f64>,
+    pub reason_if_null: Option<String>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct IterFull {
+    pub native_fetch_to_first_key: Option<u64>,
+    pub native_fetch_all: Option<u64>,
+    pub fallback_02_materialise_fetches: Option<u64>,
+    pub ordered_guaranteed: bool,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct ValueRead {
+    pub inline_fraction: Option<f64>,
+    pub fetches_native_mean: Option<f64>,
+    pub fetches_02_mean: Option<f64>,
+    pub chunks_saved_by_inline: Option<u64>,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct Update {
+    pub single: Option<SingleUpdate>,
+    pub batch: Option<BatchUpdate>,
+    pub batch_sweep: Vec<BatchPoint>,
+    pub subtree_delete: Option<SubtreeDelete>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct SingleUpdate {
+    pub update: Option<OpCost>,
+    pub insert: Option<OpCost>,
+    pub delete: Option<OpCost>,
+    pub criterion_ns_per_op: Option<f64>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct OpCost {
+    pub chunks_rewritten_mean: Option<f64>,
+    pub wall_ns: Option<u64>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct BatchUpdate {
+    pub k_ops: Option<u64>,
+    pub mix: String,
+    pub chunks_rewritten: Option<u64>,
+    pub wall_ns: Option<u64>,
+    pub write_amplification: Option<f64>,
+    pub criterion_ns_per_op: Option<f64>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct BatchPoint {
+    pub k: u64,
+    pub mix: String,
+    pub chunks_rewritten: u64,
+    pub wall_ns: u64,
+    pub write_amplification: f64,
+    pub ns_per_op: f64,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct SubtreeDelete {
+    pub prefix_utf8: Option<String>,
+    pub keys_deleted: u64,
+    pub chunks_rewritten: u64,
+    pub wall_ns: u64,
+    pub reason: Option<String>,
+}

--- a/crates/manifest-sim/src/results_v3.rs
+++ b/crates/manifest-sim/src/results_v3.rs
@@ -1,0 +1,122 @@
+//! Serializable schema for the v3 range-query performance run.
+//!
+//! Every numeric field is measured by executing the real reader or cursor; a
+//! `None` serializes to JSON `null` and is only ever set by a capability gap
+//! left with a reason, never back-filled by estimate. The one
+//! modelled quantity is the wall-clock latency, and it is always the product of
+//! a MEASURED count (fetches or cursor rounds) with a stated RTT: the `model`
+//! string on every latency block says so.
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+
+/// The whole v3 result document.
+#[derive(Debug, Serialize)]
+pub struct DocumentV3 {
+    pub meta: MetaV3,
+    /// #293 parallel-cursor rounds and the serial-vs-concurrent latency model.
+    pub parallel_cursor: Vec<ParallelCursorCell>,
+    /// #295 V1Read vs V1: fetches-per-window, depth, single-update write-amp.
+    pub v1read: Vec<ReadProfileCell>,
+    /// #296/#303 rank-directed paginate vs the O(offset) skip baseline.
+    pub paginate: Vec<PaginateCell>,
+}
+
+/// Run-level metadata.
+#[derive(Debug, Serialize)]
+pub struct MetaV3 {
+    pub generated: String,
+    pub git_branch: String,
+    pub git_commit: String,
+    pub harness_version: String,
+    pub seed_master: String,
+    pub rtt_ms_set: Vec<u32>,
+    pub read_ahead: u32,
+    pub scales: Vec<u64>,
+    pub corpora: Vec<String>,
+    pub range_windows: Vec<f64>,
+    pub paginate_offsets: Vec<u64>,
+    pub paginate_limit: u32,
+    pub chunk_body_size: u32,
+    pub caveats: Vec<String>,
+}
+
+/// One `(corpus, scale, op, window)` parallel-cursor cell.
+#[derive(Debug, Serialize)]
+pub struct ParallelCursorCell {
+    pub corpus: String,
+    pub scale: u64,
+    /// `range` (fractional window sweep) or `prefix` (a natural subtree).
+    pub op: String,
+    /// Range width as a fraction of the key domain; `null` for a prefix op.
+    pub window: Option<f64>,
+    pub keys_returned: u64,
+    /// Node fetches to drain the scan; identical for serial and concurrent.
+    pub fetch_count: u64,
+    /// Sequential fetch rounds the bounded-concurrency cursor actually takes,
+    /// read off a paused virtual clock (READ_AHEAD cap), never guessed.
+    pub rounds: u64,
+    pub read_ahead: u32,
+    /// Per-RTT serial and bounded-concurrent latency and their speedup.
+    pub by_rtt_ms: BTreeMap<String, CursorLatency>,
+    pub model: String,
+}
+
+/// Serial and concurrent wall-clock at one RTT, with the speedup between them.
+#[derive(Debug, Serialize)]
+pub struct CursorLatency {
+    /// `fetch_count * rtt`: one round trip per node.
+    pub serial_ms: f64,
+    /// `rounds * rtt`: the measured bounded-concurrency round count times RTT.
+    pub concurrent_ms: f64,
+    /// `serial_ms / concurrent_ms` (== `fetch_count / rounds`).
+    pub speedup: Option<f64>,
+}
+
+/// One `(corpus, scale)` V1Read-vs-V1 cell.
+#[derive(Debug, Serialize)]
+pub struct ReadProfileCell {
+    pub corpus: String,
+    pub scale: u64,
+    pub v1: ReadProfileSide,
+    pub v1read: ReadProfileSide,
+    /// Per-window `v1read_fetch / v1_fetch`; below 1.0 is the read win.
+    pub fetch_ratio_by_window: BTreeMap<String, f64>,
+    /// `v1read` mean get-depth over `v1` mean get-depth.
+    pub depth_ratio: Option<f64>,
+    /// The honest cost: `v1read - v1` mean chunks rewritten per single update.
+    pub single_update_wa_delta: f64,
+    /// `v1read / v1` single-update write-amplification.
+    pub single_update_wa_ratio: Option<f64>,
+}
+
+/// One format's read-profile figures.
+#[derive(Debug, Serialize)]
+pub struct ReadProfileSide {
+    pub version_byte: u8,
+    pub inline_max: u32,
+    pub tree_depth_mean: f64,
+    pub tree_depth_max: u64,
+    /// Fetches to drain each range window, keyed by window fraction.
+    pub range_fetch_by_window: BTreeMap<String, u64>,
+    /// Mean chunks rewritten by a single-key update over the sample.
+    pub single_update_chunks_mean: f64,
+}
+
+/// One `(corpus, scale, offset)` pagination cell.
+#[derive(Debug, Serialize)]
+pub struct PaginateCell {
+    pub corpus: String,
+    pub scale: u64,
+    pub offset: u64,
+    pub limit: u32,
+    pub keys_returned: u64,
+    /// Rank-directed `paginate` node fetches: O(depth), ~constant.
+    pub paginate_fetch_count: u64,
+    /// Baseline `iter().skip(offset).take(limit)` node fetches: grows with
+    /// offset.
+    pub skip_baseline_fetch_count: u64,
+    /// `skip_baseline / paginate`; grows with offset as the win widens.
+    pub skip_over_paginate: Option<f64>,
+}

--- a/crates/manifest-sim/src/store.rs
+++ b/crates/manifest-sim/src/store.rs
@@ -1,0 +1,198 @@
+//! Shared instrumented in-memory chunk store.
+//!
+//! One wrapper type satisfies both formats: it is generic over the chunk
+//! registry, so `CountingStore<StandardChunkSet>` backs mantaray 1.0 and
+//! `CountingStore<AnyChunkSet<4096>>` backs mantaray 0.2. Both hold 4096-byte
+//! content-chunk bodies, so every byte and chunk metric is directly
+//! comparable across formats.
+//!
+//! Counters are atomic so the store stays `Sync` (satisfies `MaybeSync`) and
+//! a caller snapshots gets/puts around a single operation to read off hops and
+//! chunks-rewritten by difference.
+
+use std::sync::atomic::{AtomicU64, Ordering::SeqCst};
+use std::time::Duration;
+
+use nectar_primitives::ChunkOps;
+use nectar_primitives::chunk::{Chunk, ChunkAddress, ChunkRegistry, StandardChunkSet, Verified};
+use nectar_primitives::store::{ChunkGet, ChunkHas, ChunkPut, MemoryStore};
+
+/// A point-in-time read of every counter plus the resident chunk count.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Counters {
+    /// Total `get()` calls; the delta around one operation is that operation's
+    /// hop count.
+    pub gets: u64,
+    /// Total `put()` calls, counting rewrites of an already-resident address.
+    pub puts: u64,
+    /// Sum of payload bytes over every `put()`.
+    pub put_bytes: u64,
+    /// Payload bytes currently resident (grows only on a not-yet-present
+    /// address).
+    pub live_bytes: u64,
+    /// Peak of `live_bytes` observed so far.
+    pub peak_live_bytes: u64,
+    /// Puts of an address that was not already resident.
+    pub distinct_puts: u64,
+    /// Distinct resident addresses (`inner.len()`).
+    pub total_chunks: u64,
+}
+
+/// In-memory chunk store that counts gets, puts and byte residency.
+#[derive(Debug)]
+pub struct CountingStore<R: ChunkRegistry = StandardChunkSet> {
+    inner: MemoryStore<R>,
+    gets: AtomicU64,
+    puts: AtomicU64,
+    put_bytes: AtomicU64,
+    live_bytes: AtomicU64,
+    peak_live_bytes: AtomicU64,
+    distinct_puts: AtomicU64,
+}
+
+impl<R: ChunkRegistry> Default for CountingStore<R> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<R: ChunkRegistry> CountingStore<R> {
+    /// An empty counting store.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            inner: MemoryStore::new(),
+            gets: AtomicU64::new(0),
+            puts: AtomicU64::new(0),
+            put_bytes: AtomicU64::new(0),
+            live_bytes: AtomicU64::new(0),
+            peak_live_bytes: AtomicU64::new(0),
+            distinct_puts: AtomicU64::new(0),
+        }
+    }
+
+    /// Read every counter and the resident chunk count.
+    #[must_use]
+    pub fn snapshot(&self) -> Counters {
+        Counters {
+            gets: self.gets.load(SeqCst),
+            puts: self.puts.load(SeqCst),
+            put_bytes: self.put_bytes.load(SeqCst),
+            live_bytes: self.live_bytes.load(SeqCst),
+            peak_live_bytes: self.peak_live_bytes.load(SeqCst),
+            distinct_puts: self.distinct_puts.load(SeqCst),
+            total_chunks: self.inner.len() as u64,
+        }
+    }
+
+    /// Zero the flow counters (gets/puts/put_bytes) while keeping stored chunks
+    /// and residency figures.
+    pub fn reset_flow(&self) {
+        self.gets.store(0, SeqCst);
+        self.puts.store(0, SeqCst);
+        self.put_bytes.store(0, SeqCst);
+    }
+
+    /// Distinct resident addresses.
+    #[must_use]
+    pub fn total_chunks(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Gets observed so far.
+    #[must_use]
+    pub fn gets(&self) -> u64 {
+        self.gets.load(SeqCst)
+    }
+
+    /// Puts observed so far.
+    #[must_use]
+    pub fn puts(&self) -> u64 {
+        self.puts.load(SeqCst)
+    }
+}
+
+impl<R: ChunkRegistry> ChunkPut<R> for CountingStore<R> {
+    type Error = std::convert::Infallible;
+
+    async fn put(&self, chunk: Chunk<Verified, R>) -> Result<(), Self::Error> {
+        let n = chunk.envelope().data().len() as u64;
+        let addr = *chunk.address();
+        let is_new = !ChunkHas::has(&self.inner, &addr).await;
+        self.puts.fetch_add(1, SeqCst);
+        self.put_bytes.fetch_add(n, SeqCst);
+        if is_new {
+            self.distinct_puts.fetch_add(1, SeqCst);
+            let lb = self.live_bytes.fetch_add(n, SeqCst) + n;
+            self.peak_live_bytes.fetch_max(lb, SeqCst);
+        }
+        ChunkPut::put(&self.inner, chunk).await
+    }
+}
+
+impl<R: ChunkRegistry> ChunkGet<R> for CountingStore<R> {
+    type Trust = Verified;
+    type Error = <MemoryStore<R> as ChunkGet<R>>::Error;
+
+    async fn get(&self, address: &ChunkAddress) -> Result<Chunk<Verified, R>, Self::Error> {
+        self.gets.fetch_add(1, SeqCst);
+        ChunkGet::get(&self.inner, address).await
+    }
+}
+
+impl<R: ChunkRegistry> ChunkHas for CountingStore<R> {
+    async fn has(&self, address: &ChunkAddress) -> bool {
+        ChunkHas::has(&self.inner, address).await
+    }
+}
+
+/// A read-only store that models one network round trip per node fetch: every
+/// `get` awaits `rtt`, then serves the chunk from an already-populated backing
+/// store, counting the fetch.
+///
+/// Driven under a paused virtual clock, the ordered cursor's bounded-concurrency
+/// read-ahead makes independent fetches share a deadline, so they fire in one
+/// clock advance: the elapsed virtual time is exactly `rounds * rtt`, read off
+/// the real cursor rather than derived. The fetch count is unchanged from a
+/// serial walk; only the wall-clock differs.
+#[derive(Debug)]
+pub struct LatencyStore<'a, R: ChunkRegistry = StandardChunkSet> {
+    inner: &'a MemoryStore<R>,
+    rtt: Duration,
+    gets: AtomicU64,
+}
+
+impl<'a, R: ChunkRegistry> LatencyStore<'a, R> {
+    /// Wrap a populated store, charging `rtt` of virtual latency per fetch.
+    #[must_use]
+    pub const fn new(inner: &'a MemoryStore<R>, rtt: Duration) -> Self {
+        Self {
+            inner,
+            rtt,
+            gets: AtomicU64::new(0),
+        }
+    }
+
+    /// Fetches served so far.
+    #[must_use]
+    pub fn gets(&self) -> u64 {
+        self.gets.load(SeqCst)
+    }
+}
+
+impl<R: ChunkRegistry> ChunkGet<R> for LatencyStore<'_, R> {
+    type Trust = Verified;
+    type Error = <MemoryStore<R> as ChunkGet<R>>::Error;
+
+    async fn get(&self, address: &ChunkAddress) -> Result<Chunk<Verified, R>, Self::Error> {
+        self.gets.fetch_add(1, SeqCst);
+        tokio::time::sleep(self.rtt).await;
+        ChunkGet::get(self.inner, address).await
+    }
+}
+
+impl<R: ChunkRegistry> ChunkHas for LatencyStore<'_, R> {
+    async fn has(&self, address: &ChunkAddress) -> bool {
+        ChunkHas::has(self.inner, address).await
+    }
+}

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -94,6 +94,7 @@ mod fork;
 mod format;
 mod meta;
 mod node;
+mod order;
 mod packing;
 mod reader;
 mod scan;

--- a/crates/manifest/src/order.rs
+++ b/crates/manifest/src/order.rs
@@ -1,0 +1,676 @@
+//! Order-statistic queries: rank, select, count and rank-directed pagination
+//! in O(depth), not O(window).
+//!
+//! Every fork's subtree carries its distinct key-count on the wire (spec 5.6):
+//! a referenced child's count is the stored annotation, an embedded child's is
+//! summed in the parent buffer, and a spilled node's segment descriptors carry a
+//! per-segment sum. A rank or index descent therefore skips a whole subtree by
+//! reading its count and routes a spilled node's segments by `seg_count`, so it
+//! fetches one node per referenced hop on the path and never the window it steps
+//! over.
+
+use bytes::Bytes;
+use nectar_primitives::store::MaybeSync;
+use nectar_primitives::{ChunkAddress, ChunkOps};
+
+use crate::codec::{DecodeError, DecodedChunk, SegDesc, SegmentDir};
+use crate::fork::{Child, ForkTable};
+use crate::format::Format;
+use crate::node::{Node, RootExtension};
+use crate::reader::{Reader, ReaderError};
+use crate::scan::{Cursor, successor};
+use crate::store::{NodeGet, StoreError};
+use crate::value::{Entry, Key};
+
+/// One flattened position of a chunk's fork table, in ascending key order, with
+/// the count of the keys it stands for. A value stands for itself; a referenced
+/// or encrypted child stands for its whole subtree, counted without a fetch.
+enum Ranked<F: Format> {
+    /// A key terminates here with this value; it counts once.
+    Value {
+        /// Key bytes below the chunk root.
+        suffix: Vec<u8>,
+        /// The bound value.
+        entry: Entry<F>,
+    },
+    /// The trie continues into a referenced child holding `count` keys.
+    Ref {
+        /// Key bytes below the chunk root leading to the child.
+        suffix: Vec<u8>,
+        /// The child chunk address.
+        addr: ChunkAddress,
+        /// The child subtree's distinct key-count.
+        count: u64,
+    },
+    /// An encrypted child the plain reader cannot open, holding `count` keys.
+    /// Its count still routes a rank past it; only a descent into it fails.
+    Encrypted {
+        /// Key bytes below the chunk root leading to the child.
+        suffix: Vec<u8>,
+        /// The child subtree's distinct key-count.
+        count: u64,
+    },
+}
+
+impl<F: Format> Ranked<F> {
+    /// The key bytes below the chunk root.
+    fn suffix(&self) -> &[u8] {
+        match self {
+            Self::Value { suffix, .. }
+            | Self::Ref { suffix, .. }
+            | Self::Encrypted { suffix, .. } => suffix,
+        }
+    }
+
+    /// The number of keys this position stands for.
+    const fn count(&self) -> u64 {
+        match self {
+            Self::Value { .. } => 1,
+            Self::Ref { count, .. } | Self::Encrypted { count, .. } => *count,
+        }
+    }
+}
+
+/// Flatten a chunk's fork table into ascending-key ranked positions, recursing
+/// embedded children in the parent buffer so only referenced hops leave a step.
+///
+/// A referenced child's count is the stored annotation; an embedded child is
+/// expanded in place, so the positions of one chunk carry no fetch between them.
+fn ranked<F: Format>(table: &ForkTable<F>) -> Vec<Ranked<F>> {
+    let mut steps = Vec::new();
+    let mut prefix = Vec::new();
+    ranked_table(table, &mut prefix, &mut steps);
+    steps
+}
+
+/// Walk a fork table in wire order, appending each terminal and referenced child
+/// as a ranked position and recursing embedded children in place.
+fn ranked_table<F: Format>(table: &ForkTable<F>, prefix: &mut Vec<u8>, steps: &mut Vec<Ranked<F>>) {
+    for (first, record) in table.iter() {
+        let mark = prefix.len();
+        prefix.push(first);
+        prefix.extend_from_slice(record.tail().as_bytes());
+        if let Some(entry) = record.entry() {
+            steps.push(Ranked::Value {
+                suffix: prefix.clone(),
+                entry: entry.clone(),
+            });
+        }
+        match record.child() {
+            Some(Child::Embedded(inner)) => ranked_table(inner, prefix, steps),
+            Some(Child::Ref32(reference)) => steps.push(Ranked::Ref {
+                suffix: prefix.clone(),
+                addr: *reference.address(),
+                count: record.child_count().unwrap_or_default().get(),
+            }),
+            Some(Child::Ref64(_)) => steps.push(Ranked::Encrypted {
+                suffix: prefix.clone(),
+                count: record.child_count().unwrap_or_default().get(),
+            }),
+            None => {}
+        }
+        prefix.truncate(mark);
+    }
+}
+
+/// The on-path contents of one node: its fork-table positions and the keys in
+/// the segments strictly before them. A spilled node contributes only the
+/// covering leaf's positions; `Before` means the target precedes every fork.
+enum OnPath<F: Format> {
+    /// The target precedes every fork in the node; nothing at or below it.
+    Before,
+    /// The covering fragment's positions and the count skipped before them.
+    Fragment {
+        /// Keys in the segments strictly before the covering fragment.
+        before: u64,
+        /// The covering fragment's ranked positions.
+        steps: Vec<Ranked<F>>,
+    },
+}
+
+/// The empty-key value a decoded root carries: its root extension entry.
+fn root_entry<F: Format>(decoded: &DecodedChunk<F>) -> Option<Entry<F>> {
+    match decoded {
+        DecodedChunk::Node(node) => node.entry().cloned(),
+        DecodedChunk::Segmented(root, _) => root.as_ref().and_then(RootExtension::entry).cloned(),
+        DecodedChunk::Leaf(_) | DecodedChunk::Directory(_) => None,
+    }
+}
+
+/// The descriptor covering `byte`: the one with the greatest first key not past
+/// it, and the summed count of every descriptor before it. `None` when `byte`
+/// precedes the first descriptor.
+fn covering(dir: &SegmentDir, byte: u8) -> Option<(u64, &SegDesc)> {
+    let mut before = 0u64;
+    let mut cover: Option<&SegDesc> = None;
+    for desc in &dir.descriptors {
+        if desc.first_key > byte {
+            break;
+        }
+        if let Some(prior) = cover {
+            before = before.saturating_add(prior.seg_count.get());
+        }
+        cover = Some(desc);
+    }
+    cover.map(|desc| (before, desc))
+}
+
+/// Where an index falls across a directory's descriptors: the residual index
+/// into the covering descriptor and the descriptor itself, subtracting the
+/// skipped segments' counts. `None` when the index runs past the node's total.
+fn covering_index(dir: &SegmentDir, index: u64) -> Option<(u64, &SegDesc)> {
+    let mut index = index;
+    for desc in &dir.descriptors {
+        let count = desc.seg_count.get();
+        if index < count {
+            return Some((index, desc));
+        }
+        index = index.saturating_sub(count);
+    }
+    None
+}
+
+impl<S, F> Reader<S, F>
+where
+    S: NodeGet + MaybeSync,
+    F: Format,
+{
+    /// The number of keys with `lo <= key < hi`, computed as `rank(hi) -
+    /// rank(lo)` in two O(depth) descents, so a window's size never fetches it.
+    pub async fn count(&self, root: &ChunkAddress, lo: &Key, hi: &Key) -> Result<u64, ReaderError> {
+        let high = self.rank(root, hi).await?;
+        let low = self.rank(root, lo).await?;
+        Ok(high.saturating_sub(low))
+    }
+
+    /// The number of keys strictly less than `key`: its position in ascending
+    /// key order.
+    ///
+    /// Descends one referenced hop per level, adding the whole-subtree count of
+    /// every fork and segment strictly before the target and recursing only the
+    /// one child on its path. An encrypted subtree on the path cannot be opened;
+    /// one merely before the target routes by its stored count.
+    pub async fn rank(&self, root: &ChunkAddress, key: &Key) -> Result<u64, ReaderError> {
+        let target = key.as_bytes();
+        let mut address = *root;
+        let mut consumed = 0usize;
+        let mut acc = 0u64;
+        let mut is_root = true;
+        loop {
+            let decoded = decode_at::<S, F>(self.store(), &address).await?;
+            if is_root && !target.is_empty() && root_entry(&decoded).is_some() {
+                acc = acc.saturating_add(1);
+            }
+            let Some(remaining) = target.get(consumed..).filter(|rest| !rest.is_empty()) else {
+                return Ok(acc);
+            };
+            let steps = match on_path(self.store(), &decoded, remaining).await? {
+                OnPath::Before => return Ok(acc),
+                OnPath::Fragment { before, steps } => {
+                    acc = acc.saturating_add(before);
+                    steps
+                }
+            };
+            match rank_fragment(&steps, remaining) {
+                Step::Here(count) => return Ok(acc.saturating_add(count)),
+                Step::Encrypted => return Err(ReaderError::EncryptedChild),
+                Step::Cross {
+                    addr,
+                    matched,
+                    before,
+                } => {
+                    acc = acc.saturating_add(before);
+                    consumed = consumed.saturating_add(matched);
+                    address = addr;
+                    is_root = false;
+                }
+            }
+        }
+    }
+
+    /// The key and value at position `index` in ascending key order, or `None`
+    /// when `index` is at or past the key count.
+    ///
+    /// Descends one referenced hop per level, skipping any subtree whose count
+    /// the index clears and routing a spilled node's segments by `seg_count`, so
+    /// the offset costs O(depth), never O(index).
+    pub async fn select(
+        &self,
+        root: &ChunkAddress,
+        index: u64,
+    ) -> Result<Option<(Key, Entry<F>)>, ReaderError> {
+        let mut address = *root;
+        let mut index = index;
+        let mut path: Vec<u8> = Vec::new();
+        let mut is_root = true;
+        loop {
+            let decoded = decode_at::<S, F>(self.store(), &address).await?;
+            if is_root && let Some(entry) = root_entry(&decoded) {
+                if index == 0 {
+                    return Ok(Some((Key::new(Bytes::from(path)), entry)));
+                }
+                index = index.saturating_sub(1);
+            }
+            let Some(steps) = index_path(self.store(), &decoded, &mut index).await? else {
+                return Ok(None);
+            };
+            match select_fragment(steps, &mut index) {
+                Some(Reach::Found { suffix, entry }) => {
+                    path.extend_from_slice(&suffix);
+                    return Ok(Some((Key::new(Bytes::from(path)), entry)));
+                }
+                Some(Reach::Encrypted) => return Err(ReaderError::EncryptedChild),
+                Some(Reach::Cross { addr, suffix }) => {
+                    path.extend_from_slice(&suffix);
+                    address = addr;
+                    is_root = false;
+                }
+                None => return Ok(None),
+            }
+        }
+    }
+
+    /// A cursor over the keys with `lo <= key < hi`, positioned `offset` keys in
+    /// and yielding at most `limit`.
+    ///
+    /// The offset is a rank-directed seek, so paging deep into a listing costs
+    /// O(depth), not O(offset); the yielded slice equals `range(lo, hi)` skipped
+    /// `offset` and taken `limit`.
+    pub async fn paginate(
+        &self,
+        root: &ChunkAddress,
+        lo: &Key,
+        hi: &Key,
+        offset: u64,
+        limit: usize,
+    ) -> Result<Cursor<'_, S, F>, ReaderError> {
+        let end = Some(Bytes::copy_from_slice(hi.as_bytes()));
+        let start = self.rank(root, lo).await?.saturating_add(offset);
+        self.page(root, start, end, limit).await
+    }
+
+    /// A cursor over the keys carrying `prefix`, positioned `offset` keys in and
+    /// yielding at most `limit`; the empty prefix pages the whole manifest.
+    ///
+    /// The offset is a rank-directed seek, so it costs O(depth), not O(offset);
+    /// the yielded slice equals `prefix(prefix)` skipped `offset` and taken
+    /// `limit`.
+    pub async fn paginate_prefix(
+        &self,
+        root: &ChunkAddress,
+        prefix: &Key,
+        offset: u64,
+        limit: usize,
+    ) -> Result<Cursor<'_, S, F>, ReaderError> {
+        let end = successor(prefix.as_bytes());
+        let start = self.rank(root, prefix).await?.saturating_add(offset);
+        self.page(root, start, end, limit).await
+    }
+
+    /// Position a bounded cursor at the key of absolute rank `start`: select that
+    /// key, then seek to it under `end`, capped at `limit`. An out-of-range start
+    /// yields an exhausted cursor.
+    async fn page(
+        &self,
+        root: &ChunkAddress,
+        start: u64,
+        end: Option<Bytes>,
+        limit: usize,
+    ) -> Result<Cursor<'_, S, F>, ReaderError> {
+        match self.select(root, start).await? {
+            None => Ok(Cursor::exhausted(self.store())),
+            Some((key, _)) => Ok(Cursor::seek(self.store(), root, key.as_bytes(), end)
+                .await?
+                .with_limit(limit)),
+        }
+    }
+}
+
+/// Fetch and decode the chunk at `address` without materializing a spilled
+/// node's segments: the descent routes them itself by `seg_count`.
+async fn decode_at<S, F>(store: &S, address: &ChunkAddress) -> Result<DecodedChunk<F>, ReaderError>
+where
+    S: NodeGet + MaybeSync,
+    F: Format,
+{
+    let chunk = store.get(address).await.map_err(StoreError::store)?;
+    Node::<F>::decode_chunk(chunk.envelope().data())
+        .map_err(|error| ReaderError::Store(StoreError::Decode(error)))
+}
+
+/// Resolve the ranked positions on the target's path through a decoded chunk,
+/// routing a spilled node's segments by `seg_count` so only the covering one is
+/// fetched. `remaining` is the target key from this node's root, never empty.
+async fn on_path<S, F>(
+    store: &S,
+    decoded: &DecodedChunk<F>,
+    remaining: &[u8],
+) -> Result<OnPath<F>, ReaderError>
+where
+    S: NodeGet + MaybeSync,
+    F: Format,
+{
+    match decoded {
+        DecodedChunk::Node(node) => Ok(OnPath::Fragment {
+            before: 0,
+            steps: ranked(node.forks()),
+        }),
+        DecodedChunk::Segmented(_, dir) => route_key(store, dir, remaining).await,
+        DecodedChunk::Leaf(_) | DecodedChunk::Directory(_) => Err(segment_context()),
+    }
+}
+
+/// Route a spilled node's directory to the leaf fragment covering `remaining`,
+/// summing the counts of the segments strictly before it. Descends at most the
+/// two directory levels the frozen bounds allow (spec 5.4).
+async fn route_key<S, F>(
+    store: &S,
+    dir: &SegmentDir,
+    remaining: &[u8],
+) -> Result<OnPath<F>, ReaderError>
+where
+    S: NodeGet + MaybeSync,
+    F: Format,
+{
+    let Some(&byte) = remaining.first() else {
+        return Ok(OnPath::Before);
+    };
+    let mut before = 0u64;
+    let mut current = match covering(dir, byte) {
+        Some((skip, desc)) => {
+            before = before.saturating_add(skip);
+            desc.clone()
+        }
+        None => return Ok(OnPath::Before),
+    };
+    for _ in 0..2 {
+        if current.key.is_some() {
+            return Err(ReaderError::EncryptedChild);
+        }
+        match decode_at::<S, F>(store, &current.address).await? {
+            DecodedChunk::Leaf(table) => {
+                return Ok(OnPath::Fragment {
+                    before,
+                    steps: ranked(&table),
+                });
+            }
+            DecodedChunk::Directory(inner) => match covering(&inner, byte) {
+                Some((skip, desc)) => {
+                    before = before.saturating_add(skip);
+                    current = desc.clone();
+                }
+                None => return Ok(OnPath::Before),
+            },
+            _ => return Err(segment_context()),
+        }
+    }
+    Err(segment_context())
+}
+
+/// Route a decoded chunk to the ranked positions holding the `index`th key,
+/// subtracting a spilled node's skipped-segment counts from `index`. `None` when
+/// the index runs past the node's total.
+async fn index_path<S, F>(
+    store: &S,
+    decoded: &DecodedChunk<F>,
+    index: &mut u64,
+) -> Result<Option<Vec<Ranked<F>>>, ReaderError>
+where
+    S: NodeGet + MaybeSync,
+    F: Format,
+{
+    match decoded {
+        DecodedChunk::Node(node) => Ok(Some(ranked(node.forks()))),
+        DecodedChunk::Segmented(_, dir) => {
+            let mut dir = dir.clone();
+            for _ in 0..2 {
+                let Some((residual, desc)) = covering_index(&dir, *index) else {
+                    return Ok(None);
+                };
+                *index = residual;
+                if desc.key.is_some() {
+                    return Err(ReaderError::EncryptedChild);
+                }
+                match decode_at::<S, F>(store, &desc.address).await? {
+                    DecodedChunk::Leaf(table) => return Ok(Some(ranked(&table))),
+                    DecodedChunk::Directory(inner) => dir = inner,
+                    _ => return Err(segment_context()),
+                }
+            }
+            Err(segment_context())
+        }
+        DecodedChunk::Leaf(_) | DecodedChunk::Directory(_) => Err(segment_context()),
+    }
+}
+
+/// A malformed-segment decode error: a reference named a node but a bare segment
+/// decoded, or a directory nested past its bound.
+const fn segment_context() -> ReaderError {
+    ReaderError::Store(StoreError::Decode(DecodeError::SegmentContext))
+}
+
+/// The outcome of ranking `remaining` through one chunk's fork-table fragment.
+enum Step {
+    /// The rank resolves here, adding this many in-fragment keys before it.
+    Here(u64),
+    /// The target descends into a referenced child at `addr`, `matched` key
+    /// bytes below the fragment root, with this many in-fragment keys before it.
+    Cross {
+        addr: ChunkAddress,
+        matched: usize,
+        before: u64,
+    },
+    /// The target descends into an encrypted child that cannot be opened.
+    Encrypted,
+}
+
+/// Count the keys strictly before `remaining` within one fragment's positions,
+/// stopping where the target descends into a referenced child.
+///
+/// A position wholly before the target adds its whole-subtree count; the one the
+/// target funnels into is recursed, not counted; the rest are past the target.
+fn rank_fragment<F: Format>(steps: &[Ranked<F>], remaining: &[u8]) -> Step {
+    let mut before = 0u64;
+    for step in steps {
+        let suffix = step.suffix();
+        if suffix >= remaining {
+            return Step::Here(before);
+        }
+        // `suffix < remaining`: a prefix of it means the target descends here.
+        let descends = remaining.starts_with(suffix);
+        match step {
+            Ranked::Value { .. } => before = before.saturating_add(1),
+            Ranked::Ref { addr, count, .. } => {
+                if descends {
+                    return Step::Cross {
+                        addr: *addr,
+                        matched: suffix.len(),
+                        before,
+                    };
+                }
+                before = before.saturating_add(*count);
+            }
+            Ranked::Encrypted { count, .. } => {
+                if descends {
+                    return Step::Encrypted;
+                }
+                before = before.saturating_add(*count);
+            }
+        }
+    }
+    Step::Here(before)
+}
+
+/// Where an index lands within one fragment's positions.
+enum Reach<F: Format> {
+    /// The index is this fragment's value at `suffix`.
+    Found { suffix: Vec<u8>, entry: Entry<F> },
+    /// The index falls inside the referenced child at `addr`, `suffix` below the
+    /// fragment root; the residual index stays in the caller's counter.
+    Cross { addr: ChunkAddress, suffix: Vec<u8> },
+    /// The index falls inside an encrypted child that cannot be opened.
+    Encrypted,
+}
+
+/// Resolve `index` within one fragment's positions, subtracting the counts of
+/// the positions before it. `None` when the index runs past the fragment total.
+fn select_fragment<F: Format>(steps: Vec<Ranked<F>>, index: &mut u64) -> Option<Reach<F>> {
+    for step in steps {
+        let count = step.count();
+        if *index < count {
+            return Some(match step {
+                Ranked::Value { suffix, entry } => Reach::Found { suffix, entry },
+                Ranked::Ref { suffix, addr, .. } => Reach::Cross { addr, suffix },
+                Ranked::Encrypted { .. } => Reach::Encrypted,
+            });
+        }
+        *index = index.saturating_sub(count);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::executor::block_on;
+    use nectar_primitives::store::MemoryStore;
+    use nectar_primitives::{ChunkAddress, ChunkRef, EncryptedChunkRef, EncryptionKey};
+
+    use crate::bounded::Prefix;
+    use crate::count::SubtreeCount;
+    use crate::fork::{Child, ForkTable};
+    use crate::format::V1;
+    use crate::node::{Node, RootExtension};
+    use crate::store::NodePut;
+    use crate::value::{Entry, Key};
+
+    use super::*;
+
+    fn entry(byte: u8) -> Entry<V1> {
+        ChunkRef::new(ChunkAddress::new([byte; 32])).into()
+    }
+
+    fn prefix(bytes: &[u8]) -> Prefix<V1> {
+        Prefix::try_from(bytes).unwrap()
+    }
+
+    #[test]
+    fn the_root_entry_is_index_zero_and_lifts_every_rank() {
+        let store = MemoryStore::default();
+        let root_ext = RootExtension::new(Some(entry(9)), None);
+        let mut forks = ForkTable::new();
+        forks.insert(prefix(b"k"), entry(1).into(), None).unwrap();
+        let root = block_on(store.put_node(&Node::<V1>::new(root_ext, forks))).unwrap();
+        let reader = Reader::<&MemoryStore, V1>::new(&store);
+
+        // The empty key leads iteration at index 0; "k" follows at index 1.
+        assert_eq!(
+            block_on(reader.select(&root, 0)).unwrap(),
+            Some((Key::empty(), entry(9)))
+        );
+        assert_eq!(
+            block_on(reader.select(&root, 1)).unwrap(),
+            Some((Key::from(&b"k"[..]), entry(1)))
+        );
+        assert_eq!(block_on(reader.select(&root, 2)).unwrap(), None);
+
+        // Nothing is strictly before the empty key; the root entry sits before
+        // every other key, so it lifts their ranks by one.
+        assert_eq!(block_on(reader.rank(&root, &Key::empty())).unwrap(), 0);
+        assert_eq!(
+            block_on(reader.rank(&root, &Key::from(&b"k"[..]))).unwrap(),
+            1
+        );
+        assert_eq!(
+            block_on(reader.rank(&root, &Key::from(&b"z"[..]))).unwrap(),
+            2
+        );
+        assert_eq!(
+            block_on(reader.count(&root, &Key::empty(), &Key::from(&b"z"[..]))).unwrap(),
+            2
+        );
+    }
+
+    // A root holding "a" and "z" as plain values with an encrypted five-key
+    // subtree wedged between them under "m"; the count rides the fork record.
+    fn with_encrypted(store: &MemoryStore) -> ChunkAddress {
+        let mut forks = ForkTable::new();
+        forks
+            .insert(prefix(b"a"), entry(0xA1).into(), None)
+            .unwrap();
+        forks
+            .insert(
+                prefix(b"m"),
+                Child::Ref64(EncryptedChunkRef::new(
+                    ChunkAddress::new([0x4D; 32]),
+                    EncryptionKey::from([0xC7; 32]),
+                ))
+                .into(),
+                None,
+            )
+            .unwrap();
+        forks
+            .get_mut(b'm')
+            .unwrap()
+            .set_child_count(Some(SubtreeCount::new(5)));
+        forks
+            .insert(prefix(b"z"), entry(0x2C).into(), None)
+            .unwrap();
+        block_on(store.put_node(&Node::<V1>::new(None, forks))).unwrap()
+    }
+
+    #[test]
+    fn an_encrypted_subtree_is_counted_without_being_opened() {
+        let store = MemoryStore::default();
+        let root = with_encrypted(&store);
+        let reader = Reader::<&MemoryStore, V1>::new(&store);
+
+        // Ranking past the encrypted subtree adds its stored count: "a", then its
+        // five keys, all strictly before "z".
+        assert_eq!(
+            block_on(reader.rank(&root, &Key::from(&b"z"[..]))).unwrap(),
+            6
+        );
+        // A key at the encrypted prefix does not descend; its keys are longer.
+        assert_eq!(
+            block_on(reader.rank(&root, &Key::from(&b"m"[..]))).unwrap(),
+            1
+        );
+        // Selecting the key just past the subtree skips all five by count.
+        assert_eq!(
+            block_on(reader.select(&root, 6)).unwrap(),
+            Some((Key::from(&b"z"[..]), entry(0x2C)))
+        );
+    }
+
+    #[test]
+    fn descending_into_an_encrypted_subtree_is_an_error() {
+        let store = MemoryStore::default();
+        let root = with_encrypted(&store);
+        let reader = Reader::<&MemoryStore, V1>::new(&store);
+
+        // A rank whose key funnels into the encrypted subtree cannot be answered.
+        assert!(matches!(
+            block_on(reader.rank(&root, &Key::from(&b"mx"[..]))),
+            Err(ReaderError::EncryptedChild)
+        ));
+        // An index landing inside the encrypted subtree cannot be opened.
+        assert!(matches!(
+            block_on(reader.select(&root, 3)),
+            Err(ReaderError::EncryptedChild)
+        ));
+    }
+
+    #[test]
+    fn an_empty_manifest_has_no_keys() {
+        let store = MemoryStore::default();
+        let root = block_on(store.put_node(&Node::<V1>::empty())).unwrap();
+        let reader = Reader::<&MemoryStore, V1>::new(&store);
+        assert_eq!(
+            block_on(reader.rank(&root, &Key::from(&b"x"[..]))).unwrap(),
+            0
+        );
+        assert_eq!(block_on(reader.select(&root, 0)).unwrap(), None);
+        let mut cursor = block_on(reader.paginate_prefix(&root, &Key::empty(), 0, 10)).unwrap();
+        assert!(block_on(cursor.next()).unwrap().is_none());
+    }
+}

--- a/crates/manifest/src/scan.rs
+++ b/crates/manifest/src/scan.rs
@@ -133,6 +133,8 @@ pub struct Cursor<'a, S, F: Format = V1> {
     ready: Vec<Fetched<F>>,
     /// The next fetch sequence id to hand out.
     next_seq: usize,
+    /// Remaining yields a paginated cursor may return; `None` is unbounded.
+    remaining: Option<usize>,
 }
 
 /// What visiting the top frame's next step resolves to, computed under a short
@@ -223,7 +225,30 @@ where
             inflight: FuturesUnordered::new(),
             ready: Vec::new(),
             next_seq: 0,
+            remaining: None,
         })
+    }
+
+    /// An already-exhausted cursor: yields nothing. Used when a paginated seek
+    /// starts past the last key.
+    pub(crate) fn exhausted(store: &'a S) -> Self {
+        Self {
+            store,
+            stack: Vec::new(),
+            end: None,
+            done: true,
+            inflight: FuturesUnordered::new(),
+            ready: Vec::new(),
+            next_seq: 0,
+            remaining: None,
+        }
+    }
+
+    /// Cap this cursor at `limit` yields, for a paginated page of a listing.
+    #[must_use]
+    pub(crate) const fn with_limit(mut self, limit: usize) -> Self {
+        self.remaining = Some(limit);
+        self
     }
 
     /// The next `(key, value)` in key order, or `None` at the end of the walk.
@@ -233,6 +258,10 @@ where
     /// fetch per key.
     pub async fn next(&mut self) -> Result<Option<(Key, Entry<F>)>, ReaderError> {
         if self.done {
+            return Ok(None);
+        }
+        if self.remaining == Some(0) {
+            self.done = true;
             return Ok(None);
         }
         loop {
@@ -272,6 +301,9 @@ where
                     if self.past_end(&key) {
                         self.done = true;
                         return Ok(None);
+                    }
+                    if let Some(left) = self.remaining {
+                        self.remaining = Some(left.saturating_sub(1));
                     }
                     return Ok(Some((Key::new(Bytes::from(key)), entry)));
                 }

--- a/crates/manifest/tests/order.rs
+++ b/crates/manifest/tests/order.rs
@@ -1,0 +1,361 @@
+//! Order-statistic conformance: rank, select and count
+//! agree with a full-walk oracle across corpora and shuffled builds; paginate
+//! returns the same slice as `iter().skip(offset).take(limit)`; and the offset
+//! seek costs O(depth), not O(offset), witnessed through a fetch-counting store.
+
+use std::error::Error;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use futures::executor::block_on;
+use nectar_manifest::{Builder, Entry, Key, Reader, V1};
+use nectar_primitives::store::{ChunkGet, MemoryStore};
+use nectar_primitives::{Chunk, ChunkAddress, ChunkRef, StandardChunkSet, Verified};
+
+type TestResult = Result<(), Box<dyn Error>>;
+
+/// A key set paired with the value each key carries.
+type KeySet = Vec<(Key, u8)>;
+
+/// The `(key, value)` pairs a walk yields, in key order.
+type Pairs = Vec<(Key, Entry<V1>)>;
+
+fn ensure(cond: bool, what: String) -> TestResult {
+    if cond { Ok(()) } else { Err(what.into()) }
+}
+
+fn entry(fill: u8) -> Entry<V1> {
+    Entry::from(ChunkRef::new(ChunkAddress::new([fill; 32])))
+}
+
+/// A store that counts every `get`, so a test reads how many nodes a query
+/// fetched.
+#[derive(Debug, Default)]
+struct CountingStore {
+    inner: MemoryStore,
+    gets: AtomicUsize,
+}
+
+impl CountingStore {
+    fn reset(&self) {
+        self.gets.store(0, Ordering::Relaxed);
+    }
+
+    fn gets(&self) -> usize {
+        self.gets.load(Ordering::Relaxed)
+    }
+}
+
+impl ChunkGet<StandardChunkSet> for CountingStore {
+    type Trust = Verified;
+    type Error = <MemoryStore as ChunkGet>::Error;
+
+    async fn get(
+        &self,
+        address: &ChunkAddress,
+    ) -> Result<Chunk<Verified, StandardChunkSet>, Self::Error> {
+        self.gets.fetch_add(1, Ordering::Relaxed);
+        ChunkGet::get(&self.inner, address).await
+    }
+}
+
+/// Every `radix`-ary key of length `len`, ascending, each valued on its last
+/// byte. A multi-byte alphabet fans the trie into referenced children and, at a
+/// full first-byte spread, spills interior nodes across segments.
+fn radix_keys(radix: u8, len: usize) -> KeySet {
+    let mut out = Vec::new();
+    let mut key = Vec::new();
+    fill(radix, len, &mut key, &mut out);
+    out
+}
+
+fn fill(radix: u8, remaining: usize, key: &mut Vec<u8>, out: &mut KeySet) {
+    match remaining {
+        0 => out.push((Key::from(key.as_slice()), key.last().copied().unwrap_or(0))),
+        _ => {
+            for digit in 0..radix {
+                key.push(digit);
+                fill(radix, remaining.saturating_sub(1), key, out);
+                key.pop();
+            }
+        }
+    }
+}
+
+/// A corpus whose root spills into a segment directory: a full 256 first-byte
+/// spread, each carrying a 50-key subtree too large to embed, so the root
+/// references 256 children and its own fork table overruns one chunk. Distinct
+/// values keep the children from collapsing, so the descent routes real
+/// segments. Order-statistic queries must route these by `seg_count`.
+fn wide_keys() -> KeySet {
+    let mut out = Vec::new();
+    for a in 0u16..256 {
+        for c in 0u8..50 {
+            let byte = u8::try_from(a).unwrap_or(0);
+            out.push((Key::from(&[byte, c][..]), byte.wrapping_add(c)));
+        }
+    }
+    out
+}
+
+fn build(store: &MemoryStore, keys: &[(Key, u8)]) -> Result<ChunkAddress, Box<dyn Error>> {
+    let mut builder = Builder::<V1>::new();
+    for (key, fill) in keys {
+        builder.insert(key.clone(), entry(*fill), None);
+    }
+    Ok(*block_on(builder.build(store))
+        .map_err(|e| e.to_string())?
+        .root())
+}
+
+/// The ground-truth ordering: every `(key, value)` a full walk yields.
+fn oracle(reader: &Reader<MemoryStore, V1>, root: &ChunkAddress) -> Result<Pairs, Box<dyn Error>> {
+    let mut out = Vec::new();
+    let mut cursor = block_on(reader.iter(root)).map_err(|e| e.to_string())?;
+    while let Some(pair) = block_on(cursor.next()).map_err(|e| e.to_string())? {
+        out.push(pair);
+    }
+    Ok(out)
+}
+
+#[test]
+fn rank_select_count_agree_with_a_full_walk_oracle() -> TestResult {
+    let store = MemoryStore::default();
+    let keys = radix_keys(12, 3);
+    let root = build(&store, &keys)?;
+    let reader = Reader::<MemoryStore, V1>::new(store);
+    let all = oracle(&reader, &root)?;
+    ensure(all.len() == keys.len(), "oracle lost keys".to_owned())?;
+
+    // select(i) is the i-th key; one past the end is None.
+    for (i, (key, value)) in all.iter().enumerate() {
+        let index = u64::try_from(i)?;
+        let got = block_on(reader.select(&root, index)).map_err(|e| e.to_string())?;
+        ensure(
+            got.as_ref() == Some(&(key.clone(), value.clone())),
+            format!("select({i}) mismatch"),
+        )?;
+    }
+    let end = u64::try_from(all.len())?;
+    ensure(
+        block_on(reader.select(&root, end))
+            .map_err(|e| e.to_string())?
+            .is_none(),
+        "select past the end must be None".to_owned(),
+    )?;
+
+    // rank(key) is the count of strictly-smaller keys, checked at present keys
+    // and at the absent points that bracket, precede and follow the key set.
+    let probes = [
+        Key::empty(),
+        Key::from(&[0u8][..]),
+        Key::from(&[3u8, 5][..]),
+        Key::from(&[3u8, 5, 5][..]),
+        Key::from(&[3u8, 5, 6][..]),
+        Key::from(&[6u8, 0, 0][..]),
+        Key::from(&[11u8, 11, 11][..]),
+        Key::from(&[12u8][..]),
+        Key::from(&[255u8][..]),
+    ];
+    for probe in &probes {
+        let expected = u64::try_from(all.iter().filter(|(k, _)| k < probe).count())?;
+        let got = block_on(reader.rank(&root, probe)).map_err(|e| e.to_string())?;
+        ensure(
+            got == expected,
+            format!("rank mismatch: {got} != {expected}"),
+        )?;
+    }
+
+    // count(lo, hi) is the size of the half-open window.
+    for (lo, hi) in [
+        (Key::from(&[0u8, 0, 0][..]), Key::from(&[3u8, 0, 0][..])),
+        (Key::from(&[3u8, 5, 5][..]), Key::from(&[7u8, 2, 2][..])),
+        (Key::empty(), Key::from(&[12u8][..])),
+        (Key::from(&[9u8][..]), Key::from(&[3u8][..])),
+    ] {
+        let expected = u64::try_from(all.iter().filter(|(k, _)| lo <= *k && *k < hi).count())?;
+        let got = block_on(reader.count(&root, &lo, &hi)).map_err(|e| e.to_string())?;
+        ensure(
+            got == expected,
+            format!("count mismatch: {got} != {expected}"),
+        )?;
+    }
+    Ok(())
+}
+
+#[test]
+fn spilled_node_order_statistics_agree_with_the_oracle() -> TestResult {
+    // A corpus whose root is a segmented node, so every query routes the root's
+    // segment directory by seg_count before descending a referenced child.
+    let store = MemoryStore::default();
+    let keys = wide_keys();
+    let root = build(&store, &keys)?;
+    let reader = Reader::<MemoryStore, V1>::new(store);
+    let all = oracle(&reader, &root)?;
+    ensure(all.len() == keys.len(), "oracle lost keys".to_owned())?;
+
+    // Sampled select and its inverse rank agree with the oracle across the whole
+    // spilled listing, including both ends.
+    let last = all.len().saturating_sub(1);
+    for i in (0..all.len()).step_by(311).chain([last]) {
+        let (key, value) = all.get(i).ok_or("oracle index out of range")?;
+        let index = u64::try_from(i)?;
+        let got = block_on(reader.select(&root, index)).map_err(|e| e.to_string())?;
+        ensure(
+            got.as_ref() == Some(&(key.clone(), value.clone())),
+            format!("spilled select({i}) mismatch"),
+        )?;
+        let rank = block_on(reader.rank(&root, key)).map_err(|e| e.to_string())?;
+        ensure(rank == index, format!("spilled rank at {i} mismatch"))?;
+    }
+
+    // Windows spanning several segments count exactly.
+    for (lo, hi) in [
+        (Key::from(&[0u8, 0][..]), Key::from(&[100u8, 0][..])),
+        (Key::from(&[40u8, 25][..]), Key::from(&[210u8, 10][..])),
+        (Key::empty(), Key::from(&[255u8, 255][..])),
+    ] {
+        let expected = u64::try_from(all.iter().filter(|(k, _)| lo <= *k && *k < hi).count())?;
+        let got = block_on(reader.count(&root, &lo, &hi)).map_err(|e| e.to_string())?;
+        ensure(
+            got == expected,
+            format!("spilled count mismatch: {got} != {expected}"),
+        )?;
+    }
+
+    // A page deep in the spilled listing is the matching oracle slice.
+    let mut got = Vec::new();
+    let mut cursor = block_on(reader.paginate_prefix(&root, &Key::empty(), 9000, 25))
+        .map_err(|e| e.to_string())?;
+    while let Some(pair) = block_on(cursor.next()).map_err(|e| e.to_string())? {
+        got.push(pair);
+    }
+    let want: Vec<_> = all.iter().skip(9000).take(25).cloned().collect();
+    ensure(got == want, "spilled paginate mismatch".to_owned())?;
+    Ok(())
+}
+
+#[test]
+fn order_statistics_are_stable_under_shuffled_build_order() -> TestResult {
+    let forward = radix_keys(10, 3);
+    let mut reversed = forward.clone();
+    reversed.reverse();
+
+    let a_store = MemoryStore::default();
+    let a = build(&a_store, &forward)?;
+    let b_store = MemoryStore::default();
+    let b = build(&b_store, &reversed)?;
+    ensure(a == b, "shuffled build must root identically".to_owned())?;
+
+    let reader = Reader::<MemoryStore, V1>::new(a_store);
+    // A shuffled build is the same tree, so every rank and select is unchanged.
+    for index in [0u64, 1, 250, 500, 999] {
+        let got = block_on(reader.select(&a, index)).map_err(|e| e.to_string())?;
+        let (key, _) = got.ok_or("select fell off the shuffled build")?;
+        let rank = block_on(reader.rank(&a, &key)).map_err(|e| e.to_string())?;
+        ensure(rank == index, format!("rank/select disagree at {index}"))?;
+    }
+    Ok(())
+}
+
+#[test]
+fn paginate_matches_iter_skip_take() -> TestResult {
+    let store = MemoryStore::default();
+    let keys = radix_keys(10, 3);
+    let root = build(&store, &keys)?;
+    let reader = Reader::<MemoryStore, V1>::new(store);
+    let all = oracle(&reader, &root)?;
+
+    // Whole-manifest pagination is exactly iter().skip(offset).take(limit).
+    for (offset, limit) in [(0u64, 7usize), (13, 20), (500, 33), (995, 50), (2000, 4)] {
+        let mut got = Vec::new();
+        let mut cursor = block_on(reader.paginate_prefix(&root, &Key::empty(), offset, limit))
+            .map_err(|e| e.to_string())?;
+        while let Some(pair) = block_on(cursor.next()).map_err(|e| e.to_string())? {
+            got.push(pair);
+        }
+        let start = usize::try_from(offset)?;
+        let want: Vec<_> = all.iter().skip(start).take(limit).cloned().collect();
+        ensure(
+            got == want,
+            format!("paginate_prefix({offset}, {limit}) mismatch"),
+        )?;
+    }
+
+    // Range pagination is the same over the range's own slice.
+    let lo = Key::from(&[3u8, 0, 0][..]);
+    let hi = Key::from(&[7u8, 0, 0][..]);
+    let window: Vec<_> = all
+        .iter()
+        .filter(|(k, _)| lo <= *k && *k < hi)
+        .cloned()
+        .collect();
+    for (offset, limit) in [(0u64, 10usize), (25, 40), (300, 12)] {
+        let mut got = Vec::new();
+        let mut cursor =
+            block_on(reader.paginate(&root, &lo, &hi, offset, limit)).map_err(|e| e.to_string())?;
+        while let Some(pair) = block_on(cursor.next()).map_err(|e| e.to_string())? {
+            got.push(pair);
+        }
+        let start = usize::try_from(offset)?;
+        let want: Vec<_> = window.iter().skip(start).take(limit).cloned().collect();
+        ensure(got == want, format!("paginate({offset}, {limit}) mismatch"))?;
+    }
+    Ok(())
+}
+
+#[test]
+fn the_offset_seek_costs_depth_not_offset() -> TestResult {
+    // A wide, spilled corpus: a full first-byte spread forces the root to spill
+    // into a segment directory, so the seek must route by seg_count.
+    let inner = MemoryStore::default();
+    let keys = wide_keys();
+    let root = build(&inner, &keys)?;
+    let store = CountingStore {
+        inner,
+        gets: AtomicUsize::new(0),
+    };
+    let reader = Reader::<CountingStore, V1>::new(store);
+    let total = u64::try_from(keys.len())?;
+
+    // Selecting near the start and deep into the listing fetches the same handful
+    // of nodes: a few directory and node hops per level, never the offset.
+    let mut costs = Vec::new();
+    for index in [0u64, total / 2, total.saturating_sub(1)] {
+        reader.store().reset();
+        let got = block_on(reader.select(&root, index)).map_err(|e| e.to_string())?;
+        ensure(got.is_some(), format!("select({index}) fell off"))?;
+        costs.push(reader.store().gets());
+    }
+    for cost in &costs {
+        ensure(
+            *cost <= 32,
+            format!("select fetched {cost} nodes, not O(depth)"),
+        )?;
+    }
+
+    // Paginating at a large offset fetches no more than at offset zero plus the
+    // page and its read-ahead: the offset itself is free.
+    reader.store().reset();
+    let mut head =
+        block_on(reader.paginate_prefix(&root, &Key::empty(), 0, 5)).map_err(|e| e.to_string())?;
+    while block_on(head.next()).map_err(|e| e.to_string())?.is_some() {}
+    let head_cost = reader.store().gets();
+
+    reader.store().reset();
+    let deep_offset = total.saturating_sub(5);
+    let mut deep = block_on(reader.paginate_prefix(&root, &Key::empty(), deep_offset, 5))
+        .map_err(|e| e.to_string())?;
+    while block_on(deep.next()).map_err(|e| e.to_string())?.is_some() {}
+    let deep_cost = reader.store().gets();
+
+    // The deep page pays for its own depth and window, not the offset it skipped.
+    ensure(
+        deep_cost <= head_cost.saturating_mul(2).saturating_add(32),
+        format!("deep page fetched {deep_cost} vs head {head_cost}: offset is not free"),
+    )?;
+    ensure(
+        u64::try_from(deep_cost)? < deep_offset,
+        format!("deep page fetched {deep_cost}, proportional to the offset"),
+    )?;
+    Ok(())
+}


### PR DESCRIPTION
## What

Adds the v3 read-side benchmark suite to `crates/manifest-sim`: range scans, pagination, parallel-cursor and read-profile measurements over generated corpora, with results emitted as versioned JSON documents (`meta`, `parallel_cursor`, `v1read`, `paginate` cell families). Every figure is produced by executing a real reader or cursor against a counting store.

The proof-performance cells present in an earlier revision are gone with the closed proof PRs (#309 to #313); proving moves to zkVM guests (#301 to #305).

## Why

The counted baseline and the read-optimized profile need empirical numbers behind their design constants; this harness produces them reproducibly.

## Testing

`cargo check`/`clippy`/`fmt` clean for `nectar-manifest-sim` (locked), workspace check clean at the branch tip, and a smoke run at `--scales 1000` completes all four corpora with exactly the four expected cell families in the output JSON.

## AI Assistance

Written with AI assistance; reviewed and tested by the author.
