### PR TITLE
ci: share compiles via sccache and drop redundant build jobs

### DIFF
--- a/.github/actions/rust-setup/action.yml
+++ b/.github/actions/rust-setup/action.yml
@@ -1,5 +1,5 @@
 name: rust-setup
-description: Pinned Rust 1.92 + sccache (GitHub Actions cache backend) + registry-only Swatinem cache shared across jobs.
+description: Pinned Rust 1.94 + sccache (GitHub Actions cache backend) + registry-only Swatinem cache shared across jobs.
 
 inputs:
   targets:
@@ -31,7 +31,7 @@ runs:
     # per job and compiles with the file's pin anyway.
     - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master 2026-03-27
       with:
-        toolchain: "1.92"
+        toolchain: "1.94"
         targets: ${{ inputs.targets }}
         components: ${{ inputs.components }}
     # Content-addressed rustc cache shared across jobs AND runs, backed by the

--- a/.github/actions/rust-setup/action.yml
+++ b/.github/actions/rust-setup/action.yml
@@ -1,0 +1,46 @@
+name: rust-setup
+description: Pinned Rust 1.92 + sccache (GitHub Actions cache backend) + registry-only Swatinem cache shared across jobs.
+
+inputs:
+  targets:
+    description: "extra rustup targets, space-separated"
+    default: ""
+  components:
+    description: "extra rustup components, space-separated"
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    # Must precede sccache-action: it exports the GHA cache credentials only when
+    # SCCACHE_GHA_ENABLED is already set. Incremental is off because sccache cannot
+    # cache incremental compiles. cargo's rustc version-probe also routes through
+    # the wrapper, so RUSTC_WRAPPER=sccache is safe globally. Keep RUSTFLAGS
+    # byte-identical across jobs: any per-job delta re-fingerprints the whole graph
+    # and every sccache key, defeating reuse.
+    - name: enable sccache
+      shell: bash
+      run: |
+        {
+          echo "RUSTC_WRAPPER=sccache"
+          echo "SCCACHE_GHA_ENABLED=true"
+          echo "CARGO_INCREMENTAL=0"
+        } >> "$GITHUB_ENV"
+    # Keep the channel in sync with rust-toolchain.toml: rustup resolves the
+    # toolchain file at cargo time, so a drift here downloads a second toolchain
+    # per job and compiles with the file's pin anyway.
+    - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master 2026-03-27
+      with:
+        toolchain: "1.92"
+        targets: ${{ inputs.targets }}
+        components: ${{ inputs.components }}
+    # Content-addressed rustc cache shared across jobs AND runs, backed by the
+    # GitHub Actions cache. Unlike rust-cache it caches the workspace crates too
+    # (rust-cache deletes local-package artifacts before saving).
+    - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+    # Swatinem caches ONLY ~/.cargo (registry index + git + downloaded crate
+    # sources); target/ is owned by sccache. One shared registry key for every job.
+    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      with:
+        cache-targets: "false"
+        shared-key: registry

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -18,7 +18,6 @@ on:
 permissions:
   contents: read
   issues: write
-  checks: write
 
 jobs:
   audit:
