### PR TITLE
ci: add no_std rv64/wasm32 lanes and dependency spike

### DIFF
--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -1,0 +1,54 @@
+# Gates the no_std core on a bare-metal rv64 target (the zkVM-guest shape)
+# and on wasm32 (the browser shape). Only the crates that already build
+# without std are listed; extend the -p list as crates flip to no_std. The
+# spike crate pins the streaming pipeline's dependency base (futures-util
+# with alloc only, bytes with default features off) on both targets.
+name: no_std
+
+on:
+    pull_request:
+    merge_group:
+    push:
+        branches: [main]
+
+env:
+    CARGO_TERM_COLOR: always
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: true
+
+jobs:
+    check:
+        name: no_std / ${{ matrix.target }}
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        strategy:
+            fail-fast: false
+            matrix:
+                target:
+                    - riscv64imac-unknown-none-elf
+                    - wasm32-unknown-unknown
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+            - uses: ./.github/actions/rust-setup
+              with:
+                  targets: ${{ matrix.target }}
+            - name: Check no_std crates without std
+              run: |
+                  cargo check --locked \
+                    -p nectar-swarms -p nectar-contracts -p nectar-nostd-spike \
+                    --no-default-features \
+                    --target ${{ matrix.target }}
+
+    nostd-success:
+        name: no_std success
+        runs-on: ubuntu-latest
+        if: always()
+        needs: [check]
+        timeout-minutes: 30
+        steps:
+            - name: Decide whether the needed jobs succeeded or failed
+              uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # release/v1
+              with:
+                  jobs: ${{ toJSON(needs) }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2087,6 +2087,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "nectar-nostd-spike"
+version = "0.4.0"
+dependencies = [
+ "bytes",
+ "futures-util",
+]
+
+[[package]]
 name = "nectar-postage"
 version = "0.4.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ rayon = "1.10"
 
 # Core dependencies
 bytes = { version = "1.11", default-features = false }
+futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 thiserror = { version = "2.0", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }

--- a/crates/nostd-spike/Cargo.toml
+++ b/crates/nostd-spike/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "nectar-nostd-spike"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Spike proving the no_std dependency base for the streaming file pipeline"
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+bytes = { workspace = true }
+futures-util = { workspace = true }

--- a/crates/nostd-spike/src/lib.rs
+++ b/crates/nostd-spike/src/lib.rs
@@ -1,0 +1,88 @@
+//! Dependency spike for the streaming file pipeline's no_std base.
+//!
+//! Exercises `futures-util` (alloc only) and `bytes` (default features off)
+//! so the bare-metal and wasm CI lanes prove the dependency base compiles,
+//! and the host test lane proves it behaves under manual polling.
+
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+// Test code may freely unwrap/index/panic; the runtime-safety restriction
+// lints target production code paths.
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::get_unwrap,
+        clippy::indexing_slicing,
+        clippy::string_slice,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::panic_in_result_fn
+    )
+)]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use core::{
+    num::NonZeroUsize,
+    pin::pin,
+    task::{Context, Poll, Waker},
+};
+
+use bytes::{BufMut, Bytes, BytesMut};
+use futures_util::stream::{self, Stream, StreamExt};
+
+/// Reassembles frames into one contiguous buffer, in iteration order.
+pub fn reassemble<'a, I>(frames: I) -> Bytes
+where
+    I: IntoIterator<Item = &'a [u8]>,
+{
+    let mut buf = BytesMut::new();
+    for frame in frames {
+        buf.put_slice(frame);
+    }
+    buf.freeze()
+}
+
+/// Drains an item source through an alloc-backed stream combinator by
+/// polling with a no-op waker; no runtime is involved.
+pub fn chunked<I>(items: I, width: NonZeroUsize) -> Vec<Vec<I::Item>>
+where
+    I: IntoIterator,
+{
+    let mut cx = Context::from_waker(Waker::noop());
+    let mut chunks = pin!(stream::iter(items).chunks(width.get()));
+    let mut out = Vec::new();
+    while let Poll::Ready(Some(chunk)) = chunks.as_mut().poll_next(&mut cx) {
+        out.push(chunk);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use super::*;
+
+    #[test]
+    fn reassemble_concatenates_in_order() {
+        let joined = reassemble([b"swarm".as_slice(), b" ", b"chunks"]);
+        assert_eq!(joined.as_ref(), b"swarm chunks");
+    }
+
+    #[test]
+    fn reassemble_of_nothing_is_empty() {
+        assert!(reassemble([]).is_empty());
+    }
+
+    #[test]
+    fn chunked_preserves_order_with_ragged_tail() {
+        let width = NonZeroUsize::new(2).unwrap();
+        assert_eq!(chunked(1..=5, width), vec![vec![1, 2], vec![3, 4], vec![5]]);
+    }
+}


### PR DESCRIPTION
## What

- Add `.github/workflows/nostd.yml`: a `no_std` CI workflow with a fail-fast-off matrix over `riscv64imac-unknown-none-elf` and `wasm32-unknown-unknown`, running `cargo check --locked --no-default-features` on `nectar-swarms`, `nectar-contracts` and the new `nectar-nostd-spike` crate via the shared `rust-setup` composite, plus an `alls-green` join job.
- Add `crates/nostd-spike`: a `publish = false`, `#![no_std]` + `alloc` crate that exercises the streaming pipeline's dependency base on both targets: `BytesMut`/`freeze` reassembly (`bytes`, default-features off) and an alloc-gated `StreamExt::chunks` combinator drained by manual polling with `Waker::noop` (`futures-util` 0.3, default-features off, `features = ["alloc"]`).
- Add workspace dependency `futures-util = { version = "0.3", default-features = false, features = ["alloc"] }` alongside the existing `bytes`.

## Why

Gates the `no_std` core on the bare-metal rv64 (zkVM-guest) and wasm32 (browser) target shapes, extending the pattern from the unmerged `ci/nostd-gate` branch, and proves via a minimal dependency spike that `futures-util`'s alloc-only feature set is usable for the streaming pipeline before it lands in real crates.

Closes #326

## Testing

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --locked`: no warnings in `nectar-nostd-spike`; pre-existing warnings in untouched crates are not introduced by this diff.
- `cargo nextest run -p nectar-nostd-spike --locked`: 3/3 tests pass (`reassemble_concatenates_in_order`, `reassemble_of_nothing_is_empty`, `chunked_preserves_order_with_ragged_tail`).
- `cargo check -p nectar-swarms -p nectar-contracts -p nectar-nostd-spike --no-default-features --target riscv64imac-unknown-none-elf` and `--target wasm32-unknown-unknown`: both build.
- `zepter run check`: exit 0.
- `actionlint`: clean.

## AI Assistance

Implementation by Fable, review by Opus, PR description by Sonnet.

