### PR TITLE
feat(file): add poll-native walk engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2061,6 +2061,13 @@ dependencies = [
 [[package]]
 name = "nectar-file"
 version = "0.4.0"
+dependencies = [
+ "bytes",
+ "futures",
+ "futures-util",
+ "nectar-primitives",
+ "thiserror",
+]
 
 [[package]]
 name = "nectar-manifest"

--- a/crates/file/Cargo.toml
+++ b/crates/file/Cargo.toml
@@ -17,12 +17,31 @@ categories = ["no-std", "asynchronous", "data-structures"]
 [lints]
 workspace = true
 
+[dependencies]
+bytes = { workspace = true, optional = true }
+futures-util = { workspace = true, optional = true }
+nectar-primitives = { workspace = true, optional = true }
+thiserror = { workspace = true, optional = true }
+
+[dev-dependencies]
+futures.workspace = true
+
 [features]
 default = [ "std" ]
 
 # Standard library interop; the filesystem and io adapters land with the
-# engines.
-std = []
+# write engine. The walk engine rides this feature until the primitives core
+# builds bare-metal.
+std = [
+	"bytes?/std",
+	"dep:bytes",
+	"dep:futures-util",
+	"dep:nectar-primitives",
+	"dep:thiserror",
+	"futures-util?/std",
+	"nectar-primitives?/std",
+	"thiserror?/std",
+]
 
 # Async reader and writer adapters over the poll surface. Implies `std`.
 tokio = [ "std" ]
@@ -32,7 +51,11 @@ tokio = [ "std" ]
 rayon = [ "std" ]
 
 # Split-side encrypted mode. Joining encrypted references stays unconditional.
-encryption = []
+encryption = [ "nectar-primitives?/encryption" ]
+
+# Single-thread send escape: relaxes the boxed fetch future off `Send` in
+# lockstep with the primitives store traits.
+unsync = [ "nectar-primitives?/unsync" ]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/file/README.md
+++ b/crates/file/README.md
@@ -6,5 +6,6 @@ The crate currently carries the pipeline's foundations:
 
 - **Geometry** (`geometry`): every fan-out fact of a chunk tree derives from its body size and reference mode (plain 32-byte references, encrypted 64-byte references). Each concrete profile is pinned at compile time by `assert_tree_geometry!`, whose checks run in `u128` so coverage of the full `u64` length range is provable without overflow.
 - **Admission budgets** (`config`): `Window` (bounded fetch window), `PutWindow` (bounded put window) and the derived `BranchBudget` that keeps tree descent live at any window size.
+- **Walk engine** (`walk`): the one poll-native descent every read mode drains. Two-budget admission with a head-liveness reservation, range pruning, address-equality checks on every completion, typed terminal errors and no retries; ordered and completion-order drains over the same state machine.
 
-The core is `#![no_std]`; the read and write engines stack on top of these invariants. Feature flags: `std` (default), `tokio`, `rayon`, `encryption`.
+The core is `#![no_std]`; the write engine stacks on the same invariants. Feature flags: `std` (default), `tokio`, `rayon`, `encryption`, `unsync`.

--- a/crates/file/src/lib.rs
+++ b/crates/file/src/lib.rs
@@ -2,8 +2,9 @@
 //! over a chunk store.
 //!
 //! This crate carries the pipeline's foundations: per-profile tree
-//! [`geometry`] pinned at compile time, and the [`config`] admission budgets
-//! the engines drain against.
+//! [`geometry`] pinned at compile time, the [`config`] admission budgets the
+//! engines drain against, and the poll-native [`walk`] engine every read
+//! mode drains.
 
 #![no_std]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
@@ -21,12 +22,23 @@
         clippy::arithmetic_side_effects,
         clippy::panic,
         clippy::unreachable,
-        clippy::panic_in_result_fn
+        clippy::panic_in_result_fn,
+        clippy::as_conversions
     )
 )]
 
+#[cfg(feature = "std")]
+extern crate alloc;
+#[cfg(test)]
+extern crate std;
+
 pub mod config;
 pub mod geometry;
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+pub mod walk;
 
 pub use config::{BranchBudget, PutWindow, Window};
 pub use geometry::{DEFAULT_BODY_SIZE, Mode, branches, max_depth};
+#[cfg(feature = "std")]
+pub use walk::{Frame, Plain, ShapeError, Walk, WalkError, WalkMode, WalkStats};

