### PR TITLE
feat(file): add the poll-native streaming splitter

### DIFF
--- a/crates/file/src/lib.rs
+++ b/crates/file/src/lib.rs
@@ -3,8 +3,8 @@
 //!
 //! This crate carries the pipeline's foundations: per-profile tree
 //! [`geometry`] pinned at compile time, the [`config`] admission budgets the
-//! engines drain against, and the poll-native [`walk`] engine every read
-//! mode drains.
+//! engines drain against, the poll-native [`walk`] engine every read mode
+//! drains, and the poll-native [`split`] engine every write mode feeds.
 
 #![no_std]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
@@ -35,10 +35,17 @@ extern crate std;
 pub mod config;
 pub mod geometry;
 #[cfg(feature = "std")]
+mod num;
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+pub mod split;
+#[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod walk;
 
 pub use config::{BranchBudget, PutWindow, Window};
 pub use geometry::{DEFAULT_BODY_SIZE, Mode, branches, max_depth};
+#[cfg(feature = "std")]
+pub use split::{Sealed, Split, SplitError, SplitMode, SplitStats};
 #[cfg(feature = "std")]
 pub use walk::{Frame, Plain, ShapeError, Walk, WalkError, WalkMode, WalkStats};

--- a/crates/file/src/num.rs
+++ b/crates/file/src/num.rs
@@ -1,0 +1,29 @@
+//! Widening casts and the fan-out quotient shared by both engines.
+
+/// Lossless widening; `From` is not const-callable here.
+#[cfg(target_pointer_width = "64")]
+pub(crate) const fn u64_from_usize(value: usize) -> u64 {
+    u64::from_le_bytes(value.to_le_bytes())
+}
+
+/// Lossless widening; `From` is not const-callable here.
+#[cfg(target_pointer_width = "32")]
+pub(crate) const fn u64_from_usize(value: usize) -> u64 {
+    let [a, b, c, d] = value.to_le_bytes();
+    u64::from_le_bytes([a, b, c, d, 0, 0, 0, 0])
+}
+
+/// Lossless widening; `From` is not const-callable.
+pub(crate) const fn u64_from_u32(value: u32) -> u64 {
+    let [a, b, c, d] = value.to_le_bytes();
+    u64::from_le_bytes([a, b, c, d, 0, 0, 0, 0])
+}
+
+/// References per intermediate body; zero only for a degenerate profile the
+/// compile-time guard rejects.
+pub(crate) const fn fan_out(body: u64, ref_size: u64) -> u64 {
+    match body.checked_div(ref_size) {
+        Some(fan) => fan,
+        None => 0,
+    }
+}

