### PR TITLE
feat: derived address newtype for chunk sealing

### DIFF
--- a/crates/primitives/src/bmt/derived.rs
+++ b/crates/primitives/src/bmt/derived.rs
@@ -1,0 +1,54 @@
+//! Hasher-derived BMT root.
+
+use alloy_primitives::B256;
+
+/// A BMT root carrying hasher provenance in the type.
+///
+/// The field is private and the only constructor lives inside the bmt
+/// module, so a held value was computed by
+/// [`Hasher::sum_derived`](super::Hasher::sum_derived), never supplied.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct DerivedAddress(B256);
+
+impl DerivedAddress {
+    /// Wrap a freshly computed root; unreachable outside the bmt module.
+    pub(super) const fn new(root: B256) -> Self {
+        Self(root)
+    }
+}
+
+impl From<DerivedAddress> for B256 {
+    fn from(derived: DerivedAddress) -> Self {
+        derived.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::Hasher;
+    use super::*;
+
+    #[test]
+    fn derived_root_equals_sum() {
+        let mut hasher: Hasher = Hasher::new();
+        hasher.set_span(11);
+        hasher.update(b"hello world");
+        assert_eq!(B256::from(hasher.sum_derived()), hasher.sum());
+    }
+
+    /// A configured prefix participates: the derived value tracks the
+    /// transformed root, exactly as `sum` does.
+    #[test]
+    fn prefixed_derivation_tracks_the_transformed_root() {
+        let mut plain: Hasher = Hasher::new();
+        plain.set_span(3);
+        plain.update(b"foo");
+
+        let mut prefixed: Hasher = Hasher::with_prefix(b"anchor");
+        prefixed.set_span(3);
+        prefixed.update(b"foo");
+
+        assert_eq!(B256::from(prefixed.sum_derived()), prefixed.sum());
+        assert_ne!(prefixed.sum_derived(), plain.sum_derived());
+    }
+}

--- a/crates/primitives/src/bmt/hasher.rs
+++ b/crates/primitives/src/bmt/hasher.rs
@@ -11,6 +11,7 @@ use hybrid_array::{Array, sizes::U32};
 use once_cell::race::OnceBox;
 
 use super::constants::*;
+use super::derived::DerivedAddress;
 
 /// Number of zero tree levels for the default body size.
 const ZERO_TREE_LEVELS: usize = zero_tree_levels(DEFAULT_BODY_SIZE);
@@ -205,6 +206,15 @@ impl<const BODY_SIZE: usize> Hasher<BODY_SIZE> {
     #[must_use]
     pub fn sum(&self) -> B256 {
         self.finalize_with_prefix(self.hash_internal())
+    }
+
+    /// Compute the BMT root as a [`DerivedAddress`]: the value of
+    /// [`sum`](Self::sum) carried with hasher provenance. A configured
+    /// prefix participates, making the result the transformed root.
+    #[inline]
+    #[must_use]
+    pub fn sum_derived(&self) -> DerivedAddress {
+        DerivedAddress::new(self.sum())
     }
 
     /// Check if a byte slice is all zeros.

--- a/crates/primitives/src/bmt/mod.rs
+++ b/crates/primitives/src/bmt/mod.rs
@@ -31,11 +31,13 @@
 //! ```
 
 mod constants;
+mod derived;
 pub(crate) mod error;
 mod hasher;
 mod proof;
 
 pub use constants::{BRANCHES, DEFAULT_BODY_SIZE, HASH_SIZE, SPAN_SIZE};
+pub use derived::DerivedAddress;
 pub use error::BmtError;
 pub use hasher::{Hasher, HasherFactory};
 pub use proof::{Proof, Prover};

--- a/crates/primitives/src/chunk/address.rs
+++ b/crates/primitives/src/chunk/address.rs
@@ -12,6 +12,7 @@ use derive_more::{AsRef, Display, From, Into};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+use crate::bmt::DerivedAddress;
 use crate::error::{Result, WrongLength};
 use crate::xor_metric::XorMetric;
 
@@ -66,6 +67,13 @@ impl ChunkAddress {
     /// Create a new zero-filled address.
     pub const fn zero() -> Self {
         Self::ZERO
+    }
+}
+
+/// Adopt a hasher-derived BMT root as an address; the conversion is one-way.
+impl From<DerivedAddress> for ChunkAddress {
+    fn from(derived: DerivedAddress) -> Self {
+        Self(derived.into())
     }
 }
 

--- a/crates/primitives/src/chunk/bmt_body.rs
+++ b/crates/primitives/src/chunk/bmt_body.rs
@@ -7,7 +7,7 @@ use bytes::{Bytes, BytesMut};
 use std::marker::PhantomData;
 use std::sync::OnceLock;
 
-use crate::bmt::{DEFAULT_BODY_SIZE, Hasher, SPAN_SIZE};
+use crate::bmt::{DEFAULT_BODY_SIZE, DerivedAddress, Hasher, SPAN_SIZE};
 use crate::chunk::ChunkAddress;
 use crate::chunk::error::{self, ChunkError};
 use crate::error::{PrimitivesError, Result};
@@ -17,7 +17,7 @@ use crate::error::{PrimitivesError, Result};
 pub struct BmtBody<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> {
     span: u64,
     data: Bytes,
-    cached_hash: OnceLock<ChunkAddress>,
+    cached_hash: OnceLock<DerivedAddress>,
 }
 
 /// Structural equality over span and payload. Never derives the hash: when
@@ -75,14 +75,19 @@ impl<const BODY_SIZE: usize> BmtBody<BODY_SIZE> {
 
     /// Compute the BMT hash of this body
     pub fn hash(&self) -> ChunkAddress {
+        ChunkAddress::from(self.derived_hash())
+    }
+
+    /// The body's BMT root with hasher provenance; computed once, cached.
+    pub(crate) fn derived_hash(&self) -> DerivedAddress {
         *self.cached_hash.get_or_init(|| self.calculate_hash())
     }
 
-    fn calculate_hash(&self) -> ChunkAddress {
+    fn calculate_hash(&self) -> DerivedAddress {
         let mut hasher: Hasher<BODY_SIZE> = Hasher::new();
         hasher.set_span(self.span);
         hasher.update(self.data.as_ref());
-        hasher.sum().into()
+        hasher.sum_derived()
     }
 
     /// Compute the anchor-keyed *transformed* BMT root of this body.

--- a/crates/primitives/src/chunk/content.rs
+++ b/crates/primitives/src/chunk/content.rs
@@ -16,7 +16,9 @@ use super::address::ChunkAddress;
 use super::bmt_body::BmtBody;
 use super::error::ChunkError;
 use super::inner::ChunkInner;
+use super::registry::ChunkRegistry;
 use super::traits::{ChunkHeader, ChunkOps};
+use super::trust::{Chunk, Verified};
 use super::type_id::ChunkTypeId;
 use super::type_tag::ChunkVersion;
 
@@ -94,6 +96,26 @@ impl<const BODY_SIZE: usize> ContentChunk<BODY_SIZE> {
     #[must_use]
     pub const fn from_body(body: BmtBody<BODY_SIZE>) -> Self {
         Self::from_header_and_body(CacHeader, body)
+    }
+
+    /// Seal into the verified currency at the derived address, hashing once.
+    ///
+    /// Sound for content chunks only: the acceptance rule is exactly
+    /// `address == body hash`, and the sealed address is a hasher-derived
+    /// [`DerivedAddress`](crate::bmt::DerivedAddress), never supplied. Debug
+    /// builds retain a full rehash assertion through [`ChunkOps::verify`].
+    #[must_use]
+    pub fn seal<R>(self) -> Chunk<Verified, R>
+    where
+        R: ChunkRegistry,
+        R::Envelope: From<Self>,
+    {
+        let address = ChunkAddress::from(self.body().derived_hash());
+        debug_assert!(
+            self.verify(&address).is_ok(),
+            "a content chunk must certify at its derived address"
+        );
+        Chunk::from_verified_parts(address, R::Envelope::from(self))
     }
 }
 
@@ -212,7 +234,7 @@ impl<'a, const BODY_SIZE: usize> arbitrary::Arbitrary<'a> for ContentChunk<BODY_
 mod tests {
     use crate::{
         DEFAULT_BODY_SIZE,
-        chunk::{ChunkOps, error::ChunkError},
+        chunk::{ChunkOps, ContentOnlyChunkSet, StandardChunkSet, error::ChunkError},
         error::PrimitivesError,
     };
 
@@ -288,6 +310,24 @@ mod tests {
         fn test_deserialize_invalid_chunks(data in proptest::collection::vec(any::<u8>(), 0..8)) {
             let result = DefaultContentChunk::try_from(data.as_slice());
             prop_assert_eq!(matches!(result, Err(PrimitivesError::Chunk(ChunkError::InvalidSize { .. }))), true);
+        }
+
+        /// Differential accept set: seal certifies exactly the (chunk, address)
+        /// pairs verify accepts. Everything seal emits passes verify; the
+        /// verify-certified constructor lands on the same address and bytes;
+        /// off the derived address verify accepts nothing, and seal never
+        /// seals there.
+        #[test]
+        fn seal_accept_set_matches_verify(chunk in chunk_strategy(), lie in arb::<ChunkAddress>()) {
+            let sealed = chunk.clone().seal::<StandardChunkSet>();
+            prop_assert!(sealed.envelope().verify(sealed.address()).is_ok());
+
+            let verified = Chunk::<Verified>::from_envelope(chunk.clone().into()).unwrap();
+            prop_assert_eq!(sealed.address(), verified.address());
+            prop_assert_eq!(sealed.typed_bytes(), verified.typed_bytes());
+
+            prop_assume!(lie != *sealed.address());
+            prop_assert!(chunk.verify(&lie).is_err());
         }
     }
 
@@ -388,6 +428,15 @@ mod tests {
             CacHeader.seal_transformed(&address, root),
             ChunkAddress::from(root)
         );
+    }
+
+    #[test]
+    fn seal_supports_single_member_registries() {
+        let chunk = DefaultContentChunk::new(b"content only".to_vec()).unwrap();
+        let expected = *chunk.address();
+        let sealed = chunk.seal::<ContentOnlyChunkSet>();
+        assert_eq!(sealed.address(), &expected);
+        assert!(sealed.envelope().verify(&expected).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## What

- New `DerivedAddress` newtype in `crates/primitives/src/bmt/derived.rs`: private field, `pub(super)` constructor, `Hasher::sum_derived` is the only producer.
- One-way `From` conversions from `DerivedAddress` to `B256` and `ChunkAddress`.
- `BmtBody` caches the derived root.
- `ContentChunk::seal<R>()` produces `Chunk<Verified, R>` in a single hash, with the retained debug rehash assertion.

## Why

Closes #327

## Testing

- Differential accept-set proptest proves `seal` certifies exactly the (chunk, address) pairs `verify` accepts: agreement with `from_envelope` on address and typed bytes, rejection everywhere off the derived address.
- Single-member-registry unit test.

## AI Assistance

Implementation by Fable, review by Opus, PR by Sonnet.

