### PR TITLE
feat(primitives): add unsync feature for single-thread Send escape

### DIFF
--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -43,10 +43,12 @@ jobs:
             # nectar-primitives does not yet build bare-metal, so the
             # single-thread send escape (the unsync feature) and its
             # !Send-store compile proof are checked for the host inside the
-            # rv64 lane, the target shape the escape exists for.
+            # rv64 lane, the target shape the escape exists for. tokio is on
+            # so the relaxed boxed-future reader shells (the surface whose
+            # Send bound the escape relaxes) are compiled too.
             - name: Check the unsync send escape
               if: matrix.target == 'riscv64imac-unknown-none-elf'
-              run: cargo check --locked -p nectar-primitives --features unsync
+              run: cargo check --locked -p nectar-primitives --features unsync,tokio
 
     nostd-success:
         name: no_std success

--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -40,6 +40,13 @@ jobs:
                     -p nectar-swarms -p nectar-contracts -p nectar-nostd-spike \
                     --no-default-features \
                     --target ${{ matrix.target }}
+            # nectar-primitives does not yet build bare-metal, so the
+            # single-thread send escape (the unsync feature) and its
+            # !Send-store compile proof are checked for the host inside the
+            # rv64 lane, the target shape the escape exists for.
+            - name: Check the unsync send escape
+              if: matrix.target == 'riscv64imac-unknown-none-elf'
+              run: cargo check --locked -p nectar-primitives --features unsync
 
     nostd-success:
         name: no_std success

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -111,6 +111,11 @@ serde = [ "dep:serde" ]
 arbitrary = [ "alloy-primitives/arbitrary", "dep:arbitrary", "dep:rand", "std" ]
 encryption = [ "dep:rand" ]
 tokio = [ "dep:tokio" ]
+# Single-thread send escape for non-wasm targets (e.g. zkVM guests): applies
+# the wasm32 relaxation of MaybeSend/MaybeSync and the boxed error aliases on
+# any target. An explicit feature rather than a target cfg so CI can exercise
+# the relaxed shape off-wasm.
+unsync = []
 
 [[bench]]
 name = "primitives"

--- a/crates/primitives/src/file/error.rs
+++ b/crates/primitives/src/file/error.rs
@@ -30,9 +30,9 @@ pub enum FileError {
     #[error("store error")]
     Store(#[source] BoxedError),
 
-    /// Write sink failed. Rendered to a string so the error stays `Send + Sync`
-    /// even when the sink's own error is not (a single-threaded browser
-    /// writable).
+    /// Write sink failed. Rendered to a string so the sink's own error type,
+    /// which may be `!Send` (a single-threaded browser writable), never
+    /// enters `FileError`.
     #[error("sink error: {0}")]
     Sink(String),
 
@@ -91,10 +91,27 @@ impl FileError {
         Self::Getter(Box::new(err))
     }
 
-    /// Create a sink error by rendering any sink error to a string. Keeps
-    /// `FileError: Send + Sync` while accepting a `!Send` wasm sink error.
+    /// Create a sink error by rendering any sink error to a string, so a
+    /// `!Send` sink error never enters `FileError`.
     pub fn sink<E: std::error::Error>(err: E) -> Self {
         Self::Sink(err.to_string())
+    }
+}
+
+/// Carries the typed error as the payload.
+#[cfg(not(any(target_arch = "wasm32", feature = "unsync")))]
+impl From<FileError> for std::io::Error {
+    fn from(e: FileError) -> Self {
+        Self::other(e)
+    }
+}
+
+/// The relaxed shape may hold a `!Send` source, which `std::io::Error` cannot
+/// carry, so the error is rendered to a string.
+#[cfg(any(target_arch = "wasm32", feature = "unsync"))]
+impl From<FileError> for std::io::Error {
+    fn from(e: FileError) -> Self {
+        Self::other(e.to_string())
     }
 }
 

--- a/crates/primitives/src/file/joiner.rs
+++ b/crates/primitives/src/file/joiner.rs
@@ -484,10 +484,10 @@ where
             Failed(FileError),
         }
 
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(not(any(target_arch = "wasm32", feature = "unsync")))]
         type BoxResolvedFuture<M> =
             std::pin::Pin<Box<dyn std::future::Future<Output = Resolved<M>> + Send>>;
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(any(target_arch = "wasm32", feature = "unsync"))]
         type BoxResolvedFuture<M> =
             std::pin::Pin<Box<dyn std::future::Future<Output = Resolved<M>>>>;
 