--- a/crates/file/src/split/engine.rs
+++ b/crates/file/src/split/engine.rs
@@ -1,0 +1,439 @@
+//! The bounded ascent state machine.
+
+use alloc::boxed::Box;
+use alloc::collections::VecDeque;
+use alloc::vec::Vec;
+use core::fmt;
+use core::future::Future;
+use core::mem;
+use core::pin::Pin;
+use core::task::{Context, Poll};
+
+use bytes::Bytes;
+use futures_util::stream::{FuturesUnordered, Stream};
+use nectar_primitives::DEFAULT_BODY_SIZE;
+use nectar_primitives::bmt::SPAN_SIZE;
+use nectar_primitives::chunk::{AnyChunkSet, Chunk, ChunkAddress, Verified};
+use nectar_primitives::store::ChunkPut;
+
+use super::SplitStats;
+use super::error::SplitError;
+use super::mode::SplitMode;
+use crate::config::PutWindow;
+use crate::num::{fan_out, u64_from_u32, u64_from_usize};
+
+/// Completion payload; the future carries the chunk's address back for the
+/// error context.
+type PutDone<E> = (ChunkAddress, Result<(), E>);
+
+/// Boxed put future: `Send` on multi-threaded targets, unbounded on wasm32
+/// and under the `unsync` feature.
+#[cfg(not(any(target_arch = "wasm32", feature = "unsync")))]
+type BoxPut<E> = Pin<Box<dyn Future<Output = PutDone<E>> + Send>>;
+/// Boxed put future: `Send` on multi-threaded targets, unbounded on wasm32
+/// and under the `unsync` feature.
+#[cfg(any(target_arch = "wasm32", feature = "unsync"))]
+type BoxPut<E> = Pin<Box<dyn Future<Output = PutDone<E>>>>;
+
+/// One spine level: references awaiting a close and the bytes they span.
+struct Level<M: SplitMode> {
+    refs: Vec<M::Ref>,
+    span: u64,
+}
+
+impl<M: SplitMode> Level<M> {
+    const fn new() -> Self {
+        Self {
+            refs: Vec::new(),
+            span: 0,
+        }
+    }
+}
+
+/// Lifecycle of a split; the finished and poisoned phases are fuses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Phase {
+    /// Accepting writes.
+    Writing,
+    /// Tail leaf sealed; closing the spine bottom up.
+    Closing,
+    /// Root chosen; draining the put window.
+    Draining,
+    /// Root delivered; every later finish returns it again.
+    Finished,
+    /// A terminal failure; every later poll returns `Poisoned`.
+    Poisoned,
+}
+
+/// The one poll-native split: a bounded, spill-on-close ascent building a
+/// chunk tree over a byte stream.
+///
+/// All state lives here, so every poll is cancel-safe and dropping the
+/// split loses only in-flight puts. The module docs state the normative
+/// admission invariants.
+pub struct Split<S, M, const B: usize = DEFAULT_BODY_SIZE>
+where
+    S: ChunkPut<AnyChunkSet<B>>,
+    M: SplitMode,
+{
+    store: S,
+    /// Data-carrying reference slots per intermediate, from the mode.
+    slots: u64,
+    window: usize,
+    /// Partial tail leaf, always shorter than the body.
+    leaf: Vec<u8>,
+    /// Spine frontier: per-level references awaiting a close, bottom up.
+    spine: Vec<Level<M>>,
+    /// Sealed chunks awaiting a put slot; bounded by the spine height.
+    pending: VecDeque<Chunk<Verified, AnyChunkSet<B>>>,
+    in_flight: FuturesUnordered<BoxPut<S::Error>>,
+    phase: Phase,
+    root: Option<M::Root>,
+    stats: SplitStats,
+}
+
+impl<S, M, const B: usize> Split<S, M, B>
+where
+    S: ChunkPut<AnyChunkSet<B>> + Clone + 'static,
+    M: SplitMode,
+{
+    /// Compile-time profile guard for the split's span arithmetic.
+    const PROFILE: () = {
+        assert!(B.is_power_of_two(), "body size must be a power of two");
+        assert!(
+            u64_from_usize(B) <= u64_from_u32(u32::MAX),
+            "body size must fit the u32 geometry"
+        );
+        let fan = fan_out(u64_from_usize(B), u64_from_u32(M::MODE.ref_size()));
+        assert!(fan >= 2, "fan-out must be at least two");
+    };
+
+    /// Split a byte stream into the tree under `store`, holding at most
+    /// `window` puts in flight.
+    pub fn new(store: S, window: PutWindow) -> Self {
+        const { Self::PROFILE };
+        let branches = fan_out(u64_from_usize(B), u64_from_u32(M::MODE.ref_size()));
+        // A close must shrink its level, so the seam floors at two slots.
+        let slots = M::data_slots(branches).max(2);
+        Self {
+            store,
+            slots,
+            window: usize::from(window.get()),
+            leaf: Vec::new(),
+            spine: Vec::new(),
+            pending: VecDeque::new(),
+            in_flight: FuturesUnordered::new(),
+            phase: Phase::Writing,
+            root: None,
+            stats: SplitStats::default(),
+        }
+    }
+
+    /// Occupancy witnesses accumulated so far.
+    pub const fn stats(&self) -> SplitStats {
+        self.stats
+    }
+
+    /// Whether the split has delivered its root or failed.
+    pub const fn is_finished(&self) -> bool {
+        matches!(self.phase, Phase::Finished | Phase::Poisoned)
+    }
+
+    /// Consume bytes from `buf`, sealing and spilling as leaves fill; at
+    /// most one leaf body is consumed per call.
+    ///
+    /// Cancel-safe: a put slot is secured before any byte is consumed, so a
+    /// poll that returns `Pending` has consumed nothing.
+    pub fn poll_write(
+        &mut self,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, SplitError<S::Error>>> {
+        match self.phase {
+            Phase::Writing => {}
+            Phase::Poisoned => return Poll::Ready(Err(SplitError::Poisoned)),
+            Phase::Closing | Phase::Draining | Phase::Finished => {
+                return Poll::Ready(Err(SplitError::Finished));
+            }
+        }
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+        if let Err(error) = self.step_puts(cx) {
+            return Poll::Ready(Err(self.poison(error)));
+        }
+        if !self.pending.is_empty() || self.in_flight.len() >= self.window {
+            return Poll::Pending;
+        }
+        let take = buf.len().min(B.saturating_sub(self.leaf.len()));
+        let Some((bytes, _)) = buf.split_at_checked(take) else {
+            return Poll::Ready(Ok(0));
+        };
+        self.leaf.extend_from_slice(bytes);
+        self.stats.bytes = self.stats.bytes.saturating_add(u64_from_usize(take));
+        if self.leaf.len() == B {
+            let data = mem::take(&mut self.leaf);
+            if let Err(error) = self.spill_leaf(data) {
+                return Poll::Ready(Err(self.poison(error)));
+            }
+        }
+        Poll::Ready(Ok(take))
+    }
+
+    /// Drive the split to its root: seal the tail, close the spine bottom
+    /// up, drain the put window, then deliver the root.
+    ///
+    /// Cancel-safe and fused: all progress lives in `self`, an abandoned
+    /// call loses nothing, and every call after the first delivery returns
+    /// the same root again.
+    pub fn poll_finish(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<M::Root, SplitError<S::Error>>> {
+        loop {
+            match self.phase {
+                Phase::Poisoned => return Poll::Ready(Err(SplitError::Poisoned)),
+                Phase::Finished => return Poll::Ready(self.delivered()),
+                Phase::Writing | Phase::Closing => {
+                    if let Err(error) = self.step_puts(cx) {
+                        return Poll::Ready(Err(self.poison(error)));
+                    }
+                    if !self.pending.is_empty() || self.in_flight.len() >= self.window {
+                        return Poll::Pending;
+                    }
+                    let step = if let Phase::Writing = self.phase {
+                        self.flush_tail()
+                    } else {
+                        self.close_step()
+                    };
+                    if let Err(error) = step {
+                        return Poll::Ready(Err(self.poison(error)));
+                    }
+                }
+                Phase::Draining => {
+                    if let Err(error) = self.step_puts(cx) {
+                        return Poll::Ready(Err(self.poison(error)));
+                    }
+                    if self.pending.is_empty() && self.in_flight.is_empty() {
+                        self.phase = Phase::Finished;
+                        continue;
+                    }
+                    return Poll::Pending;
+                }
+            }
+        }
+    }
+
+    /// The fused root; its absence past the finish is a broken invariant.
+    fn delivered(&mut self) -> Result<M::Root, SplitError<S::Error>> {
+        match &self.root {
+            Some(root) => Ok(root.clone()),
+            None => Err(self.poison(SplitError::SpineDepleted)),
+        }
+    }
+
+    /// Fuse the split shut, handing the terminal error back.
+    const fn poison(&mut self, error: SplitError<S::Error>) -> SplitError<S::Error> {
+        self.phase = Phase::Poisoned;
+        error
+    }
+
+    /// Seal the tail leaf (or the empty stream's empty chunk) and enter the
+    /// closing phase.
+    fn flush_tail(&mut self) -> Result<(), SplitError<S::Error>> {
+        if !self.leaf.is_empty() || self.stats.bytes == 0 {
+            let data = mem::take(&mut self.leaf);
+            self.spill_leaf(data)?;
+        }
+        self.phase = Phase::Closing;
+        Ok(())
+    }
+
+    /// Close the lowest occupied level: carry a lone reference up for free,
+    /// seal a filled group, or crown the root at the top.
+    fn close_step(&mut self) -> Result<(), SplitError<S::Error>> {
+        loop {
+            let Some(at) = self.spine.iter().position(|level| !level.refs.is_empty()) else {
+                return Err(SplitError::SpineDepleted);
+            };
+            let above = at.saturating_add(1);
+            let top = self
+                .spine
+                .iter()
+                .skip(above)
+                .all(|level| level.refs.is_empty());
+            let Some(level) = self.spine.get_mut(at) else {
+                return Err(SplitError::SpineDepleted);
+            };
+            if top && level.refs.len() == 1 {
+                let refs = mem::take(&mut level.refs);
+                level.span = 0;
+                let Some(only) = refs.into_iter().next() else {
+                    return Err(SplitError::SpineDepleted);
+                };
+                self.root = Some(M::into_root(only));
+                self.phase = Phase::Draining;
+                return Ok(());
+            }
+            let refs = mem::take(&mut level.refs);
+            let span = mem::replace(&mut level.span, 0);
+            if let [only] = refs.as_slice() {
+                // A lone reference carries up unwrapped: wrapping it would
+                // declare a span its single child already covers.
+                self.push_carry(above, only.clone(), span)?;
+                continue;
+            }
+            let sealed = self.seal_intermediate(span, &refs)?;
+            self.push_carry(above, sealed, span)?;
+            // One seal per step; the caller re-secures put capacity.
+            return Ok(());
+        }
+    }
+
+    /// Seal one leaf payload and thread its reference into the spine.
+    fn spill_leaf(&mut self, data: Vec<u8>) -> Result<(), SplitError<S::Error>> {
+        let span = u64_from_usize(data.len());
+        let mut payload = Vec::with_capacity(SPAN_SIZE.saturating_add(data.len()));
+        payload.extend_from_slice(&span.to_le_bytes());
+        payload.extend_from_slice(&data);
+        let (chunk, reference) = M::seal::<B>(Bytes::from(payload))?;
+        self.stats.leaves = self.stats.leaves.saturating_add(1);
+        self.enqueue(chunk);
+        self.push_ref(0, reference, span)
+    }
+
+    /// Thread a reference into the spine at `at`, closing and spilling
+    /// every level it fills.
+    fn push_ref(
+        &mut self,
+        at: usize,
+        reference: M::Ref,
+        span: u64,
+    ) -> Result<(), SplitError<S::Error>> {
+        let mut at = at;
+        let mut reference = reference;
+        let mut span = span;
+        loop {
+            self.push_carry(at, reference, span)?;
+            let Some(level) = self.spine.get_mut(at) else {
+                return Err(SplitError::SpineDepleted);
+            };
+            if u64_from_usize(level.refs.len()) < self.slots {
+                return Ok(());
+            }
+            let refs = mem::take(&mut level.refs);
+            let closed = mem::replace(&mut level.span, 0);
+            reference = self.seal_intermediate(closed, &refs)?;
+            span = closed;
+            at = at.saturating_add(1);
+        }
+    }
+
+    /// Append a reference at `at` without the close-on-full check; the
+    /// closing phase wraps each level as it reaches it.
+    fn push_carry(
+        &mut self,
+        at: usize,
+        reference: M::Ref,
+        span: u64,
+    ) -> Result<(), SplitError<S::Error>> {
+        while self.spine.len() <= at {
+            self.spine.push(Level::new());
+        }
+        self.stats.peak_spine = self.stats.peak_spine.max(self.spine.len());
+        let Some(level) = self.spine.get_mut(at) else {
+            return Err(SplitError::SpineDepleted);
+        };
+        let sum = level
+            .span
+            .checked_add(span)
+            .ok_or(SplitError::SpanOverflow {
+                span: level.span,
+                add: span,
+            })?;
+        level.refs.push(reference);
+        level.span = sum;
+        Ok(())
+    }
+
+    /// Seal one intermediate payload from its children's references.
+    fn seal_intermediate(
+        &mut self,
+        span: u64,
+        refs: &[M::Ref],
+    ) -> Result<M::Ref, SplitError<S::Error>> {
+        let ref_size = usize::try_from(M::MODE.ref_size()).unwrap_or(usize::MAX);
+        let capacity = SPAN_SIZE.saturating_add(refs.len().saturating_mul(ref_size));
+        let mut payload = Vec::with_capacity(capacity);
+        payload.extend_from_slice(&span.to_le_bytes());
+        for reference in refs {
+            M::write_ref(reference, &mut payload);
+        }
+        let (chunk, reference) = M::seal::<B>(Bytes::from(payload))?;
+        self.stats.intermediates = self.stats.intermediates.saturating_add(1);
+        self.enqueue(chunk);
+        Ok(reference)
+    }
+
+    /// Queue a sealed chunk for the put window, admitting what fits.
+    fn enqueue(&mut self, chunk: Chunk<Verified, AnyChunkSet<B>>) {
+        self.pending.push_back(chunk);
+        self.admit();
+        self.stats.peak_pending = self.stats.peak_pending.max(self.pending.len());
+    }
+
+    /// Move pending chunks into the put window while slots are free.
+    fn admit(&mut self) {
+        while self.in_flight.len() < self.window {
+            let Some(chunk) = self.pending.pop_front() else {
+                return;
+            };
+            self.dispatch(chunk);
+        }
+    }
+
+    /// Start one put, moving the chunk into its future; the completion
+    /// carries the address back.
+    fn dispatch(&mut self, chunk: Chunk<Verified, AnyChunkSet<B>>) {
+        let store = self.store.clone();
+        let put: BoxPut<S::Error> = Box::pin(async move {
+            let address = *chunk.address();
+            (address, store.put(chunk).await)
+        });
+        self.in_flight.push(put);
+        self.stats.puts = self.stats.puts.saturating_add(1);
+        self.stats.peak_put_in_flight = self.stats.peak_put_in_flight.max(self.in_flight.len());
+    }
+
+    /// Fold completed puts back in and admit pending chunks; a failed put
+    /// is terminal.
+    fn step_puts(&mut self, cx: &mut Context<'_>) -> Result<(), SplitError<S::Error>> {
+        loop {
+            self.admit();
+            match Pin::new(&mut self.in_flight).poll_next(cx) {
+                Poll::Ready(Some((address, result))) => {
+                    result.map_err(|source| SplitError::Put { address, source })?;
+                }
+                Poll::Ready(None) | Poll::Pending => return Ok(()),
+            }
+        }
+    }
+}
+
+impl<S, M, const B: usize> fmt::Debug for Split<S, M, B>
+where
+    S: ChunkPut<AnyChunkSet<B>>,
+    M: SplitMode,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Split")
+            .field("phase", &self.phase)
+            .field("window", &self.window)
+            .field("slots", &self.slots)
+            .field("leaf_len", &self.leaf.len())
+            .field("spine_levels", &self.spine.len())
+            .field("pending", &self.pending.len())
+            .field("in_flight", &self.in_flight.len())
+            .finish_non_exhaustive()
+    }
+}