@@ -26,6 +25,28 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998  # v2.0.0
+      # Prebuilt binary: `cargo audit` only parses Cargo.lock, so it needs no
+      # toolchain. rustsec/audit-check instead compiled cargo-audit from source
+      # with the repo-pinned toolchain, which broke once cargo-audit's own
+      # dependency tree outgrew that toolchain's version.
+      - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853  # v2.83.2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          tool: cargo-audit
+
+      - name: cargo audit
+        run: cargo audit
+
+      - name: Open or update advisory issue
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title="Security audit found vulnerable dependencies"
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          body=$(printf 'The scheduled security audit failed: a RustSec advisory matches a dependency in Cargo.lock.\n\nFailed run: %s\n\nUpdate the affected dependency to a patched version shown in the run log.' "$run_url")
+          existing=$(gh issue list --state open --search "in:title \"$title\"" --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$title" --body "$body"
+          fi

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -19,15 +19,9 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-            - name: Install Rust
-              uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+            - uses: ./.github/actions/rust-setup
               with:
                   targets: wasm32-unknown-unknown
-
-            - name: Cache Rust dependencies
-              uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
-              with:
-                  shared-key: "wasm-demo"
 
             - name: Install Trunk
               uses: jetli/trunk-action@1346cc09eace4beb84e403e199a471346d4684c9  # v0.5.1
@@ -37,9 +31,7 @@ jobs:
             - name: Build WASM Demo
               run: |
                   cd crates/primitives/examples/wasm-demo
-                  # rust-toolchain.toml pins 1.92, whose wasm32 std is not
-                  # installed here; build with the stable toolchain that has it.
-                  RUSTUP_TOOLCHAIN=stable trunk build --release --public-url /nectar/
+                  trunk build --release --public-url /nectar/
 
             - name: Deploy to GitHub Pages
               uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f  # v4.8.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,12 +22,9 @@ jobs:
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
             - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444  # v1
-            - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+            - uses: ./.github/actions/rust-setup
               with:
                   components: clippy
-            - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
-              with:
-                  cache-on-failure: true
             # Lints lib+bins with default features; the `deny`-level restriction
             # lints in `[workspace.lints.clippy]` make this fail on any
             # panicking/overflowing operation in production code.

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,4 +1,4 @@
-# Runs unit tests.
+# Runs unit, integration and doc tests.
 name: unit
 
 on:
@@ -16,103 +16,49 @@ concurrency:
 
 jobs:
     test:
-        # name: test / ${{ matrix.type }} (${{ matrix.partition }}/${{ matrix.total_partitions }})
-        name: test / ${{ matrix.type }}
+        name: test / swarm
         runs-on: ubuntu-latest
         env:
             RUST_BACKTRACE: 1
-        strategy:
-            matrix:
-                include:
-                    - type: swarm
-                      args: ""
-                    # - type: ethereum
-                    #   args: --features "asm-keccak ethereum" --locked
-                    #   partition: 1
-                    #   total_partitions: 2
-                    # - type: ethereum
-                    #   args: --features "asm-keccak ethereum" --locked
-                    #   partition: 2
-                    #   total_partitions: 2
-                    # - type: optimism
-                    #   args: --features "asm-keccak optimism" --locked --exclude reth --exclude reth-bench --exclude "example-*" --exclude "reth-ethereum-*" --exclude "*-ethereum"
-                    #   partition: 1
-                    #   total_partitions: 2
-                    # - type: optimism
-                    #   args: --features "asm-keccak optimism" --locked --exclude reth --exclude reth-bench --exclude "example-*" --exclude "reth-ethereum-*" --exclude "*-ethereum"
-                    #   partition: 2
-                    #   total_partitions: 2
-                    # - type: book
-                    #   args: --manifest-path book/sources/Cargo.toml
-                    #   partition: 1
-                    #   total_partitions: 1
         timeout-minutes: 30
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+            # mold is symlinked as `ld`, NOT put in RUSTFLAGS: it keeps linking
+            # fast (which sccache cannot cache anyway) without a linker flag in
+            # the compile cache key.
             - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444  # v1
-            - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
-            - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+            - uses: ./.github/actions/rust-setup
+            - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853  # v2.83.2
               with:
-                  cache-on-failure: true
-            - uses: taiki-e/install-action@1b57bc699ba2af96a06eb2a2a0d32b43a7d8e8b8  # nextest
-            - if: "${{ matrix.type == 'book' }}"
-              uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b  # v3.0.0
-              with:
-                  repo-token: ${{ secrets.GITHUB_TOKEN }}
+                  tool: nextest
             - name: Run tests
               run: |
                   cargo nextest run \
-                    ${{ matrix.args }} --workspace \
-                    --no-tests=warn \
-                    -E "!kind(test)"
-
-    doc:
-        name: doc tests (${{ matrix.network }})
-        runs-on: ubuntu-latest
-        env:
-            RUST_BACKTRACE: 1
-        timeout-minutes: 30
-        # strategy:
-        #     matrix:
-        #         network: ["ethereum", "optimism"]
-        steps:
-            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-            - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444  # v1
-            - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
-            - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
-              with:
-                  cache-on-failure: true
+                    --workspace --locked \
+                    --no-tests=warn --no-fail-fast
+            # nextest does not run doctests; cover them here on the warm target
+            # dir rather than in a separate job that rebuilds the workspace.
             - name: Run doctests
-              # run: cargo test --doc --workspace --features "${{ matrix.network }}"
-              run: cargo test --doc --workspace
+              run: cargo test --doc --workspace --locked
 
     wasm:
         # The postage-usage client facade is meant to run in a browser. The
         # thread pool (wasm-bindgen-rayon) is opt-in behind the primitives
         # `parallel` / `wasm-threads` features, so the crate builds for wasm32
-        # single-threaded by default. A plain stable check on the default
-        # features is therefore the faithful one.
+        # single-threaded by default. A plain check on the default features is
+        # therefore the faithful one.
         name: wasm / postage-usage
         runs-on: ubuntu-latest
         timeout-minutes: 30
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-            - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444  # v1
-            - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+            - uses: ./.github/actions/rust-setup
               with:
                   targets: wasm32-unknown-unknown
-            - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
-              with:
-                  cache-on-failure: true
             - name: Check postage-usage builds for wasm32
-              env:
-                  # The workspace rust-toolchain.toml pins 1.92, which has no
-                  # wasm32 std installed here; use the stable toolchain the setup
-                  # step added the wasm32 target to.
-                  RUSTUP_TOOLCHAIN: stable
               run: |
                   cargo check \
-                    -p nectar-postage-usage --features client \
+                    -p nectar-postage-usage --features client --locked \
                     --target wasm32-unknown-unknown
 
     unit-success:

--- a/.github/workflows/upstream-addresses.yml
+++ b/.github/workflows/upstream-addresses.yml
@@ -39,10 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          workspaces: . -> target
+      - uses: ./.github/actions/rust-setup
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: stable

--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770520253,
-        "narHash": "sha256-6rWuHgSENXKnC6HGGAdRolQrnp/8IzscDn7FQEo1uEQ=",
+        "lastModified": 1784091390,
+        "narHash": "sha256-aILAwrBQPhKldL98N8lmsbfst3OPtbMM4vT2VXn40/Y=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "ebb8a141f60bb0ec33836333e0ca7928a072217f",
+        "rev": "a7887636a3959168bd1ba7ef24a8a70b168dcb56",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -18,8 +18,9 @@
           inherit system overlays;
         };
 