@@ -726,10 +726,10 @@ where
         Failed(FileError),
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(any(target_arch = "wasm32", feature = "unsync")))]
     type BoxResolvedFuture<M> =
         std::pin::Pin<Box<dyn std::future::Future<Output = Resolved<M>> + Send>>;
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(any(target_arch = "wasm32", feature = "unsync"))]
     type BoxResolvedFuture<M> = std::pin::Pin<Box<dyn std::future::Future<Output = Resolved<M>>>>;
 
     // Fetch one node: a leaf yields its body, an intermediate yields its
@@ -900,6 +900,16 @@ where
     })
 }
 
+/// Cfg-gated boxed read-future alias: `+ Send` on multi-threaded targets,
+/// unbounded on wasm32 and under the `unsync` feature.
+#[cfg(all(
+    feature = "tokio",
+    not(any(target_arch = "wasm32", feature = "unsync"))
+))]
+type BoxReadFuture = std::pin::Pin<Box<dyn std::future::Future<Output = Result<Vec<u8>>> + Send>>;
+#[cfg(all(feature = "tokio", any(target_arch = "wasm32", feature = "unsync")))]
+type BoxReadFuture = std::pin::Pin<Box<dyn std::future::Future<Output = Result<Vec<u8>>>>>;
+
 /// Wrapper providing `tokio::io::AsyncRead` over a [`GenericJoiner`].
 ///
 /// Created via [`GenericJoiner::into_reader`].
@@ -910,8 +920,7 @@ where
 {
     joiner: GenericJoiner<G, M, BODY_SIZE>,
     buffer: Bytes,
-    #[allow(clippy::type_complexity)]
-    future: Option<std::pin::Pin<Box<dyn std::future::Future<Output = Result<Vec<u8>>> + Send>>>,
+    future: Option<BoxReadFuture>,
 }
 
 #[cfg(feature = "tokio")]
@@ -1016,7 +1025,7 @@ where
             }
             Poll::Ready(Err(e)) => {
                 this.future = None;
-                Poll::Ready(Err(std::io::Error::other(e)))
+                Poll::Ready(Err(std::io::Error::from(e)))
             }
             Poll::Pending => Poll::Pending,
         }

--- a/crates/primitives/src/file/splitter_parallel.rs
+++ b/crates/primitives/src/file/splitter_parallel.rs
@@ -2,7 +2,7 @@
 
 use std::marker::PhantomData;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(any(target_arch = "wasm32", feature = "unsync")))]
 use rayon::prelude::*;
 
 use crate::bmt::DEFAULT_BODY_SIZE;
@@ -126,11 +126,12 @@ where
             Ok(reference)
         };
 
-        // Rayon lanes carry `Send` items; on wasm32 `FileError` may hold a
-        // `!Send` store error, so drive the same closure inline there.
-        #[cfg(not(target_arch = "wasm32"))]
+        // Rayon lanes carry `Send` items; on wasm32 and under `unsync`
+        // `FileError` may hold a `!Send` store error, so drive the same
+        // closure inline there.
+        #[cfg(not(any(target_arch = "wasm32", feature = "unsync")))]
         let results: Vec<Result<M::Ref>> = (0..data_chunks).into_par_iter().map(produce).collect();
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(any(target_arch = "wasm32", feature = "unsync"))]
         let results: Vec<Result<M::Ref>> = (0..data_chunks).map(produce).collect();
 
         results.into_iter().collect()
@@ -199,12 +200,13 @@ where
             Ok(reference)
         };
 
-        // Rayon lanes carry `Send` items; on wasm32 `FileError` may hold a
-        // `!Send` store error, so drive the same closure inline there.
-        #[cfg(not(target_arch = "wasm32"))]
+        // Rayon lanes carry `Send` items; on wasm32 and under `unsync`
+        // `FileError` may hold a `!Send` store error, so drive the same
+        // closure inline there.
+        #[cfg(not(any(target_arch = "wasm32", feature = "unsync")))]
         let results: Vec<Result<M::Ref>> =
             (0..chunks_at_level).into_par_iter().map(produce).collect();
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(any(target_arch = "wasm32", feature = "unsync"))]
         let results: Vec<Result<M::Ref>> = (0..chunks_at_level).map(produce).collect();
 
         results.into_iter().collect()