--- a/crates/file/src/split/error.rs
+++ b/crates/file/src/split/error.rs
@@ -1,0 +1,39 @@
+//! Typed split failures; every error is terminal (the engine never retries).
+
+use nectar_primitives::PrimitivesError;
+use nectar_primitives::chunk::ChunkAddress;
+
+/// Terminal split failure.
+#[derive(Debug, thiserror::Error)]
+pub enum SplitError<E> {
+    /// A store put failed.
+    #[error("put failed at {address}")]
+    Put {
+        /// Address of the chunk the put carried.
+        address: ChunkAddress,
+        /// Store error behind the failure.
+        source: E,
+    },
+    /// Sealing a payload into a chunk failed.
+    #[error("seal failed")]
+    Seal(#[from] PrimitivesError),
+    /// Accumulated child spans overflowed the `u64` length domain.
+    #[error("span overflow adding {add} to {span}")]
+    SpanOverflow {
+        /// Span already accumulated at the level.
+        span: u64,
+        /// Child span whose addition overflowed.
+        add: u64,
+    },
+    /// A write arrived after `finish` began; the split accepts no more
+    /// bytes.
+    #[error("write after finish")]
+    Finished,
+    /// An earlier failure fused the split shut.
+    #[error("poisoned by an earlier failure")]
+    Poisoned,
+    /// The spine emptied without yielding a root; a split invariant is
+    /// broken.
+    #[error("spine depleted without a root")]
+    SpineDepleted,
+}

--- a/crates/file/src/split/mod.rs
+++ b/crates/file/src/split/mod.rs
@@ -1,0 +1,57 @@
+//! Poll-native split engine: the one bounded ascent building a chunk tree.
+//!
+//! Every write mode feeds this engine; nothing else in the crate seals tree
+//! nodes. The engine is push-driven and io-free (no spawns, channels or
+//! timers), all state lives in the [`Split`], and sealed chunks flow to the
+//! store through a bounded put window.
+//!
+//! Normative invariants, each pinned by a test:
+//!
+//! 1. Root identity: the sealed chunk set and root over any byte stream
+//!    equal a whole-buffer split of the same bytes, including the lone
+//!    trailing reference that carries up unwrapped.
+//! 2. Bounded put window: puts in flight never exceed the
+//!    [`PutWindow`](crate::PutWindow); sealed chunks awaiting a slot are
+//!    bounded by the spine height, and no further bytes are consumed while
+//!    any remain.
+//! 3. Cancel-safe write: a put slot is secured before any byte is consumed,
+//!    so an abandoned `poll_write` consumes nothing.
+//! 4. Poisoned fuse: every error is terminal; after one, every poll returns
+//!    [`Poisoned`](SplitError::Poisoned). Retry policy composes beneath the
+//!    store seam.
+//! 5. Fused finish: `poll_finish` is cancel-safe and re-callable; after the
+//!    root is delivered every later call returns the same root.
+
+mod engine;
+mod error;
+mod mode;
+#[cfg(test)]
+mod tests;
+
+pub use engine::Split;
+pub use error::SplitError;
+pub use mode::{Sealed, SplitMode};
+
+/// Occupancy witnesses of one split.
+///
+/// The peaks pin the engine's memory bounds in tests: puts in flight never
+/// exceed the window, and sealed chunks awaiting a slot stay within the
+/// spine height.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct SplitStats {
+    /// File bytes consumed.
+    pub bytes: u64,
+    /// Leaf chunks sealed.
+    pub leaves: u64,
+    /// Intermediate chunks sealed.
+    pub intermediates: u64,
+    /// Store puts dispatched.
+    pub puts: u64,
+    /// Peak puts in flight.
+    pub peak_put_in_flight: usize,
+    /// Peak sealed chunks awaiting a put slot.
+    pub peak_pending: usize,
+    /// Spine levels touched.
+    pub peak_spine: usize,
+}

