### PR TITLE
feat(file): scaffold nectar-file crate with tree geometry

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,7 +40,7 @@ jobs:
               run: |
                   for crate in nectar-primitives nectar-mantaray nectar-postage \
                                nectar-postage-issuer nectar-postage-usage \
-                               nectar-swarms nectar-contracts; do
+                               nectar-swarms nectar-contracts nectar-file; do
                       cargo rustc --locked -p "$crate" --lib -- -D unused_crate_dependencies
                   done
 

--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -37,7 +37,8 @@ jobs:
             - name: Check no_std crates without std
               run: |
                   cargo check --locked \
-                    -p nectar-swarms -p nectar-contracts -p nectar-nostd-spike \
+                    -p nectar-swarms -p nectar-contracts -p nectar-file \
+                    -p nectar-nostd-spike \
                     --no-default-features \
                     --target ${{ matrix.target }}
             # nectar-primitives does not yet build bare-metal, so the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2059,6 +2059,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "nectar-file"
+version = "0.4.0"
+
+[[package]]
 name = "nectar-manifest"
 version = "0.4.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ check.all_targets = true
 [workspace.dependencies]
 # nectar crates
 nectar-contracts = { version = "0.4.0", path = "crates/contracts" }
+nectar-file = { version = "0.4.0", path = "crates/file" }
 nectar-manifest = { version = "0.4.0", path = "crates/manifest" }
 nectar-mantaray = { version = "0.4.0", path = "crates/mantaray" }
 nectar-primitives = { version = "0.4.0", path = "crates/primitives" }

--- a/crates/file/Cargo.toml
+++ b/crates/file/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "nectar-file"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+description = "Streaming file pipeline for Ethereum Swarm: bounded chunk-tree reads and writes"
+documentation = "https://docs.rs/nectar-file"
+readme = "README.md"
+keywords = ["swarm", "ethereum", "file", "streaming", "no_std"]
+categories = ["no-std", "asynchronous", "data-structures"]
+
+[lints]
+workspace = true
+
+[features]
+default = [ "std" ]
+
+# Standard library interop; the filesystem and io adapters land with the
+# engines.
+std = []
+
+# Async reader and writer adapters over the poll surface. Implies `std`.
+tokio = [ "std" ]
+
+# Batch leaf hashing and read-at ingest. Implies `std`; rayon on wasm32 is a
+# compile error, never a silent fallback.
+rayon = [ "std" ]
+
+# Split-side encrypted mode. Joining encrypted references stays unconditional.
+encryption = []
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/file/README.md
+++ b/crates/file/README.md
@@ -1,0 +1,10 @@
+# nectar-file
+
+Streaming file pipeline for Ethereum Swarm: bounded chunk-tree reads and writes over a chunk store.
+
+The crate currently carries the pipeline's foundations:
+
+- **Geometry** (`geometry`): every fan-out fact of a chunk tree derives from its body size and reference mode (plain 32-byte references, encrypted 64-byte references). Each concrete profile is pinned at compile time by `assert_tree_geometry!`, whose checks run in `u128` so coverage of the full `u64` length range is provable without overflow.
+- **Admission budgets** (`config`): `Window` (bounded fetch window), `PutWindow` (bounded put window) and the derived `BranchBudget` that keeps tree descent live at any window size.
+
+The core is `#![no_std]`; the read and write engines stack on top of these invariants. Feature flags: `std` (default), `tokio`, `rayon`, `encryption`.

