### PR TITLE
test: wasm-only smoke test for !Send store traits

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -96,11 +96,37 @@ jobs:
                     -p nectar-manifest --locked \
                     --target wasm32-unknown-unknown
 
+    wasm-smoke:
+        # Executable proof of the wasm store-trait relaxation: a !Send store
+        # satisfies ChunkGet only on wasm32, so the smoke test must actually run
+        # there. Executes under Node via wasm-bindgen-test-runner, which nextest
+        # cannot host; hence a separate plain-cargo job. The runner version must
+        # equal the locked wasm-bindgen version (kept in lockstep by the
+        # workspace's exact wasm-bindgen-test pin).
+        name: wasm / node smoke
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+            - uses: ./.github/actions/rust-setup
+              with:
+                  targets: wasm32-unknown-unknown
+            - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853  # v2.83.2
+              with:
+                  tool: wasm-bindgen@0.2.122
+            - name: Run wasm smoke tests
+              env:
+                  CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER: wasm-bindgen-test-runner
+              run: |
+                  cargo test \
+                    -p nectar-testing --test wasm_smoke --locked \
+                    --target wasm32-unknown-unknown
+
     unit-success:
         name: unit success
         runs-on: ubuntu-latest
         if: always()
-        needs: [test, wasm]
+        needs: [test, wasm, wasm-smoke]
         timeout-minutes: 30
         steps:
             - name: Decide whether the needed jobs succeeded or failed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2055,6 +2055,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "nectar-contracts"
 version = "0.4.0"
 dependencies = [
@@ -2263,7 +2273,20 @@ dependencies = [
 name = "nectar-testing"
 version = "0.4.0"
 dependencies = [
+ "futures",
  "futures-executor",
+ "nectar-file",
+ "nectar-primitives 0.4.0",
+ "wasm-bindgen-test",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3606,6 +3629,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3648,6 +3681,45 @@ checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fde991ccdc895cb7fbaa14b137d62af74d9011be67b71c694bfc40edd3119c"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e925354648d2a4d1bf205412e36d520a800280622eef4719678d268e5d40e978"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "684365b586a9a6256c1cc3544eee8680de48d6041142f581776ec7b139622ae9"
 
 [[package]]
 name = "wasm-encoder"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,9 @@ futures-executor = "0.3"
 
 # wasm
 wasm-bindgen = "0.2"
+# Exact pin: 0.3.72 requires wasm-bindgen =0.2.122, so the resolved wasm-bindgen
+# stays in lockstep with the wasm-bindgen-test-runner version CI installs.
+wasm-bindgen-test = "=0.3.72"
 wasm-bindgen-rayon = "1.3"
 js-sys = "0.3"
 console_error_panic_hook = "0.1"

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -16,3 +16,11 @@ publish = false
 
 [dependencies]
 futures-executor.workspace = true
+
+# The wasm smoke test is the executable proof that a !Send store satisfies the
+# chunk traits on wasm32; the same store cannot compile on native targets.
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+futures.workspace = true
+nectar-file.workspace = true
+nectar-primitives.workspace = true
+wasm-bindgen-test.workspace = true

--- a/crates/testing/tests/wasm_smoke.rs
+++ b/crates/testing/tests/wasm_smoke.rs
@@ -1,0 +1,109 @@
+//! Node smoke test proving the wasm relaxation of the store traits: a `!Send`
+//! store round-trips a file and the windowed reader honours its read-ahead
+//! bound. Native targets compile this file to nothing.
+#![cfg(target_arch = "wasm32")]
+
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use futures::StreamExt;
+use nectar_file::{File, Plain, Split, Window};
+use nectar_primitives::{
+    AnyChunkSet, Chunk, ChunkAddress, ChunkGet, ChunkPut, ChunkStoreError, DEFAULT_BODY_SIZE,
+    Verified,
+};
+use wasm_bindgen_test::wasm_bindgen_test;
+
+type SealedChunk = Chunk<Verified, AnyChunkSet<DEFAULT_BODY_SIZE>>;
+
+/// `Rc`/`RefCell` make this store neither `Send` nor `Sync`, so it satisfies
+/// the chunk traits only on wasm32.
+#[derive(Clone, Default)]
+struct RcStore {
+    chunks: Rc<RefCell<HashMap<ChunkAddress, SealedChunk>>>,
+    in_flight: Rc<Cell<usize>>,
+    peak: Rc<Cell<usize>>,
+}
+
+impl ChunkPut<AnyChunkSet<DEFAULT_BODY_SIZE>> for RcStore {
+    type Error = std::convert::Infallible;
+
+    async fn put(&self, chunk: SealedChunk) -> Result<(), Self::Error> {
+        self.chunks.borrow_mut().insert(*chunk.address(), chunk);
+        Ok(())
+    }
+}
+
+impl ChunkGet<AnyChunkSet<DEFAULT_BODY_SIZE>> for RcStore {
+    type Trust = Verified;
+    type Error = ChunkStoreError;
+
+    /// Yields once mid-fetch so overlapping gets register in `peak`.
+    async fn get(&self, address: &ChunkAddress) -> Result<SealedChunk, Self::Error> {
+        self.in_flight.set(self.in_flight.get() + 1);
+        self.peak.set(self.peak.get().max(self.in_flight.get()));
+        nectar_testing::yield_now().await;
+        self.in_flight.set(self.in_flight.get() - 1);
+        self.chunks
+            .borrow()
+            .get(address)
+            .cloned()
+            .ok_or_else(|| ChunkStoreError::not_found(address))
+    }
+}
+
+/// Five leaves under one intermediate: the walk has read-ahead to exercise.
+fn sample_data() -> Vec<u8> {
+    (0..DEFAULT_BODY_SIZE * 4 + 123)
+        .map(|i| u8::try_from(i % 251).unwrap())
+        .collect()
+}
+
+/// Split `data` into the store, delivering the plain root address.
+async fn write_file(store: &RcStore, data: &[u8]) -> ChunkAddress {
+    Split::<_, Plain, DEFAULT_BODY_SIZE>::collect(store.clone(), data)
+        .await
+        .unwrap()
+}
+
+#[wasm_bindgen_test]
+async fn non_send_store_round_trips_a_file() {
+    let store = RcStore::default();
+    let data = sample_data();
+    let root = write_file(&store, &data).await;
+    let file = File::<_, Plain, DEFAULT_BODY_SIZE>::open(store.clone(), root)
+        .await
+        .unwrap();
+    let out = file.collect(u64::MAX).await.unwrap();
+    assert_eq!(out, data);
+}
+
+#[wasm_bindgen_test]
+async fn windowed_read_ahead_stays_within_bound() {
+    const WINDOW: u16 = 2;
+    let store = RcStore::default();
+    let data = sample_data();
+    let root = write_file(&store, &data).await;
+    let file = File::<_, Plain, DEFAULT_BODY_SIZE>::open(store.clone(), root)
+        .await
+        .unwrap();
+
+    store.in_flight.set(0);
+    store.peak.set(0);
+
+    let mut stream = file.read().window(Window::new(WINDOW).unwrap()).stream();
+    let mut out = Vec::new();
+    while let Some(run) = stream.next().await {
+        out.extend_from_slice(&run.unwrap());
+    }
+
+    assert_eq!(out, data);
+    let peak = store.peak.get();
+    assert!(
+        peak <= usize::from(WINDOW),
+        "read-ahead exceeded the window: {peak}"
+    );
+    assert!(peak > 1, "leaf fetches never overlapped: {peak}");
+    assert_eq!(store.in_flight.get(), 0);
+}


### PR DESCRIPTION
## What

- Adds `crates/testing/tests/wasm_smoke.rs`: a wasm32-only integration test with an `Rc`/`RefCell`-backed `RcStore` (neither `Send` nor `Sync`) implementing `ChunkGet`/`ChunkPut`, that round-trips a five-leaf file via `write_file`/`read_file` and bounds the windowed reader (window=2) to its read-ahead limit using a yield-once `get` that records peak overlapping fetches.
- Pins `wasm-bindgen-test = "=0.3.72"` in the workspace `Cargo.toml`, which locks `wasm-bindgen` at 0.2.122 to match the CI-installed runner.
- Adds wasm32-gated dev-dependencies (`futures`, `nectar-primitives`, `wasm-bindgen-test`) to `crates/testing/Cargo.toml`.
- Wires a new `wasm-smoke` job ("wasm / node smoke") in `.github/workflows/unit.yml`: `rust-setup` + `taiki-e/install-action` for `wasm-bindgen@0.2.122`, then `cargo test -p nectar-testing --test wasm_smoke --target wasm32-unknown-unknown` under `wasm-bindgen-test-runner` on Node. Included in `unit-success`'s `needs`.

## Why

The store traits are relaxed to allow `!Send`/`!Sync` implementations on wasm32; this needed an executable proof that actually runs on that target, since `cargo test`/nextest on native targets can't host a `!Send` store or exercise the wasm-only trait bound. wasm-bindgen-test-runner can't be hosted by nextest, hence the separate plain-cargo CI job.

Closes #355

## Testing

- Both smoke tests (round-trip, windowed read-ahead bound) verified green locally under Node with a source-built `wasm-bindgen-test-runner` 0.2.122.
- Independent review additionally downloaded the matching `wasm-bindgen-test-runner` 0.2.122 and ran the suite under Node 22: both tests pass.
- Review probed `WINDOW=4` and observed `peak=4`, confirming the `peak<=WINDOW` and `peak>1` overlap assertions are load-bearing and would catch over-fetch regressions.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --locked`: no warnings in the diff's crate; pre-existing warnings in nectar-primitives/nectar-mantaray are untouched by this branch and not gated by the wasm-smoke job (it runs `cargo test`, not clippy).

## AI Assistance

Implementation by Fable, review by Opus, PR description by Sonnet.