--- a/crates/primitives/src/file/windowed.rs
+++ b/crates/primitives/src/file/windowed.rs
@@ -149,10 +149,11 @@ where
     }
 }
 
-/// Cfg-gated boxed resolved-future alias: `+ Send` on native, unbounded on wasm.
-#[cfg(not(target_arch = "wasm32"))]
+/// Cfg-gated boxed resolved-future alias: `+ Send` on multi-threaded targets,
+/// unbounded on wasm32 and under the `unsync` feature.
+#[cfg(not(any(target_arch = "wasm32", feature = "unsync")))]
 type BoxResolvedFuture<M> = Pin<Box<dyn std::future::Future<Output = Resolved<M>> + Send>>;
-#[cfg(target_arch = "wasm32")]
+#[cfg(any(target_arch = "wasm32", feature = "unsync"))]
 type BoxResolvedFuture<M> = Pin<Box<dyn std::future::Future<Output = Resolved<M>>>>;
 
 /// One unit of pending work: a tree node plus its remaining retry budget. The
@@ -465,6 +466,16 @@ where
     })
 }
 
+/// Cfg-gated boxed body-stream alias: `+ Send` on multi-threaded targets,
+/// unbounded on wasm32 and under the `unsync` feature.
+#[cfg(all(
+    feature = "tokio",
+    not(any(target_arch = "wasm32", feature = "unsync"))
+))]
+type BoxBodyStream = Pin<Box<dyn Stream<Item = Result<Bytes>> + Send>>;
+#[cfg(all(feature = "tokio", any(target_arch = "wasm32", feature = "unsync")))]
+type BoxBodyStream = Pin<Box<dyn Stream<Item = Result<Bytes>>>>;
+
 /// Native `AsyncRead` + `AsyncSeek` shim, draining [`WindowedReader::stream`]
 /// into a residual buffer.
 #[cfg(feature = "tokio")]
@@ -474,8 +485,7 @@ where
 {
     reader: WindowedReader<G, M, BODY_SIZE>,
     residual: Bytes,
-    #[allow(clippy::type_complexity)]
-    stream: Option<Pin<Box<dyn Stream<Item = Result<Bytes>> + Send>>>,
+    stream: Option<BoxBodyStream>,
 }
 
 #[cfg(feature = "tokio")]
@@ -570,7 +580,7 @@ where
                 }
                 Poll::Ready(Ok(()))
             }
-            Poll::Ready(Some(Err(e))) => Poll::Ready(Err(std::io::Error::other(e))),
+            Poll::Ready(Some(Err(e))) => Poll::Ready(Err(std::io::Error::from(e))),
             Poll::Ready(None) => Poll::Ready(Ok(())),
             Poll::Pending => Poll::Pending,
         }

--- a/crates/primitives/src/store/maybe_send.rs
+++ b/crates/primitives/src/store/maybe_send.rs
@@ -1,31 +1,37 @@
-//! `Send`/`Sync` on native, unbounded on wasm32.
+//! `Send`/`Sync` on multi-threaded targets, unbounded on wasm32 and under the
+//! `unsync` feature (the single-thread escape for non-wasm targets such as
+//! zkVM guests).
 
-/// `Send` on native targets, no bound on wasm32. The browser executor is
-/// single-threaded, so a getter future holding a JS handle across an await
-/// point is `!Send` there and must still satisfy the store traits.
-#[cfg(not(target_arch = "wasm32"))]
+/// `Send` on multi-threaded targets, no bound on wasm32 or with the `unsync`
+/// feature. A single-threaded executor runs futures that may hold `!Send`
+/// state (a JS handle in the browser) across an await point, and such a
+/// store must still satisfy the store traits.
+#[cfg(not(any(target_arch = "wasm32", feature = "unsync")))]
 pub trait MaybeSend: Send {}
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(any(target_arch = "wasm32", feature = "unsync")))]
 impl<T: ?Sized + Send> MaybeSend for T {}
 
-/// `Send` on native targets, no bound on wasm32. The browser executor is
-/// single-threaded, so a getter future holding a JS handle across an await
-/// point is `!Send` there and must still satisfy the store traits.
-#[cfg(target_arch = "wasm32")]
+/// `Send` on multi-threaded targets, no bound on wasm32 or with the `unsync`
+/// feature. A single-threaded executor runs futures that may hold `!Send`
+/// state (a JS handle in the browser) across an await point, and such a
+/// store must still satisfy the store traits.
+#[cfg(any(target_arch = "wasm32", feature = "unsync"))]
 pub trait MaybeSend {}