--- a/crates/file/src/config.rs
+++ b/crates/file/src/config.rs
@@ -1,0 +1,172 @@
+//! Engine admission budgets: the bounded windows the drains admit work
+//! against.
+
+use core::num::{NonZeroU16, NonZeroU32};
+
+/// Sixteen slots: the default depth of both bounded windows.
+const DEFAULT_SLOTS: NonZeroU16 = match NonZeroU16::new(16) {
+    Some(slots) => slots,
+    None => NonZeroU16::MIN,
+};
+const _: () = assert!(DEFAULT_SLOTS.get() == 16);
+
+/// Fetch window: leaf fetches a read drain may hold in flight.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Window(NonZeroU16);
+
+impl Window {
+    /// Default window of sixteen fetch slots.
+    pub const DEFAULT: Self = Self(DEFAULT_SLOTS);
+
+    /// `None` when `slots` is zero; const twin of the `NonZeroU16`
+    /// conversion.
+    pub const fn new(slots: u16) -> Option<Self> {
+        match NonZeroU16::new(slots) {
+            Some(slots) => Some(Self(slots)),
+            None => None,
+        }
+    }
+
+    /// Window depth in slots.
+    pub const fn get(self) -> u16 {
+        self.0.get()
+    }
+}
+
+impl Default for Window {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+impl From<NonZeroU16> for Window {
+    fn from(slots: NonZeroU16) -> Self {
+        Self(slots)
+    }
+}
+
+impl From<Window> for NonZeroU16 {
+    fn from(window: Window) -> Self {
+        window.0
+    }
+}
+
+/// Put window: sealed chunks a write drain may hold awaiting store puts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PutWindow(NonZeroU16);
+
+impl PutWindow {
+    /// Default window of sixteen put slots.
+    pub const DEFAULT: Self = Self(DEFAULT_SLOTS);
+
+    /// `None` when `slots` is zero; const twin of the `NonZeroU16`
+    /// conversion.
+    pub const fn new(slots: u16) -> Option<Self> {
+        match NonZeroU16::new(slots) {
+            Some(slots) => Some(Self(slots)),
+            None => None,
+        }
+    }
+
+    /// Window depth in slots.
+    pub const fn get(self) -> u16 {
+        self.0.get()
+    }
+}
+
+impl Default for PutWindow {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+impl From<NonZeroU16> for PutWindow {
+    fn from(slots: NonZeroU16) -> Self {
+        Self(slots)
+    }
+}
+
+impl From<PutWindow> for NonZeroU16 {
+    fn from(window: PutWindow) -> Self {
+        window.0
+    }
+}
+
+/// Branch budget: intermediate fetches a walk may hold in flight. Derived
+/// from the fetch window, never configured directly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct BranchBudget(NonZeroU32);
+
+impl BranchBudget {
+    /// `max(1, 1 + window / branches)`: a branch is admitted only when the
+    /// pending-reference queue can absorb its full expansion, and the floor
+    /// of one slot keeps descent live at any window.
+    pub const fn derive(window: Window, branches: u32) -> Self {
+        let per_expansion = match u32_from_u16(window.get()).checked_div(branches) {
+            Some(quotient) => quotient,
+            // A zero fan-out has no expansion to absorb; the floor stands.
+            None => 0,
+        };
+        Self(at_least_one(per_expansion.saturating_add(1)))
+    }
+
+    /// Budget depth in slots.
+    pub const fn get(self) -> u32 {
+        self.0.get()
+    }
+}
+
+/// `max(1, value)`: budgets never fall below one slot.
+const fn at_least_one(value: u32) -> NonZeroU32 {
+    match NonZeroU32::new(value) {
+        Some(slots) => slots,
+        None => NonZeroU32::MIN,
+    }
+}
+
+/// Lossless const widening; `From` is not const-callable.
+const fn u32_from_u16(value: u16) -> u32 {
+    let [low, high] = value.to_le_bytes();
+    u32::from_le_bytes([low, high, 0, 0])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn windows_reject_zero() {
+        assert!(Window::new(0).is_none());
+        assert!(PutWindow::new(0).is_none());
+    }
+
+    #[test]
+    fn window_defaults_are_sixteen() {
+        assert_eq!(Window::DEFAULT.get(), 16);
+        assert_eq!(Window::default(), Window::DEFAULT);
+        assert_eq!(PutWindow::DEFAULT.get(), 16);
+        assert_eq!(PutWindow::default(), PutWindow::DEFAULT);
+    }
+
+    #[test]
+    fn windows_round_trip_through_nonzero() {
+        let slots = NonZeroU16::new(5).unwrap();
+        assert_eq!(NonZeroU16::from(Window::from(slots)), slots);
+        assert_eq!(NonZeroU16::from(PutWindow::from(slots)), slots);
+    }
+
+    #[test]
+    fn branch_budget_floors_at_one() {
+        assert_eq!(BranchBudget::derive(Window::DEFAULT, 128).get(), 1);
+        assert_eq!(BranchBudget::derive(Window::DEFAULT, 0).get(), 1);
+        let one = Window::new(1).unwrap();
+        assert_eq!(BranchBudget::derive(one, 128).get(), 1);
+    }
+
+    #[test]
+    fn branch_budget_tracks_expansion() {
+        let window = Window::new(256).unwrap();
+        assert_eq!(BranchBudget::derive(window, 64).get(), 5);
+        assert_eq!(BranchBudget::derive(window, 128).get(), 3);
+    }
+}

--- a/crates/file/src/geometry.rs
+++ b/crates/file/src/geometry.rs
@@ -1,0 +1,182 @@
+//! Chunk-tree geometry: every fan-out fact derives from (body size, mode).
+//!
+//! Const-assert policy: each concrete profile is pinned by
+//! [`assert_tree_geometry`], evaluated at compile time with `u128` arithmetic
+//! so coverage of the full `u64` length range is provable without overflow. A
+//! violated invariant is a build error, never a runtime panic; `assert!` in
+//! const-evaluated items is the one sanctioned panicking form here.
+
+/// How a tree references its children.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Mode {
+    /// References carry a 32-byte address.
+    Plain,
+    /// References carry a 32-byte address plus a 32-byte decryption key.
+    Encrypted,
+}
+
+/// Address width of a reference in bytes.
+const ADDRESS_SIZE: u32 = 32;
+/// Decryption-key width of an encrypted reference in bytes.
+const KEY_SIZE: u32 = 32;
+
+/// Plain reference width in bytes.
+const PLAIN_REF_SIZE: u32 = ADDRESS_SIZE;
+/// Encrypted reference width in bytes.
+const ENCRYPTED_REF_SIZE: u32 = ADDRESS_SIZE + KEY_SIZE;
+
+impl Mode {
+    /// Reference width in bytes.
+    pub const fn ref_size(self) -> u32 {
+        match self {
+            Self::Plain => PLAIN_REF_SIZE,
+            Self::Encrypted => ENCRYPTED_REF_SIZE,
+        }
+    }
+}
+
+/// References per intermediate chunk body: 128 plain, 64 encrypted at the
+/// default 4096-byte body. Valid profiles are pinned by
+/// [`assert_tree_geometry`].
+pub const fn branches(body_size: u32, mode: Mode) -> u32 {
+    match mode {
+        Mode::Plain => body_size / PLAIN_REF_SIZE,
+        Mode::Encrypted => body_size / ENCRYPTED_REF_SIZE,
+    }
+}
+
+/// Upper bound of the [`max_depth`] search; even a two-branch profile covers
+/// `u64` within it. Degenerate profiles saturate here and are rejected by
+/// [`assert_tree_geometry`].
+const DEPTH_SEARCH_LIMIT: u32 = 64;
+
+/// Least depth whose leaf capacity spans every `u64` byte length: 9 plain,
+/// 10 encrypted at the default 4096-byte body.
+pub const fn max_depth(body_size: u32, mode: Mode) -> u32 {
+    let mut depth = 1;
+    while depth < DEPTH_SEARCH_LIMIT && !covers_u64(body_size, mode, depth) {
+        depth = depth.saturating_add(1);
+    }
+    depth
+}
+
+/// One more than `u64::MAX`: capacity at or past this covers every length.
+const EVERY_U64_LENGTH: u128 = 1u128 << 64;
+
+/// Whether a tree of `depth` levels spans every `u64` byte length; the
+/// capacity `branches^(depth - 1) * body_size` is computed in `u128`.
+const fn covers_u64(body_size: u32, mode: Mode, depth: u32) -> bool {
+    let fan_out = u128_from_u32(branches(body_size, mode));
+    let mut capacity = u128_from_u32(body_size);
+    let mut hops = depth.saturating_sub(1);
+    while hops > 0 {
+        capacity = match capacity.checked_mul(fan_out) {
+            Some(grown) => grown,
+            // Overflowing u128 already exceeds the bound.
+            None => return true,
+        };
+        hops = hops.saturating_sub(1);
+    }
+    capacity >= EVERY_U64_LENGTH
+}
+
+/// Lossless const widening; `From` is not const-callable.
+const fn u128_from_u32(value: u32) -> u128 {
+    let [a, b, c, d] = value.to_le_bytes();
+    u128::from_le_bytes([a, b, c, d, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+}
+
+/// Const-evaluated profile check behind [`assert_tree_geometry`]; call it
+/// only from const context.
+///
+/// # Panics
+/// During const evaluation (a build error) when the profile is invalid.
+#[doc(hidden)]
+pub const fn assert_profile(body_size: u32, mode: Mode) {
+    assert!(
+        body_size.is_power_of_two(),
+        "body size must be a power of two"
+    );
+    let fan_out = branches(body_size, mode);
+    assert!(fan_out >= 2, "fan-out must be at least two");
+    let covered = match fan_out.checked_mul(mode.ref_size()) {
+        Some(bytes) => bytes,
+        None => 0,
+    };
+    assert!(
+        covered == body_size,
+        "reference width must divide the body exactly"
+    );
+    let depth = max_depth(body_size, mode);
+    assert!(
+        covers_u64(body_size, mode, depth),
+        "max depth must span every u64 length"
+    );
+    assert!(
+        !covers_u64(body_size, mode, depth.saturating_sub(1)),
+        "max depth must be minimal"
+    );
+}
+
+/// Pins the tree geometry of one body-size profile at compile time, for both
+/// modes: exact reference-width division, a fan-out of at least two, and a
+/// minimal [`max_depth`] spanning every `u64` length.
+#[macro_export]
+macro_rules! assert_tree_geometry {
+    ($body_size:expr) => {
+        const _: () = {
+            $crate::geometry::assert_profile($body_size, $crate::geometry::Mode::Plain);
+            $crate::geometry::assert_profile($body_size, $crate::geometry::Mode::Encrypted);
+        };
+    };
+}
+
+/// Body size of a standard Swarm content chunk in bytes.
+pub const DEFAULT_BODY_SIZE: u32 = 4096;
+
+assert_tree_geometry!(DEFAULT_BODY_SIZE);
+
+// Default-profile pins: the values the engines are designed around.
+const _: () = {
+    assert!(branches(DEFAULT_BODY_SIZE, Mode::Plain) == 128);
+    assert!(branches(DEFAULT_BODY_SIZE, Mode::Encrypted) == 64);
+    assert!(max_depth(DEFAULT_BODY_SIZE, Mode::Plain) == 9);
+    assert!(max_depth(DEFAULT_BODY_SIZE, Mode::Encrypted) == 10);
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ref_widths() {
+        assert_eq!(Mode::Plain.ref_size(), 32);
+        assert_eq!(Mode::Encrypted.ref_size(), 64);
+    }
+
+    #[test]
+    fn default_profile_fan_out() {
+        assert_eq!(branches(DEFAULT_BODY_SIZE, Mode::Plain), 128);
+        assert_eq!(branches(DEFAULT_BODY_SIZE, Mode::Encrypted), 64);
+    }
+
+    #[test]
+    fn default_profile_depth_is_minimal() {
+        assert_eq!(max_depth(DEFAULT_BODY_SIZE, Mode::Plain), 9);
+        assert_eq!(max_depth(DEFAULT_BODY_SIZE, Mode::Encrypted), 10);
+        assert!(!covers_u64(DEFAULT_BODY_SIZE, Mode::Plain, 8));
+        assert!(!covers_u64(DEFAULT_BODY_SIZE, Mode::Encrypted, 9));
+    }
+
+    #[test]
+    fn one_level_covers_nothing_beyond_its_body() {
+        assert!(!covers_u64(DEFAULT_BODY_SIZE, Mode::Plain, 1));
+    }
+
+    #[test]
+    fn smallest_plain_profile_reaches_u64() {
+        // A 64-byte body forks two ways: 6 + (depth - 1) bits must reach 64.
+        assert_eq!(branches(64, Mode::Plain), 2);
+        assert_eq!(max_depth(64, Mode::Plain), 59);
+    }
+}

--- a/crates/file/src/lib.rs
+++ b/crates/file/src/lib.rs
@@ -1,0 +1,32 @@
+//! Streaming file pipeline for Swarm chunk trees: bounded reads and writes
+//! over a chunk store.
+//!
+//! This crate carries the pipeline's foundations: per-profile tree
+//! [`geometry`] pinned at compile time, and the [`config`] admission budgets
+//! the engines drain against.
+
+#![no_std]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+// Test code may freely unwrap/index/panic; the runtime-safety restriction
+// lints target production code paths.
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::get_unwrap,
+        clippy::indexing_slicing,
+        clippy::string_slice,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::panic_in_result_fn
+    )
+)]
+
+pub mod config;
+pub mod geometry;
+
+pub use config::{BranchBudget, PutWindow, Window};
+pub use geometry::{DEFAULT_BODY_SIZE, Mode, branches, max_depth};

