### PR TITLE
ci: lint every target with clippy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,11 +25,12 @@ jobs:
             - uses: ./.github/actions/rust-setup
               with:
                   components: clippy
-            # Lints lib+bins with default features; the `deny`-level restriction
-            # lints in `[workspace.lints.clippy]` make this fail on any
-            # panicking/overflowing operation in production code.
+            # Lints every target (libs, bins, tests, benches, examples) with
+            # default features; the `deny`-level restriction lints in
+            # `[workspace.lints.clippy]` fail on panicking/overflowing
+            # operations, with test code exempted per crate.
             - name: cargo clippy
-              run: cargo clippy --workspace --locked
+              run: cargo clippy --workspace --all-targets --locked
             # `unused_crate_dependencies` is enforced per-library via `cargo
             # rustc` (not `[workspace.lints]`) so the flag applies only to each
             # crate's own lib target — never to benches/examples/tests (which

--- a/crates/mantaray/src/builder.rs
+++ b/crates/mantaray/src/builder.rs
@@ -42,7 +42,7 @@ use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{ChunkAddress, ChunkRef, Reference};
 use nectar_primitives::file::{ChunkPutExt, ReadAt};
 use nectar_primitives::store::{ChunkPut, MaybeSend, TrustedStore};
-use nectar_primitives::{AnyChunkSet, Chunk};
+use nectar_primitives::AnyChunkSet;
 
 use crate::entry::Entry;
 use crate::manifest::Manifest;


### PR DESCRIPTION
## What

Adds `--all-targets` to the clippy job, which previously linted only libs and bins: every test, bench and example in the workspace escaped all lints. Fixes the one unused import the wider net surfaces (`Chunk` in `mantaray/builder.rs`). Three unused-macro warnings in the feature-gated joiner/splitter test helpers remain visible deliberately: the async-testing rework converts their only call sites to ungated tests, making them used again.

## Why

The deny-level restriction lints and the upcoming `disallowed-methods` gate for `block_on` are meaningless over test code that clippy never sees. Warnings do not gate (no `-D warnings` change here), so this widens coverage without altering merge semantics.

## Testing

`cargo clippy --workspace --all-targets --locked` exits clean locally (warnings only, no deny-lint failures); 119 mantaray tests pass after the import fix; actionlint clean.

## AI Assistance

Written with AI assistance; reviewed and tested by the author.