--- a/crates/file/src/walk/engine.rs
+++ b/crates/file/src/walk/engine.rs
@@ -1,0 +1,559 @@
+//! The bounded descent state machine.
+
+use alloc::boxed::Box;
+use alloc::collections::{BTreeMap, VecDeque};
+use core::fmt;
+use core::future::Future;
+use core::ops::Range;
+use core::pin::Pin;
+use core::task::{Context, Poll};
+
+use bytes::Bytes;
+use futures_util::stream::{FuturesUnordered, Stream};
+use nectar_primitives::DEFAULT_BODY_SIZE;
+use nectar_primitives::chunk::{AnyChunkSet, Chunk, ChunkAddress, ChunkOps, Verified};
+use nectar_primitives::store::TrustedGet;
+
+use super::error::{ShapeError, WalkError};
+use super::mode::WalkMode;
+use super::{Frame, WalkStats};
+use crate::config::{BranchBudget, Window};
+
+/// One pending tree node: where its bytes live and what fetches it.
+struct Node<M: WalkMode> {
+    address: ChunkAddress,
+    /// Reference context routed with the node; the encrypted mode's body
+    /// decoder consumes it.
+    #[allow(dead_code, reason = "consumed once the encrypted decoder lands")]
+    context: M::Context,
+    /// Absolute offset of the subtree's first byte.
+    start: u64,
+    /// Bytes the subtree covers.
+    span: u64,
+}
+
+impl<M: WalkMode> Node<M> {
+    /// Sequence key: the node's first in-range byte.
+    fn key(&self, range_start: u64) -> u64 {
+        self.start.max(range_start)
+    }
+}
+
+/// Completion payload; the future carries its node back, which is the whole
+/// of sequence routing.
+type Fetched<M, E, const B: usize> = (Node<M>, Result<Chunk<Verified, AnyChunkSet<B>>, E>);
+
+/// Boxed fetch future: `Send` on multi-threaded targets, unbounded on wasm32
+/// and under the `unsync` feature.
+#[cfg(not(any(target_arch = "wasm32", feature = "unsync")))]
+type BoxFetch<M, E, const B: usize> = Pin<Box<dyn Future<Output = Fetched<M, E, B>> + Send>>;
+/// Boxed fetch future: `Send` on multi-threaded targets, unbounded on wasm32
+/// and under the `unsync` feature.
+#[cfg(any(target_arch = "wasm32", feature = "unsync"))]
+type BoxFetch<M, E, const B: usize> = Pin<Box<dyn Future<Output = Fetched<M, E, B>>>>;
+
+/// Which frame a drain takes from the ready set.
+#[derive(Clone, Copy)]
+enum Drain {
+    /// Only the head frame, in file order.
+    Ordered,
+    /// The lowest ready frame, regardless of order.
+    Any,
+}
+
+/// The one poll-native walk: a bounded, sequence-routed descent of a chunk
+/// tree over a byte range.
+///
+/// All state lives here, so every poll is cancel-safe and dropping the walk
+/// loses only in-flight round trips. The module docs state the normative
+/// admission invariants.
+pub struct Walk<S, M, const B: usize = DEFAULT_BODY_SIZE>
+where
+    S: TrustedGet<AnyChunkSet<B>>,
+    M: WalkMode,
+{
+    store: S,
+    range_start: u64,
+    range_end: u64,
+    body: u64,
+    branches: u64,
+    window: usize,
+    branch_budget: usize,
+    /// Discovered leaves awaiting a window slot, ascending by key.
+    leaf_frontier: VecDeque<Node<M>>,
+    /// Discovered intermediates awaiting descent, ascending by key; the
+    /// flattened frame stack of the serial walk.
+    branch_frontier: VecDeque<Node<M>>,
+    in_flight: FuturesUnordered<BoxFetch<M, S::Error, B>>,
+    /// Keys of in-flight leaf fetches, counted per key.
+    leaf_keys: BTreeMap<u64, usize>,
+    /// Keys of in-flight branch fetches, counted per key.
+    branch_keys: BTreeMap<u64, usize>,
+    leaf_in_flight: usize,
+    branch_in_flight: usize,
+    /// Resolved leaf bodies, clipped to the range, keyed by offset.
+    ready: BTreeMap<u64, Bytes>,
+    done: bool,
+    stats: WalkStats,
+}
+
+impl<S, M, const B: usize> Walk<S, M, B>
+where
+    S: TrustedGet<AnyChunkSet<B>> + Clone + 'static,
+    M: WalkMode,
+{
+    /// Compile-time profile guard for the walk's span arithmetic.
+    const PROFILE: () = {
+        assert!(B.is_power_of_two(), "body size must be a power of two");
+        assert!(
+            u64_from_usize(B) <= u64_from_u32(u32::MAX),
+            "body size must fit the u32 geometry"
+        );
+        let fan_out = fan_out(u64_from_usize(B), u64_from_u32(M::MODE.ref_size()));
+        assert!(fan_out >= 2, "fan-out must be at least two");
+    };
+
+    /// Walk `range` of the tree under `root`, whose total `span` the caller
+    /// read from the root chunk. The engine re-fetches the root as its first
+    /// node, so the fetch set stays identical to a cold serial walk.
+    pub fn new(
+        store: S,
+        root: ChunkAddress,
+        context: M::Context,
+        span: u64,
+        range: Range<u64>,
+        window: Window,
+    ) -> Self {
+        const { Self::PROFILE };
+        let body = u64_from_usize(B);
+        let branches = fan_out(body, u64_from_u32(M::MODE.ref_size()));
+        let range_end = range.end.min(span);
+        let range_start = range.start.min(range_end);
+        let budget = BranchBudget::derive(window, u32::try_from(branches).unwrap_or(u32::MAX));
+        let mut walk = Self {
+            store,
+            range_start,
+            range_end,
+            body,
+            branches,
+            window: usize::from(window.get()),
+            branch_budget: usize::try_from(budget.get()).unwrap_or(usize::MAX),
+            leaf_frontier: VecDeque::new(),
+            branch_frontier: VecDeque::new(),
+            in_flight: FuturesUnordered::new(),
+            leaf_keys: BTreeMap::new(),
+            branch_keys: BTreeMap::new(),
+            leaf_in_flight: 0,
+            branch_in_flight: 0,
+            ready: BTreeMap::new(),
+            done: false,
+            stats: WalkStats::default(),
+        };
+        walk.enqueue(Node {
+            address: root,
+            context,
+            start: 0,
+            span,
+        });
+        walk
+    }
+
+    /// Clipped absolute byte range this walk delivers.
+    pub const fn range(&self) -> Range<u64> {
+        self.range_start..self.range_end
+    }
+
+    /// Occupancy witnesses accumulated so far.
+    pub const fn stats(&self) -> WalkStats {
+        self.stats
+    }
+
+    /// Whether the walk has delivered its last frame or failed.
+    pub const fn is_finished(&self) -> bool {
+        self.done
+    }
+
+    /// Deliver the next frame in file order: consecutive frames tile the
+    /// range gaplessly.
+    ///
+    /// Cancel-safe: all progress lives in `self`, so an abandoned call loses
+    /// nothing. `Ready(None)` after the last in-range byte or after a
+    /// terminal error.
+    pub fn poll_next_ordered(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame, WalkError<S::Error>>>> {
+        self.poll_frame(cx, Drain::Ordered)
+    }
+
+    /// Deliver the next frame in completion order, lowest ready offset
+    /// first. Same contract as [`poll_next_ordered`](Self::poll_next_ordered)
+    /// without the ordering guarantee.
+    pub fn poll_next_any(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame, WalkError<S::Error>>>> {
+        self.poll_frame(cx, Drain::Any)
+    }
+
+    fn poll_frame(
+        &mut self,
+        cx: &mut Context<'_>,
+        drain: Drain,
+    ) -> Poll<Option<Result<Frame, WalkError<S::Error>>>> {
+        if self.done {
+            return Poll::Ready(None);
+        }
+        loop {
+            self.admit();
+            if let Some(frame) = self.take_ready(drain) {
+                return Poll::Ready(Some(Ok(frame)));
+            }
+            match Pin::new(&mut self.in_flight).poll_next(cx) {
+                Poll::Ready(Some((node, fetched))) => {
+                    if let Err(error) = self.absorb(node, fetched) {
+                        self.done = true;
+                        return Poll::Ready(Some(Err(error)));
+                    }
+                }
+                Poll::Ready(None) => {
+                    self.done = true;
+                    let pending = self
+                        .leaf_frontier
+                        .len()
+                        .saturating_add(self.branch_frontier.len());
+                    if pending == 0 && self.ready.is_empty() {
+                        return Poll::Ready(None);
+                    }
+                    return Poll::Ready(Some(Err(WalkError::Stalled {
+                        pending,
+                        occupancy: self.occupancy(),
+                    })));
+                }
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+
+    /// Admit queued nodes until neither lane may proceed.
+    fn admit(&mut self) {
+        loop {
+            let Some(head) = self.head_key() else { return };
+            let branch = self.try_admit_branch(head);
+            let leaf = self.try_admit_leaf(head);
+            if !branch && !leaf {
+                return;
+            }
+        }
+    }
+
+    /// The head: the lowest key still owed to the consumer. Every byte below
+    /// it has been yielded, because a node only leaves the walk by being
+    /// yielded or expanded into its children.
+    fn head_key(&self) -> Option<u64> {
+        let candidates = [
+            self.leaf_frontier
+                .front()
+                .map(|node| node.key(self.range_start)),
+            self.branch_frontier
+                .front()
+                .map(|node| node.key(self.range_start)),
+            self.leaf_keys.first_key_value().map(|(&key, _)| key),
+            self.branch_keys.first_key_value().map(|(&key, _)| key),
+            self.ready.first_key_value().map(|(&key, _)| key),
+        ];
+        candidates.into_iter().flatten().min()
+    }
+
+    /// Whether the head already occupies a window slot (an in-flight leaf
+    /// fetch or a buffered frame); the reservation stands only while it does
+    /// not.
+    fn head_holds_slot(&self, head: u64) -> bool {
+        self.leaf_keys.contains_key(&head)
+            || self
+                .ready
+                .first_key_value()
+                .is_some_and(|(&key, _)| key == head)
+    }
+
+    /// Leaf bodies held: in flight plus buffered.
+    fn occupancy(&self) -> usize {
+        self.leaf_in_flight.saturating_add(self.ready.len())
+    }
+
+    /// Admit the lowest queued branch. The head branch only needs a budget
+    /// slot (liveness over the reference cap); any other branch also needs
+    /// absorption room.
+    fn try_admit_branch(&mut self, head: u64) -> bool {
+        if self.branch_in_flight >= self.branch_budget {
+            return false;
+        }
+        let Some(front) = self.branch_frontier.front() else {
+            return false;
+        };
+        if front.key(self.range_start) != head && !self.expansion_room() {
+            return false;
+        }
+        let Some(node) = self.branch_frontier.pop_front() else {
+            return false;
+        };
+        self.dispatch(node);
+        true
+    }
+
+    /// Admit the lowest queued leaf. The head leaf may take the last window
+    /// slot; any other leaf must leave it free until the head holds one.
+    fn try_admit_leaf(&mut self, head: u64) -> bool {
+        let Some(front) = self.leaf_frontier.front() else {
+            return false;
+        };
+        let cap = if front.key(self.range_start) == head || self.head_holds_slot(head) {
+            self.window
+        } else {
+            self.window.saturating_sub(1)
+        };
+        if self.occupancy() >= cap {
+            return false;
+        }
+        let Some(node) = self.leaf_frontier.pop_front() else {
+            return false;
+        };
+        self.dispatch(node);
+        true
+    }
+
+    /// Whether the leaf frontier can absorb every outstanding expansion plus
+    /// one more, keeping buffered leaf references within `window + branches`
+    /// outside the head exemption.
+    fn expansion_room(&self) -> bool {
+        let pending = u64_from_usize(self.leaf_frontier.len());
+        let reserved = u64_from_usize(self.branch_in_flight)
+            .saturating_add(1)
+            .saturating_mul(self.branches);
+        pending.saturating_add(reserved)
+            <= u64_from_usize(self.window).saturating_add(self.branches)
+    }
+
+    /// Start one fetch, moving the node into its future; the completion
+    /// carries it back.
+    fn dispatch(&mut self, node: Node<M>) {
+        let key = node.key(self.range_start);
+        if node.span <= self.body {
+            let slot = self.leaf_keys.entry(key).or_insert(0);
+            *slot = slot.saturating_add(1);
+            self.leaf_in_flight = self.leaf_in_flight.saturating_add(1);
+            self.stats.peak_occupancy = self.stats.peak_occupancy.max(self.occupancy());
+        } else {
+            let slot = self.branch_keys.entry(key).or_insert(0);
+            *slot = slot.saturating_add(1);
+            self.branch_in_flight = self.branch_in_flight.saturating_add(1);
+            self.stats.peak_branch_in_flight =
+                self.stats.peak_branch_in_flight.max(self.branch_in_flight);
+        }
+        self.stats.fetches = self.stats.fetches.saturating_add(1);
+        let store = self.store.clone();
+        let fetch: BoxFetch<M, S::Error, B> = Box::pin(async move {
+            let address = node.address;
+            let fetched = store.get(&address).await;
+            (node, fetched)
+        });
+        self.in_flight.push(fetch);
+    }
+
+    /// Retire a completed fetch from the in-flight accounting.
+    fn retire(&mut self, key: u64, leaf: bool) {
+        let keys = if leaf {
+            &mut self.leaf_keys
+        } else {
+            &mut self.branch_keys
+        };
+        if let Some(count) = keys.get_mut(&key) {
+            *count = count.saturating_sub(1);
+            if *count == 0 {
+                keys.remove(&key);
+            }
+        }
+        if leaf {
+            self.leaf_in_flight = self.leaf_in_flight.saturating_sub(1);
+        } else {
+            self.branch_in_flight = self.branch_in_flight.saturating_sub(1);
+        }
+    }
+
+    /// Fold one completion back into the walk: buffer a leaf body or expand
+    /// an intermediate. Every completion must return the requested address.
+    fn absorb(
+        &mut self,
+        node: Node<M>,
+        fetched: Result<Chunk<Verified, AnyChunkSet<B>>, S::Error>,
+    ) -> Result<(), WalkError<S::Error>> {
+        let leaf = node.span <= self.body;
+        let key = node.key(self.range_start);
+        self.retire(key, leaf);
+        let chunk = fetched.map_err(|source| WalkError::Fetch {
+            address: node.address,
+            source,
+        })?;
+        let returned = *chunk.address();
+        if returned != node.address {
+            return Err(WalkError::AddressMismatch {
+                requested: node.address,
+                returned,
+            });
+        }
+        let data = chunk.into_envelope().data().clone();
+        if leaf {
+            let len = u64_from_usize(data.len());
+            if len != node.span {
+                return Err(ShapeError::LeafLength {
+                    offset: node.start,
+                    span: node.span,
+                    len,
+                }
+                .into());
+            }
+            self.ready.insert(key, self.clip(&node, data));
+            Ok(())
+        } else {
+            self.expand(&node, &data).map_err(WalkError::from)
+        }
+    }
+
+    /// Expand an intermediate body into its overlapping children.
+    fn expand(&mut self, node: &Node<M>, body: &Bytes) -> Result<(), ShapeError> {
+        let sub = child_subspan(node.span, self.body, self.branches);
+        let expected = node.span.div_ceil(sub);
+        let mut input: &[u8] = body;
+        for index in 0..expected {
+            let Some((address, context)) = M::take_ref(&mut input) else {
+                return Err(ShapeError::Arity {
+                    offset: node.start,
+                    expected,
+                    have: index,
+                });
+            };
+            let overflow = ShapeError::Offset {
+                offset: node.start,
+                span: node.span,
+            };
+            let delta = index.checked_mul(sub).ok_or(overflow)?;
+            let start = node.start.checked_add(delta).ok_or(overflow)?;
+            let span = sub.min(node.span.saturating_sub(delta));
+            self.enqueue(Node {
+                address,
+                context,
+                start,
+                span,
+            });
+        }
+        Ok(())
+    }
+
+    /// Queue a node in key order, pruning subtrees outside the range; an
+    /// empty range prunes everything.
+    fn enqueue(&mut self, node: Node<M>) {
+        let end = node.start.saturating_add(node.span);
+        if self.range_start >= self.range_end
+            || node.start >= self.range_end
+            || end <= self.range_start
+        {
+            return;
+        }
+        let range_start = self.range_start;
+        let key = node.key(range_start);
+        let queue = if node.span <= self.body {
+            &mut self.leaf_frontier
+        } else {
+            &mut self.branch_frontier
+        };
+        let at = queue.partition_point(|queued| queued.key(range_start) <= key);
+        queue.insert(at, node);
+        self.stats.peak_leaf_frontier = self.stats.peak_leaf_frontier.max(self.leaf_frontier.len());
+    }
+
+    /// Clip a leaf body to the in-range window; the bounds are clamped into
+    /// the body by construction, so the slice cannot be out of range.
+    fn clip(&self, node: &Node<M>, data: Bytes) -> Bytes {
+        let len = data.len();
+        let low = clamp_index(self.range_start.saturating_sub(node.start), len);
+        let high = clamp_index(self.range_end.saturating_sub(node.start), len).max(low);
+        data.slice(low..high)
+    }
+
+    /// Take the next deliverable frame, if the drain permits one.
+    fn take_ready(&mut self, drain: Drain) -> Option<Frame> {
+        if let Drain::Ordered = drain {
+            let head = self.head_key()?;
+            let (&key, _) = self.ready.first_key_value()?;
+            if key != head {
+                return None;
+            }
+        }
+        self.ready
+            .pop_first()
+            .map(|(offset, data)| Frame { offset, data })
+    }
+}
+
+impl<S, M, const B: usize> fmt::Debug for Walk<S, M, B>
+where
+    S: TrustedGet<AnyChunkSet<B>>,
+    M: WalkMode,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Walk")
+            .field("range_start", &self.range_start)
+            .field("range_end", &self.range_end)
+            .field("window", &self.window)
+            .field("branch_budget", &self.branch_budget)
+            .field("leaf_in_flight", &self.leaf_in_flight)
+            .field("branch_in_flight", &self.branch_in_flight)
+            .field("done", &self.done)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Lossless widening; `From` is not const-callable here.
+#[cfg(target_pointer_width = "64")]
+const fn u64_from_usize(value: usize) -> u64 {
+    u64::from_le_bytes(value.to_le_bytes())
+}
+
+/// Lossless widening; `From` is not const-callable here.
+#[cfg(target_pointer_width = "32")]
+const fn u64_from_usize(value: usize) -> u64 {
+    let [a, b, c, d] = value.to_le_bytes();
+    u64::from_le_bytes([a, b, c, d, 0, 0, 0, 0])
+}
+
+/// Lossless widening; `From` is not const-callable.
+const fn u64_from_u32(value: u32) -> u64 {
+    let [a, b, c, d] = value.to_le_bytes();
+    u64::from_le_bytes([a, b, c, d, 0, 0, 0, 0])
+}
+
+/// References per intermediate body; zero only for a degenerate profile the
+/// compile-time guard rejects.
+const fn fan_out(body: u64, ref_size: u64) -> u64 {
+    match body.checked_div(ref_size) {
+        Some(fan) => fan,
+        None => 0,
+    }
+}
+
+/// Child span under a parent covering `span` bytes: the smallest
+/// `body * branches^k` whose full fan-out reaches the parent span.
+const fn child_subspan(span: u64, body: u64, branches: u64) -> u64 {
+    let mut sub = body;
+    loop {
+        match sub.checked_mul(branches) {
+            Some(covered) if covered < span => sub = covered,
+            _ => return sub,
+        }
+    }
+}
+
+/// Clamp a body-relative offset into an index of a `len`-byte body.
+fn clamp_index(value: u64, len: usize) -> usize {
+    usize::try_from(value).unwrap_or(len).min(len)
+}

--- a/crates/file/src/walk/error.rs
+++ b/crates/file/src/walk/error.rs
@@ -1,0 +1,69 @@
+//! Typed walk failures; every error is terminal (the engine never retries).
+
+use nectar_primitives::chunk::ChunkAddress;
+
+/// Terminal walk failure.
+#[derive(Debug, thiserror::Error)]
+pub enum WalkError<E> {
+    /// A store fetch failed.
+    #[error("fetch failed at {address}")]
+    Fetch {
+        /// Requested chunk address.
+        address: ChunkAddress,
+        /// Store error behind the failure.
+        source: E,
+    },
+    /// The store completed a fetch with a chunk at a different address.
+    #[error("store returned {returned} for requested {requested}")]
+    AddressMismatch {
+        /// Address the engine asked for.
+        requested: ChunkAddress,
+        /// Address of the chunk the store handed back.
+        returned: ChunkAddress,
+    },
+    /// The tree's bytes contradict its declared spans.
+    #[error(transparent)]
+    Shape(#[from] ShapeError),
+    /// The engine could neither admit nor await work; a walk invariant is
+    /// broken.
+    #[error("walk stalled with {pending} pending nodes and occupancy {occupancy}")]
+    Stalled {
+        /// Nodes still queued in the frontiers.
+        pending: usize,
+        /// Leaf bodies held (in flight plus buffered).
+        occupancy: usize,
+    },
+}
+
+/// Contradiction between a node's bytes and the span its parent declared.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum ShapeError {
+    /// A leaf body's length disagrees with its declared span.
+    #[error("leaf at {offset} spans {span} bytes but carries {len}")]
+    LeafLength {
+        /// Absolute offset of the leaf's first byte.
+        offset: u64,
+        /// Span the parent declared for the leaf.
+        span: u64,
+        /// Bytes the leaf body actually carries.
+        len: u64,
+    },
+    /// An intermediate body carries fewer references than its span requires.
+    #[error("intermediate at {offset} holds {have} of {expected} references")]
+    Arity {
+        /// Absolute offset of the intermediate's first byte.
+        offset: u64,
+        /// References the declared span requires.
+        expected: u64,
+        /// References the body actually holds.
+        have: u64,
+    },
+    /// A child offset overflows the addressable file range.
+    #[error("child offsets overflow at {offset} with span {span}")]
+    Offset {
+        /// Absolute offset of the overflowing parent.
+        offset: u64,
+        /// Span the parent declared.
+        span: u64,
+    },
+}

--- a/crates/file/src/walk/mod.rs
+++ b/crates/file/src/walk/mod.rs
@@ -1,0 +1,64 @@
+//! Poll-native walk engine: the one bounded descent over a chunk tree.
+//!
+//! Every read mode drains this engine; nothing else in the crate fetches
+//! tree nodes. The engine is pull-driven and io-free (no spawns, channels or
+//! timers), all state lives in the [`Walk`], and completions are routed back
+//! by the offset sequence each fetch carries.
+//!
+//! Normative invariants, each pinned by a test:
+//!
+//! 1. Fetch identity: the fetch set over the requested range equals the
+//!    serial walk's, every node is fetched at most once, and every
+//!    completion must return the requested address.
+//! 2. Two-budget admission: leaf fetches draw on the
+//!    [`Window`](crate::Window); branch fetches draw on the derived
+//!    [`BranchBudget`](crate::BranchBudget), and a non-head branch is
+//!    admitted only when the leaf frontier can absorb every outstanding
+//!    expansion, capping buffered leaf references at `window + 2 *
+//!    branches`.
+//! 3. Head liveness: in-flight plus buffered leaf bodies never exceed the
+//!    window, one slot stays reserved for the head (the node covering the
+//!    lowest unconsumed offset) until the head holds one, and the head is
+//!    exempt from the absorption rule, so the ordered drain progresses at
+//!    any window depth.
+//! 4. No retries: every store error is terminal and typed; retry policy
+//!    composes beneath the store seam.
+
+mod engine;
+mod error;
+mod mode;
+#[cfg(test)]
+mod tests;
+
+use bytes::Bytes;
+
+pub use engine::Walk;
+pub use error::{ShapeError, WalkError};
+pub use mode::{Plain, WalkMode};
+
+/// One delivered run of file bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Frame {
+    /// Absolute byte offset of the run.
+    pub offset: u64,
+    /// In-range body bytes at that offset.
+    pub data: Bytes,
+}
+
+/// Occupancy witnesses of one walk.
+///
+/// The peaks pin the engine's memory bounds in tests: leaf bodies never
+/// exceed the window, branch fetches never exceed the derived budget, and
+/// buffered leaf references stay within `window + 2 * branches`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct WalkStats {
+    /// Store fetches dispatched.
+    pub fetches: u64,
+    /// Peak leaf bodies held at once, in flight plus buffered.
+    pub peak_occupancy: usize,
+    /// Peak branch fetches in flight.
+    pub peak_branch_in_flight: usize,
+    /// Peak buffered leaf references awaiting dispatch.
+    pub peak_leaf_frontier: usize,
+}

--- a/crates/file/src/walk/mode.rs
+++ b/crates/file/src/walk/mode.rs
@@ -1,0 +1,41 @@
+//! Reference grammar seam: how a walk reads child references.
+
+use core::fmt::Debug;
+
+use nectar_primitives::chunk::ChunkAddress;
+use nectar_primitives::store::{MaybeSend, MaybeSync};
+
+use crate::geometry::Mode;
+
+/// Reference grammar of one tree profile.
+///
+/// The engine stays mode-blind: a mode contributes its [`Mode`] geometry and
+/// the parser for one wire reference; the descent itself is shared.
+pub trait WalkMode: MaybeSend + MaybeSync + 'static {
+    /// Reference layout this mode walks.
+    const MODE: Mode;
+
+    /// Companion data a reference carries beyond the address, threaded to
+    /// every fetched node (an encrypted reference's decryption key).
+    type Context: Clone + Debug + MaybeSend + MaybeSync + 'static;
+
+    /// Read one reference off the front of `input`, advancing it past the
+    /// consumed bytes; `None` when fewer than one reference remains.
+    fn take_ref(input: &mut &[u8]) -> Option<(ChunkAddress, Self::Context)>;
+}
+
+/// Plain mode: a reference is a bare chunk address.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Plain;
+
+impl WalkMode for Plain {
+    const MODE: Mode = Mode::Plain;
+
+    type Context = ();
+
+    fn take_ref(input: &mut &[u8]) -> Option<(ChunkAddress, ())> {
+        let (address, rest) = input.split_first_chunk::<{ ChunkAddress::SIZE }>()?;
+        *input = rest;
+        Some((ChunkAddress::new(*address), ()))
+    }
+}

--- a/crates/file/src/walk/tests.rs
+++ b/crates/file/src/walk/tests.rs
@@ -1,0 +1,626 @@
+//! Walk-engine oracles: fetch-set equality against a serial walk, counting
+//! store, liveness under an adversarial store, occupancy witnesses.
+
+use core::future::{Future, poll_fn};
+use core::ops::Range;
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::vec;
+use std::vec::Vec;
+
+use bytes::Bytes;
+use futures::executor::block_on;
+use nectar_primitives::chunk::{
+    AnyChunk, AnyChunkSet, Chunk, ChunkAddress, ChunkOps, ContentChunk, Verified,
+};
+use nectar_primitives::store::{ChunkGet, ChunkStoreError, TrustedGet};
+
+use super::{Frame, Plain, ShapeError, Walk, WalkError};
+use crate::config::Window;
+
+/// Tiny body size: fan-out 8, so a few hundred leaves already build a deep
+/// tree.
+const TINY: usize = 256;
+const TINY_U64: u64 = 256;
+const BRANCHES: usize = 8;
+
+type TinyRegistry = AnyChunkSet<TINY>;
+type TinyChunk = Chunk<Verified, TinyRegistry>;
+type TinyWalk<S> = Walk<S, Plain, TINY>;
+
+/// Distinct byte per file position so every leaf (and thus every node
+/// address) is unique.
+fn fill(len: usize) -> Vec<u8> {
+    (0..len as u64)
+        .map(|i| (i.wrapping_mul(2_654_435_761) >> 11) as u8)
+        .collect()
+}
+
+fn seal(content: ContentChunk<TINY>) -> (ChunkAddress, TinyChunk) {
+    let address = *content.address();
+    let chunk = Chunk::from_envelope(AnyChunk::from(content)).unwrap();
+    (address, chunk)
+}
+
+struct Tree {
+    root: ChunkAddress,
+    span: u64,
+    chunks: HashMap<ChunkAddress, TinyChunk>,
+    /// Leaf address to file offset; total because leaf bodies are unique.
+    leaves: HashMap<ChunkAddress, u64>,
+}
+
+/// Hand splitter: leaves then packed intermediate levels, spans summed from
+/// the children.
+fn build_tree(data: &[u8]) -> Tree {
+    let mut chunks = HashMap::new();
+    let mut leaves = HashMap::new();
+    if data.is_empty() {
+        let (address, chunk) = seal(ContentChunk::<TINY>::new(Vec::new()).unwrap());
+        chunks.insert(address, chunk);
+        leaves.insert(address, 0);
+        return Tree {
+            root: address,
+            span: 0,
+            chunks,
+            leaves,
+        };
+    }
+    let mut level: Vec<(ChunkAddress, u64)> = Vec::new();
+    for (index, block) in data.chunks(TINY).enumerate() {
+        let (address, chunk) = seal(ContentChunk::<TINY>::new(block.to_vec()).unwrap());
+        chunks.insert(address, chunk);
+        leaves.insert(address, (index * TINY) as u64);
+        level.push((address, block.len() as u64));
+    }
+    while level.len() > 1 {
+        let mut next = Vec::new();
+        for group in level.chunks(BRANCHES) {
+            // A trailing single chunk carries up unchanged; wrapping it
+            // would declare a span its one reference cannot cover.
+            if let [only] = group {
+                next.push(*only);
+                continue;
+            }
+            let span: u64 = group.iter().map(|(_, s)| *s).sum();
+            let mut wire = span.to_le_bytes().to_vec();
+            for (address, _) in group {
+                wire.extend_from_slice(address.as_bytes());
+            }
+            let (address, chunk) = seal(ContentChunk::<TINY>::try_from(Bytes::from(wire)).unwrap());
+            chunks.insert(address, chunk);
+            next.push((address, span));
+        }
+        level = next;
+    }
+    let (root, span) = level[0];
+    Tree {
+        root,
+        span,
+        chunks,
+        leaves,
+    }
+}
+
+/// Independent serial reference walk: DFS with the same range pruning,
+/// returning the fetched addresses in visit order.
+fn serial_walk(tree: &Tree, range: Range<u64>) -> Vec<ChunkAddress> {
+    let range_end = range.end.min(tree.span);
+    let range_start = range.start.min(range_end);
+    let mut fetched = Vec::new();
+    if range_start >= range_end {
+        return fetched;
+    }
+    let mut stack = vec![(tree.root, 0u64, tree.span)];
+    while let Some((address, start, span)) = stack.pop() {
+        if start >= range_end || start + span <= range_start {
+            continue;
+        }
+        fetched.push(address);
+        if span <= TINY_U64 {
+            continue;
+        }
+        let body = tree.chunks[&address].envelope().data().clone();
+        let mut sub = TINY_U64;
+        while sub * (BRANCHES as u64) < span {
+            sub *= BRANCHES as u64;
+        }
+        let expected = span.div_ceil(sub);
+        let mut children = Vec::new();
+        for index in 0..expected {
+            let at = index as usize * ChunkAddress::SIZE;
+            let raw: [u8; 32] = body[at..at + ChunkAddress::SIZE].try_into().unwrap();
+            let child_span = sub.min(span - index * sub);
+            children.push((ChunkAddress::new(raw), start + index * sub, child_span));
+        }
+        for child in children.into_iter().rev() {
+            stack.push(child);
+        }
+    }
+    fetched
+}
+
+/// A self-waking yield: `Pending` once with an immediate wake, so
+/// `block_on` keeps polling.
+fn yield_now() -> impl Future<Output = ()> {
+    struct YieldNow(bool);
+    impl Future for YieldNow {
+        type Output = ();
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+            if self.0 {
+                Poll::Ready(())
+            } else {
+                self.0 = true;
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+        }
+    }
+    YieldNow(false)
+}
+
+/// Counting store: logs every fetch, resolving after `delay` yields.
+#[derive(Clone)]
+struct Recording {
+    chunks: Arc<HashMap<ChunkAddress, TinyChunk>>,
+    log: Arc<Mutex<Vec<ChunkAddress>>>,
+    delay: usize,
+}
+
+impl Recording {
+    fn new(tree: &Tree, delay: usize) -> Self {
+        Self {
+            chunks: Arc::new(tree.chunks.clone()),
+            log: Arc::new(Mutex::new(Vec::new())),
+            delay,
+        }
+    }
+
+    fn log(&self) -> Vec<ChunkAddress> {
+        self.log.lock().unwrap().clone()
+    }
+}
+
+impl ChunkGet<TinyRegistry> for Recording {
+    type Trust = Verified;
+    type Error = ChunkStoreError;
+
+    async fn get(&self, address: &ChunkAddress) -> Result<TinyChunk, ChunkStoreError> {
+        self.log.lock().unwrap().push(*address);
+        for _ in 0..self.delay {
+            yield_now().await;
+        }
+        self.chunks
+            .get(address)
+            .cloned()
+            .ok_or_else(|| ChunkStoreError::not_found(address))
+    }
+}
+
+/// Adversarial store: parks the leaf at `slow_offset` until `gate` other
+/// leaves have resolved.
+#[derive(Clone)]
+struct HeadLast {
+    chunks: Arc<HashMap<ChunkAddress, TinyChunk>>,
+    leaves: Arc<HashMap<ChunkAddress, u64>>,
+    slow_offset: u64,
+    released: Arc<Mutex<usize>>,
+    gate: usize,
+}
+
+impl ChunkGet<TinyRegistry> for HeadLast {
+    type Trust = Verified;
+    type Error = ChunkStoreError;
+
+    async fn get(&self, address: &ChunkAddress) -> Result<TinyChunk, ChunkStoreError> {
+        if self.leaves.get(address) == Some(&self.slow_offset) {
+            while *self.released.lock().unwrap() < self.gate {
+                yield_now().await;
+            }
+            for _ in 0..4 {
+                yield_now().await;
+            }
+        } else {
+            for _ in 0..4 {
+                yield_now().await;
+            }
+            if self.leaves.contains_key(address) {
+                *self.released.lock().unwrap() += 1;
+            }
+        }
+        self.chunks
+            .get(address)
+            .cloned()
+            .ok_or_else(|| ChunkStoreError::not_found(address))
+    }
+}
+
+/// Hostile store: answers `from` with the chunk stored at `to`.
+#[derive(Clone)]
+struct Swapped {
+    chunks: Arc<HashMap<ChunkAddress, TinyChunk>>,
+    from: ChunkAddress,
+    to: ChunkAddress,
+}
+
+impl ChunkGet<TinyRegistry> for Swapped {
+    type Trust = Verified;
+    type Error = ChunkStoreError;
+
+    async fn get(&self, address: &ChunkAddress) -> Result<TinyChunk, ChunkStoreError> {
+        let target = if *address == self.from {
+            self.to
+        } else {
+            *address
+        };
+        self.chunks
+            .get(&target)
+            .cloned()
+            .ok_or_else(|| ChunkStoreError::not_found(address))
+    }
+}
+
+fn walk_range<S>(store: S, tree: &Tree, range: Range<u64>, window: u16) -> TinyWalk<S>
+where
+    S: TrustedGet<TinyRegistry> + Clone + 'static,
+{
+    Walk::new(
+        store,
+        tree.root,
+        (),
+        tree.span,
+        range,
+        Window::new(window).unwrap(),
+    )
+}
+
+fn collect_ordered<S>(walk: &mut TinyWalk<S>) -> Result<Vec<Frame>, WalkError<ChunkStoreError>>
+where
+    S: TrustedGet<TinyRegistry, Error = ChunkStoreError> + Clone + 'static,
+{
+    block_on(async {
+        let mut frames = Vec::new();
+        while let Some(frame) = poll_fn(|cx| walk.poll_next_ordered(cx)).await {
+            frames.push(frame?);
+        }
+        Ok(frames)
+    })
+}
+
+fn collect_any<S>(walk: &mut TinyWalk<S>) -> Result<Vec<Frame>, WalkError<ChunkStoreError>>
+where
+    S: TrustedGet<TinyRegistry, Error = ChunkStoreError> + Clone + 'static,
+{
+    block_on(async {
+        let mut frames = Vec::new();
+        while let Some(frame) = poll_fn(|cx| walk.poll_next_any(cx)).await {
+            frames.push(frame?);
+        }
+        Ok(frames)
+    })
+}
+
+/// Assert the frames tile `[start, end)` gaplessly in order and concatenate
+/// to `expected`.
+fn assert_tiles(frames: &[Frame], start: u64, expected: &[u8]) {
+    let mut cursor = start;
+    let mut assembled = Vec::new();
+    for frame in frames {
+        assert_eq!(frame.offset, cursor, "frames must be gapless and ordered");
+        assert!(!frame.data.is_empty(), "no empty frames");
+        cursor += frame.data.len() as u64;
+        assembled.extend_from_slice(&frame.data);
+    }
+    assert_eq!(assembled, expected);
+}
+
+fn sorted(mut addresses: Vec<ChunkAddress>) -> Vec<ChunkAddress> {
+    addresses.sort();
+    addresses
+}
+
+#[test]
+fn ordered_read_is_byte_exact() {
+    // 100 leaves at fan-out 8: a four-level tree.
+    let data = fill(100 * TINY - 77);
+    let tree = build_tree(&data);
+    let store = Recording::new(&tree, 2);
+    let mut walk = walk_range(store, &tree, 0..u64::MAX, 4);
+    let frames = collect_ordered(&mut walk).unwrap();
+    assert_tiles(&frames, 0, &data);
+    assert!(walk.is_finished());
+}
+
+#[test]
+fn fetch_set_equals_serial_walk() {
+    let data = fill(40 * TINY + 100);
+    let tree = build_tree(&data);
+    let span = tree.span;
+    let cases = [
+        0..span,
+        0..1,
+        1000..1001,
+        span - 1..span,
+        255..513,
+        300..2000,
+        0..0,
+        span..span + 10,
+        span / 2..span,
+    ];
+    for range in cases {
+        let store = Recording::new(&tree, 2);
+        let mut walk = walk_range(store.clone(), &tree, range.clone(), 3);
+        let frames = collect_ordered(&mut walk).unwrap();
+
+        let clipped_end = range.end.min(span);
+        let clipped_start = range.start.min(clipped_end);
+        assert_tiles(
+            &frames,
+            clipped_start,
+            &data[clipped_start as usize..clipped_end as usize],
+        );
+
+        let log = store.log();
+        let serial = serial_walk(&tree, range.clone());
+        assert_eq!(
+            sorted(log.clone()),
+            sorted(serial),
+            "fetch set diverged for {range:?}"
+        );
+        let mut dedup = sorted(log.clone());
+        dedup.dedup();
+        assert_eq!(dedup.len(), log.len(), "a node was fetched twice");
+    }
+}
+
+#[test]
+fn window_one_stays_live_and_serial() {
+    let data = fill(30 * TINY + 5);
+    let tree = build_tree(&data);
+    let store = Recording::new(&tree, 1);
+    let mut walk = walk_range(store.clone(), &tree, 0..tree.span, 1);
+    let frames = collect_ordered(&mut walk).unwrap();
+    assert_tiles(&frames, 0, &data);
+    // Descent progresses at the smallest window, one leaf body at a time,
+    // and still fetches exactly the serial set.
+    assert_eq!(
+        sorted(store.log()),
+        sorted(serial_walk(&tree, 0..tree.span))
+    );
+    assert!(walk.stats().peak_occupancy <= 1);
+}
+
+#[test]
+fn empty_range_and_empty_file_fetch_nothing() {
+    let data = fill(10 * TINY);
+    let tree = build_tree(&data);
+    let store = Recording::new(&tree, 0);
+    let mut walk = walk_range(store.clone(), &tree, 5..5, 4);
+    assert!(collect_ordered(&mut walk).unwrap().is_empty());
+    assert_eq!(store.log().len(), 0);
+
+    let empty = build_tree(&[]);
+    let store = Recording::new(&empty, 0);
+    let mut walk = walk_range(store.clone(), &empty, 0..u64::MAX, 4);
+    assert!(collect_ordered(&mut walk).unwrap().is_empty());
+    assert_eq!(store.log().len(), 0);
+}
+
+#[test]
+fn tail_read_fetches_one_path() {
+    // 100 leaves: depth four, so the last byte costs the root, two
+    // intermediates, and one leaf.
+    let data = fill(100 * TINY);
+    let tree = build_tree(&data);
+    let store = Recording::new(&tree, 1);
+    let mut walk = walk_range(store.clone(), &tree, tree.span - 1..tree.span, 4);
+    let frames = collect_ordered(&mut walk).unwrap();
+    assert_tiles(&frames, tree.span - 1, &data[data.len() - 1..]);
+    assert_eq!(
+        store.log().len(),
+        4,
+        "range pruning must skip every other subtree"
+    );
+}
+
+#[test]
+fn address_mismatch_is_detected() {
+    let data = fill(10 * TINY);
+    let tree = build_tree(&data);
+    let mut offsets: Vec<(u64, ChunkAddress)> = tree.leaves.iter().map(|(a, o)| (*o, *a)).collect();
+    offsets.sort();
+    let requested = offsets[3].1;
+    let substituted = offsets[4].1;
+    let store = Swapped {
+        chunks: Arc::new(tree.chunks.clone()),
+        from: requested,
+        to: substituted,
+    };
+    let mut walk = walk_range(store, &tree, 0..tree.span, 4);
+    let error = collect_ordered(&mut walk).unwrap_err();
+    match error {
+        WalkError::AddressMismatch {
+            requested: want,
+            returned,
+        } => {
+            assert_eq!(want, requested);
+            assert_eq!(returned, substituted);
+        }
+        other => panic!("expected AddressMismatch, got {other:?}"),
+    }
+}
+
+#[test]
+fn store_error_is_terminal_without_retry() {
+    let data = fill(12 * TINY);
+    let mut tree = build_tree(&data);
+    let mut offsets: Vec<(u64, ChunkAddress)> = tree.leaves.iter().map(|(a, o)| (*o, *a)).collect();
+    offsets.sort();
+    let missing = offsets[5].1;
+    tree.chunks.remove(&missing);
+
+    let store = Recording::new(&tree, 1);
+    let mut walk = walk_range(store.clone(), &tree, 0..tree.span, 4);
+    let error = collect_ordered(&mut walk).unwrap_err();
+    match error {
+        WalkError::Fetch { address, .. } => assert_eq!(address, missing),
+        other => panic!("expected Fetch, got {other:?}"),
+    }
+    let attempts = store.log().iter().filter(|a| **a == missing).count();
+    assert_eq!(attempts, 1, "the engine must not retry");
+    assert!(walk.is_finished());
+    block_on(async {
+        assert!(poll_fn(|cx| walk.poll_next_ordered(cx)).await.is_none());
+    });
+}
+
+#[test]
+fn head_last_liveness_under_slow_consumer() {
+    // The head leaf resolves last among the leaves the window admits, and
+    // the consumer pauses between frames: the walk must still deliver in
+    // order without exceeding the window.
+    let leaves = 40;
+    let window = 4u16;
+    let data = fill(leaves * TINY);
+    let tree = build_tree(&data);
+    let store = HeadLast {
+        chunks: Arc::new(tree.chunks.clone()),
+        leaves: Arc::new(tree.leaves.clone()),
+        slow_offset: 0,
+        released: Arc::new(Mutex::new(0)),
+        gate: usize::from(window) - 1,
+    };
+    let mut walk = walk_range(store, &tree, 0..tree.span, window);
+    let frames = block_on(async {
+        let mut frames = Vec::new();
+        while let Some(frame) = poll_fn(|cx| walk.poll_next_ordered(cx)).await {
+            frames.push(frame.unwrap());
+            for _ in 0..3 {
+                yield_now().await;
+            }
+        }
+        frames
+    });
+    assert_tiles(&frames, 0, &data);
+    assert!(
+        walk.stats().peak_occupancy <= usize::from(window),
+        "occupancy {} exceeded window {window}",
+        walk.stats().peak_occupancy
+    );
+}
+
+#[test]
+fn occupancy_witnesses_hold() {
+    let leaves = 200;
+    let data = fill(leaves * TINY);
+    let tree = build_tree(&data);
+    for window in [5u16, 32] {
+        let store = Recording::new(&tree, 3);
+        let mut walk = walk_range(store, &tree, 0..tree.span, window);
+        let frames = collect_ordered(&mut walk).unwrap();
+        assert_tiles(&frames, 0, &data);
+        let stats = walk.stats();
+        let budget =
+            crate::config::BranchBudget::derive(Window::new(window).unwrap(), BRANCHES as u32);
+        assert!(stats.peak_occupancy <= usize::from(window));
+        assert!(stats.peak_branch_in_flight <= budget.get() as usize);
+        assert!(stats.peak_leaf_frontier <= usize::from(window) + 2 * BRANCHES);
+        assert_eq!(
+            stats.fetches as usize,
+            serial_walk(&tree, 0..tree.span).len()
+        );
+    }
+}
+
+#[test]
+fn any_drain_reassembles_the_range() {
+    let data = fill(60 * TINY + 9);
+    let tree = build_tree(&data);
+    let range = 100..15_000u64;
+    let store = Recording::new(&tree, 4);
+    let mut walk = walk_range(store, &tree, range.clone(), 6);
+    let mut frames = collect_any(&mut walk).unwrap();
+    frames.sort_by_key(|frame| frame.offset);
+    assert_tiles(
+        &frames,
+        range.start,
+        &data[range.start as usize..range.end as usize],
+    );
+}
+
+#[test]
+fn short_intermediate_is_an_arity_error() {
+    // A parent claiming three children but carrying two references.
+    let mut chunks = HashMap::new();
+    let blocks = fill(3 * TINY);
+    let (a, ca) = seal(ContentChunk::<TINY>::new(blocks[..TINY].to_vec()).unwrap());
+    let (b, cb) = seal(ContentChunk::<TINY>::new(blocks[TINY..2 * TINY].to_vec()).unwrap());
+    chunks.insert(a, ca);
+    chunks.insert(b, cb);
+    let span = 3 * TINY_U64;
+    let mut wire = span.to_le_bytes().to_vec();
+    wire.extend_from_slice(a.as_bytes());
+    wire.extend_from_slice(b.as_bytes());
+    let (root, chunk) = seal(ContentChunk::<TINY>::try_from(Bytes::from(wire)).unwrap());
+    chunks.insert(root, chunk);
+
+    let store = Recording {
+        chunks: Arc::new(chunks),
+        log: Arc::new(Mutex::new(Vec::new())),
+        delay: 0,
+    };
+    let mut walk: TinyWalk<_> = Walk::new(store, root, (), span, 0..span, Window::new(4).unwrap());
+    let error = collect_ordered(&mut walk).unwrap_err();
+    match error {
+        WalkError::Shape(ShapeError::Arity { expected, have, .. }) => {
+            assert_eq!((expected, have), (3, 2));
+        }
+        other => panic!("expected Arity, got {other:?}"),
+    }
+}
+
+#[test]
+fn short_leaf_is_a_length_error() {
+    // The parent declares a 256-byte child; the referenced leaf carries 100.
+    let mut chunks = HashMap::new();
+    let blocks = fill(TINY + 100);
+    let (a, ca) = seal(ContentChunk::<TINY>::new(blocks[..TINY].to_vec()).unwrap());
+    let (b, cb) = seal(ContentChunk::<TINY>::new(blocks[TINY..].to_vec()).unwrap());
+    chunks.insert(a, ca);
+    chunks.insert(b, cb);
+    let span = 2 * TINY_U64;
+    let mut wire = span.to_le_bytes().to_vec();
+    wire.extend_from_slice(a.as_bytes());
+    wire.extend_from_slice(b.as_bytes());
+    let (root, chunk) = seal(ContentChunk::<TINY>::try_from(Bytes::from(wire)).unwrap());
+    chunks.insert(root, chunk);
+
+    let store = Recording {
+        chunks: Arc::new(chunks),
+        log: Arc::new(Mutex::new(Vec::new())),
+        delay: 0,
+    };
+    let mut walk: TinyWalk<_> = Walk::new(store, root, (), span, 0..span, Window::new(4).unwrap());
+    let error = collect_ordered(&mut walk).unwrap_err();
+    match error {
+        WalkError::Shape(ShapeError::LeafLength { offset, span, len }) => {
+            assert_eq!((offset, span, len), (TINY_U64, TINY_U64, 100));
+        }
+        other => panic!("expected LeafLength, got {other:?}"),
+    }
+}
+
+#[test]
+fn mid_leaf_range_is_clipped() {
+    let data = fill(4 * TINY);
+    let tree = build_tree(&data);
+    let store = Recording::new(&tree, 1);
+    let mut walk = walk_range(store.clone(), &tree, 300..400, 4);
+    let frames = collect_ordered(&mut walk).unwrap();
+    assert_eq!(frames.len(), 1);
+    assert_tiles(&frames, 300, &data[300..400]);
+    // Root plus the single overlapping leaf.
+    assert_eq!(store.log().len(), 2);
+}

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
         # `nix develop` so the local toolchain matches CI/CD.
         rustToolchain = pkgs.rust-bin.stable."1.94.0".default.override {
           extensions = [ "rust-analyzer" "rust-src" "clippy" "rustfmt" ];
-          targets = [ "wasm32-unknown-unknown" ];
+          targets = [ "wasm32-unknown-unknown" "riscv64imac-unknown-none-elf" ];
         };
 
         # Nightly toolchain for WASM threading (wasm-bindgen-rayon)


### PR DESCRIPTION
## What

Adds the poll-native walk engine (`crates/file/src/walk/`): a single `Walk<S, M, const B>` state machine over `TrustedGet` stores with offset-sequence routing (each boxed fetch carries its `Node` back), ordered leaf/branch frontiers as a flattened frame stack, two-budget admission (`Window` for leaves, a derived `BranchBudget` plus an expansion-absorption room rule for branches), a head-liveness reservation (one slot reserved for the head until the head holds one; head branch exempt from the room rule so descent progresses at window 1), range pruning with clip-to-range leaf delivery, address-equality checks on every completion, and typed terminal errors with no retries.

`poll_next_ordered` and `poll_next_any` share one poll loop; no spawns/channels/timers, all state lives in `self`. Includes the `WalkMode` reference-grammar seam with `Plain` implemented (`Context` is the forward seam for encrypted decoding).

Also bumps the dev toolchain to add the bare-metal rv64 target.

## Why

Closes #331

## Testing

Verified on a fresh worktree at detached FETCH_HEAD of `s323/20-walk-engine` (base `origin/s323/18-derived-address`).

- `cargo fmt --all --check`: clean
- `cargo clippy --workspace --all-targets --locked`: no warnings in the diff crate (`nectar-file`); remaining workspace warnings are pre-existing in untouched crates (primitives, mantaray)
- `cargo nextest run -p nectar-file --all-features --locked`: 23/23 pass
- `cargo test -p nectar-file --all-features --doc`: 0 doctests, ok
- `zepter run check` (Cargo.toml changed): clean
- rv64 no_std core build (`cargo build -p nectar-file --no-default-features --target riscv64imac-unknown-none-elf` under `nix develop`): compiles, confirming the walk engine is std-gated and core stays no_std
- wasm32 and actionlint gates: not applicable (no manifest/postage-usage or workflow changes)
- Sweeps clean: no em-dash, no bee/alloy/reth references, no issue refs in `.rs`, no divider comments, no restriction-lint suppressions

## AI Assistance

Implementation by Fable, review by Opus, PR description by Sonnet.

Closes #242