-#[cfg(target_arch = "wasm32")]
+#[cfg(any(target_arch = "wasm32", feature = "unsync"))]
 impl<T: ?Sized> MaybeSend for T {}
 
-/// `Sync` on native targets, no bound on wasm32. A browser store holding
-/// JS handles is `!Sync`; on the single-threaded wasm executor that is sound.
-#[cfg(not(target_arch = "wasm32"))]
+/// `Sync` on multi-threaded targets, no bound on wasm32 or with the `unsync`
+/// feature. A store holding single-thread state (a JS handle) is `!Sync`;
+/// on a single-threaded executor that is sound.
+#[cfg(not(any(target_arch = "wasm32", feature = "unsync")))]
 pub trait MaybeSync: Sync {}
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(any(target_arch = "wasm32", feature = "unsync")))]
 impl<T: ?Sized + Sync> MaybeSync for T {}
 
-/// `Sync` on native targets, no bound on wasm32. A browser store holding
-/// JS handles is `!Sync`; on the single-threaded wasm executor that is sound.
-#[cfg(target_arch = "wasm32")]
+/// `Sync` on multi-threaded targets, no bound on wasm32 or with the `unsync`
+/// feature. A store holding single-thread state (a JS handle) is `!Sync`;
+/// on a single-threaded executor that is sound.
+#[cfg(any(target_arch = "wasm32", feature = "unsync"))]
 pub trait MaybeSync {}
-#[cfg(target_arch = "wasm32")]
+#[cfg(any(target_arch = "wasm32", feature = "unsync"))]
 impl<T: ?Sized> MaybeSync for T {}

--- a/crates/primitives/src/store/mod.rs
+++ b/crates/primitives/src/store/mod.rs
@@ -1,7 +1,8 @@
 //! Chunk storage traits and implementations.
 //!
 //! `ChunkGet`, `ChunkPut`, and `ChunkHas` are async and carry `MaybeSend`/
-//! `MaybeSync` bounds so a store may be `!Send` on wasm.
+//! `MaybeSync` bounds so a store may be `!Send` on single-threaded targets
+//! (wasm32, or any target under the `unsync` feature).
 
 mod maybe_send;
 mod memory;
@@ -15,22 +16,26 @@ pub use typed::{ChunkGet, ChunkHas, ChunkPut, TrustedGet};
 
 use crate::chunk::{Chunk, ChunkAddress, ChunkRegistry, Verified};
 
-/// Boxed store error: `Send + Sync` on native, unbounded on wasm32 where a
-/// backend error may hold a JS handle.
-#[cfg(not(target_arch = "wasm32"))]
+/// Boxed store error: `Send + Sync` on multi-threaded targets, unbounded on
+/// wasm32 and under the `unsync` feature where a backend error may hold
+/// single-thread state (a JS handle).
+#[cfg(not(any(target_arch = "wasm32", feature = "unsync")))]
 pub type BoxedError = Box<dyn core::error::Error + Send + Sync>;
-/// Boxed store error: `Send + Sync` on native, unbounded on wasm32 where a
-/// backend error may hold a JS handle.
-#[cfg(target_arch = "wasm32")]
+/// Boxed store error: `Send + Sync` on multi-threaded targets, unbounded on
+/// wasm32 and under the `unsync` feature where a backend error may hold
+/// single-thread state (a JS handle).
+#[cfg(any(target_arch = "wasm32", feature = "unsync"))]
 pub type BoxedError = Box<dyn core::error::Error>;
 
-/// Shared store error: `Send + Sync` on native, unbounded on wasm32 where a
-/// backend error may hold a JS handle.
-#[cfg(not(target_arch = "wasm32"))]
+/// Shared store error: `Send + Sync` on multi-threaded targets, unbounded on
+/// wasm32 and under the `unsync` feature where a backend error may hold
+/// single-thread state (a JS handle).
+#[cfg(not(any(target_arch = "wasm32", feature = "unsync")))]
 pub type SharedError = std::sync::Arc<dyn core::error::Error + Send + Sync>;