-        # Stable toolchain for regular development
-        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+        # Pinned to match CI and rust-toolchain.toml exactly. Develop with
+        # `nix develop` so the local toolchain matches CI/CD.
+        rustToolchain = pkgs.rust-bin.stable."1.94.0".default.override {
           extensions = [ "rust-analyzer" "rust-src" "clippy" "rustfmt" ];
           targets = [ "wasm32-unknown-unknown" ];
         };
@@ -45,6 +46,7 @@
           buildInputs = with pkgs; [
             rustToolchain
             rustNightly
+            cargo-nextest
             wasm-pack
             wasm-bindgen-cli
             miniserve
@@ -57,13 +59,28 @@
             git-cliff
             cargo-deny
             cargo-audit
-          ];
+          ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.mold ];
 
           OPENSSL_DIR = "${pkgs.openssl.dev}";
           OPENSSL_LIB_DIR = "${pkgs.openssl.out}/lib";
           PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig";
 
+          # Link native Linux builds with mold. Scoped per-target so it never
+          # touches wasm linking, and set as env (not a committed .cargo config)
+          # so CI keeps its own linker setup.
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS =
+            pkgs.lib.optionalString pkgs.stdenv.isLinux "-Clink-arg=-fuse-ld=mold";
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUSTFLAGS =
+            pkgs.lib.optionalString pkgs.stdenv.isLinux "-Clink-arg=-fuse-ld=mold";
+
           shellHook = ''