--- a/crates/file/src/split/mode.rs
+++ b/crates/file/src/split/mode.rs
@@ -1,0 +1,74 @@
+//! Reference grammar seam: how a split writes child references.
+
+use alloc::vec::Vec;
+use core::fmt::Debug;
+
+use bytes::Bytes;
+use nectar_primitives::PrimitivesError;
+use nectar_primitives::chunk::{AnyChunkSet, Chunk, ChunkAddress, ContentChunk, Verified};
+use nectar_primitives::store::{MaybeSend, MaybeSync};
+
+use crate::geometry::Mode;
+use crate::walk::Plain;
+
+/// A sealed chunk and the reference that names it.
+pub type Sealed<M, const B: usize> = (Chunk<Verified, AnyChunkSet<B>>, <M as SplitMode>::Ref);
+
+/// Write-side reference grammar of one tree profile.
+///
+/// The engine stays mode-blind: a mode contributes its [`Mode`] geometry,
+/// the per-intermediate data-slot count (the parity retrofit seam), and the
+/// sealer for one payload; the ascent itself is shared.
+pub trait SplitMode: MaybeSend + MaybeSync + 'static {
+    /// Reference layout this mode writes.
+    const MODE: Mode;
+
+    /// Reference to a sealed subtree, embedded in its parent's body.
+    type Ref: Clone + Debug + MaybeSend + MaybeSync + 'static;
+
+    /// Reference naming the finished tree.
+    type Root: Clone + Debug + MaybeSend + MaybeSync + 'static;
+
+    /// Data-carrying reference slots per intermediate body. Plain modes use
+    /// every slot; a parity variant reserves trailing slots instead.
+    fn data_slots(branches: u64) -> u64;
+
+    /// Seal one payload into a chunk and the reference that names it.
+    ///
+    /// The payload is the chunk's wire body: a little-endian `u64` span
+    /// followed by the spanned content (leaf bytes or packed references).
+    fn seal<const B: usize>(payload: Bytes) -> Result<Sealed<Self, B>, PrimitivesError>;
+
+    /// Append one reference's wire bytes to a parent payload under build.
+    fn write_ref(reference: &Self::Ref, out: &mut Vec<u8>);
+
+    /// The root of a finished tree from its sole surviving reference.
+    fn into_root(reference: Self::Ref) -> Self::Root;
+}
+
+/// Plain split: a reference is the bare chunk address. One marker serves
+/// both engines.
+impl SplitMode for Plain {
+    const MODE: Mode = Mode::Plain;
+
+    type Ref = ChunkAddress;
+    type Root = ChunkAddress;
+
+    fn data_slots(branches: u64) -> u64 {
+        branches
+    }
+
+    fn seal<const B: usize>(payload: Bytes) -> Result<Sealed<Self, B>, PrimitivesError> {
+        let chunk = ContentChunk::<B>::try_from(payload)?.seal::<AnyChunkSet<B>>();
+        let address = *chunk.address();
+        Ok((chunk, address))
+    }
+
+    fn write_ref(reference: &ChunkAddress, out: &mut Vec<u8>) {
+        out.extend_from_slice(reference.as_bytes());
+    }
+
+    fn into_root(reference: ChunkAddress) -> ChunkAddress {
+        reference
+    }
+}