-/// Shared store error: `Send + Sync` on native, unbounded on wasm32 where a
-/// backend error may hold a JS handle.
-#[cfg(target_arch = "wasm32")]
+/// Shared store error: `Send + Sync` on multi-threaded targets, unbounded on
+/// wasm32 and under the `unsync` feature where a backend error may hold
+/// single-thread state (a JS handle).
+#[cfg(any(target_arch = "wasm32", feature = "unsync"))]
 pub type SharedError = std::sync::Arc<dyn core::error::Error>;
 
 /// Errors from chunk storage operations.

--- a/crates/primitives/src/store/typed.rs
+++ b/crates/primitives/src/store/typed.rs
@@ -2,7 +2,7 @@
 //!
 //! `ChunkGet`, `ChunkPut`, and `ChunkHas` are async and carry `MaybeSend`/
 //! `MaybeSync` bounds (on the traits and their error types) so a store may be
-//! `!Send` on wasm. Writes are uniformly sealed ([`ChunkPut`] only accepts
+//! `!Send` on single-threaded targets. Writes are uniformly sealed ([`ChunkPut`] only accepts
 //! `Chunk<Verified, R>`); trust is a property of the read medium, declared
 //! once per backend through [`ChunkGet::Trust`].
 
@@ -90,11 +90,12 @@ pub trait TrustedGet<R: ChunkRegistry = StandardChunkSet>: ChunkGet<R, Trust = V
 
 impl<R: ChunkRegistry, T: ChunkGet<R, Trust = Verified> + ?Sized> TrustedGet<R> for T {}
 
-#[cfg(target_arch = "wasm32")]
-mod wasm_send_sync_proof {
+#[cfg(any(target_arch = "wasm32", feature = "unsync"))]
+mod send_sync_relaxation_proof {
     // A store that is neither Send nor Sync (raw pointer marker) must still
-    // satisfy ChunkGet on wasm32, proving the MaybeSend + MaybeSync relaxation
-    // for the store and for its error type alike.
+    // satisfy ChunkGet wherever the relaxation applies (wasm32, or the unsync
+    // feature), proving the MaybeSend + MaybeSync relaxation for the store
+    // and for its error type alike.
     use super::*;
     use crate::chunk::Unverified;
 
@@ -115,10 +116,10 @@ mod wasm_send_sync_proof {
         }
     }
 
-    fn _assert<S: ChunkGet<StandardChunkSet>>() {}
+    const fn _assert<S: ChunkGet<StandardChunkSet>>() {}
 
     #[allow(dead_code)]
-    fn _proof() {
+    const fn _proof() {
         _assert::<NotSendSync>()
     }
 }


### PR DESCRIPTION
## What

Adds an explicit `unsync` cargo feature to `nectar-primitives` as the single-thread Send escape, re-keying the crate's Send/Sync relaxation off wasm-only onto `cfg(any(target_arch = "wasm32", feature = "unsync"))`.

- `store/maybe_send.rs`: `MaybeSend`/`MaybeSync` gated on `any(wasm32, unsync)` instead of wasm-only.
- `store/mod.rs`: `BoxedError`/`SharedError` aliases follow the same relaxation.
- `file/joiner.rs`, `file/windowed.rs`: boxed walk-future aliases updated; new `BoxReadFuture`/`BoxBodyStream` aliases replace the tokio readers' hard `+ Send` boxes.
- `file/splitter_parallel.rs`: rayon-vs-inline splitter lanes switched on the same cfg.
- `file/error.rs`: new paired `From<FileError> for std::io::Error` (typed payload on the Send-bound path, string-rendered on the relaxed path), replacing the two `io::Error::other` call sites.
- `store/typed.rs`: adjusted for the re-keyed bounds.
- `.github/workflows/nostd.yml`: CI wiring for the new feature combination.

## Why

Closes #329

## Testing

- `check` across default, `unsync`, `unsync`+tokio, `all-features`, and `wasm32` feature/target combinations: green.
- `clippy`, `fmt`, `zepter`, `actionlint`: green.
- 304 nextest tests pass.
- A genuine `!Send`-store compile proof (forces a `!Send` store+error through `ChunkGet`'s `MaybeSend`+`MaybeSync` bounds) is exercised on the rv64 lane and fails correctly on the strict (non-relaxed) arm.

No wire changes, no memory-bound or cancel-safety impact.

## AI Assistance

Implementation by Fable, review by Opus, PR by Sonnet.

