### PR TITLE
feat: relax trust bounds and rename TrustedStore to TrustedGet

### DIFF
--- a/crates/manifest/src/builder.rs
+++ b/crates/manifest/src/builder.rs
@@ -11,7 +11,7 @@ use std::collections::BTreeMap;
 use std::io::Write;
 
 use bytes::Bytes;
-use nectar_primitives::store::{ChunkPut, MaybeSync};
+use nectar_primitives::store::{BoxedError, ChunkPut, MaybeSend, MaybeSync};
 use nectar_primitives::{
     Chunk, ChunkAddress, ChunkRef, ContentChunk, DefaultSplitter, FileError, PrimitivesError,
 };
@@ -50,7 +50,7 @@ pub enum BuildError {
     Seal(#[source] PrimitivesError),
     /// The backing store rejected a file chunk.
     #[error("store file chunk")]
-    Backend(#[source] Box<dyn core::error::Error + Send + Sync>),
+    Backend(#[source] BoxedError),
     /// A compacted edge exceeded the format's prefix bound.
     #[error(transparent)]
     Prefix(#[from] PrefixTooLong),
@@ -69,7 +69,7 @@ pub enum BuildError {
 
 impl BuildError {
     /// Box a backend error behind the seam.
-    fn backend<E: core::error::Error + Send + Sync + 'static>(err: E) -> Self {
+    fn backend<E: core::error::Error + MaybeSend + MaybeSync + 'static>(err: E) -> Self {
         Self::Backend(Box::new(err))
     }
 }

--- a/crates/manifest/src/encryption.rs
+++ b/crates/manifest/src/encryption.rs
@@ -31,7 +31,7 @@
 use core::future::Future;
 
 use alloy_primitives::Keccak256;
-use nectar_primitives::store::{ChunkPut, MaybeSend, MaybeSync, TrustedStore};
+use nectar_primitives::store::{ChunkPut, MaybeSend, MaybeSync, TrustedGet};
 use nectar_primitives::{
     Chunk, ChunkOps, ContentChunk, EncryptedChunkRef, EncryptionKey, transcrypt_in_place,
 };
@@ -147,9 +147,9 @@ impl<T: ChunkPut> EncryptedNodePut for T {}
 
 /// Async encrypted-node retrieval over a trusted store.
 ///
-/// Blanket-implemented for every [`TrustedStore`]; the ref64 carries both the
+/// Blanket-implemented for every [`TrustedGet`]; the ref64 carries both the
 /// address to fetch and the key to decrypt with.
-pub trait EncryptedNodeGet: TrustedStore {
+pub trait EncryptedNodeGet: TrustedGet {
     /// Load the chunk at `reference`'s address and decrypt it with its key.
     fn get_node_encrypted<F: Format>(
         &self,
@@ -168,7 +168,7 @@ pub trait EncryptedNodeGet: TrustedStore {
     }
 }
 
-impl<T: TrustedStore> EncryptedNodeGet for T {}
+impl<T: TrustedGet> EncryptedNodeGet for T {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/manifest/src/store.rs
+++ b/crates/manifest/src/store.rs
@@ -2,7 +2,7 @@
 //!
 //! A node is a content-addressed chunk whose address is the BMT of its encoded
 //! payload. The store is the trust boundary: a node read back from a
-//! [`TrustedStore`] is decoded straight from the certified bytes, so the read
+//! [`TrustedGet`] is decoded straight from the certified bytes, so the read
 //! path never re-hashes. The write path seals a freshly built payload into a
 //! [`Verified`] content chunk, deriving the address rather than trusting one.
 //!
@@ -11,7 +11,7 @@
 
 use core::future::Future;
 
-use nectar_primitives::store::{ChunkPut, MaybeSend, MaybeSync, TrustedStore};
+use nectar_primitives::store::{BoxedError, ChunkPut, MaybeSend, MaybeSync, TrustedGet};
 use nectar_primitives::{Chunk, ChunkAddress, ChunkOps, ContentChunk, Verified};
 
 use crate::codec::{DecodeError, DecodedChunk, EncodeError};
@@ -38,12 +38,12 @@ pub enum StoreError {
     Seal(#[source] nectar_primitives::PrimitivesError),
     /// The backing store failed.
     #[error("store")]
-    Store(#[source] Box<dyn core::error::Error + Send + Sync>),
+    Store(#[source] BoxedError),
 }
 
 impl StoreError {
     /// Box a backend error behind the seam.
-    pub(crate) fn store<E: core::error::Error + Send + Sync + 'static>(err: E) -> Self {
+    pub(crate) fn store<E: core::error::Error + MaybeSend + MaybeSync + 'static>(err: E) -> Self {
         Self::Store(Box::new(err))
     }
 }
@@ -68,9 +68,9 @@ impl<F: Format> Node<F> {
 
 /// Async node retrieval over a trusted store.
 ///
-/// Blanket-implemented for every [`TrustedStore`]; the `Trust = Verified`
+/// Blanket-implemented for every [`TrustedGet`]; the `Trust = Verified`
 /// bound is what lets [`get_node`](Self::get_node) skip re-hashing.
-pub trait NodeGet: TrustedStore {
+pub trait NodeGet: TrustedGet {
     /// Load and decode the node at `address`, materializing a spilled node's
     /// forks from its segments so the caller always sees one logical node.
     ///
@@ -88,7 +88,7 @@ pub trait NodeGet: TrustedStore {
     }
 }
 
-impl<T: TrustedStore> NodeGet for T {}
+impl<T: TrustedGet> NodeGet for T {}
 
 /// The greatest legal segment-directory depth (spec 5.4); a deeper nesting is a
 /// malformed image, not a tree this format ever produces.
@@ -97,7 +97,7 @@ const MAX_DIR_DEPTH: usize = 2;
 /// Load the node at `address`, reassembling a segmented node's forks in place.
 async fn materialize_node<S, F>(store: &S, address: &ChunkAddress) -> Result<Node<F>, StoreError>
 where
-    S: TrustedStore + MaybeSync,
+    S: TrustedGet + MaybeSync,
     F: Format,
 {
     let chunk = store.get(address).await.map_err(StoreError::store)?;
@@ -122,7 +122,7 @@ async fn collect_segment_forks<S, F>(
     depth: usize,
 ) -> Result<ForkTable<F>, StoreError>
 where
-    S: TrustedStore + MaybeSync,
+    S: TrustedGet + MaybeSync,
     F: Format,
 {
     if depth >= MAX_DIR_DEPTH {

--- a/crates/mantaray/src/builder.rs
+++ b/crates/mantaray/src/builder.rs
@@ -41,7 +41,7 @@ use alloc::collections::BTreeMap;
 use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{ChunkAddress, ChunkRef, Reference};
 use nectar_primitives::file::{ChunkPutExt, ReadAt};
-use nectar_primitives::store::{ChunkPut, MaybeSend, TrustedStore};
+use nectar_primitives::store::{ChunkPut, MaybeSend, TrustedGet};
 use nectar_primitives::{AnyChunkSet, Chunk};
 
 use crate::entry::Entry;
@@ -94,7 +94,7 @@ impl<S, R: Reference, const BS: usize> ManifestBuilder<S, R, BS> {
     }
 }
 
-impl<S: TrustedStore<AnyChunkSet<BS>>, R: Reference + MaybeSend, const BS: usize>
+impl<S: TrustedGet<AnyChunkSet<BS>>, R: Reference + MaybeSend, const BS: usize>
     ManifestBuilder<S, R, BS>
 {
     /// Stage a path with a typed reference.
@@ -138,7 +138,7 @@ impl<S: TrustedStore<AnyChunkSet<BS>>, R: Reference + MaybeSend, const BS: usize
     }
 }
 
-impl<S: TrustedStore<AnyChunkSet<BS>> + ChunkPut<AnyChunkSet<BS>>, const BS: usize>
+impl<S: TrustedGet<AnyChunkSet<BS>> + ChunkPut<AnyChunkSet<BS>>, const BS: usize>
     ManifestBuilder<S, ChunkRef, BS>
 {
     /// Split `data`, store its chunks, and stage the resulting root at `path`.
@@ -161,7 +161,7 @@ impl<S: TrustedStore<AnyChunkSet<BS>> + ChunkPut<AnyChunkSet<BS>>, const BS: usi
 }
 
 #[cfg(feature = "encryption")]
-impl<S: TrustedStore<AnyChunkSet<BS>> + ChunkPut<AnyChunkSet<BS>>, const BS: usize>
+impl<S: TrustedGet<AnyChunkSet<BS>> + ChunkPut<AnyChunkSet<BS>>, const BS: usize>
     ManifestBuilder<S, nectar_primitives::EncryptedChunkRef, BS>
 {
     /// Split `data` in encrypted mode, store its chunks, and stage the root at `path`.
@@ -185,7 +185,7 @@ impl<S: TrustedStore<AnyChunkSet<BS>> + ChunkPut<AnyChunkSet<BS>>, const BS: usi
     }
 }
 
-impl<S: TrustedStore<AnyChunkSet<BS>> + ChunkPut<AnyChunkSet<BS>>, const BS: usize>
+impl<S: TrustedGet<AnyChunkSet<BS>> + ChunkPut<AnyChunkSet<BS>>, const BS: usize>
     ManifestBuilder<S, nectar_primitives::EncryptedChunkRef, BS>
 {
     /// Persist the encrypted manifest, consuming the builder.

--- a/crates/mantaray/src/error.rs
+++ b/crates/mantaray/src/error.rs
@@ -1,9 +1,8 @@
 //! Error types for mantaray operations.
 
-use alloc::sync::Arc;
-
 use nectar_primitives::chunk::ChunkAddress;
 use nectar_primitives::error::PrimitivesError;
+use nectar_primitives::store::SharedError;
 
 /// Result type alias for mantaray operations.
 pub type Result<T> = core::result::Result<T, MantarayError>;
@@ -148,13 +147,13 @@ pub enum MantarayError {
     #[error("store get error: {source}")]
     StoreGet {
         /// Original store error, preserved for downcasting.
-        source: Arc<dyn core::error::Error + Send + Sync>,
+        source: SharedError,
     },
     /// Error from the typed chunk store during put operations.
     #[error("store put error: {source}")]
     StorePut {
         /// Original store error, preserved for downcasting.
-        source: Arc<dyn core::error::Error + Send + Sync>,
+        source: SharedError,
     },
 }
 

--- a/crates/mantaray/src/lib.rs
+++ b/crates/mantaray/src/lib.rs
@@ -161,7 +161,7 @@ pub mod hazmat {
 
 // Re-export typed storage traits from primitives.
 pub use nectar_primitives::DefaultMemoryStore;
-pub use nectar_primitives::store::{ChunkGet, ChunkHas, ChunkPut, MemoryStore, TrustedStore};
+pub use nectar_primitives::store::{ChunkGet, ChunkHas, ChunkPut, MemoryStore, TrustedGet};
 
 /// Default manifest type using [`DEFAULT_BODY_SIZE`] and plain mode.
 pub type DefaultManifest<S> = PlainManifest<S, DEFAULT_BODY_SIZE>;

--- a/crates/mantaray/src/manifest.rs
+++ b/crates/mantaray/src/manifest.rs
@@ -7,7 +7,7 @@ use nectar_primitives::AnyChunkSet;
 use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{ChunkAddress, ChunkRef, Reference};
 use nectar_primitives::file::join;
-use nectar_primitives::store::{ChunkPut, MaybeSend, TrustedStore};
+use nectar_primitives::store::{ChunkPut, MaybeSend, TrustedGet};
 
 use crate::entry::Entry;
 use crate::node::Node;
@@ -96,9 +96,7 @@ impl<S, R: Reference, const BS: usize> Manifest<S, R, BS> {
     }
 }
 
-impl<S: TrustedStore<AnyChunkSet<BS>>, R: Reference + MaybeSend, const BS: usize>
-    Manifest<S, R, BS>
-{
+impl<S: TrustedGet<AnyChunkSet<BS>>, R: Reference + MaybeSend, const BS: usize> Manifest<S, R, BS> {
     /// Add a path with a typed reference (compile-time enforced by entry type).
     pub async fn add(&mut self, path: &str, reference: impl Into<R>) -> Result<()> {
         let entry = reference.into();
@@ -375,7 +373,7 @@ impl<S: TrustedStore<AnyChunkSet<BS>>, R: Reference + MaybeSend, const BS: usize
     }
 }
 
-impl<S: TrustedStore<AnyChunkSet<BS>>, const BS: usize> Manifest<S, ChunkRef, BS> {
+impl<S: TrustedGet<AnyChunkSet<BS>>, const BS: usize> Manifest<S, ChunkRef, BS> {
     /// Look up `path` and join the file it references into memory.
     ///
     /// Shared-read (`&self`); `None` when the path is absent or is not a value.
@@ -395,7 +393,7 @@ impl<S: TrustedStore<AnyChunkSet<BS>>, const BS: usize> Manifest<S, ChunkRef, BS
     }
 }
 
-impl<S: TrustedStore<AnyChunkSet<BS>> + ChunkPut<AnyChunkSet<BS>>, const BS: usize>
+impl<S: TrustedGet<AnyChunkSet<BS>> + ChunkPut<AnyChunkSet<BS>>, const BS: usize>
     Manifest<S, ChunkRef, BS>
 {
     /// Persist the plain manifest trie to storage, returning the root chunk address.
@@ -410,7 +408,7 @@ impl<S: TrustedStore<AnyChunkSet<BS>> + ChunkPut<AnyChunkSet<BS>>, const BS: usi
 }
 
 #[cfg(feature = "encryption")]
-impl<S: TrustedStore<AnyChunkSet<BS>>, const BS: usize>
+impl<S: TrustedGet<AnyChunkSet<BS>>, const BS: usize>
     Manifest<S, nectar_primitives::EncryptedChunkRef, BS>
 {
     /// Look up `path` and join the encrypted file it references into memory.
@@ -433,7 +431,7 @@ impl<S: TrustedStore<AnyChunkSet<BS>>, const BS: usize>
     }
 }
 
-impl<S: TrustedStore<AnyChunkSet<BS>> + ChunkPut<AnyChunkSet<BS>>, const BS: usize>
+impl<S: TrustedGet<AnyChunkSet<BS>> + ChunkPut<AnyChunkSet<BS>>, const BS: usize>
     Manifest<S, nectar_primitives::EncryptedChunkRef, BS>
 {
     /// Persist the encrypted manifest trie, returning a [`ManifestRef`](crate::ManifestRef).
@@ -491,9 +489,7 @@ struct IterFrame<R: Reference> {
     key_idx: usize,
 }
 
-impl<'a, S: TrustedStore<AnyChunkSet<BS>>, R: Reference, const BS: usize>
-    ManifestIter<'a, S, R, BS>
-{
+impl<'a, S: TrustedGet<AnyChunkSet<BS>>, R: Reference, const BS: usize> ManifestIter<'a, S, R, BS> {
     pub(crate) const fn new(trie: &'a mut Node<R>, store: &'a S) -> Self {
         Self {
             trie,
@@ -623,7 +619,7 @@ struct SharedFrame<R: Reference> {
     key_idx: usize,
 }
 
-impl<'a, S: TrustedStore<AnyChunkSet<BS>>, R: Reference, const BS: usize> SharedIter<'a, S, R, BS> {
+impl<'a, S: TrustedGet<AnyChunkSet<BS>>, R: Reference, const BS: usize> SharedIter<'a, S, R, BS> {
     const fn new(root: Node<R>, store: &'a S) -> Self {
         Self {
             store,
@@ -728,7 +724,7 @@ mod tests {
     type PlainManifest<S, const BS: usize = DEFAULT_BODY_SIZE> = super::Manifest<S, ChunkRef, BS>;
 
     /// Drain an async manifest iterator into a `Vec`, propagating the first error.
-    fn drain<S: TrustedStore<AnyChunkSet<BS>>, R: Reference, const BS: usize>(
+    fn drain<S: TrustedGet<AnyChunkSet<BS>>, R: Reference, const BS: usize>(
         mut iter: ManifestIter<'_, S, R, BS>,
     ) -> Result<Vec<Entry>> {
         block_on(async move {
@@ -1381,7 +1377,7 @@ mod tests {
         block_on(m.add("a.txt", make_addr("a"))).unwrap();
 
         // All read accessors are callable through a shared borrow.
-        fn read_all<S: TrustedStore<StandardChunkSet>>(m: &PlainManifest<S>) {
+        fn read_all<S: TrustedGet<StandardChunkSet>>(m: &PlainManifest<S>) {
             assert!(block_on(m.get("a.txt")).unwrap().is_some());
             assert_eq!(block_on(m.entries()).unwrap().len(), 2);
             assert_eq!(

--- a/crates/mantaray/src/node.rs
+++ b/crates/mantaray/src/node.rs
@@ -9,7 +9,7 @@ use crate::obfuscation::ObfuscationKey;
 use crate::{PATH_SEPARATOR, PREFIX_MAX_LEN};
 use bytes::Bytes;
 use nectar_primitives::chunk::{ChunkAddress, ChunkOps, ChunkRef, ContentChunk, Reference};
-use nectar_primitives::store::{ChunkPut, MaybeSend, TrustedStore};
+use nectar_primitives::store::{ChunkPut, MaybeSend, TrustedGet};
 use nectar_primitives::wire::{Cursor, FromCursor, ToWriter, Writer};
 use nectar_primitives::{AnyChunkSet, Chunk, EncryptedChunkRef, EncryptionKey};
 
@@ -397,7 +397,7 @@ impl<R: Reference> Node<R> {
     }
 
     /// Load forks from storage if the node hasn't been loaded yet.
-    async fn ensure_loaded<S: TrustedStore<AnyChunkSet<BS>>, const BS: usize>(
+    async fn ensure_loaded<S: TrustedGet<AnyChunkSet<BS>>, const BS: usize>(
         &mut self,
         store: &S,
     ) -> Result<()> {
@@ -408,7 +408,7 @@ impl<R: Reference> Node<R> {
     }
 
     /// Load this node from storage by its reference.
-    pub(crate) async fn load<S: TrustedStore<AnyChunkSet<BS>>, const BS: usize>(
+    pub(crate) async fn load<S: TrustedGet<AnyChunkSet<BS>>, const BS: usize>(
         &mut self,
         store: &S,
     ) -> Result<()> {
@@ -438,7 +438,7 @@ impl<R: Reference> Node<R> {
 
     /// Look up the node at the given path, loading from storage as needed.
     #[allow(clippy::indexing_slicing)] // `rest` is checked non-empty before `rest[0]`; `c <= rest.len()` from common_prefix_len
-    pub(crate) async fn lookup_node<S: TrustedStore<AnyChunkSet<BS>>, const BS: usize>(
+    pub(crate) async fn lookup_node<S: TrustedGet<AnyChunkSet<BS>>, const BS: usize>(
         &mut self,
         path: &[u8],
         store: &S,
@@ -476,7 +476,7 @@ impl<R: Reference> Node<R> {
     /// `&self` and clones each descended fork, so reading a persisted manifest
     /// leaves the trie untouched. Returns `None` for an absent path.
     #[allow(clippy::indexing_slicing)] // `rest` is checked non-empty before `rest[0]`; `c <= rest.len()` from common_prefix_len
-    pub(crate) async fn get_node<S: TrustedStore<AnyChunkSet<BS>>, const BS: usize>(
+    pub(crate) async fn get_node<S: TrustedGet<AnyChunkSet<BS>>, const BS: usize>(
         &self,
         path: &[u8],
         store: &S,
@@ -508,7 +508,7 @@ impl<R: Reference> Node<R> {
 
     /// Look up the entry at the given path, loading from storage as needed.
     #[cfg(test)]
-    pub(crate) async fn lookup<S: TrustedStore<AnyChunkSet<BS>>, const BS: usize>(
+    pub(crate) async fn lookup<S: TrustedGet<AnyChunkSet<BS>>, const BS: usize>(
         &mut self,
         path: &[u8],
         store: &S,
@@ -531,7 +531,7 @@ impl<R: Reference> Node<R> {
     // <= min(prefix.len(), path.len()), bounding every split; the fork at
     // `path[0]` is checked present (`contains_key`) before each get/expect.
     #[allow(clippy::indexing_slicing, clippy::expect_used)]
-    pub(crate) fn add<'a, S: TrustedStore<AnyChunkSet<BS>>, const BS: usize>(
+    pub(crate) fn add<'a, S: TrustedGet<AnyChunkSet<BS>>, const BS: usize>(
         &'a mut self,
         path: &'a [u8],
         entry: Option<R>,
@@ -661,7 +661,7 @@ impl<R: Reference> Node<R> {
     // `path.starts_with(&prefix)` guarantees `prefix.len() <= path.len()`;
     // the fork at `first` is checked present before the get_mut/expect.
     #[allow(clippy::indexing_slicing, clippy::expect_used)]
-    pub(crate) fn remove<'a, S: TrustedStore<AnyChunkSet<BS>>, const BS: usize>(
+    pub(crate) fn remove<'a, S: TrustedGet<AnyChunkSet<BS>>, const BS: usize>(
         &'a mut self,
         path: &'a [u8],
         store: &'a S,
@@ -711,7 +711,7 @@ impl<R: Reference> Node<R> {
 
     /// Test whether a prefix exists in the trie, loading from storage as needed.
     #[allow(clippy::indexing_slicing)] // `rest` is checked non-empty before `rest[0]`; `c <= rest.len()` from common_prefix_len
-    pub(crate) async fn has_prefix<S: TrustedStore<AnyChunkSet<BS>>, const BS: usize>(
+    pub(crate) async fn has_prefix<S: TrustedGet<AnyChunkSet<BS>>, const BS: usize>(
         &mut self,
         path: &[u8],
         store: &S,
@@ -826,7 +826,7 @@ impl<R: Reference> Node<R> {
     }
 
     /// Walk all nodes depth-first, calling `f` for each node with its path.
-    pub(crate) async fn walk<S: TrustedStore<AnyChunkSet<BS>>, const BS: usize, F>(
+    pub(crate) async fn walk<S: TrustedGet<AnyChunkSet<BS>>, const BS: usize, F>(
         &mut self,
         store: &S,
         f: &mut F,
@@ -839,7 +839,7 @@ impl<R: Reference> Node<R> {
     }
 
     /// Walk the subtree at `root`, calling `f` for each node.
-    pub(crate) async fn walk_from<S: TrustedStore<AnyChunkSet<BS>>, const BS: usize, F>(
+    pub(crate) async fn walk_from<S: TrustedGet<AnyChunkSet<BS>>, const BS: usize, F>(
         &mut self,
         root: &[u8],
         store: &S,
@@ -862,7 +862,7 @@ impl<R: Reference> Node<R> {
 ///
 /// The visitor `f` only reads loaded nodes, so it stays a synchronous `FnMut`.
 #[allow(clippy::arithmetic_side_effects)] // the only arithmetic is the fork-cursor `key_idx += 1`, bounded by keys.len() <= 256
-async fn walk_inner<R: Reference, S: TrustedStore<AnyChunkSet<BS>>, const BS: usize, F>(
+async fn walk_inner<R: Reference, S: TrustedGet<AnyChunkSet<BS>>, const BS: usize, F>(
     path_buf: &mut Vec<u8>,
     node: &mut Node<R>,
     store: &S,

--- a/crates/primitives/src/file/error.rs
+++ b/crates/primitives/src/file/error.rs
@@ -1,6 +1,7 @@
 //! Error types for file splitting and joining operations.
 
 use crate::ChunkAddress;
+use crate::store::{BoxedError, MaybeSend, MaybeSync};
 use thiserror::Error;
 
 /// Errors from file splitting and joining operations.
@@ -27,7 +28,7 @@ pub enum FileError {
 
     /// Chunk store failed to store a chunk.
     #[error("store error")]
-    Store(#[source] Box<dyn std::error::Error + Send + Sync>),
+    Store(#[source] BoxedError),
 
     /// Write sink failed. Rendered to a string so the error stays `Send + Sync`
     /// even when the sink's own error is not (a single-threaded browser
@@ -37,7 +38,7 @@ pub enum FileError {
 
     /// Chunk getter failed to retrieve a chunk.
     #[error("getter error")]
-    Getter(#[source] Box<dyn std::error::Error + Send + Sync>),
+    Getter(#[source] BoxedError),
 
     /// Invalid chunk reference encountered during tree traversal.
     #[error("invalid reference at level {level}")]
@@ -81,12 +82,12 @@ pub enum FileError {
 
 impl FileError {
     /// Create a store error from any error type.
-    pub fn store<E: std::error::Error + Send + Sync + 'static>(err: E) -> Self {
+    pub fn store<E: core::error::Error + MaybeSend + MaybeSync + 'static>(err: E) -> Self {
         Self::Store(Box::new(err))
     }
 
     /// Create a getter error from any error type.
-    pub fn getter<E: std::error::Error + Send + Sync + 'static>(err: E) -> Self {
+    pub fn getter<E: core::error::Error + MaybeSend + MaybeSync + 'static>(err: E) -> Self {
         Self::Getter(Box::new(err))
     }
 

--- a/crates/primitives/src/file/fold.rs
+++ b/crates/primitives/src/file/fold.rs
@@ -16,11 +16,11 @@ use super::error::Result;
 use super::joiner::GenericJoiner;
 use super::mode::JoinMode;
 use crate::chunk::AnyChunkSet;
-use crate::store::{MaybeSend, TrustedStore};
+use crate::store::{MaybeSend, TrustedGet};
 
 impl<G, M, const BODY_SIZE: usize> GenericJoiner<G, M, BODY_SIZE>
 where
-    G: TrustedStore<AnyChunkSet<BODY_SIZE>> + 'static,
+    G: TrustedGet<AnyChunkSet<BODY_SIZE>> + 'static,
     M: JoinMode + MaybeSend + Sync,
 {
     /// Visit each leaf body as it lands, out of order, tagged with its absolute

--- a/crates/primitives/src/file/frontier.rs
+++ b/crates/primitives/src/file/frontier.rs
@@ -180,7 +180,7 @@ pub(crate) async fn expand_frontier<G, M, const BS: usize>(
     target_subtrees: usize,
 ) -> Result<Vec<SubtreeNode<M>>>
 where
-    G: crate::store::TrustedStore<crate::chunk::AnyChunkSet<BS>>,
+    G: crate::store::TrustedGet<crate::chunk::AnyChunkSet<BS>>,
     M: JoinMode + MaybeSend + Sync,
 {
     use futures::stream::{self, StreamExt};
@@ -231,7 +231,7 @@ pub(crate) async fn read_subtree_bodies<G, M, const BS: usize>(
     chunk_range: &ChunkRange,
 ) -> Result<Vec<Bytes>>
 where
-    G: crate::store::TrustedStore<crate::chunk::AnyChunkSet<BS>>,
+    G: crate::store::TrustedGet<crate::chunk::AnyChunkSet<BS>>,
     M: JoinMode + MaybeSend + Sync,
 {
     let mut out = Vec::new();

--- a/crates/primitives/src/file/joiner.rs
+++ b/crates/primitives/src/file/joiner.rs
@@ -40,7 +40,7 @@ use super::frontier::{
 };
 use super::mode::{JoinMode, PlainMode};
 use super::tree::{ChunkRange, TreeParams};
-use crate::store::{MaybeSend, TrustedStore};
+use crate::store::{MaybeSend, TrustedGet};
 
 #[cfg(feature = "encryption")]
 use super::mode::EncryptedMode;
@@ -48,7 +48,7 @@ use super::mode::EncryptedMode;
 /// Generic async joiner parameterized by chunk mode.
 pub struct GenericJoiner<G, M: JoinMode, const BODY_SIZE: usize = DEFAULT_BODY_SIZE>
 where
-    G: TrustedStore<AnyChunkSet<BODY_SIZE>>,
+    G: TrustedGet<AnyChunkSet<BODY_SIZE>>,
 {
     getter: Arc<G>,
     root: ChunkAddress,
@@ -73,7 +73,7 @@ pub type EncryptedJoiner<G, const BODY_SIZE: usize = DEFAULT_BODY_SIZE> =
 
 impl<G, M, const BODY_SIZE: usize> std::fmt::Debug for GenericJoiner<G, M, BODY_SIZE>
 where
-    G: TrustedStore<AnyChunkSet<BODY_SIZE>>,
+    G: TrustedGet<AnyChunkSet<BODY_SIZE>>,
     M: JoinMode,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -94,7 +94,7 @@ async fn collect_subtree_bodies<G, M, const BODY_SIZE: usize>(
     concurrency: usize,
 ) -> Result<Vec<Bytes>>
 where
-    G: TrustedStore<AnyChunkSet<BODY_SIZE>>,
+    G: TrustedGet<AnyChunkSet<BODY_SIZE>>,
     M: JoinMode + MaybeSend + Sync,
 {
     let bodies: Vec<Bytes> = stream::iter(subtrees)
@@ -115,7 +115,7 @@ where
 
 impl<G, M, const BODY_SIZE: usize> GenericJoiner<G, M, BODY_SIZE>
 where
-    G: TrustedStore<AnyChunkSet<BODY_SIZE>>,
+    G: TrustedGet<AnyChunkSet<BODY_SIZE>>,
     M: JoinMode + MaybeSend + Sync,
 {
     /// Create an async joiner from a root reference.
@@ -499,7 +499,7 @@ where
             pending: Pending<M>,
         ) -> Resolved<M>
         where
-            G: TrustedStore<AnyChunkSet<BS>>,
+            G: TrustedGet<AnyChunkSet<BS>>,
             M: JoinMode + MaybeSend + Sync,
         {
             let node = &pending.node;
@@ -695,7 +695,7 @@ pub(crate) fn chunked_range_stream_from<G, M, const BODY_SIZE: usize>(
     len: u64,
 ) -> impl Stream<Item = Result<(u64, Bytes)>> + 'static
 where
-    G: TrustedStore<AnyChunkSet<BODY_SIZE>> + 'static,
+    G: TrustedGet<AnyChunkSet<BODY_SIZE>> + 'static,
     M: JoinMode + MaybeSend + Sync,
 {
     let width = concurrency.max(1);
@@ -741,7 +741,7 @@ where
         pending: Pending<M>,
     ) -> Resolved<M>
     where
-        G: TrustedStore<AnyChunkSet<BS>>,
+        G: TrustedGet<AnyChunkSet<BS>>,
         M: JoinMode + MaybeSend + Sync,
     {
         let node = &pending.node;
@@ -906,7 +906,7 @@ where
 #[cfg(feature = "tokio")]
 pub struct JoinerReader<G, M: JoinMode, const BODY_SIZE: usize = DEFAULT_BODY_SIZE>
 where
-    G: TrustedStore<AnyChunkSet<BODY_SIZE>>,
+    G: TrustedGet<AnyChunkSet<BODY_SIZE>>,
 {
     joiner: GenericJoiner<G, M, BODY_SIZE>,
     buffer: Bytes,
@@ -917,7 +917,7 @@ where
 #[cfg(feature = "tokio")]
 impl<G, M, const BODY_SIZE: usize> std::fmt::Debug for JoinerReader<G, M, BODY_SIZE>
 where
-    G: TrustedStore<AnyChunkSet<BODY_SIZE>>,
+    G: TrustedGet<AnyChunkSet<BODY_SIZE>>,
     M: JoinMode,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -932,7 +932,7 @@ where
 // Safety: JoinerReader contains no self-referential data.
 // The boxed future is heap-allocated and all other fields are plain data.
 #[cfg(feature = "tokio")]
-impl<G: TrustedStore<AnyChunkSet<BODY_SIZE>>, M: JoinMode, const BODY_SIZE: usize> Unpin
+impl<G: TrustedGet<AnyChunkSet<BODY_SIZE>>, M: JoinMode, const BODY_SIZE: usize> Unpin
     for JoinerReader<G, M, BODY_SIZE>
 {
 }
@@ -940,7 +940,7 @@ impl<G: TrustedStore<AnyChunkSet<BODY_SIZE>>, M: JoinMode, const BODY_SIZE: usiz
 #[cfg(feature = "tokio")]
 impl<G, M, const BODY_SIZE: usize> tokio::io::AsyncRead for JoinerReader<G, M, BODY_SIZE>
 where
-    G: TrustedStore<AnyChunkSet<BODY_SIZE>> + 'static,
+    G: TrustedGet<AnyChunkSet<BODY_SIZE>> + 'static,
     M: JoinMode + Send + Sync + 'static,
 {
     #[allow(
@@ -1026,7 +1026,7 @@ where
 #[cfg(feature = "tokio")]
 impl<G, M, const BODY_SIZE: usize> tokio::io::AsyncSeek for JoinerReader<G, M, BODY_SIZE>
 where
-    G: TrustedStore<AnyChunkSet<BODY_SIZE>> + 'static,
+    G: TrustedGet<AnyChunkSet<BODY_SIZE>> + 'static,
     M: JoinMode + Send + Sync + 'static,
 {
     fn start_seek(self: std::pin::Pin<&mut Self>, pos: SeekFrom) -> std::io::Result<()> {
@@ -1089,7 +1089,7 @@ mod tests {
 
     async fn drain_chunked_to_buf<G>(joiner: GenericJoiner<G, PlainMode>, total: usize) -> Vec<u8>
     where
-        G: TrustedStore + 'static,
+        G: TrustedGet + 'static,
     {
         let stream = joiner.into_offset_stream_chunked();
         futures::pin_mut!(stream);

--- a/crates/primitives/src/file/mod.rs
+++ b/crates/primitives/src/file/mod.rs
@@ -68,7 +68,7 @@ mod write_at;
 #[cfg(feature = "encryption")]
 use crate::chunk::encryption::EncryptedChunkRef;
 use crate::chunk::{AnyChunkSet, Chunk, ChunkAddress, ContentChunk, Verified};
-use crate::store::{ChunkPut, MaybeSend, MaybeSync, TrustedStore};
+use crate::store::{ChunkPut, MaybeSend, MaybeSync, TrustedGet};
 
 // Async (primary) re-exports
 #[cfg(feature = "encryption")]
@@ -162,7 +162,7 @@ pub(crate) fn resolve_seek_position(
 pub async fn join<R, G, const BODY_SIZE: usize>(getter: G, root: R) -> error::Result<Vec<u8>>
 where
     R: JoinRef,
-    G: TrustedStore<AnyChunkSet<BODY_SIZE>>,
+    G: TrustedGet<AnyChunkSet<BODY_SIZE>>,
 {
     GenericJoiner::<G, R::Mode, BODY_SIZE>::new(getter, root.into_root_ref())
         .await?
@@ -225,7 +225,7 @@ pub(crate) const fn levels(length: u64, chunk_size: usize) -> usize {
 /// Extension methods for async chunk getters.
 ///
 /// Uses [`JoinRef`] for unified plain/encrypted dispatch.
-pub trait ChunkGetExt<const BODY_SIZE: usize>: TrustedStore<AnyChunkSet<BODY_SIZE>> {
+pub trait ChunkGetExt<const BODY_SIZE: usize>: TrustedGet<AnyChunkSet<BODY_SIZE>> {
     /// Open a file for async reading.
     fn joiner<R: JoinRef>(
         self,
@@ -251,7 +251,7 @@ pub trait ChunkGetExt<const BODY_SIZE: usize>: TrustedStore<AnyChunkSet<BODY_SIZ
 }
 
 impl<T, const BODY_SIZE: usize> ChunkGetExt<BODY_SIZE> for T where
-    T: TrustedStore<AnyChunkSet<BODY_SIZE>>
+    T: TrustedGet<AnyChunkSet<BODY_SIZE>>
 {
 }
 

--- a/crates/primitives/src/file/mode.rs
+++ b/crates/primitives/src/file/mode.rs
@@ -108,7 +108,7 @@ pub trait JoinMode: Sized + 'static {
 /// Initialize joiner: fetch root chunk, extract span and context.
 pub(crate) async fn joiner_init<
     M: JoinMode + MaybeSend + Sync,
-    G: crate::store::TrustedStore<AnyChunkSet<BS>>,
+    G: crate::store::TrustedGet<AnyChunkSet<BS>>,
     const BS: usize,
 >(
     getter: &G,
@@ -126,7 +126,7 @@ pub(crate) async fn joiner_init<
 /// Read chunk body at address with context. Returns body bytes (after decryption if needed).
 pub(crate) async fn read_chunk_body<
     M: JoinMode + MaybeSend + Sync,
-    G: crate::store::TrustedStore<AnyChunkSet<BS>>,
+    G: crate::store::TrustedGet<AnyChunkSet<BS>>,
     const BS: usize,
 >(
     getter: &G,

--- a/crates/primitives/src/file/splitter_parallel.rs
+++ b/crates/primitives/src/file/splitter_parallel.rs
@@ -2,6 +2,7 @@
 
 use std::marker::PhantomData;
 
+#[cfg(not(target_arch = "wasm32"))]
 use rayon::prelude::*;
 
 use crate::bmt::DEFAULT_BODY_SIZE;
@@ -102,31 +103,35 @@ where
         let data_chunks = tree.data_chunks();
         let size = tree.size();
 
-        let results: Vec<Result<M::Ref>> = (0..data_chunks)
-            .into_par_iter()
-            .map(|i| {
-                let offset = i * crate::cast::u64_from_usize(BODY_SIZE);
-                // The min against BODY_SIZE bounds the chunk size.
-                let chunk_size = crate::cast::usize_from_u64(size - offset).min(BODY_SIZE);
+        let produce = |i: u64| {
+            let offset = i * crate::cast::u64_from_usize(BODY_SIZE);
+            // The min against BODY_SIZE bounds the chunk size.
+            let chunk_size = crate::cast::usize_from_u64(size - offset).min(BODY_SIZE);
 
-                let mut buf = vec![0u8; chunk_size];
-                source
-                    .read_at(offset, &mut buf)
-                    .map_err(|e| FileError::Store(Box::new(e)))?;
+            let mut buf = vec![0u8; chunk_size];
+            source
+                .read_at(offset, &mut buf)
+                .map_err(|e| FileError::Store(Box::new(e)))?;
 
-                let span = if i + 1 == data_chunks {
-                    size - offset
-                } else {
-                    crate::cast::u64_from_usize(BODY_SIZE)
-                };
+            let span = if i + 1 == data_chunks {
+                size - offset
+            } else {
+                crate::cast::u64_from_usize(BODY_SIZE)
+            };
 
-                let chunk_bytes = super::helpers::build_intermediate_payload(span, &buf);
+            let chunk_bytes = super::helpers::build_intermediate_payload(span, &buf);
 
-                let (chunk, reference) = M::prepare_chunk::<BODY_SIZE>(chunk_bytes)?;
-                sink(chunk);
-                Ok(reference)
-            })
-            .collect();
+            let (chunk, reference) = M::prepare_chunk::<BODY_SIZE>(chunk_bytes)?;
+            sink(chunk);
+            Ok(reference)
+        };
+
+        // Rayon lanes carry `Send` items; on wasm32 `FileError` may hold a
+        // `!Send` store error, so drive the same closure inline there.
+        #[cfg(not(target_arch = "wasm32"))]
+        let results: Vec<Result<M::Ref>> = (0..data_chunks).into_par_iter().map(produce).collect();
+        #[cfg(target_arch = "wasm32")]
+        let results: Vec<Result<M::Ref>> = (0..data_chunks).map(produce).collect();
 
         results.into_iter().collect()
     }
@@ -167,35 +172,40 @@ where
         let chunks_at_level = refs.len().div_ceil(refs_per_chunk);
         let max_span = spans[level] * crate::cast::u64_from_usize(BODY_SIZE);
 
-        let results: Vec<Result<M::Ref>> = (0..chunks_at_level)
-            .into_par_iter()
-            .map(|i| {
-                let start = i * refs_per_chunk;
-                let end = (start + refs_per_chunk).min(refs.len());
-                let child_refs = &refs[start..end];
+        let produce = |i: usize| {
+            let start = i * refs_per_chunk;
+            let end = (start + refs_per_chunk).min(refs.len());
+            let child_refs = &refs[start..end];
 
-                // Single reference: carry up without wrapping (dangling chunk optimization).
-                if child_refs.len() == 1 {
-                    return Ok(child_refs[0].clone());
-                }
+            // Single reference: carry up without wrapping (dangling chunk optimization).
+            if child_refs.len() == 1 {
+                return Ok(child_refs[0].clone());
+            }
 
-                let span = if i + 1 == chunks_at_level {
-                    total_size.saturating_sub(crate::cast::u64_from_usize(i) * max_span)
-                } else {
-                    max_span
-                };
+            let span = if i + 1 == chunks_at_level {
+                total_size.saturating_sub(crate::cast::u64_from_usize(i) * max_span)
+            } else {
+                max_span
+            };
 
-                let mut ref_data = Vec::with_capacity(child_refs.len() * M::REF_SIZE);
-                for reference in child_refs {
-                    M::extend_ref_bytes(reference, &mut ref_data);
-                }
-                let chunk_bytes = super::helpers::build_intermediate_payload(span, &ref_data);
+            let mut ref_data = Vec::with_capacity(child_refs.len() * M::REF_SIZE);
+            for reference in child_refs {
+                M::extend_ref_bytes(reference, &mut ref_data);
+            }
+            let chunk_bytes = super::helpers::build_intermediate_payload(span, &ref_data);
 
-                let (chunk, reference) = M::prepare_chunk::<BODY_SIZE>(chunk_bytes)?;
-                sink(chunk);
-                Ok(reference)
-            })
-            .collect();
+            let (chunk, reference) = M::prepare_chunk::<BODY_SIZE>(chunk_bytes)?;
+            sink(chunk);
+            Ok(reference)
+        };
+
+        // Rayon lanes carry `Send` items; on wasm32 `FileError` may hold a
+        // `!Send` store error, so drive the same closure inline there.
+        #[cfg(not(target_arch = "wasm32"))]
+        let results: Vec<Result<M::Ref>> =
+            (0..chunks_at_level).into_par_iter().map(produce).collect();
+        #[cfg(target_arch = "wasm32")]
+        let results: Vec<Result<M::Ref>> = (0..chunks_at_level).map(produce).collect();
 
         results.into_iter().collect()
     }

--- a/crates/primitives/src/file/windowed.rs
+++ b/crates/primitives/src/file/windowed.rs
@@ -24,7 +24,7 @@ use super::frontier::{SubtreeNode, overlapping_children};
 use super::joiner::{GenericJoiner, MAX_INTERMEDIATE_IN_FLIGHT};
 use super::mode::JoinMode;
 use super::tree::{ChunkRange, TreeParams};
-use crate::store::{MaybeSend, TrustedStore};
+use crate::store::{MaybeSend, TrustedGet};
 
 /// Number of times a failed leaf fetch is re-enqueued before the walk surfaces
 /// the error.
@@ -54,7 +54,7 @@ fn record_occupancy(occupancy: usize) {
 /// only repositions; it never re-fetches intermediates.
 pub struct WindowedReader<G, M: JoinMode, const BODY_SIZE: usize = DEFAULT_BODY_SIZE>
 where
-    G: TrustedStore<AnyChunkSet<BODY_SIZE>>,
+    G: TrustedGet<AnyChunkSet<BODY_SIZE>>,
 {
     getter: Arc<G>,
     subtrees: Vec<SubtreeNode<M>>,
@@ -72,7 +72,7 @@ where
 
 impl<G, M, const BODY_SIZE: usize> std::fmt::Debug for WindowedReader<G, M, BODY_SIZE>
 where
-    G: TrustedStore<AnyChunkSet<BODY_SIZE>>,
+    G: TrustedGet<AnyChunkSet<BODY_SIZE>>,
     M: JoinMode,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -86,7 +86,7 @@ where
 
 impl<G, M, const BODY_SIZE: usize> GenericJoiner<G, M, BODY_SIZE>
 where
-    G: TrustedStore<AnyChunkSet<BODY_SIZE>> + 'static,
+    G: TrustedGet<AnyChunkSet<BODY_SIZE>> + 'static,
     M: JoinMode + MaybeSend + Sync,
 {
     /// Seek-and-play reader over a window that slides with the read cursor. Peak
@@ -110,7 +110,7 @@ where
 
 impl<G, M, const BODY_SIZE: usize> WindowedReader<G, M, BODY_SIZE>
 where
-    G: TrustedStore<AnyChunkSet<BODY_SIZE>> + 'static,
+    G: TrustedGet<AnyChunkSet<BODY_SIZE>> + 'static,
     M: JoinMode + MaybeSend + Sync,
 {
     /// In-order leaf bodies from the current position to EOF. Each item is one
@@ -190,7 +190,7 @@ async fn fetch_one<G, M, const BS: usize>(
     pending: Pending<M>,
 ) -> Resolved<M>
 where
-    G: TrustedStore<AnyChunkSet<BS>>,
+    G: TrustedGet<AnyChunkSet<BS>>,
     M: JoinMode + MaybeSend + Sync,
 {
     let node = &pending.node;
@@ -264,7 +264,7 @@ fn windowed_walk<G, M, const BODY_SIZE: usize>(
     window: usize,
 ) -> impl Stream<Item = Result<Bytes>>
 where
-    G: TrustedStore<AnyChunkSet<BODY_SIZE>> + 'static,
+    G: TrustedGet<AnyChunkSet<BODY_SIZE>> + 'static,
     M: JoinMode + MaybeSend + Sync,
 {
     let width = concurrency.max(1);
@@ -470,7 +470,7 @@ where
 #[cfg(feature = "tokio")]
 pub struct WindowedJoinerReader<G, M: JoinMode, const BODY_SIZE: usize = DEFAULT_BODY_SIZE>
 where
-    G: TrustedStore<AnyChunkSet<BODY_SIZE>>,
+    G: TrustedGet<AnyChunkSet<BODY_SIZE>>,
 {
     reader: WindowedReader<G, M, BODY_SIZE>,
     residual: Bytes,
@@ -481,7 +481,7 @@ where
 #[cfg(feature = "tokio")]
 impl<G, M, const BODY_SIZE: usize> std::fmt::Debug for WindowedJoinerReader<G, M, BODY_SIZE>
 where
-    G: TrustedStore<AnyChunkSet<BODY_SIZE>>,
+    G: TrustedGet<AnyChunkSet<BODY_SIZE>>,
     M: JoinMode,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -496,7 +496,7 @@ where
 #[cfg(feature = "tokio")]
 impl<G, M, const BODY_SIZE: usize> WindowedReader<G, M, BODY_SIZE>
 where
-    G: TrustedStore<AnyChunkSet<BODY_SIZE>> + 'static,
+    G: TrustedGet<AnyChunkSet<BODY_SIZE>> + 'static,
     M: JoinMode + Send + Sync + 'static,
 {
     /// Wrap as a tokio `AsyncRead` + `AsyncSeek` reader. Native-only.
@@ -510,7 +510,7 @@ where
 }
 
 #[cfg(feature = "tokio")]
-impl<G: TrustedStore<AnyChunkSet<BODY_SIZE>>, M: JoinMode, const BODY_SIZE: usize> Unpin
+impl<G: TrustedGet<AnyChunkSet<BODY_SIZE>>, M: JoinMode, const BODY_SIZE: usize> Unpin
     for WindowedJoinerReader<G, M, BODY_SIZE>
 {
 }
@@ -518,7 +518,7 @@ impl<G: TrustedStore<AnyChunkSet<BODY_SIZE>>, M: JoinMode, const BODY_SIZE: usiz
 #[cfg(feature = "tokio")]
 impl<G, M, const BODY_SIZE: usize> tokio::io::AsyncRead for WindowedJoinerReader<G, M, BODY_SIZE>
 where
-    G: TrustedStore<AnyChunkSet<BODY_SIZE>> + 'static,
+    G: TrustedGet<AnyChunkSet<BODY_SIZE>> + 'static,
     M: JoinMode + Send + Sync + 'static,
 {
     #[allow(
@@ -580,7 +580,7 @@ where
 #[cfg(feature = "tokio")]
 impl<G, M, const BODY_SIZE: usize> tokio::io::AsyncSeek for WindowedJoinerReader<G, M, BODY_SIZE>
 where
-    G: TrustedStore<AnyChunkSet<BODY_SIZE>> + 'static,
+    G: TrustedGet<AnyChunkSet<BODY_SIZE>> + 'static,
     M: JoinMode + Send + Sync + 'static,
 {
     fn start_seek(self: Pin<&mut Self>, pos: SeekFrom) -> std::io::Result<()> {

--- a/crates/primitives/src/file/write_at.rs
+++ b/crates/primitives/src/file/write_at.rs
@@ -9,7 +9,7 @@ use super::error::FileError;
 use super::joiner::GenericJoiner;
 use super::mode::JoinMode;
 use crate::chunk::AnyChunkSet;
-use crate::store::{MaybeSend, MaybeSync, TrustedStore};
+use crate::store::{MaybeSend, MaybeSync, TrustedGet};
 
 /// Async random-access write sink. Each leaf body is written at its absolute
 /// offset; when every offset is written the sink is whole. Not `Send`-bound so
@@ -138,7 +138,7 @@ impl<T: WriteAt + ?Sized> WriteAt for &T {
 
 impl<G, M, const BODY_SIZE: usize> GenericJoiner<G, M, BODY_SIZE>
 where
-    G: TrustedStore<AnyChunkSet<BODY_SIZE>> + 'static,
+    G: TrustedGet<AnyChunkSet<BODY_SIZE>> + 'static,
     M: JoinMode + MaybeSend + Sync,
 {
     /// Reassemble the whole file into `sink`, writing each out-of-order leaf at

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -155,7 +155,7 @@ pub type DefaultMemoryStore = MemoryStore<StandardChunkSet>;
 // Chunk storage traits
 pub use store::{
     ChunkGet, ChunkHas, ChunkPut, ChunkStoreError, MemoryStore, RetryConfig, RetryingChunkGet,
-    Sleeper, TrustedStore,
+    Sleeper, TrustedGet,
 };
 
 // File joining (async)

--- a/crates/primitives/src/store/mod.rs
+++ b/crates/primitives/src/store/mod.rs
@@ -11,9 +11,27 @@ mod typed;
 pub use maybe_send::{MaybeSend, MaybeSync};
 pub use memory::MemoryStore;
 pub use retry::{RetryConfig, RetryingChunkGet, Sleeper};
-pub use typed::{ChunkGet, ChunkHas, ChunkPut, TrustedStore};
+pub use typed::{ChunkGet, ChunkHas, ChunkPut, TrustedGet};
 
 use crate::chunk::{Chunk, ChunkAddress, ChunkRegistry, Verified};
+
+/// Boxed store error: `Send + Sync` on native, unbounded on wasm32 where a
+/// backend error may hold a JS handle.
+#[cfg(not(target_arch = "wasm32"))]
+pub type BoxedError = Box<dyn core::error::Error + Send + Sync>;
+/// Boxed store error: `Send + Sync` on native, unbounded on wasm32 where a
+/// backend error may hold a JS handle.
+#[cfg(target_arch = "wasm32")]
+pub type BoxedError = Box<dyn core::error::Error>;
+
+/// Shared store error: `Send + Sync` on native, unbounded on wasm32 where a
+/// backend error may hold a JS handle.
+#[cfg(not(target_arch = "wasm32"))]
+pub type SharedError = std::sync::Arc<dyn core::error::Error + Send + Sync>;
+/// Shared store error: `Send + Sync` on native, unbounded on wasm32 where a
+/// backend error may hold a JS handle.
+#[cfg(target_arch = "wasm32")]
+pub type SharedError = std::sync::Arc<dyn core::error::Error>;
 
 /// Errors from chunk storage operations.
 #[non_exhaustive]
@@ -24,7 +42,7 @@ pub enum ChunkStoreError {
     NotFound(ChunkAddress),
     /// Catch-all for backend-specific errors.
     #[error("{0}")]
-    Other(#[source] Box<dyn std::error::Error + Send + Sync>),
+    Other(#[source] BoxedError),
 }
 
 impl ChunkStoreError {

--- a/crates/primitives/src/store/typed.rs
+++ b/crates/primitives/src/store/typed.rs
@@ -1,10 +1,10 @@
 //! Typed chunk storage traits.
 //!
 //! `ChunkGet`, `ChunkPut`, and `ChunkHas` are async and carry `MaybeSend`/
-//! `MaybeSync` bounds so a store may be `!Send` on wasm. Writes are uniformly
-//! sealed ([`ChunkPut`] only accepts `Chunk<Verified, R>`); trust is a
-//! property of the read medium, declared once per backend through
-//! [`ChunkGet::Trust`].
+//! `MaybeSync` bounds (on the traits and their error types) so a store may be
+//! `!Send` on wasm. Writes are uniformly sealed ([`ChunkPut`] only accepts
+//! `Chunk<Verified, R>`); trust is a property of the read medium, declared
+//! once per backend through [`ChunkGet::Trust`].
 
 use std::future::Future;
 
@@ -21,7 +21,7 @@ pub trait ChunkGet<R: ChunkRegistry = StandardChunkSet>: MaybeSend + MaybeSync {
     type Trust: TrustState;
 
     /// Error type for get operations.
-    type Error: std::error::Error + Send + Sync + 'static;
+    type Error: core::error::Error + MaybeSend + MaybeSync + 'static;
 
     /// Get a chunk by address.
     fn get(
@@ -61,7 +61,7 @@ impl<T: ChunkHas + ?Sized> ChunkHas for &T {
 /// mutability (e.g. `Mutex`, `RwLock`).
 pub trait ChunkPut<R: ChunkRegistry = StandardChunkSet>: MaybeSend + MaybeSync {
     /// Error type for put operations.
-    type Error: std::error::Error + Send + Sync + 'static;
+    type Error: core::error::Error + MaybeSend + MaybeSync + 'static;
 
     /// Store a sealed chunk.
     fn put(
@@ -81,32 +81,37 @@ impl<R: ChunkRegistry, T: ChunkPut<R> + ?Sized> ChunkPut<R> for &T {
     }
 }
 
-/// Marker for stores whose read medium hands back exactly what was sealed:
+/// Marker for getters whose read medium hands back exactly what was sealed:
 /// [`ChunkGet`] with `Trust = Verified`.
 ///
 /// Blanket-implemented. Consensus consumers bound on this, so feeding them
 /// from an untrusted medium is a type error, not a runtime concern.
-pub trait TrustedStore<R: ChunkRegistry = StandardChunkSet>: ChunkGet<R, Trust = Verified> {}
+pub trait TrustedGet<R: ChunkRegistry = StandardChunkSet>: ChunkGet<R, Trust = Verified> {}
 
-impl<R: ChunkRegistry, T: ChunkGet<R, Trust = Verified> + ?Sized> TrustedStore<R> for T {}
+impl<R: ChunkRegistry, T: ChunkGet<R, Trust = Verified> + ?Sized> TrustedGet<R> for T {}
 
 #[cfg(target_arch = "wasm32")]
 mod wasm_send_sync_proof {
     // A store that is neither Send nor Sync (raw pointer marker) must still
-    // satisfy ChunkGet on wasm32, proving the MaybeSend + MaybeSync relaxation.
+    // satisfy ChunkGet on wasm32, proving the MaybeSend + MaybeSync relaxation
+    // for the store and for its error type alike.
     use super::*;
     use crate::chunk::Unverified;
 
     struct NotSendSync(core::marker::PhantomData<*const ()>);
 
+    #[derive(Debug, thiserror::Error)]
+    #[error("not send")]
+    struct NotSendError(core::marker::PhantomData<*const ()>);
+
     impl ChunkGet<StandardChunkSet> for NotSendSync {
         type Trust = Unverified;
-        type Error = std::io::Error;
+        type Error = NotSendError;
         async fn get(
             &self,
             _addr: &ChunkAddress,
         ) -> Result<Chunk<Unverified, StandardChunkSet>, Self::Error> {
-            unreachable!()
+            Err(NotSendError(core::marker::PhantomData))
         }
     }
 


### PR DESCRIPTION
## What

- Relaxed `ChunkGet::Error` and `ChunkPut::Error` bounds from `std::error::Error + Send + Sync` to `core::error::Error + MaybeSend + MaybeSync + 'static`.
- Renamed `TrustedStore` to `TrustedGet` (subtrait + blanket impl over `ChunkGet<Trust = Verified>`).
- Added cfg'd store-seam aliases `BoxedError`/`SharedError` in `nectar_primitives::store` (`Send + Sync` on native, unbounded on wasm32), and routed `FileError::Store`/`Getter`, `ChunkStoreError::Other`, manifest `StoreError::Store`/`BuildError::Backend`, and mantaray `StoreGet`/`StorePut` through them.
- Updated helper functions to bound `E: core::error::Error + MaybeSend + MaybeSync + 'static`.
- On wasm32, the parallel splitter's two rayon lanes now drive the same closure inline (rayon requires `Send` items).

## Why

Closes #322

## Testing

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --locked`: 9 pre-existing warning lines in touched crates (unused test macros in joiner_tests.rs/splitter_tests.rs, use_self in chunk/type_tag.rs, unused `Chunk` import in mantaray/builder.rs gated behind the `encryption` feature); identical count on origin/main baseline for the same crates.
- No stale `TrustedStore` references remain anywhere in the tree.

## AI Assistance

Implementation by Fable, review by Opus, PR by Sonnet.