--- a/crates/file/src/split/tests.rs
+++ b/crates/file/src/split/tests.rs
@@ -1,0 +1,465 @@
+//! Split-engine oracles: root and chunk-set differentials against the
+//! legacy buffered splitter, put-window witnesses, cancellation and fuse
+//! behaviour.
+
+#![allow(deprecated)]
+
+use core::future::{Future, poll_fn};
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use std::collections::HashMap;
+use std::io::Write as _;
+use std::string::ToString;
+use std::sync::{Arc, Mutex};
+use std::vec;
+use std::vec::Vec;
+
+use futures::executor::block_on;
+use futures::task::noop_waker;
+use nectar_primitives::chunk::{AnyChunkSet, Chunk, ChunkAddress, ChunkOps, Verified};
+use nectar_primitives::file::Splitter;
+use nectar_primitives::store::{ChunkGet, ChunkPut, ChunkStoreError};
+
+use super::{Split, SplitError, SplitStats};
+use crate::config::{PutWindow, Window};
+use crate::walk::{Plain, Walk};
+
+/// Tiny body size: fan-out 8, so a few dozen leaves already build a deep
+/// tree.
+const TINY: usize = 256;
+const BRANCHES: usize = 8;
+
+type TinySplit = Split<TestStore<TINY>, Plain, TINY>;
+
+/// Distinct byte per file position so every node address is unique.
+fn fill(len: usize) -> Vec<u8> {
+    (0..len as u64).map(pattern).collect()
+}
+
+/// The byte at absolute file position `i`.
+fn pattern(i: u64) -> u8 {
+    (i.wrapping_mul(2_654_435_761) >> 11) as u8
+}
+
+/// A self-waking yield: `Pending` once with an immediate wake, so
+/// `block_on` keeps polling.
+fn yield_now() -> impl Future<Output = ()> {
+    struct YieldNow(bool);
+    impl Future for YieldNow {
+        type Output = ();
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+            if self.0 {
+                Poll::Ready(())
+            } else {
+                self.0 = true;
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+        }
+    }
+    YieldNow(false)
+}
+
+/// Shared put store: logs accepted puts in order, resolves after `delay`
+/// yields, parks while `gate` is shut, refuses puts past `fail_after`.
+struct TestStore<const B: usize> {
+    chunks: Arc<Mutex<HashMap<ChunkAddress, Chunk<Verified, AnyChunkSet<B>>>>>,
+    log: Arc<Mutex<Vec<ChunkAddress>>>,
+    delay: usize,
+    gate: Option<Arc<Mutex<bool>>>,
+    fail_after: Option<usize>,
+}
+
+impl<const B: usize> Clone for TestStore<B> {
+    fn clone(&self) -> Self {
+        Self {
+            chunks: Arc::clone(&self.chunks),
+            log: Arc::clone(&self.log),
+            delay: self.delay,
+            gate: self.gate.clone(),
+            fail_after: self.fail_after,
+        }
+    }
+}
+
+impl<const B: usize> TestStore<B> {
+    fn new(delay: usize) -> Self {
+        Self {
+            chunks: Arc::new(Mutex::new(HashMap::new())),
+            log: Arc::new(Mutex::new(Vec::new())),
+            delay,
+            gate: None,
+            fail_after: None,
+        }
+    }
+
+    fn gated(gate: Arc<Mutex<bool>>) -> Self {
+        Self {
+            gate: Some(gate),
+            ..Self::new(0)
+        }
+    }
+
+    fn failing_after(fail_after: usize) -> Self {
+        Self {
+            fail_after: Some(fail_after),
+            ..Self::new(0)
+        }
+    }
+
+    fn log(&self) -> Vec<ChunkAddress> {
+        self.log.lock().unwrap().clone()
+    }
+}
+
+impl<const B: usize> ChunkPut<AnyChunkSet<B>> for TestStore<B> {
+    type Error = ChunkStoreError;
+
+    async fn put(&self, chunk: Chunk<Verified, AnyChunkSet<B>>) -> Result<(), ChunkStoreError> {
+        if let Some(gate) = &self.gate {
+            while !*gate.lock().unwrap() {
+                yield_now().await;
+            }
+        }
+        for _ in 0..self.delay {
+            yield_now().await;
+        }
+        if let Some(limit) = self.fail_after
+            && self.log.lock().unwrap().len() >= limit
+        {
+            return Err(ChunkStoreError::Other("put refused".to_string().into()));
+        }
+        let address = *chunk.address();
+        self.log.lock().unwrap().push(address);
+        self.chunks.lock().unwrap().insert(address, chunk);
+        Ok(())
+    }
+}
+
+impl<const B: usize> ChunkGet<AnyChunkSet<B>> for TestStore<B> {
+    type Trust = Verified;
+    type Error = ChunkStoreError;
+
+    async fn get(
+        &self,
+        address: &ChunkAddress,
+    ) -> Result<Chunk<Verified, AnyChunkSet<B>>, ChunkStoreError> {
+        self.chunks
+            .lock()
+            .unwrap()
+            .get(address)
+            .cloned()
+            .ok_or_else(|| ChunkStoreError::not_found(address))
+    }
+}
+
+/// The legacy buffered splitter as the oracle: root plus every produced
+/// chunk address.
+fn legacy_split<const B: usize>(data: &[u8]) -> (ChunkAddress, Vec<ChunkAddress>) {
+    let mut splitter = Splitter::<B>::new(data.len() as u64);
+    splitter.write_all(data).unwrap();
+    let (root, chunks) = splitter.finish().unwrap();
+    let addresses = chunks.iter().map(|chunk| *chunk.address()).collect();
+    (root, addresses)
+}
+
+/// Stream `data` through a fresh split in `step`-byte writes.
+fn stream_split<const B: usize>(
+    data: &[u8],
+    window: u16,
+    step: usize,
+    delay: usize,
+) -> (ChunkAddress, TestStore<B>, SplitStats) {
+    let store = TestStore::<B>::new(delay);
+    let mut split: Split<TestStore<B>, Plain, B> =
+        Split::new(store.clone(), PutWindow::new(window).unwrap());
+    let root = block_on(async {
+        for piece in data.chunks(step.max(1)) {
+            let mut buf = piece;
+            while !buf.is_empty() {
+                let n = poll_fn(|cx| split.poll_write(cx, buf)).await.unwrap();
+                buf = &buf[n..];
+            }
+        }
+        poll_fn(|cx| split.poll_finish(cx)).await.unwrap()
+    });
+    let stats = split.stats();
+    (root, store, stats)
+}
+
+fn sorted(mut addresses: Vec<ChunkAddress>) -> Vec<ChunkAddress> {
+    addresses.sort();
+    addresses
+}
+
+#[test]
+fn roots_and_chunk_sets_match_the_legacy_splitter() {
+    let b = TINY;
+    let kb = BRANCHES * b;
+    let k2b = BRANCHES * kb;
+    let sizes = [
+        0,
+        1,
+        b - 1,
+        b,
+        b + 1,
+        kb - 1,
+        kb,
+        kb + 1,
+        k2b - 1,
+        k2b,
+        k2b + 1,
+        3 * kb + 517,
+    ];
+    for size in sizes {
+        let data = fill(size);
+        let (legacy_root, legacy_chunks) = legacy_split::<TINY>(&data);
+        let (root, store, stats) = stream_split::<TINY>(&data, 4, 719, 1);
+        assert_eq!(root, legacy_root, "root diverged at {size}");
+        assert_eq!(
+            sorted(store.log()),
+            sorted(legacy_chunks),
+            "chunk set diverged at {size}"
+        );
+        assert_eq!(stats.bytes, size as u64);
+        assert_eq!(stats.leaves + stats.intermediates, stats.puts);
+    }
+}
+
+#[test]
+fn default_profile_roots_match_the_legacy_splitter() {
+    const B: usize = nectar_primitives::DEFAULT_BODY_SIZE;
+    const K: usize = 128;
+    let sizes = [0, 1, B - 1, B, B + 1, K * B - 1, K * B, K * B + 1];
+    for size in sizes {
+        let data = fill(size);
+        let (legacy_root, _) = legacy_split::<B>(&data);
+        let (root, _, _) = stream_split::<B>(&data, 8, 65_536, 0);
+        assert_eq!(root, legacy_root, "root diverged at {size}");
+    }
+}
+
+#[test]
+fn split_then_walk_round_trips() {
+    let data = fill(37 * TINY + 41);
+    let (root, store, _) = stream_split::<TINY>(&data, 4, usize::MAX, 1);
+    let mut walk: Walk<TestStore<TINY>, Plain, TINY> = Walk::new(
+        store,
+        root,
+        (),
+        data.len() as u64,
+        0..u64::MAX,
+        Window::new(4).unwrap(),
+    );
+    let bytes = block_on(async {
+        let mut bytes = Vec::new();
+        while let Some(frame) = poll_fn(|cx| walk.poll_next_ordered(cx)).await {
+            bytes.extend_from_slice(&frame.unwrap().data);
+        }
+        bytes
+    });
+    assert_eq!(bytes, data);
+}
+
+#[test]
+fn put_window_witnesses_hold() {
+    let data = fill(200 * TINY + 63);
+    for window in [1u16, 4, 16] {
+        let (_, store, stats) = stream_split::<TINY>(&data, window, 997, 3);
+        assert!(
+            stats.peak_put_in_flight <= usize::from(window),
+            "in-flight {} exceeded window {window}",
+            stats.peak_put_in_flight
+        );
+        assert!(
+            stats.peak_pending <= stats.peak_spine,
+            "pending {} exceeded the spine height {}",
+            stats.peak_pending,
+            stats.peak_spine
+        );
+        assert_eq!(stats.leaves + stats.intermediates, stats.puts);
+        assert_eq!(store.log().len() as u64, stats.puts);
+    }
+}
+
+#[test]
+fn write_secures_capacity_before_consuming() {
+    let gate = Arc::new(Mutex::new(false));
+    let store = TestStore::<TINY>::gated(Arc::clone(&gate));
+    let mut split: TinySplit = Split::new(store, PutWindow::new(1).unwrap());
+    let waker = noop_waker();
+    let mut cx = Context::from_waker(&waker);
+
+    // First leaf: capacity is free, bytes are consumed, the put parks.
+    let data = fill(2 * TINY);
+    let first = split.poll_write(&mut cx, &data[..TINY]);
+    assert!(matches!(first, Poll::Ready(Ok(TINY))));
+    assert_eq!(split.stats().bytes, TINY as u64);
+
+    // Window full: repeated polls consume nothing.
+    for _ in 0..5 {
+        assert!(split.poll_write(&mut cx, &data[TINY..]).is_pending());
+        assert_eq!(split.stats().bytes, TINY as u64);
+    }
+
+    // Opening the gate frees the slot and the write proceeds.
+    *gate.lock().unwrap() = true;
+    let resumed = split.poll_write(&mut cx, &data[TINY..]);
+    assert!(matches!(resumed, Poll::Ready(Ok(TINY))));
+    assert_eq!(split.stats().bytes, 2 * TINY as u64);
+}
+
+#[test]
+fn empty_write_consumes_nothing() {
+    let store = TestStore::<TINY>::new(0);
+    let mut split: TinySplit = Split::new(store, PutWindow::DEFAULT);
+    let waker = noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    assert!(matches!(split.poll_write(&mut cx, &[]), Poll::Ready(Ok(0))));
+    assert_eq!(split.stats().bytes, 0);
+}
+
+#[test]
+fn a_failed_put_poisons_the_fuse() {
+    let store = TestStore::<TINY>::failing_after(0);
+    let mut split: TinySplit = Split::new(store, PutWindow::new(2).unwrap());
+    let data = fill(3 * TINY);
+    let error = block_on(async {
+        let mut buf = data.as_slice();
+        loop {
+            match poll_fn(|cx| split.poll_write(cx, buf)).await {
+                Ok(n) => buf = &buf[n..],
+                Err(error) => break error,
+            }
+            if buf.is_empty() {
+                break poll_fn(|cx| split.poll_finish(cx)).await.unwrap_err();
+            }
+        }
+    });
+    assert!(matches!(error, SplitError::Put { .. }), "got {error:?}");
+
+    // Every later poll returns the poisoned fuse.
+    let waker = noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    assert!(matches!(
+        split.poll_write(&mut cx, &data),
+        Poll::Ready(Err(SplitError::Poisoned))
+    ));
+    assert!(matches!(
+        split.poll_finish(&mut cx),
+        Poll::Ready(Err(SplitError::Poisoned))
+    ));
+    assert!(split.is_finished());
+}
+
+#[test]
+fn finish_is_fused_and_recallable() {
+    let data = fill(20 * TINY + 3);
+    let store = TestStore::<TINY>::new(2);
+    let mut split: TinySplit = Split::new(store, PutWindow::new(2).unwrap());
+    let waker = noop_waker();
+    let mut cx = Context::from_waker(&waker);
+
+    let mut buf = data.as_slice();
+    let mut polls = 0usize;
+    while !buf.is_empty() {
+        match split.poll_write(&mut cx, buf) {
+            Poll::Ready(Ok(n)) => buf = &buf[n..],
+            Poll::Ready(Err(error)) => panic!("write failed: {error:?}"),
+            Poll::Pending => {
+                polls += 1;
+                assert!(polls < 100_000, "write stuck");
+            }
+        }
+    }
+
+    // Finish across many abandoned polls: progress is never lost.
+    let root = loop {
+        match split.poll_finish(&mut cx) {
+            Poll::Ready(result) => break result.unwrap(),
+            Poll::Pending => {
+                polls += 1;
+                assert!(polls < 100_000, "finish stuck");
+            }
+        }
+    };
+    assert!(split.is_finished());
+
+    // Re-callable: the fused root is delivered again, and writes refuse.
+    let again = split.poll_finish(&mut cx);
+    assert!(matches!(again, Poll::Ready(Ok(address)) if address == root));
+    assert!(matches!(
+        split.poll_write(&mut cx, &data),
+        Poll::Ready(Err(SplitError::Finished))
+    ));
+
+    let (legacy_root, _) = legacy_split::<TINY>(&data);
+    assert_eq!(root, legacy_root);
+}
+
+/// Nightly gate: a stream past the `u32` span boundary keeps root equality
+/// with the legacy splitter while memory stays bounded.
+#[test]
+#[ignore = "nightly: streams more than 4 GiB"]
+fn huge_stream_root_matches_the_legacy_splitter() {
+    use nectar_primitives::file::{ParallelSplitter, ReadAt};
+
+    const B: usize = nectar_primitives::DEFAULT_BODY_SIZE;
+    let size: u64 = (1u64 << 32) + (B as u64) + 17;
+
+    /// Deterministic source: byte `i` is `pattern(i)`, never materialized.
+    struct Pattern {
+        len: u64,
+    }
+
+    impl ReadAt for Pattern {
+        fn read_at(&self, offset: u64, buf: &mut [u8]) -> std::io::Result<usize> {
+            let available = self.len.saturating_sub(offset);
+            let take = buf.len().min(available as usize);
+            for (i, slot) in buf[..take].iter_mut().enumerate() {
+                *slot = pattern(offset + i as u64);
+            }
+            Ok(take)
+        }
+
+        fn len(&self) -> u64 {
+            self.len
+        }
+    }
+
+    #[derive(Clone)]
+    struct Discard;
+
+    impl ChunkPut<AnyChunkSet<B>> for Discard {
+        type Error = std::convert::Infallible;
+
+        async fn put(&self, _chunk: Chunk<Verified, AnyChunkSet<B>>) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    }
+
+    let legacy_root =
+        ParallelSplitter::<B>::split_into(&Pattern { len: size }, |_chunk| {}).unwrap();
+
+    let mut split: Split<Discard, Plain, B> = Split::new(Discard, PutWindow::new(16).unwrap());
+    let root = block_on(async {
+        let mut buf = vec![0u8; 1 << 20];
+        let mut offset = 0u64;
+        while offset < size {
+            let take = buf.len().min((size - offset) as usize);
+            for (i, slot) in buf[..take].iter_mut().enumerate() {
+                *slot = pattern(offset + i as u64);
+            }
+            let mut piece = &buf[..take];
+            while !piece.is_empty() {
+                let n = poll_fn(|cx| split.poll_write(cx, piece)).await.unwrap();
+                piece = &piece[n..];
+            }
+            offset += take as u64;
+        }
+        poll_fn(|cx| split.poll_finish(cx)).await.unwrap()
+    });
+
+    assert_eq!(root, legacy_root);
+    assert_eq!(split.stats().bytes, size);
+}

