### PR TITLE
test: convert primitives/mantaray/manifest to async house pattern

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -68,11 +68,37 @@ jobs:
                     -p nectar-manifest --locked \
                     --target wasm32-unknown-unknown
 
+    wasm-smoke:
+        # Executable proof of the wasm store-trait relaxation: a !Send store
+        # satisfies ChunkGet only on wasm32, so the smoke test must actually run
+        # there. Executes under Node via wasm-bindgen-test-runner, which nextest
+        # cannot host; hence a separate plain-cargo job. The runner version must
+        # equal the locked wasm-bindgen version (kept in lockstep by the
+        # workspace's exact wasm-bindgen-test pin).
+        name: wasm / node smoke
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+            - uses: ./.github/actions/rust-setup
+              with:
+                  targets: wasm32-unknown-unknown
+            - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853  # v2.83.2
+              with:
+                  tool: wasm-bindgen@0.2.122
+            - name: Run wasm smoke tests
+              env:
+                  CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER: wasm-bindgen-test-runner
+              run: |
+                  cargo test \
+                    -p nectar-testing --test wasm_smoke --locked \
+                    --target wasm32-unknown-unknown
+
     unit-success:
         name: unit success
         runs-on: ubuntu-latest
         if: always()
-        needs: [test, wasm]
+        needs: [test, wasm, wasm-smoke]
         timeout-minutes: 30
         steps:
             - name: Decide whether the needed jobs succeeded or failed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2049,6 +2049,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "nectar-contracts"
 version = "0.4.0"
 dependencies = [
@@ -2193,7 +2203,19 @@ dependencies = [
 name = "nectar-testing"
 version = "0.4.0"
 dependencies = [
+ "futures",
  "futures-executor",
+ "nectar-primitives",
+ "wasm-bindgen-test",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3526,6 +3548,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3568,6 +3600,45 @@ checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fde991ccdc895cb7fbaa14b137d62af74d9011be67b71c694bfc40edd3119c"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e925354648d2a4d1bf205412e36d520a800280622eef4719678d268e5d40e978"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "684365b586a9a6256c1cc3544eee8680de48d6041142f581776ec7b139622ae9"
 
 [[package]]
 name = "wasm-encoder"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,6 +1006,7 @@ dependencies = [
  "codspeed",
  "codspeed-criterion-compat-walltime",
  "colored",
+ "futures",
 ]
 
 [[package]]
@@ -1020,6 +1021,7 @@ dependencies = [
  "clap",
  "codspeed",
  "criterion-plot",
+ "futures",
  "is-terminal",
  "itertools 0.10.5",
  "num-traits",
@@ -2076,6 +2078,7 @@ dependencies = [
  "bytes",
  "futures",
  "nectar-primitives",
+ "nectar-testing",
  "proptest",
  "thiserror",
 ]
@@ -2091,6 +2094,7 @@ dependencies = [
  "codspeed-criterion-compat",
  "futures",
  "nectar-primitives",
+ "nectar-testing",
  "rand 0.10.1",
  "serde_json",
  "thiserror",
@@ -2172,6 +2176,7 @@ dependencies = [
  "hybrid-array",
  "js-sys",
  "keccak-batch",
+ "nectar-testing",
  "parking_lot",
  "proptest",
  "proptest-arbitrary-interop",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2190,6 +2190,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "nectar-testing"
+version = "0.4.0"
+dependencies = [
+ "futures-executor",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,9 @@ futures-executor = "0.3"
 
 # wasm
 wasm-bindgen = "0.2"
+# Exact pin: 0.3.72 requires wasm-bindgen =0.2.122, so the resolved wasm-bindgen
+# stays in lockstep with the wasm-bindgen-test-runner version CI installs.
+wasm-bindgen-test = "=0.3.72"
 wasm-bindgen-rayon = "1.3"
 js-sys = "0.3"
 console_error_panic_hook = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 
 # For tests and examples
 arbitrary = "1.4"
-criterion = { package = "codspeed-criterion-compat", version = "2.10.1" }
+criterion = { package = "codspeed-criterion-compat", version = "2.10.1", features = ["async_futures"] }
 proptest = "1"
 proptest-arbitrary-interop = "0.1"
 proptest-derive = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ nectar-swarms = { version = "0.4.0", path = "crates/swarms" }
 nectar-postage = { version = "0.4.0", path = "crates/postage" }
 nectar-postage-issuer = { version = "0.4.0", path = "crates/postage-issuer" }
 nectar-postage-usage = { version = "0.4.0", path = "crates/postage-usage" }
+nectar-testing = { path = "crates/testing" }
 
 # alloy
 alloy-primitives = { version = "1.6", default-features = false }
@@ -118,6 +119,7 @@ proptest-derive = "0.5"
 rand = "0.10"
 tokio = { version = "1", features = ["rt", "macros"] }
 futures = "0.3"
+futures-executor = "0.3"
 
 # wasm
 wasm-bindgen = "0.2"

--- a/crates/manifest/Cargo.toml
+++ b/crates/manifest/Cargo.toml
@@ -25,6 +25,7 @@ nectar-primitives = { workspace = true }
 thiserror.workspace = true
 
 [dev-dependencies]
+nectar-testing.workspace = true
 proptest.workspace = true
 
 [features]

--- a/crates/manifest/src/apply.rs
+++ b/crates/manifest/src/apply.rs
@@ -642,9 +642,9 @@ fn common_prefix(a: &[u8], b: &[u8]) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use futures::executor::block_on;
     use nectar_primitives::store::MemoryStore;
     use nectar_primitives::{ChunkAddress, ChunkRef};
+    use nectar_testing::run;
 
     use crate::builder::Builder;
     use crate::format::V1;
@@ -658,256 +658,286 @@ mod tests {
 
     // Walk the counted tree, asserting every stored referenced-child count
     // equals the walked subtree size, and return the subtree's key count.
-    fn walk_counts(store: &MemoryStore, table: &ForkTable<V1>) -> u64 {
-        let mut total = 0u64;
-        for (_, record) in table.iter() {
-            let child = match record.child() {
-                None => 0,
-                Some(Child::Embedded(inner)) => walk_counts(store, inner),
-                Some(Child::Ref32(reference)) => {
-                    let node = block_on(store.get_node::<V1>(reference.address())).unwrap();
-                    let actual = walk_counts(store, node.forks());
-                    assert_eq!(
-                        record.child_count(),
-                        Some(SubtreeCount::new(actual)),
-                        "stored count must equal the walked subtree size"
-                    );
-                    actual
-                }
-                Some(Child::Ref64(_)) => unreachable!("a plaintext build has no encrypted child"),
-            };
-            total += u64::from(record.entry().is_some()) + child;
-        }
-        total
+    // Boxed return: the recursion needs an indirected future type.
+    fn walk_counts<'a>(
+        store: &'a MemoryStore,
+        table: &'a ForkTable<V1>,
+    ) -> futures::future::LocalBoxFuture<'a, u64> {
+        Box::pin(async move {
+            let mut total = 0u64;
+            for (_, record) in table.iter() {
+                let child = match record.child() {
+                    None => 0,
+                    Some(Child::Embedded(inner)) => walk_counts(store, inner).await,
+                    Some(Child::Ref32(reference)) => {
+                        let node = store.get_node::<V1>(reference.address()).await.unwrap();
+                        let actual = walk_counts(store, node.forks()).await;
+                        assert_eq!(
+                            record.child_count(),
+                            Some(SubtreeCount::new(actual)),
+                            "stored count must equal the walked subtree size"
+                        );
+                        actual
+                    }
+                    Some(Child::Ref64(_)) => {
+                        unreachable!("a plaintext build has no encrypted child")
+                    }
+                };
+                total += u64::from(record.entry().is_some()) + child;
+            }
+            total
+        })
     }
 
     #[test]
     fn counted_child_counts_match_a_full_walk_oracle() {
-        let store = MemoryStore::default();
-        let mut builder = Builder::<V1>::new();
-        let mut expected = 0u64;
-        // Many wide sub-trees, each referenced (over the embedding budget), under
-        // enough root forks to spill the root into a segment directory: exercises
-        // referenced-child counts and the segment path at once.
-        for p in 0u8..128 {
-            for x in 0u8..44 {
-                builder.insert(Key::from(&[p, x][..]), entry(x), None);
-                expected += 1;
+        run(async {
+            let store = MemoryStore::default();
+            let mut builder = Builder::<V1>::new();
+            let mut expected = 0u64;
+            // Many wide sub-trees, each referenced (over the embedding budget), under
+            // enough root forks to spill the root into a segment directory: exercises
+            // referenced-child counts and the segment path at once.
+            for p in 0u8..128 {
+                for x in 0u8..44 {
+                    builder.insert(Key::from(&[p, x][..]), entry(x), None);
+                    expected += 1;
+                }
             }
-        }
-        let root = *block_on(builder.build(&store)).unwrap().root();
-        let node = block_on(store.get_node::<V1>(&root)).unwrap();
-        let total = u64::from(node.entry().is_some()) + walk_counts(&store, node.forks());
-        assert_eq!(total, expected);
+            let root = *builder.build(&store).await.unwrap().root();
+            let node = store.get_node::<V1>(&root).await.unwrap();
+            let total = u64::from(node.entry().is_some()) + walk_counts(&store, node.forks()).await;
+            assert_eq!(total, expected);
+        })
     }
 
     #[test]
     fn counted_apply_matches_a_rebuild_and_preserves_counts() {
-        let store = MemoryStore::default();
-        // A base that references a wide sub-tree under "a", then a changeset that
-        // deepens it: apply must reproduce the from-scratch counted root.
-        let mut base = Builder::<V1>::new();
-        for x in 0u8..40 {
-            base.insert(Key::from(&[b'a', x][..]), entry(x), None);
-        }
-        let base_root = *block_on(base.build(&store)).unwrap().root();
+        run(async {
+            let store = MemoryStore::default();
+            // A base that references a wide sub-tree under "a", then a changeset that
+            // deepens it: apply must reproduce the from-scratch counted root.
+            let mut base = Builder::<V1>::new();
+            for x in 0u8..40 {
+                base.insert(Key::from(&[b'a', x][..]), entry(x), None);
+            }
+            let base_root = *base.build(&store).await.unwrap().root();
 
-        let mut cs = Changeset::<V1>::new();
-        for x in 40u8..64 {
-            cs.put(Key::from(&[b'a', x][..]), entry(x), None);
-        }
-        let applied = block_on(apply(&store, &base_root, &cs)).unwrap();
+            let mut cs = Changeset::<V1>::new();
+            for x in 40u8..64 {
+                cs.put(Key::from(&[b'a', x][..]), entry(x), None);
+            }
+            let applied = apply(&store, &base_root, &cs).await.unwrap();
 
-        let mut scratch = Builder::<V1>::new();
-        for x in 0u8..64 {
-            scratch.insert(Key::from(&[b'a', x][..]), entry(x), None);
-        }
-        let scratch_root = *block_on(scratch.build(&MemoryStore::default()))
-            .unwrap()
-            .root();
-        assert_eq!(applied, scratch_root, "apply must match a counted rebuild");
+            let mut scratch = Builder::<V1>::new();
+            for x in 0u8..64 {
+                scratch.insert(Key::from(&[b'a', x][..]), entry(x), None);
+            }
+            let scratch_root = *scratch.build(&MemoryStore::default()).await.unwrap().root();
+            assert_eq!(applied, scratch_root, "apply must match a counted rebuild");
 
-        // The applied tree's stored counts still equal the walked subtree sizes.
-        let node = block_on(store.get_node::<V1>(&applied)).unwrap();
-        let total = u64::from(node.entry().is_some()) + walk_counts(&store, node.forks());
-        assert_eq!(total, 64);
+            // The applied tree's stored counts still equal the walked subtree sizes.
+            let node = store.get_node::<V1>(&applied).await.unwrap();
+            let total = u64::from(node.entry().is_some()) + walk_counts(&store, node.forks()).await;
+            assert_eq!(total, 64);
+        })
     }
 
     // Build a manifest from `keys` and return its root.
-    fn build(store: &MemoryStore, keys: &[(&[u8], u8)]) -> ChunkAddress {
+    async fn build(store: &MemoryStore, keys: &[(&[u8], u8)]) -> ChunkAddress {
         let mut builder = Builder::<V1>::new();
         for (key, fill) in keys {
             builder.insert(Key::from(*key), entry(*fill), None);
         }
-        *block_on(builder.build(store)).unwrap().root()
+        *builder.build(store).await.unwrap().root()
     }
 
     // The root a from-scratch build of `keys` produces, for the byte-identity
     // check: a fresh store makes the address depend on the bytes alone.
-    fn rebuilt(keys: &[(&[u8], u8)]) -> ChunkAddress {
-        build(&MemoryStore::default(), keys)
+    async fn rebuilt(keys: &[(&[u8], u8)]) -> ChunkAddress {
+        build(&MemoryStore::default(), keys).await
     }
 
     #[test]
     fn an_empty_changeset_returns_the_root_unchanged() {
-        let store = MemoryStore::default();
-        let root = build(&store, &[(b"a", 1), (b"b", 2)]);
-        let out = block_on(apply(&store, &root, &Changeset::<V1>::new())).unwrap();
-        assert_eq!(out, root);
+        run(async {
+            let store = MemoryStore::default();
+            let root = build(&store, &[(b"a", 1), (b"b", 2)]).await;
+            let out = apply(&store, &root, &Changeset::<V1>::new()).await.unwrap();
+            assert_eq!(out, root);
+        })
     }
 
     #[test]
     fn a_single_insert_equals_a_rebuild() {
-        let store = MemoryStore::default();
-        let root = build(&store, &[(b"a", 1), (b"c", 3)]);
-        let mut cs = Changeset::<V1>::new();
-        cs.put(Key::from(&b"b"[..]), entry(2), None);
-        let out = block_on(apply(&store, &root, &cs)).unwrap();
-        assert_eq!(out, rebuilt(&[(b"a", 1), (b"b", 2), (b"c", 3)]));
+        run(async {
+            let store = MemoryStore::default();
+            let root = build(&store, &[(b"a", 1), (b"c", 3)]).await;
+            let mut cs = Changeset::<V1>::new();
+            cs.put(Key::from(&b"b"[..]), entry(2), None);
+            let out = apply(&store, &root, &cs).await.unwrap();
+            assert_eq!(out, rebuilt(&[(b"a", 1), (b"b", 2), (b"c", 3)]).await);
+        })
     }
 
     #[test]
     fn a_batch_touching_one_ancestor_equals_a_rebuild() {
-        let store = MemoryStore::default();
-        let root = build(&store, &[(b"road", 1), (b"roam", 2)]);
-        // Two inserts under the shared "ro" ancestor, rewritten in one pass.
-        let mut cs = Changeset::<V1>::new();
-        cs.put(Key::from(&b"rock"[..]), entry(3), None);
-        cs.put(Key::from(&b"rose"[..]), entry(4), None);
-        let out = block_on(apply(&store, &root, &cs)).unwrap();
-        assert_eq!(
-            out,
-            rebuilt(&[(b"road", 1), (b"roam", 2), (b"rock", 3), (b"rose", 4)])
-        );
+        run(async {
+            let store = MemoryStore::default();
+            let root = build(&store, &[(b"road", 1), (b"roam", 2)]).await;
+            // Two inserts under the shared "ro" ancestor, rewritten in one pass.
+            let mut cs = Changeset::<V1>::new();
+            cs.put(Key::from(&b"rock"[..]), entry(3), None);
+            cs.put(Key::from(&b"rose"[..]), entry(4), None);
+            let out = apply(&store, &root, &cs).await.unwrap();
+            assert_eq!(
+                out,
+                rebuilt(&[(b"road", 1), (b"roam", 2), (b"rock", 3), (b"rose", 4)]).await
+            );
+        })
     }
 
     #[test]
     fn an_update_overwrites_in_place() {
-        let store = MemoryStore::default();
-        let root = build(&store, &[(b"a", 1), (b"b", 2)]);
-        let mut cs = Changeset::<V1>::new();
-        cs.put(Key::from(&b"a"[..]), entry(9), None);
-        let out = block_on(apply(&store, &root, &cs)).unwrap();
-        assert_eq!(out, rebuilt(&[(b"a", 9), (b"b", 2)]));
+        run(async {
+            let store = MemoryStore::default();
+            let root = build(&store, &[(b"a", 1), (b"b", 2)]).await;
+            let mut cs = Changeset::<V1>::new();
+            cs.put(Key::from(&b"a"[..]), entry(9), None);
+            let out = apply(&store, &root, &cs).await.unwrap();
+            assert_eq!(out, rebuilt(&[(b"a", 9), (b"b", 2)]).await);
+        })
     }
 
     #[test]
     fn a_deletion_that_re_inlines_a_sibling_equals_a_rebuild() {
-        let store = MemoryStore::default();
-        // "roam"/"road" share a "roa" branch; deleting one collapses the branch
-        // back into a single compacted edge.
-        let root = build(&store, &[(b"roam", 1), (b"road", 2), (b"x", 3)]);
-        let mut cs = Changeset::<V1>::new();
-        cs.remove(Key::from(&b"road"[..]));
-        let out = block_on(apply(&store, &root, &cs)).unwrap();
-        assert_eq!(out, rebuilt(&[(b"roam", 1), (b"x", 3)]));
+        run(async {
+            let store = MemoryStore::default();
+            // "roam"/"road" share a "roa" branch; deleting one collapses the branch
+            // back into a single compacted edge.
+            let root = build(&store, &[(b"roam", 1), (b"road", 2), (b"x", 3)]).await;
+            let mut cs = Changeset::<V1>::new();
+            cs.remove(Key::from(&b"road"[..]));
+            let out = apply(&store, &root, &cs).await.unwrap();
+            assert_eq!(out, rebuilt(&[(b"roam", 1), (b"x", 3)]).await);
+        })
     }
 
     #[test]
     fn deleting_the_last_child_removes_the_fork() {
-        let store = MemoryStore::default();
-        let root = build(&store, &[(b"a", 1), (b"b", 2)]);
-        let mut cs = Changeset::<V1>::new();
-        cs.remove(Key::from(&b"a"[..]));
-        let out = block_on(apply(&store, &root, &cs)).unwrap();
-        assert_eq!(out, rebuilt(&[(b"b", 2)]));
+        run(async {
+            let store = MemoryStore::default();
+            let root = build(&store, &[(b"a", 1), (b"b", 2)]).await;
+            let mut cs = Changeset::<V1>::new();
+            cs.remove(Key::from(&b"a"[..]));
+            let out = apply(&store, &root, &cs).await.unwrap();
+            assert_eq!(out, rebuilt(&[(b"b", 2)]).await);
+        })
     }
 
     #[test]
     fn deleting_an_absent_key_is_a_no_op() {
-        let store = MemoryStore::default();
-        let root = build(&store, &[(b"a", 1), (b"ab", 2)]);
-        let mut cs = Changeset::<V1>::new();
-        cs.remove(Key::from(&b"absent"[..]));
-        cs.remove(Key::from(&b"a"[..]));
-        cs.put(Key::from(&b"a"[..]), entry(1), None);
-        let out = block_on(apply(&store, &root, &cs)).unwrap();
-        assert_eq!(out, rebuilt(&[(b"a", 1), (b"ab", 2)]));
+        run(async {
+            let store = MemoryStore::default();
+            let root = build(&store, &[(b"a", 1), (b"ab", 2)]).await;
+            let mut cs = Changeset::<V1>::new();
+            cs.remove(Key::from(&b"absent"[..]));
+            cs.remove(Key::from(&b"a"[..]));
+            cs.put(Key::from(&b"a"[..]), entry(1), None);
+            let out = apply(&store, &root, &cs).await.unwrap();
+            assert_eq!(out, rebuilt(&[(b"a", 1), (b"ab", 2)]).await);
+        })
     }
 
     #[test]
     fn a_split_within_an_edge_equals_a_rebuild() {
-        let store = MemoryStore::default();
-        // "abcdef" sits behind a long compacted edge; inserting "abz" branches
-        // inside that edge.
-        let root = build(&store, &[(b"abcdef", 1)]);
-        let mut cs = Changeset::<V1>::new();
-        cs.put(Key::from(&b"abz"[..]), entry(2), None);
-        let out = block_on(apply(&store, &root, &cs)).unwrap();
-        assert_eq!(out, rebuilt(&[(b"abcdef", 1), (b"abz", 2)]));
+        run(async {
+            let store = MemoryStore::default();
+            // "abcdef" sits behind a long compacted edge; inserting "abz" branches
+            // inside that edge.
+            let root = build(&store, &[(b"abcdef", 1)]).await;
+            let mut cs = Changeset::<V1>::new();
+            cs.put(Key::from(&b"abz"[..]), entry(2), None);
+            let out = apply(&store, &root, &cs).await.unwrap();
+            assert_eq!(out, rebuilt(&[(b"abcdef", 1), (b"abz", 2)]).await);
+        })
     }
 
     #[test]
     fn a_split_above_a_chain_boundary_recompacts_like_a_rebuild() {
-        let store = MemoryStore::default();
-        // A 256-byte key sits behind a PLEN_MAX(255) chain: one 255-byte edge
-        // over a child holding its last byte. Inserting a key that shares only
-        // the first byte branches above that chain, shortening the existing edge
-        // so its final byte re-merges into the edge, no longer a child hop.
-        let mut base = vec![2u8];
-        base.extend(std::iter::repeat_n(0u8, 255));
-        let root = build(&store, &[(&base[..], 1)]);
-        let mut cs = Changeset::<V1>::new();
-        let branched = [2u8, 2, 1];
-        cs.put(Key::from(&branched[..]), entry(2), None);
-        let out = block_on(apply(&store, &root, &cs)).unwrap();
-        assert_eq!(out, rebuilt(&[(&base[..], 1), (&branched[..], 2)]));
+        run(async {
+            let store = MemoryStore::default();
+            // A 256-byte key sits behind a PLEN_MAX(255) chain: one 255-byte edge
+            // over a child holding its last byte. Inserting a key that shares only
+            // the first byte branches above that chain, shortening the existing edge
+            // so its final byte re-merges into the edge, no longer a child hop.
+            let mut base = vec![2u8];
+            base.extend(std::iter::repeat_n(0u8, 255));
+            let root = build(&store, &[(&base[..], 1)]).await;
+            let mut cs = Changeset::<V1>::new();
+            let branched = [2u8, 2, 1];
+            cs.put(Key::from(&branched[..]), entry(2), None);
+            let out = apply(&store, &root, &cs).await.unwrap();
+            assert_eq!(out, rebuilt(&[(&base[..], 1), (&branched[..], 2)]).await);
+        })
     }
 
     #[test]
     fn the_empty_key_sets_and_clears_the_root_value() {
-        let store = MemoryStore::default();
-        let root = build(&store, &[(b"a", 1)]);
-        let mut set = Changeset::<V1>::new();
-        set.put(Key::empty(), entry(7), None);
-        let with_root = block_on(apply(&store, &root, &set)).unwrap();
+        run(async {
+            let store = MemoryStore::default();
+            let root = build(&store, &[(b"a", 1)]).await;
+            let mut set = Changeset::<V1>::new();
+            set.put(Key::empty(), entry(7), None);
+            let with_root = apply(&store, &root, &set).await.unwrap();
 
-        let mut expect = Builder::<V1>::new();
-        expect.insert(Key::empty(), entry(7), None);
-        expect.insert(Key::from(&b"a"[..]), entry(1), None);
-        let rebuilt_root = *block_on(expect.build(&MemoryStore::default()))
-            .unwrap()
-            .root();
-        assert_eq!(with_root, rebuilt_root);
+            let mut expect = Builder::<V1>::new();
+            expect.insert(Key::empty(), entry(7), None);
+            expect.insert(Key::from(&b"a"[..]), entry(1), None);
+            let rebuilt_root = *expect.build(&MemoryStore::default()).await.unwrap().root();
+            assert_eq!(with_root, rebuilt_root);
 
-        let mut clear = Changeset::<V1>::new();
-        clear.remove(Key::empty());
-        let cleared = block_on(apply(&store, &with_root, &clear)).unwrap();
-        assert_eq!(cleared, rebuilt(&[(b"a", 1)]));
+            let mut clear = Changeset::<V1>::new();
+            clear.remove(Key::empty());
+            let cleared = apply(&store, &with_root, &clear).await.unwrap();
+            assert_eq!(cleared, rebuilt(&[(b"a", 1)]).await);
+        })
     }
 
     #[test]
     fn a_collapse_past_the_prefix_bound_chains_like_a_rebuild() {
-        let store = MemoryStore::default();
-        // Two keys sharing a 200-byte prefix, total length 260: the fork over
-        // the shared run terminates one key and continues to the other. Deleting
-        // the terminal leaves a single 260-byte key whose from-scratch shape is
-        // a PLEN_MAX(255)-capped chain, not one over-long edge.
-        let short = vec![b'a'; 200];
-        let mut long = short.clone();
-        long.extend(std::iter::repeat_n(b'b', 60));
-        let root = build(&store, &[(&short[..], 1), (&long[..], 2)]);
-        let mut cs = Changeset::<V1>::new();
-        cs.remove(Key::from(&short[..]));
-        let out = block_on(apply(&store, &root, &cs)).unwrap();
-        assert_eq!(out, rebuilt(&[(&long[..], 2)]));
+        run(async {
+            let store = MemoryStore::default();
+            // Two keys sharing a 200-byte prefix, total length 260: the fork over
+            // the shared run terminates one key and continues to the other. Deleting
+            // the terminal leaves a single 260-byte key whose from-scratch shape is
+            // a PLEN_MAX(255)-capped chain, not one over-long edge.
+            let short = vec![b'a'; 200];
+            let mut long = short.clone();
+            long.extend(std::iter::repeat_n(b'b', 60));
+            let root = build(&store, &[(&short[..], 1), (&long[..], 2)]).await;
+            let mut cs = Changeset::<V1>::new();
+            cs.remove(Key::from(&short[..]));
+            let out = apply(&store, &root, &cs).await.unwrap();
+            assert_eq!(out, rebuilt(&[(&long[..], 2)]).await);
+        })
     }
 
     #[test]
     fn carried_metadata_survives_a_rebuild() {
-        let store = MemoryStore::default();
-        let meta = Metadata::new(KeyId::ContentType, Bytes::from_static(b"text/html")).unwrap();
-        let root = build(&store, &[(b"a", 1)]);
-        let mut cs = Changeset::<V1>::new();
-        cs.put(Key::from(&b"index.html"[..]), entry(2), Some(meta.clone()));
-        let out = block_on(apply(&store, &root, &cs)).unwrap();
+        run(async {
+            let store = MemoryStore::default();
+            let meta = Metadata::new(KeyId::ContentType, Bytes::from_static(b"text/html")).unwrap();
+            let root = build(&store, &[(b"a", 1)]).await;
+            let mut cs = Changeset::<V1>::new();
+            cs.put(Key::from(&b"index.html"[..]), entry(2), Some(meta.clone()));
+            let out = apply(&store, &root, &cs).await.unwrap();
 
-        let mut expect = Builder::<V1>::new();
-        expect.insert(Key::from(&b"a"[..]), entry(1), None);
-        expect.insert(Key::from(&b"index.html"[..]), entry(2), Some(meta));
-        let rebuilt_root = *block_on(expect.build(&MemoryStore::default()))
-            .unwrap()
-            .root();
-        assert_eq!(out, rebuilt_root);
+            let mut expect = Builder::<V1>::new();
+            expect.insert(Key::from(&b"a"[..]), entry(1), None);
+            expect.insert(Key::from(&b"index.html"[..]), entry(2), Some(meta));
+            let rebuilt_root = *expect.build(&MemoryStore::default()).await.unwrap().root();
+            assert_eq!(out, rebuilt_root);
+        })
     }
 }

--- a/crates/manifest/src/dx.rs
+++ b/crates/manifest/src/dx.rs
@@ -65,7 +65,7 @@ where
     /// exact bytes [`build_files`](crate::build_files) streamed in under it.
     ///
     /// ```
-    /// use futures::executor::block_on;
+    /// use nectar_testing::run;
     /// use nectar_manifest::{build_files, Key, Reader};
     /// use nectar_primitives::MemoryStore;
     ///
@@ -91,8 +91,8 @@ where
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
-    use futures::executor::block_on;
     use nectar_primitives::store::MemoryStore;
+    use nectar_testing::run;
 
     use crate::builder::{Builder, build_files};
     use crate::value::{Entry, Key};
@@ -101,56 +101,71 @@ mod tests {
 
     #[test]
     fn publish_then_fetch_round_trips_file_bytes() {
-        let store = MemoryStore::default();
-        let files = [
-            (
-                Key::from(&b"index.html"[..]),
-                Bytes::from_static(b"<h1>hi</h1>"),
-            ),
-            (
-                Key::from(&b"img/logo.png"[..]),
-                Bytes::from(vec![0xAB; 9000]),
-            ),
-        ];
-        let root = *block_on(build_files(&store, files)).unwrap().root();
+        run(async {
+            let store = MemoryStore::default();
+            let files = [
+                (
+                    Key::from(&b"index.html"[..]),
+                    Bytes::from_static(b"<h1>hi</h1>"),
+                ),
+                (
+                    Key::from(&b"img/logo.png"[..]),
+                    Bytes::from(vec![0xAB; 9000]),
+                ),
+            ];
+            let root = *build_files(&store, files).await.unwrap().root();
 
-        let reader: Reader<_> = Reader::new(&store);
-        assert_eq!(
-            block_on(reader.fetch(&root, &Key::from(&b"index.html"[..]))).unwrap(),
-            Some(Bytes::from_static(b"<h1>hi</h1>")),
-        );
-        // A multi-chunk file rejoins byte-exact through the shared BMT.
-        assert_eq!(
-            block_on(reader.fetch(&root, &Key::from(&b"img/logo.png"[..]))).unwrap(),
-            Some(Bytes::from(vec![0xAB; 9000])),
-        );
+            let reader: Reader<_> = Reader::new(&store);
+            assert_eq!(
+                reader
+                    .fetch(&root, &Key::from(&b"index.html"[..]))
+                    .await
+                    .unwrap(),
+                Some(Bytes::from_static(b"<h1>hi</h1>")),
+            );
+            // A multi-chunk file rejoins byte-exact through the shared BMT.
+            assert_eq!(
+                reader
+                    .fetch(&root, &Key::from(&b"img/logo.png"[..]))
+                    .await
+                    .unwrap(),
+                Some(Bytes::from(vec![0xAB; 9000])),
+            );
+        })
     }
 
     #[test]
     fn fetch_of_an_absent_key_is_none() {
-        let store = MemoryStore::default();
-        let files = [(Key::from(&b"a"[..]), Bytes::from_static(b"x"))];
-        let root = *block_on(build_files(&store, files)).unwrap().root();
+        run(async {
+            let store = MemoryStore::default();
+            let files = [(Key::from(&b"a"[..]), Bytes::from_static(b"x"))];
+            let root = *build_files(&store, files).await.unwrap().root();
 
-        let reader: Reader<_> = Reader::new(&store);
-        assert_eq!(
-            block_on(reader.fetch(&root, &Key::from(&b"missing"[..]))).unwrap(),
-            None,
-        );
+            let reader: Reader<_> = Reader::new(&store);
+            assert_eq!(
+                reader
+                    .fetch(&root, &Key::from(&b"missing"[..]))
+                    .await
+                    .unwrap(),
+                None,
+            );
+        })
     }
 
     #[test]
     fn read_returns_inline_bytes_directly() {
-        let store = MemoryStore::default();
-        let mut builder = Builder::new();
-        let value: Entry = Entry::inline(Bytes::from_static(b"inline")).unwrap();
-        builder.insert(Key::from(&b"k"[..]), value, None);
-        let root = *block_on(builder.build(&store)).unwrap().root();
+        run(async {
+            let store = MemoryStore::default();
+            let mut builder = Builder::new();
+            let value: Entry = Entry::inline(Bytes::from_static(b"inline")).unwrap();
+            builder.insert(Key::from(&b"k"[..]), value, None);
+            let root = *builder.build(&store).await.unwrap().root();
 
-        let reader: Reader<_> = Reader::new(&store);
-        assert_eq!(
-            block_on(reader.fetch(&root, &Key::from(&b"k"[..]))).unwrap(),
-            Some(Bytes::from_static(b"inline")),
-        );
+            let reader: Reader<_> = Reader::new(&store);
+            assert_eq!(
+                reader.fetch(&root, &Key::from(&b"k"[..])).await.unwrap(),
+                Some(Bytes::from_static(b"inline")),
+            );
+        })
     }
 }

--- a/crates/manifest/src/dx.rs
+++ b/crates/manifest/src/dx.rs
@@ -65,7 +65,7 @@ where
     /// exact bytes [`build_files`](crate::build_files) streamed in under it.
     ///
     /// ```
-    /// use nectar_testing::run;
+    /// use futures::executor::block_on;
     /// use nectar_manifest::{build_files, Key, Reader};
     /// use nectar_primitives::MemoryStore;
     ///

--- a/crates/manifest/src/encryption.rs
+++ b/crates/manifest/src/encryption.rs
@@ -173,9 +173,9 @@ impl<T: TrustedStore> EncryptedNodeGet for T {}
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
-    use futures::executor::block_on;
     use nectar_primitives::store::MemoryStore;
     use nectar_primitives::{ChunkAddress, ChunkRef};
+    use nectar_testing::run;
 
     use crate::bounded::Prefix;
     use crate::fork::Child;
@@ -265,38 +265,42 @@ mod tests {
 
     #[test]
     fn round_trips_through_a_memory_store() {
-        let store = MemoryStore::default();
-        let node = sample();
-        let reference = block_on(store.put_node_encrypted(&node, SECRET)).unwrap();
-        let opened: Node = block_on(store.get_node_encrypted(&reference)).unwrap();
-        assert_eq!(opened, node);
+        run(async {
+            let store = MemoryStore::default();
+            let node = sample();
+            let reference = store.put_node_encrypted(&node, SECRET).await.unwrap();
+            let opened: Node = store.get_node_encrypted(&reference).await.unwrap();
+            assert_eq!(opened, node);
+        })
     }
 
     #[test]
     fn a_ref64_transports_the_child_key_into_its_parent() {
-        // The privacy rule made concrete: sealing a child yields a ref64 whose
-        // key is exactly the child's derived key, so a parent that records the
-        // ref64 carries that key in its own bytes.
-        let store = MemoryStore::default();
-        let child = sample();
-        let reference = block_on(store.put_node_encrypted(&child, SECRET)).unwrap();
-        assert_eq!(
-            reference.key(),
-            &derive_key::<crate::V1>(SECRET, &child.encode().unwrap())
-        );
+        run(async {
+            // The privacy rule made concrete: sealing a child yields a ref64 whose
+            // key is exactly the child's derived key, so a parent that records the
+            // ref64 carries that key in its own bytes.
+            let store = MemoryStore::default();
+            let child = sample();
+            let reference = store.put_node_encrypted(&child, SECRET).await.unwrap();
+            assert_eq!(
+                reference.key(),
+                &derive_key::<crate::V1>(SECRET, &child.encode().unwrap())
+            );
 
-        let mut parent = Node::empty();
-        parent
-            .forks_mut()
-            .insert(
-                Prefix::try_from(&b"dir/"[..]).unwrap(),
-                Child::Ref64(reference).into(),
-                None,
-            )
-            .unwrap();
-        // The child key round-trips through the parent's own wire bytes.
-        let bytes = parent.encode().unwrap();
-        let decoded: Node = Node::decode(&bytes).unwrap();
-        assert_eq!(decoded, parent);
+            let mut parent = Node::empty();
+            parent
+                .forks_mut()
+                .insert(
+                    Prefix::try_from(&b"dir/"[..]).unwrap(),
+                    Child::Ref64(reference).into(),
+                    None,
+                )
+                .unwrap();
+            // The child key round-trips through the parent's own wire bytes.
+            let bytes = parent.encode().unwrap();
+            let decoded: Node = Node::decode(&bytes).unwrap();
+            assert_eq!(decoded, parent);
+        })
     }
 }

--- a/crates/manifest/src/folder.rs
+++ b/crates/manifest/src/folder.rs
@@ -337,9 +337,9 @@ fn directory_index<F: Format>(path: &[u8], index: &[u8]) -> Key {
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
-    use futures::executor::block_on;
     use nectar_primitives::store::MemoryStore;
     use nectar_primitives::{ChunkAddress, ChunkRef};
+    use nectar_testing::run;
 
     use crate::builder::Builder;
     use crate::meta::{KeyId, Metadata};
@@ -351,18 +351,18 @@ mod tests {
     }
 
     /// Build a manifest from `(key, value)` pairs and return its root address.
-    fn manifest(store: &MemoryStore, pairs: &[(&[u8], u8)]) -> ChunkAddress {
+    async fn manifest(store: &MemoryStore, pairs: &[(&[u8], u8)]) -> ChunkAddress {
         let mut builder = Builder::new();
         for (key, byte) in pairs {
             builder.insert(Key::from(&key[..]), entry(*byte), None);
         }
-        *block_on(builder.build(store)).unwrap().root()
+        *builder.build(store).await.unwrap().root()
     }
 
     /// Drain a listing into its entries.
-    fn entries(mut listing: Listing<'_, &MemoryStore>) -> Vec<DirEntry> {
+    async fn entries(mut listing: Listing<'_, &MemoryStore>) -> Vec<DirEntry> {
         let mut out = Vec::new();
-        while let Some(item) = block_on(listing.next()).unwrap() {
+        while let Some(item) = listing.next().await.unwrap() {
             out.push(item);
         }
         out
@@ -383,263 +383,298 @@ mod tests {
 
     #[test]
     fn list_collapses_subdirectories_at_the_separator() {
-        let store = MemoryStore::default();
-        let root = manifest(
-            &store,
-            &[
-                (b"index.html", 0x01),
-                (b"img/logo.png", 0x02),
-                (b"img/icons/a.png", 0x03),
-                (b"style.css", 0x04),
-            ],
-        );
-        let reader: Reader<_> = Reader::new(&store);
+        run(async {
+            let store = MemoryStore::default();
+            let root = manifest(
+                &store,
+                &[
+                    (b"index.html", 0x01),
+                    (b"img/logo.png", 0x02),
+                    (b"img/icons/a.png", 0x03),
+                    (b"style.css", 0x04),
+                ],
+            )
+            .await;
+            let reader: Reader<_> = Reader::new(&store);
 
-        // The root lists two files and one collapsed directory, in key order.
-        let got = entries(block_on(reader.list(&root, &Key::empty())).unwrap());
-        assert_eq!(
-            got,
-            vec![
-                dir(b"img/"),
-                file(b"index.html", 0x01),
-                file(b"style.css", 0x04),
-            ]
-        );
+            // The root lists two files and one collapsed directory, in key order.
+            let got = entries(reader.list(&root, &Key::empty()).await.unwrap()).await;
+            assert_eq!(
+                got,
+                vec![
+                    dir(b"img/"),
+                    file(b"index.html", 0x01),
+                    file(b"style.css", 0x04),
+                ]
+            );
+        })
     }
 
     #[test]
     fn list_of_a_nested_directory_reads_one_level() {
-        let store = MemoryStore::default();
-        let root = manifest(
-            &store,
-            &[
-                (b"img/logo.png", 0x02),
-                (b"img/icons/a.png", 0x03),
-                (b"img/icons/b.png", 0x05),
-                (b"other.txt", 0x06),
-            ],
-        );
-        let reader: Reader<_> = Reader::new(&store);
+        run(async {
+            let store = MemoryStore::default();
+            let root = manifest(
+                &store,
+                &[
+                    (b"img/logo.png", 0x02),
+                    (b"img/icons/a.png", 0x03),
+                    (b"img/icons/b.png", 0x05),
+                    (b"other.txt", 0x06),
+                ],
+            )
+            .await;
+            let reader: Reader<_> = Reader::new(&store);
 
-        let got = entries(block_on(reader.list(&root, &Key::from(&b"img/"[..]))).unwrap());
-        assert_eq!(got, vec![dir(b"img/icons/"), file(b"img/logo.png", 0x02)]);
+            let got = entries(reader.list(&root, &Key::from(&b"img/"[..])).await.unwrap()).await;
+            assert_eq!(got, vec![dir(b"img/icons/"), file(b"img/logo.png", 0x02)]);
+        })
     }
 
     #[test]
     fn list_collapses_consecutive_subdirectories() {
-        let store = MemoryStore::default();
-        // Two subdirectories in a row exercise the reseek-then-collapse-again
-        // path: each named subtree must be skipped without swallowing the next.
-        let root = manifest(
-            &store,
-            &[
-                (b"a/1", 0x01),
-                (b"a/2", 0x02),
-                (b"b/1", 0x03),
-                (b"c.txt", 0x04),
-            ],
-        );
-        let reader: Reader<_> = Reader::new(&store);
+        run(async {
+            let store = MemoryStore::default();
+            // Two subdirectories in a row exercise the reseek-then-collapse-again
+            // path: each named subtree must be skipped without swallowing the next.
+            let root = manifest(
+                &store,
+                &[
+                    (b"a/1", 0x01),
+                    (b"a/2", 0x02),
+                    (b"b/1", 0x03),
+                    (b"c.txt", 0x04),
+                ],
+            )
+            .await;
+            let reader: Reader<_> = Reader::new(&store);
 
-        let got = entries(block_on(reader.list(&root, &Key::empty())).unwrap());
-        assert_eq!(got, vec![dir(b"a/"), dir(b"b/"), file(b"c.txt", 0x04)]);
+            let got = entries(reader.list(&root, &Key::empty()).await.unwrap()).await;
+            assert_eq!(got, vec![dir(b"a/"), dir(b"b/"), file(b"c.txt", 0x04)]);
+        })
     }
 
     #[test]
     fn list_skips_the_directory_key_itself() {
-        let store = MemoryStore::default();
-        // A key exactly equal to the listed directory path is the directory
-        // itself, not a child.
-        let root = manifest(&store, &[(b"dir/", 0x01), (b"dir/a", 0x02)]);
-        let reader: Reader<_> = Reader::new(&store);
+        run(async {
+            let store = MemoryStore::default();
+            // A key exactly equal to the listed directory path is the directory
+            // itself, not a child.
+            let root = manifest(&store, &[(b"dir/", 0x01), (b"dir/a", 0x02)]).await;
+            let reader: Reader<_> = Reader::new(&store);
 
-        let got = entries(block_on(reader.list(&root, &Key::from(&b"dir/"[..]))).unwrap());
-        assert_eq!(got, vec![file(b"dir/a", 0x02)]);
+            let got = entries(reader.list(&root, &Key::from(&b"dir/"[..])).await.unwrap()).await;
+            assert_eq!(got, vec![file(b"dir/a", 0x02)]);
+        })
     }
 
     #[test]
     fn list_does_not_fetch_deeper_subtrees() {
-        let store = CountingStore::default();
-        // A wide, deep subdirectory the listing must not descend into.
-        let mut pairs: Vec<(Vec<u8>, u8)> = Vec::new();
-        for i in 0u8..64 {
-            pairs.push((format!("deep/{i:03}/leaf").into_bytes(), i));
-        }
-        pairs.push((b"top.txt".to_vec(), 0xFF));
-        let refs: Vec<(&[u8], u8)> = pairs.iter().map(|(k, v)| (k.as_slice(), *v)).collect();
-        let root = manifest(&store.inner, &refs);
-        store.reset();
+        run(async {
+            let store = CountingStore::default();
+            // A wide, deep subdirectory the listing must not descend into.
+            let mut pairs: Vec<(Vec<u8>, u8)> = Vec::new();
+            for i in 0u8..64 {
+                pairs.push((format!("deep/{i:03}/leaf").into_bytes(), i));
+            }
+            pairs.push((b"top.txt".to_vec(), 0xFF));
+            let refs: Vec<(&[u8], u8)> = pairs.iter().map(|(k, v)| (k.as_slice(), *v)).collect();
+            let root = manifest(&store.inner, &refs).await;
+            store.reset();
 
-        let reader: Reader<_> = Reader::new(&store);
-        let got = entries_counting(block_on(reader.list(&root, &Key::empty())).unwrap());
-        assert_eq!(got, vec![dir(b"deep/"), file(b"top.txt", 0xFF)]);
-        // Seeking past the subtree keeps the fetch count to the frontier, far
-        // below the 64 leaves under it.
-        assert!(store.gets() < 16, "fetched {} nodes", store.gets());
+            let reader: Reader<_> = Reader::new(&store);
+            let got = entries_counting(reader.list(&root, &Key::empty()).await.unwrap()).await;
+            assert_eq!(got, vec![dir(b"deep/"), file(b"top.txt", 0xFF)]);
+            // Seeking past the subtree keeps the fetch count to the frontier, far
+            // below the 64 leaves under it.
+            assert!(store.gets() < 16, "fetched {} nodes", store.gets());
+        })
     }
 
     #[test]
     fn list_delegates_a_referenced_subtree() {
-        use crate::bounded::Prefix;
-        use crate::fork::{Child, ForkTable};
-        use crate::node::Node;
-        use crate::store::NodePut;
+        run(async {
+            use crate::bounded::Prefix;
+            use crate::fork::{Child, ForkTable};
+            use crate::node::Node;
+            use crate::store::NodePut;
 
-        let store = MemoryStore::default();
-        // A referenced "mg/" subtree holding a nested subdirectory and a file,
-        // so listing it delegates to the subtree root and still collapses and
-        // reseeks in the subtree's own key space.
-        let mut inner = ForkTable::new();
-        inner
-            .insert(
-                Prefix::try_from(&b"1"[..]).unwrap(),
-                entry(0x01).into(),
+            let store = MemoryStore::default();
+            // A referenced "mg/" subtree holding a nested subdirectory and a file,
+            // so listing it delegates to the subtree root and still collapses and
+            // reseeks in the subtree's own key space.
+            let mut inner = ForkTable::new();
+            inner
+                .insert(
+                    Prefix::try_from(&b"1"[..]).unwrap(),
+                    entry(0x01).into(),
+                    None,
+                )
+                .unwrap();
+            inner
+                .insert(
+                    Prefix::try_from(&b"2"[..]).unwrap(),
+                    entry(0x02).into(),
+                    None,
+                )
+                .unwrap();
+            let mut leaf = ForkTable::new();
+            leaf.insert(
+                Prefix::try_from(&b"a/"[..]).unwrap(),
+                Child::Embedded(inner).into(),
                 None,
             )
             .unwrap();
-        inner
-            .insert(
-                Prefix::try_from(&b"2"[..]).unwrap(),
-                entry(0x02).into(),
+            leaf.insert(
+                Prefix::try_from(&b"logo.png"[..]).unwrap(),
+                entry(0xBB).into(),
                 None,
             )
             .unwrap();
-        let mut leaf = ForkTable::new();
-        leaf.insert(
-            Prefix::try_from(&b"a/"[..]).unwrap(),
-            Child::Embedded(inner).into(),
-            None,
-        )
-        .unwrap();
-        leaf.insert(
-            Prefix::try_from(&b"logo.png"[..]).unwrap(),
-            entry(0xBB).into(),
-            None,
-        )
-        .unwrap();
-        let leaf_ref = block_on(store.put_node(&Node::new(None, leaf))).unwrap();
+            let leaf_ref = store.put_node(&Node::new(None, leaf)).await.unwrap();
 
-        let mut forks: ForkTable = ForkTable::new();
-        forks
-            .insert(
-                Prefix::try_from(&b"mg/"[..]).unwrap(),
-                Child::Ref32(ChunkRef::new(leaf_ref)).into(),
-                None,
-            )
-            .unwrap();
-        let root = block_on(store.put_node(&Node::new(None, forks))).unwrap();
+            let mut forks: ForkTable = ForkTable::new();
+            forks
+                .insert(
+                    Prefix::try_from(&b"mg/"[..]).unwrap(),
+                    Child::Ref32(ChunkRef::new(leaf_ref)).into(),
+                    None,
+                )
+                .unwrap();
+            let root = store.put_node(&Node::new(None, forks)).await.unwrap();
 
-        let reader: Reader<_> = Reader::new(&store);
-        let got = entries(block_on(reader.list(&root, &Key::from(&b"mg/"[..]))).unwrap());
-        assert_eq!(got, vec![dir(b"mg/a/"), file(b"mg/logo.png", 0xBB)]);
+            let reader: Reader<_> = Reader::new(&store);
+            let got = entries(reader.list(&root, &Key::from(&b"mg/"[..])).await.unwrap()).await;
+            assert_eq!(got, vec![dir(b"mg/a/"), file(b"mg/logo.png", 0xBB)]);
+        })
     }
 
     #[test]
     fn serve_prefers_an_exact_key() {
-        let store = MemoryStore::default();
-        let root = manifest(&store, &[(b"a.html", 0x01)]);
-        let reader: Reader<_> = Reader::new(&store);
-        assert_eq!(
-            block_on(reader.serve(&root, &Key::from(&b"a.html"[..]))).unwrap(),
-            Served::Exact {
-                key: Key::from(&b"a.html"[..]),
-                entry: entry(0x01),
-            }
-        );
+        run(async {
+            let store = MemoryStore::default();
+            let root = manifest(&store, &[(b"a.html", 0x01)]).await;
+            let reader: Reader<_> = Reader::new(&store);
+            assert_eq!(
+                reader
+                    .serve(&root, &Key::from(&b"a.html"[..]))
+                    .await
+                    .unwrap(),
+                Served::Exact {
+                    key: Key::from(&b"a.html"[..]),
+                    entry: entry(0x01),
+                }
+            );
+        })
     }
 
     #[test]
     fn serve_falls_back_to_the_index_document() {
-        let store = MemoryStore::default();
-        let mut builder = Builder::new();
-        builder.insert(Key::from(&b"index.html"[..]), entry(0x01), None);
-        builder.insert(Key::from(&b"docs/index.html"[..]), entry(0x02), None);
-        builder.manifest_metadata(
-            Metadata::new(
-                KeyId::WebsiteIndexDocument,
-                Bytes::from_static(b"index.html"),
-            )
-            .unwrap(),
-        );
-        let root = *block_on(builder.build(&store)).unwrap().root();
-        let reader: Reader<_> = Reader::new(&store);
+        run(async {
+            let store = MemoryStore::default();
+            let mut builder = Builder::new();
+            builder.insert(Key::from(&b"index.html"[..]), entry(0x01), None);
+            builder.insert(Key::from(&b"docs/index.html"[..]), entry(0x02), None);
+            builder.manifest_metadata(
+                Metadata::new(
+                    KeyId::WebsiteIndexDocument,
+                    Bytes::from_static(b"index.html"),
+                )
+                .unwrap(),
+            );
+            let root = *builder.build(&store).await.unwrap().root();
+            let reader: Reader<_> = Reader::new(&store);
 
-        // The root path resolves to the top-level index document.
-        assert_eq!(
-            block_on(reader.serve(&root, &Key::empty())).unwrap(),
-            Served::Index {
-                key: Key::from(&b"index.html"[..]),
-                entry: entry(0x01),
-            }
-        );
-        // A directory path (trailing separator) resolves to its index document.
-        assert_eq!(
-            block_on(reader.serve(&root, &Key::from(&b"docs/"[..]))).unwrap(),
-            Served::Index {
-                key: Key::from(&b"docs/index.html"[..]),
-                entry: entry(0x02),
-            }
-        );
-        // A directory path without a trailing separator is read as one too.
-        assert_eq!(
-            block_on(reader.serve(&root, &Key::from(&b"docs"[..]))).unwrap(),
-            Served::Index {
-                key: Key::from(&b"docs/index.html"[..]),
-                entry: entry(0x02),
-            }
-        );
+            // The root path resolves to the top-level index document.
+            assert_eq!(
+                reader.serve(&root, &Key::empty()).await.unwrap(),
+                Served::Index {
+                    key: Key::from(&b"index.html"[..]),
+                    entry: entry(0x01),
+                }
+            );
+            // A directory path (trailing separator) resolves to its index document.
+            assert_eq!(
+                reader
+                    .serve(&root, &Key::from(&b"docs/"[..]))
+                    .await
+                    .unwrap(),
+                Served::Index {
+                    key: Key::from(&b"docs/index.html"[..]),
+                    entry: entry(0x02),
+                }
+            );
+            // A directory path without a trailing separator is read as one too.
+            assert_eq!(
+                reader.serve(&root, &Key::from(&b"docs"[..])).await.unwrap(),
+                Served::Index {
+                    key: Key::from(&b"docs/index.html"[..]),
+                    entry: entry(0x02),
+                }
+            );
+        })
     }
 
     #[test]
     fn serve_falls_back_to_the_error_document() {
-        let store = MemoryStore::default();
-        let mut builder = Builder::new();
-        builder.insert(Key::from(&b"404.html"[..]), entry(0x09), None);
-        builder.manifest_metadata(
-            Metadata::new(KeyId::WebsiteErrorDocument, Bytes::from_static(b"404.html")).unwrap(),
-        );
-        let root = *block_on(builder.build(&store)).unwrap().root();
-        let reader: Reader<_> = Reader::new(&store);
+        run(async {
+            let store = MemoryStore::default();
+            let mut builder = Builder::new();
+            builder.insert(Key::from(&b"404.html"[..]), entry(0x09), None);
+            builder.manifest_metadata(
+                Metadata::new(KeyId::WebsiteErrorDocument, Bytes::from_static(b"404.html"))
+                    .unwrap(),
+            );
+            let root = *builder.build(&store).await.unwrap().root();
+            let reader: Reader<_> = Reader::new(&store);
 
-        assert_eq!(
-            block_on(reader.serve(&root, &Key::from(&b"missing"[..]))).unwrap(),
-            Served::Error {
-                key: Key::from(&b"404.html"[..]),
-                entry: entry(0x09),
-            }
-        );
+            assert_eq!(
+                reader
+                    .serve(&root, &Key::from(&b"missing"[..]))
+                    .await
+                    .unwrap(),
+                Served::Error {
+                    key: Key::from(&b"404.html"[..]),
+                    entry: entry(0x09),
+                }
+            );
+        })
     }
 
     #[test]
     fn serve_missing_without_conventions_is_missing() {
-        let store = MemoryStore::default();
-        let root = manifest(&store, &[(b"a.html", 0x01)]);
-        let reader: Reader<_> = Reader::new(&store);
-        assert_eq!(
-            block_on(reader.serve(&root, &Key::from(&b"nope"[..]))).unwrap(),
-            Served::Missing
-        );
+        run(async {
+            let store = MemoryStore::default();
+            let root = manifest(&store, &[(b"a.html", 0x01)]).await;
+            let reader: Reader<_> = Reader::new(&store);
+            assert_eq!(
+                reader.serve(&root, &Key::from(&b"nope"[..])).await.unwrap(),
+                Served::Missing
+            );
+        })
     }
 
     #[test]
     fn website_reads_the_root_conventions() {
-        let store = MemoryStore::default();
-        let mut builder = Builder::new();
-        builder.insert(Key::from(&b"index.html"[..]), entry(0x01), None);
-        let mut meta = Metadata::new(
-            KeyId::WebsiteIndexDocument,
-            Bytes::from_static(b"index.html"),
-        )
-        .unwrap();
-        meta.insert(KeyId::WebsiteErrorDocument, Bytes::from_static(b"404.html"))
+        run(async {
+            let store = MemoryStore::default();
+            let mut builder = Builder::new();
+            builder.insert(Key::from(&b"index.html"[..]), entry(0x01), None);
+            let mut meta = Metadata::new(
+                KeyId::WebsiteIndexDocument,
+                Bytes::from_static(b"index.html"),
+            )
             .unwrap();
-        builder.manifest_metadata(meta);
-        let root = *block_on(builder.build(&store)).unwrap().root();
-        let reader: Reader<_> = Reader::new(&store);
+            meta.insert(KeyId::WebsiteErrorDocument, Bytes::from_static(b"404.html"))
+                .unwrap();
+            builder.manifest_metadata(meta);
+            let root = *builder.build(&store).await.unwrap().root();
+            let reader: Reader<_> = Reader::new(&store);
 
-        let site = block_on(reader.website(&root)).unwrap();
-        assert_eq!(site.index(), Some(&b"index.html"[..]));
-        assert_eq!(site.error(), Some(&b"404.html"[..]));
+            let site = reader.website(&root).await.unwrap();
+            assert_eq!(site.index(), Some(&b"index.html"[..]));
+            assert_eq!(site.error(), Some(&b"404.html"[..]));
+        })
     }
 
     // A trusted store that counts each fetch, so a test can read off how many
@@ -678,9 +713,9 @@ mod tests {
         }
     }
 
-    fn entries_counting(mut listing: Listing<'_, &CountingStore>) -> Vec<DirEntry> {
+    async fn entries_counting(mut listing: Listing<'_, &CountingStore>) -> Vec<DirEntry> {
         let mut out = Vec::new();
-        while let Some(item) = block_on(listing.next()).unwrap() {
+        while let Some(item) = listing.next().await.unwrap() {
             out.push(item);
         }
         out

--- a/crates/manifest/src/order.rs
+++ b/crates/manifest/src/order.rs
@@ -531,9 +531,9 @@ fn select_fragment<F: Format>(steps: Vec<Ranked<F>>, index: &mut u64) -> Option<
 
 #[cfg(test)]
 mod tests {
-    use futures::executor::block_on;
     use nectar_primitives::store::MemoryStore;
     use nectar_primitives::{ChunkAddress, ChunkRef, EncryptedChunkRef, EncryptionKey};
+    use nectar_testing::run;
 
     use crate::bounded::Prefix;
     use crate::count::SubtreeCount;
@@ -555,44 +555,46 @@ mod tests {
 
     #[test]
     fn the_root_entry_is_index_zero_and_lifts_every_rank() {
-        let store = MemoryStore::default();
-        let root_ext = RootExtension::new(Some(entry(9)), None);
-        let mut forks = ForkTable::new();
-        forks.insert(prefix(b"k"), entry(1).into(), None).unwrap();
-        let root = block_on(store.put_node(&Node::<V1>::new(root_ext, forks))).unwrap();
-        let reader = Reader::<&MemoryStore, V1>::new(&store);
+        run(async {
+            let store = MemoryStore::default();
+            let root_ext = RootExtension::new(Some(entry(9)), None);
+            let mut forks = ForkTable::new();
+            forks.insert(prefix(b"k"), entry(1).into(), None).unwrap();
+            let root = store
+                .put_node(&Node::<V1>::new(root_ext, forks))
+                .await
+                .unwrap();
+            let reader = Reader::<&MemoryStore, V1>::new(&store);
 
-        // The empty key leads iteration at index 0; "k" follows at index 1.
-        assert_eq!(
-            block_on(reader.select(&root, 0)).unwrap(),
-            Some((Key::empty(), entry(9)))
-        );
-        assert_eq!(
-            block_on(reader.select(&root, 1)).unwrap(),
-            Some((Key::from(&b"k"[..]), entry(1)))
-        );
-        assert_eq!(block_on(reader.select(&root, 2)).unwrap(), None);
+            // The empty key leads iteration at index 0; "k" follows at index 1.
+            assert_eq!(
+                reader.select(&root, 0).await.unwrap(),
+                Some((Key::empty(), entry(9)))
+            );
+            assert_eq!(
+                reader.select(&root, 1).await.unwrap(),
+                Some((Key::from(&b"k"[..]), entry(1)))
+            );
+            assert_eq!(reader.select(&root, 2).await.unwrap(), None);
 
-        // Nothing is strictly before the empty key; the root entry sits before
-        // every other key, so it lifts their ranks by one.
-        assert_eq!(block_on(reader.rank(&root, &Key::empty())).unwrap(), 0);
-        assert_eq!(
-            block_on(reader.rank(&root, &Key::from(&b"k"[..]))).unwrap(),
-            1
-        );
-        assert_eq!(
-            block_on(reader.rank(&root, &Key::from(&b"z"[..]))).unwrap(),
-            2
-        );
-        assert_eq!(
-            block_on(reader.count(&root, &Key::empty(), &Key::from(&b"z"[..]))).unwrap(),
-            2
-        );
+            // Nothing is strictly before the empty key; the root entry sits before
+            // every other key, so it lifts their ranks by one.
+            assert_eq!(reader.rank(&root, &Key::empty()).await.unwrap(), 0);
+            assert_eq!(reader.rank(&root, &Key::from(&b"k"[..])).await.unwrap(), 1);
+            assert_eq!(reader.rank(&root, &Key::from(&b"z"[..])).await.unwrap(), 2);
+            assert_eq!(
+                reader
+                    .count(&root, &Key::empty(), &Key::from(&b"z"[..]))
+                    .await
+                    .unwrap(),
+                2
+            );
+        })
     }
 
     // A root holding "a" and "z" as plain values with an encrypted five-key
     // subtree wedged between them under "m"; the count rides the fork record.
-    fn with_encrypted(store: &MemoryStore) -> ChunkAddress {
+    async fn with_encrypted(store: &MemoryStore) -> ChunkAddress {
         let mut forks = ForkTable::new();
         forks
             .insert(prefix(b"a"), entry(0xA1).into(), None)
@@ -615,62 +617,62 @@ mod tests {
         forks
             .insert(prefix(b"z"), entry(0x2C).into(), None)
             .unwrap();
-        block_on(store.put_node(&Node::<V1>::new(None, forks))).unwrap()
+        store.put_node(&Node::<V1>::new(None, forks)).await.unwrap()
     }
 
     #[test]
     fn an_encrypted_subtree_is_counted_without_being_opened() {
-        let store = MemoryStore::default();
-        let root = with_encrypted(&store);
-        let reader = Reader::<&MemoryStore, V1>::new(&store);
+        run(async {
+            let store = MemoryStore::default();
+            let root = with_encrypted(&store).await;
+            let reader = Reader::<&MemoryStore, V1>::new(&store);
 
-        // Ranking past the encrypted subtree adds its stored count: "a", then its
-        // five keys, all strictly before "z".
-        assert_eq!(
-            block_on(reader.rank(&root, &Key::from(&b"z"[..]))).unwrap(),
-            6
-        );
-        // A key at the encrypted prefix does not descend; its keys are longer.
-        assert_eq!(
-            block_on(reader.rank(&root, &Key::from(&b"m"[..]))).unwrap(),
-            1
-        );
-        // Selecting the key just past the subtree skips all five by count.
-        assert_eq!(
-            block_on(reader.select(&root, 6)).unwrap(),
-            Some((Key::from(&b"z"[..]), entry(0x2C)))
-        );
+            // Ranking past the encrypted subtree adds its stored count: "a", then its
+            // five keys, all strictly before "z".
+            assert_eq!(reader.rank(&root, &Key::from(&b"z"[..])).await.unwrap(), 6);
+            // A key at the encrypted prefix does not descend; its keys are longer.
+            assert_eq!(reader.rank(&root, &Key::from(&b"m"[..])).await.unwrap(), 1);
+            // Selecting the key just past the subtree skips all five by count.
+            assert_eq!(
+                reader.select(&root, 6).await.unwrap(),
+                Some((Key::from(&b"z"[..]), entry(0x2C)))
+            );
+        })
     }
 
     #[test]
     fn descending_into_an_encrypted_subtree_is_an_error() {
-        let store = MemoryStore::default();
-        let root = with_encrypted(&store);
-        let reader = Reader::<&MemoryStore, V1>::new(&store);
+        run(async {
+            let store = MemoryStore::default();
+            let root = with_encrypted(&store).await;
+            let reader = Reader::<&MemoryStore, V1>::new(&store);
 
-        // A rank whose key funnels into the encrypted subtree cannot be answered.
-        assert!(matches!(
-            block_on(reader.rank(&root, &Key::from(&b"mx"[..]))),
-            Err(ReaderError::EncryptedChild)
-        ));
-        // An index landing inside the encrypted subtree cannot be opened.
-        assert!(matches!(
-            block_on(reader.select(&root, 3)),
-            Err(ReaderError::EncryptedChild)
-        ));
+            // A rank whose key funnels into the encrypted subtree cannot be answered.
+            assert!(matches!(
+                reader.rank(&root, &Key::from(&b"mx"[..])).await,
+                Err(ReaderError::EncryptedChild)
+            ));
+            // An index landing inside the encrypted subtree cannot be opened.
+            assert!(matches!(
+                reader.select(&root, 3).await,
+                Err(ReaderError::EncryptedChild)
+            ));
+        })
     }
 
     #[test]
     fn an_empty_manifest_has_no_keys() {
-        let store = MemoryStore::default();
-        let root = block_on(store.put_node(&Node::<V1>::empty())).unwrap();
-        let reader = Reader::<&MemoryStore, V1>::new(&store);
-        assert_eq!(
-            block_on(reader.rank(&root, &Key::from(&b"x"[..]))).unwrap(),
-            0
-        );
-        assert_eq!(block_on(reader.select(&root, 0)).unwrap(), None);
-        let mut cursor = block_on(reader.paginate_prefix(&root, &Key::empty(), 0, 10)).unwrap();
-        assert!(block_on(cursor.next()).unwrap().is_none());
+        run(async {
+            let store = MemoryStore::default();
+            let root = store.put_node(&Node::<V1>::empty()).await.unwrap();
+            let reader = Reader::<&MemoryStore, V1>::new(&store);
+            assert_eq!(reader.rank(&root, &Key::from(&b"x"[..])).await.unwrap(), 0);
+            assert_eq!(reader.select(&root, 0).await.unwrap(), None);
+            let mut cursor = reader
+                .paginate_prefix(&root, &Key::empty(), 0, 10)
+                .await
+                .unwrap();
+            assert!(cursor.next().await.unwrap().is_none());
+        })
     }
 }

--- a/crates/manifest/src/reader.rs
+++ b/crates/manifest/src/reader.rs
@@ -389,9 +389,9 @@ fn descend<F: Format>(table: &ForkTable<F>, key: &[u8], pos: usize) -> Descent<F
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
-    use futures::executor::block_on;
     use nectar_primitives::store::MemoryStore;
     use nectar_primitives::{ChunkAddress, ChunkRef, EncryptedChunkRef, EncryptionKey};
+    use nectar_testing::run;
 
     use crate::bounded::Prefix;
     use crate::fork::{Child, ForkPayload, ForkTable};
@@ -411,114 +411,134 @@ mod tests {
 
     #[test]
     fn descends_embedded_and_referenced_children_alike() {
-        let store = MemoryStore::default();
+        run(async {
+            let store = MemoryStore::default();
 
-        // A leaf reached by reference, holding the key "img/logo.png".
-        let mut leaf = ForkTable::new();
-        leaf.insert(prefix(b"logo.png"), entry(0xBB).into(), None)
-            .unwrap();
-        let leaf_ref = block_on(store.put_node(&Node::new(None, leaf))).unwrap();
+            // A leaf reached by reference, holding the key "img/logo.png".
+            let mut leaf = ForkTable::new();
+            leaf.insert(prefix(b"logo.png"), entry(0xBB).into(), None)
+                .unwrap();
+            let leaf_ref = store.put_node(&Node::new(None, leaf)).await.unwrap();
 
-        // The root: "index.html" behind an embedded child, "mg/" behind the
-        // referenced leaf.
-        let mut embedded = ForkTable::new();
-        embedded
-            .insert(prefix(b"ndex.html"), entry(0xAA).into(), None)
-            .unwrap();
-        let mut forks = ForkTable::new();
-        forks
-            .insert(prefix(b"i"), Child::Embedded(embedded).into(), None)
-            .unwrap();
-        forks
-            .insert(
-                prefix(b"mg/"),
-                Child::Ref32(ChunkRef::new(leaf_ref)).into(),
+            // The root: "index.html" behind an embedded child, "mg/" behind the
+            // referenced leaf.
+            let mut embedded = ForkTable::new();
+            embedded
+                .insert(prefix(b"ndex.html"), entry(0xAA).into(), None)
+                .unwrap();
+            let mut forks = ForkTable::new();
+            forks
+                .insert(prefix(b"i"), Child::Embedded(embedded).into(), None)
+                .unwrap();
+            forks
+                .insert(
+                    prefix(b"mg/"),
+                    Child::Ref32(ChunkRef::new(leaf_ref)).into(),
+                    None,
+                )
+                .unwrap();
+            let root = store.put_node(&Node::new(None, forks)).await.unwrap();
+
+            let reader: Reader<_> = Reader::new(&store);
+            assert_eq!(
+                reader
+                    .get(&root, &Key::from(&b"index.html"[..]))
+                    .await
+                    .unwrap(),
+                Some(entry(0xAA)),
+            );
+            assert_eq!(
+                reader
+                    .get(&root, &Key::from(&b"mg/logo.png"[..]))
+                    .await
+                    .unwrap(),
+                Some(entry(0xBB)),
+            );
+            // A key that prefixes an edge without reaching its end is absent.
+            assert_eq!(
+                reader
+                    .get(&root, &Key::from(&b"mg/logo"[..]))
+                    .await
+                    .unwrap(),
                 None,
-            )
-            .unwrap();
-        let root = block_on(store.put_node(&Node::new(None, forks))).unwrap();
-
-        let reader: Reader<_> = Reader::new(&store);
-        assert_eq!(
-            block_on(reader.get(&root, &Key::from(&b"index.html"[..]))).unwrap(),
-            Some(entry(0xAA)),
-        );
-        assert_eq!(
-            block_on(reader.get(&root, &Key::from(&b"mg/logo.png"[..]))).unwrap(),
-            Some(entry(0xBB)),
-        );
-        // A key that prefixes an edge without reaching its end is absent.
-        assert_eq!(
-            block_on(reader.get(&root, &Key::from(&b"mg/logo"[..]))).unwrap(),
-            None,
-        );
-        // A key past a fork with no matching continuation is absent.
-        assert_eq!(
-            block_on(reader.get(&root, &Key::from(&b"other"[..]))).unwrap(),
-            None,
-        );
+            );
+            // A key past a fork with no matching continuation is absent.
+            assert_eq!(
+                reader.get(&root, &Key::from(&b"other"[..])).await.unwrap(),
+                None,
+            );
+        })
     }
 
     #[test]
     fn a_fork_with_only_a_child_holds_no_value_at_its_own_prefix() {
-        let store = MemoryStore::default();
-        let mut child = ForkTable::new();
-        child.insert(prefix(b"b"), entry(1).into(), None).unwrap();
-        let mut forks = ForkTable::new();
-        forks
-            .insert(prefix(b"a"), Child::Embedded(child).into(), None)
-            .unwrap();
-        let root = block_on(store.put_node(&Node::new(None, forks))).unwrap();
+        run(async {
+            let store = MemoryStore::default();
+            let mut child = ForkTable::new();
+            child.insert(prefix(b"b"), entry(1).into(), None).unwrap();
+            let mut forks = ForkTable::new();
+            forks
+                .insert(prefix(b"a"), Child::Embedded(child).into(), None)
+                .unwrap();
+            let root = store.put_node(&Node::new(None, forks)).await.unwrap();
 
-        let reader: Reader<_> = Reader::new(&store);
-        // "ab" terminates, "a" is only a branch.
-        assert_eq!(
-            block_on(reader.get(&root, &Key::from(&b"ab"[..]))).unwrap(),
-            Some(entry(1)),
-        );
-        assert_eq!(
-            block_on(reader.get(&root, &Key::from(&b"a"[..]))).unwrap(),
-            None,
-        );
+            let reader: Reader<_> = Reader::new(&store);
+            // "ab" terminates, "a" is only a branch.
+            assert_eq!(
+                reader.get(&root, &Key::from(&b"ab"[..])).await.unwrap(),
+                Some(entry(1)),
+            );
+            assert_eq!(
+                reader.get(&root, &Key::from(&b"a"[..])).await.unwrap(),
+                None,
+            );
+        })
     }
 
     #[test]
     fn the_empty_key_reads_the_root_extension_value() {
-        let store = MemoryStore::default();
-        let root_ext = crate::node::RootExtension::new(Some(entry(9)), None);
-        let root = block_on(store.put_node(&Node::new(root_ext, ForkTable::new()))).unwrap();
+        run(async {
+            let store = MemoryStore::default();
+            let root_ext = crate::node::RootExtension::new(Some(entry(9)), None);
+            let root = store
+                .put_node(&Node::new(root_ext, ForkTable::new()))
+                .await
+                .unwrap();
 
-        let reader: Reader<_> = Reader::new(&store);
-        assert_eq!(
-            block_on(reader.get(&root, &Key::empty())).unwrap(),
-            Some(entry(9)),
-        );
+            let reader: Reader<_> = Reader::new(&store);
+            assert_eq!(
+                reader.get(&root, &Key::empty()).await.unwrap(),
+                Some(entry(9)),
+            );
+        })
     }
 
     #[test]
     fn inline_values_read_back_whole() {
-        let store = MemoryStore::default();
-        let value = Entry::inline(Bytes::from_static(b"hi")).unwrap();
-        let mut forks = ForkTable::new();
-        forks
-            .insert(prefix(b"k"), ForkPayload::Entry(value.clone()), None)
-            .unwrap();
-        let root = block_on(store.put_node(&Node::new(None, forks))).unwrap();
+        run(async {
+            let store = MemoryStore::default();
+            let value = Entry::inline(Bytes::from_static(b"hi")).unwrap();
+            let mut forks = ForkTable::new();
+            forks
+                .insert(prefix(b"k"), ForkPayload::Entry(value.clone()), None)
+                .unwrap();
+            let root = store.put_node(&Node::new(None, forks)).await.unwrap();
 
-        let reader: Reader<_> = Reader::new(&store);
-        assert_eq!(
-            block_on(reader.get(&root, &Key::from(&b"k"[..]))).unwrap(),
-            Some(value),
-        );
+            let reader: Reader<_> = Reader::new(&store);
+            assert_eq!(
+                reader.get(&root, &Key::from(&b"k"[..])).await.unwrap(),
+                Some(value),
+            );
+        })
     }
 
     // A manifest whose "mg/" directory is a referenced subtree holding one key
     // "mg/logo.png", with "index.html" embedded in the root under "i".
-    fn subtree_sample(store: &MemoryStore) -> (ChunkAddress, ChunkAddress) {
+    async fn subtree_sample(store: &MemoryStore) -> (ChunkAddress, ChunkAddress) {
         let mut leaf = ForkTable::new();
         leaf.insert(prefix(b"logo.png"), entry(0xBB).into(), None)
             .unwrap();
-        let leaf_ref = block_on(store.put_node(&Node::new(None, leaf))).unwrap();
+        let leaf_ref = store.put_node(&Node::new(None, leaf)).await.unwrap();
 
         let mut embedded = ForkTable::new();
         embedded
@@ -535,142 +555,171 @@ mod tests {
                 None,
             )
             .unwrap();
-        let root = block_on(store.put_node(&Node::new(None, forks))).unwrap();
+        let root = store.put_node(&Node::new(None, forks)).await.unwrap();
         (root, leaf_ref)
     }
 
     #[test]
     fn subtree_of_the_empty_prefix_is_the_root() {
-        let store = MemoryStore::default();
-        let (root, _) = subtree_sample(&store);
-        let reader: Reader<_> = Reader::new(&store);
-        assert_eq!(
-            block_on(reader.subtree(&root, &Key::empty())).unwrap(),
-            Some(ChunkRef::new(root)),
-        );
+        run(async {
+            let store = MemoryStore::default();
+            let (root, _) = subtree_sample(&store).await;
+            let reader: Reader<_> = Reader::new(&store);
+            assert_eq!(
+                reader.subtree(&root, &Key::empty()).await.unwrap(),
+                Some(ChunkRef::new(root)),
+            );
+        })
     }
 
     #[test]
     fn subtree_returns_the_referenced_child_covering_the_prefix() {
-        let store = MemoryStore::default();
-        let (root, leaf_ref) = subtree_sample(&store);
-        let reader: Reader<_> = Reader::new(&store);
-        // The prefix ends exactly at the referenced edge: the child is the
-        // subtree root, and its key set is exactly the "mg/" keys.
-        assert_eq!(
-            block_on(reader.subtree(&root, &Key::from(&b"mg/"[..]))).unwrap(),
-            Some(ChunkRef::new(leaf_ref)),
-        );
-        // A shorter prefix funnels into the same lone child with no branch or
-        // key between: still one node boundary, still the child.
-        assert_eq!(
-            block_on(reader.subtree(&root, &Key::from(&b"m"[..]))).unwrap(),
-            Some(ChunkRef::new(leaf_ref)),
-        );
+        run(async {
+            let store = MemoryStore::default();
+            let (root, leaf_ref) = subtree_sample(&store).await;
+            let reader: Reader<_> = Reader::new(&store);
+            // The prefix ends exactly at the referenced edge: the child is the
+            // subtree root, and its key set is exactly the "mg/" keys.
+            assert_eq!(
+                reader
+                    .subtree(&root, &Key::from(&b"mg/"[..]))
+                    .await
+                    .unwrap(),
+                Some(ChunkRef::new(leaf_ref)),
+            );
+            // A shorter prefix funnels into the same lone child with no branch or
+            // key between: still one node boundary, still the child.
+            assert_eq!(
+                reader.subtree(&root, &Key::from(&b"m"[..])).await.unwrap(),
+                Some(ChunkRef::new(leaf_ref)),
+            );
+        })
     }
 
     #[test]
     fn subtree_of_a_mid_edge_prefix_with_no_boundary_is_none() {
-        let store = MemoryStore::default();
-        let (root, _) = subtree_sample(&store);
-        let reader: Reader<_> = Reader::new(&store);
-        // "mg/logo" lands within the leaf's "logo.png" edge, which terminates a
-        // key rather than referencing a child: no chunk holds exactly its keys.
-        assert_eq!(
-            block_on(reader.subtree(&root, &Key::from(&b"mg/logo"[..]))).unwrap(),
-            None,
-        );
+        run(async {
+            let store = MemoryStore::default();
+            let (root, _) = subtree_sample(&store).await;
+            let reader: Reader<_> = Reader::new(&store);
+            // "mg/logo" lands within the leaf's "logo.png" edge, which terminates a
+            // key rather than referencing a child: no chunk holds exactly its keys.
+            assert_eq!(
+                reader
+                    .subtree(&root, &Key::from(&b"mg/logo"[..]))
+                    .await
+                    .unwrap(),
+                None,
+            );
+        })
     }
 
     #[test]
     fn subtree_of_an_embedded_prefix_is_none() {
-        let store = MemoryStore::default();
-        let (root, _) = subtree_sample(&store);
-        let reader: Reader<_> = Reader::new(&store);
-        // "index.html" lives embedded in the root chunk, with no chunk of its
-        // own to hand off.
-        assert_eq!(
-            block_on(reader.subtree(&root, &Key::from(&b"i"[..]))).unwrap(),
-            None,
-        );
+        run(async {
+            let store = MemoryStore::default();
+            let (root, _) = subtree_sample(&store).await;
+            let reader: Reader<_> = Reader::new(&store);
+            // "index.html" lives embedded in the root chunk, with no chunk of its
+            // own to hand off.
+            assert_eq!(
+                reader.subtree(&root, &Key::from(&b"i"[..])).await.unwrap(),
+                None,
+            );
+        })
     }
 
     #[test]
     fn subtree_of_an_absent_prefix_is_none() {
-        let store = MemoryStore::default();
-        let (root, _) = subtree_sample(&store);
-        let reader: Reader<_> = Reader::new(&store);
-        assert_eq!(
-            block_on(reader.subtree(&root, &Key::from(&b"zzz"[..]))).unwrap(),
-            None,
-        );
+        run(async {
+            let store = MemoryStore::default();
+            let (root, _) = subtree_sample(&store).await;
+            let reader: Reader<_> = Reader::new(&store);
+            assert_eq!(
+                reader
+                    .subtree(&root, &Key::from(&b"zzz"[..]))
+                    .await
+                    .unwrap(),
+                None,
+            );
+        })
     }
 
     #[test]
     fn subtree_through_an_encrypted_child_is_an_error() {
-        let store = MemoryStore::default();
-        // A "sec/" directory referenced through an encrypted (ref64) child: the
-        // plain reader cannot open it, and a 32-byte reference cannot carry it.
-        let mut forks = ForkTable::new();
-        forks
-            .insert(
-                prefix(b"sec/"),
-                Child::Ref64(EncryptedChunkRef::new(
-                    ChunkAddress::new([0x5E; 32]),
-                    EncryptionKey::from([0xA1; 32]),
-                ))
-                .into(),
-                None,
-            )
-            .unwrap();
-        let root = block_on(store.put_node(&Node::new(None, forks))).unwrap();
-        let reader: Reader<_> = Reader::new(&store);
-        // The boundary lands exactly on the encrypted edge.
-        assert!(matches!(
-            block_on(reader.subtree(&root, &Key::from(&b"sec/"[..]))),
-            Err(ReaderError::EncryptedChild),
-        ));
-        // A shorter prefix funnelling into the same encrypted child errs alike.
-        assert!(matches!(
-            block_on(reader.subtree(&root, &Key::from(&b"s"[..]))),
-            Err(ReaderError::EncryptedChild),
-        ));
+        run(async {
+            let store = MemoryStore::default();
+            // A "sec/" directory referenced through an encrypted (ref64) child: the
+            // plain reader cannot open it, and a 32-byte reference cannot carry it.
+            let mut forks = ForkTable::new();
+            forks
+                .insert(
+                    prefix(b"sec/"),
+                    Child::Ref64(EncryptedChunkRef::new(
+                        ChunkAddress::new([0x5E; 32]),
+                        EncryptionKey::from([0xA1; 32]),
+                    ))
+                    .into(),
+                    None,
+                )
+                .unwrap();
+            let root = store.put_node(&Node::new(None, forks)).await.unwrap();
+            let reader: Reader<_> = Reader::new(&store);
+            // The boundary lands exactly on the encrypted edge.
+            assert!(matches!(
+                reader.subtree(&root, &Key::from(&b"sec/"[..])).await,
+                Err(ReaderError::EncryptedChild),
+            ));
+            // A shorter prefix funnelling into the same encrypted child errs alike.
+            assert!(matches!(
+                reader.subtree(&root, &Key::from(&b"s"[..])).await,
+                Err(ReaderError::EncryptedChild),
+            ));
+        })
     }
 
     #[test]
     fn subtree_covers_exactly_the_prefix_key_set() {
-        let store = MemoryStore::default();
-        let (root, leaf_ref) = subtree_sample(&store);
-        let reader: Reader<_> = Reader::new(&store);
-        let sub = block_on(reader.subtree(&root, &Key::from(&b"mg/"[..])))
-            .unwrap()
-            .unwrap();
-        assert_eq!(sub.address(), &leaf_ref);
+        run(async {
+            let store = MemoryStore::default();
+            let (root, leaf_ref) = subtree_sample(&store).await;
+            let reader: Reader<_> = Reader::new(&store);
+            let sub = reader
+                .subtree(&root, &Key::from(&b"mg/"[..]))
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(sub.address(), &leaf_ref);
 
-        // The delegated subtree, walked from its own root, yields the same keys
-        // as the prefix range walked from the manifest root.
-        let mut delegated = Vec::new();
-        let mut cursor = block_on(reader.iter(sub.address())).unwrap();
-        while let Some((key, value)) = block_on(cursor.next()).unwrap() {
-            let mut full = b"mg/".to_vec();
-            full.extend_from_slice(key.as_bytes());
-            delegated.push((full, value));
-        }
+            // The delegated subtree, walked from its own root, yields the same keys
+            // as the prefix range walked from the manifest root.
+            let mut delegated = Vec::new();
+            let mut cursor = reader.iter(sub.address()).await.unwrap();
+            while let Some((key, value)) = cursor.next().await.unwrap() {
+                let mut full = b"mg/".to_vec();
+                full.extend_from_slice(key.as_bytes());
+                delegated.push((full, value));
+            }
 
-        let mut walked = Vec::new();
-        let mut cursor = block_on(reader.prefix(&root, &Key::from(&b"mg/"[..]))).unwrap();
-        while let Some((key, value)) = block_on(cursor.next()).unwrap() {
-            walked.push((key.as_bytes().to_vec(), value));
-        }
-        assert_eq!(delegated, walked);
+            let mut walked = Vec::new();
+            let mut cursor = reader.prefix(&root, &Key::from(&b"mg/"[..])).await.unwrap();
+            while let Some((key, value)) = cursor.next().await.unwrap() {
+                walked.push((key.as_bytes().to_vec(), value));
+            }
+            assert_eq!(delegated, walked);
+        })
     }
 
     #[test]
     fn a_missing_root_is_a_store_error() {
-        let store = MemoryStore::default();
-        let reader: Reader<_> = Reader::new(&store);
-        let err =
-            block_on(reader.get(&ChunkAddress::new([0; 32]), &Key::from(&b"x"[..]))).unwrap_err();
-        assert!(matches!(err, ReaderError::Store(StoreError::Store(_))));
+        run(async {
+            let store = MemoryStore::default();
+            let reader: Reader<_> = Reader::new(&store);
+            let err = reader
+                .get(&ChunkAddress::new([0; 32]), &Key::from(&b"x"[..]))
+                .await
+                .unwrap_err();
+            assert!(matches!(err, ReaderError::Store(StoreError::Store(_))));
+        })
     }
 }

--- a/crates/manifest/src/scan.rs
+++ b/crates/manifest/src/scan.rs
@@ -658,9 +658,9 @@ pub(crate) fn successor(prefix: &[u8]) -> Option<Bytes> {
 
 #[cfg(test)]
 mod tests {
-    use futures::executor::block_on;
     use nectar_primitives::store::MemoryStore;
     use nectar_primitives::{ChunkAddress, ChunkRef, EncryptedChunkRef, EncryptionKey};
+    use nectar_testing::run;
 
     use crate::bounded::Prefix;
     use crate::fork::{Child, ForkTable};
@@ -678,9 +678,9 @@ mod tests {
         Prefix::try_from(bytes).unwrap()
     }
 
-    fn drain(mut cursor: Cursor<'_, &MemoryStore>) -> Vec<(Vec<u8>, Entry)> {
+    async fn drain(mut cursor: Cursor<'_, &MemoryStore>) -> Vec<(Vec<u8>, Entry)> {
         let mut out = Vec::new();
-        while let Some((key, value)) = block_on(cursor.next()).unwrap() {
+        while let Some((key, value)) = cursor.next().await.unwrap() {
             out.push((key.as_bytes().to_vec(), value));
         }
         out
@@ -688,10 +688,10 @@ mod tests {
 
     // A two-level manifest: a root fork "a" behind an embedded child holding
     // "aa"/"ab", and "b" behind a referenced leaf holding "ba".
-    fn sample(store: &MemoryStore) -> ChunkAddress {
+    async fn sample(store: &MemoryStore) -> ChunkAddress {
         let mut leaf = ForkTable::new();
         leaf.insert(prefix(b"a"), entry(0xBA).into(), None).unwrap();
-        let leaf_ref = block_on(store.put_node(&Node::new(None, leaf))).unwrap();
+        let leaf_ref = store.put_node(&Node::new(None, leaf)).await.unwrap();
 
         let mut embedded = ForkTable::new();
         embedded
@@ -711,100 +711,120 @@ mod tests {
                 None,
             )
             .unwrap();
-        block_on(store.put_node(&Node::new(None, forks))).unwrap()
+        store.put_node(&Node::new(None, forks)).await.unwrap()
     }
 
     #[test]
     fn iteration_is_ascending_across_embedded_and_referenced_children() {
-        let store = MemoryStore::default();
-        let root = sample(&store);
-        let reader: Reader<_> = Reader::new(&store);
-        let got = drain(block_on(reader.iter(&root)).unwrap());
-        assert_eq!(
-            got,
-            vec![
-                (b"aa".to_vec(), entry(0xAA)),
-                (b"ab".to_vec(), entry(0xAB)),
-                (b"ba".to_vec(), entry(0xBA)),
-            ]
-        );
+        run(async {
+            let store = MemoryStore::default();
+            let root = sample(&store).await;
+            let reader: Reader<_> = Reader::new(&store);
+            let got = drain(reader.iter(&root).await.unwrap()).await;
+            assert_eq!(
+                got,
+                vec![
+                    (b"aa".to_vec(), entry(0xAA)),
+                    (b"ab".to_vec(), entry(0xAB)),
+                    (b"ba".to_vec(), entry(0xBA)),
+                ]
+            );
+        })
     }
 
     #[test]
     fn the_root_value_is_the_empty_key_and_leads_iteration() {
-        let store = MemoryStore::default();
-        let root_ext = crate::node::RootExtension::new(Some(entry(9)), None);
-        let mut forks = ForkTable::new();
-        forks.insert(prefix(b"k"), entry(1).into(), None).unwrap();
-        let root = block_on(store.put_node(&Node::new(root_ext, forks))).unwrap();
-        let reader: Reader<_> = Reader::new(&store);
-        let got = drain(block_on(reader.iter(&root)).unwrap());
-        assert_eq!(got, vec![(Vec::new(), entry(9)), (b"k".to_vec(), entry(1))]);
+        run(async {
+            let store = MemoryStore::default();
+            let root_ext = crate::node::RootExtension::new(Some(entry(9)), None);
+            let mut forks = ForkTable::new();
+            forks.insert(prefix(b"k"), entry(1).into(), None).unwrap();
+            let root = store.put_node(&Node::new(root_ext, forks)).await.unwrap();
+            let reader: Reader<_> = Reader::new(&store);
+            let got = drain(reader.iter(&root).await.unwrap()).await;
+            assert_eq!(got, vec![(Vec::new(), entry(9)), (b"k".to_vec(), entry(1))]);
+        })
     }
 
     #[test]
     fn range_is_half_open() {
-        let store = MemoryStore::default();
-        let root = sample(&store);
-        let reader: Reader<_> = Reader::new(&store);
-        let got = drain(
-            block_on(reader.range(&root, &Key::from(&b"aa"[..]), &Key::from(&b"ba"[..]))).unwrap(),
-        );
-        // "aa" is included, "ba" is the excluded upper bound.
-        assert_eq!(
-            got,
-            vec![(b"aa".to_vec(), entry(0xAA)), (b"ab".to_vec(), entry(0xAB))]
-        );
+        run(async {
+            let store = MemoryStore::default();
+            let root = sample(&store).await;
+            let reader: Reader<_> = Reader::new(&store);
+            let got = drain(
+                reader
+                    .range(&root, &Key::from(&b"aa"[..]), &Key::from(&b"ba"[..]))
+                    .await
+                    .unwrap(),
+            )
+            .await;
+            // "aa" is included, "ba" is the excluded upper bound.
+            assert_eq!(
+                got,
+                vec![(b"aa".to_vec(), entry(0xAA)), (b"ab".to_vec(), entry(0xAB))]
+            );
+        })
     }
 
     #[test]
     fn range_starting_between_keys_seeks_to_the_ceiling() {
-        let store = MemoryStore::default();
-        let root = sample(&store);
-        let reader: Reader<_> = Reader::new(&store);
-        let got = drain(
-            block_on(reader.range(&root, &Key::from(&b"ac"[..]), &Key::from(&b"z"[..]))).unwrap(),
-        );
-        assert_eq!(got, vec![(b"ba".to_vec(), entry(0xBA))]);
+        run(async {
+            let store = MemoryStore::default();
+            let root = sample(&store).await;
+            let reader: Reader<_> = Reader::new(&store);
+            let got = drain(
+                reader
+                    .range(&root, &Key::from(&b"ac"[..]), &Key::from(&b"z"[..]))
+                    .await
+                    .unwrap(),
+            )
+            .await;
+            assert_eq!(got, vec![(b"ba".to_vec(), entry(0xBA))]);
+        })
     }
 
     #[test]
     fn prefix_selects_one_subtree() {
-        let store = MemoryStore::default();
-        let root = sample(&store);
-        let reader: Reader<_> = Reader::new(&store);
-        let got = drain(block_on(reader.prefix(&root, &Key::from(&b"a"[..]))).unwrap());
-        assert_eq!(
-            got,
-            vec![(b"aa".to_vec(), entry(0xAA)), (b"ab".to_vec(), entry(0xAB))]
-        );
+        run(async {
+            let store = MemoryStore::default();
+            let root = sample(&store).await;
+            let reader: Reader<_> = Reader::new(&store);
+            let got = drain(reader.prefix(&root, &Key::from(&b"a"[..])).await.unwrap()).await;
+            assert_eq!(
+                got,
+                vec![(b"aa".to_vec(), entry(0xAA)), (b"ab".to_vec(), entry(0xAB))]
+            );
+        })
     }
 
     #[test]
     fn floor_resolves_present_absent_and_below_all_keys() {
-        let store = MemoryStore::default();
-        let root = sample(&store);
-        let reader: Reader<_> = Reader::new(&store);
-        // Exact hit.
-        assert_eq!(
-            block_on(reader.floor(&root, &Key::from(&b"ab"[..]))).unwrap(),
-            Some((Key::from(&b"ab"[..]), entry(0xAB)))
-        );
-        // Between "ab" and "ba": floor is "ab".
-        assert_eq!(
-            block_on(reader.floor(&root, &Key::from(&b"az"[..]))).unwrap(),
-            Some((Key::from(&b"ab"[..]), entry(0xAB)))
-        );
-        // Past the last key: floor is the greatest key, reached through the ref.
-        assert_eq!(
-            block_on(reader.floor(&root, &Key::from(&b"zz"[..]))).unwrap(),
-            Some((Key::from(&b"ba"[..]), entry(0xBA)))
-        );
-        // Below every key: nothing.
-        assert_eq!(
-            block_on(reader.floor(&root, &Key::from(&b"a"[..]))).unwrap(),
-            None
-        );
+        run(async {
+            let store = MemoryStore::default();
+            let root = sample(&store).await;
+            let reader: Reader<_> = Reader::new(&store);
+            // Exact hit.
+            assert_eq!(
+                reader.floor(&root, &Key::from(&b"ab"[..])).await.unwrap(),
+                Some((Key::from(&b"ab"[..]), entry(0xAB)))
+            );
+            // Between "ab" and "ba": floor is "ab".
+            assert_eq!(
+                reader.floor(&root, &Key::from(&b"az"[..])).await.unwrap(),
+                Some((Key::from(&b"ab"[..]), entry(0xAB)))
+            );
+            // Past the last key: floor is the greatest key, reached through the ref.
+            assert_eq!(
+                reader.floor(&root, &Key::from(&b"zz"[..])).await.unwrap(),
+                Some((Key::from(&b"ba"[..]), entry(0xBA)))
+            );
+            // Below every key: nothing.
+            assert_eq!(
+                reader.floor(&root, &Key::from(&b"a"[..])).await.unwrap(),
+                None
+            );
+        })
     }
 
     // An encrypted (ref64) child the plain reader cannot open.
@@ -817,7 +837,7 @@ mod tests {
 
     // A root holding "a" and "z" as plain values with an encrypted subtree
     // wedged between them under "m".
-    fn with_encrypted(store: &MemoryStore) -> ChunkAddress {
+    async fn with_encrypted(store: &MemoryStore) -> ChunkAddress {
         let mut forks = ForkTable::new();
         forks
             .insert(prefix(b"a"), entry(0xA1).into(), None)
@@ -828,64 +848,79 @@ mod tests {
         forks
             .insert(prefix(b"z"), entry(0x2C).into(), None)
             .unwrap();
-        block_on(store.put_node(&Node::new(None, forks))).unwrap()
+        store.put_node(&Node::new(None, forks)).await.unwrap()
     }
 
     #[test]
     fn iteration_surfaces_an_encrypted_subtree_as_an_error() {
-        let store = MemoryStore::default();
-        let root = with_encrypted(&store);
-        let reader: Reader<_> = Reader::new(&store);
-        let mut cursor = block_on(reader.iter(&root)).unwrap();
-        // The plain value before the encrypted edge reads back.
-        assert_eq!(
-            block_on(cursor.next()).unwrap(),
-            Some((Key::from(&b"a"[..]), entry(0xA1)))
-        );
-        // Reaching the encrypted child stops the walk with an error.
-        assert!(matches!(
-            block_on(cursor.next()).unwrap_err(),
-            ReaderError::EncryptedChild
-        ));
+        run(async {
+            let store = MemoryStore::default();
+            let root = with_encrypted(&store).await;
+            let reader: Reader<_> = Reader::new(&store);
+            let mut cursor = reader.iter(&root).await.unwrap();
+            // The plain value before the encrypted edge reads back.
+            assert_eq!(
+                cursor.next().await.unwrap(),
+                Some((Key::from(&b"a"[..]), entry(0xA1)))
+            );
+            // Reaching the encrypted child stops the walk with an error.
+            assert!(matches!(
+                cursor.next().await.unwrap_err(),
+                ReaderError::EncryptedChild
+            ));
+        })
     }
 
     #[test]
     fn a_bound_short_of_the_encrypted_edge_prunes_it() {
-        let store = MemoryStore::default();
-        let root = with_encrypted(&store);
-        let reader: Reader<_> = Reader::new(&store);
-        // "m" is the exclusive upper bound, so the encrypted child at "m" is
-        // pruned rather than fetched, and the scan completes without error.
-        let got = drain(
-            block_on(reader.range(&root, &Key::from(&b"a"[..]), &Key::from(&b"m"[..]))).unwrap(),
-        );
-        assert_eq!(got, vec![(b"a".to_vec(), entry(0xA1))]);
+        run(async {
+            let store = MemoryStore::default();
+            let root = with_encrypted(&store).await;
+            let reader: Reader<_> = Reader::new(&store);
+            // "m" is the exclusive upper bound, so the encrypted child at "m" is
+            // pruned rather than fetched, and the scan completes without error.
+            let got = drain(
+                reader
+                    .range(&root, &Key::from(&b"a"[..]), &Key::from(&b"m"[..]))
+                    .await
+                    .unwrap(),
+            )
+            .await;
+            assert_eq!(got, vec![(b"a".to_vec(), entry(0xA1))]);
+        })
     }
 
     #[test]
     fn floor_past_an_encrypted_edge_reads_the_plain_key() {
-        let store = MemoryStore::default();
-        let root = with_encrypted(&store);
-        let reader: Reader<_> = Reader::new(&store);
-        // The floor of "z" is "z" itself; the encrypted subtree is left of the
-        // path and never opened.
-        assert_eq!(
-            block_on(reader.floor(&root, &Key::from(&b"z"[..]))).unwrap(),
-            Some((Key::from(&b"z"[..]), entry(0x2C)))
-        );
+        run(async {
+            let store = MemoryStore::default();
+            let root = with_encrypted(&store).await;
+            let reader: Reader<_> = Reader::new(&store);
+            // The floor of "z" is "z" itself; the encrypted subtree is left of the
+            // path and never opened.
+            assert_eq!(
+                reader.floor(&root, &Key::from(&b"z"[..])).await.unwrap(),
+                Some((Key::from(&b"z"[..]), entry(0x2C)))
+            );
+        })
     }
 
     #[test]
     fn floor_landing_in_an_encrypted_subtree_cannot_be_read() {
-        let store = MemoryStore::default();
-        let root = with_encrypted(&store);
-        let reader: Reader<_> = Reader::new(&store);
-        // Every key at or below "n" that could be the floor lives in the
-        // encrypted subtree under "m", so the answer is unreadable.
-        assert!(matches!(
-            block_on(reader.floor(&root, &Key::from(&b"n"[..]))).unwrap_err(),
-            ReaderError::EncryptedChild
-        ));
+        run(async {
+            let store = MemoryStore::default();
+            let root = with_encrypted(&store).await;
+            let reader: Reader<_> = Reader::new(&store);
+            // Every key at or below "n" that could be the floor lives in the
+            // encrypted subtree under "m", so the answer is unreadable.
+            assert!(matches!(
+                reader
+                    .floor(&root, &Key::from(&b"n"[..]))
+                    .await
+                    .unwrap_err(),
+                ReaderError::EncryptedChild
+            ));
+        })
     }
 
     #[test]

--- a/crates/manifest/src/store.rs
+++ b/crates/manifest/src/store.rs
@@ -189,9 +189,9 @@ impl<T: ChunkPut> NodePut for T {}
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
-    use futures::executor::block_on;
     use nectar_primitives::store::MemoryStore;
     use nectar_primitives::{ChunkAddress, ChunkRef, DefaultContentChunk};
+    use nectar_testing::run;
 
     use crate::bounded::Prefix;
     use crate::meta::{KeyId, Metadata};
@@ -224,13 +224,15 @@ mod tests {
 
     #[test]
     fn round_trips_through_a_memory_store() {
-        let store = MemoryStore::default();
-        let node = sample();
+        run(async {
+            let store = MemoryStore::default();
+            let node = sample();
 
-        let address = block_on(store.put_node(&node)).unwrap();
-        let loaded: Node = block_on(store.get_node(&address)).unwrap();
+            let address = store.put_node(&node).await.unwrap();
+            let loaded: Node = store.get_node(&address).await.unwrap();
 
-        assert_eq!(loaded, node);
+            assert_eq!(loaded, node);
+        })
     }
 
     #[test]
@@ -252,8 +254,13 @@ mod tests {
 
     #[test]
     fn missing_address_is_a_store_error() {
-        let store = MemoryStore::default();
-        let err = block_on(store.get_node::<crate::V1>(&ChunkAddress::new([0; 32]))).unwrap_err();
-        assert!(matches!(err, StoreError::Store(_)));
+        run(async {
+            let store = MemoryStore::default();
+            let err = store
+                .get_node::<crate::V1>(&ChunkAddress::new([0; 32]))
+                .await
+                .unwrap_err();
+            assert!(matches!(err, StoreError::Store(_)));
+        })
     }
 }

--- a/crates/manifest/tests/apply.rs
+++ b/crates/manifest/tests/apply.rs
@@ -8,9 +8,9 @@
 use std::collections::BTreeMap;
 
 use bytes::Bytes;
-use futures::executor::block_on;
 use nectar_manifest::{Builder, Changeset, Entry, Key, KeyId, Metadata, V1, apply};
 use nectar_primitives::{ChunkAddress, ChunkRef, MemoryStore};
+use nectar_testing::run;
 use proptest::prelude::*;
 
 /// A key's value plus optional metadata, the payload both paths carry.
@@ -48,13 +48,16 @@ fn value(inline: bool, fill: u8, blob: &[u8], meta: bool) -> Result<Value, TestC
 
 /// The root a from-scratch build of `map` produces in a fresh store, so the
 /// address depends on the merged bytes alone.
-fn rebuild(map: &BTreeMap<Vec<u8>, Value>) -> Result<ChunkAddress, TestCaseError> {
+async fn rebuild(map: &BTreeMap<Vec<u8>, Value>) -> Result<ChunkAddress, TestCaseError> {
     let store = MemoryStore::default();
     let mut builder = Builder::<V1>::new();
     for (key, (entry, meta)) in map {
         builder.insert(Key::from(key.clone()), entry.clone(), meta.clone());
     }
-    let built = block_on(builder.build(&store)).map_err(|e| TestCaseError::fail(e.to_string()))?;
+    let built = builder
+        .build(&store)
+        .await
+        .map_err(|e| TestCaseError::fail(e.to_string()))?;
     Ok(*built.root())
 }
 
@@ -104,7 +107,7 @@ fn long_change_set() -> impl Strategy<Value = Vec<(Vec<u8>, Option<Parts>)>> {
 
 /// Fold `changes` into a manifest built from `base` and assert the applied root
 /// is byte-identical to a from-scratch build of the merged key set.
-fn assert_apply_equals_rebuild(
+async fn assert_apply_equals_rebuild(
     base: &[(Vec<u8>, Parts)],
     changes: &[(Vec<u8>, Option<Parts>)],
 ) -> Result<(), TestCaseError> {
@@ -118,7 +121,9 @@ fn assert_apply_equals_rebuild(
     for (key, val) in &map {
         builder.insert(Key::from(key.clone()), val.0.clone(), val.1.clone());
     }
-    let root = *block_on(builder.build(&store))
+    let root = *builder
+        .build(&store)
+        .await
         .map_err(|e| TestCaseError::fail(e.to_string()))?
         .root();
 
@@ -150,9 +155,10 @@ fn assert_apply_equals_rebuild(
         }
     }
 
-    let applied = block_on(apply(&store, &root, &changeset))
+    let applied = apply(&store, &root, &changeset)
+        .await
         .map_err(|e| TestCaseError::fail(e.to_string()))?;
-    let expected = rebuild(&map)?;
+    let expected = rebuild(&map).await?;
     prop_assert_eq!(applied, expected);
     Ok(())
 }
@@ -165,13 +171,19 @@ proptest! {
     // inserts, updates and deletes, some overlapping near the root.
     #[test]
     fn apply_equals_rebuild(base in base_set(), changes in change_set()) {
-        assert_apply_equals_rebuild(&base, &changes)?;
+        run(async {
+            assert_apply_equals_rebuild(&base, &changes).await?;
+            Ok::<(), TestCaseError>(())
+        })?;
     }
 
     // The same equation over long, low-entropy keys, so collapses cross the
     // 255-byte prefix bound and exercise the chain-compaction path.
     #[test]
     fn apply_equals_rebuild_over_long_keys(base in long_base_set(), changes in long_change_set()) {
-        assert_apply_equals_rebuild(&base, &changes)?;
+        run(async {
+            assert_apply_equals_rebuild(&base, &changes).await?;
+            Ok::<(), TestCaseError>(())
+        })?;
     }
 }

--- a/crates/manifest/tests/builder.rs
+++ b/crates/manifest/tests/builder.rs
@@ -7,12 +7,12 @@
 use std::error::Error;
 
 use bytes::Bytes;
-use futures::executor::block_on;
 use nectar_manifest::{
     BuildStats, Builder, Child, Entry, ForkPayload, ForkTable, Key, KeyId, Metadata, Node, NodeGet,
     Prefix, RootExtension, V1, build_files,
 };
 use nectar_primitives::{ChunkAddress, ChunkOps, ChunkRef, DEFAULT_BODY_SIZE, MemoryStore, split};
+use nectar_testing::run;
 
 type TestResult = Result<(), Box<dyn Error>>;
 
@@ -78,74 +78,82 @@ fn worked_example_node() -> Result<Node, Box<dyn Error>> {
 
 #[test]
 fn builds_the_worked_example_byte_for_byte() -> TestResult {
-    let store = MemoryStore::default();
-    let mut builder: Builder = Builder::new();
-    builder
-        .insert(
-            Key::from(&b"index.html"[..]),
-            Entry::from(ref32(0xAA)),
-            Some(content_type(b"text/html")?),
-        )
-        .insert(
-            Key::from(&b"img/logo.png"[..]),
-            Entry::from(ref32(0xBB)),
-            Some(content_type(b"image/png")?),
-        )
-        .manifest_metadata(website_index()?);
+    run(async {
+        let store = MemoryStore::default();
+        let mut builder: Builder = Builder::new();
+        builder
+            .insert(
+                Key::from(&b"index.html"[..]),
+                Entry::from(ref32(0xAA)),
+                Some(content_type(b"text/html")?),
+            )
+            .insert(
+                Key::from(&b"img/logo.png"[..]),
+                Entry::from(ref32(0xBB)),
+                Some(content_type(b"image/png")?),
+            )
+            .manifest_metadata(website_index()?);
 
-    let built = block_on(builder.build(&store))?;
+        let built = builder.build(&store).await?;
 
-    // The shared child is inlined, so the whole manifest is one chunk.
-    ensure_eq(built.stats().nodes_written(), 1, "one node written")?;
-    ensure_eq(built.stats().nodes_embedded(), 1, "one child embedded")?;
+        // The shared child is inlined, so the whole manifest is one chunk.
+        ensure_eq(built.stats().nodes_written(), 1, "one node written")?;
+        ensure_eq(built.stats().nodes_embedded(), 1, "one child embedded")?;
 
-    let chunk = store.get(built.root()).ok_or("root not stored")?;
-    let expected = worked_example_node()?.encode()?;
-    ensure_eq(expected.len(), 150, "worked example is 150 bytes")?;
-    ensure_eq(
-        chunk.envelope().data().as_ref(),
-        expected.as_slice(),
-        "root payload",
-    )?;
+        let chunk = store.get(built.root()).ok_or("root not stored")?;
+        let expected = worked_example_node()?.encode()?;
+        ensure_eq(expected.len(), 150, "worked example is 150 bytes")?;
+        ensure_eq(
+            chunk.envelope().data().as_ref(),
+            expected.as_slice(),
+            "root payload",
+        )?;
 
-    let decoded: Node = block_on(store.get_node(built.root()))?;
-    ensure_eq(decoded, worked_example_node()?, "decoded root")
+        let decoded: Node = store.get_node(built.root()).await?;
+        ensure_eq(decoded, worked_example_node()?, "decoded root")
+    })
 }
 
-fn root_of(order: &[(&[u8], u8)]) -> Result<ChunkAddress, Box<dyn Error>> {
+async fn root_of(order: &[(&[u8], u8)]) -> Result<ChunkAddress, Box<dyn Error>> {
     let store = MemoryStore::default();
     let mut builder: Builder = Builder::new();
     for (key, fill) in order {
         builder.insert(Key::from(*key), Entry::from(ref32(*fill)), None);
     }
-    Ok(*block_on(builder.build(&store))?.root())
+    Ok(*builder.build(&store).await?.root())
 }
 
 #[test]
 fn the_published_root_is_history_independent() -> TestResult {
-    // A key set that exercises a terminating-and-continuing fork ("a" under
-    // "about"), a nested shared edge ("about-us"), and a shared directory
-    // ("img/").
-    let order: [(&[u8], u8); 6] = [
-        (b"a", 1),
-        (b"about", 2),
-        (b"about-us", 3),
-        (b"img/logo.png", 4),
-        (b"img/icon.svg", 5),
-        (b"index.html", 6),
-    ];
-    let forward = root_of(&order)?;
+    run(async {
+        // A key set that exercises a terminating-and-continuing fork ("a" under
+        // "about"), a nested shared edge ("about-us"), and a shared directory
+        // ("img/").
+        let order: [(&[u8], u8); 6] = [
+            (b"a", 1),
+            (b"about", 2),
+            (b"about-us", 3),
+            (b"img/logo.png", 4),
+            (b"img/icon.svg", 5),
+            (b"index.html", 6),
+        ];
+        let forward = root_of(&order).await?;
 
-    let mut reversed = order;
-    reversed.reverse();
-    ensure_eq(root_of(&reversed)?, forward, "reversed order")?;
+        let mut reversed = order;
+        reversed.reverse();
+        ensure_eq(root_of(&reversed).await?, forward, "reversed order")?;
 
-    let mut rotated = order;
-    rotated.rotate_left(3);
-    ensure_eq(root_of(&rotated)?, forward, "rotated order")
+        let mut rotated = order;
+        rotated.rotate_left(3);
+        ensure_eq(root_of(&rotated).await?, forward, "rotated order")
+    })
 }
 
-fn two_level_stats(store: &MemoryStore, fan: u16, width: u8) -> Result<BuildStats, Box<dyn Error>> {
+async fn two_level_stats(
+    store: &MemoryStore,
+    fan: u16,
+    width: u8,
+) -> Result<BuildStats, Box<dyn Error>> {
     let mut builder: Builder<V1> = Builder::new();
     for hi in 0..fan {
         let hi = u8::try_from(hi)?;
@@ -153,108 +161,116 @@ fn two_level_stats(store: &MemoryStore, fan: u16, width: u8) -> Result<BuildStat
             builder.insert(Key::from(&[hi, lo][..]), Entry::from(ref32(hi)), None);
         }
     }
-    Ok(*block_on(builder.build(store))?.stats())
+    Ok(*builder.build(store).await?.stats())
 }
 
 #[test]
 fn peak_node_buffers_track_depth_not_key_count() -> TestResult {
-    // Two two-level manifests whose second level is wide enough that each child
-    // spills to its own chunk. The narrow build has 8 subtrees, the wide one 64;
-    // the wide build stores many more nodes, yet both keep the same tiny number
-    // of nodes open at once, so peak memory follows depth, not key count.
-    let narrow = MemoryStore::default();
-    let wide = MemoryStore::default();
-    let narrow_stats = two_level_stats(&narrow, 8, 80)?;
-    let wide_stats = two_level_stats(&wide, 64, 80)?;
+    run(async {
+        // Two two-level manifests whose second level is wide enough that each child
+        // spills to its own chunk. The narrow build has 8 subtrees, the wide one 64;
+        // the wide build stores many more nodes, yet both keep the same tiny number
+        // of nodes open at once, so peak memory follows depth, not key count.
+        let narrow = MemoryStore::default();
+        let wide = MemoryStore::default();
+        let narrow_stats = two_level_stats(&narrow, 8, 80).await?;
+        let wide_stats = two_level_stats(&wide, 64, 80).await?;
 
-    // Root plus one open child: never a whole level or frontier.
-    ensure_eq(narrow_stats.peak_open_nodes(), 2, "narrow peak")?;
-    ensure_eq(wide_stats.peak_open_nodes(), 2, "wide peak")?;
+        // Root plus one open child: never a whole level or frontier.
+        ensure_eq(narrow_stats.peak_open_nodes(), 2, "narrow peak")?;
+        ensure_eq(wide_stats.peak_open_nodes(), 2, "wide peak")?;
 
-    // The children are spilled, not embedded, so work scales with the fan.
-    ensure_eq(narrow_stats.nodes_embedded(), 0, "narrow spills all")?;
-    ensure_eq(narrow_stats.nodes_written(), 9, "narrow node count")?;
-    ensure_eq(wide_stats.nodes_written(), 65, "wide node count")?;
+        // The children are spilled, not embedded, so work scales with the fan.
+        ensure_eq(narrow_stats.nodes_embedded(), 0, "narrow spills all")?;
+        ensure_eq(narrow_stats.nodes_written(), 9, "narrow node count")?;
+        ensure_eq(wide_stats.nodes_written(), 65, "wide node count")?;
 
-    // Eight times the keys, eight times the stored nodes, identical peak.
-    ensure(
-        wide_stats.nodes_written() > narrow_stats.nodes_written().saturating_mul(7),
-        "work scales with keys",
-    )?;
-    ensure_eq(
-        narrow_stats.peak_open_nodes(),
-        wide_stats.peak_open_nodes(),
-        "peak is key-count independent",
-    )
+        // Eight times the keys, eight times the stored nodes, identical peak.
+        ensure(
+            wide_stats.nodes_written() > narrow_stats.nodes_written().saturating_mul(7),
+            "work scales with keys",
+        )?;
+        ensure_eq(
+            narrow_stats.peak_open_nodes(),
+            wide_stats.peak_open_nodes(),
+            "peak is key-count independent",
+        )
+    })
 }
 
 #[test]
 fn the_empty_builder_publishes_the_empty_root() -> TestResult {
-    let store = MemoryStore::default();
-    let builder: Builder = Builder::new();
-    let built = block_on(builder.build(&store))?;
+    run(async {
+        let store = MemoryStore::default();
+        let builder: Builder = Builder::new();
+        let built = builder.build(&store).await?;
 
-    ensure_eq(built.stats().peak_open_nodes(), 1, "one open node")?;
-    ensure_eq(built.stats().nodes_written(), 1, "one node written")?;
+        ensure_eq(built.stats().peak_open_nodes(), 1, "one open node")?;
+        ensure_eq(built.stats().nodes_written(), 1, "one node written")?;
 
-    let node: Node = block_on(store.get_node(built.root()))?;
-    ensure(node.is_empty(), "root is the empty map")
+        let node: Node = store.get_node(built.root()).await?;
+        ensure(node.is_empty(), "root is the empty map")
+    })
 }
 
 #[test]
 fn build_files_splits_through_bmt_and_references_the_stored_roots() -> TestResult {
-    let store = MemoryStore::default();
-    let logo = Bytes::from(vec![0x42u8; 12_000]); // several chunks
-    let page = Bytes::from_static(b"<h1>hello</h1>");
-    let files = [
-        (Key::from(&b"index.html"[..]), page.clone()),
-        (Key::from(&b"logo.png"[..]), logo.clone()),
-    ];
+    run(async {
+        let store = MemoryStore::default();
+        let logo = Bytes::from(vec![0x42u8; 12_000]); // several chunks
+        let page = Bytes::from_static(b"<h1>hello</h1>");
+        let files = [
+            (Key::from(&b"index.html"[..]), page.clone()),
+            (Key::from(&b"logo.png"[..]), logo.clone()),
+        ];
 
-    let built = block_on(build_files(&store, files))?;
-    let node: Node = block_on(store.get_node(built.root()))?;
+        let built = build_files(&store, files).await?;
+        let node: Node = store.get_node(built.root()).await?;
 
-    // Each file's manifest entry is its independent BMT root, and every file
-    // chunk is present in the same store.
-    for (first, tail, data) in [
-        (b'i', &b"ndex.html"[..], page),
-        (b'l', &b"ogo.png"[..], logo),
-    ] {
-        let record = node.forks().get(first).ok_or("missing fork")?;
-        ensure_eq(record.tail().as_bytes(), tail, "fork tail")?;
-        let address = record
-            .entry()
-            .ok_or("fork has no entry")?
-            .address()
-            .ok_or("entry is not a reference")?;
+        // Each file's manifest entry is its independent BMT root, and every file
+        // chunk is present in the same store.
+        for (first, tail, data) in [
+            (b'i', &b"ndex.html"[..], page),
+            (b'l', &b"ogo.png"[..], logo),
+        ] {
+            let record = node.forks().get(first).ok_or("missing fork")?;
+            ensure_eq(record.tail().as_bytes(), tail, "fork tail")?;
+            let address = record
+                .entry()
+                .ok_or("fork has no entry")?
+                .address()
+                .ok_or("entry is not a reference")?;
 
-        let (expected_root, _) = split::<DEFAULT_BODY_SIZE>(&data)?;
-        ensure_eq(address, &expected_root, "file root reference")?;
-        ensure(store.get(address).is_some(), "file root stored")?;
-    }
-    Ok(())
+            let (expected_root, _) = split::<DEFAULT_BODY_SIZE>(&data)?;
+            ensure_eq(address, &expected_root, "file root reference")?;
+            ensure(store.get(address).is_some(), "file root stored")?;
+        }
+        Ok(())
+    })
 }
 
 #[test]
 fn a_key_that_prefixes_another_shares_a_fork() -> TestResult {
-    let store = MemoryStore::default();
-    let mut builder: Builder = Builder::new();
-    builder
-        .insert(Key::from(&b"a"[..]), Entry::from(ref32(1)), None)
-        .insert(Key::from(&b"ab"[..]), Entry::from(ref32(2)), None);
-    let built = block_on(builder.build(&store))?;
+    run(async {
+        let store = MemoryStore::default();
+        let mut builder: Builder = Builder::new();
+        builder
+            .insert(Key::from(&b"a"[..]), Entry::from(ref32(1)), None)
+            .insert(Key::from(&b"ab"[..]), Entry::from(ref32(2)), None);
+        let built = builder.build(&store).await?;
 
-    let node: Node = block_on(store.get_node(built.root()))?;
-    let record = node.forks().get(b'a').ok_or("missing fork a")?;
-    ensure(record.tail().is_empty(), "single-byte edge")?;
-    // "a" terminates here and the trie continues to "ab".
-    ensure(
-        matches!(record.payload(), ForkPayload::Both { .. }),
-        "fork is entry-and-child",
-    )?;
-    ensure_eq(
-        record.entry(),
-        Some(&Entry::from(ref32(1))),
-        "terminating value",
-    )
+        let node: Node = store.get_node(built.root()).await?;
+        let record = node.forks().get(b'a').ok_or("missing fork a")?;
+        ensure(record.tail().is_empty(), "single-byte edge")?;
+        // "a" terminates here and the trie continues to "ab".
+        ensure(
+            matches!(record.payload(), ForkPayload::Both { .. }),
+            "fork is entry-and-child",
+        )?;
+        ensure_eq(
+            record.entry(),
+            Some(&Entry::from(ref32(1))),
+            "terminating value",
+        )
+    })
 }

--- a/crates/manifest/tests/counted.rs
+++ b/crates/manifest/tests/counted.rs
@@ -6,9 +6,9 @@
 use std::error::Error;
 
 use bytes::Bytes;
-use futures::executor::block_on;
 use nectar_manifest::{Builder, Changeset, Entry, Key, Reader, V1, apply};
 use nectar_primitives::{ChunkAddress, ChunkRef, MemoryStore};
+use nectar_testing::run;
 
 type TestResult = Result<(), Box<dyn Error>>;
 
@@ -32,81 +32,94 @@ fn keys() -> Vec<(Key, u8)> {
     out
 }
 
-fn build<F: nectar_manifest::Format>(order: &[(Key, u8)]) -> Result<ChunkAddress, Box<dyn Error>> {
+async fn build<F: nectar_manifest::Format>(
+    order: &[(Key, u8)],
+) -> Result<ChunkAddress, Box<dyn Error>> {
     let store = MemoryStore::default();
     let mut builder = Builder::<F>::new();
     for (key, fill) in order {
         builder.insert(key.clone(), ref_entry::<F>(*fill), None);
     }
-    Ok(*block_on(builder.build(&store))?.root())
+    Ok(*builder.build(&store).await?.root())
 }
 
 #[test]
 fn counted_canonical_bytes_are_stable_under_shuffled_build_order() -> TestResult {
-    let forward = keys();
-    let mut reversed = forward.clone();
-    reversed.reverse();
-    let a = build::<V1>(&forward)?;
-    let b = build::<V1>(&reversed)?;
-    ensure(a == b, "counted root must not depend on insertion order")?;
-    Ok(())
+    run(async {
+        let forward = keys();
+        let mut reversed = forward.clone();
+        reversed.reverse();
+        let a = build::<V1>(&forward).await?;
+        let b = build::<V1>(&reversed).await?;
+        ensure(a == b, "counted root must not depend on insertion order")?;
+        Ok(())
+    })
 }
 
 #[test]
 fn build_then_read_round_trips_every_key() -> TestResult {
-    let store = MemoryStore::default();
-    let all = keys();
-    let mut builder = Builder::<V1>::new();
-    for (key, fill) in &all {
-        builder.insert(key.clone(), ref_entry::<V1>(*fill), None);
-    }
-    let root = *block_on(builder.build(&store))?.root();
+    run(async {
+        let store = MemoryStore::default();
+        let all = keys();
+        let mut builder = Builder::<V1>::new();
+        for (key, fill) in &all {
+            builder.insert(key.clone(), ref_entry::<V1>(*fill), None);
+        }
+        let root = *builder.build(&store).await?.root();
 
-    let reader = Reader::<MemoryStore, V1>::new(store);
-    for (key, fill) in &all {
-        let got = block_on(reader.get(&root, key))?;
-        ensure(got == Some(ref_entry::<V1>(*fill)), "read value mismatch")?;
-    }
-    ensure(
-        block_on(reader.get(&root, &Key::from(&b"absent"[..])))?.is_none(),
-        "absent key must read as None",
-    )?;
-    Ok(())
+        let reader = Reader::<MemoryStore, V1>::new(store);
+        for (key, fill) in &all {
+            let got = reader.get(&root, key).await?;
+            ensure(got == Some(ref_entry::<V1>(*fill)), "read value mismatch")?;
+        }
+        ensure(
+            reader
+                .get(&root, &Key::from(&b"absent"[..]))
+                .await?
+                .is_none(),
+            "absent key must read as None",
+        )?;
+        Ok(())
+    })
 }
 
 #[test]
 fn apply_matches_a_from_scratch_build() -> TestResult {
-    let all = keys();
-    let split = all.len() * 3 / 4;
+    run(async {
+        let all = keys();
+        let split = all.len() * 3 / 4;
 
-    let store = MemoryStore::default();
-    let mut base = Builder::<V1>::new();
-    for (key, fill) in all.iter().take(split) {
-        base.insert(key.clone(), ref_entry::<V1>(*fill), None);
-    }
-    let base_root = *block_on(base.build(&store))?.root();
+        let store = MemoryStore::default();
+        let mut base = Builder::<V1>::new();
+        for (key, fill) in all.iter().take(split) {
+            base.insert(key.clone(), ref_entry::<V1>(*fill), None);
+        }
+        let base_root = *base.build(&store).await?.root();
 
-    let mut changeset = Changeset::<V1>::new();
-    for (key, fill) in all.iter().skip(split) {
-        changeset.put(key.clone(), ref_entry::<V1>(*fill), None);
-    }
-    let applied = block_on(apply(&store, &base_root, &changeset))?;
+        let mut changeset = Changeset::<V1>::new();
+        for (key, fill) in all.iter().skip(split) {
+            changeset.put(key.clone(), ref_entry::<V1>(*fill), None);
+        }
+        let applied = apply(&store, &base_root, &changeset).await?;
 
-    let scratch = build::<V1>(&all)?;
-    ensure(applied == scratch, "apply must match a from-scratch build")?;
-    Ok(())
+        let scratch = build::<V1>(&all).await?;
+        ensure(applied == scratch, "apply must match a from-scratch build")?;
+        Ok(())
+    })
 }
 
 #[test]
 fn an_inline_value_round_trips() -> TestResult {
-    let store = MemoryStore::default();
-    let mut builder = Builder::<V1>::new();
-    let value = Entry::<V1>::inline(Bytes::from_static(b"<h1>hi</h1>"))?;
-    builder.insert(Key::from(&b"index.html"[..]), value.clone(), None);
-    let root = *block_on(builder.build(&store))?.root();
+    run(async {
+        let store = MemoryStore::default();
+        let mut builder = Builder::<V1>::new();
+        let value = Entry::<V1>::inline(Bytes::from_static(b"<h1>hi</h1>"))?;
+        builder.insert(Key::from(&b"index.html"[..]), value.clone(), None);
+        let root = *builder.build(&store).await?.root();
 
-    let reader = Reader::<MemoryStore, V1>::new(store);
-    let got = block_on(reader.get(&root, &Key::from(&b"index.html"[..])))?;
-    ensure(got == Some(value), "inline value must round-trip")?;
-    Ok(())
+        let reader = Reader::<MemoryStore, V1>::new(store);
+        let got = reader.get(&root, &Key::from(&b"index.html"[..])).await?;
+        ensure(got == Some(value), "inline value must round-trip")?;
+        Ok(())
+    })
 }

--- a/crates/manifest/tests/membound.rs
+++ b/crates/manifest/tests/membound.rs
@@ -11,7 +11,6 @@ use std::error::Error;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use bytes::Bytes;
-use futures::executor::block_on;
 use nectar_manifest::{
     ApplyError, BuildStats, Builder, Changeset, Entry, Key, KeyId, Metadata, Reader, V1, apply,
     recanonicalize,
@@ -20,6 +19,7 @@ use nectar_primitives::store::{ChunkGet, MemoryStore};
 use nectar_primitives::{
     Chunk, ChunkAddress, ChunkOps, ChunkRef, DEFAULT_BODY_SIZE, StandardChunkSet, Verified,
 };
+use nectar_testing::run;
 use proptest::prelude::*;
 
 type TestResult = Result<(), Box<dyn Error>>;
@@ -79,10 +79,14 @@ fn fill_radix(builder: &mut Builder<V1>, radix: u8, remaining: u32, key: &mut Ve
 
 /// Build every `radix`-ary key of length `len` into `store`, returning the build
 /// stats.
-fn build_radix(store: &MemoryStore, radix: u8, len: u32) -> Result<BuildStats, Box<dyn Error>> {
+async fn build_radix(
+    store: &MemoryStore,
+    radix: u8,
+    len: u32,
+) -> Result<BuildStats, Box<dyn Error>> {
     let mut builder = Builder::<V1>::new();
     fill_radix(&mut builder, radix, len, &mut Vec::new(), 0x11);
-    let built = block_on(builder.build(store)).map_err(|e| e.to_string())?;
+    let built = builder.build(store).await.map_err(|e| e.to_string())?;
     Ok(*built.stats())
 }
 
@@ -101,37 +105,39 @@ fn assert_single_chunk_nodes(store: &MemoryStore) -> TestResult {
 
 #[test]
 fn peak_open_nodes_tracks_depth_not_width() -> TestResult {
-    // radix 10, depth 2 is 100 keys two nodes deep.
-    let shallow_narrow = build_radix(&MemoryStore::default(), 10, 2)?;
-    // radix 60, depth 2 is 3_600 keys, still two deep but far wider per level.
-    let shallow_wide = build_radix(&MemoryStore::default(), 60, 2)?;
-    // radix 10, depth 4 is 10_000 keys four nodes deep.
-    let deep = build_radix(&MemoryStore::default(), 10, 4)?;
+    run(async {
+        // radix 10, depth 2 is 100 keys two nodes deep.
+        let shallow_narrow = build_radix(&MemoryStore::default(), 10, 2).await?;
+        // radix 60, depth 2 is 3_600 keys, still two deep but far wider per level.
+        let shallow_wide = build_radix(&MemoryStore::default(), 60, 2).await?;
+        // radix 10, depth 4 is 10_000 keys four nodes deep.
+        let deep = build_radix(&MemoryStore::default(), 10, 4).await?;
 
-    // Same depth, very different width: identical peak, whatever the fan.
-    ensure(
-        shallow_narrow.peak_open_nodes() == shallow_wide.peak_open_nodes(),
-        format!(
-            "peak {} != {} across widths at equal depth",
-            shallow_narrow.peak_open_nodes(),
-            shallow_wide.peak_open_nodes(),
-        ),
-    )?;
-    // Greater depth raises the peak; width alone never does.
-    ensure(
-        deep.peak_open_nodes() > shallow_wide.peak_open_nodes(),
-        format!(
-            "deeper build peak {} did not exceed shallow peak {}",
-            deep.peak_open_nodes(),
-            shallow_wide.peak_open_nodes(),
-        ),
-    )?;
-    // The wide build writes far more nodes than its peak: work is O(tree), the
-    // retained frontier is O(depth).
-    ensure(
-        shallow_wide.nodes_written() > shallow_wide.peak_open_nodes().saturating_mul(10),
-        "wide build node count is not far above its peak".to_owned(),
-    )
+        // Same depth, very different width: identical peak, whatever the fan.
+        ensure(
+            shallow_narrow.peak_open_nodes() == shallow_wide.peak_open_nodes(),
+            format!(
+                "peak {} != {} across widths at equal depth",
+                shallow_narrow.peak_open_nodes(),
+                shallow_wide.peak_open_nodes(),
+            ),
+        )?;
+        // Greater depth raises the peak; width alone never does.
+        ensure(
+            deep.peak_open_nodes() > shallow_wide.peak_open_nodes(),
+            format!(
+                "deeper build peak {} did not exceed shallow peak {}",
+                deep.peak_open_nodes(),
+                shallow_wide.peak_open_nodes(),
+            ),
+        )?;
+        // The wide build writes far more nodes than its peak: work is O(tree), the
+        // retained frontier is O(depth).
+        ensure(
+            shallow_wide.nodes_written() > shallow_wide.peak_open_nodes().saturating_mul(10),
+            "wide build node count is not far above its peak".to_owned(),
+        )
+    })
 }
 
 /// Stream a byte-keyed profile into the builder: the first two key positions
@@ -155,198 +161,217 @@ fn fill_radix256(builder: &mut Builder<V1>, tail: u16, fill: u8) -> Result<(), B
 
 #[test]
 fn a_million_key_manifest_is_depth_bounded() -> TestResult {
-    // A byte-keyed radix-256 profile: 256*256*16 = 1_048_576 keys three nodes
-    // deep, whose level-0 and level-1 nodes are full 256-fork tables that a
-    // naive encoder would reject as over-budget. Spill packs each into a segment
-    // directory, so one build witnesses all three bounds: the builder's peak
-    // retained buffer count is the depth, every emitted chunk fits one chunk
-    // body, and a lookup stays O(depth) even through the spilled levels.
-    let inner = MemoryStore::default();
-    let mut builder = Builder::<V1>::new();
-    fill_radix256(&mut builder, 16, 0x22)?;
-    let built = block_on(builder.build(&inner)).map_err(|e| e.to_string())?;
-    let stats = *built.stats();
-    let root = *built.root();
+    run(async {
+        // A byte-keyed radix-256 profile: 256*256*16 = 1_048_576 keys three nodes
+        // deep, whose level-0 and level-1 nodes are full 256-fork tables that a
+        // naive encoder would reject as over-budget. Spill packs each into a segment
+        // directory, so one build witnesses all three bounds: the builder's peak
+        // retained buffer count is the depth, every emitted chunk fits one chunk
+        // body, and a lookup stays O(depth) even through the spilled levels.
+        let inner = MemoryStore::default();
+        let mut builder = Builder::<V1>::new();
+        fill_radix256(&mut builder, 16, 0x22)?;
+        let built = builder.build(&inner).await.map_err(|e| e.to_string())?;
+        let stats = *built.stats();
+        let root = *built.root();
 
-    ensure(
-        stats.peak_open_nodes() <= 8,
-        format!(
-            "peak {} open nodes is not O(depth) at 10^6 keys",
-            stats.peak_open_nodes(),
-        ),
-    )?;
-    // The tree is spilled across many chunks, orders of magnitude above the
-    // peak, so the bound is a genuine streaming bound, not a small tree.
-    ensure(
-        stats.nodes_written() > stats.peak_open_nodes().saturating_mul(100),
-        format!(
-            "only {} nodes written, no wider than the peak",
-            stats.nodes_written(),
-        ),
-    )?;
-    // Every emitted node fits one chunk body, checked at 10^6-key scale over a
-    // profile whose interior nodes are all spilled.
-    assert_single_chunk_nodes(&inner)?;
-
-    // Read a spread of keys through a counting store: each lookup is O(depth).
-    // A spilled level costs its segmented node plus the covering segments, a
-    // small constant per level, so the fetch count is bounded independent of the
-    // key count.
-    let store = CountingStore {
-        inner,
-        gets: AtomicUsize::new(0),
-    };
-    let reader: Reader<_> = Reader::new(&store);
-    for probe in [[0u8, 0, 0], [255, 255, 15], [128, 64, 8], [7, 200, 3]] {
-        store.gets.store(0, Ordering::Relaxed);
-        let value =
-            block_on(reader.get(&root, &Key::from(&probe[..]))).map_err(|e| e.to_string())?;
-        ensure(value == Some(entry(0x22)), format!("missing key {probe:?}"))?;
-        // Three levels, each at most a segmented node and its covering segments.
         ensure(
-            store.gets() <= 24,
-            format!("lookup fetched {} nodes, not O(depth)", store.gets()),
+            stats.peak_open_nodes() <= 8,
+            format!(
+                "peak {} open nodes is not O(depth) at 10^6 keys",
+                stats.peak_open_nodes(),
+            ),
         )?;
-    }
-    Ok(())
+        // The tree is spilled across many chunks, orders of magnitude above the
+        // peak, so the bound is a genuine streaming bound, not a small tree.
+        ensure(
+            stats.nodes_written() > stats.peak_open_nodes().saturating_mul(100),
+            format!(
+                "only {} nodes written, no wider than the peak",
+                stats.nodes_written(),
+            ),
+        )?;
+        // Every emitted node fits one chunk body, checked at 10^6-key scale over a
+        // profile whose interior nodes are all spilled.
+        assert_single_chunk_nodes(&inner)?;
+
+        // Read a spread of keys through a counting store: each lookup is O(depth).
+        // A spilled level costs its segmented node plus the covering segments, a
+        // small constant per level, so the fetch count is bounded independent of the
+        // key count.
+        let store = CountingStore {
+            inner,
+            gets: AtomicUsize::new(0),
+        };
+        let reader: Reader<_> = Reader::new(&store);
+        for probe in [[0u8, 0, 0], [255, 255, 15], [128, 64, 8], [7, 200, 3]] {
+            store.gets.store(0, Ordering::Relaxed);
+            let value = reader
+                .get(&root, &Key::from(&probe[..]))
+                .await
+                .map_err(|e| e.to_string())?;
+            ensure(value == Some(entry(0x22)), format!("missing key {probe:?}"))?;
+            // Three levels, each at most a segmented node and its covering segments.
+            ensure(
+                store.gets() <= 24,
+                format!("lookup fetched {} nodes, not O(depth)", store.gets()),
+            )?;
+        }
+        Ok(())
+    })
 }
 
 #[test]
 fn a_full_radix_256_node_of_heavy_records_packs_and_reads() -> TestResult {
-    // A single node holding all 256 first-byte forks, each carrying a heavy
-    // metadata block: a ~9.5 KB fork table that far overruns one chunk. The
-    // builder spills it into a segment directory; every emitted chunk still fits
-    // one body, and each key reads back through the reassembled node.
-    let store = MemoryStore::default();
-    let mut builder = Builder::<V1>::new();
-    for first in 0u16..256 {
-        let byte = u8::try_from(first)?;
-        let meta = Metadata::new(KeyId::ContentType, Bytes::from(vec![b'a'; 900]))
-            .map_err(|e| e.to_string())?;
-        builder.insert(Key::from(vec![byte]), entry(byte), Some(meta));
-    }
-    let built = block_on(builder.build(&store)).map_err(|e| e.to_string())?;
+    run(async {
+        // A single node holding all 256 first-byte forks, each carrying a heavy
+        // metadata block: a ~9.5 KB fork table that far overruns one chunk. The
+        // builder spills it into a segment directory; every emitted chunk still fits
+        // one body, and each key reads back through the reassembled node.
+        let store = MemoryStore::default();
+        let mut builder = Builder::<V1>::new();
+        for first in 0u16..256 {
+            let byte = u8::try_from(first)?;
+            let meta = Metadata::new(KeyId::ContentType, Bytes::from(vec![b'a'; 900]))
+                .map_err(|e| e.to_string())?;
+            builder.insert(Key::from(vec![byte]), entry(byte), Some(meta));
+        }
+        let built = builder.build(&store).await.map_err(|e| e.to_string())?;
 
-    // The node did not fit one chunk, so it was spilled across several.
-    ensure(
-        built.stats().nodes_written() > 1,
-        "a full radix-256 heavy node must spill into several chunks".to_owned(),
-    )?;
-    assert_single_chunk_nodes(&store)?;
-
-    let reader: Reader<_> = Reader::new(&store);
-    for first in [0u8, 1, 127, 200, 255] {
-        let value = block_on(reader.get(built.root(), &Key::from(vec![first])))
-            .map_err(|e| e.to_string())?;
+        // The node did not fit one chunk, so it was spilled across several.
         ensure(
-            value == Some(entry(first)),
-            format!("missing key {first} after spill"),
+            built.stats().nodes_written() > 1,
+            "a full radix-256 heavy node must spill into several chunks".to_owned(),
         )?;
-    }
-    Ok(())
+        assert_single_chunk_nodes(&store)?;
+
+        let reader: Reader<_> = Reader::new(&store);
+        for first in [0u8, 1, 127, 200, 255] {
+            let value = reader
+                .get(built.root(), &Key::from(vec![first]))
+                .await
+                .map_err(|e| e.to_string())?;
+            ensure(
+                value == Some(entry(first)),
+                format!("missing key {first} after spill"),
+            )?;
+        }
+        Ok(())
+    })
 }
 
 #[test]
 fn every_spilled_chunk_re_encodes_to_its_own_bytes() -> TestResult {
-    // The canonical-form check (spec 6.2) over a whole spilled node set: decode
-    // each stored chunk and re-encode it, and the bytes must match, plain node,
-    // segmented node and segment alike. This is the build-roundtrip fuzz oracle
-    // exercised on a deterministic set that is known to spill.
-    let store = MemoryStore::default();
-    let mut builder = Builder::<V1>::new();
-    for first in 0u16..256 {
-        let byte = u8::try_from(first)?;
-        let meta = Metadata::new(KeyId::ContentType, Bytes::from(vec![b'a'; 700]))
-            .map_err(|e| e.to_string())?;
-        builder.insert(Key::from(vec![byte]), entry(byte), Some(meta));
-    }
-    block_on(builder.build(&store)).map_err(|e| e.to_string())?;
-
-    let mut saw_segment = false;
-    for chunk in store.into_chunks().into_values() {
-        let payload = chunk.envelope().data();
-        let reencoded = recanonicalize::<V1>(payload.as_ref()).map_err(|e| e.to_string())?;
-        ensure(
-            reencoded.as_slice() == payload.as_ref(),
-            "a stored chunk did not re-encode to its own bytes".to_owned(),
-        )?;
-        // The flags byte follows the two preamble bytes; a set SEGMENTED or
-        // SEGMENT bit witnesses that spill actually fired.
-        if payload
-            .as_ref()
-            .get(2)
-            .is_some_and(|flags| flags & 0x60 != 0)
-        {
-            saw_segment = true;
+    run(async {
+        // The canonical-form check (spec 6.2) over a whole spilled node set: decode
+        // each stored chunk and re-encode it, and the bytes must match, plain node,
+        // segmented node and segment alike. This is the build-roundtrip fuzz oracle
+        // exercised on a deterministic set that is known to spill.
+        let store = MemoryStore::default();
+        let mut builder = Builder::<V1>::new();
+        for first in 0u16..256 {
+            let byte = u8::try_from(first)?;
+            let meta = Metadata::new(KeyId::ContentType, Bytes::from(vec![b'a'; 700]))
+                .map_err(|e| e.to_string())?;
+            builder.insert(Key::from(vec![byte]), entry(byte), Some(meta));
         }
-    }
-    ensure(
-        saw_segment,
-        "the heavy set did not spill into segments".to_owned(),
-    )?;
-    Ok(())
+        builder.build(&store).await.map_err(|e| e.to_string())?;
+
+        let mut saw_segment = false;
+        for chunk in store.into_chunks().into_values() {
+            let payload = chunk.envelope().data();
+            let reencoded = recanonicalize::<V1>(payload.as_ref()).map_err(|e| e.to_string())?;
+            ensure(
+                reencoded.as_slice() == payload.as_ref(),
+                "a stored chunk did not re-encode to its own bytes".to_owned(),
+            )?;
+            // The flags byte follows the two preamble bytes; a set SEGMENTED or
+            // SEGMENT bit witnesses that spill actually fired.
+            if payload
+                .as_ref()
+                .get(2)
+                .is_some_and(|flags| flags & 0x60 != 0)
+            {
+                saw_segment = true;
+            }
+        }
+        ensure(
+            saw_segment,
+            "the heavy set did not spill into segments".to_owned(),
+        )?;
+        Ok(())
+    })
 }
 
 #[test]
 fn apply_over_a_spilled_node_matches_a_from_scratch_build() -> TestResult {
-    // History independence across the spill boundary: folding a changeset into a
-    // base whose root node spills must reach the exact root a from-scratch build
-    // of the merged key set reaches, byte for byte. This drives the whole
-    // materialize-then-re-spill path apply now takes over a segmented node.
-    let heavy = || Metadata::new(KeyId::ContentType, Bytes::from(vec![b'a'; 800]));
+    run(async {
+        // History independence across the spill boundary: folding a changeset into a
+        // base whose root node spills must reach the exact root a from-scratch build
+        // of the merged key set reaches, byte for byte. This drives the whole
+        // materialize-then-re-spill path apply now takes over a segmented node.
+        let heavy = || Metadata::new(KeyId::ContentType, Bytes::from(vec![b'a'; 800]));
 
-    // The base: 200 single-byte keys whose root node overruns one chunk.
-    let base_store = MemoryStore::default();
-    let mut base_builder = Builder::<V1>::new();
-    for first in 0u16..200 {
-        let byte = u8::try_from(first)?;
-        base_builder.insert(
-            Key::from(vec![byte]),
-            entry(byte),
-            Some(heavy().map_err(|e| e.to_string())?),
-        );
-    }
-    let base = block_on(base_builder.build(&base_store)).map_err(|e| e.to_string())?;
-    ensure(
-        base.stats().nodes_written() > 1,
-        "the base root node must spill".to_owned(),
-    )?;
+        // The base: 200 single-byte keys whose root node overruns one chunk.
+        let base_store = MemoryStore::default();
+        let mut base_builder = Builder::<V1>::new();
+        for first in 0u16..200 {
+            let byte = u8::try_from(first)?;
+            base_builder.insert(
+                Key::from(vec![byte]),
+                entry(byte),
+                Some(heavy().map_err(|e| e.to_string())?),
+            );
+        }
+        let base = base_builder
+            .build(&base_store)
+            .await
+            .map_err(|e| e.to_string())?;
+        ensure(
+            base.stats().nodes_written() > 1,
+            "the base root node must spill".to_owned(),
+        )?;
 
-    // The changeset overwrites the tail of the base and extends past it, so the
-    // merged key set is 0..256.
-    let mut changeset = Changeset::<V1>::new();
-    for first in 150u16..256 {
-        let byte = u8::try_from(first)?;
-        changeset.put(
-            Key::from(vec![byte]),
-            entry(byte),
-            Some(heavy().map_err(|e| e.to_string())?),
-        );
-    }
-    let applied =
-        block_on(apply(&base_store, base.root(), &changeset)).map_err(|e| e.to_string())?;
+        // The changeset overwrites the tail of the base and extends past it, so the
+        // merged key set is 0..256.
+        let mut changeset = Changeset::<V1>::new();
+        for first in 150u16..256 {
+            let byte = u8::try_from(first)?;
+            changeset.put(
+                Key::from(vec![byte]),
+                entry(byte),
+                Some(heavy().map_err(|e| e.to_string())?),
+            );
+        }
+        let applied = apply(&base_store, base.root(), &changeset)
+            .await
+            .map_err(|e| e.to_string())?;
 
-    // A from-scratch build of the merged key set.
-    let scratch_store = MemoryStore::default();
-    let mut scratch_builder = Builder::<V1>::new();
-    for first in 0u16..256 {
-        let byte = u8::try_from(first)?;
-        scratch_builder.insert(
-            Key::from(vec![byte]),
-            entry(byte),
-            Some(heavy().map_err(|e| e.to_string())?),
-        );
-    }
-    let scratch = block_on(scratch_builder.build(&scratch_store)).map_err(|e| e.to_string())?;
+        // A from-scratch build of the merged key set.
+        let scratch_store = MemoryStore::default();
+        let mut scratch_builder = Builder::<V1>::new();
+        for first in 0u16..256 {
+            let byte = u8::try_from(first)?;
+            scratch_builder.insert(
+                Key::from(vec![byte]),
+                entry(byte),
+                Some(heavy().map_err(|e| e.to_string())?),
+            );
+        }
+        let scratch = scratch_builder
+            .build(&scratch_store)
+            .await
+            .map_err(|e| e.to_string())?;
 
-    ensure(
-        applied == *scratch.root(),
-        format!(
-            "apply root {applied:?} diverged from the from-scratch root {:?}",
-            scratch.root()
-        ),
-    )?;
-    Ok(())
+        ensure(
+            applied == *scratch.root(),
+            format!(
+                "apply root {applied:?} diverged from the from-scratch root {:?}",
+                scratch.root()
+            ),
+        )?;
+        Ok(())
+    })
 }
 
 /// Chunk payload lengths of a store, for the budget assertions below.
@@ -381,20 +406,23 @@ proptest! {
     // construction across arbitrary key sets.
     #[test]
     fn no_built_node_exceeds_budget(entries in wide_heavy_set()) {
-        let store = MemoryStore::default();
-        let mut builder = Builder::<V1>::new();
-        for (key, fill, meta) in &entries {
-            let metadata = match meta {
-                Some(len) => Some(filler_meta(*len)?),
-                None => None,
-            };
-            builder.insert(Key::from(key.clone()), entry(*fill), metadata);
-        }
-        let built = block_on(builder.build(&store));
-        prop_assert!(built.is_ok(), "a wide/heavy set must spill, not error: {built:?}");
-        for len in chunk_lengths(&store) {
-            prop_assert!(len <= DEFAULT_BODY_SIZE, "built node over one chunk body");
-        }
+        run(async {
+            let store = MemoryStore::default();
+            let mut builder = Builder::<V1>::new();
+            for (key, fill, meta) in &entries {
+                let metadata = match meta {
+                    Some(len) => Some(filler_meta(*len)?),
+                    None => None,
+                };
+                builder.insert(Key::from(key.clone()), entry(*fill), metadata);
+            }
+            let built = builder.build(&store).await;
+            prop_assert!(built.is_ok(), "a wide/heavy set must spill, not error: {built:?}");
+            for len in chunk_lengths(&store) {
+                prop_assert!(len <= DEFAULT_BODY_SIZE, "built node over one chunk body");
+            }
+            Ok::<(), TestCaseError>(())
+        })?;
     }
 
     // apply upholds the same invariant: folding a fuzzed changeset into a base
@@ -404,27 +432,30 @@ proptest! {
         base in wide_heavy_set(),
         delta in wide_heavy_set(),
     ) {
-        let store = MemoryStore::default();
-        let mut builder = Builder::<V1>::new();
-        for (key, fill, _) in &base {
-            builder.insert(Key::from(key.clone()), entry(*fill), None);
-        }
-        let Ok(built) = block_on(builder.build(&store)) else {
-            return Ok(());
-        };
-        let mut changeset = Changeset::<V1>::new();
-        for (key, fill, _) in &delta {
-            changeset.put(Key::from(key.clone()), entry(*fill), None);
-        }
-        match block_on(apply(&store, built.root(), &changeset)) {
-            Ok(_) => {
-                for len in chunk_lengths(&store) {
-                    prop_assert!(len <= DEFAULT_BODY_SIZE, "applied node over one chunk body");
-                }
+        run(async {
+            let store = MemoryStore::default();
+            let mut builder = Builder::<V1>::new();
+            for (key, fill, _) in &base {
+                builder.insert(Key::from(key.clone()), entry(*fill), None);
             }
-            // A wide/heavy merge that cannot fit a node reports a typed error.
-            Err(ApplyError::Build(_) | ApplyError::Store(_)) => {}
-            Err(other) => prop_assert!(false, "unexpected apply error: {:?}", other),
-        }
+            let Ok(built) = builder.build(&store).await else {
+                return Ok(());
+            };
+            let mut changeset = Changeset::<V1>::new();
+            for (key, fill, _) in &delta {
+                changeset.put(Key::from(key.clone()), entry(*fill), None);
+            }
+            match apply(&store, built.root(), &changeset).await {
+                Ok(_) => {
+                    for len in chunk_lengths(&store) {
+                        prop_assert!(len <= DEFAULT_BODY_SIZE, "applied node over one chunk body");
+                    }
+                }
+                // A wide/heavy merge that cannot fit a node reports a typed error.
+                Err(ApplyError::Build(_) | ApplyError::Store(_)) => {}
+                Err(other) => prop_assert!(false, "unexpected apply error: {:?}", other),
+            }
+            Ok::<(), TestCaseError>(())
+        })?;
     }
 }

--- a/crates/manifest/tests/order.rs
+++ b/crates/manifest/tests/order.rs
@@ -6,10 +6,10 @@
 use std::error::Error;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use futures::executor::block_on;
 use nectar_manifest::{Builder, Entry, Key, Reader, V1};
 use nectar_primitives::store::{ChunkGet, MemoryStore};
 use nectar_primitives::{Chunk, ChunkAddress, ChunkRef, StandardChunkSet, Verified};
+use nectar_testing::run;
 
 type TestResult = Result<(), Box<dyn Error>>;
 
@@ -97,21 +97,26 @@ fn wide_keys() -> KeySet {
     out
 }
 
-fn build(store: &MemoryStore, keys: &[(Key, u8)]) -> Result<ChunkAddress, Box<dyn Error>> {
+async fn build(store: &MemoryStore, keys: &[(Key, u8)]) -> Result<ChunkAddress, Box<dyn Error>> {
     let mut builder = Builder::<V1>::new();
     for (key, fill) in keys {
         builder.insert(key.clone(), entry(*fill), None);
     }
-    Ok(*block_on(builder.build(store))
+    Ok(*builder
+        .build(store)
+        .await
         .map_err(|e| e.to_string())?
         .root())
 }
 
 /// The ground-truth ordering: every `(key, value)` a full walk yields.
-fn oracle(reader: &Reader<MemoryStore, V1>, root: &ChunkAddress) -> Result<Pairs, Box<dyn Error>> {
+async fn oracle(
+    reader: &Reader<MemoryStore, V1>,
+    root: &ChunkAddress,
+) -> Result<Pairs, Box<dyn Error>> {
     let mut out = Vec::new();
-    let mut cursor = block_on(reader.iter(root)).map_err(|e| e.to_string())?;
-    while let Some(pair) = block_on(cursor.next()).map_err(|e| e.to_string())? {
+    let mut cursor = reader.iter(root).await.map_err(|e| e.to_string())?;
+    while let Some(pair) = cursor.next().await.map_err(|e| e.to_string())? {
         out.push(pair);
     }
     Ok(out)
@@ -119,243 +124,280 @@ fn oracle(reader: &Reader<MemoryStore, V1>, root: &ChunkAddress) -> Result<Pairs
 
 #[test]
 fn rank_select_count_agree_with_a_full_walk_oracle() -> TestResult {
-    let store = MemoryStore::default();
-    let keys = radix_keys(12, 3);
-    let root = build(&store, &keys)?;
-    let reader = Reader::<MemoryStore, V1>::new(store);
-    let all = oracle(&reader, &root)?;
-    ensure(all.len() == keys.len(), "oracle lost keys".to_owned())?;
+    run(async {
+        let store = MemoryStore::default();
+        let keys = radix_keys(12, 3);
+        let root = build(&store, &keys).await?;
+        let reader = Reader::<MemoryStore, V1>::new(store);
+        let all = oracle(&reader, &root).await?;
+        ensure(all.len() == keys.len(), "oracle lost keys".to_owned())?;
 
-    // select(i) is the i-th key; one past the end is None.
-    for (i, (key, value)) in all.iter().enumerate() {
-        let index = u64::try_from(i)?;
-        let got = block_on(reader.select(&root, index)).map_err(|e| e.to_string())?;
+        // select(i) is the i-th key; one past the end is None.
+        for (i, (key, value)) in all.iter().enumerate() {
+            let index = u64::try_from(i)?;
+            let got = reader
+                .select(&root, index)
+                .await
+                .map_err(|e| e.to_string())?;
+            ensure(
+                got.as_ref() == Some(&(key.clone(), value.clone())),
+                format!("select({i}) mismatch"),
+            )?;
+        }
+        let end = u64::try_from(all.len())?;
         ensure(
-            got.as_ref() == Some(&(key.clone(), value.clone())),
-            format!("select({i}) mismatch"),
+            reader
+                .select(&root, end)
+                .await
+                .map_err(|e| e.to_string())?
+                .is_none(),
+            "select past the end must be None".to_owned(),
         )?;
-    }
-    let end = u64::try_from(all.len())?;
-    ensure(
-        block_on(reader.select(&root, end))
-            .map_err(|e| e.to_string())?
-            .is_none(),
-        "select past the end must be None".to_owned(),
-    )?;
 
-    // rank(key) is the count of strictly-smaller keys, checked at present keys
-    // and at the absent points that bracket, precede and follow the key set.
-    let probes = [
-        Key::empty(),
-        Key::from(&[0u8][..]),
-        Key::from(&[3u8, 5][..]),
-        Key::from(&[3u8, 5, 5][..]),
-        Key::from(&[3u8, 5, 6][..]),
-        Key::from(&[6u8, 0, 0][..]),
-        Key::from(&[11u8, 11, 11][..]),
-        Key::from(&[12u8][..]),
-        Key::from(&[255u8][..]),
-    ];
-    for probe in &probes {
-        let expected = u64::try_from(all.iter().filter(|(k, _)| k < probe).count())?;
-        let got = block_on(reader.rank(&root, probe)).map_err(|e| e.to_string())?;
-        ensure(
-            got == expected,
-            format!("rank mismatch: {got} != {expected}"),
-        )?;
-    }
+        // rank(key) is the count of strictly-smaller keys, checked at present keys
+        // and at the absent points that bracket, precede and follow the key set.
+        let probes = [
+            Key::empty(),
+            Key::from(&[0u8][..]),
+            Key::from(&[3u8, 5][..]),
+            Key::from(&[3u8, 5, 5][..]),
+            Key::from(&[3u8, 5, 6][..]),
+            Key::from(&[6u8, 0, 0][..]),
+            Key::from(&[11u8, 11, 11][..]),
+            Key::from(&[12u8][..]),
+            Key::from(&[255u8][..]),
+        ];
+        for probe in &probes {
+            let expected = u64::try_from(all.iter().filter(|(k, _)| k < probe).count())?;
+            let got = reader.rank(&root, probe).await.map_err(|e| e.to_string())?;
+            ensure(
+                got == expected,
+                format!("rank mismatch: {got} != {expected}"),
+            )?;
+        }
 
-    // count(lo, hi) is the size of the half-open window.
-    for (lo, hi) in [
-        (Key::from(&[0u8, 0, 0][..]), Key::from(&[3u8, 0, 0][..])),
-        (Key::from(&[3u8, 5, 5][..]), Key::from(&[7u8, 2, 2][..])),
-        (Key::empty(), Key::from(&[12u8][..])),
-        (Key::from(&[9u8][..]), Key::from(&[3u8][..])),
-    ] {
-        let expected = u64::try_from(all.iter().filter(|(k, _)| lo <= *k && *k < hi).count())?;
-        let got = block_on(reader.count(&root, &lo, &hi)).map_err(|e| e.to_string())?;
-        ensure(
-            got == expected,
-            format!("count mismatch: {got} != {expected}"),
-        )?;
-    }
-    Ok(())
+        // count(lo, hi) is the size of the half-open window.
+        for (lo, hi) in [
+            (Key::from(&[0u8, 0, 0][..]), Key::from(&[3u8, 0, 0][..])),
+            (Key::from(&[3u8, 5, 5][..]), Key::from(&[7u8, 2, 2][..])),
+            (Key::empty(), Key::from(&[12u8][..])),
+            (Key::from(&[9u8][..]), Key::from(&[3u8][..])),
+        ] {
+            let expected = u64::try_from(all.iter().filter(|(k, _)| lo <= *k && *k < hi).count())?;
+            let got = reader
+                .count(&root, &lo, &hi)
+                .await
+                .map_err(|e| e.to_string())?;
+            ensure(
+                got == expected,
+                format!("count mismatch: {got} != {expected}"),
+            )?;
+        }
+        Ok(())
+    })
 }
 
 #[test]
 fn spilled_node_order_statistics_agree_with_the_oracle() -> TestResult {
-    // A corpus whose root is a segmented node, so every query routes the root's
-    // segment directory by seg_count before descending a referenced child.
-    let store = MemoryStore::default();
-    let keys = wide_keys();
-    let root = build(&store, &keys)?;
-    let reader = Reader::<MemoryStore, V1>::new(store);
-    let all = oracle(&reader, &root)?;
-    ensure(all.len() == keys.len(), "oracle lost keys".to_owned())?;
+    run(async {
+        // A corpus whose root is a segmented node, so every query routes the root's
+        // segment directory by seg_count before descending a referenced child.
+        let store = MemoryStore::default();
+        let keys = wide_keys();
+        let root = build(&store, &keys).await?;
+        let reader = Reader::<MemoryStore, V1>::new(store);
+        let all = oracle(&reader, &root).await?;
+        ensure(all.len() == keys.len(), "oracle lost keys".to_owned())?;
 
-    // Sampled select and its inverse rank agree with the oracle across the whole
-    // spilled listing, including both ends.
-    let last = all.len().saturating_sub(1);
-    for i in (0..all.len()).step_by(311).chain([last]) {
-        let (key, value) = all.get(i).ok_or("oracle index out of range")?;
-        let index = u64::try_from(i)?;
-        let got = block_on(reader.select(&root, index)).map_err(|e| e.to_string())?;
-        ensure(
-            got.as_ref() == Some(&(key.clone(), value.clone())),
-            format!("spilled select({i}) mismatch"),
-        )?;
-        let rank = block_on(reader.rank(&root, key)).map_err(|e| e.to_string())?;
-        ensure(rank == index, format!("spilled rank at {i} mismatch"))?;
-    }
+        // Sampled select and its inverse rank agree with the oracle across the whole
+        // spilled listing, including both ends.
+        let last = all.len().saturating_sub(1);
+        for i in (0..all.len()).step_by(311).chain([last]) {
+            let (key, value) = all.get(i).ok_or("oracle index out of range")?;
+            let index = u64::try_from(i)?;
+            let got = reader
+                .select(&root, index)
+                .await
+                .map_err(|e| e.to_string())?;
+            ensure(
+                got.as_ref() == Some(&(key.clone(), value.clone())),
+                format!("spilled select({i}) mismatch"),
+            )?;
+            let rank = reader.rank(&root, key).await.map_err(|e| e.to_string())?;
+            ensure(rank == index, format!("spilled rank at {i} mismatch"))?;
+        }
 
-    // Windows spanning several segments count exactly.
-    for (lo, hi) in [
-        (Key::from(&[0u8, 0][..]), Key::from(&[100u8, 0][..])),
-        (Key::from(&[40u8, 25][..]), Key::from(&[210u8, 10][..])),
-        (Key::empty(), Key::from(&[255u8, 255][..])),
-    ] {
-        let expected = u64::try_from(all.iter().filter(|(k, _)| lo <= *k && *k < hi).count())?;
-        let got = block_on(reader.count(&root, &lo, &hi)).map_err(|e| e.to_string())?;
-        ensure(
-            got == expected,
-            format!("spilled count mismatch: {got} != {expected}"),
-        )?;
-    }
+        // Windows spanning several segments count exactly.
+        for (lo, hi) in [
+            (Key::from(&[0u8, 0][..]), Key::from(&[100u8, 0][..])),
+            (Key::from(&[40u8, 25][..]), Key::from(&[210u8, 10][..])),
+            (Key::empty(), Key::from(&[255u8, 255][..])),
+        ] {
+            let expected = u64::try_from(all.iter().filter(|(k, _)| lo <= *k && *k < hi).count())?;
+            let got = reader
+                .count(&root, &lo, &hi)
+                .await
+                .map_err(|e| e.to_string())?;
+            ensure(
+                got == expected,
+                format!("spilled count mismatch: {got} != {expected}"),
+            )?;
+        }
 
-    // A page deep in the spilled listing is the matching oracle slice.
-    let mut got = Vec::new();
-    let mut cursor = block_on(reader.paginate_prefix(&root, &Key::empty(), 9000, 25))
-        .map_err(|e| e.to_string())?;
-    while let Some(pair) = block_on(cursor.next()).map_err(|e| e.to_string())? {
-        got.push(pair);
-    }
-    let want: Vec<_> = all.iter().skip(9000).take(25).cloned().collect();
-    ensure(got == want, "spilled paginate mismatch".to_owned())?;
-    Ok(())
+        // A page deep in the spilled listing is the matching oracle slice.
+        let mut got = Vec::new();
+        let mut cursor = reader
+            .paginate_prefix(&root, &Key::empty(), 9000, 25)
+            .await
+            .map_err(|e| e.to_string())?;
+        while let Some(pair) = cursor.next().await.map_err(|e| e.to_string())? {
+            got.push(pair);
+        }
+        let want: Vec<_> = all.iter().skip(9000).take(25).cloned().collect();
+        ensure(got == want, "spilled paginate mismatch".to_owned())?;
+        Ok(())
+    })
 }
 
 #[test]
 fn order_statistics_are_stable_under_shuffled_build_order() -> TestResult {
-    let forward = radix_keys(10, 3);
-    let mut reversed = forward.clone();
-    reversed.reverse();
+    run(async {
+        let forward = radix_keys(10, 3);
+        let mut reversed = forward.clone();
+        reversed.reverse();
 
-    let a_store = MemoryStore::default();
-    let a = build(&a_store, &forward)?;
-    let b_store = MemoryStore::default();
-    let b = build(&b_store, &reversed)?;
-    ensure(a == b, "shuffled build must root identically".to_owned())?;
+        let a_store = MemoryStore::default();
+        let a = build(&a_store, &forward).await?;
+        let b_store = MemoryStore::default();
+        let b = build(&b_store, &reversed).await?;
+        ensure(a == b, "shuffled build must root identically".to_owned())?;
 
-    let reader = Reader::<MemoryStore, V1>::new(a_store);
-    // A shuffled build is the same tree, so every rank and select is unchanged.
-    for index in [0u64, 1, 250, 500, 999] {
-        let got = block_on(reader.select(&a, index)).map_err(|e| e.to_string())?;
-        let (key, _) = got.ok_or("select fell off the shuffled build")?;
-        let rank = block_on(reader.rank(&a, &key)).map_err(|e| e.to_string())?;
-        ensure(rank == index, format!("rank/select disagree at {index}"))?;
-    }
-    Ok(())
+        let reader = Reader::<MemoryStore, V1>::new(a_store);
+        // A shuffled build is the same tree, so every rank and select is unchanged.
+        for index in [0u64, 1, 250, 500, 999] {
+            let got = reader.select(&a, index).await.map_err(|e| e.to_string())?;
+            let (key, _) = got.ok_or("select fell off the shuffled build")?;
+            let rank = reader.rank(&a, &key).await.map_err(|e| e.to_string())?;
+            ensure(rank == index, format!("rank/select disagree at {index}"))?;
+        }
+        Ok(())
+    })
 }
 
 #[test]
 fn paginate_matches_iter_skip_take() -> TestResult {
-    let store = MemoryStore::default();
-    let keys = radix_keys(10, 3);
-    let root = build(&store, &keys)?;
-    let reader = Reader::<MemoryStore, V1>::new(store);
-    let all = oracle(&reader, &root)?;
+    run(async {
+        let store = MemoryStore::default();
+        let keys = radix_keys(10, 3);
+        let root = build(&store, &keys).await?;
+        let reader = Reader::<MemoryStore, V1>::new(store);
+        let all = oracle(&reader, &root).await?;
 
-    // Whole-manifest pagination is exactly iter().skip(offset).take(limit).
-    for (offset, limit) in [(0u64, 7usize), (13, 20), (500, 33), (995, 50), (2000, 4)] {
-        let mut got = Vec::new();
-        let mut cursor = block_on(reader.paginate_prefix(&root, &Key::empty(), offset, limit))
-            .map_err(|e| e.to_string())?;
-        while let Some(pair) = block_on(cursor.next()).map_err(|e| e.to_string())? {
-            got.push(pair);
+        // Whole-manifest pagination is exactly iter().skip(offset).take(limit).
+        for (offset, limit) in [(0u64, 7usize), (13, 20), (500, 33), (995, 50), (2000, 4)] {
+            let mut got = Vec::new();
+            let mut cursor = reader
+                .paginate_prefix(&root, &Key::empty(), offset, limit)
+                .await
+                .map_err(|e| e.to_string())?;
+            while let Some(pair) = cursor.next().await.map_err(|e| e.to_string())? {
+                got.push(pair);
+            }
+            let start = usize::try_from(offset)?;
+            let want: Vec<_> = all.iter().skip(start).take(limit).cloned().collect();
+            ensure(
+                got == want,
+                format!("paginate_prefix({offset}, {limit}) mismatch"),
+            )?;
         }
-        let start = usize::try_from(offset)?;
-        let want: Vec<_> = all.iter().skip(start).take(limit).cloned().collect();
-        ensure(
-            got == want,
-            format!("paginate_prefix({offset}, {limit}) mismatch"),
-        )?;
-    }
 
-    // Range pagination is the same over the range's own slice.
-    let lo = Key::from(&[3u8, 0, 0][..]);
-    let hi = Key::from(&[7u8, 0, 0][..]);
-    let window: Vec<_> = all
-        .iter()
-        .filter(|(k, _)| lo <= *k && *k < hi)
-        .cloned()
-        .collect();
-    for (offset, limit) in [(0u64, 10usize), (25, 40), (300, 12)] {
-        let mut got = Vec::new();
-        let mut cursor =
-            block_on(reader.paginate(&root, &lo, &hi, offset, limit)).map_err(|e| e.to_string())?;
-        while let Some(pair) = block_on(cursor.next()).map_err(|e| e.to_string())? {
-            got.push(pair);
+        // Range pagination is the same over the range's own slice.
+        let lo = Key::from(&[3u8, 0, 0][..]);
+        let hi = Key::from(&[7u8, 0, 0][..]);
+        let window: Vec<_> = all
+            .iter()
+            .filter(|(k, _)| lo <= *k && *k < hi)
+            .cloned()
+            .collect();
+        for (offset, limit) in [(0u64, 10usize), (25, 40), (300, 12)] {
+            let mut got = Vec::new();
+            let mut cursor = reader
+                .paginate(&root, &lo, &hi, offset, limit)
+                .await
+                .map_err(|e| e.to_string())?;
+            while let Some(pair) = cursor.next().await.map_err(|e| e.to_string())? {
+                got.push(pair);
+            }
+            let start = usize::try_from(offset)?;
+            let want: Vec<_> = window.iter().skip(start).take(limit).cloned().collect();
+            ensure(got == want, format!("paginate({offset}, {limit}) mismatch"))?;
         }
-        let start = usize::try_from(offset)?;
-        let want: Vec<_> = window.iter().skip(start).take(limit).cloned().collect();
-        ensure(got == want, format!("paginate({offset}, {limit}) mismatch"))?;
-    }
-    Ok(())
+        Ok(())
+    })
 }
 
 #[test]
 fn the_offset_seek_costs_depth_not_offset() -> TestResult {
-    // A wide, spilled corpus: a full first-byte spread forces the root to spill
-    // into a segment directory, so the seek must route by seg_count.
-    let inner = MemoryStore::default();
-    let keys = wide_keys();
-    let root = build(&inner, &keys)?;
-    let store = CountingStore {
-        inner,
-        gets: AtomicUsize::new(0),
-    };
-    let reader = Reader::<CountingStore, V1>::new(store);
-    let total = u64::try_from(keys.len())?;
+    run(async {
+        // A wide, spilled corpus: a full first-byte spread forces the root to spill
+        // into a segment directory, so the seek must route by seg_count.
+        let inner = MemoryStore::default();
+        let keys = wide_keys();
+        let root = build(&inner, &keys).await?;
+        let store = CountingStore {
+            inner,
+            gets: AtomicUsize::new(0),
+        };
+        let reader = Reader::<CountingStore, V1>::new(store);
+        let total = u64::try_from(keys.len())?;
 
-    // Selecting near the start and deep into the listing fetches the same handful
-    // of nodes: a few directory and node hops per level, never the offset.
-    let mut costs = Vec::new();
-    for index in [0u64, total / 2, total.saturating_sub(1)] {
+        // Selecting near the start and deep into the listing fetches the same handful
+        // of nodes: a few directory and node hops per level, never the offset.
+        let mut costs = Vec::new();
+        for index in [0u64, total / 2, total.saturating_sub(1)] {
+            reader.store().reset();
+            let got = reader
+                .select(&root, index)
+                .await
+                .map_err(|e| e.to_string())?;
+            ensure(got.is_some(), format!("select({index}) fell off"))?;
+            costs.push(reader.store().gets());
+        }
+        for cost in &costs {
+            ensure(
+                *cost <= 32,
+                format!("select fetched {cost} nodes, not O(depth)"),
+            )?;
+        }
+
+        // Paginating at a large offset fetches no more than at offset zero plus the
+        // page and its read-ahead: the offset itself is free.
         reader.store().reset();
-        let got = block_on(reader.select(&root, index)).map_err(|e| e.to_string())?;
-        ensure(got.is_some(), format!("select({index}) fell off"))?;
-        costs.push(reader.store().gets());
-    }
-    for cost in &costs {
+        let mut head = reader
+            .paginate_prefix(&root, &Key::empty(), 0, 5)
+            .await
+            .map_err(|e| e.to_string())?;
+        while head.next().await.map_err(|e| e.to_string())?.is_some() {}
+        let head_cost = reader.store().gets();
+
+        reader.store().reset();
+        let deep_offset = total.saturating_sub(5);
+        let mut deep = reader
+            .paginate_prefix(&root, &Key::empty(), deep_offset, 5)
+            .await
+            .map_err(|e| e.to_string())?;
+        while deep.next().await.map_err(|e| e.to_string())?.is_some() {}
+        let deep_cost = reader.store().gets();
+
+        // The deep page pays for its own depth and window, not the offset it skipped.
         ensure(
-            *cost <= 32,
-            format!("select fetched {cost} nodes, not O(depth)"),
+            deep_cost <= head_cost.saturating_mul(2).saturating_add(32),
+            format!("deep page fetched {deep_cost} vs head {head_cost}: offset is not free"),
         )?;
-    }
-
-    // Paginating at a large offset fetches no more than at offset zero plus the
-    // page and its read-ahead: the offset itself is free.
-    reader.store().reset();
-    let mut head =
-        block_on(reader.paginate_prefix(&root, &Key::empty(), 0, 5)).map_err(|e| e.to_string())?;
-    while block_on(head.next()).map_err(|e| e.to_string())?.is_some() {}
-    let head_cost = reader.store().gets();
-
-    reader.store().reset();
-    let deep_offset = total.saturating_sub(5);
-    let mut deep = block_on(reader.paginate_prefix(&root, &Key::empty(), deep_offset, 5))
-        .map_err(|e| e.to_string())?;
-    while block_on(deep.next()).map_err(|e| e.to_string())?.is_some() {}
-    let deep_cost = reader.store().gets();
-
-    // The deep page pays for its own depth and window, not the offset it skipped.
-    ensure(
-        deep_cost <= head_cost.saturating_mul(2).saturating_add(32),
-        format!("deep page fetched {deep_cost} vs head {head_cost}: offset is not free"),
-    )?;
-    ensure(
-        u64::try_from(deep_cost)? < deep_offset,
-        format!("deep page fetched {deep_cost}, proportional to the offset"),
-    )?;
-    Ok(())
+        ensure(
+            u64::try_from(deep_cost)? < deep_offset,
+            format!("deep page fetched {deep_cost}, proportional to the offset"),
+        )?;
+        Ok(())
+    })
 }

--- a/crates/manifest/tests/read_profile.rs
+++ b/crates/manifest/tests/read_profile.rs
@@ -6,9 +6,9 @@
 use std::error::Error;
 
 use bytes::Bytes;
-use futures::executor::block_on;
 use nectar_manifest::{Builder, Changeset, Entry, Key, Reader, V1, V1Read, apply};
 use nectar_primitives::{ChunkAddress, ChunkRef, MemoryStore};
+use nectar_testing::run;
 
 type TestResult = Result<(), Box<dyn Error>>;
 
@@ -30,115 +30,129 @@ fn windowed_keys() -> Vec<(Key, u8)> {
 
 /// Build the windowed key set under `F`, returning the root and the number of
 /// distinct chunks the build stored.
-fn build_windowed<F: nectar_manifest::Format>() -> Result<(ChunkAddress, usize), Box<dyn Error>> {
+async fn build_windowed<F: nectar_manifest::Format>()
+-> Result<(ChunkAddress, usize), Box<dyn Error>> {
     let store = MemoryStore::default();
     let mut builder = Builder::<F>::new();
     for (key, fill) in windowed_keys() {
         builder.insert(key, ref_entry::<F>(fill), None);
     }
-    let built = block_on(builder.build(&store))?;
+    let built = builder.build(&store).await?;
     Ok((*built.root(), store.len()))
 }
 
 #[test]
 fn the_read_profile_stores_fewer_chunks_for_a_windowed_subtree() -> TestResult {
-    let (_, v1_chunks) = build_windowed::<V1>()?;
-    let (_, read_chunks) = build_windowed::<V1Read>()?;
-    // The sub-node is referenced under V1 (its own chunk) but embedded under
-    // the read profile (folded into the root), so the read build stores fewer.
-    ensure(
-        read_chunks < v1_chunks,
-        "read profile must store fewer chunks than V1 for the windowed subtree",
-    )?;
-    Ok(())
+    run(async {
+        let (_, v1_chunks) = build_windowed::<V1>().await?;
+        let (_, read_chunks) = build_windowed::<V1Read>().await?;
+        // The sub-node is referenced under V1 (its own chunk) but embedded under
+        // the read profile (folded into the root), so the read build stores fewer.
+        ensure(
+            read_chunks < v1_chunks,
+            "read profile must store fewer chunks than V1 for the windowed subtree",
+        )?;
+        Ok(())
+    })
 }
 
 #[test]
 fn the_read_profile_and_v1_produce_distinct_roots() -> TestResult {
-    let (v1_root, _) = build_windowed::<V1>()?;
-    let (read_root, _) = build_windowed::<V1Read>()?;
-    // A distinct wire version and a distinct shape: byte-distinct manifests.
-    ensure(
-        v1_root != read_root,
-        "the two profiles must root differently",
-    )?;
-    Ok(())
+    run(async {
+        let (v1_root, _) = build_windowed::<V1>().await?;
+        let (read_root, _) = build_windowed::<V1Read>().await?;
+        // A distinct wire version and a distinct shape: byte-distinct manifests.
+        ensure(
+            v1_root != read_root,
+            "the two profiles must root differently",
+        )?;
+        Ok(())
+    })
 }
 
 #[test]
 fn build_then_read_round_trips_every_key_under_the_read_profile() -> TestResult {
-    let store = MemoryStore::default();
-    let mut builder = Builder::<V1Read>::new();
-    for (key, fill) in windowed_keys() {
-        builder.insert(key, ref_entry::<V1Read>(fill), None);
-    }
-    let root = *block_on(builder.build(&store))?.root();
+    run(async {
+        let store = MemoryStore::default();
+        let mut builder = Builder::<V1Read>::new();
+        for (key, fill) in windowed_keys() {
+            builder.insert(key, ref_entry::<V1Read>(fill), None);
+        }
+        let root = *builder.build(&store).await?.root();
 
-    let reader = Reader::<MemoryStore, V1Read>::new(store);
-    for (key, fill) in windowed_keys() {
-        let got = block_on(reader.get(&root, &key))?;
+        let reader = Reader::<MemoryStore, V1Read>::new(store);
+        for (key, fill) in windowed_keys() {
+            let got = reader.get(&root, &key).await?;
+            ensure(
+                got == Some(ref_entry::<V1Read>(fill)),
+                "read value mismatch",
+            )?;
+        }
+        // An absent key still reads as absent under the profile.
         ensure(
-            got == Some(ref_entry::<V1Read>(fill)),
-            "read value mismatch",
+            reader
+                .get(&root, &Key::from(&b"absent"[..]))
+                .await?
+                .is_none(),
+            "absent key must read as None",
         )?;
-    }
-    // An absent key still reads as absent under the profile.
-    ensure(
-        block_on(reader.get(&root, &Key::from(&b"absent"[..])))?.is_none(),
-        "absent key must read as None",
-    )?;
-    Ok(())
+        Ok(())
+    })
 }
 
 #[test]
 fn apply_matches_a_from_scratch_build_under_the_read_profile() -> TestResult {
-    let all = windowed_keys();
-    let split = 40usize;
+    run(async {
+        let all = windowed_keys();
+        let split = 40usize;
 
-    // A base of the first keys, then a changeset staging the rest.
-    let store = MemoryStore::default();
-    let mut base = Builder::<V1Read>::new();
-    for (key, fill) in all.iter().take(split) {
-        base.insert(key.clone(), ref_entry::<V1Read>(*fill), None);
-    }
-    let base_root = *block_on(base.build(&store))?.root();
+        // A base of the first keys, then a changeset staging the rest.
+        let store = MemoryStore::default();
+        let mut base = Builder::<V1Read>::new();
+        for (key, fill) in all.iter().take(split) {
+            base.insert(key.clone(), ref_entry::<V1Read>(*fill), None);
+        }
+        let base_root = *base.build(&store).await?.root();
 
-    let mut changeset = Changeset::<V1Read>::new();
-    for (key, fill) in all.iter().skip(split) {
-        changeset.put(key.clone(), ref_entry::<V1Read>(*fill), None);
-    }
-    let applied = block_on(apply(&store, &base_root, &changeset))?;
+        let mut changeset = Changeset::<V1Read>::new();
+        for (key, fill) in all.iter().skip(split) {
+            changeset.put(key.clone(), ref_entry::<V1Read>(*fill), None);
+        }
+        let applied = apply(&store, &base_root, &changeset).await?;
 
-    // A from-scratch build of the merged key set lands on the same root, byte
-    // for byte: history independence holds under the read profile too.
-    let (scratch_root, _) = build_windowed::<V1Read>()?;
-    ensure(
-        applied == scratch_root,
-        "apply must match a from-scratch build under the read profile",
-    )?;
-
-    // The applied manifest reads back the full key set.
-    let reader = Reader::<MemoryStore, V1Read>::new(store);
-    for (key, fill) in &all {
-        let got = block_on(reader.get(&applied, key))?;
+        // A from-scratch build of the merged key set lands on the same root, byte
+        // for byte: history independence holds under the read profile too.
+        let (scratch_root, _) = build_windowed::<V1Read>().await?;
         ensure(
-            got == Some(ref_entry::<V1Read>(*fill)),
-            "applied value mismatch",
+            applied == scratch_root,
+            "apply must match a from-scratch build under the read profile",
         )?;
-    }
-    Ok(())
+
+        // The applied manifest reads back the full key set.
+        let reader = Reader::<MemoryStore, V1Read>::new(store);
+        for (key, fill) in &all {
+            let got = reader.get(&applied, key).await?;
+            ensure(
+                got == Some(ref_entry::<V1Read>(*fill)),
+                "applied value mismatch",
+            )?;
+        }
+        Ok(())
+    })
 }
 
 #[test]
 fn an_inline_value_round_trips_under_the_read_profile() -> TestResult {
-    let store = MemoryStore::default();
-    let mut builder = Builder::<V1Read>::new();
-    let value = Entry::<V1Read>::inline(Bytes::from_static(b"<h1>hi</h1>"))?;
-    builder.insert(Key::from(&b"index.html"[..]), value.clone(), None);
-    let root = *block_on(builder.build(&store))?.root();
+    run(async {
+        let store = MemoryStore::default();
+        let mut builder = Builder::<V1Read>::new();
+        let value = Entry::<V1Read>::inline(Bytes::from_static(b"<h1>hi</h1>"))?;
+        builder.insert(Key::from(&b"index.html"[..]), value.clone(), None);
+        let root = *builder.build(&store).await?.root();
 
-    let reader = Reader::<MemoryStore, V1Read>::new(store);
-    let got = block_on(reader.get(&root, &Key::from(&b"index.html"[..])))?;
-    ensure(got == Some(value), "inline value must round-trip")?;
-    Ok(())
+        let reader = Reader::<MemoryStore, V1Read>::new(store);
+        let got = reader.get(&root, &Key::from(&b"index.html"[..])).await?;
+        ensure(got == Some(value), "inline value must round-trip")?;
+        Ok(())
+    })
 }

--- a/crates/manifest/tests/reader.rs
+++ b/crates/manifest/tests/reader.rs
@@ -6,10 +6,10 @@ use std::error::Error;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use bytes::Bytes;
-use futures::executor::block_on;
 use nectar_manifest::{Builder, Child, Entry, ForkTable, Key, Node, NodePut, Prefix, Reader, V1};
 use nectar_primitives::store::{ChunkGet, MemoryStore};
 use nectar_primitives::{Chunk, ChunkAddress, ChunkRef, StandardChunkSet, Verified};
+use nectar_testing::run;
 
 type TestResult = Result<(), Box<dyn Error>>;
 
@@ -61,163 +61,176 @@ fn entry(byte: u8) -> Entry {
 /// Build a deliberately wide two-level manifest: a root whose fork table holds
 /// one referenced leaf per first byte, each leaf terminating a single key. The
 /// second level is `width` chunks wide, but any one key sits two nodes deep.
-fn wide_manifest(store: &MemoryStore, width: u16) -> Result<ChunkAddress, Box<dyn Error>> {
+async fn wide_manifest(store: &MemoryStore, width: u16) -> Result<ChunkAddress, Box<dyn Error>> {
     let mut forks = ForkTable::<V1>::new();
     for first in 0..width {
         let first = u8::try_from(first)?;
         let mut leaf = ForkTable::new();
         leaf.insert(Prefix::try_from(&[0xFFu8][..])?, entry(first).into(), None)?;
-        let leaf_ref = block_on(store.put_node(&Node::new(None, leaf)))?;
+        let leaf_ref = store.put_node(&Node::new(None, leaf)).await?;
         forks.insert(
             Prefix::try_from(&[first][..])?,
             Child::Ref32(ChunkRef::new(leaf_ref)).into(),
             None,
         )?;
     }
-    Ok(block_on(store.put_node(&Node::new(None, forks)))?)
+    Ok(store.put_node(&Node::new(None, forks)).await?)
 }
 
 #[test]
 fn a_lookup_fetches_depth_nodes_not_the_wide_level() -> TestResult {
-    // Wide enough to dwarf the depth-2 path, yet inside one root chunk (a
-    // radix-full root spills to a directory, which is a later car's concern).
-    let width = 100u16;
-    let memory = MemoryStore::default();
-    let root = wide_manifest(&memory, width)?;
+    run(async {
+        // Wide enough to dwarf the depth-2 path, yet inside one root chunk (a
+        // radix-full root spills to a directory, which is a later car's concern).
+        let width = 100u16;
+        let memory = MemoryStore::default();
+        let root = wide_manifest(&memory, width).await?;
 
-    // The whole manifest is one root plus `width` leaves.
-    ensure_eq(memory.len(), usize::from(width) + 1, "stored node count")?;
+        // The whole manifest is one root plus `width` leaves.
+        ensure_eq(memory.len(), usize::from(width) + 1, "stored node count")?;
 
-    let store = CountingStore {
-        inner: memory,
-        gets: AtomicUsize::new(0),
-    };
-    let reader: Reader<_> = Reader::new(&store);
+        let store = CountingStore {
+            inner: memory,
+            gets: AtomicUsize::new(0),
+        };
+        let reader: Reader<_> = Reader::new(&store);
 
-    // Look up one key: first byte 0x2A, then the leaf's 0xFF fork.
-    let key = Key::from(&[0x2Au8, 0xFF][..]);
-    let value = block_on(reader.get(&root, &key))?;
-    ensure_eq(value, Some(entry(0x2A)), "looked-up value")?;
+        // Look up one key: first byte 0x2A, then the leaf's 0xFF fork.
+        let key = Key::from(&[0x2Au8, 0xFF][..]);
+        let value = reader.get(&root, &key).await?;
+        ensure_eq(value, Some(entry(0x2A)), "looked-up value")?;
 
-    // Two hops: the root and the single leaf on the path. Never the wide
-    // sibling level, so fetches track depth, not width.
-    ensure_eq(store.gets(), 2, "fetches equal path depth")?;
-    ensure(
-        store.gets() < usize::from(width),
-        "fetches below level width",
-    )?;
+        // Two hops: the root and the single leaf on the path. Never the wide
+        // sibling level, so fetches track depth, not width.
+        ensure_eq(store.gets(), 2, "fetches equal path depth")?;
+        ensure(
+            store.gets() < usize::from(width),
+            "fetches below level width",
+        )?;
 
-    // A second lookup on a different branch is again two hops: the frontier is
-    // never widened, each key pays only its own path.
-    store.gets.store(0, Ordering::Relaxed);
-    let value = block_on(reader.get(&root, &Key::from(&[0x50u8, 0xFF][..])))?;
-    ensure_eq(value, Some(entry(0x50)), "second value")?;
-    ensure_eq(store.gets(), 2, "second lookup is also depth-bounded")
+        // A second lookup on a different branch is again two hops: the frontier is
+        // never widened, each key pays only its own path.
+        store.gets.store(0, Ordering::Relaxed);
+        let value = reader.get(&root, &Key::from(&[0x50u8, 0xFF][..])).await?;
+        ensure_eq(value, Some(entry(0x50)), "second value")?;
+        ensure_eq(store.gets(), 2, "second lookup is also depth-bounded")
+    })
 }
 
 #[test]
 fn every_builder_key_reads_back_through_referenced_hops() -> TestResult {
-    // Build a real manifest through the builder so the reader is exercised
-    // against the wire structure it exists to read, not a hand-laid table: the
-    // shared-prefix grid forces compacted edges, embedded subtrees and, once a
-    // subtree outgrows the inline bound, referenced children the reader must
-    // fetch and descend.
-    let memory = MemoryStore::default();
-    let mut builder = Builder::new();
-    let mut expected: Vec<(String, Entry)> = Vec::new();
-    for dir in 0u8..16 {
-        for file in 0u8..40 {
-            let key = format!("dir{dir:02}/file{file:04}.txt");
-            let value = entry((dir ^ file).wrapping_add(1));
-            builder.insert(Key::from(key.clone().into_bytes()), value.clone(), None);
-            expected.push((key, value));
+    run(async {
+        // Build a real manifest through the builder so the reader is exercised
+        // against the wire structure it exists to read, not a hand-laid table: the
+        // shared-prefix grid forces compacted edges, embedded subtrees and, once a
+        // subtree outgrows the inline bound, referenced children the reader must
+        // fetch and descend.
+        let memory = MemoryStore::default();
+        let mut builder = Builder::new();
+        let mut expected: Vec<(String, Entry)> = Vec::new();
+        for dir in 0u8..16 {
+            for file in 0u8..40 {
+                let key = format!("dir{dir:02}/file{file:04}.txt");
+                let value = entry((dir ^ file).wrapping_add(1));
+                builder.insert(Key::from(key.clone().into_bytes()), value.clone(), None);
+                expected.push((key, value));
+            }
         }
-    }
-    // A key that is a strict prefix of another exercises a fork carrying both a
-    // terminal value and a continuation.
-    builder.insert(Key::from(&b"pre"[..]), entry(0x11), None);
-    expected.push(("pre".to_owned(), entry(0x11)));
-    builder.insert(Key::from(&b"prefix"[..]), entry(0x22), None);
-    expected.push(("prefix".to_owned(), entry(0x22)));
-    // An inline value must read back whole, not as a reference.
-    let inline = Entry::inline(Bytes::from_static(b"hello")).map_err(|e| e.to_string())?;
-    builder.insert(Key::from(&b"inline.txt"[..]), inline.clone(), None);
-    expected.push(("inline.txt".to_owned(), inline));
-    // The empty key sets the manifest's own value in the root extension.
-    builder.insert(Key::empty(), entry(0x99), None);
+        // A key that is a strict prefix of another exercises a fork carrying both a
+        // terminal value and a continuation.
+        builder.insert(Key::from(&b"pre"[..]), entry(0x11), None);
+        expected.push(("pre".to_owned(), entry(0x11)));
+        builder.insert(Key::from(&b"prefix"[..]), entry(0x22), None);
+        expected.push(("prefix".to_owned(), entry(0x22)));
+        // An inline value must read back whole, not as a reference.
+        let inline = Entry::inline(Bytes::from_static(b"hello")).map_err(|e| e.to_string())?;
+        builder.insert(Key::from(&b"inline.txt"[..]), inline.clone(), None);
+        expected.push(("inline.txt".to_owned(), inline));
+        // The empty key sets the manifest's own value in the root extension.
+        builder.insert(Key::empty(), entry(0x99), None);
 
-    let built = block_on(builder.build(&memory)).map_err(|e| e.to_string())?;
-    let root = *built.root();
-    // More than one node spilled: the builder emitted referenced children, so
-    // reading keys beneath them genuinely drives the fetch-and-descend path.
-    ensure(
-        built.stats().nodes_written() > 1,
-        "builder spilled referenced children",
-    )?;
-
-    let store = CountingStore {
-        inner: memory,
-        gets: AtomicUsize::new(0),
-    };
-    let reader: Reader<_> = Reader::new(&store);
-
-    // The root extension answers the empty key.
-    ensure_eq(
-        block_on(reader.get(&root, &Key::empty())).map_err(|e| e.to_string())?,
-        Some(entry(0x99)),
-        "empty key reads the root value",
-    )?;
-
-    // Every key reads back its exact value, and no single lookup ever fetches a
-    // whole level: the deepest path stays a small multiple of the tree depth,
-    // far below the spilled node count.
-    let mut deepest = 0usize;
-    for (key, value) in &expected {
-        store.gets.store(0, Ordering::Relaxed);
-        let got = block_on(reader.get(&root, &Key::from(key.clone().into_bytes())))
-            .map_err(|e| e.to_string())?;
-        ensure_eq(got.as_ref(), Some(value), key)?;
-        deepest = deepest.max(store.gets());
-    }
-    ensure(deepest >= 2, "at least one key descends a referenced hop")?;
-    ensure(
-        deepest < built.stats().nodes_written(),
-        "no lookup fetches the whole tree",
-    )?;
-
-    // Keys that diverge from, fall short of, or overrun a stored key are absent.
-    for absent in [
-        "nope",
-        "dir99/file0000.txt",
-        "dir00/file9999.txt",
-        "pr",
-        "prefixed",
-    ] {
-        ensure_eq(
-            block_on(reader.get(&root, &Key::from(absent.as_bytes())))
-                .map_err(|e| e.to_string())?,
-            None,
-            absent,
+        let built = builder.build(&memory).await.map_err(|e| e.to_string())?;
+        let root = *built.root();
+        // More than one node spilled: the builder emitted referenced children, so
+        // reading keys beneath them genuinely drives the fetch-and-descend path.
+        ensure(
+            built.stats().nodes_written() > 1,
+            "builder spilled referenced children",
         )?;
-    }
-    Ok(())
+
+        let store = CountingStore {
+            inner: memory,
+            gets: AtomicUsize::new(0),
+        };
+        let reader: Reader<_> = Reader::new(&store);
+
+        // The root extension answers the empty key.
+        ensure_eq(
+            reader
+                .get(&root, &Key::empty())
+                .await
+                .map_err(|e| e.to_string())?,
+            Some(entry(0x99)),
+            "empty key reads the root value",
+        )?;
+
+        // Every key reads back its exact value, and no single lookup ever fetches a
+        // whole level: the deepest path stays a small multiple of the tree depth,
+        // far below the spilled node count.
+        let mut deepest = 0usize;
+        for (key, value) in &expected {
+            store.gets.store(0, Ordering::Relaxed);
+            let got = reader
+                .get(&root, &Key::from(key.clone().into_bytes()))
+                .await
+                .map_err(|e| e.to_string())?;
+            ensure_eq(got.as_ref(), Some(value), key)?;
+            deepest = deepest.max(store.gets());
+        }
+        ensure(deepest >= 2, "at least one key descends a referenced hop")?;
+        ensure(
+            deepest < built.stats().nodes_written(),
+            "no lookup fetches the whole tree",
+        )?;
+
+        // Keys that diverge from, fall short of, or overrun a stored key are absent.
+        for absent in [
+            "nope",
+            "dir99/file0000.txt",
+            "dir00/file9999.txt",
+            "pr",
+            "prefixed",
+        ] {
+            ensure_eq(
+                reader
+                    .get(&root, &Key::from(absent.as_bytes()))
+                    .await
+                    .map_err(|e| e.to_string())?,
+                None,
+                absent,
+            )?;
+        }
+        Ok(())
+    })
 }
 
 #[test]
 fn an_absent_key_stops_at_the_first_unmatched_fork() -> TestResult {
-    let width = 64u16;
-    let memory = MemoryStore::default();
-    let root = wide_manifest(&memory, width)?;
+    run(async {
+        let width = 64u16;
+        let memory = MemoryStore::default();
+        let root = wide_manifest(&memory, width).await?;
 
-    let store = CountingStore {
-        inner: memory,
-        gets: AtomicUsize::new(0),
-    };
-    let reader: Reader<_> = Reader::new(&store);
+        let store = CountingStore {
+            inner: memory,
+            gets: AtomicUsize::new(0),
+        };
+        let reader: Reader<_> = Reader::new(&store);
 
-    // A first byte no root fork carries: the walk stops at the root without
-    // fetching any leaf.
-    let value = block_on(reader.get(&root, &Key::from(&[0xFFu8, 0x00][..])))?;
-    ensure_eq(value, None, "absent value")?;
-    ensure_eq(store.gets(), 1, "only the root is fetched")
+        // A first byte no root fork carries: the walk stops at the root without
+        // fetching any leaf.
+        let value = reader.get(&root, &Key::from(&[0xFFu8, 0x00][..])).await?;
+        ensure_eq(value, None, "absent value")?;
+        ensure_eq(store.gets(), 1, "only the root is fetched")
+    })
 }

--- a/crates/manifest/tests/scan.rs
+++ b/crates/manifest/tests/scan.rs
@@ -10,10 +10,10 @@ use std::error::Error;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use bytes::Bytes;
-use futures::executor::block_on;
 use nectar_manifest::{Builder, Cursor, Entry, Format, Key, Reader, V1};
 use nectar_primitives::store::{ChunkGet, MemoryStore};
 use nectar_primitives::{Chunk, ChunkAddress, StandardChunkSet, Verified};
+use nectar_testing::run;
 use proptest::prelude::*;
 
 type TestResult = Result<(), Box<dyn Error>>;
@@ -86,7 +86,7 @@ fn corpus() -> Vec<(Key, Vec<u8>)> {
 }
 
 /// Build the corpus into `store` and return the root and an ordered oracle.
-fn build(store: &MemoryStore) -> Result<(ChunkAddress, Oracle), Box<dyn Error>> {
+async fn build(store: &MemoryStore) -> Result<(ChunkAddress, Oracle), Box<dyn Error>> {
     let mut builder = Builder::new();
     let mut oracle = Oracle::new();
     for (key, bytes) in corpus() {
@@ -94,14 +94,14 @@ fn build(store: &MemoryStore) -> Result<(ChunkAddress, Oracle), Box<dyn Error>> 
         builder.insert(key.clone(), value.clone(), None);
         oracle.insert(key.as_bytes().to_vec(), value);
     }
-    let built = block_on(builder.build(store)).map_err(|e| e.to_string())?;
+    let built = builder.build(store).await.map_err(|e| e.to_string())?;
     Ok((*built.root(), oracle))
 }
 
 /// Collect a whole cursor into an ordered vector.
-fn collect(mut cursor: Cursor<'_, &CountingStore>) -> Result<Rows, Box<dyn Error>> {
+async fn collect(mut cursor: Cursor<'_, &CountingStore>) -> Result<Rows, Box<dyn Error>> {
     let mut out = Vec::new();
-    while let Some((key, value)) = block_on(cursor.next()).map_err(|e| e.to_string())? {
+    while let Some((key, value)) = cursor.next().await.map_err(|e| e.to_string())? {
         out.push((key.as_bytes().to_vec(), value));
     }
     Ok(out)
@@ -109,92 +109,103 @@ fn collect(mut cursor: Cursor<'_, &CountingStore>) -> Result<Rows, Box<dyn Error
 
 #[test]
 fn iteration_fetches_nodes_not_values() -> TestResult {
-    let memory = MemoryStore::default();
-    let (root, oracle) = build(&memory)?;
-    // The builder spilled referenced children, so the walk genuinely crosses
-    // fetched hops rather than reading one embedded root.
-    let nodes = memory.len();
-    ensure(nodes > 1, "manifest spilled referenced children")?;
-    // Every value is inline, so the store holds trie nodes only. If iteration
-    // fetched values it would fetch chunks that do not exist.
-    ensure(oracle.len() > nodes, "more keys than trie nodes")?;
+    run(async {
+        let memory = MemoryStore::default();
+        let (root, oracle) = build(&memory).await?;
+        // The builder spilled referenced children, so the walk genuinely crosses
+        // fetched hops rather than reading one embedded root.
+        let nodes = memory.len();
+        ensure(nodes > 1, "manifest spilled referenced children")?;
+        // Every value is inline, so the store holds trie nodes only. If iteration
+        // fetched values it would fetch chunks that do not exist.
+        ensure(oracle.len() > nodes, "more keys than trie nodes")?;
 
-    let store = CountingStore {
-        inner: memory,
-        gets: AtomicUsize::new(0),
-    };
-    let reader: Reader<_> = Reader::new(&store);
+        let store = CountingStore {
+            inner: memory,
+            gets: AtomicUsize::new(0),
+        };
+        let reader: Reader<_> = Reader::new(&store);
 
-    let got = collect(block_on(reader.iter(&root)).map_err(|e| e.to_string())?)?;
-    let expected: Rows = oracle.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-    ensure_eq(got, expected, "iteration matches the ordered oracle")?;
+        let got = collect(reader.iter(&root).await.map_err(|e| e.to_string())?).await?;
+        let expected: Rows = oracle.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+        ensure_eq(got, expected, "iteration matches the ordered oracle")?;
 
-    // The whole walk fetched exactly the trie nodes, once each, and far fewer
-    // than the key count: values ride in the fork records, so no leaf is pulled.
-    ensure_eq(store.gets(), nodes, "one fetch per trie node")?;
-    ensure(store.gets() < oracle.len(), "fetches below the key count")
+        // The whole walk fetched exactly the trie nodes, once each, and far fewer
+        // than the key count: values ride in the fork records, so no leaf is pulled.
+        ensure_eq(store.gets(), nodes, "one fetch per trie node")?;
+        ensure(store.gets() < oracle.len(), "fetches below the key count")
+    })
 }
 
 #[test]
 fn range_matches_the_oracle() -> TestResult {
-    let store = MemoryStore::default();
-    let (root, oracle) = build(&store)?;
-    let counting = CountingStore {
-        inner: store,
-        gets: AtomicUsize::new(0),
-    };
-    let reader: Reader<_> = Reader::new(&counting);
+    run(async {
+        let store = MemoryStore::default();
+        let (root, oracle) = build(&store).await?;
+        let counting = CountingStore {
+            inner: store,
+            gets: AtomicUsize::new(0),
+        };
+        let reader: Reader<_> = Reader::new(&counting);
 
-    for (lo, hi) in [
-        (&b"dir03"[..], &b"dir07"[..]),
-        (&b"dir05/file0010.txt"[..], &b"dir05/file0020.txt"[..]),
-        (&b""[..], &b"dir00/file0005.txt"[..]),
-        (&b"pre"[..], &b"zzz"[..]),
-        (&b"dir11/file0039.txt"[..], &b"zzz"[..]),
-    ] {
-        let got = collect(
-            block_on(reader.range(&root, &Key::from(lo), &Key::from(hi)))
-                .map_err(|e| e.to_string())?,
-        )?;
-        let expected: Rows = oracle
-            .range(lo.to_vec()..hi.to_vec())
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
-        ensure_eq(got, expected, "range matches the oracle")?;
-    }
-    Ok(())
+        for (lo, hi) in [
+            (&b"dir03"[..], &b"dir07"[..]),
+            (&b"dir05/file0010.txt"[..], &b"dir05/file0020.txt"[..]),
+            (&b""[..], &b"dir00/file0005.txt"[..]),
+            (&b"pre"[..], &b"zzz"[..]),
+            (&b"dir11/file0039.txt"[..], &b"zzz"[..]),
+        ] {
+            let got = collect(
+                reader
+                    .range(&root, &Key::from(lo), &Key::from(hi))
+                    .await
+                    .map_err(|e| e.to_string())?,
+            )
+            .await?;
+            let expected: Rows = oracle
+                .range(lo.to_vec()..hi.to_vec())
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect();
+            ensure_eq(got, expected, "range matches the oracle")?;
+        }
+        Ok(())
+    })
 }
 
 #[test]
 fn prefix_matches_the_oracle() -> TestResult {
-    let store = MemoryStore::default();
-    let (root, oracle) = build(&store)?;
-    let reader: Reader<_> = Reader::new(&store);
+    run(async {
+        let store = MemoryStore::default();
+        let (root, oracle) = build(&store).await?;
+        let reader: Reader<_> = Reader::new(&store);
 
-    for p in [
-        &b"dir05/"[..],
-        &b"dir1"[..],
-        &b"pre"[..],
-        &b"dir05/file000"[..],
-        &b""[..],
-    ] {
-        let got: Rows = {
-            let mut cursor =
-                block_on(reader.prefix(&root, &Key::from(p))).map_err(|e| e.to_string())?;
-            let mut out = Vec::new();
-            while let Some((key, value)) = block_on(cursor.next()).map_err(|e| e.to_string())? {
-                out.push((key.as_bytes().to_vec(), value));
-            }
-            out
-        };
-        let expected: Rows = oracle
-            .iter()
-            .filter(|(k, _)| k.starts_with(p))
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
-        ensure_eq(got, expected, "prefix matches the oracle")?;
-    }
-    Ok(())
+        for p in [
+            &b"dir05/"[..],
+            &b"dir1"[..],
+            &b"pre"[..],
+            &b"dir05/file000"[..],
+            &b""[..],
+        ] {
+            let got: Rows = {
+                let mut cursor = reader
+                    .prefix(&root, &Key::from(p))
+                    .await
+                    .map_err(|e| e.to_string())?;
+                let mut out = Vec::new();
+                while let Some((key, value)) = cursor.next().await.map_err(|e| e.to_string())? {
+                    out.push((key.as_bytes().to_vec(), value));
+                }
+                out
+            };
+            let expected: Rows = oracle
+                .iter()
+                .filter(|(k, _)| k.starts_with(p))
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect();
+            ensure_eq(got, expected, "prefix matches the oracle")?;
+        }
+        Ok(())
+    })
 }
 
 /// A future that yields once: `Pending` on the first poll, `Ready` after. It
@@ -253,7 +264,7 @@ impl ChunkGet<StandardChunkSet> for GatedStore {
 /// Build a wide manifest whose first-byte subtrees each outgrow the inline bound
 /// and become referenced children, so the root fans out into many sibling nodes
 /// a scan must fetch. Returns the root and an ordered oracle.
-fn wide_build(store: &MemoryStore) -> Result<(ChunkAddress, Oracle), Box<dyn Error>> {
+async fn wide_build(store: &MemoryStore) -> Result<(ChunkAddress, Oracle), Box<dyn Error>> {
     let mut builder = Builder::new();
     let mut oracle = Oracle::new();
     for a in 0u8..48 {
@@ -264,53 +275,55 @@ fn wide_build(store: &MemoryStore) -> Result<(ChunkAddress, Oracle), Box<dyn Err
             oracle.insert(key, value);
         }
     }
-    let built = block_on(builder.build(store)).map_err(|e| e.to_string())?;
+    let built = builder.build(store).await.map_err(|e| e.to_string())?;
     Ok((*built.root(), oracle))
 }
 
 #[test]
 fn read_ahead_bounds_in_flight_and_matches_the_oracle() -> TestResult {
-    let memory = MemoryStore::default();
-    let (root, oracle) = wide_build(&memory)?;
-    // The root fans out into referenced children, so the walk crosses many
-    // sibling hops rather than reading one embedded root.
-    let nodes = memory.len();
-    ensure(nodes > 8, "manifest fans out into many referenced children")?;
+    run(async {
+        let memory = MemoryStore::default();
+        let (root, oracle) = wide_build(&memory).await?;
+        // The root fans out into referenced children, so the walk crosses many
+        // sibling hops rather than reading one embedded root.
+        let nodes = memory.len();
+        ensure(nodes > 8, "manifest fans out into many referenced children")?;
 
-    let store = GatedStore {
-        inner: memory,
-        ..Default::default()
-    };
-    let reader: Reader<_> = Reader::new(&store);
+        let store = GatedStore {
+            inner: memory,
+            ..Default::default()
+        };
+        let reader: Reader<_> = Reader::new(&store);
 
-    let got: Rows = {
-        let mut cursor = block_on(reader.iter(&root)).map_err(|e| e.to_string())?;
-        let mut out = Vec::new();
-        while let Some((key, value)) = block_on(cursor.next()).map_err(|e| e.to_string())? {
-            out.push((key.as_bytes().to_vec(), value));
-        }
-        out
-    };
-    let expected: Rows = oracle.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-    ensure_eq(got, expected, "read-ahead iteration matches the oracle")?;
+        let got: Rows = {
+            let mut cursor = reader.iter(&root).await.map_err(|e| e.to_string())?;
+            let mut out = Vec::new();
+            while let Some((key, value)) = cursor.next().await.map_err(|e| e.to_string())? {
+                out.push((key.as_bytes().to_vec(), value));
+            }
+            out
+        };
+        let expected: Rows = oracle.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+        ensure_eq(got, expected, "read-ahead iteration matches the oracle")?;
 
-    // The concurrent walk fetches exactly the trie nodes a serial walk would,
-    // once each: read-ahead cuts round trips, not fetch count.
-    ensure_eq(
-        store.gets.load(Ordering::Relaxed),
-        nodes,
-        "one fetch per trie node",
-    )?;
+        // The concurrent walk fetches exactly the trie nodes a serial walk would,
+        // once each: read-ahead cuts round trips, not fetch count.
+        ensure_eq(
+            store.gets.load(Ordering::Relaxed),
+            nodes,
+            "one fetch per trie node",
+        )?;
 
-    let peak = store.peak.load(Ordering::Relaxed);
-    let cap = V1::READ_AHEAD;
-    // The window overlapped fetches: read-ahead is genuinely concurrent.
-    ensure(peak > 1, "read-ahead ran fetches concurrently")?;
-    // Peak in-flight never exceeds the cap: the window is bounded, not O(width).
-    ensure(
-        peak <= cap,
-        &format!("peak in-flight {peak} exceeded the read-ahead cap {cap}"),
-    )
+        let peak = store.peak.load(Ordering::Relaxed);
+        let cap = V1::READ_AHEAD;
+        // The window overlapped fetches: read-ahead is genuinely concurrent.
+        ensure(peak > 1, "read-ahead ran fetches concurrently")?;
+        // Peak in-flight never exceeds the cap: the window is bounded, not O(width).
+        ensure(
+            peak <= cap,
+            &format!("peak in-flight {peak} exceeded the read-ahead cap {cap}"),
+        )
+    })
 }
 
 proptest! {
@@ -324,115 +337,127 @@ proptest! {
             0..300,
         ),
     ) {
-        let mut oracle = Oracle::new();
-        for (key, fill) in pairs {
-            let value = Entry::inline(Bytes::from(vec![fill; 32]))
-                .map_err(|e| TestCaseError::fail(e.to_string()))?;
-            oracle.insert(key, value);
-        }
-        let store = MemoryStore::default();
-        let mut builder = Builder::new();
-        for (key, value) in &oracle {
-            builder.insert(Key::from(key.clone()), value.clone(), None);
-        }
-        let built = block_on(builder.build(&store))
-            .map_err(|e| TestCaseError::fail(e.to_string()))?;
-        let reader: Reader<_> = Reader::new(&store);
-        let got: Rows = {
-            let mut cursor = block_on(reader.iter(built.root()))
-                .map_err(|e| TestCaseError::fail(e.to_string()))?;
-            let mut out = Vec::new();
-            while let Some((key, value)) = block_on(cursor.next())
-                .map_err(|e| TestCaseError::fail(e.to_string()))?
-            {
-                out.push((key.as_bytes().to_vec(), value));
+        run(async {
+            let mut oracle = Oracle::new();
+            for (key, fill) in pairs {
+                let value = Entry::inline(Bytes::from(vec![fill; 32]))
+                    .map_err(|e| TestCaseError::fail(e.to_string()))?;
+                oracle.insert(key, value);
             }
-            out
-        };
-        let expected: Rows = oracle.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-        prop_assert_eq!(got, expected);
+            let store = MemoryStore::default();
+            let mut builder = Builder::new();
+            for (key, value) in &oracle {
+                builder.insert(Key::from(key.clone()), value.clone(), None);
+            }
+            let built = builder.build(&store).await
+                .map_err(|e| TestCaseError::fail(e.to_string()))?;
+            let reader: Reader<_> = Reader::new(&store);
+            let got: Rows = {
+                let mut cursor = reader.iter(built.root()).await
+                    .map_err(|e| TestCaseError::fail(e.to_string()))?;
+                let mut out = Vec::new();
+                while let Some((key, value)) = cursor.next().await
+                    .map_err(|e| TestCaseError::fail(e.to_string()))?
+                {
+                    out.push((key.as_bytes().to_vec(), value));
+                }
+                out
+            };
+            let expected: Rows = oracle.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+            prop_assert_eq!(got, expected);
+            Ok::<(), TestCaseError>(())
+        })?;
     }
 }
 
 #[test]
 fn read_ahead_never_fetches_past_the_upper_bound() -> TestResult {
-    let memory = MemoryStore::default();
-    let (root, oracle) = wide_build(&memory)?;
-    // The root fans out into one referenced child per leading byte, so there are
-    // more sibling subtrees than the window: an unbounded prefetch would pull
-    // whole subtrees the bounded walk never visits.
-    let siblings = memory.len().saturating_sub(1);
-    ensure(
-        siblings > V1::READ_AHEAD,
-        "more sibling subtrees than the window",
-    )?;
+    run(async {
+        let memory = MemoryStore::default();
+        let (root, oracle) = wide_build(&memory).await?;
+        // The root fans out into one referenced child per leading byte, so there are
+        // more sibling subtrees than the window: an unbounded prefetch would pull
+        // whole subtrees the bounded walk never visits.
+        let siblings = memory.len().saturating_sub(1);
+        ensure(
+            siblings > V1::READ_AHEAD,
+            "more sibling subtrees than the window",
+        )?;
 
-    // A gated store is essential here: its fetches park on the first poll, so a
-    // future the window launches past the bound genuinely starts (and is
-    // counted), the way a real async store would. An immediately-ready store
-    // hides the over-fetch, because the awaited fetch completes before the
-    // executor ever polls the surplus futures.
-    let store = GatedStore {
-        inner: memory,
-        ..Default::default()
-    };
-    let reader: Reader<_> = Reader::new(&store);
+        // A gated store is essential here: its fetches park on the first poll, so a
+        // future the window launches past the bound genuinely starts (and is
+        // counted), the way a real async store would. An immediately-ready store
+        // hides the over-fetch, because the awaited fetch completes before the
+        // executor ever polls the surplus futures.
+        let store = GatedStore {
+            inner: memory,
+            ..Default::default()
+        };
+        let reader: Reader<_> = Reader::new(&store);
 
-    // A range over the single leading byte 0x00: its subtree is in range; every
-    // sibling at 0x01.. is at or past the exclusive bound. Read-ahead must stop
-    // at the bound, so only the root and that one subtree are ever fetched.
-    let lo = Key::from(&[0u8][..]);
-    let hi = Key::from(&[1u8][..]);
-    let got: Rows = {
-        let mut cursor = block_on(reader.range(&root, &lo, &hi)).map_err(|e| e.to_string())?;
-        let mut out = Vec::new();
-        while let Some((key, value)) = block_on(cursor.next()).map_err(|e| e.to_string())? {
-            out.push((key.as_bytes().to_vec(), value));
-        }
-        out
-    };
-    let expected: Rows = oracle
-        .iter()
-        .filter(|(k, _)| k.as_slice() >= lo.as_bytes() && k.as_slice() < hi.as_bytes())
-        .map(|(k, v)| (k.clone(), v.clone()))
-        .collect();
-    ensure(!expected.is_empty(), "the range covers the first subtree")?;
-    ensure_eq(got, expected, "bounded read-ahead matches the range oracle")?;
+        // A range over the single leading byte 0x00: its subtree is in range; every
+        // sibling at 0x01.. is at or past the exclusive bound. Read-ahead must stop
+        // at the bound, so only the root and that one subtree are ever fetched.
+        let lo = Key::from(&[0u8][..]);
+        let hi = Key::from(&[1u8][..]);
+        let got: Rows = {
+            let mut cursor = reader
+                .range(&root, &lo, &hi)
+                .await
+                .map_err(|e| e.to_string())?;
+            let mut out = Vec::new();
+            while let Some((key, value)) = cursor.next().await.map_err(|e| e.to_string())? {
+                out.push((key.as_bytes().to_vec(), value));
+            }
+            out
+        };
+        let expected: Rows = oracle
+            .iter()
+            .filter(|(k, _)| k.as_slice() >= lo.as_bytes() && k.as_slice() < hi.as_bytes())
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        ensure(!expected.is_empty(), "the range covers the first subtree")?;
+        ensure_eq(got, expected, "bounded read-ahead matches the range oracle")?;
 
-    // Exactly the root and the one in-range subtree: no sibling past the bound is
-    // prefetched, so the window respects the range at the serial fetch count.
-    ensure_eq(
-        store.gets.load(Ordering::Relaxed),
-        2,
-        "root and the one in-range subtree only",
-    )
+        // Exactly the root and the one in-range subtree: no sibling past the bound is
+        // prefetched, so the window respects the range at the serial fetch count.
+        ensure_eq(
+            store.gets.load(Ordering::Relaxed),
+            2,
+            "root and the one in-range subtree only",
+        )
+    })
 }
 
 #[test]
 fn floor_matches_the_oracle() -> TestResult {
-    let store = MemoryStore::default();
-    let (root, oracle) = build(&store)?;
-    let reader: Reader<_> = Reader::new(&store);
+    run(async {
+        let store = MemoryStore::default();
+        let (root, oracle) = build(&store).await?;
+        let reader: Reader<_> = Reader::new(&store);
 
-    for target in [
-        &b""[..],
-        &b"a"[..],
-        &b"dir05/file0015.txt"[..],
-        &b"dir05/file0015.tyt"[..],
-        &b"dir05/file00155"[..],
-        &b"pre"[..],
-        &b"prefix"[..],
-        &b"prefiy"[..],
-        &b"zzzzz"[..],
-    ] {
-        let got = block_on(reader.floor(&root, &Key::from(target)))
-            .map_err(|e| e.to_string())?
-            .map(|(k, v)| (k.as_bytes().to_vec(), v));
-        let expected = oracle
-            .range(..=target.to_vec())
-            .next_back()
-            .map(|(k, v)| (k.clone(), v.clone()));
-        ensure_eq(got, expected, "floor matches the oracle")?;
-    }
-    Ok(())
+        for target in [
+            &b""[..],
+            &b"a"[..],
+            &b"dir05/file0015.txt"[..],
+            &b"dir05/file0015.tyt"[..],
+            &b"dir05/file00155"[..],
+            &b"pre"[..],
+            &b"prefix"[..],
+            &b"prefiy"[..],
+            &b"zzzzz"[..],
+        ] {
+            let got = reader
+                .floor(&root, &Key::from(target))
+                .await
+                .map_err(|e| e.to_string())?
+                .map(|(k, v)| (k.as_bytes().to_vec(), v));
+            let expected = oracle
+                .range(..=target.to_vec())
+                .next_back()
+                .map(|(k, v)| (k.clone(), v.clone()));
+            ensure_eq(got, expected, "floor matches the oracle")?;
+        }
+        Ok(())
+    })
 }

--- a/crates/mantaray/Cargo.toml
+++ b/crates/mantaray/Cargo.toml
@@ -32,6 +32,7 @@ rand = { workspace = true, optional = true }
 arbitrary = { workspace = true, features = ["derive"] }
 criterion.workspace = true
 nectar-primitives = { workspace = true, features = ["arbitrary"] }
+nectar-testing.workspace = true
 rand.workspace = true
 serde_json.workspace = true
 

--- a/crates/mantaray/benches/mantaray_bench.rs
+++ b/crates/mantaray/benches/mantaray_bench.rs
@@ -13,12 +13,15 @@
 )]
 // The lookup benches deliberately measure the mutating `&mut self` lookup path.
 #![allow(deprecated)]
+use std::cell::RefCell;
+
+use criterion::async_executor::FuturesExecutor;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use futures::executor::block_on;
 use nectar_mantaray::hazmat;
 use nectar_mantaray::{MemoryStore, PlainManifest};
 use nectar_primitives::StandardChunkSet;
 use nectar_primitives::chunk::ChunkAddress;
+use nectar_testing::run;
 
 type Store = MemoryStore<StandardChunkSet>;
 
@@ -47,25 +50,29 @@ const SPA_PATHS: &[&str] = &[
 
 /// Build a PlainManifest with the SPA website dataset.
 fn build_spa_manifest() -> PlainManifest<Store> {
-    let store = Store::new();
-    let mut m = PlainManifest::new(store);
-    for &p in SPA_PATHS {
-        let addr = make_addr(p.as_bytes());
-        block_on(m.add(p, addr)).unwrap();
-    }
-    m
+    run(async {
+        let store = Store::new();
+        let mut m = PlainManifest::new(store);
+        for &p in SPA_PATHS {
+            let addr = make_addr(p.as_bytes());
+            m.add(p, addr).await.unwrap();
+        }
+        m
+    })
 }
 
 /// Build a PlainManifest with many paths for larger-scale benchmarks.
 fn build_large_manifest(count: usize) -> PlainManifest<Store> {
-    let store = Store::new();
-    let mut m = PlainManifest::new(store);
-    for i in 0..count {
-        let path = format!("dir{}/subdir{}/file{}.dat", i / 100, i / 10, i);
-        let addr = make_addr(path.as_bytes());
-        block_on(m.add(&path, addr)).unwrap();
-    }
-    m
+    run(async {
+        let store = Store::new();
+        let mut m = PlainManifest::new(store);
+        for i in 0..count {
+            let path = format!("dir{}/subdir{}/file{}.dat", i / 100, i / 10, i);
+            let addr = make_addr(path.as_bytes());
+            m.add(&path, addr).await.unwrap();
+        }
+        m
+    })
 }
 
 fn bench_add(c: &mut Criterion) {
@@ -83,12 +90,12 @@ fn bench_add(c: &mut Criterion) {
     ];
 
     group.bench_function("8_paths", |b| {
-        b.iter(|| {
+        b.to_async(FuturesExecutor).iter(|| async {
             let store = Store::new();
             let mut m = PlainManifest::new(store);
             for &p in paths {
                 let addr = make_addr(p.as_bytes());
-                block_on(m.add(p, addr)).unwrap();
+                m.add(p, addr).await.unwrap();
             }
             m
         });
@@ -104,11 +111,11 @@ fn bench_add(c: &mut Criterion) {
             .collect();
 
         group.bench_with_input(BenchmarkId::new("paths", count), &entries, |b, entries| {
-            b.iter(|| {
+            b.to_async(FuturesExecutor).iter(|| async {
                 let store = Store::new();
                 let mut m = PlainManifest::new(store);
                 for (path, addr) in entries {
-                    block_on(m.add(path, *addr)).unwrap();
+                    m.add(path, *addr).await.unwrap();
                 }
                 m
             });
@@ -121,21 +128,27 @@ fn bench_add(c: &mut Criterion) {
 fn bench_lookup(c: &mut Criterion) {
     let mut group = c.benchmark_group("lookup");
 
-    let mut m = build_spa_manifest();
+    // RefCell hands the mutating lookup path a shared handle, so each polled
+    // iteration future can reborrow the same warm manifest.
+    let m = RefCell::new(build_spa_manifest());
 
     group.bench_function("existing_path", |b| {
-        b.iter(|| {
-            let entry = block_on(m.lookup("js/app.js")).unwrap();
+        b.to_async(FuturesExecutor).iter(|| async {
+            let entry = m.borrow_mut().lookup("js/app.js").await.unwrap();
             entry.address().is_some()
         });
     });
 
     // lookup in a larger trie
-    let mut large = build_large_manifest(500);
+    let large = RefCell::new(build_large_manifest(500));
 
     group.bench_function("500_paths_deep", |b| {
-        b.iter(|| {
-            let entry = block_on(large.lookup("dir4/subdir49/file499.dat")).unwrap();
+        b.to_async(FuturesExecutor).iter(|| async {
+            let entry = large
+                .borrow_mut()
+                .lookup("dir4/subdir49/file499.dat")
+                .await
+                .unwrap();
             entry.address().is_some()
         });
     });
@@ -147,10 +160,10 @@ fn bench_remove(c: &mut Criterion) {
     let mut group = c.benchmark_group("remove");
 
     group.bench_function("single_leaf", |b| {
-        b.iter_batched(
+        b.to_async(FuturesExecutor).iter_batched(
             build_spa_manifest,
-            |mut m| {
-                block_on(m.remove("js/app.js")).unwrap();
+            |mut m| async move {
+                m.remove("js/app.js").await.unwrap();
                 m
             },
             criterion::BatchSize::SmallInput,
@@ -163,30 +176,38 @@ fn bench_remove(c: &mut Criterion) {
 fn bench_has_prefix(c: &mut Criterion) {
     let mut group = c.benchmark_group("has_prefix");
 
-    let mut m = build_spa_manifest();
+    let m = RefCell::new(build_spa_manifest());
 
     group.bench_function("existing_prefix", |b| {
-        b.iter(|| block_on(m.has_prefix("js/")).unwrap());
+        b.to_async(FuturesExecutor)
+            .iter(|| async { m.borrow_mut().has_prefix("js/").await.unwrap() });
     });
 
     group.bench_function("missing_prefix", |b| {
-        b.iter(|| block_on(m.has_prefix("nonexistent/")).unwrap());
+        b.to_async(FuturesExecutor)
+            .iter(|| async { m.borrow_mut().has_prefix("nonexistent/").await.unwrap() });
     });
 
     group.finish();
 }
 
+/// Save the SPA trie, reload it, and force-load every node.
+fn loaded_spa_trie() -> hazmat::Node<nectar_primitives::chunk::ChunkRef> {
+    run(async {
+        let mut m = build_spa_manifest();
+        let root_ref = m.save().await.unwrap();
+        let (_, store) = m.into_parts();
+        let mut m2 = PlainManifest::open(root_ref, store);
+        m2.walk(&mut |_, _| Ok(())).await.unwrap();
+        let (n, _) = m2.into_parts();
+        n
+    })
+}
+
 fn bench_encode(c: &mut Criterion) {
     let mut group = c.benchmark_group("encode");
 
-    // Build a trie via PlainManifest, save to get references assigned, reload.
-    let mut m = build_spa_manifest();
-    let root_ref = block_on(m.save()).unwrap();
-    let (_, store) = m.into_parts();
-    let mut m2 = PlainManifest::open(root_ref, store);
-    // Force-load the entire trie
-    block_on(m2.walk(&mut |_, _| Ok(()))).unwrap();
-    let (n, _) = m2.into_parts();
+    let n = loaded_spa_trie();
 
     group.bench_function("spa_trie", |b| {
         b.iter(|| hazmat::encode(&n).unwrap());
@@ -198,13 +219,7 @@ fn bench_encode(c: &mut Criterion) {
 fn bench_decode(c: &mut Criterion) {
     let mut group = c.benchmark_group("decode");
 
-    // Build trie via PlainManifest, save, encode to get binary data.
-    let mut m = build_spa_manifest();
-    let root_ref = block_on(m.save()).unwrap();
-    let (_, store) = m.into_parts();
-    let mut m2 = PlainManifest::open(root_ref, store);
-    block_on(m2.walk(&mut |_, _| Ok(()))).unwrap();
-    let (n, _) = m2.into_parts();
+    let n = loaded_spa_trie();
     let data = hazmat::encode(&n).unwrap();
 
     group.bench_function("spa_trie", |b| {
@@ -218,28 +233,32 @@ fn bench_walk(c: &mut Criterion) {
     let mut group = c.benchmark_group("walk");
 
     group.bench_function("spa_trie", |b| {
-        let mut m = build_spa_manifest();
-        b.iter(|| {
+        let m = RefCell::new(build_spa_manifest());
+        b.to_async(FuturesExecutor).iter(|| async {
             let mut count = 0u32;
-            block_on(m.walk(&mut |_path, _node| {
-                count += 1;
-                Ok(())
-            }))
-            .unwrap();
+            m.borrow_mut()
+                .walk(&mut |_path, _node| {
+                    count += 1;
+                    Ok(())
+                })
+                .await
+                .unwrap();
             count
         });
     });
 
     for &count in &[100, 500] {
         group.bench_with_input(BenchmarkId::new("paths", count), &count, |b, &count| {
-            let mut m = build_large_manifest(count);
-            b.iter(|| {
+            let m = RefCell::new(build_large_manifest(count));
+            b.to_async(FuturesExecutor).iter(|| async {
                 let mut visited = 0u32;
-                block_on(m.walk(&mut |_path, _node| {
-                    visited += 1;
-                    Ok(())
-                }))
-                .unwrap();
+                m.borrow_mut()
+                    .walk(&mut |_path, _node| {
+                        visited += 1;
+                        Ok(())
+                    })
+                    .await
+                    .unwrap();
                 visited
             });
         });
@@ -252,10 +271,10 @@ fn bench_save_load(c: &mut Criterion) {
     let mut group = c.benchmark_group("save_load");
 
     group.bench_function("save_spa_trie", |b| {
-        b.iter_batched(
+        b.to_async(FuturesExecutor).iter_batched(
             build_spa_manifest,
-            |mut m| {
-                block_on(m.save()).unwrap();
+            |mut m| async move {
+                m.save().await.unwrap();
                 m
             },
             criterion::BatchSize::SmallInput,
@@ -263,25 +282,28 @@ fn bench_save_load(c: &mut Criterion) {
     });
 
     group.bench_function("load_spa_trie", |b| {
-        let mut m = build_spa_manifest();
-        let root_ref = block_on(m.save()).unwrap();
-        let (_, store) = m.into_parts();
+        let (root_ref, store) = run(async {
+            let mut m = build_spa_manifest();
+            let root_ref = m.save().await.unwrap();
+            let (_, store) = m.into_parts();
+            (root_ref, store)
+        });
 
-        b.iter(|| {
+        b.to_async(FuturesExecutor).iter(|| async {
             let mut m2 = PlainManifest::open(root_ref, store.clone());
-            let _ = block_on(m2.lookup("index.html")).unwrap();
+            let _ = m2.lookup("index.html").await.unwrap();
             m2
         });
     });
 
     group.bench_function("save_load_roundtrip", |b| {
-        b.iter_batched(
+        b.to_async(FuturesExecutor).iter_batched(
             build_spa_manifest,
-            |mut m| {
-                let root_ref = block_on(m.save()).unwrap();
+            |mut m| async move {
+                let root_ref = m.save().await.unwrap();
                 let (_, store) = m.into_parts();
                 let mut m2 = PlainManifest::open(root_ref, store);
-                let _ = block_on(m2.lookup("index.html")).unwrap();
+                let _ = m2.lookup("index.html").await.unwrap();
                 m2
             },
             criterion::BatchSize::SmallInput,
@@ -295,9 +317,9 @@ fn bench_full_workflow(c: &mut Criterion) {
     let mut group = c.benchmark_group("full_workflow");
 
     group.bench_function("add_save_load_lookup", |b| {
-        b.iter(|| {
+        b.to_async(FuturesExecutor).iter(|| async {
             let mut m = build_spa_manifest();
-            let root_ref = block_on(m.save()).unwrap();
+            let root_ref = m.save().await.unwrap();
             let (_, store) = m.into_parts();
             let mut m2 = PlainManifest::open(root_ref, store);
 
@@ -309,7 +331,7 @@ fn bench_full_workflow(c: &mut Criterion) {
                 "js/app.js",
             ];
             for &p in paths {
-                block_on(m2.lookup(p)).unwrap();
+                m2.lookup(p).await.unwrap();
             }
         });
     });
@@ -322,38 +344,38 @@ fn bench_iter(c: &mut Criterion) {
 
     // In-memory iteration (no save/load)
     group.bench_function("spa_trie_in_memory", |b| {
-        let mut m = build_spa_manifest();
+        let m = RefCell::new(build_spa_manifest());
 
-        b.iter(|| {
-            block_on(async {
-                let mut count = 0u32;
-                let mut iter = m.iter();
-                while let Some(result) = iter.next().await {
-                    result.unwrap();
-                    count += 1;
-                }
-                count
-            })
+        b.to_async(FuturesExecutor).iter(|| async {
+            let mut m = m.borrow_mut();
+            let mut count = 0u32;
+            let mut iter = m.iter();
+            while let Some(result) = iter.next().await {
+                result.unwrap();
+                count += 1;
+            }
+            count
         });
     });
 
     // Lazy iteration after save/load (exercises storage loading)
     group.bench_function("spa_trie_lazy", |b| {
-        let mut m = build_spa_manifest();
-        let root_ref = block_on(m.save()).unwrap();
-        let (_, store) = m.into_parts();
+        let (root_ref, store) = run(async {
+            let mut m = build_spa_manifest();
+            let root_ref = m.save().await.unwrap();
+            let (_, store) = m.into_parts();
+            (root_ref, store)
+        });
 
-        b.iter(|| {
+        b.to_async(FuturesExecutor).iter(|| async {
             let mut m2 = PlainManifest::open(root_ref, store.clone());
-            block_on(async {
-                let mut count = 0u32;
-                let mut iter = m2.iter();
-                while let Some(result) = iter.next().await {
-                    result.unwrap();
-                    count += 1;
-                }
-                count
-            })
+            let mut count = 0u32;
+            let mut iter = m2.iter();
+            while let Some(result) = iter.next().await {
+                result.unwrap();
+                count += 1;
+            }
+            count
         });
     });
 
@@ -361,8 +383,8 @@ fn bench_iter(c: &mut Criterion) {
     group.bench_function("entries_spa_trie", |b| {
         let m = build_spa_manifest();
 
-        b.iter(|| {
-            let entries = block_on(m.entries()).unwrap();
+        b.to_async(FuturesExecutor).iter(|| async {
+            let entries = m.entries().await.unwrap();
             entries.len()
         });
     });

--- a/crates/mantaray/src/builder.rs
+++ b/crates/mantaray/src/builder.rs
@@ -206,11 +206,11 @@ impl<S: TrustedStore<AnyChunkSet<BS>> + ChunkPut<AnyChunkSet<BS>>, const BS: usi
 
 #[cfg(test)]
 mod tests {
-    use futures::executor::block_on;
     use nectar_primitives::StandardChunkSet;
     use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
     use nectar_primitives::chunk::ChunkAddress;
     use nectar_primitives::store::MemoryStore;
+    use nectar_testing::run;
 
     use super::*;
     use crate::metadata;
@@ -227,186 +227,220 @@ mod tests {
 
     #[test]
     fn save_returns_root_and_read_handle() {
-        let mut builder: ManifestBuilder<Store> = ManifestBuilder::new(Store::new());
-        let paths = &["index.html", "img/1.png", "img/2.png", "robots.txt"];
-        for &path in paths {
-            block_on(builder.add(path, make_addr(path))).unwrap();
-        }
+        run(async {
+            let mut builder: ManifestBuilder<Store> = ManifestBuilder::new(Store::new());
+            let paths = &["index.html", "img/1.png", "img/2.png", "robots.txt"];
+            for &path in paths {
+                builder.add(path, make_addr(path)).await.unwrap();
+            }
 
-        let (root, manifest) = block_on(builder.save()).unwrap();
-        assert_eq!(manifest.reference(), Some(&root));
+            let (root, manifest) = builder.save().await.unwrap();
+            assert_eq!(manifest.reference(), Some(&root));
 
-        for &path in paths {
-            let entry = block_on(manifest.get(path)).unwrap().unwrap();
-            assert_eq!(entry.address(), Some(&make_addr(path)));
-        }
+            for &path in paths {
+                let entry = manifest.get(path).await.unwrap().unwrap();
+                assert_eq!(entry.address(), Some(&make_addr(path)));
+            }
+        })
     }
 
     #[test]
     fn empty_builder_saves_to_a_root() {
-        let builder: ManifestBuilder<Store> = ManifestBuilder::new(Store::new());
-        let (_root, manifest) = block_on(builder.save()).unwrap();
-        assert!(block_on(manifest.entries()).unwrap().is_empty());
+        run(async {
+            let builder: ManifestBuilder<Store> = ManifestBuilder::new(Store::new());
+            let (_root, manifest) = builder.save().await.unwrap();
+            assert!(manifest.entries().await.unwrap().is_empty());
+        })
     }
 
     #[test]
     fn root_metadata_is_rejected_at_save() {
-        let mut builder: ManifestBuilder<Store> = ManifestBuilder::new(Store::new());
-        // The empty path targets the root node itself; attaching metadata there
-        // produces the unserializable shape the guard must catch.
-        let mut meta = BTreeMap::new();
-        meta.insert("k".to_string(), "v".to_string());
-        block_on(builder.add_with_metadata("", make_addr("root"), meta)).unwrap();
+        run(async {
+            let mut builder: ManifestBuilder<Store> = ManifestBuilder::new(Store::new());
+            // The empty path targets the root node itself; attaching metadata there
+            // produces the unserializable shape the guard must catch.
+            let mut meta = BTreeMap::new();
+            meta.insert("k".to_string(), "v".to_string());
+            builder
+                .add_with_metadata("", make_addr("root"), meta)
+                .await
+                .unwrap();
 
-        let err = block_on(builder.save()).unwrap_err();
-        assert!(matches!(err, MantarayError::RootMetadata));
+            let err = builder.save().await.unwrap_err();
+            assert!(matches!(err, MantarayError::RootMetadata));
+        })
     }
 
     #[test]
     fn root_entry_without_metadata_saves() {
-        // A root value with no metadata is serializable (the entry slot lives
-        // in the node header); only root metadata is rejected.
-        let mut builder: ManifestBuilder<Store> = ManifestBuilder::new(Store::new());
-        block_on(builder.add("", make_addr("root"))).unwrap();
-        assert!(block_on(builder.save()).is_ok());
+        run(async {
+            // A root value with no metadata is serializable (the entry slot lives
+            // in the node header); only root metadata is rejected.
+            let mut builder: ManifestBuilder<Store> = ManifestBuilder::new(Store::new());
+            builder.add("", make_addr("root")).await.unwrap();
+            assert!(builder.save().await.is_ok());
+        })
     }
 
     #[test]
     fn oversized_metadata_is_rejected_at_save() {
-        let mut builder: ManifestBuilder<Store> = ManifestBuilder::new(Store::new());
-        let mut meta = BTreeMap::new();
-        meta.insert("k".to_string(), "a".repeat(usize::from(u16::MAX) + 16));
-        block_on(builder.add_with_metadata("file", make_addr("file"), meta)).unwrap();
+        run(async {
+            let mut builder: ManifestBuilder<Store> = ManifestBuilder::new(Store::new());
+            let mut meta = BTreeMap::new();
+            meta.insert("k".to_string(), "a".repeat(usize::from(u16::MAX) + 16));
+            builder
+                .add_with_metadata("file", make_addr("file"), meta)
+                .await
+                .unwrap();
 
-        let err = block_on(builder.save()).unwrap_err();
-        assert!(matches!(err, MantarayError::MetadataTooLarge { .. }));
+            let err = builder.save().await.unwrap_err();
+            assert!(matches!(err, MantarayError::MetadataTooLarge { .. }));
+        })
     }
 
     #[test]
     fn website_documents_round_trip_through_the_handle() {
-        let mut builder: ManifestBuilder<Store> = ManifestBuilder::new(Store::new());
-        block_on(builder.add("index.html", make_addr("index.html"))).unwrap();
-        block_on(builder.set_index_document("index.html")).unwrap();
-        block_on(builder.set_error_document("404.html")).unwrap();
+        run(async {
+            let mut builder: ManifestBuilder<Store> = ManifestBuilder::new(Store::new());
+            builder
+                .add("index.html", make_addr("index.html"))
+                .await
+                .unwrap();
+            builder.set_index_document("index.html").await.unwrap();
+            builder.set_error_document("404.html").await.unwrap();
 
-        let (_root, manifest) = block_on(builder.save()).unwrap();
-        let index = block_on(manifest.get(metadata::ROOT_PATH))
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            index.metadata().get(metadata::WEBSITE_INDEX_DOCUMENT),
-            Some(&"index.html".to_string())
-        );
-        assert_eq!(
-            index.metadata().get(metadata::WEBSITE_ERROR_DOCUMENT),
-            Some(&"404.html".to_string())
-        );
+            let (_root, manifest) = builder.save().await.unwrap();
+            let index = manifest.get(metadata::ROOT_PATH).await.unwrap().unwrap();
+            assert_eq!(
+                index.metadata().get(metadata::WEBSITE_INDEX_DOCUMENT),
+                Some(&"index.html".to_string())
+            );
+            assert_eq!(
+                index.metadata().get(metadata::WEBSITE_ERROR_DOCUMENT),
+                Some(&"404.html".to_string())
+            );
+        })
     }
 
     #[cfg(feature = "std")]
     #[test]
     fn encrypted_builder_round_trips_the_reference() {
-        use nectar_primitives::file::EntryRef;
-        use nectar_primitives::{EncryptedChunkRef, EncryptionKey};
+        run(async {
+            use nectar_primitives::file::EntryRef;
+            use nectar_primitives::{EncryptedChunkRef, EncryptionKey};
 
-        let mut builder = ManifestBuilder::<Store, EncryptedChunkRef>::new_encrypted(Store::new());
-        let eref = EncryptedChunkRef::new(
-            make_addr("index.html"),
-            EncryptionKey::from([7u8; EncryptionKey::SIZE]),
-        );
-        block_on(builder.add("index.html", eref.clone())).unwrap();
+            let mut builder =
+                ManifestBuilder::<Store, EncryptedChunkRef>::new_encrypted(Store::new());
+            let eref = EncryptedChunkRef::new(
+                make_addr("index.html"),
+                EncryptionKey::from([7u8; EncryptionKey::SIZE]),
+            );
+            builder.add("index.html", eref.clone()).await.unwrap();
 
-        let (root, manifest) = block_on(builder.save()).unwrap();
-        // The returned reference addresses the saved root.
-        assert_eq!(manifest.reference(), Some(root.address()));
+            let (root, manifest) = builder.save().await.unwrap();
+            // The returned reference addresses the saved root.
+            assert_eq!(manifest.reference(), Some(root.address()));
 
-        // Address and decryption key both survive encode and decode.
-        let entry = block_on(manifest.get("index.html")).unwrap().unwrap();
-        assert_eq!(entry.reference(), Some(&EntryRef::Encrypted(eref)));
+            // Address and decryption key both survive encode and decode.
+            let entry = manifest.get("index.html").await.unwrap().unwrap();
+            assert_eq!(entry.reference(), Some(&EntryRef::Encrypted(eref)));
+        })
     }
 
     #[cfg(feature = "std")]
     #[test]
     fn encrypted_builder_rejects_root_metadata() {
-        use nectar_primitives::{EncryptedChunkRef, EncryptionKey};
+        run(async {
+            use nectar_primitives::{EncryptedChunkRef, EncryptionKey};
 
-        let mut builder = ManifestBuilder::<Store, EncryptedChunkRef>::new_encrypted(Store::new());
-        let eref = EncryptedChunkRef::new(
-            make_addr("root"),
-            EncryptionKey::from([9u8; EncryptionKey::SIZE]),
-        );
-        let mut meta = BTreeMap::new();
-        meta.insert("k".to_string(), "v".to_string());
-        block_on(builder.add_with_metadata("", eref, meta)).unwrap();
+            let mut builder =
+                ManifestBuilder::<Store, EncryptedChunkRef>::new_encrypted(Store::new());
+            let eref = EncryptedChunkRef::new(
+                make_addr("root"),
+                EncryptionKey::from([9u8; EncryptionKey::SIZE]),
+            );
+            let mut meta = BTreeMap::new();
+            meta.insert("k".to_string(), "v".to_string());
+            builder.add_with_metadata("", eref, meta).await.unwrap();
 
-        let err = block_on(builder.save()).unwrap_err();
-        assert!(matches!(err, MantarayError::RootMetadata));
+            let err = builder.save().await.unwrap_err();
+            assert!(matches!(err, MantarayError::RootMetadata));
+        })
     }
 
     #[test]
     fn put_file_round_trips_through_read() {
-        let mut builder: ManifestBuilder<Store> = ManifestBuilder::new(Store::new());
-        // A multi-chunk payload exercises the splitter and joiner, not just a
-        // single content chunk.
-        let big = vec![0xabu8; DEFAULT_BODY_SIZE * 3 + 17];
-        block_on(builder.put_file("a.txt", b"file A contents".to_vec())).unwrap();
-        block_on(builder.put_file("dir/big.bin", big.clone())).unwrap();
+        run(async {
+            let mut builder: ManifestBuilder<Store> = ManifestBuilder::new(Store::new());
+            // A multi-chunk payload exercises the splitter and joiner, not just a
+            // single content chunk.
+            let big = vec![0xabu8; DEFAULT_BODY_SIZE * 3 + 17];
+            builder
+                .put_file("a.txt", b"file A contents".to_vec())
+                .await
+                .unwrap();
+            builder.put_file("dir/big.bin", big.clone()).await.unwrap();
 
-        let (root, manifest) = block_on(builder.save()).unwrap();
+            let (root, manifest) = builder.save().await.unwrap();
 
-        assert_eq!(
-            block_on(manifest.read("a.txt")).unwrap().unwrap(),
-            b"file A contents"
-        );
-        assert_eq!(
-            block_on(manifest.read("dir/big.bin")).unwrap().unwrap(),
-            big
-        );
-        // Absent path reads as None, not an error.
-        assert!(block_on(manifest.read("missing.txt")).unwrap().is_none());
+            assert_eq!(
+                manifest.read("a.txt").await.unwrap().unwrap(),
+                b"file A contents"
+            );
+            assert_eq!(manifest.read("dir/big.bin").await.unwrap().unwrap(), big);
+            // Absent path reads as None, not an error.
+            assert!(manifest.read("missing.txt").await.unwrap().is_none());
 
-        // Reopen from storage: read drives the lazy-load path.
-        let (_, store) = manifest.into_parts();
-        let reopened = super::Manifest::<Store, ChunkRef>::open(root, store);
-        assert_eq!(
-            block_on(reopened.read("dir/big.bin")).unwrap().unwrap(),
-            big
-        );
+            // Reopen from storage: read drives the lazy-load path.
+            let (_, store) = manifest.into_parts();
+            let reopened = super::Manifest::<Store, ChunkRef>::open(root, store);
+            assert_eq!(reopened.read("dir/big.bin").await.unwrap().unwrap(), big);
+        })
     }
 
     #[cfg(feature = "encryption")]
     #[test]
     fn encrypted_put_file_round_trips_through_read() {
-        use nectar_primitives::EncryptedChunkRef;
+        run(async {
+            use nectar_primitives::EncryptedChunkRef;
 
-        let mut builder = ManifestBuilder::<Store, EncryptedChunkRef>::new_encrypted(Store::new());
-        let big = vec![0x5cu8; DEFAULT_BODY_SIZE * 2 + 5];
-        block_on(builder.put_file("secret.txt", b"secret data".to_vec())).unwrap();
-        block_on(builder.put_file("blob.bin", big.clone())).unwrap();
+            let mut builder =
+                ManifestBuilder::<Store, EncryptedChunkRef>::new_encrypted(Store::new());
+            let big = vec![0x5cu8; DEFAULT_BODY_SIZE * 2 + 5];
+            builder
+                .put_file("secret.txt", b"secret data".to_vec())
+                .await
+                .unwrap();
+            builder.put_file("blob.bin", big.clone()).await.unwrap();
 
-        let (_root, manifest) = block_on(builder.save()).unwrap();
+            let (_root, manifest) = builder.save().await.unwrap();
 
-        assert_eq!(
-            block_on(manifest.read("secret.txt")).unwrap().unwrap(),
-            b"secret data"
-        );
-        assert_eq!(block_on(manifest.read("blob.bin")).unwrap().unwrap(), big);
-        assert!(block_on(manifest.read("absent")).unwrap().is_none());
+            assert_eq!(
+                manifest.read("secret.txt").await.unwrap().unwrap(),
+                b"secret data"
+            );
+            assert_eq!(manifest.read("blob.bin").await.unwrap().unwrap(), big);
+            assert!(manifest.read("absent").await.unwrap().is_none());
+        })
     }
 
     #[test]
     fn remove_before_save_drops_the_path() {
-        let mut builder: ManifestBuilder<Store> = ManifestBuilder::new(Store::new());
-        block_on(builder.add("a.txt", make_addr("a"))).unwrap();
-        block_on(builder.add("b.txt", make_addr("b"))).unwrap();
-        block_on(builder.remove("a.txt")).unwrap();
+        run(async {
+            let mut builder: ManifestBuilder<Store> = ManifestBuilder::new(Store::new());
+            builder.add("a.txt", make_addr("a")).await.unwrap();
+            builder.add("b.txt", make_addr("b")).await.unwrap();
+            builder.remove("a.txt").await.unwrap();
 
-        let (_root, manifest) = block_on(builder.save()).unwrap();
-        let paths: Vec<_> = block_on(manifest.entries())
-            .unwrap()
-            .into_iter()
-            .map(|e| e.path().to_vec())
-            .collect();
-        assert_eq!(paths, vec![b"b.txt".to_vec()]);
+            let (_root, manifest) = builder.save().await.unwrap();
+            let paths: Vec<_> = manifest
+                .entries()
+                .await
+                .unwrap()
+                .into_iter()
+                .map(|e| e.path().to_vec())
+                .collect();
+            assert_eq!(paths, vec![b"b.txt".to_vec()]);
+        })
     }
 }

--- a/crates/mantaray/src/codec.rs
+++ b/crates/mantaray/src/codec.rs
@@ -547,6 +547,7 @@ mod tests {
     use alloy_primitives::hex;
     use alloy_primitives::utils::keccak256;
     use nectar_primitives::chunk::{ChunkAddress, ChunkRef};
+    use nectar_testing::run;
 
     const ENCODED_V01: &str = "52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c64950ac787fbce1061870e8d34e0a638bc7e812c7ca4ebd31d626a572ba47b06f6952fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c64952fdfc072102654f163f5f0fa0621d729566c74d10037c4d7bbb0407d1e2c64950fcd3072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c64952fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c64950f89d6640e3044f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c64952fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c64850ff9f642182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c64952fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c64b50fc98072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c64952fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c64a50ff99622182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c64952fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c64d";
     const ENCODED_V02: &str = "52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c64905954fb18659339d0b25e0fb9723d3cd5d528fb3c8d495fd157bd7b7a210496952fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c64952fdfc072102654f163f5f0fa0621d729566c74d10037c4d7bbb0407d1e2c64940fcd3072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c64952fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c64952e3872548ec012a6e123b60f9177017fb12e57732621d2c1ada267adbe8cc4350f89d6640e3044f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c64952fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c64850ff9f642182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c64952fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c64b50fc98072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c64952fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c64a50ff99622182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c64952fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c64d";
@@ -1117,25 +1118,27 @@ mod tests {
     /// than emit a truncated, undecodable stream.
     #[test]
     fn encode_fork_with_unsaved_child_errors() {
-        let mut n = Node::<ChunkRef>::new_unencrypted();
+        run(async {
+            let mut n = Node::<ChunkRef>::new_unencrypted();
 
-        let path = b"aaaaa";
-        let e = {
-            let mut buf = [0u8; 32];
-            buf[32 - path.len()..].copy_from_slice(path);
-            ChunkRef::from(ChunkAddress::from(buf))
-        };
-        futures::executor::block_on(n.add::<
+            let path = b"aaaaa";
+            let e = {
+                let mut buf = [0u8; 32];
+                buf[32 - path.len()..].copy_from_slice(path);
+                ChunkRef::from(ChunkAddress::from(buf))
+            };
+            n.add::<
             nectar_primitives::store::NullLoader,
             { nectar_primitives::bmt::DEFAULT_BODY_SIZE },
         >(
             path, Some(e), BTreeMap::new(), &nectar_primitives::store::NullLoader,
-        ))
+        ).await
         .unwrap();
 
-        // The fork's child node has no reference assigned (never persisted).
-        let result = n.encode();
-        assert!(matches!(result, Err(MantarayError::MissingReference)));
+            // The fork's child node has no reference assigned (never persisted).
+            let result = n.encode();
+            assert!(matches!(result, Err(MantarayError::MissingReference)));
+        })
     }
 
     /// Build a leaf fork whose child is exactly what the single body decoder
@@ -1264,49 +1267,51 @@ mod tests {
     /// Encode-decode round-trip preserves entries and metadata.
     #[test]
     fn encode_decode_round_trip() {
-        let mut n = Node::<ChunkRef>::new_unencrypted();
+        run(async {
+            let mut n = Node::<ChunkRef>::new_unencrypted();
 
-        for entry in test_entries() {
-            let path = entry.path.as_bytes();
-            let e = {
-                let mut buf = [0u8; 32];
-                let len = path.len().min(32);
-                buf[32 - len..].copy_from_slice(&path[..len]);
-                ChunkRef::from(ChunkAddress::from(buf))
-            };
-            futures::executor::block_on(n.add::<
+            for entry in test_entries() {
+                let path = entry.path.as_bytes();
+                let e = {
+                    let mut buf = [0u8; 32];
+                    let len = path.len().min(32);
+                    buf[32 - len..].copy_from_slice(&path[..len]);
+                    ChunkRef::from(ChunkAddress::from(buf))
+                };
+                n.add::<
                 nectar_primitives::store::NullLoader,
                 { nectar_primitives::bmt::DEFAULT_BODY_SIZE },
             >(
                 path, Some(e), entry.metadata, &nectar_primitives::store::NullLoader,
-            ))
+            ).await
             .unwrap();
-        }
-
-        // assign deterministic references to forks so encoding works
-        for (counter, fork) in n.forks.values_mut().enumerate() {
-            let mut addr = [0u8; 32];
-            #[allow(clippy::as_conversions)] // forks are keyed by u8, so counter <= 255
-            let counter_byte = counter as u8;
-            addr[31] = counter_byte;
-            fork.node
-                .mark_persisted(ChunkRef::from(ChunkAddress::from(addr)));
-        }
-
-        let encoded = n.encode().unwrap();
-        let n2 = Node::<ChunkRef>::decode(encoded.as_slice()).unwrap();
-
-        // Root has no entry; encoding writes zero bytes, decoding reads them back as None
-        assert!(n2.entry().is_none());
-        assert_eq!(n.forks().len(), n2.forks().len());
-
-        for entry in test_entries() {
-            let key = entry.path.as_bytes()[0];
-            assert!(n2.forks().contains_key(&key));
-            assert_eq!(n2.forks()[&key].prefix(), entry.path.as_bytes());
-            if !entry.metadata.is_empty() {
-                assert_eq!(n2.forks()[&key].node().metadata(), &entry.metadata);
             }
-        }
+
+            // assign deterministic references to forks so encoding works
+            for (counter, fork) in n.forks.values_mut().enumerate() {
+                let mut addr = [0u8; 32];
+                #[allow(clippy::as_conversions)] // forks are keyed by u8, so counter <= 255
+                let counter_byte = counter as u8;
+                addr[31] = counter_byte;
+                fork.node
+                    .mark_persisted(ChunkRef::from(ChunkAddress::from(addr)));
+            }
+
+            let encoded = n.encode().unwrap();
+            let n2 = Node::<ChunkRef>::decode(encoded.as_slice()).unwrap();
+
+            // Root has no entry; encoding writes zero bytes, decoding reads them back as None
+            assert!(n2.entry().is_none());
+            assert_eq!(n.forks().len(), n2.forks().len());
+
+            for entry in test_entries() {
+                let key = entry.path.as_bytes()[0];
+                assert!(n2.forks().contains_key(&key));
+                assert_eq!(n2.forks()[&key].prefix(), entry.path.as_bytes());
+                if !entry.metadata.is_empty() {
+                    assert_eq!(n2.forks()[&key].node().metadata(), &entry.metadata);
+                }
+            }
+        })
     }
 }

--- a/crates/mantaray/src/manifest.rs
+++ b/crates/mantaray/src/manifest.rs
@@ -716,11 +716,11 @@ impl<'a, S: TrustedStore<AnyChunkSet<BS>>, R: Reference, const BS: usize> Shared
 
 #[cfg(test)]
 mod tests {
-    use futures::executor::block_on;
     use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
     use nectar_primitives::chunk::ChunkAddress;
     use nectar_primitives::store::{ChunkGet, MemoryStore};
     use nectar_primitives::{StandardChunkSet, Verified};
+    use nectar_testing::run;
 
     use super::*;
 
@@ -728,16 +728,14 @@ mod tests {
     type PlainManifest<S, const BS: usize = DEFAULT_BODY_SIZE> = super::Manifest<S, ChunkRef, BS>;
 
     /// Drain an async manifest iterator into a `Vec`, propagating the first error.
-    fn drain<S: TrustedStore<AnyChunkSet<BS>>, R: Reference, const BS: usize>(
+    async fn drain<S: TrustedStore<AnyChunkSet<BS>>, R: Reference, const BS: usize>(
         mut iter: ManifestIter<'_, S, R, BS>,
     ) -> Result<Vec<Entry>> {
-        block_on(async move {
-            let mut out = Vec::new();
-            while let Some(item) = iter.next().await {
-                out.push(item?);
-            }
-            Ok(out)
-        })
+        let mut out = Vec::new();
+        while let Some(item) = iter.next().await {
+            out.push(item?);
+        }
+        Ok(out)
     }
 
     /// Create a ChunkAddress from a string, right-padded with zeroes.
@@ -758,307 +756,333 @@ mod tests {
 
     #[test]
     fn persist_idempotence() {
-        let store = Store::new();
+        run(async {
+            let store = Store::new();
 
-        let mut m = PlainManifest::new(store);
+            let mut m = PlainManifest::new(store);
 
-        let paths = &[
-            "aa", "b", "aaaaaa", "aaaaab", "abbbb", "abbba", "bbbbba", "bbbaaa", "bbbaab",
-        ];
+            let paths = &[
+                "aa", "b", "aaaaaa", "aaaaab", "abbbb", "abbba", "bbbbba", "bbbaaa", "bbbaab",
+            ];
 
-        for &path in paths {
-            block_on(m.save()).unwrap();
-            let addr = make_addr(path);
-            block_on(m.add(path, addr)).unwrap();
-        }
+            for &path in paths {
+                m.save().await.unwrap();
+                let addr = make_addr(path);
+                m.add(path, addr).await.unwrap();
+            }
 
-        block_on(m.save()).unwrap();
+            m.save().await.unwrap();
 
-        for &path in paths {
-            let entry = block_on(m.get(path)).unwrap().unwrap();
-            let expected = make_addr(path);
-            assert_eq!(entry.address(), Some(&expected));
-        }
+            for &path in paths {
+                let entry = m.get(path).await.unwrap().unwrap();
+                let expected = make_addr(path);
+                assert_eq!(entry.address(), Some(&expected));
+            }
+        })
     }
 
     #[test]
     fn manifest_entries() {
-        let store = Store::new();
-        let mut m = PlainManifest::new(store);
+        run(async {
+            let store = Store::new();
+            let mut m = PlainManifest::new(store);
 
-        let paths = &["index.html", "img/1.png", "img/2.png", "robots.txt"];
-        for &path in paths {
-            let addr = make_addr(path);
-            block_on(m.add(path, addr)).unwrap();
-        }
+            let paths = &["index.html", "img/1.png", "img/2.png", "robots.txt"];
+            for &path in paths {
+                let addr = make_addr(path);
+                m.add(path, addr).await.unwrap();
+            }
 
-        let entries = block_on(m.entries()).unwrap();
-        assert_eq!(entries.len(), paths.len());
+            let entries = m.entries().await.unwrap();
+            assert_eq!(entries.len(), paths.len());
 
-        for &path in paths {
-            assert!(
-                entries.iter().any(|e| e.path() == path.as_bytes()),
-                "path {path} not found in entries"
-            );
-        }
+            for &path in paths {
+                assert!(
+                    entries.iter().any(|e| e.path() == path.as_bytes()),
+                    "path {path} not found in entries"
+                );
+            }
+        })
     }
 
     #[test]
     fn website_document_helpers() {
-        let store = Store::new();
-        let mut m = PlainManifest::new(store);
+        run(async {
+            let store = Store::new();
+            let mut m = PlainManifest::new(store);
 
-        // Add a dummy entry so the root "/" path has an entry
-        block_on(m.add("/", ChunkAddress::from([0u8; 32]))).unwrap();
+            // Add a dummy entry so the root "/" path has an entry
+            m.add("/", ChunkAddress::from([0u8; 32])).await.unwrap();
 
-        block_on(m.set_index_document("index.html")).unwrap();
-        block_on(m.set_error_document("404.html")).unwrap();
+            m.set_index_document("index.html").await.unwrap();
+            m.set_error_document("404.html").await.unwrap();
 
-        assert_eq!(
-            block_on(m.index_document()).unwrap(),
-            Some("index.html".to_string())
-        );
-        assert_eq!(
-            block_on(m.error_document()).unwrap(),
-            Some("404.html".to_string())
-        );
+            assert_eq!(
+                m.index_document().await.unwrap(),
+                Some("index.html".to_string())
+            );
+            assert_eq!(
+                m.error_document().await.unwrap(),
+                Some("404.html".to_string())
+            );
+        })
     }
 
     #[test]
     fn website_document_helpers_merge_metadata() {
-        let store = Store::new();
-        let mut m = PlainManifest::new(store);
+        run(async {
+            let store = Store::new();
+            let mut m = PlainManifest::new(store);
 
-        block_on(m.set_index_document("index.html")).unwrap();
-        block_on(m.set_error_document("404.html")).unwrap();
+            m.set_index_document("index.html").await.unwrap();
+            m.set_error_document("404.html").await.unwrap();
 
-        assert_eq!(
-            block_on(m.index_document()).unwrap(),
-            Some("index.html".to_string())
-        );
-        assert_eq!(
-            block_on(m.error_document()).unwrap(),
-            Some("404.html".to_string())
-        );
+            assert_eq!(
+                m.index_document().await.unwrap(),
+                Some("index.html".to_string())
+            );
+            assert_eq!(
+                m.error_document().await.unwrap(),
+                Some("404.html".to_string())
+            );
+        })
     }
 
     #[test]
     fn website_document_helpers_none_when_missing() {
-        let store = Store::new();
-        let m = PlainManifest::new(store);
+        run(async {
+            let store = Store::new();
+            let m = PlainManifest::new(store);
 
-        assert_eq!(block_on(m.index_document()).unwrap(), None);
-        assert_eq!(block_on(m.error_document()).unwrap(), None);
+            assert_eq!(m.index_document().await.unwrap(), None);
+            assert_eq!(m.error_document().await.unwrap(), None);
+        })
     }
 
     #[test]
     fn iterate_addresses_yields_all_refs() {
-        let store = Store::new();
-        let mut m = PlainManifest::new(store);
+        run(async {
+            let store = Store::new();
+            let mut m = PlainManifest::new(store);
 
-        let paths = &["index.html", "img/1.png", "img/2.png", "robots.txt"];
-        for &path in paths {
-            let addr = make_addr(path);
-            block_on(m.add(path, addr)).unwrap();
-        }
+            let paths = &["index.html", "img/1.png", "img/2.png", "robots.txt"];
+            for &path in paths {
+                let addr = make_addr(path);
+                m.add(path, addr).await.unwrap();
+            }
 
-        let root_ref = block_on(m.save()).unwrap();
+            let root_ref = m.save().await.unwrap();
 
-        let (_, store) = m.into_parts();
-        let mut m2 = PlainManifest::open(root_ref, store);
-        let mut addresses = Vec::new();
-        block_on(m2.iterate_addresses(|addr| {
-            addresses.push(addr.to_vec());
-            Ok(())
-        }))
-        .unwrap();
+            let (_, store) = m.into_parts();
+            let mut m2 = PlainManifest::open(root_ref, store);
+            let mut addresses = Vec::new();
+            m2.iterate_addresses(|addr| {
+                addresses.push(addr.to_vec());
+                Ok(())
+            })
+            .await
+            .unwrap();
 
-        assert!(!addresses.is_empty());
+            assert!(!addresses.is_empty());
 
-        for &path in paths {
-            let expected = make_addr(path);
-            assert!(
-                addresses.iter().any(|a| a == expected.as_bytes()),
-                "entry ref for {path} not found in addresses"
-            );
-        }
+            for &path in paths {
+                let expected = make_addr(path);
+                assert!(
+                    addresses.iter().any(|a| a == expected.as_bytes()),
+                    "entry ref for {path} not found in addresses"
+                );
+            }
+        })
     }
 
     #[test]
     fn partial_update_workflow() {
-        let store = Store::new();
-        let mut m = PlainManifest::new(store);
+        run(async {
+            let store = Store::new();
+            let mut m = PlainManifest::new(store);
 
-        // Build a manifest with 100 entries
-        for i in 0..100u32 {
-            let path = format!("dir{}/file{}.txt", i / 10, i);
-            let addr = make_addr_u32(i);
-            block_on(m.add(&path, addr)).unwrap();
-        }
-        let root_ref_1 = block_on(m.save()).unwrap();
+            // Build a manifest with 100 entries
+            for i in 0..100u32 {
+                let path = format!("dir{}/file{}.txt", i / 10, i);
+                let addr = make_addr_u32(i);
+                m.add(&path, addr).await.unwrap();
+            }
+            let root_ref_1 = m.save().await.unwrap();
 
-        // Update a single path
-        let updated_addr = make_addr_u32(999);
-        block_on(m.add("dir0/file0.txt", updated_addr)).unwrap();
-        let root_ref_2 = block_on(m.save()).unwrap();
+            // Update a single path
+            let updated_addr = make_addr_u32(999);
+            m.add("dir0/file0.txt", updated_addr).await.unwrap();
+            let root_ref_2 = m.save().await.unwrap();
 
-        assert_ne!(root_ref_1, root_ref_2);
+            assert_ne!(root_ref_1, root_ref_2);
 
-        let entry = block_on(m.get("dir0/file0.txt")).unwrap().unwrap();
-        assert_eq!(entry.address(), Some(&updated_addr));
+            let entry = m.get("dir0/file0.txt").await.unwrap().unwrap();
+            assert_eq!(entry.address(), Some(&updated_addr));
 
-        for i in 1..100u32 {
-            let path = format!("dir{}/file{}.txt", i / 10, i);
-            let entry = block_on(m.get(&path)).unwrap().unwrap();
-            let expected = make_addr_u32(i);
-            assert_eq!(
-                entry.address(),
-                Some(&expected),
-                "entry at {path} was corrupted"
-            );
-        }
+            for i in 1..100u32 {
+                let path = format!("dir{}/file{}.txt", i / 10, i);
+                let entry = m.get(&path).await.unwrap().unwrap();
+                let expected = make_addr_u32(i);
+                assert_eq!(
+                    entry.address(),
+                    Some(&expected),
+                    "entry at {path} was corrupted"
+                );
+            }
+        })
     }
 
     #[test]
     fn stream_yields_all_entries() {
-        use futures::StreamExt;
+        run(async {
+            use futures::StreamExt;
 
-        let store = Store::new();
-        let mut m = PlainManifest::new(store);
+            let store = Store::new();
+            let mut m = PlainManifest::new(store);
 
-        let paths = &["index.html", "img/1.png", "img/2.png", "robots.txt"];
-        for &path in paths {
-            let addr = make_addr(path);
-            block_on(m.add(path, addr)).unwrap();
-        }
+            let paths = &["index.html", "img/1.png", "img/2.png", "robots.txt"];
+            for &path in paths {
+                let addr = make_addr(path);
+                m.add(path, addr).await.unwrap();
+            }
 
-        let all_entries: Vec<_> =
-            block_on(async { m.stream().map(|r| r.unwrap()).collect::<Vec<_>>().await });
+            let all_entries: Vec<_> = m.stream().map(|r| r.unwrap()).collect::<Vec<_>>().await;
 
-        assert_eq!(all_entries.len(), paths.len());
-        for &path in paths {
-            assert!(
-                all_entries.iter().any(|e| e.path() == path.as_bytes()),
-                "path {path} not found via stream"
-            );
-        }
+            assert_eq!(all_entries.len(), paths.len());
+            for &path in paths {
+                assert!(
+                    all_entries.iter().any(|e| e.path() == path.as_bytes()),
+                    "path {path} not found via stream"
+                );
+            }
+        })
     }
 
     #[test]
     fn manifest_iter_lazy() {
-        let store = Store::new();
-        let mut m = PlainManifest::new(store);
+        run(async {
+            let store = Store::new();
+            let mut m = PlainManifest::new(store);
 
-        let paths = &["index.html", "img/1.png", "img/2.png", "robots.txt"];
-        for &path in paths {
-            let addr = make_addr(path);
-            block_on(m.add(path, addr)).unwrap();
-        }
+            let paths = &["index.html", "img/1.png", "img/2.png", "robots.txt"];
+            for &path in paths {
+                let addr = make_addr(path);
+                m.add(path, addr).await.unwrap();
+            }
 
-        // Save and reload to exercise lazy loading
-        let root_ref = block_on(m.save()).unwrap();
+            // Save and reload to exercise lazy loading
+            let root_ref = m.save().await.unwrap();
 
-        let (_, store) = m.into_parts();
-        let mut m2 = PlainManifest::open(root_ref, store);
+            let (_, store) = m.into_parts();
+            let mut m2 = PlainManifest::open(root_ref, store);
 
-        let mut visited = Vec::new();
-        if let Some(result) = block_on(m2.iter().next()) {
-            let entry = result.unwrap();
-            visited.push(entry.path);
-        }
-        assert_eq!(visited.len(), 1);
+            let mut visited = Vec::new();
+            if let Some(result) = m2.iter().next().await {
+                let entry = result.unwrap();
+                visited.push(entry.path);
+            }
+            assert_eq!(visited.len(), 1);
 
-        // Full iteration
-        let (_, store) = m2.into_parts();
-        let mut m3 = PlainManifest::open(root_ref, store);
-        let all_entries = drain(m3.iter()).unwrap();
+            // Full iteration
+            let (_, store) = m2.into_parts();
+            let mut m3 = PlainManifest::open(root_ref, store);
+            let all_entries = drain(m3.iter()).await.unwrap();
 
-        assert_eq!(all_entries.len(), paths.len());
-        for &path in paths {
-            assert!(
-                all_entries.iter().any(|e| e.path() == path.as_bytes()),
-                "path {path} not found via iterator"
-            );
-        }
+            assert_eq!(all_entries.len(), paths.len());
+            for &path in paths {
+                assert!(
+                    all_entries.iter().any(|e| e.path() == path.as_bytes()),
+                    "path {path} not found via iterator"
+                );
+            }
+        })
     }
 
     #[test]
     fn iter_empty_manifest() {
-        let store = Store::new();
-        let mut m = PlainManifest::new(store);
-        let entries = drain(m.iter()).unwrap();
-        assert!(entries.is_empty(), "empty manifest should yield no entries");
+        run(async {
+            let store = Store::new();
+            let mut m = PlainManifest::new(store);
+            let entries = drain(m.iter()).await.unwrap();
+            assert!(entries.is_empty(), "empty manifest should yield no entries");
+        })
     }
 
     #[test]
     fn iter_single_entry() {
-        let store = Store::new();
-        let mut m = PlainManifest::new(store);
-        let addr = make_addr("only");
-        block_on(m.add("only.txt", addr)).unwrap();
+        run(async {
+            let store = Store::new();
+            let mut m = PlainManifest::new(store);
+            let addr = make_addr("only");
+            m.add("only.txt", addr).await.unwrap();
 
-        let entries = drain(m.iter()).unwrap();
-        assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].path(), b"only.txt");
-        assert_eq!(entries[0].address(), Some(&addr));
+            let entries = drain(m.iter()).await.unwrap();
+            assert_eq!(entries.len(), 1);
+            assert_eq!(entries[0].path(), b"only.txt");
+            assert_eq!(entries[0].address(), Some(&addr));
+        })
     }
 
     #[test]
     fn iter_deep_trie_with_lazy_loading() {
-        let store = Store::new();
-        let mut m = PlainManifest::new(store);
+        run(async {
+            let store = Store::new();
+            let mut m = PlainManifest::new(store);
 
-        // Build a deep trie: paths share long prefixes, forcing multiple
-        // trie levels. After save+reload, iteration must lazily load each
-        // intermediate node via raw-pointer traversal.
-        let deep_paths: Vec<String> = (0..20)
-            .map(|i| format!("a/b/c/d/e/f/g/h/file{i:02}.dat"))
-            .collect();
-        for path in &deep_paths {
-            block_on(m.add(path, make_addr(path))).unwrap();
-        }
+            // Build a deep trie: paths share long prefixes, forcing multiple
+            // trie levels. After save+reload, iteration must lazily load each
+            // intermediate node via raw-pointer traversal.
+            let deep_paths: Vec<String> = (0..20)
+                .map(|i| format!("a/b/c/d/e/f/g/h/file{i:02}.dat"))
+                .collect();
+            for path in &deep_paths {
+                m.add(path, make_addr(path)).await.unwrap();
+            }
 
-        let root_ref = block_on(m.save()).unwrap();
-        let (_, store) = m.into_parts();
-        let mut m2 = PlainManifest::open(root_ref, store);
+            let root_ref = m.save().await.unwrap();
+            let (_, store) = m.into_parts();
+            let mut m2 = PlainManifest::open(root_ref, store);
 
-        let entries = drain(m2.iter()).unwrap();
-        assert_eq!(entries.len(), deep_paths.len());
-        for path in &deep_paths {
-            assert!(
-                entries.iter().any(|e| e.path() == path.as_bytes()),
-                "deep path {path} not found via iterator"
-            );
-        }
+            let entries = drain(m2.iter()).await.unwrap();
+            assert_eq!(entries.len(), deep_paths.len());
+            for path in &deep_paths {
+                assert!(
+                    entries.iter().any(|e| e.path() == path.as_bytes()),
+                    "deep path {path} not found via iterator"
+                );
+            }
+        })
     }
 
     #[test]
     fn iter_partial_then_reiterate() {
-        let store = Store::new();
-        let mut m = PlainManifest::new(store);
+        run(async {
+            let store = Store::new();
+            let mut m = PlainManifest::new(store);
 
-        let paths = &["a.txt", "b.txt", "c.txt", "d.txt", "e.txt"];
-        for &path in paths {
-            block_on(m.add(path, make_addr(path))).unwrap();
-        }
+            let paths = &["a.txt", "b.txt", "c.txt", "d.txt", "e.txt"];
+            for &path in paths {
+                m.add(path, make_addr(path)).await.unwrap();
+            }
 
-        // Partial iteration: take only 2 entries, then drop iterator.
-        {
-            let mut iter = m.iter();
-            let _first = block_on(iter.next()).unwrap().unwrap();
-            let _second = block_on(iter.next()).unwrap().unwrap();
-            // Iterator dropped here; must not corrupt trie state.
-        }
+            // Partial iteration: take only 2 entries, then drop iterator.
+            {
+                let mut iter = m.iter();
+                let _first = iter.next().await.unwrap().unwrap();
+                let _second = iter.next().await.unwrap().unwrap();
+                // Iterator dropped here; must not corrupt trie state.
+            }
 
-        // Full re-iteration should still yield all entries.
-        let all = drain(m.iter()).unwrap();
-        assert_eq!(all.len(), paths.len());
-        for &path in paths {
-            assert!(
-                all.iter().any(|e| e.path() == path.as_bytes()),
-                "path {path} missing after partial iteration + re-iteration"
-            );
-        }
+            // Full re-iteration should still yield all entries.
+            let all = drain(m.iter()).await.unwrap();
+            assert_eq!(all.len(), paths.len());
+            for &path in paths {
+                assert!(
+                    all.iter().any(|e| e.path() == path.as_bytes()),
+                    "path {path} missing after partial iteration + re-iteration"
+                );
+            }
+        })
     }
 
     /// A `ChunkGet` wrapper that records the peak number of concurrent
@@ -1128,13 +1152,15 @@ mod tests {
 
     /// Build a saved manifest, reopen it over a `TrackingStore`, and return it
     /// alongside the recorded paths.
-    fn saved_tracking_manifest(paths: &[&str]) -> (PlainManifest<TrackingStore>, Vec<Vec<u8>>) {
+    async fn saved_tracking_manifest(
+        paths: &[&str],
+    ) -> (PlainManifest<TrackingStore>, Vec<Vec<u8>>) {
         let store = Store::new();
         let mut m = PlainManifest::new(store);
         for &path in paths {
-            block_on(m.add(path, make_addr(path))).unwrap();
+            m.add(path, make_addr(path)).await.unwrap();
         }
-        let root_ref = block_on(m.save()).unwrap();
+        let root_ref = m.save().await.unwrap();
         let (_, store) = m.into_parts();
         let expected = paths.iter().map(|p| p.as_bytes().to_vec()).collect();
         (
@@ -1151,318 +1177,363 @@ mod tests {
 
     #[test]
     fn entries_concurrent_matches_serial() {
-        let paths = &[
-            "index.html",
-            "img/1.png",
-            "img/2.png",
-            "img/sub/deep.png",
-            "robots.txt",
-            "css/main.css",
-        ];
+        run(async {
+            let paths = &[
+                "index.html",
+                "img/1.png",
+                "img/2.png",
+                "img/sub/deep.png",
+                "robots.txt",
+                "css/main.css",
+            ];
 
-        // Serial reference set.
-        let store = Store::new();
-        let mut serial = PlainManifest::new(store);
-        for &path in paths {
-            block_on(serial.add(path, make_addr(path))).unwrap();
-        }
-        let serial_entries = block_on(serial.entries()).unwrap();
+            // Serial reference set.
+            let store = Store::new();
+            let mut serial = PlainManifest::new(store);
+            for &path in paths {
+                serial.add(path, make_addr(path)).await.unwrap();
+            }
+            let serial_entries = serial.entries().await.unwrap();
 
-        let (m, _) = saved_tracking_manifest(paths);
-        let conc = block_on(m.entries_concurrent(DEFAULT_LIST_CONCURRENCY)).unwrap();
+            let (m, _) = saved_tracking_manifest(paths).await;
+            let conc = m
+                .entries_concurrent(DEFAULT_LIST_CONCURRENCY)
+                .await
+                .unwrap();
 
-        assert_eq!(
-            sorted_paths(&serial_entries),
-            sorted_paths(&conc),
-            "concurrent listing must yield the same entry set as serial"
-        );
-        assert_eq!(conc.len(), paths.len());
+            assert_eq!(
+                sorted_paths(&serial_entries),
+                sorted_paths(&conc),
+                "concurrent listing must yield the same entry set as serial"
+            );
+            assert_eq!(conc.len(), paths.len());
+        })
     }
 
     #[test]
     fn entries_concurrent_is_bounded_and_parallel() {
-        // Twenty sibling files share the "file" prefix, so the widest trie
-        // level has many forks fetched in one batch.
-        let owned: Vec<String> = (0..20).map(|i| format!("file{i:02}.dat")).collect();
-        let paths: Vec<&str> = owned.iter().map(String::as_str).collect();
+        run(async {
+            // Twenty sibling files share the "file" prefix, so the widest trie
+            // level has many forks fetched in one batch.
+            let owned: Vec<String> = (0..20).map(|i| format!("file{i:02}.dat")).collect();
+            let paths: Vec<&str> = owned.iter().map(String::as_str).collect();
 
-        let (m, expected) = saved_tracking_manifest(&paths);
-        let width = 4;
-        let entries = block_on(m.entries_concurrent(width)).unwrap();
+            let (m, expected) = saved_tracking_manifest(&paths).await;
+            let width = 4;
+            let entries = m.entries_concurrent(width).await.unwrap();
 
-        let mut got = sorted_paths(&entries);
-        let mut want = expected;
-        want.sort();
-        assert_eq!(got.len(), paths.len());
-        got.dedup();
-        assert_eq!(got, want, "all sibling files must be listed exactly once");
+            let mut got = sorted_paths(&entries);
+            let mut want = expected;
+            want.sort();
+            assert_eq!(got.len(), paths.len());
+            got.dedup();
+            assert_eq!(got, want, "all sibling files must be listed exactly once");
 
-        let store = m.store();
-        assert!(store.gets() > 1, "listing must perform multiple fetches");
-        assert!(
-            store.max_inflight() > 1,
-            "concurrent listing must overlap fetches (got {})",
-            store.max_inflight()
-        );
-        assert!(
-            store.max_inflight() <= width,
-            "in-flight fetches must stay bounded by width {width} (got {})",
-            store.max_inflight()
-        );
+            let store = m.store();
+            assert!(store.gets() > 1, "listing must perform multiple fetches");
+            assert!(
+                store.max_inflight() > 1,
+                "concurrent listing must overlap fetches (got {})",
+                store.max_inflight()
+            );
+            assert!(
+                store.max_inflight() <= width,
+                "in-flight fetches must stay bounded by width {width} (got {})",
+                store.max_inflight()
+            );
+        })
     }
 
     #[test]
     fn entries_concurrent_width_one_is_serial() {
-        let owned: Vec<String> = (0..12).map(|i| format!("file{i:02}.dat")).collect();
-        let paths: Vec<&str> = owned.iter().map(String::as_str).collect();
+        run(async {
+            let owned: Vec<String> = (0..12).map(|i| format!("file{i:02}.dat")).collect();
+            let paths: Vec<&str> = owned.iter().map(String::as_str).collect();
 
-        let (m, _) = saved_tracking_manifest(&paths);
-        let entries = block_on(m.entries_concurrent(1)).unwrap();
+            let (m, _) = saved_tracking_manifest(&paths).await;
+            let entries = m.entries_concurrent(1).await.unwrap();
 
-        assert_eq!(entries.len(), paths.len());
-        assert_eq!(
-            m.store().max_inflight(),
-            1,
-            "width 1 must never overlap fetches"
-        );
+            assert_eq!(entries.len(), paths.len());
+            assert_eq!(
+                m.store().max_inflight(),
+                1,
+                "width 1 must never overlap fetches"
+            );
+        })
     }
 
     #[test]
     fn entries_concurrent_clamps_zero_width() {
-        let (m, _) = saved_tracking_manifest(&["a.txt", "b.txt"]);
-        let entries = block_on(m.entries_concurrent(0)).unwrap();
-        assert_eq!(entries.len(), 2);
-        assert_eq!(m.store().max_inflight(), 1, "zero width clamps to serial");
+        run(async {
+            let (m, _) = saved_tracking_manifest(&["a.txt", "b.txt"]).await;
+            let entries = m.entries_concurrent(0).await.unwrap();
+            assert_eq!(entries.len(), 2);
+            assert_eq!(m.store().max_inflight(), 1, "zero width clamps to serial");
+        })
     }
 
     #[test]
     fn entries_concurrent_empty_manifest() {
-        let store = Store::new();
-        let m = PlainManifest::new(store);
-        let entries = block_on(m.entries_concurrent(DEFAULT_LIST_CONCURRENCY)).unwrap();
-        assert!(entries.is_empty(), "empty manifest yields no entries");
+        run(async {
+            let store = Store::new();
+            let m = PlainManifest::new(store);
+            let entries = m
+                .entries_concurrent(DEFAULT_LIST_CONCURRENCY)
+                .await
+                .unwrap();
+            assert!(entries.is_empty(), "empty manifest yields no entries");
+        })
     }
 
     #[test]
     fn entries_concurrent_single_entry() {
-        let store = Store::new();
-        let mut m = PlainManifest::new(store);
-        let addr = make_addr("only");
-        block_on(m.add("only.txt", addr)).unwrap();
+        run(async {
+            let store = Store::new();
+            let mut m = PlainManifest::new(store);
+            let addr = make_addr("only");
+            m.add("only.txt", addr).await.unwrap();
 
-        let entries = block_on(m.entries_concurrent(DEFAULT_LIST_CONCURRENCY)).unwrap();
-        assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].path(), b"only.txt");
-        assert_eq!(entries[0].address(), Some(&addr));
+            let entries = m
+                .entries_concurrent(DEFAULT_LIST_CONCURRENCY)
+                .await
+                .unwrap();
+            assert_eq!(entries.len(), 1);
+            assert_eq!(entries[0].path(), b"only.txt");
+            assert_eq!(entries[0].address(), Some(&addr));
+        })
     }
 
     #[test]
     fn entries_concurrent_deep_trie() {
-        let deep_paths: Vec<String> = (0..20)
-            .map(|i| format!("a/b/c/d/e/f/g/h/file{i:02}.dat"))
-            .collect();
-        let paths: Vec<&str> = deep_paths.iter().map(String::as_str).collect();
+        run(async {
+            let deep_paths: Vec<String> = (0..20)
+                .map(|i| format!("a/b/c/d/e/f/g/h/file{i:02}.dat"))
+                .collect();
+            let paths: Vec<&str> = deep_paths.iter().map(String::as_str).collect();
 
-        let (m, _) = saved_tracking_manifest(&paths);
-        let entries = block_on(m.entries_concurrent(DEFAULT_LIST_CONCURRENCY)).unwrap();
+            let (m, _) = saved_tracking_manifest(&paths).await;
+            let entries = m
+                .entries_concurrent(DEFAULT_LIST_CONCURRENCY)
+                .await
+                .unwrap();
 
-        assert_eq!(entries.len(), deep_paths.len());
-        let got = sorted_paths(&entries);
-        for path in &deep_paths {
-            assert!(
-                got.iter().any(|p| p == path.as_bytes()),
-                "deep path {path} missing from concurrent listing"
-            );
-        }
+            assert_eq!(entries.len(), deep_paths.len());
+            let got = sorted_paths(&entries);
+            for path in &deep_paths {
+                assert!(
+                    got.iter().any(|p| p == path.as_bytes()),
+                    "deep path {path} missing from concurrent listing"
+                );
+            }
+        })
     }
 
     #[test]
     fn entries_concurrent_shared_prefix_branches() {
-        // Shared-prefix branches force the trie to split mid-prefix, exercising
-        // sibling fan-out at several levels.
-        let paths = &[
-            "aaaaaa", "aaaaab", "aaabbb", "abbbbb", "abbbba", "bbbbba", "bbbaaa", "bbbaab",
-        ];
-        let (m, _) = saved_tracking_manifest(paths);
-        let entries = block_on(m.entries_concurrent(DEFAULT_LIST_CONCURRENCY)).unwrap();
+        run(async {
+            // Shared-prefix branches force the trie to split mid-prefix, exercising
+            // sibling fan-out at several levels.
+            let paths = &[
+                "aaaaaa", "aaaaab", "aaabbb", "abbbbb", "abbbba", "bbbbba", "bbbaaa", "bbbaab",
+            ];
+            let (m, _) = saved_tracking_manifest(paths).await;
+            let entries = m
+                .entries_concurrent(DEFAULT_LIST_CONCURRENCY)
+                .await
+                .unwrap();
 
-        assert_eq!(sorted_paths(&entries), {
-            let mut v: Vec<Vec<u8>> = paths.iter().map(|p| p.as_bytes().to_vec()).collect();
-            v.sort();
-            v
-        });
+            assert_eq!(sorted_paths(&entries), {
+                let mut v: Vec<Vec<u8>> = paths.iter().map(|p| p.as_bytes().to_vec()).collect();
+                v.sort();
+                v
+            });
+        })
     }
 
     #[test]
     fn iter_partial_then_reiterate_lazy() {
-        let store = Store::new();
-        let mut m = PlainManifest::new(store);
+        run(async {
+            let store = Store::new();
+            let mut m = PlainManifest::new(store);
 
-        let paths = &["x/1.txt", "x/2.txt", "y/1.txt", "y/2.txt", "z.txt"];
-        for &path in paths {
-            block_on(m.add(path, make_addr(path))).unwrap();
-        }
+            let paths = &["x/1.txt", "x/2.txt", "y/1.txt", "y/2.txt", "z.txt"];
+            for &path in paths {
+                m.add(path, make_addr(path)).await.unwrap();
+            }
 
-        let root_ref = block_on(m.save()).unwrap();
-        let (_, store) = m.into_parts();
-        let mut m2 = PlainManifest::open(root_ref, store);
+            let root_ref = m.save().await.unwrap();
+            let (_, store) = m.into_parts();
+            let mut m2 = PlainManifest::open(root_ref, store);
 
-        // Partial iteration on a lazy-loaded manifest.
-        {
-            let mut iter = m2.iter();
-            let _first = block_on(iter.next()).unwrap().unwrap();
-        }
+            // Partial iteration on a lazy-loaded manifest.
+            {
+                let mut iter = m2.iter();
+                let _first = iter.next().await.unwrap().unwrap();
+            }
 
-        // Re-iterate: previously loaded nodes stay loaded, the rest
-        // are lazily fetched again through the raw-pointer path.
-        let all = drain(m2.iter()).unwrap();
-        assert_eq!(all.len(), paths.len());
-        for &path in paths {
-            assert!(
-                all.iter().any(|e| e.path() == path.as_bytes()),
-                "path {path} missing after partial lazy iteration"
-            );
-        }
+            // Re-iterate: previously loaded nodes stay loaded, the rest
+            // are lazily fetched again through the raw-pointer path.
+            let all = drain(m2.iter()).await.unwrap();
+            assert_eq!(all.len(), paths.len());
+            for &path in paths {
+                assert!(
+                    all.iter().any(|e| e.path() == path.as_bytes()),
+                    "path {path} missing after partial lazy iteration"
+                );
+            }
+        })
     }
 
     #[test]
     fn get_returns_some_for_present_path() {
-        let store = Store::new();
-        let mut m = PlainManifest::new(store);
-        let addr = make_addr("only");
-        block_on(m.add("only.txt", addr)).unwrap();
+        run(async {
+            let store = Store::new();
+            let mut m = PlainManifest::new(store);
+            let addr = make_addr("only");
+            m.add("only.txt", addr).await.unwrap();
 
-        let entry = block_on(m.get("only.txt")).unwrap().unwrap();
-        assert_eq!(entry.address(), Some(&addr));
+            let entry = m.get("only.txt").await.unwrap().unwrap();
+            assert_eq!(entry.address(), Some(&addr));
+        })
     }
 
     #[test]
     fn get_returns_none_for_absent_path() {
-        let store = Store::new();
-        let mut m = PlainManifest::new(store);
-        block_on(m.add("present.txt", make_addr("present"))).unwrap();
+        run(async {
+            let store = Store::new();
+            let mut m = PlainManifest::new(store);
+            m.add("present.txt", make_addr("present")).await.unwrap();
 
-        assert!(block_on(m.get("absent.txt")).unwrap().is_none());
-        // A pure prefix of an existing path is an edge, not a value.
-        assert!(block_on(m.get("present")).unwrap().is_none());
+            assert!(m.get("absent.txt").await.unwrap().is_none());
+            // A pure prefix of an existing path is an edge, not a value.
+            assert!(m.get("present").await.unwrap().is_none());
+        })
     }
 
     #[test]
     fn get_resolves_after_save_reload() {
-        let store = Store::new();
-        let mut m = PlainManifest::new(store);
-        let paths = &["index.html", "img/1.png", "img/2.png"];
-        for &path in paths {
-            block_on(m.add(path, make_addr(path))).unwrap();
-        }
-        let root_ref = block_on(m.save()).unwrap();
-        let (_, store) = m.into_parts();
-        let m2 = PlainManifest::open(root_ref, store);
+        run(async {
+            let store = Store::new();
+            let mut m = PlainManifest::new(store);
+            let paths = &["index.html", "img/1.png", "img/2.png"];
+            for &path in paths {
+                m.add(path, make_addr(path)).await.unwrap();
+            }
+            let root_ref = m.save().await.unwrap();
+            let (_, store) = m.into_parts();
+            let m2 = PlainManifest::open(root_ref, store);
 
-        // Shared reference: several reads share `&m2` without exclusive borrow.
-        let read = |p: &str| block_on(m2.get(p)).unwrap();
-        assert_eq!(
-            read("img/1.png").unwrap().address(),
-            Some(&make_addr("img/1.png"))
-        );
-        assert!(read("img/3.png").is_none());
-        assert_eq!(
-            read("index.html").unwrap().address(),
-            Some(&make_addr("index.html"))
-        );
+            // Shared reference: several reads share `&m2` without exclusive borrow.
+            let read = async |p: &str| m2.get(p).await.unwrap();
+            assert_eq!(
+                read("img/1.png").await.unwrap().address(),
+                Some(&make_addr("img/1.png"))
+            );
+            assert!(read("img/3.png").await.is_none());
+            assert_eq!(
+                read("index.html").await.unwrap().address(),
+                Some(&make_addr("index.html"))
+            );
+        })
     }
 
     #[test]
     fn shared_reads_take_shared_reference() {
-        let store = Store::new();
-        let mut m = PlainManifest::new(store);
-        block_on(m.add("/", ChunkAddress::from([0u8; 32]))).unwrap();
-        block_on(m.set_index_document("index.html")).unwrap();
-        block_on(m.add("a.txt", make_addr("a"))).unwrap();
+        run(async {
+            let store = Store::new();
+            let mut m = PlainManifest::new(store);
+            m.add("/", ChunkAddress::from([0u8; 32])).await.unwrap();
+            m.set_index_document("index.html").await.unwrap();
+            m.add("a.txt", make_addr("a")).await.unwrap();
 
-        // All read accessors are callable through a shared borrow.
-        fn read_all<S: TrustedStore<StandardChunkSet>>(m: &PlainManifest<S>) {
-            assert!(block_on(m.get("a.txt")).unwrap().is_some());
-            assert_eq!(block_on(m.entries()).unwrap().len(), 2);
-            assert_eq!(
-                block_on(m.index_document()).unwrap(),
-                Some("index.html".to_string())
-            );
-        }
-        read_all(&m);
+            // All read accessors are callable through a shared borrow.
+            async fn read_all<S: TrustedStore<StandardChunkSet>>(m: &PlainManifest<S>) {
+                assert!(m.get("a.txt").await.unwrap().is_some());
+                assert_eq!(m.entries().await.unwrap().len(), 2);
+                assert_eq!(
+                    m.index_document().await.unwrap(),
+                    Some("index.html".to_string())
+                );
+            }
+            read_all(&m).await;
+        })
     }
 
     #[test]
     #[allow(deprecated)]
     fn deprecated_lookup_still_errors_on_miss() {
-        let store = Store::new();
-        let mut m = PlainManifest::new(store);
-        block_on(m.add("present.txt", make_addr("present"))).unwrap();
+        run(async {
+            let store = Store::new();
+            let mut m = PlainManifest::new(store);
+            m.add("present.txt", make_addr("present")).await.unwrap();
 
-        assert!(block_on(m.lookup("present.txt")).is_ok());
-        assert!(block_on(m.lookup("absent.txt")).is_err());
+            assert!(m.lookup("present.txt").await.is_ok());
+            assert!(m.lookup("absent.txt").await.is_err());
+        })
     }
 
     #[test]
     fn stream_load_error_does_not_corrupt_sibling_paths() {
-        use core::sync::atomic::{AtomicUsize, Ordering};
-        use futures::StreamExt;
+        run(async {
+            use core::sync::atomic::{AtomicUsize, Ordering};
+            use futures::StreamExt;
 
-        // Store injecting a single load failure on the `fail_on`-th get,
-        // delegating every other get to the inner store.
-        struct FailOnceStore {
-            inner: Store,
-            fail_on: usize,
-            count: AtomicUsize,
-        }
-
-        impl ChunkGet<StandardChunkSet> for FailOnceStore {
-            type Trust = Verified;
-            type Error = nectar_primitives::store::ChunkStoreError;
-
-            async fn get(
-                &self,
-                address: &ChunkAddress,
-            ) -> core::result::Result<nectar_primitives::Chunk, Self::Error> {
-                let n = self.count.fetch_add(1, Ordering::SeqCst) + 1;
-                if n == self.fail_on {
-                    // Force a miss to surface a load error mid-traversal.
-                    return ChunkGet::get(&self.inner, &ChunkAddress::from([0xffu8; 32])).await;
-                }
-                ChunkGet::get(&self.inner, address).await
+            // Store injecting a single load failure on the `fail_on`-th get,
+            // delegating every other get to the inner store.
+            struct FailOnceStore {
+                inner: Store,
+                fail_on: usize,
+                count: AtomicUsize,
             }
-        }
 
-        // Two top-level leaves; 'a' sorts before 'b', so the depth-first
-        // traversal descends the 'a' fork first.
-        let store = Store::new();
-        let mut m = PlainManifest::new(store);
-        block_on(m.add("a.txt", make_addr("a.txt"))).unwrap();
-        block_on(m.add("b.txt", make_addr("b.txt"))).unwrap();
-        let root_ref = block_on(m.save()).unwrap();
-        let (_, store) = m.into_parts();
+            impl ChunkGet<StandardChunkSet> for FailOnceStore {
+                type Trust = Verified;
+                type Error = nectar_primitives::store::ChunkStoreError;
 
-        // get #1 loads the root; get #2 is the 'a' leaf and is failed; get #3
-        // is the sibling 'b' leaf and succeeds. A resumed traversal must not
-        // carry the failed fork's prefix into the sibling's path.
-        let failing = FailOnceStore {
-            inner: store,
-            fail_on: 2,
-            count: AtomicUsize::new(0),
-        };
-        let m2 = PlainManifest::open(root_ref, failing);
+                async fn get(
+                    &self,
+                    address: &ChunkAddress,
+                ) -> core::result::Result<nectar_primitives::Chunk, Self::Error> {
+                    let n = self.count.fetch_add(1, Ordering::SeqCst) + 1;
+                    if n == self.fail_on {
+                        // Force a miss to surface a load error mid-traversal.
+                        return ChunkGet::get(&self.inner, &ChunkAddress::from([0xffu8; 32])).await;
+                    }
+                    ChunkGet::get(&self.inner, address).await
+                }
+            }
 
-        let items: Vec<Result<Entry>> = block_on(m2.stream().collect::<Vec<_>>());
+            // Two top-level leaves; 'a' sorts before 'b', so the depth-first
+            // traversal descends the 'a' fork first.
+            let store = Store::new();
+            let mut m = PlainManifest::new(store);
+            m.add("a.txt", make_addr("a.txt")).await.unwrap();
+            m.add("b.txt", make_addr("b.txt")).await.unwrap();
+            let root_ref = m.save().await.unwrap();
+            let (_, store) = m.into_parts();
 
-        assert_eq!(items.len(), 2);
-        assert!(
-            items[0].is_err(),
-            "first descent should surface the injected load error"
-        );
-        assert_eq!(
-            items[1].as_ref().unwrap().path(),
-            b"b.txt",
-            "sibling path must not be prefixed by the failed fork"
-        );
+            // get #1 loads the root; get #2 is the 'a' leaf and is failed; get #3
+            // is the sibling 'b' leaf and succeeds. A resumed traversal must not
+            // carry the failed fork's prefix into the sibling's path.
+            let failing = FailOnceStore {
+                inner: store,
+                fail_on: 2,
+                count: AtomicUsize::new(0),
+            };
+            let m2 = PlainManifest::open(root_ref, failing);
+
+            let items: Vec<Result<Entry>> = m2.stream().collect::<Vec<_>>().await;
+
+            assert_eq!(items.len(), 2);
+            assert!(
+                items[0].is_err(),
+                "first descent should surface the injected load error"
+            );
+            assert_eq!(
+                items[1].as_ref().unwrap().path(),
+                b"b.txt",
+                "sibling path must not be prefixed by the failed fork"
+            );
+        })
     }
 }

--- a/crates/mantaray/src/node.rs
+++ b/crates/mantaray/src/node.rs
@@ -1225,7 +1225,7 @@ mod tests {
         ]
     }
 
-    use futures::executor::block_on;
+    use nectar_testing::run;
 
     const NL: NullLoader = NullLoader;
     const BS: usize = DEFAULT_BODY_SIZE;
@@ -1240,50 +1240,54 @@ mod tests {
     }
 
     /// In-memory add: delegates to `add` with NullLoader.
-    fn node_add(n: &mut Node, path: &[u8], entry: ChunkRef, meta: BTreeMap<String, String>) {
-        block_on(n.add::<NullLoader, BS>(path, Some(entry), meta, &NL)).unwrap();
+    async fn node_add(n: &mut Node, path: &[u8], entry: ChunkRef, meta: BTreeMap<String, String>) {
+        n.add::<NullLoader, BS>(path, Some(entry), meta, &NL)
+            .await
+            .unwrap();
     }
 
     /// In-memory lookup: delegates to `lookup` with NullLoader.
-    fn node_lookup<'n>(n: &'n mut Node, path: &[u8]) -> Result<Option<&'n ChunkRef>> {
-        block_on(n.lookup::<NullLoader, BS>(path, &NL))
+    async fn node_lookup<'n>(n: &'n mut Node, path: &[u8]) -> Result<Option<&'n ChunkRef>> {
+        n.lookup::<NullLoader, BS>(path, &NL).await
     }
 
     /// In-memory lookup_node: delegates to `lookup_node` with NullLoader.
-    fn node_lookup_node<'n>(n: &'n mut Node, path: &[u8]) -> Result<&'n mut Node> {
-        block_on(n.lookup_node::<NullLoader, BS>(path, &NL))
+    async fn node_lookup_node<'n>(n: &'n mut Node, path: &[u8]) -> Result<&'n mut Node> {
+        n.lookup_node::<NullLoader, BS>(path, &NL).await
     }
 
     /// In-memory remove: delegates to `remove` with NullLoader.
-    fn node_remove(n: &mut Node, path: &[u8]) -> Result<()> {
-        block_on(n.remove::<NullLoader, BS>(path, &NL))
+    async fn node_remove(n: &mut Node, path: &[u8]) -> Result<()> {
+        n.remove::<NullLoader, BS>(path, &NL).await
     }
 
     /// In-memory has_prefix: delegates to `has_prefix` with NullLoader.
-    fn node_has_prefix(n: &mut Node, path: &[u8]) -> Result<bool> {
-        block_on(n.has_prefix::<NullLoader, BS>(path, &NL))
+    async fn node_has_prefix(n: &mut Node, path: &[u8]) -> Result<bool> {
+        n.has_prefix::<NullLoader, BS>(path, &NL).await
     }
 
     /// In-memory walk: delegates to `walk` with NullLoader.
-    fn node_walk<F>(n: &mut Node, f: &mut F) -> Result<()>
+    async fn node_walk<F>(n: &mut Node, f: &mut F) -> Result<()>
     where
         F: FnMut(&[u8], &Node) -> Result<()>,
     {
-        block_on(n.walk::<NullLoader, BS, _>(&NL, f))
+        n.walk::<NullLoader, BS, _>(&NL, f).await
     }
 
     /// In-memory walk_node: delegates to `walk_from` with NullLoader.
-    fn node_walk_node<F>(n: &mut Node, root: &[u8], f: &mut F) -> Result<()>
+    async fn node_walk_node<F>(n: &mut Node, root: &[u8], f: &mut F) -> Result<()>
     where
         F: FnMut(&[u8], &Node) -> Result<()>,
     {
-        block_on(n.walk_from::<NullLoader, BS, _>(root, &NL, f))
+        n.walk_from::<NullLoader, BS, _>(root, &NL, f).await
     }
 
     #[test]
     fn nil_path() {
-        let mut n = Node::default();
-        assert!(node_lookup(&mut n, b"").is_ok());
+        run(async {
+            let mut n = Node::default();
+            assert!(node_lookup(&mut n, b"").await.is_ok());
+        })
     }
 
     #[test]
@@ -1384,29 +1388,31 @@ mod tests {
 
     #[test]
     fn add_and_lookup() {
-        let mut n = Node::default();
-        let items = &test_case_data()[0].items;
+        run(async {
+            let mut n = Node::default();
+            let items = &test_case_data()[0].items;
 
-        for (i, c) in items.iter().enumerate() {
-            let e = make_entry(c);
-            node_add(&mut n, c.as_bytes(), e, BTreeMap::new());
+            for (i, c) in items.iter().enumerate() {
+                let e = make_entry(c);
+                node_add(&mut n, c.as_bytes(), e, BTreeMap::new()).await;
 
-            for &d in items.iter().take(i) {
-                let r = node_lookup(&mut n, d.as_bytes()).unwrap();
-                assert_eq!(r, Some(&make_entry(d)));
+                for &d in items.iter().take(i) {
+                    let r = node_lookup(&mut n, d.as_bytes()).await.unwrap();
+                    assert_eq!(r, Some(&make_entry(d)));
+                }
             }
-        }
+        })
     }
 
-    fn run_add_and_lookup_node(items: &[&str]) {
+    async fn run_add_and_lookup_node(items: &[&str]) {
         let mut n = Node::default();
 
         for (i, c) in items.iter().enumerate() {
             let e = make_entry(c);
-            node_add(&mut n, c.as_bytes(), e, BTreeMap::new());
+            node_add(&mut n, c.as_bytes(), e, BTreeMap::new()).await;
 
             for &d in items.iter().take(i) {
-                let node = node_lookup_node(&mut n, d.as_bytes()).unwrap();
+                let node = node_lookup_node(&mut n, d.as_bytes()).await.unwrap();
                 assert!(node.is_value());
                 assert_eq!(node.entry(), Some(&make_entry(d)));
             }
@@ -1415,49 +1421,61 @@ mod tests {
 
     #[test]
     fn add_and_lookup_node_a() {
-        run_add_and_lookup_node(&test_case_data()[0].items);
+        run(async {
+            run_add_and_lookup_node(&test_case_data()[0].items).await;
+        })
     }
 
     #[test]
     fn add_and_lookup_node_simple() {
-        run_add_and_lookup_node(&test_case_data()[1].items);
+        run(async {
+            run_add_and_lookup_node(&test_case_data()[1].items).await;
+        })
     }
 
     #[test]
     fn add_and_lookup_node_nested_value() {
-        run_add_and_lookup_node(&test_case_data()[2].items);
+        run(async {
+            run_add_and_lookup_node(&test_case_data()[2].items).await;
+        })
     }
 
     #[test]
     fn add_and_lookup_node_nested_prefix() {
-        run_add_and_lookup_node(&test_case_data()[3].items);
+        run(async {
+            run_add_and_lookup_node(&test_case_data()[3].items).await;
+        })
     }
 
     #[test]
     fn add_and_lookup_node_conflicting_path() {
-        run_add_and_lookup_node(&test_case_data()[4].items);
+        run(async {
+            run_add_and_lookup_node(&test_case_data()[4].items).await;
+        })
     }
 
     #[test]
     fn add_and_lookup_node_spa_website() {
-        run_add_and_lookup_node(&test_case_data()[5].items);
+        run(async {
+            run_add_and_lookup_node(&test_case_data()[5].items).await;
+        })
     }
 
-    fn run_add_and_lookup_with_load_save(items: &[&str]) {
+    async fn run_add_and_lookup_with_load_save(items: &[&str]) {
         let mut n = Node::default();
 
         for c in items {
             let e = make_entry(c);
-            node_add(&mut n, c.as_bytes(), e, BTreeMap::new());
+            node_add(&mut n, c.as_bytes(), e, BTreeMap::new()).await;
         }
 
         let store = MemoryStore::<StandardChunkSet>::new();
-        block_on(n.save(&store)).unwrap();
+        n.save(&store).await.unwrap();
 
         let mut n2: Node = Node::from_reference(*n.reference().unwrap());
 
         for &d in items {
-            let node = block_on(n2.lookup_node(d.as_bytes(), &store)).unwrap();
+            let node = n2.lookup_node(d.as_bytes(), &store).await.unwrap();
             assert!(node.is_value());
             assert_eq!(node.entry(), Some(&make_entry(d)));
         }
@@ -1468,96 +1486,120 @@ mod tests {
     /// diagnosable rather than an anonymous wire error.
     #[test]
     fn load_corrupt_chunk_reports_address() {
-        // Fewer bytes than the obfuscation-key header cannot decode: the
-        // wire failure is `TooShort`, wrapped with the chunk's address.
-        let chunk = ContentChunk::<{ DEFAULT_BODY_SIZE }>::new(Bytes::from(vec![1u8; 8])).unwrap();
-        let address = *chunk.address();
+        run(async {
+            // Fewer bytes than the obfuscation-key header cannot decode: the
+            // wire failure is `TooShort`, wrapped with the chunk's address.
+            let chunk =
+                ContentChunk::<{ DEFAULT_BODY_SIZE }>::new(Bytes::from(vec![1u8; 8])).unwrap();
+            let address = *chunk.address();
 
-        let store = MemoryStore::<StandardChunkSet>::new();
-        block_on(store.put(Chunk::from_envelope(chunk.into()).unwrap())).unwrap();
+            let store = MemoryStore::<StandardChunkSet>::new();
+            store
+                .put(Chunk::from_envelope(chunk.into()).unwrap())
+                .await
+                .unwrap();
 
-        let mut node: Node = Node::from_reference(ChunkRef::from(address));
-        let err = block_on(node.load(&store)).unwrap_err();
-        assert!(
-            matches!(
-                err,
-                MantarayError::Corrupt { address: a, source: DecodeError::TooShort }
-                    if a == address
-            ),
-            "expected Corrupt naming the chunk address, got {err:?}"
-        );
+            let mut node: Node = Node::from_reference(ChunkRef::from(address));
+            let err = node.load(&store).await.unwrap_err();
+            assert!(
+                matches!(
+                    err,
+                    MantarayError::Corrupt { address: a, source: DecodeError::TooShort }
+                        if a == address
+                ),
+                "expected Corrupt naming the chunk address, got {err:?}"
+            );
+        })
     }
 
     #[test]
     fn add_and_lookup_with_load_save_a() {
-        run_add_and_lookup_with_load_save(&test_case_data()[0].items);
+        run(async {
+            run_add_and_lookup_with_load_save(&test_case_data()[0].items).await;
+        })
     }
 
     #[test]
     fn add_and_lookup_with_load_save_simple() {
-        run_add_and_lookup_with_load_save(&test_case_data()[1].items);
+        run(async {
+            run_add_and_lookup_with_load_save(&test_case_data()[1].items).await;
+        })
     }
 
     #[test]
     fn add_and_lookup_with_load_save_nested_value() {
-        run_add_and_lookup_with_load_save(&test_case_data()[2].items);
+        run(async {
+            run_add_and_lookup_with_load_save(&test_case_data()[2].items).await;
+        })
     }
 
     #[test]
     fn add_and_lookup_with_load_save_nested_prefix() {
-        run_add_and_lookup_with_load_save(&test_case_data()[3].items);
+        run(async {
+            run_add_and_lookup_with_load_save(&test_case_data()[3].items).await;
+        })
     }
 
     #[test]
     fn add_and_lookup_with_load_save_conflicting_path() {
-        run_add_and_lookup_with_load_save(&test_case_data()[4].items);
+        run(async {
+            run_add_and_lookup_with_load_save(&test_case_data()[4].items).await;
+        })
     }
 
     #[test]
     fn add_and_lookup_with_load_save_spa_website() {
-        run_add_and_lookup_with_load_save(&test_case_data()[5].items);
+        run(async {
+            run_add_and_lookup_with_load_save(&test_case_data()[5].items).await;
+        })
     }
 
-    fn run_remove(tc: RemoveTestCase) {
+    async fn run_remove(tc: RemoveTestCase) {
         let mut n = Node::default();
 
         for (i, c) in tc.items.iter().enumerate() {
             let e = make_entry(&c.path);
-            node_add(&mut n, c.path.as_bytes(), e, c.metadata.clone());
+            node_add(&mut n, c.path.as_bytes(), e, c.metadata.clone()).await;
 
             for item in tc.items.iter().take(i) {
-                let r = node_lookup(&mut n, item.path.as_bytes()).unwrap();
+                let r = node_lookup(&mut n, item.path.as_bytes()).await.unwrap();
                 assert_eq!(r, Some(&make_entry(&item.path)));
             }
         }
 
         for c in &tc.remove {
-            node_remove(&mut n, c.as_bytes()).unwrap();
-            assert!(node_lookup(&mut n, c.as_bytes()).is_err());
+            node_remove(&mut n, c.as_bytes()).await.unwrap();
+            assert!(node_lookup(&mut n, c.as_bytes()).await.is_err());
         }
     }
 
     #[test]
     fn remove_simple() {
-        run_remove(remove_test_case_data()[0].clone());
+        run(async {
+            run_remove(remove_test_case_data()[0].clone()).await;
+        })
     }
 
     #[test]
     fn remove_nested_prefix() {
-        run_remove(remove_test_case_data()[1].clone());
+        run(async {
+            run_remove(remove_test_case_data()[1].clone()).await;
+        })
     }
 
-    fn run_has_prefix(tc: HasPrefixTestCase) {
+    async fn run_has_prefix(tc: HasPrefixTestCase) {
         let mut n = Node::default();
 
         for c in &tc.paths {
             let e = make_entry(c);
-            node_add(&mut n, c.as_bytes(), e, BTreeMap::default());
+            node_add(&mut n, c.as_bytes(), e, BTreeMap::default()).await;
         }
 
         for (i, test_prefix) in tc.test_paths.iter().enumerate() {
             assert_eq!(
-                node_has_prefix(&mut n, test_prefix.as_bytes()).unwrap(),
+                node_has_prefix(&mut n, test_prefix.as_bytes())
+                    .await
+                    .unwrap(),
                 tc.should_exist[i],
             );
         }
@@ -1565,40 +1607,46 @@ mod tests {
 
     #[test]
     fn has_prefix_simple() {
-        run_has_prefix(has_prefix_test_case_data()[0].clone());
+        run(async {
+            run_has_prefix(has_prefix_test_case_data()[0].clone()).await;
+        })
     }
 
     #[test]
     fn has_prefix_nested_single() {
-        run_has_prefix(has_prefix_test_case_data()[1].clone());
+        run(async {
+            run_has_prefix(has_prefix_test_case_data()[1].clone()).await;
+        })
     }
 
     // Tests save->reload->remove->save->reload->verify-removed cycle.
 
-    fn run_persist_remove(tc: RemoveTestCase) {
+    async fn run_persist_remove(tc: RemoveTestCase) {
         let store = MemoryStore::<StandardChunkSet>::new();
 
         // add entries and persist
         let mut n = Node::default();
         for c in &tc.items {
             let e = make_entry(&c.path);
-            block_on(n.add(c.path.as_bytes(), Some(e), c.metadata.clone(), &store)).unwrap();
+            n.add(c.path.as_bytes(), Some(e), c.metadata.clone(), &store)
+                .await
+                .unwrap();
         }
-        block_on(n.save(&store)).unwrap();
+        n.save(&store).await.unwrap();
         let ref_ = *n.reference().unwrap();
 
         // reload and remove
         let mut nn: Node = Node::from_reference(ref_);
         for path in &tc.remove {
-            block_on(nn.remove(path.as_bytes(), &store)).unwrap();
+            nn.remove(path.as_bytes(), &store).await.unwrap();
         }
-        block_on(nn.save(&store)).unwrap();
+        nn.save(&store).await.unwrap();
         let ref2 = *nn.reference().unwrap();
 
         // reload and verify removed paths are gone
         let mut nnn: Node = Node::from_reference(ref2);
         for path in &tc.remove {
-            let result = block_on(nnn.lookup_node(path.as_bytes(), &store));
+            let result = nnn.lookup_node(path.as_bytes(), &store).await;
             assert!(
                 result.is_err(),
                 "expected removed path '{path}' to be not found"
@@ -1608,12 +1656,16 @@ mod tests {
 
     #[test]
     fn persist_remove_simple() {
-        run_persist_remove(remove_test_case_data()[0].clone());
+        run(async {
+            run_persist_remove(remove_test_case_data()[0].clone()).await;
+        })
     }
 
     #[test]
     fn persist_remove_nested_prefix() {
-        run_persist_remove(remove_test_case_data()[1].clone());
+        run(async {
+            run_persist_remove(remove_test_case_data()[1].clone()).await;
+        })
     }
 
     fn make_entry_bytes(s: &[u8]) -> ChunkRef {
@@ -1625,176 +1677,188 @@ mod tests {
 
     #[test]
     fn walk_visits_all_nodes() {
-        let mut root = Node::default();
+        run(async {
+            let mut root = Node::default();
 
-        let paths = &["index.html", "img/1.png", "img/2.png", "robots.txt"];
-        for &p in paths {
-            let entry = make_entry_bytes(p.as_bytes());
-            node_add(&mut root, p.as_bytes(), entry, BTreeMap::new());
-        }
+            let paths = &["index.html", "img/1.png", "img/2.png", "robots.txt"];
+            for &p in paths {
+                let entry = make_entry_bytes(p.as_bytes());
+                node_add(&mut root, p.as_bytes(), entry, BTreeMap::new()).await;
+            }
 
-        let mut visited: Vec<(Vec<u8>, bool)> = Vec::new();
-        node_walk(&mut root, &mut |path, node| {
-            visited.push((path.to_vec(), node.is_value()));
-            Ok(())
+            let mut visited: Vec<(Vec<u8>, bool)> = Vec::new();
+            node_walk(&mut root, &mut |path, node| {
+                visited.push((path.to_vec(), node.is_value()));
+                Ok(())
+            })
+            .await
+            .unwrap();
+
+            for &p in paths {
+                assert!(
+                    visited
+                        .iter()
+                        .any(|(vp, is_val)| vp == p.as_bytes() && *is_val),
+                    "path {p} not visited as value"
+                );
+            }
         })
-        .unwrap();
-
-        for &p in paths {
-            assert!(
-                visited
-                    .iter()
-                    .any(|(vp, is_val)| vp == p.as_bytes() && *is_val),
-                "path {p} not visited as value"
-            );
-        }
     }
 
     #[test]
     fn walk_node_exact_order() {
-        let to_add: &[&[u8]] = &[
-            b"index.html.backup",
-            b"index.html",
-            b"img/test/oho.png",
-            b"img/test/old/test.png.backup",
-            b"img/test/old/test.png",
-            b"img/2.png",
-            b"img/1.png",
-            b"robots.txt",
-        ];
+        run(async {
+            let to_add: &[&[u8]] = &[
+                b"index.html.backup",
+                b"index.html",
+                b"img/test/oho.png",
+                b"img/test/old/test.png.backup",
+                b"img/test/old/test.png",
+                b"img/2.png",
+                b"img/1.png",
+                b"robots.txt",
+            ];
 
-        let expected: &[&[u8]] = &[
-            b"",
-            b"i",
-            b"img/",
-            b"img/1.png",
-            b"img/2.png",
-            b"img/test/o",
-            b"img/test/oho.png",
-            b"img/test/old/test.png",
-            b"img/test/old/test.png.backup",
-            b"index.html",
-            b"index.html.backup",
-            b"robots.txt",
-        ];
+            let expected: &[&[u8]] = &[
+                b"",
+                b"i",
+                b"img/",
+                b"img/1.png",
+                b"img/2.png",
+                b"img/test/o",
+                b"img/test/oho.png",
+                b"img/test/old/test.png",
+                b"img/test/old/test.png.backup",
+                b"index.html",
+                b"index.html.backup",
+                b"robots.txt",
+            ];
 
-        let mut n = Node::default();
-        for &path in to_add {
-            let entry = make_entry_bytes(path);
-            node_add(&mut n, path, entry, BTreeMap::new());
-        }
+            let mut n = Node::default();
+            for &path in to_add {
+                let entry = make_entry_bytes(path);
+                node_add(&mut n, path, entry, BTreeMap::new()).await;
+            }
 
-        let mut walked: Vec<Vec<u8>> = Vec::new();
-        node_walk_node(&mut n, b"", &mut |path, _node| {
-            walked.push(path.to_vec());
-            Ok(())
-        })
-        .unwrap();
+            let mut walked: Vec<Vec<u8>> = Vec::new();
+            node_walk_node(&mut n, b"", &mut |path, _node| {
+                walked.push(path.to_vec());
+                Ok(())
+            })
+            .await
+            .unwrap();
 
-        assert_eq!(
-            walked.len(),
-            expected.len(),
-            "expected {} nodes, got {}",
-            expected.len(),
-            walked.len()
-        );
-
-        for (i, (got, &want)) in walked.iter().zip(expected.iter()).enumerate() {
             assert_eq!(
-                got.as_slice(),
-                want,
-                "walk step {i}: expected {:?}, got {:?}",
-                core::str::from_utf8(want).unwrap_or("<non-utf8>"),
-                core::str::from_utf8(got).unwrap_or("<non-utf8>"),
+                walked.len(),
+                expected.len(),
+                "expected {} nodes, got {}",
+                expected.len(),
+                walked.len()
             );
-        }
+
+            for (i, (got, &want)) in walked.iter().zip(expected.iter()).enumerate() {
+                assert_eq!(
+                    got.as_slice(),
+                    want,
+                    "walk step {i}: expected {:?}, got {:?}",
+                    core::str::from_utf8(want).unwrap_or("<non-utf8>"),
+                    core::str::from_utf8(got).unwrap_or("<non-utf8>"),
+                );
+            }
+        })
     }
 
     #[test]
     fn walk_node_from_subtree() {
-        let to_add: &[&[u8]] = &[b"index.html", b"img/1.png", b"img/2.png", b"robots.txt"];
+        run(async {
+            let to_add: &[&[u8]] = &[b"index.html", b"img/1.png", b"img/2.png", b"robots.txt"];
 
-        let mut n = Node::default();
-        for &path in to_add {
-            let entry = make_entry_bytes(path);
-            node_add(&mut n, path, entry, BTreeMap::new());
-        }
+            let mut n = Node::default();
+            for &path in to_add {
+                let entry = make_entry_bytes(path);
+                node_add(&mut n, path, entry, BTreeMap::new()).await;
+            }
 
-        let mut walked: Vec<Vec<u8>> = Vec::new();
-        node_walk_node(&mut n, b"img/", &mut |path, _node| {
-            walked.push(path.to_vec());
-            Ok(())
+            let mut walked: Vec<Vec<u8>> = Vec::new();
+            node_walk_node(&mut n, b"img/", &mut |path, _node| {
+                walked.push(path.to_vec());
+                Ok(())
+            })
+            .await
+            .unwrap();
+
+            assert!(walked.iter().any(|p| p == b"img/1.png"));
+            assert!(walked.iter().any(|p| p == b"img/2.png"));
+            assert!(!walked.iter().any(|p| p == b"index.html"));
+            assert!(!walked.iter().any(|p| p == b"robots.txt"));
         })
-        .unwrap();
-
-        assert!(walked.iter().any(|p| p == b"img/1.png"));
-        assert!(walked.iter().any(|p| p == b"img/2.png"));
-        assert!(!walked.iter().any(|p| p == b"index.html"));
-        assert!(!walked.iter().any(|p| p == b"robots.txt"));
     }
 
     #[test]
     fn walk_node_exact_order_with_load_save() {
-        let to_add: &[&[u8]] = &[
-            b"index.html.backup",
-            b"index.html",
-            b"img/test/oho.png",
-            b"img/test/old/test.png.backup",
-            b"img/test/old/test.png",
-            b"img/2.png",
-            b"img/1.png",
-            b"robots.txt",
-        ];
+        run(async {
+            let to_add: &[&[u8]] = &[
+                b"index.html.backup",
+                b"index.html",
+                b"img/test/oho.png",
+                b"img/test/old/test.png.backup",
+                b"img/test/old/test.png",
+                b"img/2.png",
+                b"img/1.png",
+                b"robots.txt",
+            ];
 
-        let expected: &[&[u8]] = &[
-            b"",
-            b"i",
-            b"img/",
-            b"img/1.png",
-            b"img/2.png",
-            b"img/test/o",
-            b"img/test/oho.png",
-            b"img/test/old/test.png",
-            b"img/test/old/test.png.backup",
-            b"index.html",
-            b"index.html.backup",
-            b"robots.txt",
-        ];
+            let expected: &[&[u8]] = &[
+                b"",
+                b"i",
+                b"img/",
+                b"img/1.png",
+                b"img/2.png",
+                b"img/test/o",
+                b"img/test/oho.png",
+                b"img/test/old/test.png",
+                b"img/test/old/test.png.backup",
+                b"index.html",
+                b"index.html.backup",
+                b"robots.txt",
+            ];
 
-        let mut n = Node::default();
-        for &path in to_add {
-            let entry = make_entry_bytes(path);
-            node_add(&mut n, path, entry, BTreeMap::new());
-        }
+            let mut n = Node::default();
+            for &path in to_add {
+                let entry = make_entry_bytes(path);
+                node_add(&mut n, path, entry, BTreeMap::new()).await;
+            }
 
-        let store = MemoryStore::<StandardChunkSet>::new();
-        block_on(n.save(&store)).unwrap();
+            let store = MemoryStore::<StandardChunkSet>::new();
+            n.save(&store).await.unwrap();
 
-        let mut n2: Node = Node::from_reference(*n.reference().unwrap());
+            let mut n2: Node = Node::from_reference(*n.reference().unwrap());
 
-        let mut walked: Vec<Vec<u8>> = Vec::new();
-        block_on(n2.walk_from(b"", &store, &mut |path: &[u8], _node: &Node| {
-            walked.push(path.to_vec());
-            Ok(())
-        }))
-        .unwrap();
+            let mut walked: Vec<Vec<u8>> = Vec::new();
+            n2.walk_from(b"", &store, &mut |path: &[u8], _node: &Node| {
+                walked.push(path.to_vec());
+                Ok(())
+            })
+            .await
+            .unwrap();
 
-        assert_eq!(
-            walked.len(),
-            expected.len(),
-            "expected {} nodes, got {}",
-            expected.len(),
-            walked.len()
-        );
-
-        for (i, (got, &want)) in walked.iter().zip(expected.iter()).enumerate() {
             assert_eq!(
-                got.as_slice(),
-                want,
-                "walk step {i}: expected {:?}, got {:?}",
-                core::str::from_utf8(want).unwrap_or("<non-utf8>"),
-                core::str::from_utf8(got).unwrap_or("<non-utf8>"),
+                walked.len(),
+                expected.len(),
+                "expected {} nodes, got {}",
+                expected.len(),
+                walked.len()
             );
-        }
+
+            for (i, (got, &want)) in walked.iter().zip(expected.iter()).enumerate() {
+                assert_eq!(
+                    got.as_slice(),
+                    want,
+                    "walk step {i}: expected {:?}, got {:?}",
+                    core::str::from_utf8(want).unwrap_or("<non-utf8>"),
+                    core::str::from_utf8(got).unwrap_or("<non-utf8>"),
+                );
+            }
+        })
     }
 }

--- a/crates/mantaray/tests/file_manifest_integration.rs
+++ b/crates/mantaray/tests/file_manifest_integration.rs
@@ -12,12 +12,12 @@
     clippy::as_conversions,
     clippy::missing_panics_doc
 )]
-use futures::executor::block_on;
 use nectar_mantaray::PlainManifest;
 use nectar_primitives::StandardChunkSet;
 use nectar_primitives::chunk::ChunkAddress;
 use nectar_primitives::file::{ChunkPutExt, join};
 use nectar_primitives::store::MemoryStore;
+use nectar_testing::run;
 
 type Store = MemoryStore<StandardChunkSet>;
 
@@ -25,194 +25,210 @@ type Store = MemoryStore<StandardChunkSet>;
 /// then verify lookup and round-trip.
 #[test]
 fn unified_store_workflow() {
-    let store = Store::new();
+    run(async {
+        let store = Store::new();
 
-    // Seed file chunks into the store.
-    let root_a = block_on(store.write_file(b"file A contents".to_vec())).unwrap();
-    let root_b = block_on(store.write_file(b"file B contents".to_vec())).unwrap();
+        // Seed file chunks into the store.
+        let root_a = store.write_file(b"file A contents".to_vec()).await.unwrap();
+        let root_b = store.write_file(b"file B contents".to_vec()).await.unwrap();
 
-    let files_chunk_count = store.len();
-    assert!(files_chunk_count > 0);
+        let files_chunk_count = store.len();
+        assert!(files_chunk_count > 0);
 
-    // Create manifest in the same store
-    let mut manifest = PlainManifest::new(store);
-    block_on(manifest.add_with_metadata(
-        "a.txt",
-        root_a,
-        [("Content-Type".to_string(), "text/plain".to_string())].into(),
-    ))
-    .unwrap();
-    block_on(manifest.add_with_metadata(
-        "b.txt",
-        root_b,
-        [("Content-Type".to_string(), "text/plain".to_string())].into(),
-    ))
-    .unwrap();
+        // Create manifest in the same store
+        let mut manifest = PlainManifest::new(store);
+        manifest
+            .add_with_metadata(
+                "a.txt",
+                root_a,
+                [("Content-Type".to_string(), "text/plain".to_string())].into(),
+            )
+            .await
+            .unwrap();
+        manifest
+            .add_with_metadata(
+                "b.txt",
+                root_b,
+                [("Content-Type".to_string(), "text/plain".to_string())].into(),
+            )
+            .await
+            .unwrap();
 
-    let root_ref = block_on(manifest.save()).unwrap();
+        let root_ref = manifest.save().await.unwrap();
 
-    // Now the store contains both file chunks AND manifest trie nodes
-    let (_, store) = manifest.into_parts();
-    assert!(store.len() > files_chunk_count);
+        // Now the store contains both file chunks AND manifest trie nodes
+        let (_, store) = manifest.into_parts();
+        assert!(store.len() > files_chunk_count);
 
-    // Reload manifest from the store
-    let manifest2 = PlainManifest::open(root_ref, store.clone());
+        // Reload manifest from the store
+        let manifest2 = PlainManifest::open(root_ref, store.clone());
 
-    // Verify lookup
-    let entry_a = block_on(manifest2.get("a.txt")).unwrap().unwrap();
-    assert_eq!(entry_a.address(), Some(&root_a));
-    assert_eq!(entry_a.content_type(), Some("text/plain"));
+        // Verify lookup
+        let entry_a = manifest2.get("a.txt").await.unwrap().unwrap();
+        assert_eq!(entry_a.address(), Some(&root_a));
+        assert_eq!(entry_a.content_type(), Some("text/plain"));
 
-    let entry_b = block_on(manifest2.get("b.txt")).unwrap().unwrap();
-    assert_eq!(entry_b.address(), Some(&root_b));
+        let entry_b = manifest2.get("b.txt").await.unwrap().unwrap();
+        assert_eq!(entry_b.address(), Some(&root_b));
 
-    // Verify file data round-trip through the same store
-    let recovered_a = block_on(join(store.clone(), root_a)).unwrap();
-    assert_eq!(recovered_a, b"file A contents");
+        // Verify file data round-trip through the same store
+        let recovered_a = join(store.clone(), root_a).await.unwrap();
+        assert_eq!(recovered_a, b"file A contents");
 
-    let recovered_b = block_on(join(store, root_b)).unwrap();
-    assert_eq!(recovered_b, b"file B contents");
+        let recovered_b = join(store, root_b).await.unwrap();
+        assert_eq!(recovered_b, b"file B contents");
+    })
 }
 
 /// Test that entries() collects all items from a saved manifest.
 #[test]
 fn entries_round_trip() {
-    let store = Store::new();
-    let mut manifest = PlainManifest::new(store);
+    run(async {
+        let store = Store::new();
+        let mut manifest = PlainManifest::new(store);
 
-    let paths = &["index.html", "css/style.css", "js/app.js", "img/logo.png"];
+        let paths = &["index.html", "css/style.css", "js/app.js", "img/logo.png"];
 
-    for &path in paths {
-        let addr = make_addr(path);
-        block_on(
-            manifest.add_with_metadata(
-                path,
-                addr,
-                [(
-                    "Content-Type".to_string(),
-                    "application/octet-stream".to_string(),
-                )]
-                .into(),
-            ),
-        )
-        .unwrap();
-    }
+        for &path in paths {
+            let addr = make_addr(path);
+            manifest
+                .add_with_metadata(
+                    path,
+                    addr,
+                    [(
+                        "Content-Type".to_string(),
+                        "application/octet-stream".to_string(),
+                    )]
+                    .into(),
+                )
+                .await
+                .unwrap();
+        }
 
-    let root_ref = block_on(manifest.save()).unwrap();
+        let root_ref = manifest.save().await.unwrap();
 
-    let (_, store) = manifest.into_parts();
-    let manifest2 = PlainManifest::open(root_ref, store);
+        let (_, store) = manifest.into_parts();
+        let manifest2 = PlainManifest::open(root_ref, store);
 
-    let entries = block_on(manifest2.entries()).unwrap();
-    assert_eq!(entries.len(), paths.len());
+        let entries = manifest2.entries().await.unwrap();
+        assert_eq!(entries.len(), paths.len());
 
-    for &path in paths {
-        let entry = entries
-            .iter()
-            .find(|e| e.path() == path.as_bytes())
-            .unwrap_or_else(|| panic!("missing entry for {path}"));
-        assert_eq!(
-            entry.content_type(),
-            Some("application/octet-stream"),
-            "wrong content type for {path}"
-        );
-    }
+        for &path in paths {
+            let entry = entries
+                .iter()
+                .find(|e| e.path() == path.as_bytes())
+                .unwrap_or_else(|| panic!("missing entry for {path}"));
+            assert_eq!(
+                entry.content_type(),
+                Some("application/octet-stream"),
+                "wrong content type for {path}"
+            );
+        }
+    })
 }
 
 /// Iterator over a manifest yields all added entries.
 #[test]
 fn iterator_yields_all_entries() {
-    let store = Store::new();
-    let mut manifest = PlainManifest::new(store);
+    run(async {
+        let store = Store::new();
+        let mut manifest = PlainManifest::new(store);
 
-    let paths = &["a/1", "a/2", "b/1", "c"];
-    for &path in paths {
-        let addr = make_addr(path);
-        block_on(manifest.add(path, addr)).unwrap();
-    }
-
-    let entries = block_on(async {
-        let mut out = Vec::new();
-        let mut iter = manifest.iter();
-        while let Some(item) = iter.next().await {
-            out.push(item.unwrap());
+        let paths = &["a/1", "a/2", "b/1", "c"];
+        for &path in paths {
+            let addr = make_addr(path);
+            manifest.add(path, addr).await.unwrap();
         }
-        out
-    });
-    assert_eq!(entries.len(), paths.len());
 
-    for &path in paths {
-        assert!(
-            entries.iter().any(|e| e.path() == path.as_bytes()),
-            "entry {path:?} not found in iterator",
-        );
-    }
+        let entries = {
+            let mut out = Vec::new();
+            let mut iter = manifest.iter();
+            while let Some(item) = iter.next().await {
+                out.push(item.unwrap());
+            }
+            out
+        };
+        assert_eq!(entries.len(), paths.len());
+
+        for &path in paths {
+            assert!(
+                entries.iter().any(|e| e.path() == path.as_bytes()),
+                "entry {path:?} not found in iterator",
+            );
+        }
+    })
 }
 
 /// Ergonomic API: write_file/read_file, PlainManifest::open, Entry convenience methods.
 #[test]
 fn ergonomic_api_workflow() {
-    use nectar_mantaray::DefaultMemoryStore;
-    use nectar_primitives::file::{ChunkGetExt, ChunkPutExt};
+    run(async {
+        use nectar_mantaray::DefaultMemoryStore;
+        use nectar_primitives::file::{ChunkGetExt, ChunkPutExt};
 
-    let store = DefaultMemoryStore::new();
+        let store = DefaultMemoryStore::new();
 
-    // Seed file chunks.
-    let root_a = block_on(store.write_file(b"file A contents".to_vec())).unwrap();
-    let root_b = block_on(store.write_file(b"file B contents".to_vec())).unwrap();
+        // Seed file chunks.
+        let root_a = store.write_file(b"file A contents".to_vec()).await.unwrap();
+        let root_b = store.write_file(b"file B contents".to_vec()).await.unwrap();
 
-    // Create manifest in the same store
-    let mut manifest = PlainManifest::new(store);
-    block_on(manifest.add_with_metadata(
-        "a.txt",
-        root_a,
-        [("Content-Type".to_string(), "text/plain".to_string())].into(),
-    ))
-    .unwrap();
-    block_on(manifest.add_with_metadata(
-        "b.txt",
-        root_b,
-        [("Content-Type".to_string(), "text/plain".to_string())].into(),
-    ))
-    .unwrap();
+        // Create manifest in the same store
+        let mut manifest = PlainManifest::new(store);
+        manifest
+            .add_with_metadata(
+                "a.txt",
+                root_a,
+                [("Content-Type".to_string(), "text/plain".to_string())].into(),
+            )
+            .await
+            .unwrap();
+        manifest
+            .add_with_metadata(
+                "b.txt",
+                root_b,
+                [("Content-Type".to_string(), "text/plain".to_string())].into(),
+            )
+            .await
+            .unwrap();
 
-    let root_addr = block_on(manifest.save()).unwrap();
+        let root_addr = manifest.save().await.unwrap();
 
-    let (_, store) = manifest.into_parts();
+        let (_, store) = manifest.into_parts();
 
-    // Reopen using PlainManifest::open (takes ChunkAddress)
-    let mut manifest2 = PlainManifest::open(root_addr, store);
+        // Reopen using PlainManifest::open (takes ChunkAddress)
+        let mut manifest2 = PlainManifest::open(root_addr, store);
 
-    // Iterate entries using convenience methods
-    let entries = block_on(async {
-        let mut out = Vec::new();
-        let mut iter = manifest2.iter();
-        while let Some(item) = iter.next().await {
-            out.push(item.unwrap());
+        // Iterate entries using convenience methods
+        let entries = {
+            let mut out = Vec::new();
+            let mut iter = manifest2.iter();
+            while let Some(item) = iter.next().await {
+                out.push(item.unwrap());
+            }
+            out
+        };
+
+        assert_eq!(entries.len(), 2);
+
+        for entry in &entries {
+            // path_str() convenience
+            let path = entry.path_str().unwrap();
+            assert!(path == "a.txt" || path == "b.txt");
+
+            // content_type() from metadata
+            assert_eq!(entry.content_type(), Some("text/plain"));
+
+            // address() extracts ChunkAddress from reference
+            let addr = entry.address().expect("32-byte reference yields address");
+
+            let data = manifest2.store().clone().read_file(*addr).await.unwrap();
+            if path == "a.txt" {
+                assert_eq!(data, b"file A contents");
+            } else {
+                assert_eq!(data, b"file B contents");
+            }
         }
-        out
-    });
-
-    assert_eq!(entries.len(), 2);
-
-    for entry in &entries {
-        // path_str() convenience
-        let path = entry.path_str().unwrap();
-        assert!(path == "a.txt" || path == "b.txt");
-
-        // content_type() from metadata
-        assert_eq!(entry.content_type(), Some("text/plain"));
-
-        // address() extracts ChunkAddress from reference
-        let addr = entry.address().expect("32-byte reference yields address");
-
-        let data = block_on(manifest2.store().clone().read_file(*addr)).unwrap();
-        if path == "a.txt" {
-            assert_eq!(data, b"file A contents");
-        } else {
-            assert_eq!(data, b"file B contents");
-        }
-    }
+    })
 }
 
 /// Fused seam: `ManifestBuilder::put_file` splits, stores, and stages in one
@@ -220,32 +236,40 @@ fn ergonomic_api_workflow() {
 /// write_file + add and get + join dance the earlier tests spell out.
 #[test]
 fn fused_put_file_read_workflow() {
-    use nectar_mantaray::ManifestBuilder;
+    run(async {
+        use nectar_mantaray::ManifestBuilder;
 
-    let mut builder: ManifestBuilder<Store> = ManifestBuilder::new(Store::new());
-    block_on(builder.put_file("a.txt", b"file A contents".to_vec())).unwrap();
-    block_on(builder.put_file("nested/b.txt", b"file B contents".to_vec())).unwrap();
+        let mut builder: ManifestBuilder<Store> = ManifestBuilder::new(Store::new());
+        builder
+            .put_file("a.txt", b"file A contents".to_vec())
+            .await
+            .unwrap();
+        builder
+            .put_file("nested/b.txt", b"file B contents".to_vec())
+            .await
+            .unwrap();
 
-    let (root, manifest) = block_on(builder.save()).unwrap();
+        let (root, manifest) = builder.save().await.unwrap();
 
-    // Read back through the handle the save returned.
-    assert_eq!(
-        block_on(manifest.read("a.txt")).unwrap().unwrap(),
-        b"file A contents"
-    );
-    assert_eq!(
-        block_on(manifest.read("nested/b.txt")).unwrap().unwrap(),
-        b"file B contents"
-    );
-    assert!(block_on(manifest.read("missing")).unwrap().is_none());
+        // Read back through the handle the save returned.
+        assert_eq!(
+            manifest.read("a.txt").await.unwrap().unwrap(),
+            b"file A contents"
+        );
+        assert_eq!(
+            manifest.read("nested/b.txt").await.unwrap().unwrap(),
+            b"file B contents"
+        );
+        assert!(manifest.read("missing").await.unwrap().is_none());
 
-    // Reopen from storage and read again, exercising the lazy-load path.
-    let (_, store) = manifest.into_parts();
-    let reopened = PlainManifest::open(root, store);
-    assert_eq!(
-        block_on(reopened.read("nested/b.txt")).unwrap().unwrap(),
-        b"file B contents"
-    );
+        // Reopen from storage and read again, exercising the lazy-load path.
+        let (_, store) = manifest.into_parts();
+        let reopened = PlainManifest::open(root, store);
+        assert_eq!(
+            reopened.read("nested/b.txt").await.unwrap().unwrap(),
+            b"file B contents"
+        );
+    })
 }
 
 /// Create a ChunkAddress from a string, right-padded with zeroes.

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -83,6 +83,7 @@ alloy-primitives = { workspace = true, features = ["arbitrary", "getrandom", "as
 
 arbitrary = { workspace = true, features = ["derive"] }
 criterion.workspace = true
+nectar-testing.workspace = true
 proptest.workspace = true
 proptest-arbitrary-interop.workspace = true
 rand.workspace = true

--- a/crates/primitives/benches/encryption_bench.rs
+++ b/crates/primitives/benches/encryption_bench.rs
@@ -14,8 +14,8 @@
 use std::collections::HashMap;
 use std::io::Write;
 
+use criterion::async_executor::FuturesExecutor;
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
-use futures::executor::block_on;
 use rand::{Rng, rng};
 
 use nectar_primitives::chunk::encryption::{
@@ -206,10 +206,11 @@ fn bench_encrypted_joiner(c: &mut Criterion) {
             BenchmarkId::from_parameter(name),
             &root_ref,
             |b, root_ref| {
-                b.iter(|| {
-                    let joiner =
-                        block_on(EncryptedJoiner::new(store.clone(), root_ref.clone())).unwrap();
-                    black_box(block_on(joiner.read_all()).unwrap())
+                b.to_async(FuturesExecutor).iter(|| async {
+                    let joiner = EncryptedJoiner::new(store.clone(), root_ref.clone())
+                        .await
+                        .unwrap();
+                    black_box(joiner.read_all().await.unwrap())
                 });
             },
         );
@@ -286,9 +287,9 @@ fn bench_plain_vs_encrypted_join(c: &mut Criterion) {
         group.throughput(Throughput::Bytes(size));
 
         group.bench_with_input(BenchmarkId::new("plain", name), &root, |b, root| {
-            b.iter(|| {
-                let joiner = block_on(Joiner::new(store.clone(), *root)).unwrap();
-                black_box(block_on(joiner.read_all()).unwrap())
+            b.to_async(FuturesExecutor).iter(|| async {
+                let joiner = Joiner::new(store.clone(), *root).await.unwrap();
+                black_box(joiner.read_all().await.unwrap())
             });
         });
 
@@ -296,11 +297,11 @@ fn bench_plain_vs_encrypted_join(c: &mut Criterion) {
             BenchmarkId::new("encrypted", name),
             &enc_root_ref,
             |b, root_ref| {
-                b.iter(|| {
-                    let joiner =
-                        block_on(EncryptedJoiner::new(enc_store.clone(), root_ref.clone()))
-                            .unwrap();
-                    black_box(block_on(joiner.read_all()).unwrap())
+                b.to_async(FuturesExecutor).iter(|| async {
+                    let joiner = EncryptedJoiner::new(enc_store.clone(), root_ref.clone())
+                        .await
+                        .unwrap();
+                    black_box(joiner.read_all().await.unwrap())
                 });
             },
         );
@@ -326,15 +327,15 @@ fn bench_encrypted_roundtrip(c: &mut Criterion) {
         group.throughput(Throughput::Bytes(size));
 
         group.bench_with_input(BenchmarkId::new("streaming", name), &data, |b, data| {
-            b.iter(|| {
+            b.to_async(FuturesExecutor).iter(|| async {
                 let (root_ref, store) = encrypted_split_to_store(data);
-                let joiner = block_on(EncryptedJoiner::new(store, root_ref)).unwrap();
-                black_box(block_on(joiner.read_all()).unwrap())
+                let joiner = EncryptedJoiner::new(store, root_ref).await.unwrap();
+                black_box(joiner.read_all().await.unwrap())
             });
         });
 
         group.bench_with_input(BenchmarkId::new("direct", name), &data, |b, data| {
-            b.iter(|| {
+            b.to_async(FuturesExecutor).iter(|| async {
                 let (root_ref, chunks) =
                     EncryptedParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap();
                 let store = MemoryStore::from_chunks(
@@ -342,8 +343,8 @@ fn bench_encrypted_roundtrip(c: &mut Criterion) {
                         .into_iter()
                         .map(|c| Chunk::from_envelope(c.into()).unwrap()),
                 );
-                let joiner = block_on(EncryptedJoiner::new(store, root_ref)).unwrap();
-                black_box(block_on(joiner.read_all()).unwrap())
+                let joiner = EncryptedJoiner::new(store, root_ref).await.unwrap();
+                black_box(joiner.read_all().await.unwrap())
             });
         });
     }

--- a/crates/primitives/benches/file_bench.rs
+++ b/crates/primitives/benches/file_bench.rs
@@ -20,10 +20,9 @@
 use std::collections::HashMap;
 use std::io::Write;
 
+use criterion::async_executor::FuturesExecutor;
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use rand::{Rng, rng};
-
-use futures::executor::block_on;
 
 use nectar_primitives::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{Chunk, ChunkAddress};
@@ -177,9 +176,9 @@ fn bench_joiner(c: &mut Criterion) {
 
         group.throughput(Throughput::Bytes(size));
         group.bench_with_input(BenchmarkId::from_parameter(name), &root, |b, root| {
-            b.iter(|| {
-                let joiner = block_on(Joiner::new(store.clone(), *root)).unwrap();
-                black_box(block_on(joiner.read_all()).unwrap())
+            b.to_async(FuturesExecutor).iter(|| async {
+                let joiner = Joiner::new(store.clone(), *root).await.unwrap();
+                black_box(joiner.read_all().await.unwrap())
             });
         });
     }
@@ -206,16 +205,16 @@ fn bench_roundtrip(c: &mut Criterion) {
             BenchmarkId::new("streaming_split", name),
             &data,
             |b, data| {
-                b.iter(|| {
+                b.to_async(FuturesExecutor).iter(|| async {
                     let (root, store) = split_to_store(data);
-                    let joiner = block_on(Joiner::new(store, root)).unwrap();
-                    black_box(block_on(joiner.read_all()).unwrap())
+                    let joiner = Joiner::new(store, root).await.unwrap();
+                    black_box(joiner.read_all().await.unwrap())
                 });
             },
         );
 
         group.bench_with_input(BenchmarkId::new("direct_split", name), &data, |b, data| {
-            b.iter(|| {
+            b.to_async(FuturesExecutor).iter(|| async {
                 let (root, chunks) =
                     ParallelSplitter::<DEFAULT_BODY_SIZE>::split_to_vec(data).unwrap();
                 let store = MemoryStore::from_chunks(
@@ -223,8 +222,8 @@ fn bench_roundtrip(c: &mut Criterion) {
                         .into_iter()
                         .map(|c| Chunk::from_envelope(c.into()).unwrap()),
                 );
-                let joiner = block_on(Joiner::new(store, root)).unwrap();
-                black_box(block_on(joiner.read_all()).unwrap())
+                let joiner = Joiner::new(store, root).await.unwrap();
+                black_box(joiner.read_all().await.unwrap())
             });
         });
     }

--- a/crates/primitives/src/file/fold.rs
+++ b/crates/primitives/src/file/fold.rs
@@ -72,7 +72,7 @@ mod tests {
     use crate::chunk::{Chunk, ChunkAddress};
     use crate::file::Joiner;
     use crate::file::split;
-    use futures::executor::block_on;
+    use nectar_testing::run;
     use std::collections::HashMap;
 
     fn split_and_store(data: &[u8]) -> (ChunkAddress, HashMap<ChunkAddress, Chunk>) {
@@ -82,60 +82,60 @@ mod tests {
 
     /// `for_each_chunk` visits every leaf exactly once; reassembling by offset
     /// equals `read_all`.
-    fn assert_for_each_chunk_matches(data: &[u8], width: usize) {
+    async fn assert_for_each_chunk_matches(data: &[u8], width: usize) {
         let (root, store) = split_and_store(data);
-        block_on(async {
-            let expected = Joiner::new(store.clone(), root)
-                .await
-                .unwrap()
-                .read_all()
-                .await
-                .unwrap();
+        let expected = Joiner::new(store.clone(), root)
+            .await
+            .unwrap()
+            .read_all()
+            .await
+            .unwrap();
 
-            let joiner = Joiner::new(store, root)
-                .await
-                .unwrap()
-                .with_concurrency(width);
-            let total = joiner.size();
+        let joiner = Joiner::new(store, root)
+            .await
+            .unwrap()
+            .with_concurrency(width);
+        let total = joiner.size();
 
-            let mut reassembled = vec![0u8; total as usize];
-            let mut covered = 0u64;
-            let mut seen = std::collections::HashSet::new();
-            joiner
-                .for_each_chunk(|off, body| {
-                    assert!(seen.insert(off), "offset {off} visited more than once");
-                    let start = off as usize;
-                    reassembled[start..start + body.len()].copy_from_slice(body);
-                    covered += body.len() as u64;
-                    ControlFlow::Continue(())
-                })
-                .await
-                .unwrap();
+        let mut reassembled = vec![0u8; total as usize];
+        let mut covered = 0u64;
+        let mut seen = std::collections::HashSet::new();
+        joiner
+            .for_each_chunk(|off, body| {
+                assert!(seen.insert(off), "offset {off} visited more than once");
+                let start = off as usize;
+                reassembled[start..start + body.len()].copy_from_slice(body);
+                covered += body.len() as u64;
+                ControlFlow::Continue(())
+            })
+            .await
+            .unwrap();
 
-            assert_eq!(covered, total, "every byte covered exactly once");
-            assert_eq!(reassembled, expected, "reassembly equals read_all");
-            assert_eq!(reassembled, data, "reassembly equals input");
-        });
+        assert_eq!(covered, total, "every byte covered exactly once");
+        assert_eq!(reassembled, expected, "reassembly equals read_all");
+        assert_eq!(reassembled, data, "reassembly equals input");
     }
 
     #[test]
     fn for_each_chunk_reassembles() {
-        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3 + 123)
-            .map(|i| (i % 256) as u8)
-            .collect();
-        assert_for_each_chunk_matches(b"hello world", 8);
-        assert_for_each_chunk_matches(&data, 8);
-        // width 1 (degenerate concurrent path) still visits every leaf.
-        assert_for_each_chunk_matches(&data, 1);
+        run(async {
+            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3 + 123)
+                .map(|i| (i % 256) as u8)
+                .collect();
+            assert_for_each_chunk_matches(b"hello world", 8).await;
+            assert_for_each_chunk_matches(&data, 8).await;
+            // width 1 (degenerate concurrent path) still visits every leaf.
+            assert_for_each_chunk_matches(&data, 1).await;
+        })
     }
 
     #[test]
     fn for_each_chunk_break_stops_early() {
-        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5)
-            .map(|i| (i % 256) as u8)
-            .collect();
-        let (root, store) = split_and_store(&data);
-        block_on(async {
+        run(async {
+            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5)
+                .map(|i| (i % 256) as u8)
+                .collect();
+            let (root, store) = split_and_store(&data);
             let joiner = Joiner::new(store, root).await.unwrap();
             let mut visited = 0usize;
             let res = joiner
@@ -150,42 +150,42 @@ mod tests {
                 .await;
             assert!(res.is_ok(), "early break returns Ok");
             assert_eq!(visited, 2, "stops on the breaking leaf");
-        });
+        })
     }
 
     /// Concatenating the in-order runs equals the file.
-    fn assert_window_concat_matches(data: &[u8], window: usize) {
+    async fn assert_window_concat_matches(data: &[u8], window: usize) {
         let (root, store) = split_and_store(data);
-        block_on(async {
-            let joiner = Joiner::new(store, root).await.unwrap();
-            let out = joiner
-                .try_for_each_window(window, Vec::new(), |mut acc: Vec<u8>, run| {
-                    acc.extend_from_slice(run);
-                    ControlFlow::Continue(acc)
-                })
-                .await
-                .unwrap();
-            assert_eq!(out, data, "window concat equals file (window {window})");
-        });
+        let joiner = Joiner::new(store, root).await.unwrap();
+        let out = joiner
+            .try_for_each_window(window, Vec::new(), |mut acc: Vec<u8>, run| {
+                acc.extend_from_slice(run);
+                ControlFlow::Continue(acc)
+            })
+            .await
+            .unwrap();
+        assert_eq!(out, data, "window concat equals file (window {window})");
     }
 
     #[test]
     fn try_for_each_window_concat_equals_file() {
-        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 321)
-            .map(|i| (i % 256) as u8)
-            .collect();
-        assert_window_concat_matches(&data, 16);
-        // window 1 is the tightest in-order path.
-        assert_window_concat_matches(&data, 1);
+        run(async {
+            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 321)
+                .map(|i| (i % 256) as u8)
+                .collect();
+            assert_window_concat_matches(&data, 16).await;
+            // window 1 is the tightest in-order path.
+            assert_window_concat_matches(&data, 1).await;
+        })
     }
 
     #[test]
     fn try_for_each_window_byte_count_equals_size() {
-        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 4 + 7)
-            .map(|i| (i % 256) as u8)
-            .collect();
-        let (root, store) = split_and_store(&data);
-        block_on(async {
+        run(async {
+            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 4 + 7)
+                .map(|i| (i % 256) as u8)
+                .collect();
+            let (root, store) = split_and_store(&data);
             let joiner = Joiner::new(store, root).await.unwrap();
             let size = joiner.size();
             let count = joiner
@@ -195,16 +195,16 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(count, size, "folded byte count equals size()");
-        });
+        })
     }
 
     #[test]
     fn try_for_each_window_break_returns_accumulator() {
-        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5)
-            .map(|i| (i % 256) as u8)
-            .collect();
-        let (root, store) = split_and_store(&data);
-        block_on(async {
+        run(async {
+            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5)
+                .map(|i| (i % 256) as u8)
+                .collect();
+            let (root, store) = split_and_store(&data);
             let joiner = Joiner::new(store, root).await.unwrap();
             // Stop once at least one body has been seen; the carried count comes
             // back through `Break`.
@@ -216,7 +216,7 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(count, 1, "break carries the accumulator and stops");
-        });
+        })
     }
 
     #[cfg(feature = "encryption")]
@@ -237,11 +237,11 @@ mod tests {
 
         #[test]
         fn for_each_chunk_reassembles_encrypted() {
-            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3 + 123)
-                .map(|i| (i % 256) as u8)
-                .collect();
-            let (root_ref, store) = enc_split_and_store(&data);
-            block_on(async {
+            run(async {
+                let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3 + 123)
+                    .map(|i| (i % 256) as u8)
+                    .collect();
+                let (root_ref, store) = enc_split_and_store(&data);
                 let expected = EncryptedJoiner::new(store.clone(), root_ref.clone())
                     .await
                     .unwrap()
@@ -266,16 +266,16 @@ mod tests {
                     reassembled, expected,
                     "encrypted reassembly equals read_all"
                 );
-            });
+            })
         }
 
         #[test]
         fn try_for_each_window_concat_equals_file_encrypted() {
-            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 321)
-                .map(|i| (i % 256) as u8)
-                .collect();
-            let (root_ref, store) = enc_split_and_store(&data);
-            block_on(async {
+            run(async {
+                let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 321)
+                    .map(|i| (i % 256) as u8)
+                    .collect();
+                let (root_ref, store) = enc_split_and_store(&data);
                 let joiner = EncryptedJoiner::new(store, root_ref).await.unwrap();
                 let out = joiner
                     .try_for_each_window(16, Vec::new(), |mut acc: Vec<u8>, run| {
@@ -285,7 +285,7 @@ mod tests {
                     .await
                     .unwrap();
                 assert_eq!(out, data, "encrypted window concat equals file");
-            });
+            })
         }
     }
 }

--- a/crates/primitives/src/file/joiner.rs
+++ b/crates/primitives/src/file/joiner.rs
@@ -1046,23 +1046,21 @@ where
     }
 }
 
-#[cfg(all(test, feature = "tokio"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::chunk::{Chunk, ChunkOps, StandardChunkSet, Verified};
     use crate::file::split;
     use crate::store::ChunkGet;
+    use nectar_testing::{run, yield_now};
     use std::collections::HashMap;
 
-    fn split_and_store(data: &[u8]) -> (ChunkAddress, HashMap<ChunkAddress, Chunk>) {
+    pub(super) fn split_and_store(data: &[u8]) -> (ChunkAddress, HashMap<ChunkAddress, Chunk>) {
         let (root, store) = split::<DEFAULT_BODY_SIZE>(data).unwrap();
         (root, store.into_chunks())
     }
 
-    // --- Generated shared tests (async variants) ---
-    generate_plain_joiner_tests!(tokio::test, Joiner, [async], [await]);
-
-    // --- Lazy streaming open (`open_streaming`) ---
+    generate_plain_joiner_tests!(Joiner);
 
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -1104,90 +1102,96 @@ mod tests {
 
     /// The lazy open seeds the chunked stream from the root and reproduces a
     /// multi-level file byte-for-byte.
-    #[tokio::test]
-    async fn streaming_open_assembles_byte_exact() {
-        // ~600 leaves -> root over an intermediate level, so the lazy seed must
-        // descend intermediates rather than emit a single leaf.
-        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 600 + 123)
-            .map(|i| (i % 256) as u8)
-            .collect();
-        let (root, store) = split_and_store(&data);
+    #[test]
+    fn streaming_open_assembles_byte_exact() {
+        run(async {
+            // ~600 leaves -> root over an intermediate level, so the lazy seed must
+            // descend intermediates rather than emit a single leaf.
+            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 600 + 123)
+                .map(|i| (i % 256) as u8)
+                .collect();
+            let (root, store) = split_and_store(&data);
 
-        let joiner = Joiner::open_streaming(store, root).await.unwrap();
-        let total = joiner.size() as usize;
-        let got = drain_chunked_to_buf(joiner, total).await;
-        assert_eq!(got, data);
+            let joiner = Joiner::open_streaming(store, root).await.unwrap();
+            let total = joiner.size() as usize;
+            let got = drain_chunked_to_buf(joiner, total).await;
+            assert_eq!(got, data);
+        })
     }
 
     /// The lazy open fetches only the root before returning: no level-synchronous
     /// frontier expansion, so no intermediate can stall the open. The eager
     /// [`new`](Joiner::new) over the same tree fetches strictly more.
-    #[tokio::test]
-    async fn streaming_open_fetches_only_the_root() {
-        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 600)
-            .map(|i| (i % 256) as u8)
-            .collect();
-        let (root, store) = split_and_store(&data);
-        let store = Arc::new(store);
+    #[test]
+    fn streaming_open_fetches_only_the_root() {
+        run(async {
+            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 600)
+                .map(|i| (i % 256) as u8)
+                .collect();
+            let (root, store) = split_and_store(&data);
+            let store = Arc::new(store);
 
-        let lazy_gets = Arc::new(AtomicUsize::new(0));
-        let lazy = ProbeStore {
-            inner: Arc::clone(&store),
-            gets: Arc::clone(&lazy_gets),
-        };
-        let _joiner = Joiner::open_streaming(lazy, root).await.unwrap();
-        assert_eq!(
-            lazy_gets.load(Ordering::SeqCst),
-            1,
-            "lazy open fetches only the root"
-        );
+            let lazy_gets = Arc::new(AtomicUsize::new(0));
+            let lazy = ProbeStore {
+                inner: Arc::clone(&store),
+                gets: Arc::clone(&lazy_gets),
+            };
+            let _joiner = Joiner::open_streaming(lazy, root).await.unwrap();
+            assert_eq!(
+                lazy_gets.load(Ordering::SeqCst),
+                1,
+                "lazy open fetches only the root"
+            );
 
-        let eager_gets = Arc::new(AtomicUsize::new(0));
-        let eager = ProbeStore {
-            inner: store,
-            gets: Arc::clone(&eager_gets),
-        };
-        let _joiner = Joiner::new(eager, root).await.unwrap();
-        assert!(
-            eager_gets.load(Ordering::SeqCst) > 1,
-            "eager open pre-expands the frontier (root + intermediates)"
-        );
+            let eager_gets = Arc::new(AtomicUsize::new(0));
+            let eager = ProbeStore {
+                inner: store,
+                gets: Arc::clone(&eager_gets),
+            };
+            let _joiner = Joiner::new(eager, root).await.unwrap();
+            assert!(
+                eager_gets.load(Ordering::SeqCst) > 1,
+                "eager open pre-expands the frontier (root + intermediates)"
+            );
+        })
     }
 
     /// A lazily-opened stream reassembles byte-exact even when every fetch is
     /// delayed, proving the descent is correct under latency and reordering.
-    #[tokio::test]
-    async fn streaming_open_is_byte_exact_under_latency() {
-        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 300 + 7)
-            .map(|i| (i % 256) as u8)
-            .collect();
-        let (root, store) = split_and_store(&data);
-        let joiner = Joiner::open_streaming(store, root)
-            .await
-            .unwrap()
-            .with_concurrency(4);
-        let total = joiner.size() as usize;
-        let got = drain_chunked_to_buf(joiner, total).await;
-        assert_eq!(got, data);
+    #[test]
+    fn streaming_open_is_byte_exact_under_latency() {
+        run(async {
+            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 300 + 7)
+                .map(|i| (i % 256) as u8)
+                .collect();
+            let (root, store) = split_and_store(&data);
+            let joiner = Joiner::open_streaming(store, root)
+                .await
+                .unwrap()
+                .with_concurrency(4);
+            let total = joiner.size() as usize;
+            let got = drain_chunked_to_buf(joiner, total).await;
+            assert_eq!(got, data);
+        })
     }
 
-    // --- Async-only tests: Stream, AsyncRead, AsyncSeek ---
+    #[test]
+    fn test_joiner_stream() {
+        run(async {
+            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3)
+                .map(|i| (i % 256) as u8)
+                .collect();
+            let (root, store) = split_and_store(&data);
 
-    #[tokio::test]
-    async fn test_joiner_stream() {
-        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3)
-            .map(|i| (i % 256) as u8)
-            .collect();
-        let (root, store) = split_and_store(&data);
+            let joiner = Joiner::new(store, root).await.unwrap();
+            let chunks: Vec<Result<Bytes>> = joiner.into_stream().collect().await;
 
-        let joiner = Joiner::new(store, root).await.unwrap();
-        let chunks: Vec<Result<Bytes>> = joiner.into_stream().collect().await;
-
-        let mut recovered = Vec::new();
-        for chunk in chunks {
-            recovered.extend_from_slice(&chunk.unwrap());
-        }
-        assert_eq!(recovered, data);
+            let mut recovered = Vec::new();
+            for chunk in chunks {
+                recovered.extend_from_slice(&chunk.unwrap());
+            }
+            assert_eq!(recovered, data);
+        })
     }
 
     /// Drain `into_offset_stream` into an offset-keyed map, asserting every leaf
@@ -1226,52 +1230,62 @@ mod tests {
         assert_eq!(reassembled, data, "offset reassembly equals input");
     }
 
-    #[tokio::test]
-    async fn test_offset_stream_small() {
-        assert_offset_stream_matches(b"hello world").await;
+    #[test]
+    fn test_offset_stream_small() {
+        run(async {
+            assert_offset_stream_matches(b"hello world").await;
+        })
     }
 
-    #[tokio::test]
-    async fn test_offset_stream_exact_chunk() {
-        assert_offset_stream_matches(&vec![0xAB; DEFAULT_BODY_SIZE]).await;
+    #[test]
+    fn test_offset_stream_exact_chunk() {
+        run(async {
+            assert_offset_stream_matches(&vec![0xAB; DEFAULT_BODY_SIZE]).await;
+        })
     }
 
-    #[tokio::test]
-    async fn test_offset_stream_multi_chunk() {
-        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3 + 123)
-            .map(|i| (i % 256) as u8)
-            .collect();
-        assert_offset_stream_matches(&data).await;
+    #[test]
+    fn test_offset_stream_multi_chunk() {
+        run(async {
+            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3 + 123)
+                .map(|i| (i % 256) as u8)
+                .collect();
+            assert_offset_stream_matches(&data).await;
+        })
     }
 
-    #[tokio::test]
-    async fn test_offset_stream_129_chunks() {
-        let refs_per_chunk = DEFAULT_BODY_SIZE / super::super::constants::REF_SIZE;
-        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * (refs_per_chunk + 1))
-            .map(|i| (i % 256) as u8)
-            .collect();
-        assert_offset_stream_matches(&data).await;
+    #[test]
+    fn test_offset_stream_129_chunks() {
+        run(async {
+            let refs_per_chunk = DEFAULT_BODY_SIZE / super::super::constants::REF_SIZE;
+            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * (refs_per_chunk + 1))
+                .map(|i| (i % 256) as u8)
+                .collect();
+            assert_offset_stream_matches(&data).await;
+        })
     }
 
-    #[tokio::test]
-    async fn test_offset_stream_concurrency_one() {
-        // Width 1 still yields every leaf with the right offset (degenerate
-        // concurrent path), so the reassembly invariant holds independent of fan.
-        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 7)
-            .map(|i| (i % 256) as u8)
-            .collect();
-        let (root, store) = split_and_store(&data);
-        let joiner = Joiner::new(store, root).await.unwrap().with_concurrency(1);
-        let total = joiner.size();
-        let mut reassembled = vec![0u8; total as usize];
-        let stream = joiner.into_offset_stream();
-        futures::pin_mut!(stream);
-        while let Some(pair) = stream.next().await {
-            let (offset, body) = pair.unwrap();
-            let start = offset as usize;
-            reassembled[start..start + body.len()].copy_from_slice(&body);
-        }
-        assert_eq!(reassembled, data);
+    #[test]
+    fn test_offset_stream_concurrency_one() {
+        run(async {
+            // Width 1 still yields every leaf with the right offset (degenerate
+            // concurrent path), so the reassembly invariant holds independent of fan.
+            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 7)
+                .map(|i| (i % 256) as u8)
+                .collect();
+            let (root, store) = split_and_store(&data);
+            let joiner = Joiner::new(store, root).await.unwrap().with_concurrency(1);
+            let total = joiner.size();
+            let mut reassembled = vec![0u8; total as usize];
+            let stream = joiner.into_offset_stream();
+            futures::pin_mut!(stream);
+            while let Some(pair) = stream.next().await {
+                let (offset, body) = pair.unwrap();
+                let start = offset as usize;
+                reassembled[start..start + body.len()].copy_from_slice(&body);
+            }
+            assert_eq!(reassembled, data);
+        })
     }
 
     /// Drain `into_offset_stream_chunked` into an offset-keyed buffer, asserting
@@ -1310,53 +1324,63 @@ mod tests {
         assert_eq!(reassembled, data, "chunked reassembly equals input");
     }
 
-    #[tokio::test]
-    async fn test_offset_stream_chunked_small() {
-        assert_offset_stream_chunked_matches(b"hello world").await;
+    #[test]
+    fn test_offset_stream_chunked_small() {
+        run(async {
+            assert_offset_stream_chunked_matches(b"hello world").await;
+        })
     }
 
-    #[tokio::test]
-    async fn test_offset_stream_chunked_exact_chunk() {
-        assert_offset_stream_chunked_matches(&vec![0xAB; DEFAULT_BODY_SIZE]).await;
+    #[test]
+    fn test_offset_stream_chunked_exact_chunk() {
+        run(async {
+            assert_offset_stream_chunked_matches(&vec![0xAB; DEFAULT_BODY_SIZE]).await;
+        })
     }
 
-    #[tokio::test]
-    async fn test_offset_stream_chunked_multi_chunk() {
-        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3 + 123)
-            .map(|i| (i % 256) as u8)
-            .collect();
-        assert_offset_stream_chunked_matches(&data).await;
+    #[test]
+    fn test_offset_stream_chunked_multi_chunk() {
+        run(async {
+            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3 + 123)
+                .map(|i| (i % 256) as u8)
+                .collect();
+            assert_offset_stream_chunked_matches(&data).await;
+        })
     }
 
-    #[tokio::test]
-    async fn test_offset_stream_chunked_three_level_tree() {
-        // 129 leaves needs a three-level tree, exercising intermediate-node
-        // re-queueing in the chunk-granular walk.
-        let refs_per_chunk = DEFAULT_BODY_SIZE / super::super::constants::REF_SIZE;
-        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * (refs_per_chunk + 1))
-            .map(|i| (i % 256) as u8)
-            .collect();
-        assert_offset_stream_chunked_matches(&data).await;
+    #[test]
+    fn test_offset_stream_chunked_three_level_tree() {
+        run(async {
+            // 129 leaves needs a three-level tree, exercising intermediate-node
+            // re-queueing in the chunk-granular walk.
+            let refs_per_chunk = DEFAULT_BODY_SIZE / super::super::constants::REF_SIZE;
+            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * (refs_per_chunk + 1))
+                .map(|i| (i % 256) as u8)
+                .collect();
+            assert_offset_stream_chunked_matches(&data).await;
+        })
     }
 
-    #[tokio::test]
-    async fn test_offset_stream_chunked_concurrency_one() {
-        // Width 1 still yields every leaf with the right offset.
-        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 7)
-            .map(|i| (i % 256) as u8)
-            .collect();
-        let (root, store) = split_and_store(&data);
-        let joiner = Joiner::new(store, root).await.unwrap().with_concurrency(1);
-        let total = joiner.size();
-        let mut reassembled = vec![0u8; total as usize];
-        let stream = joiner.into_offset_stream_chunked();
-        futures::pin_mut!(stream);
-        while let Some(pair) = stream.next().await {
-            let (offset, body) = pair.unwrap();
-            let start = offset as usize;
-            reassembled[start..start + body.len()].copy_from_slice(&body);
-        }
-        assert_eq!(reassembled, data);
+    #[test]
+    fn test_offset_stream_chunked_concurrency_one() {
+        run(async {
+            // Width 1 still yields every leaf with the right offset.
+            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 7)
+                .map(|i| (i % 256) as u8)
+                .collect();
+            let (root, store) = split_and_store(&data);
+            let joiner = Joiner::new(store, root).await.unwrap().with_concurrency(1);
+            let total = joiner.size();
+            let mut reassembled = vec![0u8; total as usize];
+            let stream = joiner.into_offset_stream_chunked();
+            futures::pin_mut!(stream);
+            while let Some(pair) = stream.next().await {
+                let (offset, body) = pair.unwrap();
+                let start = offset as usize;
+                reassembled[start..start + body.len()].copy_from_slice(&body);
+            }
+            assert_eq!(reassembled, data);
+        })
     }
 
     /// A getter that holds each fetch open across several executor yields so the
@@ -1380,7 +1404,7 @@ mod tests {
             // Yield several times so concurrently-admitted fetches overlap here
             // before any resolves; the peak counter then reflects pool width.
             for _ in 0..8 {
-                tokio::task::yield_now().await;
+                yield_now().await;
             }
             self.in_flight.fetch_sub(1, Ordering::SeqCst);
             self.chunks
@@ -1390,50 +1414,50 @@ mod tests {
         }
     }
 
-    #[tokio::test(flavor = "current_thread")]
-    async fn test_offset_stream_chunked_per_chunk_concurrency() {
-        // A flat two-level tree: one intermediate over many leaves. The
-        // subtree-granular stream would walk it as a single sequential descent
-        // (in-flight = 1 leaf at a time); the chunk-granular stream fans the
-        // leaves across the width.
-        let leaves = 40usize;
-        let width = 16usize;
-        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * leaves)
-            .map(|i| (i % 256) as u8)
-            .collect();
-        let (root, store) = split_and_store(&data);
+    #[test]
+    fn test_offset_stream_chunked_per_chunk_concurrency() {
+        run(async {
+            // A flat two-level tree: one intermediate over many leaves. The
+            // subtree-granular stream would walk it as a single sequential descent
+            // (in-flight = 1 leaf at a time); the chunk-granular stream fans the
+            // leaves across the width.
+            let leaves = 40usize;
+            let width = 16usize;
+            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * leaves)
+                .map(|i| (i % 256) as u8)
+                .collect();
+            let (root, store) = split_and_store(&data);
 
-        let probe = ConcurrencyProbe {
-            chunks: Arc::new(store),
-            in_flight: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            max_in_flight: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-        };
-        let max_seen = Arc::clone(&probe.max_in_flight);
+            let probe = ConcurrencyProbe {
+                chunks: Arc::new(store),
+                in_flight: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                max_in_flight: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            };
+            let max_seen = Arc::clone(&probe.max_in_flight);
 
-        let joiner = Joiner::new(probe, root)
-            .await
-            .unwrap()
-            .with_concurrency(width);
+            let joiner = Joiner::new(probe, root)
+                .await
+                .unwrap()
+                .with_concurrency(width);
 
-        let total = joiner.size();
-        let mut reassembled = vec![0u8; total as usize];
-        let stream = joiner.into_offset_stream_chunked();
-        futures::pin_mut!(stream);
-        while let Some(pair) = stream.next().await {
-            let (offset, body) = pair.unwrap();
-            let start = offset as usize;
-            reassembled[start..start + body.len()].copy_from_slice(&body);
-        }
-        assert_eq!(reassembled, data, "concurrency probe still reassembles");
+            let total = joiner.size();
+            let mut reassembled = vec![0u8; total as usize];
+            let stream = joiner.into_offset_stream_chunked();
+            futures::pin_mut!(stream);
+            while let Some(pair) = stream.next().await {
+                let (offset, body) = pair.unwrap();
+                let start = offset as usize;
+                reassembled[start..start + body.len()].copy_from_slice(&body);
+            }
+            assert_eq!(reassembled, data, "concurrency probe still reassembles");
 
-        let peak = max_seen.load(std::sync::atomic::Ordering::SeqCst);
-        assert!(
-            peak >= width,
-            "chunk-granular stream should reach width {width} in-flight, saw {peak}"
-        );
+            let peak = max_seen.load(std::sync::atomic::Ordering::SeqCst);
+            assert!(
+                peak >= width,
+                "chunk-granular stream should reach width {width} in-flight, saw {peak}"
+            );
+        })
     }
-
-    // --- Front-load / intermediate-cap guards (small body size = deep tree) ---
 
     /// Branching for a 256-byte body is `256 / REF_SIZE` = 8, so a few hundred
     /// leaves build a wide intermediate frontier with little data. This keeps the
@@ -1520,11 +1544,11 @@ mod tests {
             }
             if self.slow_addr == Some(*address) {
                 while self.delivered_leaves.load(Ordering::SeqCst) < self.slow_gate {
-                    tokio::task::yield_now().await;
+                    yield_now().await;
                 }
             }
             for _ in 0..4 {
-                tokio::task::yield_now().await;
+                yield_now().await;
             }
             if !is_leaf {
                 self.intermediate_in_flight.fetch_sub(1, Ordering::SeqCst);
@@ -1544,120 +1568,126 @@ mod tests {
     /// fetched after only a short descent (a few intermediates), never after the
     /// whole frontier is drained. The breadth-first walk fetched every
     /// intermediate first, so the first leaf landed ~frontier-size fetches in.
-    #[tokio::test(flavor = "current_thread")]
-    async fn test_offset_stream_chunked_first_leaf_before_frontier() {
-        let data = tiny_deep_data(900);
-        let (root, store) = split::<TINY_BODY>(&data).unwrap();
-        let probe = OrderProbe::new(store.into_chunks(), &data);
+    #[test]
+    fn test_offset_stream_chunked_first_leaf_before_frontier() {
+        run(async {
+            let data = tiny_deep_data(900);
+            let (root, store) = split::<TINY_BODY>(&data).unwrap();
+            let probe = OrderProbe::new(store.into_chunks(), &data);
 
-        let joiner = Joiner::<_, TINY_BODY>::new(probe.clone(), root)
-            .await
-            .unwrap();
-        // Measure only the streaming walk, not the upfront frontier expansion.
-        probe.reset();
+            let joiner = Joiner::<_, TINY_BODY>::new(probe.clone(), root)
+                .await
+                .unwrap();
+            // Measure only the streaming walk, not the upfront frontier expansion.
+            probe.reset();
 
-        let total = joiner.size();
-        let mut reassembled = vec![0u8; total as usize];
-        let stream = joiner.into_offset_stream_chunked();
-        futures::pin_mut!(stream);
-        while let Some(pair) = stream.next().await {
-            let (offset, body) = pair.unwrap();
-            reassembled[offset as usize..offset as usize + body.len()].copy_from_slice(&body);
-        }
-        assert_eq!(reassembled, data, "deep-tree reassembly is byte-exact");
+            let total = joiner.size();
+            let mut reassembled = vec![0u8; total as usize];
+            let stream = joiner.into_offset_stream_chunked();
+            futures::pin_mut!(stream);
+            while let Some(pair) = stream.next().await {
+                let (offset, body) = pair.unwrap();
+                reassembled[offset as usize..offset as usize + body.len()].copy_from_slice(&body);
+            }
+            assert_eq!(reassembled, data, "deep-tree reassembly is byte-exact");
 
-        let frontier = probe.intermediate_fetches();
-        assert!(
-            frontier >= 40,
-            "test needs a frontier far larger than the cap, saw {frontier}"
-        );
-        let before = probe.intermediates_before_first_leaf();
-        assert!(
-            before <= 4 * MAX_INTERMEDIATE_IN_FLIGHT,
-            "first leaf fetched after {before} intermediates (frontier {frontier}); \
+            let frontier = probe.intermediate_fetches();
+            assert!(
+                frontier >= 40,
+                "test needs a frontier far larger than the cap, saw {frontier}"
+            );
+            let before = probe.intermediates_before_first_leaf();
+            assert!(
+                before <= 4 * MAX_INTERMEDIATE_IN_FLIGHT,
+                "first leaf fetched after {before} intermediates (frontier {frontier}); \
              expected a short descent, not the whole frontier"
-        );
+            );
+        })
     }
 
     /// Intermediate fetches in flight never exceed the cap.
-    #[tokio::test(flavor = "current_thread")]
-    async fn test_offset_stream_chunked_intermediate_cap() {
-        let data = tiny_deep_data(900);
-        let (root, store) = split::<TINY_BODY>(&data).unwrap();
-        let probe = OrderProbe::new(store.into_chunks(), &data);
+    #[test]
+    fn test_offset_stream_chunked_intermediate_cap() {
+        run(async {
+            let data = tiny_deep_data(900);
+            let (root, store) = split::<TINY_BODY>(&data).unwrap();
+            let probe = OrderProbe::new(store.into_chunks(), &data);
 
-        let joiner = Joiner::<_, TINY_BODY>::new(probe.clone(), root)
-            .await
-            .unwrap()
-            .with_concurrency(16);
-        probe.reset();
+            let joiner = Joiner::<_, TINY_BODY>::new(probe.clone(), root)
+                .await
+                .unwrap()
+                .with_concurrency(16);
+            probe.reset();
 
-        let stream = joiner.into_offset_stream_chunked();
-        futures::pin_mut!(stream);
-        while let Some(pair) = stream.next().await {
-            pair.unwrap();
-        }
+            let stream = joiner.into_offset_stream_chunked();
+            futures::pin_mut!(stream);
+            while let Some(pair) = stream.next().await {
+                pair.unwrap();
+            }
 
-        let peak = probe
-            .peak_intermediate_in_flight
-            .load(std::sync::atomic::Ordering::SeqCst);
-        assert!(
-            peak <= MAX_INTERMEDIATE_IN_FLIGHT,
-            "intermediate in-flight peak {peak} exceeds cap {MAX_INTERMEDIATE_IN_FLIGHT}"
-        );
+            let peak = probe
+                .peak_intermediate_in_flight
+                .load(std::sync::atomic::Ordering::SeqCst);
+            assert!(
+                peak <= MAX_INTERMEDIATE_IN_FLIGHT,
+                "intermediate in-flight peak {peak} exceeds cap {MAX_INTERMEDIATE_IN_FLIGHT}"
+            );
+        })
     }
 
     /// A single slow intermediate must not stall the rest of the stream: leaves
     /// from other subtrees keep flowing while it is parked. The slow node parks
     /// until the consumer has delivered a batch of leaves, so completion proves
     /// those leaves were delivered without it.
-    #[tokio::test(flavor = "current_thread")]
-    async fn test_offset_stream_chunked_slow_intermediate_does_not_stall() {
-        let data = tiny_deep_data(900);
-        let (root, store) = split::<TINY_BODY>(&data).unwrap();
-        let store = store.into_chunks();
+    #[test]
+    fn test_offset_stream_chunked_slow_intermediate_does_not_stall() {
+        run(async {
+            let data = tiny_deep_data(900);
+            let (root, store) = split::<TINY_BODY>(&data).unwrap();
+            let store = store.into_chunks();
 
-        // Park an intermediate that only the streaming walk fetches: a leaf
-        // parent, every child a data leaf. An upper intermediate is read by
-        // the upfront frontier expansion in `new`, before any leaf can be
-        // delivered, so parking one there deadlocks the gate below.
-        let leaves = tiny_leaf_addresses(&data);
-        let slow = *store
-            .iter()
-            .find(|(addr, chunk)| {
-                let body = chunk.envelope().data();
-                !leaves.contains(*addr)
-                    && **addr != root
-                    && body.len() % super::super::constants::REF_SIZE == 0
-                    && body.chunks(super::super::constants::REF_SIZE).all(|child| {
-                        ChunkAddress::from_slice(child).is_ok_and(|a| leaves.contains(&a))
-                    })
-            })
-            .expect("a leaf-parent intermediate exists")
-            .0;
+            // Park an intermediate that only the streaming walk fetches: a leaf
+            // parent, every child a data leaf. An upper intermediate is read by
+            // the upfront frontier expansion in `new`, before any leaf can be
+            // delivered, so parking one there deadlocks the gate below.
+            let leaves = tiny_leaf_addresses(&data);
+            let slow = *store
+                .iter()
+                .find(|(addr, chunk)| {
+                    let body = chunk.envelope().data();
+                    !leaves.contains(*addr)
+                        && **addr != root
+                        && body.len() % super::super::constants::REF_SIZE == 0
+                        && body.chunks(super::super::constants::REF_SIZE).all(|child| {
+                            ChunkAddress::from_slice(child).is_ok_and(|a| leaves.contains(&a))
+                        })
+                })
+                .expect("a leaf-parent intermediate exists")
+                .0;
 
-        let mut probe = OrderProbe::new(store, &data);
-        probe.slow_addr = Some(slow);
-        probe.slow_gate = 100;
-        let delivered = Arc::clone(&probe.delivered_leaves);
+            let mut probe = OrderProbe::new(store, &data);
+            probe.slow_addr = Some(slow);
+            probe.slow_gate = 100;
+            let delivered = Arc::clone(&probe.delivered_leaves);
 
-        let joiner = Joiner::<_, TINY_BODY>::new(probe.clone(), root)
-            .await
-            .unwrap();
+            let joiner = Joiner::<_, TINY_BODY>::new(probe.clone(), root)
+                .await
+                .unwrap();
 
-        let total = joiner.size();
-        let mut reassembled = vec![0u8; total as usize];
-        let stream = joiner.into_offset_stream_chunked();
-        futures::pin_mut!(stream);
-        while let Some(pair) = stream.next().await {
-            let (offset, body) = pair.unwrap();
-            reassembled[offset as usize..offset as usize + body.len()].copy_from_slice(&body);
-            delivered.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-        }
-        assert_eq!(
-            reassembled, data,
-            "stream completes past the slow intermediate"
-        );
+            let total = joiner.size();
+            let mut reassembled = vec![0u8; total as usize];
+            let stream = joiner.into_offset_stream_chunked();
+            futures::pin_mut!(stream);
+            while let Some(pair) = stream.next().await {
+                let (offset, body) = pair.unwrap();
+                reassembled[offset as usize..offset as usize + body.len()].copy_from_slice(&body);
+                delivered.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            }
+            assert_eq!(
+                reassembled, data,
+                "stream completes past the slow intermediate"
+            );
+        })
     }
 
     /// Drain `into_offset_stream_chunked_range(start, len)`, reassemble the
@@ -1709,165 +1739,85 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_offset_stream_chunked_range_windows() {
-        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 321)
-            .map(|i| (i % 256) as u8)
-            .collect();
-        let bs = DEFAULT_BODY_SIZE as u64;
-        let total = data.len() as u64;
+    #[test]
+    fn test_offset_stream_chunked_range_windows() {
+        run(async {
+            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 321)
+                .map(|i| (i % 256) as u8)
+                .collect();
+            let bs = DEFAULT_BODY_SIZE as u64;
+            let total = data.len() as u64;
 
-        // sub-leaf: start and len both inside one leaf
-        assert_offset_stream_chunked_range_matches(&data, bs + 10, 50).await;
-        // leaf-aligned single leaf
-        assert_offset_stream_chunked_range_matches(&data, bs, bs).await;
-        // spans several leaves, partial at both ends
-        assert_offset_stream_chunked_range_matches(&data, bs / 2, bs * 3 + 7).await;
-        // last partial leaf
-        assert_offset_stream_chunked_range_matches(&data, bs * 5, total - bs * 5).await;
-        // whole file (must equal read_all)
-        assert_offset_stream_chunked_range_matches(&data, 0, total).await;
-        // zero-len (empty)
-        assert_offset_stream_chunked_range_matches(&data, bs, 0).await;
+            // sub-leaf: start and len both inside one leaf
+            assert_offset_stream_chunked_range_matches(&data, bs + 10, 50).await;
+            // leaf-aligned single leaf
+            assert_offset_stream_chunked_range_matches(&data, bs, bs).await;
+            // spans several leaves, partial at both ends
+            assert_offset_stream_chunked_range_matches(&data, bs / 2, bs * 3 + 7).await;
+            // last partial leaf
+            assert_offset_stream_chunked_range_matches(&data, bs * 5, total - bs * 5).await;
+            // whole file (must equal read_all)
+            assert_offset_stream_chunked_range_matches(&data, 0, total).await;
+            // zero-len (empty)
+            assert_offset_stream_chunked_range_matches(&data, bs, 0).await;
+        })
     }
 
-    #[tokio::test]
-    async fn test_offset_stream_chunked_range_whole_equals_chunked() {
-        // A whole-file range must reproduce `into_offset_stream_chunked` exactly:
-        // same leaves, same absolute offsets, same bodies.
-        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3 + 99)
-            .map(|i| (i % 256) as u8)
-            .collect();
-        let (root, store) = split_and_store(&data);
+    #[test]
+    fn test_offset_stream_chunked_range_whole_equals_chunked() {
+        run(async {
+            // A whole-file range must reproduce `into_offset_stream_chunked` exactly:
+            // same leaves, same absolute offsets, same bodies.
+            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3 + 99)
+                .map(|i| (i % 256) as u8)
+                .collect();
+            let (root, store) = split_and_store(&data);
 
-        let full = Joiner::new(store.clone(), root).await.unwrap();
-        let total = full.size();
-        let mut from_full: Vec<(u64, Vec<u8>)> = full
-            .into_offset_stream_chunked()
-            .collect::<Vec<_>>()
-            .await
-            .into_iter()
-            .map(|p| {
-                let (o, b) = p.unwrap();
-                (o, b.to_vec())
-            })
-            .collect();
-        from_full.sort_by_key(|(o, _)| *o);
+            let full = Joiner::new(store.clone(), root).await.unwrap();
+            let total = full.size();
+            let mut from_full: Vec<(u64, Vec<u8>)> = full
+                .into_offset_stream_chunked()
+                .collect::<Vec<_>>()
+                .await
+                .into_iter()
+                .map(|p| {
+                    let (o, b) = p.unwrap();
+                    (o, b.to_vec())
+                })
+                .collect();
+            from_full.sort_by_key(|(o, _)| *o);
 
-        let ranged = Joiner::new(store, root).await.unwrap();
-        let mut from_range: Vec<(u64, Vec<u8>)> = ranged
-            .into_offset_stream_chunked_range(0, total)
-            .collect::<Vec<_>>()
-            .await
-            .into_iter()
-            .map(|p| {
-                let (o, b) = p.unwrap();
-                (o, b.to_vec())
-            })
-            .collect();
-        from_range.sort_by_key(|(o, _)| *o);
+            let ranged = Joiner::new(store, root).await.unwrap();
+            let mut from_range: Vec<(u64, Vec<u8>)> = ranged
+                .into_offset_stream_chunked_range(0, total)
+                .collect::<Vec<_>>()
+                .await
+                .into_iter()
+                .map(|p| {
+                    let (o, b) = p.unwrap();
+                    (o, b.to_vec())
+                })
+                .collect();
+            from_range.sort_by_key(|(o, _)| *o);
 
-        assert_eq!(
-            from_range, from_full,
-            "whole-file range equals chunked walk"
-        );
+            assert_eq!(
+                from_range, from_full,
+                "whole-file range equals chunked walk"
+            );
 
-        // And the reassembly equals read_all.
-        let expected = Joiner::new(split_and_store(&data).1, root)
-            .await
-            .unwrap()
-            .read_all()
-            .await
-            .unwrap();
-        let mut reassembled = vec![0u8; total as usize];
-        for (o, b) in &from_range {
-            reassembled[*o as usize..*o as usize + b.len()].copy_from_slice(b);
-        }
-        assert_eq!(reassembled, expected);
-    }
-
-    #[cfg(feature = "tokio")]
-    #[tokio::test]
-    async fn test_reader_small() {
-        use tokio::io::AsyncReadExt;
-
-        let data = b"hello world";
-        let (root, store) = split_and_store(data);
-
-        let joiner = Joiner::new(store, root).await.unwrap();
-        let mut reader = joiner.into_reader();
-        let mut result = Vec::new();
-        reader.read_to_end(&mut result).await.unwrap();
-        assert_eq!(result, data);
-    }
-
-    #[cfg(feature = "tokio")]
-    #[tokio::test]
-    async fn test_reader_multi_chunk() {
-        use tokio::io::AsyncReadExt;
-
-        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3 + 123)
-            .map(|i| (i % 256) as u8)
-            .collect();
-        let (root, store) = split_and_store(&data);
-
-        let joiner = Joiner::new(store, root).await.unwrap();
-        let mut reader = joiner.into_reader();
-        let mut result = Vec::new();
-        reader.read_to_end(&mut result).await.unwrap();
-        assert_eq!(result, data);
-    }
-
-    #[cfg(feature = "tokio")]
-    #[tokio::test]
-    async fn test_reader_seek() {
-        use tokio::io::{AsyncReadExt, AsyncSeekExt};
-
-        let data = b"hello world";
-        let (root, store) = split_and_store(data);
-
-        let joiner = Joiner::new(store, root).await.unwrap();
-        let mut reader = joiner.into_reader();
-
-        reader.seek(SeekFrom::Start(6)).await.unwrap();
-        let mut buf = vec![0u8; 5];
-        reader.read_exact(&mut buf).await.unwrap();
-        assert_eq!(&buf, b"world");
-    }
-
-    #[cfg(feature = "tokio")]
-    #[tokio::test]
-    async fn test_reader_seek_back_and_forth() {
-        use tokio::io::{AsyncReadExt, AsyncSeekExt};
-
-        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3)
-            .map(|i| (i % 256) as u8)
-            .collect();
-        let (root, store) = split_and_store(&data);
-
-        let joiner = Joiner::new(store, root).await.unwrap();
-        let mut reader = joiner.into_reader();
-
-        // Read from middle
-        reader
-            .seek(SeekFrom::Start(DEFAULT_BODY_SIZE as u64))
-            .await
-            .unwrap();
-        let mut buf1 = vec![0u8; 100];
-        reader.read_exact(&mut buf1).await.unwrap();
-        assert_eq!(&buf1, &data[DEFAULT_BODY_SIZE..DEFAULT_BODY_SIZE + 100]);
-
-        // Seek back to start
-        reader.seek(SeekFrom::Start(0)).await.unwrap();
-        let mut buf2 = vec![0u8; 100];
-        reader.read_exact(&mut buf2).await.unwrap();
-        assert_eq!(&buf2, &data[..100]);
-
-        // Seek to near-end
-        reader.seek(SeekFrom::End(-50)).await.unwrap();
-        let mut buf3 = vec![0u8; 50];
-        reader.read_exact(&mut buf3).await.unwrap();
-        assert_eq!(&buf3, &data[data.len() - 50..]);
+            // And the reassembly equals read_all.
+            let expected = Joiner::new(split_and_store(&data).1, root)
+                .await
+                .unwrap()
+                .read_all()
+                .await
+                .unwrap();
+            let mut reassembled = vec![0u8; total as usize];
+            for (o, b) in &from_range {
+                reassembled[*o as usize..*o as usize + b.len()].copy_from_slice(b);
+            }
+            assert_eq!(reassembled, expected);
+        })
     }
 
     #[cfg(feature = "encryption")]
@@ -1885,26 +1835,25 @@ mod tests {
             (root_ref, store.into_chunks())
         }
 
-        // --- Generated shared tests (async variants) ---
-        generate_encrypted_joiner_tests!(tokio::test, EncryptedJoiner, [async], [await]);
+        generate_encrypted_joiner_tests!(EncryptedJoiner);
 
-        // --- Async-only tests: Stream ---
+        #[test]
+        fn test_encrypted_joiner_stream() {
+            run(async {
+                let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3)
+                    .map(|i| (i % 256) as u8)
+                    .collect();
+                let (root_ref, store) = encrypted_split_and_store(&data);
 
-        #[tokio::test]
-        async fn test_encrypted_joiner_stream() {
-            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3)
-                .map(|i| (i % 256) as u8)
-                .collect();
-            let (root_ref, store) = encrypted_split_and_store(&data);
+                let joiner = EncryptedJoiner::new(store, root_ref).await.unwrap();
+                let chunks: Vec<Result<Bytes>> = joiner.into_stream().collect().await;
 
-            let joiner = EncryptedJoiner::new(store, root_ref).await.unwrap();
-            let chunks: Vec<Result<Bytes>> = joiner.into_stream().collect().await;
-
-            let mut recovered = Vec::new();
-            for chunk in chunks {
-                recovered.extend_from_slice(&chunk.unwrap());
-            }
-            assert_eq!(recovered, data);
+                let mut recovered = Vec::new();
+                for chunk in chunks {
+                    recovered.extend_from_slice(&chunk.unwrap());
+                }
+                assert_eq!(recovered, data);
+            })
         }
 
         /// Encrypted analogue of `assert_offset_stream_chunked_range_matches`.
@@ -1955,26 +1904,114 @@ mod tests {
             }
         }
 
-        #[tokio::test]
-        async fn test_encrypted_offset_stream_chunked_range_windows() {
-            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 321)
-                .map(|i| (i % 256) as u8)
-                .collect();
-            let bs = DEFAULT_BODY_SIZE as u64;
-            let total = data.len() as u64;
+        #[test]
+        fn test_encrypted_offset_stream_chunked_range_windows() {
+            run(async {
+                let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 321)
+                    .map(|i| (i % 256) as u8)
+                    .collect();
+                let bs = DEFAULT_BODY_SIZE as u64;
+                let total = data.len() as u64;
 
-            // sub-leaf
-            assert_encrypted_range_matches(&data, bs + 10, 50).await;
-            // leaf-aligned single leaf
-            assert_encrypted_range_matches(&data, bs, bs).await;
-            // spans several leaves
-            assert_encrypted_range_matches(&data, bs / 2, bs * 3 + 7).await;
-            // last partial leaf
-            assert_encrypted_range_matches(&data, bs * 5, total - bs * 5).await;
-            // whole file
-            assert_encrypted_range_matches(&data, 0, total).await;
-            // zero-len
-            assert_encrypted_range_matches(&data, bs, 0).await;
+                // sub-leaf
+                assert_encrypted_range_matches(&data, bs + 10, 50).await;
+                // leaf-aligned single leaf
+                assert_encrypted_range_matches(&data, bs, bs).await;
+                // spans several leaves
+                assert_encrypted_range_matches(&data, bs / 2, bs * 3 + 7).await;
+                // last partial leaf
+                assert_encrypted_range_matches(&data, bs * 5, total - bs * 5).await;
+                // whole file
+                assert_encrypted_range_matches(&data, 0, total).await;
+                // zero-len
+                assert_encrypted_range_matches(&data, bs, 0).await;
+            })
         }
+    }
+}
+
+#[cfg(all(test, feature = "tokio"))]
+mod tokio_tests {
+    use super::tests::split_and_store;
+    use super::*;
+
+    #[tokio::test]
+    async fn test_reader_small() {
+        use tokio::io::AsyncReadExt;
+
+        let data = b"hello world";
+        let (root, store) = split_and_store(data);
+
+        let joiner = Joiner::new(store, root).await.unwrap();
+        let mut reader = joiner.into_reader();
+        let mut result = Vec::new();
+        reader.read_to_end(&mut result).await.unwrap();
+        assert_eq!(result, data);
+    }
+
+    #[tokio::test]
+    async fn test_reader_multi_chunk() {
+        use tokio::io::AsyncReadExt;
+
+        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3 + 123)
+            .map(|i| (i % 256) as u8)
+            .collect();
+        let (root, store) = split_and_store(&data);
+
+        let joiner = Joiner::new(store, root).await.unwrap();
+        let mut reader = joiner.into_reader();
+        let mut result = Vec::new();
+        reader.read_to_end(&mut result).await.unwrap();
+        assert_eq!(result, data);
+    }
+
+    #[tokio::test]
+    async fn test_reader_seek() {
+        use tokio::io::{AsyncReadExt, AsyncSeekExt};
+
+        let data = b"hello world";
+        let (root, store) = split_and_store(data);
+
+        let joiner = Joiner::new(store, root).await.unwrap();
+        let mut reader = joiner.into_reader();
+
+        reader.seek(SeekFrom::Start(6)).await.unwrap();
+        let mut buf = vec![0u8; 5];
+        reader.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"world");
+    }
+
+    #[tokio::test]
+    async fn test_reader_seek_back_and_forth() {
+        use tokio::io::{AsyncReadExt, AsyncSeekExt};
+
+        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3)
+            .map(|i| (i % 256) as u8)
+            .collect();
+        let (root, store) = split_and_store(&data);
+
+        let joiner = Joiner::new(store, root).await.unwrap();
+        let mut reader = joiner.into_reader();
+
+        // Read from middle
+        reader
+            .seek(SeekFrom::Start(DEFAULT_BODY_SIZE as u64))
+            .await
+            .unwrap();
+        let mut buf1 = vec![0u8; 100];
+        reader.read_exact(&mut buf1).await.unwrap();
+        assert_eq!(&buf1, &data[DEFAULT_BODY_SIZE..DEFAULT_BODY_SIZE + 100]);
+
+        // Seek back to start
+        reader.seek(SeekFrom::Start(0)).await.unwrap();
+        let mut buf2 = vec![0u8; 100];
+        reader.read_exact(&mut buf2).await.unwrap();
+        assert_eq!(&buf2, &data[..100]);
+
+        // Seek to near-end
+        reader.seek(SeekFrom::End(-50)).await.unwrap();
+        let mut buf3 = vec![0u8; 50];
+        reader.read_exact(&mut buf3).await.unwrap();
+        assert_eq!(&buf3, &data[data.len() - 50..]);
     }
 }

--- a/crates/primitives/src/file/joiner_tests.rs
+++ b/crates/primitives/src/file/joiner_tests.rs
@@ -1,261 +1,315 @@
-/// Generate plain (unencrypted) joiner tests for both sync and async variants.
-///
-/// # Parameters
-/// - `$test_attr`: test attribute (`test` or `tokio::test`)
-/// - `$Joiner`: joiner type name (`Joiner` or `AsyncJoiner`)
-/// - `[$($async_fn:tt)*]`: `[async]` for async, `[]` for sync
-/// - `[$($aw:tt)*]`: `[await]` for async, `[]` for sync
+/// Generate plain (unencrypted) joiner tests over `$Joiner`.
 ///
 /// The calling module must define:
 /// ```ignore
 /// fn split_and_store(data: &[u8]) -> (ChunkAddress, HashMap<ChunkAddress, Chunk>);
 /// ```
 macro_rules! generate_plain_joiner_tests {
-    ($test_attr:meta, $Joiner:ident, [$($async_fn:tt)*], [$($aw:tt)*]) => {
-        #[$test_attr]
-        $($async_fn)* fn test_joiner_empty() {
-            let data = b"";
-            let (root, store) = split_and_store(data);
-            let joiner = $Joiner::new(store, root) $(.$aw)* .unwrap();
-            assert_eq!(joiner.size(), 0);
-            let result = joiner.read_all() $(.$aw)* .unwrap();
-            assert_eq!(result, data.as_slice());
+    ($Joiner:ident) => {
+        #[test]
+        fn test_joiner_empty() {
+            nectar_testing::run(async {
+                let data = b"";
+                let (root, store) = split_and_store(data);
+                let joiner = $Joiner::new(store, root).await.unwrap();
+                assert_eq!(joiner.size(), 0);
+                let result = joiner.read_all().await.unwrap();
+                assert_eq!(result, data.as_slice());
+            })
         }
 
-        #[$test_attr]
-        $($async_fn)* fn test_joiner_small() {
-            let data = b"hello world";
-            let (root, store) = split_and_store(data);
-            let joiner = $Joiner::new(store, root) $(.$aw)* .unwrap();
-            assert_eq!(joiner.size(), data.len() as u64);
-            let result = joiner.read_all() $(.$aw)* .unwrap();
-            assert_eq!(result, data.as_slice());
+        #[test]
+        fn test_joiner_small() {
+            nectar_testing::run(async {
+                let data = b"hello world";
+                let (root, store) = split_and_store(data);
+                let joiner = $Joiner::new(store, root).await.unwrap();
+                assert_eq!(joiner.size(), data.len() as u64);
+                let result = joiner.read_all().await.unwrap();
+                assert_eq!(result, data.as_slice());
+            })
         }
 
-        #[$test_attr]
-        $($async_fn)* fn test_joiner_range() {
-            let data = b"hello world";
-            let (root, store) = split_and_store(data);
-            let joiner = $Joiner::new(store, root) $(.$aw)* .unwrap();
-            let result = joiner.read_range(6, 5) $(.$aw)* .unwrap();
-            assert_eq!(result, b"world");
+        #[test]
+        fn test_joiner_range() {
+            nectar_testing::run(async {
+                let data = b"hello world";
+                let (root, store) = split_and_store(data);
+                let joiner = $Joiner::new(store, root).await.unwrap();
+                let result = joiner.read_range(6, 5).await.unwrap();
+                assert_eq!(result, b"world");
+            })
         }
 
-        #[$test_attr]
-        $($async_fn)* fn test_joiner_two_chunks() {
-            let data: Vec<u8> =
-                (0..DEFAULT_BODY_SIZE + 100).map(|i| (i % 256) as u8).collect();
-            let (root, store) = split_and_store(&data);
-            let joiner = $Joiner::new(store, root) $(.$aw)* .unwrap();
-            let result = joiner.read_all() $(.$aw)* .unwrap();
-            assert_eq!(result, data);
+        #[test]
+        fn test_joiner_two_chunks() {
+            nectar_testing::run(async {
+                let data: Vec<u8> = (0..DEFAULT_BODY_SIZE + 100)
+                    .map(|i| (i % 256) as u8)
+                    .collect();
+                let (root, store) = split_and_store(&data);
+                let joiner = $Joiner::new(store, root).await.unwrap();
+                let result = joiner.read_all().await.unwrap();
+                assert_eq!(result, data);
+            })
         }
 
-        #[$test_attr]
-        $($async_fn)* fn test_joiner_range_spanning_chunks() {
-            let data: Vec<u8> =
-                (0..DEFAULT_BODY_SIZE * 3).map(|i| (i % 256) as u8).collect();
-            let (root, store) = split_and_store(&data);
-            let joiner = $Joiner::new(store, root) $(.$aw)* .unwrap();
-            let start = DEFAULT_BODY_SIZE - 50;
-            let len = 100;
-            let result = joiner.read_range(start as u64, len) $(.$aw)* .unwrap();
-            assert_eq!(result, &data[start..start + len]);
+        #[test]
+        fn test_joiner_range_spanning_chunks() {
+            nectar_testing::run(async {
+                let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3)
+                    .map(|i| (i % 256) as u8)
+                    .collect();
+                let (root, store) = split_and_store(&data);
+                let joiner = $Joiner::new(store, root).await.unwrap();
+                let start = DEFAULT_BODY_SIZE - 50;
+                let len = 100;
+                let result = joiner.read_range(start as u64, len).await.unwrap();
+                assert_eq!(result, &data[start..start + len]);
+            })
         }
 
-        #[$test_attr]
-        $($async_fn)* fn test_round_trip_exact_chunk() {
-            let data = vec![0xAB; DEFAULT_BODY_SIZE];
-            let (root, store) = split_and_store(&data);
-            let joiner = $Joiner::new(store, root) $(.$aw)* .unwrap();
-            let result = joiner.read_all() $(.$aw)* .unwrap();
-            assert_eq!(result, data);
+        #[test]
+        fn test_round_trip_exact_chunk() {
+            nectar_testing::run(async {
+                let data = vec![0xAB; DEFAULT_BODY_SIZE];
+                let (root, store) = split_and_store(&data);
+                let joiner = $Joiner::new(store, root).await.unwrap();
+                let result = joiner.read_all().await.unwrap();
+                assert_eq!(result, data);
+            })
         }
 
-        #[$test_attr]
-        $($async_fn)* fn test_joiner_128_chunks() {
-            let refs_per_chunk = DEFAULT_BODY_SIZE / super::super::constants::REF_SIZE;
-            let data: Vec<u8> =
-                (0..DEFAULT_BODY_SIZE * refs_per_chunk).map(|i| (i % 256) as u8).collect();
-            let (root, store) = split_and_store(&data);
-            let joiner = $Joiner::new(store, root) $(.$aw)* .unwrap();
-            let result = joiner.read_all() $(.$aw)* .unwrap();
-            assert_eq!(result, data);
+        #[test]
+        fn test_joiner_128_chunks() {
+            nectar_testing::run(async {
+                let refs_per_chunk = DEFAULT_BODY_SIZE / super::super::constants::REF_SIZE;
+                let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * refs_per_chunk)
+                    .map(|i| (i % 256) as u8)
+                    .collect();
+                let (root, store) = split_and_store(&data);
+                let joiner = $Joiner::new(store, root).await.unwrap();
+                let result = joiner.read_all().await.unwrap();
+                assert_eq!(result, data);
+            })
         }
 
-        #[$test_attr]
-        $($async_fn)* fn test_joiner_129_chunks() {
-            let refs_per_chunk = DEFAULT_BODY_SIZE / super::super::constants::REF_SIZE;
-            let data: Vec<u8> =
-                (0..DEFAULT_BODY_SIZE * (refs_per_chunk + 1)).map(|i| (i % 256) as u8).collect();
-            let (root, store) = split_and_store(&data);
-            let joiner = $Joiner::new(store, root) $(.$aw)* .unwrap();
-            let result = joiner.read_all() $(.$aw)* .unwrap();
-            assert_eq!(result, data);
+        #[test]
+        fn test_joiner_129_chunks() {
+            nectar_testing::run(async {
+                let refs_per_chunk = DEFAULT_BODY_SIZE / super::super::constants::REF_SIZE;
+                let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * (refs_per_chunk + 1))
+                    .map(|i| (i % 256) as u8)
+                    .collect();
+                let (root, store) = split_and_store(&data);
+                let joiner = $Joiner::new(store, root).await.unwrap();
+                let result = joiner.read_all().await.unwrap();
+                assert_eq!(result, data);
+            })
         }
 
-        #[$test_attr]
-        $($async_fn)* fn test_joiner_seek_past_end() {
-            let data = b"test data";
-            let (root, store) = split_and_store(data);
-            let mut joiner = $Joiner::new(store, root) $(.$aw)* .unwrap();
-            joiner.seek(std::io::SeekFrom::Start(1000)).unwrap();
-            assert_eq!(joiner.position(), 1000);
-            let result = joiner.read_range(joiner.position(), 10) $(.$aw)* .unwrap();
-            assert!(result.is_empty());
+        #[test]
+        fn test_joiner_seek_past_end() {
+            nectar_testing::run(async {
+                let data = b"test data";
+                let (root, store) = split_and_store(data);
+                let mut joiner = $Joiner::new(store, root).await.unwrap();
+                joiner.seek(std::io::SeekFrom::Start(1000)).unwrap();
+                assert_eq!(joiner.position(), 1000);
+                let result = joiner.read_range(joiner.position(), 10).await.unwrap();
+                assert!(result.is_empty());
+            })
         }
 
-        #[$test_attr]
-        $($async_fn)* fn test_joiner_seek_back_and_forth() {
-            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3).map(|i| (i % 256) as u8).collect();
-            let (root, store) = split_and_store(&data);
-            let mut joiner = $Joiner::new(store, root) $(.$aw)* .unwrap();
+        #[test]
+        fn test_joiner_seek_back_and_forth() {
+            nectar_testing::run(async {
+                let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3)
+                    .map(|i| (i % 256) as u8)
+                    .collect();
+                let (root, store) = split_and_store(&data);
+                let mut joiner = $Joiner::new(store, root).await.unwrap();
 
-            // Read from middle
-            joiner.seek(std::io::SeekFrom::Start(DEFAULT_BODY_SIZE as u64)).unwrap();
-            let buf1 = joiner.read_range(joiner.position(), 100) $(.$aw)* .unwrap();
-            assert_eq!(&buf1, &data[DEFAULT_BODY_SIZE..DEFAULT_BODY_SIZE + 100]);
+                // Read from middle
+                joiner
+                    .seek(std::io::SeekFrom::Start(DEFAULT_BODY_SIZE as u64))
+                    .unwrap();
+                let buf1 = joiner.read_range(joiner.position(), 100).await.unwrap();
+                assert_eq!(&buf1, &data[DEFAULT_BODY_SIZE..DEFAULT_BODY_SIZE + 100]);
 
-            // Seek back to start
-            joiner.seek(std::io::SeekFrom::Start(0)).unwrap();
-            let buf2 = joiner.read_range(joiner.position(), 100) $(.$aw)* .unwrap();
-            assert_eq!(&buf2, &data[..100]);
+                // Seek back to start
+                joiner.seek(std::io::SeekFrom::Start(0)).unwrap();
+                let buf2 = joiner.read_range(joiner.position(), 100).await.unwrap();
+                assert_eq!(&buf2, &data[..100]);
 
-            // Seek to near-end
-            joiner.seek(std::io::SeekFrom::End(-50)).unwrap();
-            let buf3 = joiner.read_range(joiner.position(), 50) $(.$aw)* .unwrap();
-            assert_eq!(&buf3, &data[data.len() - 50..]);
+                // Seek to near-end
+                joiner.seek(std::io::SeekFrom::End(-50)).unwrap();
+                let buf3 = joiner.read_range(joiner.position(), 50).await.unwrap();
+                assert_eq!(&buf3, &data[data.len() - 50..]);
+            })
         }
 
-        #[$test_attr]
-        $($async_fn)* fn test_joiner_seek_end() {
-            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3).map(|i| (i % 256) as u8).collect();
-            let (root, store) = split_and_store(&data);
-            let mut joiner = $Joiner::new(store, root) $(.$aw)* .unwrap();
+        #[test]
+        fn test_joiner_seek_end() {
+            nectar_testing::run(async {
+                let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 3)
+                    .map(|i| (i % 256) as u8)
+                    .collect();
+                let (root, store) = split_and_store(&data);
+                let mut joiner = $Joiner::new(store, root).await.unwrap();
 
-            joiner.seek(std::io::SeekFrom::End(-100)).unwrap();
-            let buf = joiner.read_range(joiner.position(), 100) $(.$aw)* .unwrap();
-            assert_eq!(&buf, &data[data.len() - 100..]);
+                joiner.seek(std::io::SeekFrom::End(-100)).unwrap();
+                let buf = joiner.read_range(joiner.position(), 100).await.unwrap();
+                assert_eq!(&buf, &data[data.len() - 100..]);
+            })
         }
     };
 }
 
-/// Generate encrypted joiner tests for both sync and async variants.
+/// Generate encrypted joiner tests over `$Joiner`.
 ///
 /// The calling module must define:
 /// ```ignore
 /// fn encrypted_split_and_store(data: &[u8])
 ///     -> (EncryptedChunkRef, HashMap<ChunkAddress, Chunk>);
 /// ```
+#[cfg(feature = "encryption")]
 macro_rules! generate_encrypted_joiner_tests {
-    ($test_attr:meta, $Joiner:ident, [$($async_fn:tt)*], [$($aw:tt)*]) => {
-        #[$test_attr]
-        $($async_fn)* fn test_encrypted_joiner_empty() {
-            let (root_ref, store) = encrypted_split_and_store(b"");
-            let joiner = $Joiner::new(store, root_ref) $(.$aw)* .unwrap();
-            assert_eq!(joiner.size(), 0);
-            let result = joiner.read_all() $(.$aw)* .unwrap();
-            assert!(result.is_empty());
+    ($Joiner:ident) => {
+        #[test]
+        fn test_encrypted_joiner_empty() {
+            nectar_testing::run(async {
+                let (root_ref, store) = encrypted_split_and_store(b"");
+                let joiner = $Joiner::new(store, root_ref).await.unwrap();
+                assert_eq!(joiner.size(), 0);
+                let result = joiner.read_all().await.unwrap();
+                assert!(result.is_empty());
+            })
         }
 
-        #[$test_attr]
-        $($async_fn)* fn test_encrypted_joiner_small() {
-            let data = b"hello world";
-            let (root_ref, store) = encrypted_split_and_store(data);
-            let joiner = $Joiner::new(store, root_ref) $(.$aw)* .unwrap();
-            assert_eq!(joiner.size(), data.len() as u64);
-            let result = joiner.read_all() $(.$aw)* .unwrap();
-            assert_eq!(result, data.as_slice());
+        #[test]
+        fn test_encrypted_joiner_small() {
+            nectar_testing::run(async {
+                let data = b"hello world";
+                let (root_ref, store) = encrypted_split_and_store(data);
+                let joiner = $Joiner::new(store, root_ref).await.unwrap();
+                assert_eq!(joiner.size(), data.len() as u64);
+                let result = joiner.read_all().await.unwrap();
+                assert_eq!(result, data.as_slice());
+            })
         }
 
-        #[$test_attr]
-        $($async_fn)* fn test_encrypted_joiner_range() {
-            let data = b"hello encrypted world";
-            let (root_ref, store) = encrypted_split_and_store(data);
-            let joiner = $Joiner::new(store, root_ref) $(.$aw)* .unwrap();
-            let result = joiner.read_range(6, 9) $(.$aw)* .unwrap();
-            assert_eq!(result, b"encrypted");
+        #[test]
+        fn test_encrypted_joiner_range() {
+            nectar_testing::run(async {
+                let data = b"hello encrypted world";
+                let (root_ref, store) = encrypted_split_and_store(data);
+                let joiner = $Joiner::new(store, root_ref).await.unwrap();
+                let result = joiner.read_range(6, 9).await.unwrap();
+                assert_eq!(result, b"encrypted");
+            })
         }
 
-        #[$test_attr]
-        $($async_fn)* fn test_encrypted_joiner_exact_chunk() {
-            let data = vec![0xAB; DEFAULT_BODY_SIZE];
-            let (root_ref, store) = encrypted_split_and_store(&data);
-            let joiner = $Joiner::new(store, root_ref) $(.$aw)* .unwrap();
-            let result = joiner.read_all() $(.$aw)* .unwrap();
-            assert_eq!(result, data);
+        #[test]
+        fn test_encrypted_joiner_exact_chunk() {
+            nectar_testing::run(async {
+                let data = vec![0xAB; DEFAULT_BODY_SIZE];
+                let (root_ref, store) = encrypted_split_and_store(&data);
+                let joiner = $Joiner::new(store, root_ref).await.unwrap();
+                let result = joiner.read_all().await.unwrap();
+                assert_eq!(result, data);
+            })
         }
 
-        #[$test_attr]
-        $($async_fn)* fn test_encrypted_joiner_two_chunks() {
-            let data: Vec<u8> =
-                (0..DEFAULT_BODY_SIZE + 100).map(|i| (i % 256) as u8).collect();
-            let (root_ref, store) = encrypted_split_and_store(&data);
-            let joiner = $Joiner::new(store, root_ref) $(.$aw)* .unwrap();
-            let result = joiner.read_all() $(.$aw)* .unwrap();
-            assert_eq!(result, data);
+        #[test]
+        fn test_encrypted_joiner_two_chunks() {
+            nectar_testing::run(async {
+                let data: Vec<u8> = (0..DEFAULT_BODY_SIZE + 100)
+                    .map(|i| (i % 256) as u8)
+                    .collect();
+                let (root_ref, store) = encrypted_split_and_store(&data);
+                let joiner = $Joiner::new(store, root_ref).await.unwrap();
+                let result = joiner.read_all().await.unwrap();
+                assert_eq!(result, data);
+            })
         }
 
-        #[$test_attr]
-        $($async_fn)* fn test_encrypted_joiner_128_chunks() {
-            let data: Vec<u8> =
-                (0..DEFAULT_BODY_SIZE * 128).map(|i| (i % 256) as u8).collect();
-            let (root_ref, store) = encrypted_split_and_store(&data);
-            let joiner = $Joiner::new(store, root_ref) $(.$aw)* .unwrap();
-            let result = joiner.read_all() $(.$aw)* .unwrap();
-            assert_eq!(result, data);
+        #[test]
+        fn test_encrypted_joiner_128_chunks() {
+            nectar_testing::run(async {
+                let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 128)
+                    .map(|i| (i % 256) as u8)
+                    .collect();
+                let (root_ref, store) = encrypted_split_and_store(&data);
+                let joiner = $Joiner::new(store, root_ref).await.unwrap();
+                let result = joiner.read_all().await.unwrap();
+                assert_eq!(result, data);
+            })
         }
 
-        #[$test_attr]
-        $($async_fn)* fn test_encrypted_joiner_65_chunks() {
-            let data: Vec<u8> =
-                (0..DEFAULT_BODY_SIZE * 65).map(|i| (i % 256) as u8).collect();
-            let (root_ref, store) = encrypted_split_and_store(&data);
-            let joiner = $Joiner::new(store, root_ref) $(.$aw)* .unwrap();
-            let result = joiner.read_all() $(.$aw)* .unwrap();
-            assert_eq!(result, data);
+        #[test]
+        fn test_encrypted_joiner_65_chunks() {
+            nectar_testing::run(async {
+                let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 65)
+                    .map(|i| (i % 256) as u8)
+                    .collect();
+                let (root_ref, store) = encrypted_split_and_store(&data);
+                let joiner = $Joiner::new(store, root_ref).await.unwrap();
+                let result = joiner.read_all().await.unwrap();
+                assert_eq!(result, data);
+            })
         }
 
-        #[$test_attr]
-        $($async_fn)* fn test_encrypted_joiner_256_chunks() {
-            let data: Vec<u8> =
-                (0..DEFAULT_BODY_SIZE * 256).map(|i| (i % 256) as u8).collect();
-            let (root_ref, store) = encrypted_split_and_store(&data);
-            let joiner = $Joiner::new(store, root_ref) $(.$aw)* .unwrap();
-            let result = joiner.read_all() $(.$aw)* .unwrap();
-            assert_eq!(result, data);
+        #[test]
+        fn test_encrypted_joiner_256_chunks() {
+            nectar_testing::run(async {
+                let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 256)
+                    .map(|i| (i % 256) as u8)
+                    .collect();
+                let (root_ref, store) = encrypted_split_and_store(&data);
+                let joiner = $Joiner::new(store, root_ref).await.unwrap();
+                let result = joiner.read_all().await.unwrap();
+                assert_eq!(result, data);
+            })
         }
 
-        #[$test_attr]
-        $($async_fn)* fn test_encrypted_joiner_range_from_middle() {
-            let data: Vec<u8> =
-                (0..DEFAULT_BODY_SIZE * 128).map(|i| (i % 256) as u8).collect();
-            let (root_ref, store) = encrypted_split_and_store(&data);
-            let joiner = $Joiner::new(store, root_ref) $(.$aw)* .unwrap();
-            let start = DEFAULT_BODY_SIZE * 50;
-            let len = DEFAULT_BODY_SIZE * 10;
-            let result = joiner.read_range(start as u64, len) $(.$aw)* .unwrap();
-            assert_eq!(result, &data[start..start + len]);
+        #[test]
+        fn test_encrypted_joiner_range_from_middle() {
+            nectar_testing::run(async {
+                let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 128)
+                    .map(|i| (i % 256) as u8)
+                    .collect();
+                let (root_ref, store) = encrypted_split_and_store(&data);
+                let joiner = $Joiner::new(store, root_ref).await.unwrap();
+                let start = DEFAULT_BODY_SIZE * 50;
+                let len = DEFAULT_BODY_SIZE * 10;
+                let result = joiner.read_range(start as u64, len).await.unwrap();
+                assert_eq!(result, &data[start..start + len]);
+            })
         }
 
-        #[$test_attr]
-        $($async_fn)* fn test_encrypted_joiner_seek() {
-            let data = b"hello encrypted world";
-            let (root_ref, store) = encrypted_split_and_store(data);
-            let mut joiner = $Joiner::new(store, root_ref) $(.$aw)* .unwrap();
-            joiner.seek(std::io::SeekFrom::Start(6)).unwrap();
-            let result = joiner.read_range(joiner.position(), 9) $(.$aw)* .unwrap();
-            assert_eq!(result, b"encrypted");
+        #[test]
+        fn test_encrypted_joiner_seek() {
+            nectar_testing::run(async {
+                let data = b"hello encrypted world";
+                let (root_ref, store) = encrypted_split_and_store(data);
+                let mut joiner = $Joiner::new(store, root_ref).await.unwrap();
+                joiner.seek(std::io::SeekFrom::Start(6)).unwrap();
+                let result = joiner.read_range(joiner.position(), 9).await.unwrap();
+                assert_eq!(result, b"encrypted");
+            })
         }
 
-        #[$test_attr]
-        $($async_fn)* fn test_encrypted_joiner_seek_past_end() {
-            let data = b"test data";
-            let (root_ref, store) = encrypted_split_and_store(data);
-            let mut joiner = $Joiner::new(store, root_ref) $(.$aw)* .unwrap();
-            joiner.seek(std::io::SeekFrom::Start(1000)).unwrap();
-            let result = joiner.read_range(joiner.position(), 10) $(.$aw)* .unwrap();
-            assert!(result.is_empty());
+        #[test]
+        fn test_encrypted_joiner_seek_past_end() {
+            nectar_testing::run(async {
+                let data = b"test data";
+                let (root_ref, store) = encrypted_split_and_store(data);
+                let mut joiner = $Joiner::new(store, root_ref).await.unwrap();
+                joiner.seek(std::io::SeekFrom::Start(1000)).unwrap();
+                let result = joiner.read_range(joiner.position(), 10).await.unwrap();
+                assert!(result.is_empty());
+            })
         }
     };
 }

--- a/crates/primitives/src/file/splitter_parallel.rs
+++ b/crates/primitives/src/file/splitter_parallel.rs
@@ -206,6 +206,7 @@ mod tests {
     use super::*;
     use crate::file::join;
     use crate::store::MemoryStore;
+    use nectar_testing::run;
 
     fn split_and_store(
         data: &[u8],
@@ -224,17 +225,19 @@ mod tests {
 
     #[test]
     fn test_parallel_splitter_varying_data() {
-        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 123)
-            .map(|i| (i % 256) as u8)
-            .collect();
+        run(async {
+            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 123)
+                .map(|i| (i % 256) as u8)
+                .collect();
 
-        let (root, store) = split_and_store(&data);
+            let (root, store) = split_and_store(&data);
 
-        let (seq_root, _) = crate::file::split::<DEFAULT_BODY_SIZE>(&data).unwrap();
-        assert_eq!(root, seq_root);
+            let (seq_root, _) = crate::file::split::<DEFAULT_BODY_SIZE>(&data).unwrap();
+            assert_eq!(root, seq_root);
 
-        let recovered = futures::executor::block_on(join(&store, root)).unwrap();
-        assert_eq!(recovered, data);
+            let recovered = join(&store, root).await.unwrap();
+            assert_eq!(recovered, data);
+        })
     }
 
     #[test]
@@ -275,20 +278,22 @@ mod tests {
 
         #[test]
         fn test_encrypted_parallel_matches_sequential() {
-            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 123)
-                .map(|i| (i % 256) as u8)
-                .collect();
+            run(async {
+                let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 123)
+                    .map(|i| (i % 256) as u8)
+                    .collect();
 
-            let (par_ref, par_store) = encrypted_split_and_store(&data);
-            let (seq_ref, seq_store) = split_encrypted::<DEFAULT_BODY_SIZE>(&data).unwrap();
+                let (par_ref, par_store) = encrypted_split_and_store(&data);
+                let (seq_ref, seq_store) = split_encrypted::<DEFAULT_BODY_SIZE>(&data).unwrap();
 
-            assert_eq!(par_store.len(), seq_store.len());
+                assert_eq!(par_store.len(), seq_store.len());
 
-            let par_recovered = futures::executor::block_on(join(&par_store, par_ref)).unwrap();
-            assert_eq!(par_recovered, data);
+                let par_recovered = join(&par_store, par_ref).await.unwrap();
+                assert_eq!(par_recovered, data);
 
-            let seq_recovered = futures::executor::block_on(join(&seq_store, seq_ref)).unwrap();
-            assert_eq!(seq_recovered, data);
+                let seq_recovered = join(&seq_store, seq_ref).await.unwrap();
+                assert_eq!(seq_recovered, data);
+            })
         }
 
         #[test]

--- a/crates/primitives/src/file/splitter_tests.rs
+++ b/crates/primitives/src/file/splitter_tests.rs
@@ -59,12 +59,14 @@ macro_rules! generate_plain_splitter_tests {
 
         #[test]
         fn test_splitter_roundtrip_varying() {
-            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 123)
-                .map(|i| (i % 256) as u8)
-                .collect();
-            let (root, store) = $split_fn(&data);
-            let recovered = futures::executor::block_on(crate::file::join(&store, root)).unwrap();
-            assert_eq!(recovered, data);
+            nectar_testing::run(async {
+                let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 123)
+                    .map(|i| (i % 256) as u8)
+                    .collect();
+                let (root, store) = $split_fn(&data);
+                let recovered = crate::file::join(&store, root).await.unwrap();
+                assert_eq!(recovered, data);
+            })
         }
     };
 }
@@ -76,6 +78,7 @@ macro_rules! generate_plain_splitter_tests {
 /// fn encrypted_split_and_store(data: &[u8])
 ///     -> (EncryptedChunkRef, MemoryStore<StandardChunkSet>);
 /// ```
+#[cfg(feature = "encryption")]
 macro_rules! generate_encrypted_splitter_tests {
     ($split_fn:ident) => {
         #[test]
@@ -95,25 +98,27 @@ macro_rules! generate_encrypted_splitter_tests {
 
         #[test]
         fn test_encrypted_splitter_two_chunks() {
-            let data = vec![0xCD; DEFAULT_BODY_SIZE + 1];
-            let (root_ref, store) = $split_fn(&data);
-            assert_eq!(store.len(), 3);
+            nectar_testing::run(async {
+                let data = vec![0xCD; DEFAULT_BODY_SIZE + 1];
+                let (root_ref, store) = $split_fn(&data);
+                assert_eq!(store.len(), 3);
 
-            let recovered =
-                futures::executor::block_on(crate::file::join(&store, root_ref)).unwrap();
-            assert_eq!(recovered, data);
+                let recovered = crate::file::join(&store, root_ref).await.unwrap();
+                assert_eq!(recovered, data);
+            })
         }
 
         #[test]
         fn test_encrypted_splitter_roundtrip() {
-            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 123)
-                .map(|i| (i % 256) as u8)
-                .collect();
-            let (root_ref, store) = $split_fn(&data);
+            nectar_testing::run(async {
+                let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 123)
+                    .map(|i| (i % 256) as u8)
+                    .collect();
+                let (root_ref, store) = $split_fn(&data);
 
-            let recovered =
-                futures::executor::block_on(crate::file::join(&store, root_ref)).unwrap();
-            assert_eq!(recovered, data);
+                let recovered = crate::file::join(&store, root_ref).await.unwrap();
+                assert_eq!(recovered, data);
+            })
         }
     };
 }

--- a/crates/primitives/src/file/tests.rs
+++ b/crates/primitives/src/file/tests.rs
@@ -146,7 +146,7 @@ fn test_go_vectors_large() {
 mod encrypted {
     use crate::bmt::DEFAULT_BODY_SIZE;
     use crate::file::{join, split_encrypted};
-    use futures::executor::block_on;
+    use nectar_testing::run;
 
     /// Test sizes covering various boundary conditions.
     const TEST_SIZES: &[usize] = &[
@@ -164,7 +164,7 @@ mod encrypted {
         1_000_000,
     ];
 
-    fn run_encrypted_roundtrip(size: usize) {
+    async fn run_encrypted_roundtrip(size: usize) {
         let data: Vec<u8> = (0..size).map(|i| (i % 255) as u8).collect();
 
         let (root_ref, store) = split_encrypted::<DEFAULT_BODY_SIZE>(&data).unwrap();
@@ -175,16 +175,18 @@ mod encrypted {
             "Root ref must be 64 bytes for size {size}"
         );
 
-        let recovered = block_on(join(&store, root_ref)).unwrap();
+        let recovered = join(&store, root_ref).await.unwrap();
         assert_eq!(recovered, data, "Round-trip failed for size {size}");
     }
 
     #[test]
     fn encrypted_roundtrip_all_sizes() {
-        for &size in TEST_SIZES {
-            run_encrypted_roundtrip(size);
-            eprintln!("  encrypted roundtrip: {size} bytes OK");
-        }
+        run(async {
+            for &size in TEST_SIZES {
+                run_encrypted_roundtrip(size).await;
+                eprintln!("  encrypted roundtrip: {size} bytes OK");
+            }
+        })
     }
 
     #[test]
@@ -220,58 +222,69 @@ mod write_file_ext {
     use crate::bmt::DEFAULT_BODY_SIZE;
     use crate::file::{ChunkGetExt, ChunkPutExt};
     use crate::store::MemoryStore;
-    use futures::executor::block_on;
+    use nectar_testing::run;
 
     #[test]
     fn write_file_roundtrip() {
-        let store = MemoryStore::<crate::chunk::StandardChunkSet>::new();
-        let addr = block_on(store.write_file(b"hello swarm".to_vec())).unwrap();
-        let recovered = block_on(store.read_file(addr)).unwrap();
-        assert_eq!(recovered, b"hello swarm");
+        run(async {
+            let store = MemoryStore::<crate::chunk::StandardChunkSet>::new();
+            let addr = store.write_file(b"hello swarm".to_vec()).await.unwrap();
+            let recovered = store.read_file(addr).await.unwrap();
+            assert_eq!(recovered, b"hello swarm");
+        })
     }
 
     #[test]
     fn write_file_large() {
-        let data = vec![0xAB; 8192];
-        let store = MemoryStore::<crate::chunk::StandardChunkSet>::new();
-        let addr = block_on(store.write_file(data.clone())).unwrap();
-        let recovered = block_on(store.read_file(addr)).unwrap();
-        assert_eq!(recovered, data);
+        run(async {
+            let data = vec![0xAB; 8192];
+            let store = MemoryStore::<crate::chunk::StandardChunkSet>::new();
+            let addr = store.write_file(data.clone()).await.unwrap();
+            let recovered = store.read_file(addr).await.unwrap();
+            assert_eq!(recovered, data);
+        })
     }
 
     #[test]
     fn splitter_chunks_roundtrip() {
-        use std::io::Write;
+        run(async {
+            use std::io::Write;
 
-        use crate::file::Splitter;
-        use crate::store::ChunkPut;
+            use crate::file::Splitter;
+            use crate::store::ChunkPut;
 
-        let store = MemoryStore::<crate::chunk::StandardChunkSet>::new();
-        let data = b"streaming via splitter";
-        let mut splitter = Splitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
-        splitter.write_all(data).unwrap();
-        let (root, chunks) = splitter.finish().unwrap();
-        for chunk in chunks {
-            let sealed = crate::chunk::Chunk::from_envelope(chunk.into()).unwrap();
-            block_on(store.put(sealed)).unwrap();
-        }
-        let recovered = block_on(store.read_file(root)).unwrap();
-        assert_eq!(recovered, data);
+            let store = MemoryStore::<crate::chunk::StandardChunkSet>::new();
+            let data = b"streaming via splitter";
+            let mut splitter = Splitter::<DEFAULT_BODY_SIZE>::new(data.len() as u64);
+            splitter.write_all(data).unwrap();
+            let (root, chunks) = splitter.finish().unwrap();
+            for chunk in chunks {
+                let sealed = crate::chunk::Chunk::from_envelope(chunk.into()).unwrap();
+                store.put(sealed).await.unwrap();
+            }
+            let recovered = store.read_file(root).await.unwrap();
+            assert_eq!(recovered, data);
+        })
     }
 
     #[cfg(feature = "encryption")]
     mod encrypted {
         use crate::file::{ChunkGetExt, ChunkPutExt};
         use crate::store::MemoryStore;
-        use futures::executor::block_on;
+        use nectar_testing::run;
 
         #[test]
         #[allow(deprecated)] // pins the deprecated ergonomic wrapper's behaviour until removal
         fn write_encrypted_file_roundtrip() {
-            let store = MemoryStore::<crate::chunk::StandardChunkSet>::new();
-            let enc_ref = block_on(store.write_encrypted_file(b"secret data".to_vec())).unwrap();
-            let recovered = block_on(store.read_file(enc_ref)).unwrap();
-            assert_eq!(recovered, b"secret data");
+            run(async {
+                let store = MemoryStore::<crate::chunk::StandardChunkSet>::new();
+                let enc_ref = store
+                    .write_encrypted_file(b"secret data".to_vec())
+                    .await
+                    .unwrap();
+                let recovered = store.read_file(enc_ref).await.unwrap();
+                assert_eq!(recovered, b"secret data");
+            })
         }
     }
 }

--- a/crates/primitives/src/file/windowed.rs
+++ b/crates/primitives/src/file/windowed.rs
@@ -607,7 +607,7 @@ mod tests {
     use crate::file::Joiner;
     use crate::file::split;
     use crate::store::ChunkGet;
-    use futures::executor::block_on;
+    use nectar_testing::run;
     use std::collections::HashMap;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -630,27 +630,27 @@ mod tests {
 
     #[test]
     fn stream_from_zero_equals_whole_file() {
-        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 321)
-            .map(|i| (i % 256) as u8)
-            .collect();
-        let (root, store) = split_and_store(&data);
-        block_on(async {
+        run(async {
+            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 321)
+                .map(|i| (i % 256) as u8)
+                .collect();
+            let (root, store) = split_and_store(&data);
             let joiner = Joiner::new(store, root).await.unwrap();
             let mut reader = joiner.into_windowed_reader(16);
             let got = drain(&mut reader).await;
             assert_eq!(got, data);
-        });
+        })
     }
 
     #[test]
     fn seek_then_stream_yields_suffix() {
-        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 321)
-            .map(|i| (i % 256) as u8)
-            .collect();
-        let bs = DEFAULT_BODY_SIZE as u64;
-        let cases = [bs + 10, bs, bs * 3, bs / 2, data.len() as u64 - 1];
-        let (root, store) = split_and_store(&data);
-        block_on(async {
+        run(async {
+            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 321)
+                .map(|i| (i % 256) as u8)
+                .collect();
+            let bs = DEFAULT_BODY_SIZE as u64;
+            let cases = [bs + 10, bs, bs * 3, bs / 2, data.len() as u64 - 1];
+            let (root, store) = split_and_store(&data);
             for k in cases {
                 let joiner = Joiner::new(store.clone(), root).await.unwrap();
                 let mut reader = joiner.into_windowed_reader(16);
@@ -658,17 +658,17 @@ mod tests {
                 let got = drain(&mut reader).await;
                 assert_eq!(got, &data[k as usize..], "suffix from {k}");
             }
-        });
+        })
     }
 
     #[test]
     fn backward_seek_then_read_is_correct() {
-        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 4 + 17)
-            .map(|i| (i % 256) as u8)
-            .collect();
-        let bs = DEFAULT_BODY_SIZE as u64;
-        let (root, store) = split_and_store(&data);
-        block_on(async {
+        run(async {
+            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 4 + 17)
+                .map(|i| (i % 256) as u8)
+                .collect();
+            let bs = DEFAULT_BODY_SIZE as u64;
+            let (root, store) = split_and_store(&data);
             let joiner = Joiner::new(store, root).await.unwrap();
             let mut reader = joiner.into_windowed_reader(16);
             reader.seek(SeekFrom::Start(bs * 3)).unwrap();
@@ -676,21 +676,21 @@ mod tests {
             reader.seek(SeekFrom::Start(bs)).unwrap();
             let got = drain(&mut reader).await;
             assert_eq!(got, &data[bs as usize..]);
-        });
+        })
     }
 
     #[test]
     fn width_one_correct() {
-        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 7)
-            .map(|i| (i % 256) as u8)
-            .collect();
-        let (root, store) = split_and_store(&data);
-        block_on(async {
+        run(async {
+            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 7)
+                .map(|i| (i % 256) as u8)
+                .collect();
+            let (root, store) = split_and_store(&data);
             let joiner = Joiner::new(store, root).await.unwrap().with_concurrency(1);
             let mut reader = joiner.into_windowed_reader(1);
             let got = drain(&mut reader).await;
             assert_eq!(got, data);
-        });
+        })
     }
 
     /// A self-waking yield: returns `Pending` once and immediately schedules a
@@ -746,23 +746,23 @@ mod tests {
 
     #[test]
     fn reorder_buffer_never_exceeds_window() {
-        // Many leaves, small window: leaf fetches overlap, so without the bound
-        // the in-flight peak would climb to the leaf count. The window caps it.
-        let leaves = 40usize;
-        let window = 6usize;
-        let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * leaves)
-            .map(|i| (i % 256) as u8)
-            .collect();
-        let (root, store) = split_and_store(&data);
+        run(async {
+            // Many leaves, small window: leaf fetches overlap, so without the bound
+            // the in-flight peak would climb to the leaf count. The window caps it.
+            let leaves = 40usize;
+            let window = 6usize;
+            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * leaves)
+                .map(|i| (i % 256) as u8)
+                .collect();
+            let (root, store) = split_and_store(&data);
 
-        let probe = BoundProbe {
-            chunks: Arc::new(store),
-            in_flight: Arc::new(AtomicUsize::new(0)),
-            max_in_flight: Arc::new(AtomicUsize::new(0)),
-        };
-        let max_seen = Arc::clone(&probe.max_in_flight);
+            let probe = BoundProbe {
+                chunks: Arc::new(store),
+                in_flight: Arc::new(AtomicUsize::new(0)),
+                max_in_flight: Arc::new(AtomicUsize::new(0)),
+            };
+            let max_seen = Arc::clone(&probe.max_in_flight);
 
-        block_on(async {
             let joiner = Joiner::new(probe, root)
                 .await
                 .unwrap()
@@ -775,17 +775,17 @@ mod tests {
                 total += item.unwrap().len();
             }
             assert_eq!(total, data.len());
-        });
 
-        // The reorder buffer admits at most `window` leaves, so concurrent leaf
-        // fetches (plus the intermediate node fetches that seed children) never
-        // climb far above the window. Allow a small slack for in-flight
-        // intermediates, but assert it is nowhere near the leaf count.
-        let peak = max_seen.load(Ordering::SeqCst);
-        assert!(
-            peak <= window + 2,
-            "in-flight peak {peak} exceeds window {window} (+slack)"
-        );
+            // The reorder buffer admits at most `window` leaves, so concurrent leaf
+            // fetches (plus the intermediate node fetches that seed children) never
+            // climb far above the window. Allow a small slack for in-flight
+            // intermediates, but assert it is nowhere near the leaf count.
+            let peak = max_seen.load(Ordering::SeqCst);
+            assert!(
+                peak <= window + 2,
+                "in-flight peak {peak} exceeds window {window} (+slack)"
+            );
+        })
     }
 
     /// A getter that delays the leaf at `slow_offset` until `gate` other leaves
@@ -865,32 +865,32 @@ mod tests {
 
     #[test]
     fn head_slowest_in_order_and_bounded() {
-        // The head leaf at `position` resolves last among the leaves in its
-        // window. Under the old buffer this leaks: with the head missing, the
-        // walk kept `window` leaf fetches in flight while also buffering the
-        // resolved stragglers, so resident leaf bodies reached roughly twice the
-        // window. The sliding window keeps in-flight plus buffered at `window` and
-        // delivery in order. A naive run at `gate = window` instead would deadlock
-        // the correct walk (the head can never release), so the gate is the most a
-        // non-deadlocking adversary can demand, and the old buffer still overruns
-        // it.
-        let leaves = 40usize;
-        let window = 6usize;
-        let total = (DEFAULT_BODY_SIZE * leaves) as u64;
-        let data: Vec<u8> = (0..total).map(unique_byte).collect();
-        let (root, store) = split_and_store(&data);
+        run(async {
+            // The head leaf at `position` resolves last among the leaves in its
+            // window. Under the old buffer this leaks: with the head missing, the
+            // walk kept `window` leaf fetches in flight while also buffering the
+            // resolved stragglers, so resident leaf bodies reached roughly twice the
+            // window. The sliding window keeps in-flight plus buffered at `window` and
+            // delivery in order. A naive run at `gate = window` instead would deadlock
+            // the correct walk (the head can never release), so the gate is the most a
+            // non-deadlocking adversary can demand, and the old buffer still overruns
+            // it.
+            let leaves = 40usize;
+            let window = 6usize;
+            let total = (DEFAULT_BODY_SIZE * leaves) as u64;
+            let data: Vec<u8> = (0..total).map(unique_byte).collect();
+            let (root, store) = split_and_store(&data);
 
-        PEAK_LEAF_OCCUPANCY.with(|p| p.set(0));
-        let leaf_offsets = leaf_offsets_of(total);
-        let getter = HeadSlow {
-            chunks: Arc::new(store),
-            slow_offset: 0,
-            released: Arc::new(AtomicUsize::new(0)),
-            gate: window - 1,
-            leaf_offsets: Arc::new(leaf_offsets),
-        };
+            PEAK_LEAF_OCCUPANCY.with(|p| p.set(0));
+            let leaf_offsets = leaf_offsets_of(total);
+            let getter = HeadSlow {
+                chunks: Arc::new(store),
+                slow_offset: 0,
+                released: Arc::new(AtomicUsize::new(0)),
+                gate: window - 1,
+                leaf_offsets: Arc::new(leaf_offsets),
+            };
 
-        block_on(async {
             let joiner = Joiner::new(getter, root)
                 .await
                 .unwrap()
@@ -903,13 +903,13 @@ mod tests {
                 got.extend_from_slice(&item.unwrap());
             }
             assert_eq!(got, data, "head-slowest still yields whole file in order");
-        });
 
-        let peak = PEAK_LEAF_OCCUPANCY.with(std::cell::Cell::get);
-        assert!(
-            peak <= window,
-            "leaf-body occupancy peak {peak} exceeds window {window}"
-        );
+            let peak = PEAK_LEAF_OCCUPANCY.with(std::cell::Cell::get);
+            assert!(
+                peak <= window,
+                "leaf-body occupancy peak {peak} exceeds window {window}"
+            );
+        })
     }
 
     // --- Front-load / deep-frontier guards (small body size = deep tree) ---
@@ -1004,11 +1004,11 @@ mod tests {
     /// fetched after only a short descent, not after the whole frontier drains.
     #[test]
     fn windowed_first_leaf_before_frontier() {
-        let data = tiny_deep_data(900);
-        let (root, store) = split::<TINY_BODY>(&data).unwrap();
-        let probe = TinyOrderProbe::new(store.into_chunks(), &data);
+        run(async {
+            let data = tiny_deep_data(900);
+            let (root, store) = split::<TINY_BODY>(&data).unwrap();
+            let probe = TinyOrderProbe::new(store.into_chunks(), &data);
 
-        block_on(async {
             let joiner = Joiner::<_, TINY_BODY>::new(probe.clone(), root)
                 .await
                 .unwrap();
@@ -1022,24 +1022,24 @@ mod tests {
                 got.extend_from_slice(&item.unwrap());
             }
             assert_eq!(got, data, "deep-tree in-order reassembly is byte-exact");
-        });
 
-        let frontier = probe.intermediate_fetches();
-        assert!(
-            frontier >= 40,
-            "test needs a frontier far larger than the cap, saw {frontier}"
-        );
-        let before = probe.intermediates_before_first_leaf();
-        assert!(
-            before <= 4 * MAX_INTERMEDIATE_IN_FLIGHT,
-            "first leaf fetched after {before} intermediates (frontier {frontier}); \
+            let frontier = probe.intermediate_fetches();
+            assert!(
+                frontier >= 40,
+                "test needs a frontier far larger than the cap, saw {frontier}"
+            );
+            let before = probe.intermediates_before_first_leaf();
+            assert!(
+                before <= 4 * MAX_INTERMEDIATE_IN_FLIGHT,
+                "first leaf fetched after {before} intermediates (frontier {frontier}); \
              expected a short descent, not the whole frontier"
-        );
-        let peak = probe.peak_intermediate.load(Ordering::SeqCst);
-        assert!(
-            peak <= MAX_INTERMEDIATE_IN_FLIGHT,
-            "intermediate in-flight peak {peak} exceeds cap {MAX_INTERMEDIATE_IN_FLIGHT}"
-        );
+            );
+            let peak = probe.peak_intermediate.load(Ordering::SeqCst);
+            assert!(
+                peak <= MAX_INTERMEDIATE_IN_FLIGHT,
+                "intermediate in-flight peak {peak} exceeds cap {MAX_INTERMEDIATE_IN_FLIGHT}"
+            );
+        })
     }
 
     /// A multi-level frontier (intermediates whose children are themselves
@@ -1048,14 +1048,14 @@ mod tests {
     /// contiguous emittable prefix, so the head is never starved.
     #[test]
     fn windowed_deep_frontier_in_order_and_bounded() {
-        let leaves = 2000usize;
-        let window = 5usize;
-        let data = tiny_deep_data(leaves);
-        let (root, store) = split::<TINY_BODY>(&data).unwrap();
-        let probe = TinyOrderProbe::new(store.into_chunks(), &data);
+        run(async {
+            let leaves = 2000usize;
+            let window = 5usize;
+            let data = tiny_deep_data(leaves);
+            let (root, store) = split::<TINY_BODY>(&data).unwrap();
+            let probe = TinyOrderProbe::new(store.into_chunks(), &data);
 
-        PEAK_LEAF_OCCUPANCY.with(|p| p.set(0));
-        block_on(async {
+            PEAK_LEAF_OCCUPANCY.with(|p| p.set(0));
             let joiner = Joiner::<_, TINY_BODY>::new(probe.clone(), root)
                 .await
                 .unwrap()
@@ -1069,45 +1069,45 @@ mod tests {
                 got.extend_from_slice(&item.unwrap());
             }
             assert_eq!(got, data, "deep frontier still yields whole file in order");
-        });
 
-        let occupancy = PEAK_LEAF_OCCUPANCY.with(std::cell::Cell::get);
-        assert!(
-            occupancy <= window,
-            "leaf-body occupancy peak {occupancy} exceeds window {window}"
-        );
-        let peak = probe.peak_intermediate.load(Ordering::SeqCst);
-        assert!(
-            peak <= MAX_INTERMEDIATE_IN_FLIGHT,
-            "intermediate in-flight peak {peak} exceeds cap {MAX_INTERMEDIATE_IN_FLIGHT}"
-        );
+            let occupancy = PEAK_LEAF_OCCUPANCY.with(std::cell::Cell::get);
+            assert!(
+                occupancy <= window,
+                "leaf-body occupancy peak {occupancy} exceeds window {window}"
+            );
+            let peak = probe.peak_intermediate.load(Ordering::SeqCst);
+            assert!(
+                peak <= MAX_INTERMEDIATE_IN_FLIGHT,
+                "intermediate in-flight peak {peak} exceeds cap {MAX_INTERMEDIATE_IN_FLIGHT}"
+            );
+        })
     }
 
     #[cfg(feature = "encryption")]
     #[test]
     fn head_slowest_encrypted_in_order_and_bounded() {
-        // Encrypted leaf bodies are shorter than BODY_SIZE, so the slide must
-        // advance by body.len(), not the stride. Encrypted leaf addresses hash
-        // the ciphertext and are not reconstructible from plaintext here, so the
-        // head cannot be singled out; a uniform delay across all fetches still
-        // overlaps concurrently admitted leaves, and the occupancy hook proves a
-        // correct walk holds at most `window` leaf bodies on short bodies.
-        use crate::file::EncryptedJoiner;
-        use crate::file::split_encrypted;
+        run(async {
+            // Encrypted leaf bodies are shorter than BODY_SIZE, so the slide must
+            // advance by body.len(), not the stride. Encrypted leaf addresses hash
+            // the ciphertext and are not reconstructible from plaintext here, so the
+            // head cannot be singled out; a uniform delay across all fetches still
+            // overlaps concurrently admitted leaves, and the occupancy hook proves a
+            // correct walk holds at most `window` leaf bodies on short bodies.
+            use crate::file::EncryptedJoiner;
+            use crate::file::split_encrypted;
 
-        let leaves = 30usize;
-        let window = 5usize;
-        let total = (DEFAULT_BODY_SIZE * leaves) as u64;
-        let data: Vec<u8> = (0..total).map(unique_byte).collect();
-        let (root_ref, store) = split_encrypted::<DEFAULT_BODY_SIZE>(&data).unwrap();
-        let store = store.into_chunks();
+            let leaves = 30usize;
+            let window = 5usize;
+            let total = (DEFAULT_BODY_SIZE * leaves) as u64;
+            let data: Vec<u8> = (0..total).map(unique_byte).collect();
+            let (root_ref, store) = split_encrypted::<DEFAULT_BODY_SIZE>(&data).unwrap();
+            let store = store.into_chunks();
 
-        PEAK_LEAF_OCCUPANCY.with(|p| p.set(0));
-        let getter = UniformSlow {
-            chunks: Arc::new(store),
-        };
+            PEAK_LEAF_OCCUPANCY.with(|p| p.set(0));
+            let getter = UniformSlow {
+                chunks: Arc::new(store),
+            };
 
-        block_on(async {
             let joiner = EncryptedJoiner::new(getter, root_ref)
                 .await
                 .unwrap()
@@ -1120,13 +1120,13 @@ mod tests {
                 out.extend_from_slice(&item.unwrap());
             }
             assert_eq!(out, data, "encrypted short-body slide stays in order");
-        });
 
-        let peak = PEAK_LEAF_OCCUPANCY.with(std::cell::Cell::get);
-        assert!(
-            peak <= window,
-            "encrypted leaf-body occupancy peak {peak} exceeds window {window}"
-        );
+            let peak = PEAK_LEAF_OCCUPANCY.with(std::cell::Cell::get);
+            assert!(
+                peak <= window,
+                "encrypted leaf-body occupancy peak {peak} exceeds window {window}"
+            );
+        })
     }
 
     /// A getter that holds every fetch open across several self-waking yields so
@@ -1178,13 +1178,13 @@ mod tests {
 
         #[test]
         fn encrypted_stream_and_seek() {
-            let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 321)
-                .map(|i| (i % 256) as u8)
-                .collect();
-            let bs = DEFAULT_BODY_SIZE as u64;
-            let (root_ref, store) = split_encrypted::<DEFAULT_BODY_SIZE>(&data).unwrap();
-            let store = store.into_chunks();
-            block_on(async {
+            run(async {
+                let data: Vec<u8> = (0..DEFAULT_BODY_SIZE * 5 + 321)
+                    .map(|i| (i % 256) as u8)
+                    .collect();
+                let bs = DEFAULT_BODY_SIZE as u64;
+                let (root_ref, store) = split_encrypted::<DEFAULT_BODY_SIZE>(&data).unwrap();
+                let store = store.into_chunks();
                 // whole file
                 let joiner = EncryptedJoiner::new(store.clone(), root_ref.clone())
                     .await
@@ -1201,7 +1201,7 @@ mod tests {
                     reader.seek(SeekFrom::Start(k)).unwrap();
                     assert_eq!(drain_enc(&mut reader).await, &data[k as usize..]);
                 }
-            });
+            })
         }
     }
 

--- a/crates/primitives/src/file/write_at.rs
+++ b/crates/primitives/src/file/write_at.rs
@@ -179,11 +179,11 @@ where
 mod tests {
     use super::*;
 
-    use futures::executor::block_on;
+    use nectar_testing::run;
 
     #[test]
     fn sparse_writes_reassemble() {
-        block_on(async {
+        run(async {
             let sink = Mutex::new(Vec::new());
             sink.set_len(10).await.unwrap();
             // High offset first, then a low offset.
@@ -196,7 +196,7 @@ mod tests {
 
     #[test]
     fn out_of_order_full_coverage() {
-        block_on(async {
+        run(async {
             let sink = Mutex::new(Vec::new());
             sink.set_len(6).await.unwrap();
             sink.write_at(4, b"23").await.unwrap();
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn ref_forwarding_writes_through() {
-        block_on(async {
+        run(async {
             let sink = Mutex::new(Vec::new());
             let r = &sink;
             r.set_len(4).await.unwrap();
@@ -219,7 +219,7 @@ mod tests {
 
     #[test]
     fn flush_default_is_noop() {
-        block_on(async {
+        run(async {
             let sink = Mutex::new(Vec::new());
             sink.write_at(0, b"complete").await.unwrap();
             sink.flush().await.unwrap();
@@ -229,7 +229,7 @@ mod tests {
 
     #[test]
     fn set_len_presizes() {
-        block_on(async {
+        run(async {
             let sink = Mutex::new(Vec::new());
             sink.set_len(8).await.unwrap();
             assert_eq!(sink.into_inner().unwrap(), vec![0u8; 8]);
@@ -244,7 +244,7 @@ mod download_tests {
     use crate::DEFAULT_BODY_SIZE;
     use crate::chunk::Chunk;
     use crate::file::{Joiner, split};
-    use futures::executor::block_on;
+    use nectar_testing::run;
     use std::collections::HashMap;
 
     type Store = HashMap<crate::ChunkAddress, Chunk>;
@@ -259,52 +259,59 @@ mod download_tests {
     }
 
     /// `download_into` reassembles bytes equal to `read_all` across tree shapes.
-    fn assert_download_matches(data: &[u8], width: usize) {
-        block_on(async {
-            let (root, store) = split_and_store(data);
+    async fn assert_download_matches(data: &[u8], width: usize) {
+        let (root, store) = split_and_store(data);
 
-            let expected = Joiner::new(store.clone(), root)
-                .await
-                .unwrap()
-                .read_all()
-                .await
-                .unwrap();
+        let expected = Joiner::new(store.clone(), root)
+            .await
+            .unwrap()
+            .read_all()
+            .await
+            .unwrap();
 
-            let joiner = Joiner::new(store, root)
-                .await
-                .unwrap()
-                .with_concurrency(width);
-            let sink = Mutex::new(Vec::new());
-            joiner.download_into(&sink).await.unwrap();
+        let joiner = Joiner::new(store, root)
+            .await
+            .unwrap()
+            .with_concurrency(width);
+        let sink = Mutex::new(Vec::new());
+        joiner.download_into(&sink).await.unwrap();
 
-            assert_eq!(sink.into_inner().unwrap(), expected);
-        });
+        assert_eq!(sink.into_inner().unwrap(), expected);
     }
 
     #[test]
     fn download_into_small() {
-        assert_download_matches(b"hello world", DEFAULT_BODY_SIZE);
+        run(async {
+            assert_download_matches(b"hello world", DEFAULT_BODY_SIZE).await;
+        })
     }
 
     #[test]
     fn download_into_exact_chunk() {
-        assert_download_matches(&sample(DEFAULT_BODY_SIZE), 8);
+        run(async {
+            assert_download_matches(&sample(DEFAULT_BODY_SIZE), 8).await;
+        })
     }
 
     #[test]
     fn download_into_multi_level() {
-        let refs_per_chunk = DEFAULT_BODY_SIZE / super::super::constants::REF_SIZE;
-        assert_download_matches(&sample(DEFAULT_BODY_SIZE * (refs_per_chunk + 1) + 17), 8);
+        run(async {
+            let refs_per_chunk = DEFAULT_BODY_SIZE / super::super::constants::REF_SIZE;
+            assert_download_matches(&sample(DEFAULT_BODY_SIZE * (refs_per_chunk + 1) + 17), 8)
+                .await;
+        })
     }
 
     #[test]
     fn download_into_width_one() {
-        assert_download_matches(&sample(DEFAULT_BODY_SIZE * 5 + 7), 1);
+        run(async {
+            assert_download_matches(&sample(DEFAULT_BODY_SIZE * 5 + 7), 1).await;
+        })
     }
 
     #[test]
     fn download_with_progress_monotonic() {
-        block_on(async {
+        run(async {
             let data = sample(DEFAULT_BODY_SIZE * 4 + 99);
             let (root, store) = split_and_store(&data);
             let joiner = Joiner::new(store, root).await.unwrap();
@@ -340,45 +347,50 @@ mod download_tests {
             (root_ref, store.into_chunks())
         }
 
-        fn assert_encrypted_download_matches(data: &[u8], width: usize) {
-            block_on(async {
-                let (root_ref, store) = encrypted_split_and_store(data);
+        async fn assert_encrypted_download_matches(data: &[u8], width: usize) {
+            let (root_ref, store) = encrypted_split_and_store(data);
 
-                let expected = EncryptedJoiner::new(store.clone(), root_ref.clone())
-                    .await
-                    .unwrap()
-                    .read_all()
-                    .await
-                    .unwrap();
+            let expected = EncryptedJoiner::new(store.clone(), root_ref.clone())
+                .await
+                .unwrap()
+                .read_all()
+                .await
+                .unwrap();
 
-                let joiner = EncryptedJoiner::new(store, root_ref)
-                    .await
-                    .unwrap()
-                    .with_concurrency(width);
-                let sink = Mutex::new(Vec::new());
-                joiner.download_into(&sink).await.unwrap();
+            let joiner = EncryptedJoiner::new(store, root_ref)
+                .await
+                .unwrap()
+                .with_concurrency(width);
+            let sink = Mutex::new(Vec::new());
+            joiner.download_into(&sink).await.unwrap();
 
-                assert_eq!(sink.into_inner().unwrap(), expected);
-            });
+            assert_eq!(sink.into_inner().unwrap(), expected);
         }
 
         #[test]
         fn encrypted_download_into_small() {
-            assert_encrypted_download_matches(b"hello world", DEFAULT_BODY_SIZE);
+            run(async {
+                assert_encrypted_download_matches(b"hello world", DEFAULT_BODY_SIZE).await;
+            })
         }
 
         #[test]
         fn encrypted_download_into_multi_level() {
-            let refs_per_chunk = DEFAULT_BODY_SIZE / super::super::super::constants::REF_SIZE;
-            assert_encrypted_download_matches(
-                &sample(DEFAULT_BODY_SIZE * (refs_per_chunk + 1) + 17),
-                8,
-            );
+            run(async {
+                let refs_per_chunk = DEFAULT_BODY_SIZE / super::super::super::constants::REF_SIZE;
+                assert_encrypted_download_matches(
+                    &sample(DEFAULT_BODY_SIZE * (refs_per_chunk + 1) + 17),
+                    8,
+                )
+                .await;
+            })
         }
 
         #[test]
         fn encrypted_download_into_width_one() {
-            assert_encrypted_download_matches(&sample(DEFAULT_BODY_SIZE * 5 + 7), 1);
+            run(async {
+                assert_encrypted_download_matches(&sample(DEFAULT_BODY_SIZE * 5 + 7), 1).await;
+            })
         }
     }
 }

--- a/crates/primitives/src/store/memory.rs
+++ b/crates/primitives/src/store/memory.rs
@@ -120,20 +120,22 @@ impl<R: ChunkRegistry> ChunkHas for HashMap<ChunkAddress, Chunk<Verified, R>> {
 mod tests {
     use super::*;
     use crate::chunk::{ChunkOps, ContentChunk};
-    use futures::executor::block_on;
+    use nectar_testing::run;
 
     #[test]
     fn test_memory_store() {
-        let store = MemoryStore::<StandardChunkSet>::new();
-        assert!(store.is_empty());
+        run(async {
+            let store = MemoryStore::<StandardChunkSet>::new();
+            assert!(store.is_empty());
 
-        let chunk = ContentChunk::new(b"hello".as_slice()).unwrap();
-        let addr = *chunk.address();
-        let sealed: Chunk = Chunk::from_envelope(chunk.into()).unwrap();
+            let chunk = ContentChunk::new(b"hello".as_slice()).unwrap();
+            let addr = *chunk.address();
+            let sealed: Chunk = Chunk::from_envelope(chunk.into()).unwrap();
 
-        block_on(ChunkPut::put(&store, sealed)).unwrap();
-        assert_eq!(store.len(), 1);
-        assert!(block_on(ChunkHas::has(&store, &addr)));
-        assert_eq!(store.get(&addr).map(|c| *c.address()), Some(addr));
+            ChunkPut::put(&store, sealed).await.unwrap();
+            assert_eq!(store.len(), 1);
+            assert!(ChunkHas::has(&store, &addr).await);
+            assert_eq!(store.get(&addr).map(|c| *c.address()), Some(addr));
+        })
     }
 }

--- a/crates/primitives/src/store/retry.rs
+++ b/crates/primitives/src/store/retry.rs
@@ -169,7 +169,7 @@ mod tests {
     use std::sync::Mutex;
     use std::sync::atomic::{AtomicU32, Ordering};
 
-    use futures::executor::block_on;
+    use nectar_testing::run;
 
     use crate::DefaultContentChunk;
     use crate::chunk::StandardChunkSet;
@@ -242,37 +242,46 @@ mod tests {
 
     #[test]
     fn recovers_when_failures_below_budget() {
-        // 7 failures, then success on the 8th (== max_attempts) get.
-        let store = RetryingChunkGet::with_default(FlakyStore::new(7), NoSleep);
-        let address = *store.inner.chunk.address();
+        run(async {
+            // 7 failures, then success on the 8th (== max_attempts) get.
+            let store = RetryingChunkGet::with_default(FlakyStore::new(7), NoSleep);
+            let address = *store.inner.chunk.address();
 
-        let got = block_on(store.get(&address)).expect("recovered within budget");
-        assert_eq!(got.address(), &address);
-        assert_eq!(store.inner.get_calls.load(Ordering::SeqCst), 8);
+            let got = store.get(&address).await.expect("recovered within budget");
+            assert_eq!(got.address(), &address);
+            assert_eq!(store.inner.get_calls.load(Ordering::SeqCst), 8);
+        })
     }
 
     #[test]
     fn propagates_after_exactly_max_attempts() {
-        // Always fails: expect exactly max_attempts gets, then the error.
-        let store = RetryingChunkGet::with_default(FlakyStore::new(u32::MAX), NoSleep);
-        let address = *store.inner.chunk.address();
+        run(async {
+            // Always fails: expect exactly max_attempts gets, then the error.
+            let store = RetryingChunkGet::with_default(FlakyStore::new(u32::MAX), NoSleep);
+            let address = *store.inner.chunk.address();
 
-        let err = block_on(store.get(&address));
-        assert!(err.is_err(), "budget exhausted, error must propagate");
-        assert_eq!(
-            store.inner.get_calls.load(Ordering::SeqCst),
-            RetryConfig::default().max_attempts
-        );
+            let err = store.get(&address).await;
+            assert!(err.is_err(), "budget exhausted, error must propagate");
+            assert_eq!(
+                store.inner.get_calls.load(Ordering::SeqCst),
+                RetryConfig::default().max_attempts
+            );
+        })
     }
 
     #[test]
     fn put_and_has_are_not_retried() {
-        let store = RetryingChunkGet::with_default(FlakyStore::new(u32::MAX), NoSleep);
-        let address = *store.inner.chunk.address();
+        run(async {
+            let store = RetryingChunkGet::with_default(FlakyStore::new(u32::MAX), NoSleep);
+            let address = *store.inner.chunk.address();
 
-        assert!(block_on(store.has(&address)));
-        block_on(store.put(store.inner.chunk.clone())).expect("put delegates");
-        assert_eq!(store.inner.has_calls.load(Ordering::SeqCst), 1);
-        assert_eq!(store.inner.put_calls.load(Ordering::SeqCst), 1);
+            assert!(store.has(&address).await);
+            store
+                .put(store.inner.chunk.clone())
+                .await
+                .expect("put delegates");
+            assert_eq!(store.inner.has_calls.load(Ordering::SeqCst), 1);
+            assert_eq!(store.inner.put_calls.load(Ordering::SeqCst), 1);
+        })
     }
 }

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -16,3 +16,10 @@ publish = false
 
 [dependencies]
 futures-executor.workspace = true
+
+# The wasm smoke test is the executable proof that a !Send store satisfies the
+# chunk traits on wasm32; the same store cannot compile on native targets.
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+futures.workspace = true
+nectar-primitives.workspace = true
+wasm-bindgen-test.workspace = true

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -1,0 +1,18 @@
+# No [lints] table on purpose: the harness panics by design (budget
+# exhaustion turns would-be hangs into failures), which the workspace
+# restriction lints forbid.
+
+[package]
+name = "nectar-testing"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Deterministic async test harness for the nectar workspace"
+publish = false
+
+[dependencies]
+futures-executor.workspace = true

--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -1,0 +1,284 @@
+//! Deterministic async test harness: the sanctioned executor entry point,
+//! budgeted cooperative yields, a manual-poll driver, and a gate for
+//! stepwise backpressure probes. Panics are the point: a deadlock becomes a
+//! failure instead of a hang, hence the opt-out from the workspace lints.
+
+use core::future::Future;
+use core::pin::Pin;
+use core::task::{Context, Poll, Waker};
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
+use std::task::Wake;
+
+/// Drives a future to completion on the calling thread.
+///
+/// The sole sanctioned `block_on` call site in the workspace.
+#[allow(clippy::disallowed_methods)]
+pub fn run<F: Future>(f: F) -> F::Output {
+    futures_executor::block_on(f)
+}
+
+/// Yields once so sibling futures in the same combinator get re-polled.
+pub async fn yield_now() {
+    struct YieldNow(bool);
+    impl Future for YieldNow {
+        type Output = ();
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+            if self.0 {
+                Poll::Ready(())
+            } else {
+                self.0 = true;
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+        }
+    }
+    YieldNow(false).await;
+}
+
+/// Yields up to `budget` times waiting for `cond`; panics on exhaustion so a
+/// would-be hang becomes a failure.
+pub async fn yield_until(budget: usize, cond: impl Fn() -> bool) {
+    for _ in 0..budget {
+        if cond() {
+            return;
+        }
+        yield_now().await;
+    }
+    assert!(
+        cond(),
+        "yield_until: condition still false after {budget} yields"
+    );
+}
+
+struct CountWaker(AtomicUsize);
+
+impl Wake for CountWaker {
+    fn wake(self: Arc<Self>) {
+        self.wake_by_ref();
+    }
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.0.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Manual-poll driver: single-steps a future so invariants can be asserted
+/// between polls.
+pub struct Drive<F> {
+    fut: Pin<Box<F>>,
+    counter: Arc<CountWaker>,
+    waker: Waker,
+}
+
+impl<F: Future> Drive<F> {
+    /// Wraps `f` for manual polling.
+    pub fn new(f: F) -> Self {
+        let counter = Arc::new(CountWaker(AtomicUsize::new(0)));
+        let waker = Waker::from(Arc::clone(&counter));
+        Self {
+            fut: Box::pin(f),
+            counter,
+            waker,
+        }
+    }
+
+    /// Polls the future once.
+    pub fn poll(&mut self) -> Poll<F::Output> {
+        self.fut
+            .as_mut()
+            .poll(&mut Context::from_waker(&self.waker))
+    }
+
+    /// Wakes recorded so far. Diagnostic only: exact counts couple tests to
+    /// combinator internals, so never assert equality on this.
+    pub fn wakes(&self) -> usize {
+        self.counter.0.load(Ordering::Relaxed)
+    }
+}
+
+fn lock(m: &Mutex<State>) -> MutexGuard<'_, State> {
+    m.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+#[derive(Default)]
+struct State {
+    next_id: u64,
+    queue: VecDeque<(u64, Option<Waker>)>,
+    granted: Vec<u64>,
+    peak: usize,
+}
+
+/// FIFO gate for probe stores: [`enter`](Self::enter) parks until a matching
+/// [`release`](Self::release), so backpressure is exercised at each step
+/// rather than only on the initial burst. Accounting is drop-aware: a parked
+/// waiter that is cancelled leaves the queue.
+///
+/// ```
+/// use nectar_testing::{Drive, GateStore};
+///
+/// let gate = GateStore::new();
+/// let mut d = Drive::new({
+///     let g = gate.clone();
+///     async move {
+///         g.enter().await;
+///         g.enter().await;
+///     }
+/// });
+/// assert!(d.poll().is_pending());
+/// assert_eq!(gate.waiting(), 1);
+/// gate.release(1);
+/// assert!(d.poll().is_pending()); // the second enter parks: stepwise, not burst
+/// assert_eq!(gate.waiting(), 1);
+/// gate.release(1);
+/// assert!(d.poll().is_ready());
+/// ```
+#[derive(Clone, Default)]
+pub struct GateStore {
+    state: Arc<Mutex<State>>,
+}
+
+impl GateStore {
+    /// New gate with no waiters.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Parks until granted by a later [`release`](Self::release).
+    pub fn enter(&self) -> Enter {
+        Enter {
+            gate: Arc::clone(&self.state),
+            state: EnterState::Idle,
+        }
+    }
+
+    /// Grants the `n` oldest parked waiters and wakes them.
+    pub fn release(&self, n: usize) {
+        let mut wakers = Vec::new();
+        {
+            let mut s = lock(&self.state);
+            for _ in 0..n {
+                if let Some((id, waker)) = s.queue.pop_front() {
+                    s.granted.push(id);
+                    wakers.extend(waker);
+                }
+            }
+        }
+        for w in wakers {
+            w.wake();
+        }
+    }
+
+    /// Currently parked waiters.
+    pub fn waiting(&self) -> usize {
+        lock(&self.state).queue.len()
+    }
+
+    /// High-water mark of concurrently parked waiters.
+    pub fn peak(&self) -> usize {
+        lock(&self.state).peak
+    }
+}
+
+enum EnterState {
+    Idle,
+    Parked(u64),
+    Done,
+}
+
+/// Future returned by [`GateStore::enter`].
+pub struct Enter {
+    gate: Arc<Mutex<State>>,
+    state: EnterState,
+}
+
+impl Future for Enter {
+    type Output = ();
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        let this = self.get_mut();
+        let mut s = lock(&this.gate);
+        match this.state {
+            EnterState::Idle => {
+                let id = s.next_id;
+                s.next_id += 1;
+                s.queue.push_back((id, Some(cx.waker().clone())));
+                s.peak = s.peak.max(s.queue.len());
+                this.state = EnterState::Parked(id);
+                Poll::Pending
+            }
+            EnterState::Parked(id) => {
+                if let Some(pos) = s.granted.iter().position(|&g| g == id) {
+                    s.granted.swap_remove(pos);
+                    this.state = EnterState::Done;
+                    Poll::Ready(())
+                } else {
+                    if let Some(slot) = s.queue.iter_mut().find(|(q, _)| *q == id) {
+                        slot.1 = Some(cx.waker().clone());
+                    }
+                    Poll::Pending
+                }
+            }
+            EnterState::Done => Poll::Ready(()),
+        }
+    }
+}
+
+impl Drop for Enter {
+    fn drop(&mut self) {
+        if let EnterState::Parked(id) = self.state {
+            let mut s = lock(&self.gate);
+            s.queue.retain(|(q, _)| *q != id);
+            if let Some(pos) = s.granted.iter().position(|&g| g == id) {
+                s.granted.swap_remove(pos);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::cell::Cell;
+
+    #[test]
+    fn yield_now_parks_once_then_completes() {
+        let mut d = Drive::new(yield_now());
+        assert!(d.poll().is_pending());
+        assert!(d.wakes() >= 1);
+        assert!(d.poll().is_ready());
+    }
+
+    #[test]
+    fn yield_until_returns_once_condition_holds() {
+        let polls = Cell::new(0_usize);
+        run(yield_until(10, || {
+            polls.set(polls.get() + 1);
+            polls.get() >= 3
+        }));
+        assert_eq!(polls.get(), 3);
+    }
+
+    #[test]
+    #[should_panic(expected = "yield_until")]
+    fn yield_until_panics_on_exhaustion() {
+        run(yield_until(3, || false));
+    }
+
+    #[test]
+    fn gate_grants_fifo_and_cancellation_unparks() {
+        let gate = GateStore::new();
+        let mut a = Drive::new(gate.enter());
+        let mut b = Drive::new(gate.enter());
+        assert!(a.poll().is_pending());
+        assert!(b.poll().is_pending());
+        assert_eq!((gate.waiting(), gate.peak()), (2, 2));
+        gate.release(1);
+        assert!(a.poll().is_ready());
+        assert!(b.poll().is_pending());
+        drop(b);
+        assert_eq!(gate.waiting(), 0);
+        gate.release(1);
+        let mut c = Drive::new(gate.enter());
+        assert!(c.poll().is_pending());
+    }
+}

--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -71,6 +71,14 @@ pub struct Drive<F> {
     waker: Waker,
 }
 
+impl<F> core::fmt::Debug for Drive<F> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Drive")
+            .field("wakes", &self.counter.0.load(Ordering::Relaxed))
+            .finish_non_exhaustive()
+    }
+}
+
 impl<F: Future> Drive<F> {
     /// Wraps `f` for manual polling.
     pub fn new(f: F) -> Self {
@@ -138,6 +146,12 @@ pub struct GateStore {
     state: Arc<Mutex<State>>,
 }
 
+impl core::fmt::Debug for GateStore {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GateStore").finish_non_exhaustive()
+    }
+}
+
 impl GateStore {
     /// New gate with no waiters.
     pub fn new() -> Self {
@@ -152,7 +166,9 @@ impl GateStore {
         }
     }
 
-    /// Grants the `n` oldest parked waiters and wakes them.
+    /// Grants the `n` oldest parked waiters and wakes them. No stored permits:
+    /// any `n` beyond the parked count is dropped, so releasing before a waiter
+    /// parks is a no-op.
     pub fn release(&self, n: usize) {
         let mut wakers = Vec::new();
         {
@@ -190,6 +206,12 @@ enum EnterState {
 pub struct Enter {
     gate: Arc<Mutex<State>>,
     state: EnterState,
+}
+
+impl core::fmt::Debug for Enter {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Enter").finish_non_exhaustive()
+    }
 }
 
 impl Future for Enter {

--- a/crates/testing/tests/wasm_smoke.rs
+++ b/crates/testing/tests/wasm_smoke.rs
@@ -1,0 +1,99 @@
+//! Node smoke test proving the wasm relaxation of the store traits: a `!Send`
+//! store round-trips a file and the windowed reader honours its read-ahead
+//! bound. Native targets compile this file to nothing.
+#![cfg(target_arch = "wasm32")]
+
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use futures::StreamExt;
+use nectar_primitives::{
+    AnyChunkSet, Chunk, ChunkAddress, ChunkGet, ChunkGetExt, ChunkPut, ChunkPutExt,
+    ChunkStoreError, DEFAULT_BODY_SIZE, Verified,
+};
+use wasm_bindgen_test::wasm_bindgen_test;
+
+type SealedChunk = Chunk<Verified, AnyChunkSet<DEFAULT_BODY_SIZE>>;
+
+/// `Rc`/`RefCell` make this store neither `Send` nor `Sync`, so it satisfies
+/// the chunk traits only on wasm32.
+#[derive(Clone, Default)]
+struct RcStore {
+    chunks: Rc<RefCell<HashMap<ChunkAddress, SealedChunk>>>,
+    in_flight: Rc<Cell<usize>>,
+    peak: Rc<Cell<usize>>,
+}
+
+impl ChunkPut<AnyChunkSet<DEFAULT_BODY_SIZE>> for RcStore {
+    type Error = std::convert::Infallible;
+
+    async fn put(&self, chunk: SealedChunk) -> Result<(), Self::Error> {
+        self.chunks.borrow_mut().insert(*chunk.address(), chunk);
+        Ok(())
+    }
+}
+
+impl ChunkGet<AnyChunkSet<DEFAULT_BODY_SIZE>> for RcStore {
+    type Trust = Verified;
+    type Error = ChunkStoreError;
+
+    /// Yields once mid-fetch so overlapping gets register in `peak`.
+    async fn get(&self, address: &ChunkAddress) -> Result<SealedChunk, Self::Error> {
+        self.in_flight.set(self.in_flight.get() + 1);
+        self.peak.set(self.peak.get().max(self.in_flight.get()));
+        nectar_testing::yield_now().await;
+        self.in_flight.set(self.in_flight.get() - 1);
+        self.chunks
+            .borrow()
+            .get(address)
+            .cloned()
+            .ok_or_else(|| ChunkStoreError::not_found(address))
+    }
+}
+
+/// Five leaves: a two-level tree, so the download has read-ahead to exercise.
+fn sample_data() -> Vec<u8> {
+    (0..DEFAULT_BODY_SIZE * 4 + 123)
+        .map(|i| u8::try_from(i % 251).unwrap())
+        .collect()
+}
+
+#[wasm_bindgen_test]
+async fn non_send_store_round_trips_a_file() {
+    let store = RcStore::default();
+    let data = sample_data();
+    let root = store.write_file(data.clone()).await.unwrap();
+    let out = store.clone().read_file(root).await.unwrap();
+    assert_eq!(out, data);
+}
+
+#[wasm_bindgen_test]
+async fn windowed_read_ahead_stays_within_bound() {
+    const WINDOW: usize = 2;
+    let store = RcStore::default();
+    let data = sample_data();
+    let root = store.write_file(data.clone()).await.unwrap();
+
+    let mut reader = store
+        .clone()
+        .joiner(root)
+        .await
+        .unwrap()
+        .into_windowed_reader(WINDOW);
+    store.in_flight.set(0);
+    store.peak.set(0);
+
+    let mut out = Vec::new();
+    let stream = reader.stream();
+    futures::pin_mut!(stream);
+    while let Some(run) = stream.next().await {
+        out.extend_from_slice(&run.unwrap());
+    }
+
+    assert_eq!(out, data);
+    let peak = store.peak.get();
+    assert!(peak <= WINDOW, "read-ahead exceeded the window: {peak}");
+    assert!(peak > 1, "leaf fetches never overlapped: {peak}");
+    assert_eq!(store.in_flight.get(), 0);
+}


### PR DESCRIPTION
## What

Converts the primitives, mantaray, and manifest crates to the async house pattern in three per-crate commits (`af83aefd`, `c575daff`, `ffb4df94`), plus a follow-up fix commit (`ed390d3a`):

- Replaced `block_on` litanies in tests with `nectar_testing::run(async { .. })`, awaiting calls inline.
- Moved proptest closures to the sync-over-sim shape: `run()` inside `proptest!`, with an async block returning `Ok::<(), TestCaseError>(())` and `?` propagation.
- Switched criterion benches (`file_bench`, `encryption_bench`, `mantaray_bench`) to `to_async(FuturesExecutor)` for timed sections and `nectar_testing::run` for setup/corpus building; added the `async_futures` feature to the workspace criterion dependency.
- Split `joiner.rs`'s `cfg(all(test, feature = "tokio"))` module: runtime-agnostic probes moved into a plain `#[cfg(test)] mod tests` (with `tokio::task::yield_now` replaced by `nectar_testing::yield_now`, and `current_thread` flavors dropped).
- Fixed a half-converted rustdoc example in `manifest/src/dx.rs` that imported `nectar_testing::run` but kept a `block_on` body, which broke `cargo test --doc -p nectar-manifest`.

## Why

Brings primitives, mantaray, and manifest onto the async house pattern established elsewhere in the workspace, removing runtime-specific (`block_on`/tokio-only) test scaffolding in favour of the shared `nectar_testing` harness.

Closes #353

## Testing

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --locked`: two pre-existing warnings only (`use_self` in `primitives/src/chunk/type_tag.rs:110`, encryption-gated unused import in `mantaray/src/builder.rs:45`), both verified present on the base branch (`origin/s325/12-wasm-smoke`) and byte-identical to base in this diff.
- `cargo nextest run -p nectar-manifest -p nectar-mantaray -p nectar-primitives --all-features`.
- `cargo test --doc -p nectar-manifest` (regression check for the `dx.rs` fix).

## AI Assistance

Implementation by Fable, review by Opus, PR by Sonnet.

Closes #104