+            # Opt into sccache only when the host provides it: a client must
+            # match its server's version exactly, so a copy pinned by this flake
+            # would fight the host server for the socket.
+            if command -v sccache >/dev/null; then
+              export RUSTC_WRAPPER=sccache
+              export CARGO_INCREMENTAL=0 # sccache and incremental are exclusive
+            fi
             # Alias for building WASM with threading support
             alias wasm-build-threaded='RUSTFLAGS="-C target-feature=+atomics,+bulk-memory,+mutable-globals" cargo +nightly build --target wasm32-unknown-unknown -Z build-std=panic_abort,std'
           '';

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.92"
+channel = "1.94"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## What

- Adds a `.github/actions/rust-setup` composite mirroring the pipeline recently landed in shepherd: the pinned toolchain, sccache, and a registry-only `Swatinem/rust-cache` shared across every job. Unlike shepherd, sccache is backed by the GitHub Actions cache (`SCCACHE_GHA_ENABLED`) rather than R2, so no secrets or bucket lifecycle rules are needed.
- `lint`, `unit`, `upstream-addresses`, and the wasm-demo deploy now use the composite. `target/` caching moves wholly to sccache, which is content-addressed, shared across jobs and runs, and caches the workspace crates too (rust-cache deletes local-package artefacts before saving, so the previous per-job target caches rebuilt them every run).
- The `doc` job is folded into `test`: nextest does not run doctests, but a whole separate job rebuilt the workspace just for `cargo test --doc`. It now runs on the warm target dir after nextest.
- The integration tests now run: the reth-inherited `-E "!kind(test)"` filter meant the 36 tests under `crates/mantaray/tests` and `crates/postage-usage/tests` never executed in CI.
- Rust is pinned to 1.94 everywhere it matters: `rust-toolchain.toml`, the composite, and the flake dev shell (`rust-bin.stable."1.94.0"`), so local builds, CI, and rustup all agree. Previously each job installed `stable`, rustup then downloaded the pinned channel at the first cargo invocation anyway, and the wasm/demo jobs compiled under `RUSTUP_TOOLCHAIN=stable` overrides, splitting caches across two compilers. MSRV (`rust-version = "1.92"`) is unchanged.
- The dev shell carries the CI caching over: opt-in host sccache (`RUSTC_WRAPPER`), mold for native Linux links (scoped per-target env so wasm and CI are untouched), and cargo-nextest so the local test invocation matches CI.
- Fixes the daily Security Audit failure on main (runs #537/#538): `rustsec/audit-check` compiles cargo-audit from source with the repo-pinned toolchain, and cargo-audit's dependency tree now needs Rust 1.96 (`kstring v2.0.3`). The workflow now installs a prebuilt cargo-audit via `taiki-e/install-action` (no toolchain coupling, no daily compile) and opens/updates an issue on scheduled failures, replacing the equivalent audit-check behaviour.
- Gate names are unchanged (`clippy`, `test / swarm`, `wasm / postage-usage`, `unit success`), and `fuzz` and `zepter` are untouched. The fuzz workflow builds a separate workspace on nightly, where sccache keys would churn daily; its existing target cache is the right tool.

## Why

The stacked PR trains multiply every redundant compile by the number of PRs rebased. This lands at the bottom of the stack so each train PR inherits a warm, shared compile cache instead of per-job cold target caches plus a duplicate doc build. No train branch touches `.github`, so the ripple rebase over this is conflict-free.

## Testing

- `actionlint` clean.
- Full battery locally under the new 1.94 flake shell (sccache wrapper active), matching the CI commands exactly: `cargo clippy --workspace --locked`, the per-crate `unused_crate_dependencies` loop, `cargo nextest run --workspace --locked --no-tests=warn --no-fail-fast` (including the 36 newly ungated integration tests), `cargo test --doc --workspace --locked`, the wasm32 check, and `cargo audit`.
- The composite, GHA sccache backend, and cache behaviour are exercised by this PR's own CI runs (first cold run was green across all workflows).

## AI Assistance

Drafted with AI assistance; design, review, and testing by the author.