--- a/crates/file/src/walk/engine.rs
+++ b/crates/file/src/walk/engine.rs
@@ -18,6 +18,7 @@ use super::error::{ShapeError, WalkError};
 use super::mode::WalkMode;
 use super::{Frame, WalkStats};
 use crate::config::{BranchBudget, Window};
+use crate::num::{fan_out, u64_from_u32, u64_from_usize};
 
 /// One pending tree node: where its bytes live and what fetches it.
 struct Node<M: WalkMode> {
@@ -510,34 +511,6 @@ where
             .field("branch_in_flight", &self.branch_in_flight)
             .field("done", &self.done)
             .finish_non_exhaustive()
-    }
-}
-
-/// Lossless widening; `From` is not const-callable here.
-#[cfg(target_pointer_width = "64")]
-const fn u64_from_usize(value: usize) -> u64 {
-    u64::from_le_bytes(value.to_le_bytes())
-}
-
-/// Lossless widening; `From` is not const-callable here.
-#[cfg(target_pointer_width = "32")]
-const fn u64_from_usize(value: usize) -> u64 {
-    let [a, b, c, d] = value.to_le_bytes();
-    u64::from_le_bytes([a, b, c, d, 0, 0, 0, 0])
-}
-
-/// Lossless widening; `From` is not const-callable.
-const fn u64_from_u32(value: u32) -> u64 {
-    let [a, b, c, d] = value.to_le_bytes();
-    u64::from_le_bytes([a, b, c, d, 0, 0, 0, 0])
-}
-
-/// References per intermediate body; zero only for a degenerate profile the
-/// compile-time guard rejects.
-const fn fan_out(body: u64, ref_size: u64) -> u64 {
-    match body.checked_div(ref_size) {
-        Some(fan) => fan,
-        None => 0,
     }
 }
 


