### PR TITLE
ci: gate the no_std core on a bare-metal rv64 target

### DIFF
--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -1,0 +1,34 @@
+# Gates the no_std core on a bare-metal rv64 target (the zkVM-guest shape).
+# Only the crates that already build without std are listed; extend the -p
+# list as crates flip to no_std.
+name: no_std
+
+on:
+    pull_request:
+    merge_group:
+    push:
+        branches: [main]
+
+env:
+    CARGO_TERM_COLOR: always
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: true
+
+jobs:
+    check:
+        name: no_std / riscv64imac
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+            - uses: ./.github/actions/rust-setup
+              with:
+                  targets: riscv64imac-unknown-none-elf
+            - name: Check no_std crates on a bare-metal target
+              run: |
+                  cargo check --locked \
+                    -p nectar-swarms -p nectar-contracts \
+                    --no-default-features \
+                    --target riscv64imac-unknown-none-elf


### PR DESCRIPTION
## What

Adds a `no_std` workflow: `cargo check --no-default-features --target riscv64imac-unknown-none-elf` for the crates that already build bare-metal (`nectar-swarms`, `nectar-contracts`). The `-p` list grows as the remaining crates flip to no_std.

## Why

nectar's guiding decision is full library-core no_std+alloc (alloy/revm-style) targeting zkVM guests, and the rv64 bare-metal shape matches where the guest ecosystem is heading. Nothing in CI built `--no-default-features` before, so the declared no_std surfaces rot silently; this stops that for the crates that are already there, and gives the post-train primitives no_std epic a gate to grow into.

## Testing

- Verified locally on the pinned 1.94 toolchain: both crates check clean for `riscv64imac-unknown-none-elf` in under 10 s.
- `actionlint` clean.
- The job exercises itself on this PR's own CI run (warm-cache cost is roughly a minute, in parallel with existing jobs).

## AI Assistance

Drafted with AI assistance; design, review, and testing by the author.