--- a/crates/manifest/src/builder.rs
+++ b/crates/manifest/src/builder.rs
@@ -12,6 +12,7 @@ use std::io::Write;
 
 use bytes::Bytes;
 use nectar_primitives::store::{BoxedError, ChunkPut, MaybeSend, MaybeSync};
+#[allow(deprecated)]
 use nectar_primitives::{
     Chunk, ChunkAddress, ChunkRef, ContentChunk, DefaultSplitter, FileError, PrimitivesError,
 };
@@ -40,6 +41,7 @@ pub enum BuildError {
     #[error(transparent)]
     Store(#[from] StoreError),
     /// Splitting a file into BMT chunks failed.
+    #[allow(deprecated)]
     #[error("split file")]
     Split(#[source] FileError),
     /// Buffering a file for splitting failed.
@@ -596,6 +598,7 @@ where
 
 /// Split `data` through BMT, spill its chunks to `store`, and return its plain
 /// root reference. Reuses the primitives splitter, so the BMT is shared.
+#[allow(deprecated)]
 async fn split_file<S>(store: &S, data: &[u8]) -> Result<ChunkRef, BuildError>
 where
     S: ChunkPut + MaybeSync,

--- a/crates/manifest/src/dx.rs
+++ b/crates/manifest/src/dx.rs
@@ -9,6 +9,7 @@
 
 use bytes::Bytes;
 use nectar_primitives::store::MaybeSync;
+#[allow(deprecated)]
 use nectar_primitives::{ChunkAddress, DEFAULT_BODY_SIZE, FileError, join};
 
 use crate::format::Format;
@@ -24,6 +25,7 @@ pub enum FetchError {
     #[error(transparent)]
     Read(#[from] ReaderError),
     /// Reassembling the referenced file from its chunks failed.
+    #[allow(deprecated)]
     #[error("join file")]
     Join(#[source] FileError),
     /// The entry names an encrypted file body. Per-reference node encryption
@@ -44,6 +46,7 @@ where
     /// Inline bytes return directly; a plain reference is joined from its BMT
     /// chunks over the reader's store. A ref64 names an encrypted file body,
     /// which the manifest does not reassemble.
+    #[allow(deprecated)]
     pub async fn read(&self, entry: &Entry<F>) -> Result<Bytes, FetchError> {
         match entry {
             Entry::Inline(value) => Ok(value.clone().into_bytes()),

--- a/crates/manifest/tests/builder.rs
+++ b/crates/manifest/tests/builder.rs
@@ -4,6 +4,9 @@
 //! buffers track the trie depth rather than the key count, and the files path
 //! splits through BMT and references the stored roots.
 
+// The legacy splitter seeds fixtures until the nectar-file bridge lands.
+#![allow(deprecated)]
+
 use std::error::Error;
 
 use bytes::Bytes;

--- a/crates/mantaray/src/builder.rs
+++ b/crates/mantaray/src/builder.rs
@@ -40,6 +40,7 @@ use alloc::collections::BTreeMap;
 
 use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{ChunkAddress, ChunkRef, Reference};
+#[allow(deprecated)]
 use nectar_primitives::file::{ChunkPutExt, ReadAt};
 use nectar_primitives::store::{ChunkPut, MaybeSend, TrustedGet};
 use nectar_primitives::{AnyChunkSet, Chunk};
@@ -145,6 +146,7 @@ impl<S: TrustedGet<AnyChunkSet<BS>> + ChunkPut<AnyChunkSet<BS>>, const BS: usize
     ///
     /// One mode end to end: a plain builder splits in plain mode and stages a
     /// plain reference, so a plain-encrypted pairing cannot be expressed.
+    #[allow(deprecated)]
     pub async fn put_file<D: ReadAt + Sync>(&mut self, path: &str, data: D) -> Result<()> {
         let root = self.store().write_file(data).await?;
         self.add(path, root).await

--- a/crates/mantaray/src/error.rs
+++ b/crates/mantaray/src/error.rs
@@ -141,6 +141,7 @@ pub enum MantarayError {
     #[error(transparent)]
     Primitives(#[from] PrimitivesError),
     /// Error from the file splitter or joiner across the file/manifest seam.
+    #[allow(deprecated)]
     #[error(transparent)]
     File(#[from] nectar_primitives::file::FileError),
     /// Error from the typed chunk store during get operations.

--- a/crates/mantaray/src/manifest.rs
+++ b/crates/mantaray/src/manifest.rs
@@ -6,6 +6,7 @@ use futures::{Stream, StreamExt, TryStreamExt, stream};
 use nectar_primitives::AnyChunkSet;
 use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{ChunkAddress, ChunkRef, Reference};
+#[allow(deprecated)]
 use nectar_primitives::file::join;
 use nectar_primitives::store::{ChunkPut, MaybeSend, TrustedGet};
 
@@ -380,6 +381,7 @@ impl<S: TrustedGet<AnyChunkSet<BS>>, const BS: usize> Manifest<S, ChunkRef, BS> 
     /// One mode end to end: a plain manifest joins a plain reference, so a
     /// plain-encrypted pairing surfaces as [`WrongRefKind`](MantarayError::WrongRefKind)
     /// rather than a silent byte-width mismatch.
+    #[allow(deprecated)]
     pub async fn read(&self, path: &str) -> Result<Option<Vec<u8>>> {
         let Some(entry) = self.get(path).await? else {
             return Ok(None);

--- a/crates/mantaray/tests/file_manifest_integration.rs
+++ b/crates/mantaray/tests/file_manifest_integration.rs
@@ -1,5 +1,7 @@
 //! Integration test: unified store for file splitting and manifest creation.
 
+// Exercises the legacy pipeline until its nectar-file replacement lands.
+#![allow(deprecated)]
 // Bench, example, and integration-test code: unwraps, direct indexing,
 // casts, and assertions are setup and illustration, not shipped surface.
 #![allow(

--- a/crates/postage-issuer/benches/upload_pipeline.rs
+++ b/crates/postage-issuer/benches/upload_pipeline.rs
@@ -1,4 +1,6 @@
 #![allow(missing_docs)]
+// Exercises the legacy pipeline until its nectar-file replacement lands.
+#![allow(deprecated)]
 //! End-to-end upload pipeline benchmarks.
 //!
 //! Measures the complete upload processing flow:

--- a/crates/primitives/benches/encryption_bench.rs
+++ b/crates/primitives/benches/encryption_bench.rs
@@ -1,4 +1,6 @@
 #![allow(missing_docs)]
+// Exercises the legacy pipeline until its nectar-file replacement lands.
+#![allow(deprecated)]
 // Bench and example code: unwraps, direct indexing, casts, and assertions
 // are setup and illustration, not shipped surface.
 #![allow(

--- a/crates/primitives/benches/file_bench.rs
+++ b/crates/primitives/benches/file_bench.rs
@@ -1,4 +1,6 @@
 #![allow(missing_docs)]
+// Exercises the legacy pipeline until its nectar-file replacement lands.
+#![allow(deprecated)]
 //! Benchmarks for file splitting and joining operations.
 //!
 //! Measures throughput (bytes/sec) for splitting files into chunks and

--- a/crates/primitives/src/chunk/encryption/reference.rs
+++ b/crates/primitives/src/chunk/encryption/reference.rs
@@ -2,8 +2,8 @@
 
 use crate::chunk::reference::{RefKind, Reference, WrongRefKind, sealed};
 use crate::chunk::{ChunkAddress, ChunkRef};
+use crate::entry_ref::EntryRef;
 use crate::error::WrongLength;
-use crate::file::EntryRef;
 use crate::wire::{Cursor, FromCursor, ToWriter, Underrun, Writer};
 
 use super::key::EncryptionKey;

--- a/crates/primitives/src/chunk/reference.rs
+++ b/crates/primitives/src/chunk/reference.rs
@@ -8,8 +8,8 @@
 use std::mem::size_of;
 
 use crate::chunk::ChunkAddress;
+use crate::entry_ref::EntryRef;
 use crate::error::WrongLength;
-use crate::file::EntryRef;
 use crate::wire::{Cursor, FromCursor, ToWriter, Underrun, Writer};
 
 pub(crate) mod sealed {

--- a/crates/primitives/src/chunk/wasm.rs
+++ b/crates/primitives/src/chunk/wasm.rs
@@ -115,6 +115,7 @@ impl WasmSplitResult {
 /// Split data into BMT chunks.
 ///
 /// Returns a SplitResult containing the root address and all generated chunks.
+#[allow(deprecated)]
 #[wasm_bindgen(js_name = splitFile)]
 pub fn split_file(data: &Uint8Array) -> Result<WasmSplitResult, JsValue> {
     let bytes = data.to_vec();

--- a/crates/primitives/src/entry_ref.rs
+++ b/crates/primitives/src/entry_ref.rs
@@ -3,7 +3,8 @@
 use crate::chunk::encryption::EncryptedChunkRef;
 use crate::chunk::{ChunkAddress, ChunkRef};
 
-use super::error::FileError;
+#[allow(deprecated)]
+use crate::file::error::FileError;
 
 /// A typed chunk reference: either a plain 32-byte address or an encrypted 64-byte ref.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -14,6 +15,7 @@ pub enum EntryRef {
     Encrypted(EncryptedChunkRef),
 }
 
+#[allow(deprecated)]
 impl EntryRef {
     /// Parse an entry reference from raw bytes.
     ///
@@ -91,6 +93,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn rejects_other_widths() {
         for len in [0usize, 31, 33, 63, 65, 96] {
             let bytes = vec![0u8; len];

--- a/crates/primitives/src/error.rs
+++ b/crates/primitives/src/error.rs
@@ -71,6 +71,7 @@ pub enum PrimitivesError {
     Chunk(#[from] crate::chunk::error::ChunkError),
 
     /// Errors from file operations
+    #[allow(deprecated)]
     #[error(transparent)]
     File(#[from] crate::file::error::FileError),
 

--- a/crates/primitives/src/file/mod.rs
+++ b/crates/primitives/src/file/mod.rs
@@ -6,6 +6,7 @@
 //! # Store-centric API (extension traits)
 //!
 //! ```
+//! # #![allow(deprecated)]
 //! use futures::executor::block_on;
 //! use nectar_primitives::file::{ChunkGetExt, ChunkPutExt};
 //! use nectar_primitives::DefaultMemoryStore;
@@ -19,6 +20,7 @@
 //! # Free function API
 //!
 //! ```
+//! # #![allow(deprecated)]
 //! use futures::executor::block_on;
 //! use nectar_primitives::file::{split, join};
 //! use nectar_primitives::DEFAULT_BODY_SIZE;
@@ -32,6 +34,7 @@
 //! # Encrypted split and join
 //!
 //! ```
+//! # #![allow(deprecated)]
 //! # #[cfg(feature = "encryption")] {
 //! use futures::executor::block_on;
 //! use nectar_primitives::file::{split_encrypted, join};
@@ -45,7 +48,6 @@
 //! ```
 
 mod constants;
-pub mod entry_ref;
 pub mod error;
 mod fold;
 mod frontier;
@@ -89,7 +91,7 @@ pub use splitter_parallel::EncryptedParallelSplitter;
 pub use splitter_parallel::ParallelSplitter;
 pub use write_at::WriteAt;
 
-pub use entry_ref::EntryRef;
+pub use crate::entry_ref::{self, EntryRef};
 pub use error::FileError;
 pub use tree::{ChunkRange, TreeParams};
 
@@ -261,6 +263,7 @@ impl<T, const BODY_SIZE: usize> ChunkGetExt<BODY_SIZE> for T where
 /// Uses [`JoinRef`] for unified plain/encrypted dispatch on read-back.
 ///
 /// ```
+/// # #![allow(deprecated)]
 /// use futures::executor::block_on;
 /// use nectar_primitives::file::{ChunkGetExt, ChunkPutExt};
 /// use nectar_primitives::DefaultMemoryStore;

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -44,6 +44,9 @@
         clippy::as_conversions
     )
 )]
+// The synthesized test harness references every `#[test]` inside the
+// deprecated legacy file module, so the warning would fire on each of them.
+#![cfg_attr(test, allow(deprecated))]
 
 extern crate alloc;
 
@@ -56,7 +59,9 @@ pub mod bmt;
 mod cache;
 mod cast;
 pub mod chunk;
+pub mod entry_ref;
 pub mod error;
+#[deprecated(note = "superseded by the nectar-file streaming pipeline")]
 pub mod file;
 #[cfg(any(test, feature = "arbitrary"))]
 pub mod generators;
@@ -160,22 +165,32 @@ pub use store::{
     Sleeper, TrustedGet,
 };
 
+// The width-agnostic reference union: the manifest-to-file bridge type.
+pub use entry_ref::EntryRef;
+
 // File joining (async)
+#[allow(deprecated)]
 #[cfg(feature = "encryption")]
 pub use file::EncryptedJoiner;
+#[allow(deprecated)]
 #[cfg(feature = "tokio")]
 pub use file::JoinerReader;
+#[allow(deprecated)]
 pub use file::{
-    ChunkGetExt, ChunkPutExt, ChunkRange, EntryRef, FileError, GenericJoiner, JoinRef, Joiner,
-    TreeParams, join,
+    ChunkGetExt, ChunkPutExt, ChunkRange, FileError, GenericJoiner, JoinRef, Joiner, TreeParams,
+    join,
 };
 
 // File splitting (CPU-bound, rayon)
+#[allow(deprecated)]
 #[cfg(feature = "encryption")]
 pub use file::{EncryptedParallelSplitter, EncryptedSplitter, split_encrypted};
+#[allow(deprecated)]
 pub use file::{ParallelSplitter, ReadAt, Splitter, split};
 
 /// Default sync file splitter.
+#[allow(deprecated)]
 pub type DefaultSplitter = file::Splitter<DEFAULT_BODY_SIZE>;
 /// Default async file joiner.
+#[allow(deprecated)]
 pub type DefaultJoiner<G> = file::Joiner<G, DEFAULT_BODY_SIZE>;


### PR DESCRIPTION
## What

- New `crates/file` (`nectar-file`), `#![no_std]` core with zero dependencies.
- `geometry.rs`: `Mode` (Plain/Encrypted, ref widths 32/64), const fns `branches(body_size, mode)` and `max_depth(body_size, mode)`, a u128-based `covers_u64` capacity check, and the `assert_tree_geometry!` macro (power-of-two body, exact ref-width division, fan-out >= 2, minimal depth spanning every u64 length, all const-evaluated), plus default-profile pins (128/64 branches, 9/10 depth at 4096).
- `config.rs`: `Window`/`PutWindow` (`NonZeroU16`, default 16, const `new`, `From<NonZeroU16>` both ways) and derived-only `BranchBudget` (`max(1, 1 + window/branches)`, `NonZeroU32`-backed).
- Feature matrix: `default = std`, `tokio`/`rayon` imply `std`, `encryption` standalone.
- `refactor(primitives)`: deprecates the legacy `file` module in place (moves `entry_ref.rs` up a level, adds deprecation markers) without removing any consumer-facing behaviour.
- `ci`: adds `nectar-file` to the rv64 and wasm no_std CI lanes (`lint.yml`, `nostd.yml`).

## Why

Scaffolds the `nectar-file` crate and its core tree-geometry/admission-budget primitives ahead of the streaming file re-architecture.

Closes #330

## Testing

All independent checks green; see below.

## AI Assistance

Implementation by Fable, review by Opus, PR description by Sonnet.

Closes #243