### PR DESCRIPTION
## What

Adds `crates/file/src/split/` (`engine.rs`, `mode.rs`, `error.rs`, `mod.rs`, `tests.rs`), a poll-native streaming splitter, plus shared `num.rs` helpers deduplicated out of the walk engine (`walk/engine.rs` trimmed accordingly).

- `Split<S, M, B>` keeps a per-`(B, mode)` spine frontier with spill-on-close cascades.
- Bounded put window: in-flight puts `<= PutWindow`; overflow bounded by spine height, with no further consumption while any chunk awaits a slot.
- Cancel-safe `poll_write`: the put slot is secured before any byte is consumed.
- A poisoned fuse on every terminal error, and a fused re-callable `poll_finish` delivering the root.
- Live `SplitStats`.
- `SplitMode` seam exposes `data_slots(branches)` as the named parity/erasure retrofit hook; `Plain` shares the walk's mode marker and seals span-prefixed payloads (LE u64 span, stated once).
- Differential tests pin root and chunk-set equality against the legacy buffered splitter across `{0, 1, B±1, K·B±1, K²·B±1, random}`.

## Why

Closes #337

## Testing

- `cargo fmt --all -- --check`: clean.
- `cargo clippy -p nectar-file --all-targets --locked`: zero warnings in the diff's crate (workspace run shows only pre-existing warnings in untouched crates).
- `cargo test -p nectar-file --locked`: 31 passed, 0 failed, 1 ignored (`huge_stream_root_matches_the_legacy_splitter`, nightly-only >4 GiB). 0 doc-tests (none in touched code).
- Coverage includes differential oracles against the legacy buffered splitter (`roots_and_chunk_sets_match_the_legacy_splitter`, default profile) plus dedicated tests for the bounded put window, cancel-safe write, poison fuse, and fused re-callable finish.
- Independent adversarial review found no blocking or major defects; confirmed `in_flight<=window` is enforced by `admit()` (not merely observed), all `Pending` paths precede any leaf mutation, and span is `u64` end-to-end with no truncation to `u32`.

## AI Assistance

Implementation by Fable, review by Opus, PR by Sonnet.

