### PR TITLE
feat(file): add file facade and ordered reader

### DIFF
--- a/crates/file/Cargo.toml
+++ b/crates/file/Cargo.toml
@@ -25,6 +25,9 @@ thiserror = { workspace = true, optional = true }
 
 [dev-dependencies]
 futures.workspace = true
+# The differential oracles split and join through the legacy read paths,
+# including the encrypted width.
+nectar-primitives = { workspace = true, features = ["std", "encryption"] }
 
 [features]
 default = [ "std" ]

--- a/crates/file/src/lib.rs
+++ b/crates/file/src/lib.rs
@@ -4,7 +4,9 @@
 //! This crate carries the pipeline's foundations: per-profile tree
 //! [`geometry`] pinned at compile time, the [`config`] admission budgets the
 //! engines drain against, the poll-native [`walk`] engine every read mode
-//! drains, and the poll-native [`split`] engine every write mode feeds.
+//! drains, the poll-native [`split`] engine every write mode feeds, and the
+//! [`read`] facade that opens files by either reference width and drains the
+//! walk in file order.
 
 #![no_std]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
@@ -38,6 +40,9 @@ pub mod geometry;
 mod num;
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+pub mod read;
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod split;
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
@@ -46,6 +51,10 @@ pub mod walk;
 pub use config::{BranchBudget, PutWindow, Window};
 pub use geometry::{DEFAULT_BODY_SIZE, Mode, branches, max_depth};
 #[cfg(feature = "std")]
+pub use read::{AnyFile, File, FileReader, FileStream, OpenError, ReadBuilder, SeekPastEnd};
+#[cfg(feature = "std")]
 pub use split::{Sealed, Split, SplitError, SplitMode, SplitStats};
 #[cfg(feature = "std")]
-pub use walk::{Frame, Plain, ShapeError, Walk, WalkError, WalkMode, WalkStats};
+pub use walk::{
+    DecodeError, Encrypted, Frame, Plain, ShapeError, Walk, WalkError, WalkMode, WalkStats,
+};

--- a/crates/file/src/read/error.rs
+++ b/crates/file/src/read/error.rs
@@ -1,0 +1,40 @@
+//! Typed failures of the read facade.
+
+use nectar_primitives::chunk::ChunkAddress;
+
+use crate::walk::DecodeError;
+
+/// Failure opening a file at its root chunk.
+#[derive(Debug, thiserror::Error)]
+pub enum OpenError<E> {
+    /// The root fetch failed.
+    #[error("root fetch failed at {address}")]
+    Fetch {
+        /// Requested root address.
+        address: ChunkAddress,
+        /// Store error behind the failure.
+        source: E,
+    },
+    /// The store completed the root fetch with a chunk at a different
+    /// address.
+    #[error("store returned {returned} for requested {requested}")]
+    AddressMismatch {
+        /// Address the open asked for.
+        requested: ChunkAddress,
+        /// Address of the chunk the store handed back.
+        returned: ChunkAddress,
+    },
+    /// The root body cannot be decoded under the mode's reference grammar.
+    #[error(transparent)]
+    Decode(#[from] DecodeError),
+}
+
+/// A seek past the reader's effective length; the reader never clamps.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("seek to {requested} past effective length {effective_len}")]
+pub struct SeekPastEnd {
+    /// Requested position, relative to the clipped range.
+    pub requested: u64,
+    /// The reader's effective length.
+    pub effective_len: u64,
+}

--- a/crates/file/src/read/file.rs
+++ b/crates/file/src/read/file.rs
@@ -1,0 +1,219 @@
+//! File handles: one opened chunk tree, mode pinned or runtime-dispatched.
+
+use core::fmt;
+
+use nectar_primitives::chunk::encryption::{EncryptedChunkRef, EncryptionKey, transcrypt_in_place};
+use nectar_primitives::chunk::{AnyChunkSet, ChunkAddress, ChunkOps};
+use nectar_primitives::store::TrustedGet;
+use nectar_primitives::{DEFAULT_BODY_SIZE, EntryRef};
+
+use super::error::OpenError;
+use super::reader::ReadBuilder;
+use crate::config::Window;
+use crate::geometry::Mode;
+use crate::walk::{DecodeError, Encrypted, Plain, WalkMode};
+
+/// One opened file: the root reference resolved to its address, context and
+/// total span. Opening fetches the root chunk once; reads re-fetch it so the
+/// fetch set stays identical to a cold walk.
+pub struct File<S, M: WalkMode = Plain, const B: usize = DEFAULT_BODY_SIZE> {
+    store: S,
+    root: ChunkAddress,
+    context: M::Context,
+    span: u64,
+}
+
+impl<S, M: WalkMode, const B: usize> File<S, M, B> {
+    /// Total file length in bytes.
+    pub const fn len(&self) -> u64 {
+        self.span
+    }
+
+    /// Whether the file carries no bytes.
+    pub const fn is_empty(&self) -> bool {
+        self.span == 0
+    }
+
+    /// Address of the root chunk.
+    pub const fn root(&self) -> &ChunkAddress {
+        &self.root
+    }
+}
+
+impl<S: Clone, M: WalkMode, const B: usize> File<S, M, B> {
+    /// Start building an ordered, seekable read over the whole file.
+    pub fn read(&self) -> ReadBuilder<S, M, B> {
+        ReadBuilder::new(
+            self.store.clone(),
+            self.root,
+            self.context.clone(),
+            self.span,
+            Window::DEFAULT,
+            0..u64::MAX,
+        )
+    }
+}
+
+impl<S, const B: usize> File<S, Plain, B>
+where
+    S: TrustedGet<AnyChunkSet<B>> + Clone + 'static,
+{
+    /// Open a plain file at its root address, reading the span off the root
+    /// chunk.
+    pub async fn open(store: S, root: ChunkAddress) -> Result<Self, OpenError<S::Error>> {
+        let chunk = fetch_root(&store, root).await?;
+        let span = chunk.span();
+        Ok(Self {
+            store,
+            root,
+            context: (),
+            span,
+        })
+    }
+}
+
+impl<S, const B: usize> File<S, Encrypted, B>
+where
+    S: TrustedGet<AnyChunkSet<B>> + Clone + 'static,
+{
+    /// Open an encrypted file at its root reference, decrypting the span off
+    /// the root chunk with the reference's key.
+    pub async fn open_encrypted(
+        store: S,
+        root: EncryptedChunkRef,
+    ) -> Result<Self, OpenError<S::Error>> {
+        let (address, key) = root.into_parts();
+        let chunk = fetch_root(&store, address).await?;
+        let len = chunk.data().len();
+        if len != B {
+            return Err(DecodeError::CiphertextLength { len, expected: B }.into());
+        }
+        // The span header rides its own keystream offset past the body's
+        // block count, so its bytes never share keystream with body bytes.
+        let mut span_bytes = chunk.span().to_le_bytes();
+        transcrypt_in_place(&key, span_counter(B), &mut span_bytes);
+        let span = u64::from_le_bytes(span_bytes);
+        Ok(Self {
+            store,
+            root: address,
+            context: key,
+            span,
+        })
+    }
+}
+
+impl<S, M: WalkMode, const B: usize> fmt::Debug for File<S, M, B> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("File")
+            .field("root", &self.root)
+            .field("span", &self.span)
+            .field("mode", &M::MODE)
+            .finish_non_exhaustive()
+    }
+}
+
+/// One opened file of either reference width, dispatched at runtime.
+#[derive(Debug)]
+pub enum AnyFile<S, const B: usize = DEFAULT_BODY_SIZE> {
+    /// A plain tree behind a 32-byte reference.
+    Plain(File<S, Plain, B>),
+    /// An encrypted tree behind a 64-byte reference.
+    Encrypted(File<S, Encrypted, B>),
+}
+
+impl<S, const B: usize> AnyFile<S, B>
+where
+    S: TrustedGet<AnyChunkSet<B>> + Clone + 'static,
+{
+    /// Open a file from a wire reference, dispatching the mode on the
+    /// reference width.
+    pub async fn open(store: S, root: EntryRef) -> Result<Self, OpenError<S::Error>> {
+        match root {
+            EntryRef::Plain(reference) => File::open(store, reference.into_address())
+                .await
+                .map(Self::Plain),
+            EntryRef::Encrypted(reference) => File::open_encrypted(store, reference)
+                .await
+                .map(Self::Encrypted),
+        }
+    }
+}
+
+impl<S, const B: usize> AnyFile<S, B> {
+    /// Total file length in bytes.
+    pub const fn len(&self) -> u64 {
+        match self {
+            Self::Plain(file) => file.len(),
+            Self::Encrypted(file) => file.len(),
+        }
+    }
+
+    /// Whether the file carries no bytes.
+    pub const fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Address of the root chunk.
+    pub const fn root(&self) -> &ChunkAddress {
+        match self {
+            Self::Plain(file) => file.root(),
+            Self::Encrypted(file) => file.root(),
+        }
+    }
+
+    /// Reference layout of the opened tree.
+    pub const fn mode(&self) -> Mode {
+        match self {
+            Self::Plain(_) => Mode::Plain,
+            Self::Encrypted(_) => Mode::Encrypted,
+        }
+    }
+}
+
+impl<S, const B: usize> From<File<S, Plain, B>> for AnyFile<S, B> {
+    fn from(file: File<S, Plain, B>) -> Self {
+        Self::Plain(file)
+    }
+}
+
+impl<S, const B: usize> From<File<S, Encrypted, B>> for AnyFile<S, B> {
+    fn from(file: File<S, Encrypted, B>) -> Self {
+        Self::Encrypted(file)
+    }
+}
+
+/// Fetch the root envelope, insisting the store answered for the requested
+/// address.
+async fn fetch_root<S, const B: usize>(
+    store: &S,
+    address: ChunkAddress,
+) -> Result<
+    <AnyChunkSet<B> as nectar_primitives::chunk::ChunkRegistry>::Envelope,
+    OpenError<S::Error>,
+>
+where
+    S: TrustedGet<AnyChunkSet<B>>,
+{
+    let chunk = store
+        .get(&address)
+        .await
+        .map_err(|source| OpenError::Fetch { address, source })?;
+    let returned = *chunk.address();
+    if returned != address {
+        return Err(OpenError::AddressMismatch {
+            requested: address,
+            returned,
+        });
+    }
+    Ok(chunk.into_envelope())
+}
+
+/// Span-header keystream counter: the body's 32-byte block count, one past
+/// the body's own keystream.
+fn span_counter(body_size: usize) -> u32 {
+    let blocks = body_size
+        .checked_div(EncryptionKey::SIZE)
+        .unwrap_or_default();
+    // The profile guard pins the body size within u32.
+    u32::try_from(blocks).unwrap_or(u32::MAX)
+}

--- a/crates/file/src/read/mod.rs
+++ b/crates/file/src/read/mod.rs
@@ -1,0 +1,19 @@
+//! File facade over the walk engine: open a tree by either reference width
+//! and read it in order.
+//!
+//! [`File`] pins the mode at the type level; [`AnyFile`] dispatches it at
+//! runtime from an [`EntryRef`](nectar_primitives::EntryRef) wire reference.
+//! [`ReadBuilder`] ranges use clip semantics: out-of-file bounds shrink the
+//! read instead of failing, and the clipped length is readable as
+//! [`FileReader::effective_len`]. Only [`FileReader::seek`] is typed-strict:
+//! it never clamps.
+
+mod error;
+mod file;
+mod reader;
+#[cfg(test)]
+mod tests;
+
+pub use error::{OpenError, SeekPastEnd};
+pub use file::{AnyFile, File};
+pub use reader::{FileReader, FileStream, ReadBuilder};

--- a/crates/file/src/read/reader.rs
+++ b/crates/file/src/read/reader.rs
@@ -1,0 +1,306 @@
+//! Ordered reader and stream over one walk.
+
+use core::fmt;
+use core::future::poll_fn;
+use core::mem;
+use core::ops::Range;
+use core::pin::Pin;
+use core::task::{Context, Poll};
+
+use bytes::Bytes;
+use futures_util::stream::Stream;
+use nectar_primitives::DEFAULT_BODY_SIZE;
+use nectar_primitives::chunk::{AnyChunkSet, ChunkAddress};
+use nectar_primitives::store::TrustedGet;
+
+use super::error::SeekPastEnd;
+use crate::config::Window;
+use crate::num::u64_from_usize;
+use crate::walk::{Walk, WalkError, WalkMode, WalkStats};
+
+/// Builder of one ordered read; construction is infallible.
+///
+/// Ranges use clip semantics: the built reader covers the intersection of
+/// the requested range and the file, and the clipped length is readable as
+/// [`FileReader::effective_len`].
+pub struct ReadBuilder<S, M: WalkMode, const B: usize = DEFAULT_BODY_SIZE> {
+    store: S,
+    root: ChunkAddress,
+    context: M::Context,
+    span: u64,
+    window: Window,
+    range: Range<u64>,
+}
+
+impl<S, M: WalkMode, const B: usize> ReadBuilder<S, M, B> {
+    pub(super) const fn new(
+        store: S,
+        root: ChunkAddress,
+        context: M::Context,
+        span: u64,
+        window: Window,
+        range: Range<u64>,
+    ) -> Self {
+        Self {
+            store,
+            root,
+            context,
+            span,
+            window,
+            range,
+        }
+    }
+
+    /// Fetch window the read drains against.
+    #[must_use]
+    pub const fn window(mut self, window: Window) -> Self {
+        self.window = window;
+        self
+    }
+
+    /// Absolute byte range to read, clipped to the file.
+    #[must_use]
+    pub const fn range(mut self, range: Range<u64>) -> Self {
+        self.range = range;
+        self
+    }
+}
+
+impl<S, M, const B: usize> ReadBuilder<S, M, B>
+where
+    S: TrustedGet<AnyChunkSet<B>> + Clone + 'static,
+    M: WalkMode,
+{
+    /// Build the ordered, seekable reader.
+    pub fn build(self) -> FileReader<S, M, B> {
+        let walk = Walk::new(
+            self.store.clone(),
+            self.root,
+            self.context.clone(),
+            self.span,
+            self.range,
+            self.window,
+        );
+        let clipped = walk.range();
+        FileReader {
+            store: self.store,
+            root: self.root,
+            context: self.context,
+            span: self.span,
+            window: self.window,
+            start: clipped.start,
+            end: clipped.end,
+            position: clipped.start,
+            current: Bytes::new(),
+            walk,
+        }
+    }
+
+    /// Build the ordered stream directly.
+    pub fn stream(self) -> FileStream<S, M, B> {
+        self.build().into_stream()
+    }
+}
+
+impl<S, M: WalkMode, const B: usize> fmt::Debug for ReadBuilder<S, M, B> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReadBuilder")
+            .field("root", &self.root)
+            .field("span", &self.span)
+            .field("window", &self.window)
+            .field("range", &self.range)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Ordered, seekable reader over one clipped range.
+///
+/// Positions are zero-based offsets within the clipped range. Reads are
+/// cancel-safe: all progress lives in the reader, and the position advances
+/// only when a call returns.
+pub struct FileReader<S, M, const B: usize = DEFAULT_BODY_SIZE>
+where
+    S: TrustedGet<AnyChunkSet<B>>,
+    M: WalkMode,
+{
+    store: S,
+    root: ChunkAddress,
+    context: M::Context,
+    span: u64,
+    window: Window,
+    /// Absolute first byte of the clipped range.
+    start: u64,
+    /// Absolute end of the clipped range.
+    end: u64,
+    /// Absolute offset of the next undelivered byte.
+    position: u64,
+    /// Unconsumed tail of the last delivered frame.
+    current: Bytes,
+    walk: Walk<S, M, B>,
+}
+
+impl<S, M, const B: usize> FileReader<S, M, B>
+where
+    S: TrustedGet<AnyChunkSet<B>> + Clone + 'static,
+    M: WalkMode,
+{
+    /// Current position within the clipped range.
+    pub const fn position(&self) -> u64 {
+        self.position.saturating_sub(self.start)
+    }
+
+    /// Bytes the clipped range covers.
+    pub const fn effective_len(&self) -> u64 {
+        self.end.saturating_sub(self.start)
+    }
+
+    /// Occupancy witnesses of the underlying walk.
+    pub const fn stats(&self) -> WalkStats {
+        self.walk.stats()
+    }
+
+    /// Move to `pos` within the clipped range; synchronous and typed, never
+    /// clamps. Seeking to the effective length is legal and reads as
+    /// end-of-range. A seek away from the current position abandons the
+    /// walk's prefetched frames.
+    pub fn seek(&mut self, pos: u64) -> Result<(), SeekPastEnd> {
+        let effective_len = self.effective_len();
+        if pos > effective_len {
+            return Err(SeekPastEnd {
+                requested: pos,
+                effective_len,
+            });
+        }
+        let target = self.start.saturating_add(pos);
+        if target != self.position {
+            self.current = Bytes::new();
+            self.walk = Walk::new(
+                self.store.clone(),
+                self.root,
+                self.context.clone(),
+                self.span,
+                target..self.end,
+                self.window,
+            );
+            self.position = target;
+        }
+        Ok(())
+    }
+
+    /// Copy the next in-order bytes into `buf`, returning the count; zero
+    /// means end of range (or an empty `buf`).
+    pub async fn read(&mut self, buf: &mut [u8]) -> Result<usize, WalkError<S::Error>> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        if self.current.is_empty() {
+            let Some(frame) = poll_fn(|cx| self.walk.poll_next_ordered(cx))
+                .await
+                .transpose()?
+            else {
+                return Ok(0);
+            };
+            self.current = frame.data;
+        }
+        let take = self.current.len().min(buf.len());
+        let (head, _) = buf.split_at_mut(take);
+        head.copy_from_slice(self.current.split_to(take).as_ref());
+        self.position = self.position.saturating_add(u64_from_usize(take));
+        Ok(take)
+    }
+
+    /// The next in-order run of bytes without copying; `None` at end of
+    /// range.
+    pub async fn next_segment(&mut self) -> Option<Result<Bytes, WalkError<S::Error>>> {
+        if !self.current.is_empty() {
+            let rest = mem::take(&mut self.current);
+            self.position = self.position.saturating_add(u64_from_usize(rest.len()));
+            return Some(Ok(rest));
+        }
+        match poll_fn(|cx| self.walk.poll_next_ordered(cx)).await? {
+            Ok(frame) => {
+                self.position = self
+                    .position
+                    .saturating_add(u64_from_usize(frame.data.len()));
+                Some(Ok(frame.data))
+            }
+            Err(error) => Some(Err(error)),
+        }
+    }
+
+    /// Continue as a stream from the current position, delivering any
+    /// partially consumed frame first.
+    pub fn into_stream(self) -> FileStream<S, M, B> {
+        FileStream {
+            lead: self.current,
+            walk: self.walk,
+        }
+    }
+}
+
+impl<S, M, const B: usize> fmt::Debug for FileReader<S, M, B>
+where
+    S: TrustedGet<AnyChunkSet<B>>,
+    M: WalkMode,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FileReader")
+            .field("start", &self.start)
+            .field("end", &self.end)
+            .field("position", &self.position)
+            .field("buffered", &self.current.len())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Ordered stream of byte runs over one clipped range; consecutive items
+/// tile the range gaplessly.
+pub struct FileStream<S, M, const B: usize = DEFAULT_BODY_SIZE>
+where
+    S: TrustedGet<AnyChunkSet<B>>,
+    M: WalkMode,
+{
+    /// Partially consumed frame handed over by a reader, delivered first.
+    lead: Bytes,
+    walk: Walk<S, M, B>,
+}
+
+/// Movable regardless of the store or context types: the stream owns plain
+/// state and boxed futures, never a self-reference.
+impl<S, M, const B: usize> Unpin for FileStream<S, M, B>
+where
+    S: TrustedGet<AnyChunkSet<B>>,
+    M: WalkMode,
+{
+}
+
+impl<S, M, const B: usize> Stream for FileStream<S, M, B>
+where
+    S: TrustedGet<AnyChunkSet<B>> + Clone + 'static,
+    M: WalkMode,
+{
+    type Item = Result<Bytes, WalkError<S::Error>>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        if !this.lead.is_empty() {
+            return Poll::Ready(Some(Ok(mem::take(&mut this.lead))));
+        }
+        this.walk
+            .poll_next_ordered(cx)
+            .map(|next| next.map(|frame| frame.map(|frame| frame.data)))
+    }
+}
+
+impl<S, M, const B: usize> fmt::Debug for FileStream<S, M, B>
+where
+    S: TrustedGet<AnyChunkSet<B>>,
+    M: WalkMode,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FileStream")
+            .field("lead", &self.lead.len())
+            .field("walk", &self.walk)
+            .finish_non_exhaustive()
+    }
+}

--- a/crates/file/src/read/tests.rs
+++ b/crates/file/src/read/tests.rs
@@ -1,0 +1,421 @@
+//! Facade oracles: differential equality against the legacy read paths over
+//! both reference widths, clip-with-effective-length ranges, seek, and the
+//! runtime width dispatch.
+#![allow(deprecated)]
+
+use std::string::String;
+use std::vec;
+use std::vec::Vec;
+
+use bytes::Bytes;
+use futures::executor::block_on;
+use nectar_primitives::chunk::encryption::{EncryptedChunkRef, EncryptionKey};
+use nectar_primitives::chunk::{
+    AnyChunk, AnyChunkSet, Chunk, ChunkAddress, ChunkOps, ChunkRef, ContentChunk,
+};
+use nectar_primitives::file::{ChunkGetExt, join, split, split_encrypted};
+use nectar_primitives::store::{ChunkStoreError, MemoryStore, TrustedGet};
+use nectar_primitives::{EntryRef, transcrypt};
+
+use super::{AnyFile, File, FileReader, OpenError, SeekPastEnd};
+use crate::config::Window;
+use crate::geometry::Mode;
+use crate::walk::{DecodeError, Encrypted, Plain, WalkError, WalkMode};
+
+/// Tiny body size shared with the legacy joiner tests: fan-out 8 plain and 4
+/// encrypted, so small files already build deep trees.
+const TINY: usize = 256;
+
+type TinyStore = MemoryStore<AnyChunkSet<TINY>>;
+
+/// Distinct byte per file position so slices are position-sensitive.
+fn fill(len: usize) -> Vec<u8> {
+    (0..len as u64)
+        .map(|i| (i.wrapping_mul(2_654_435_761) >> 11) as u8)
+        .collect()
+}
+
+/// Sizes crossing every geometry edge: empty, single leaf, both branch
+/// boundaries (8 plain, 4 encrypted), and a multi-level interior.
+fn edge_sizes() -> Vec<usize> {
+    vec![
+        0,
+        1,
+        TINY - 1,
+        TINY,
+        TINY + 1,
+        4 * TINY,
+        4 * TINY + 1,
+        8 * TINY,
+        8 * TINY + 3,
+        33 * TINY + 17,
+    ]
+}
+
+fn drain_reader<S, M>(reader: &mut FileReader<S, M, TINY>) -> Vec<u8>
+where
+    S: TrustedGet<AnyChunkSet<TINY>, Error = ChunkStoreError> + Clone + 'static,
+    M: WalkMode,
+{
+    block_on(async {
+        let mut out = Vec::new();
+        let mut buf = [0u8; 97];
+        loop {
+            let n = reader.read(&mut buf).await.unwrap();
+            if n == 0 {
+                break;
+            }
+            out.extend_from_slice(&buf[..n]);
+        }
+        out
+    })
+}
+
+#[test]
+fn plain_reader_matches_legacy_join() {
+    for len in edge_sizes() {
+        let data = fill(len);
+        let (root, store) = split::<TINY>(&data).unwrap();
+        let legacy = block_on(join(&store, root)).unwrap();
+        assert_eq!(legacy, data, "legacy oracle diverged at {len}");
+
+        for window in [1u16, 4] {
+            let file = block_on(File::<_, Plain, TINY>::open(store.clone(), root)).unwrap();
+            assert_eq!(file.len(), len as u64);
+            assert_eq!(file.is_empty(), len == 0);
+            let mut reader = file.read().window(Window::new(window).unwrap()).build();
+            assert_eq!(reader.effective_len(), len as u64);
+            assert_eq!(drain_reader(&mut reader), legacy, "diverged at {len}");
+            assert_eq!(reader.position(), len as u64);
+        }
+    }
+}
+
+#[test]
+fn encrypted_reader_matches_legacy_join() {
+    for len in edge_sizes() {
+        let data = fill(len);
+        let (root_ref, store) = split_encrypted::<TINY>(&data).unwrap();
+        let legacy = block_on(join(&store, root_ref.clone())).unwrap();
+        assert_eq!(legacy, data, "legacy oracle diverged at {len}");
+
+        for window in [1u16, 4] {
+            let file = block_on(File::<_, Encrypted, TINY>::open_encrypted(
+                store.clone(),
+                root_ref.clone(),
+            ))
+            .unwrap();
+            assert_eq!(file.len(), len as u64);
+            let mut reader = file.read().window(Window::new(window).unwrap()).build();
+            assert_eq!(drain_reader(&mut reader), legacy, "diverged at {len}");
+        }
+    }
+}
+
+#[test]
+fn range_reads_match_legacy_read_range_both_widths() {
+    let len = 33 * TINY + 17;
+    let data = fill(len);
+    let span = len as u64;
+    let ranges = [
+        0..10u64,
+        0..span,
+        100..3 * TINY as u64,
+        TINY as u64..TINY as u64,
+        255..513,
+        511..(TINY as u64) * 9 + 1,
+        span - 1..span,
+        span / 2..span,
+    ];
+
+    let (plain_root, plain_store) = split::<TINY>(&data).unwrap();
+    let (enc_root, enc_store) = split_encrypted::<TINY>(&data).unwrap();
+    let plain_joiner = block_on(plain_store.clone().joiner(plain_root)).unwrap();
+    let enc_joiner = block_on(enc_store.clone().joiner(enc_root.clone())).unwrap();
+    let plain_file = block_on(File::<_, Plain, TINY>::open(plain_store, plain_root)).unwrap();
+    let enc_file = block_on(File::<_, Encrypted, TINY>::open_encrypted(
+        enc_store, enc_root,
+    ))
+    .unwrap();
+
+    for range in ranges {
+        let want = usize::try_from(range.end - range.start).unwrap();
+        let legacy_plain = block_on(plain_joiner.read_range(range.start, want)).unwrap();
+        let legacy_enc = block_on(enc_joiner.read_range(range.start, want)).unwrap();
+        assert_eq!(legacy_plain, legacy_enc, "oracles diverged for {range:?}");
+
+        let mut reader = plain_file.read().range(range.clone()).build();
+        assert_eq!(reader.effective_len(), range.end - range.start);
+        assert_eq!(drain_reader(&mut reader), legacy_plain, "plain {range:?}");
+
+        let mut reader = enc_file
+            .read()
+            .range(range.clone())
+            .window(Window::new(3).unwrap())
+            .build();
+        assert_eq!(drain_reader(&mut reader), legacy_enc, "encrypted {range:?}");
+    }
+}
+
+#[test]
+fn out_of_file_ranges_clip_to_effective_length() {
+    let len = 5 * TINY + 9;
+    let data = fill(len);
+    let span = len as u64;
+    let (root, store) = split::<TINY>(&data).unwrap();
+    let file = block_on(File::<_, Plain, TINY>::open(store, root)).unwrap();
+
+    // End past the file clips to the span.
+    let mut reader = file.read().range(300..u64::MAX).build();
+    assert_eq!(reader.effective_len(), span - 300);
+    assert_eq!(drain_reader(&mut reader), &data[300..]);
+
+    // A range entirely past the file is empty, not an error.
+    let mut reader = file.read().range(span + 5..span + 50).build();
+    assert_eq!(reader.effective_len(), 0);
+    assert!(drain_reader(&mut reader).is_empty());
+
+    // An inverted clip (start past end) is empty.
+    let mut reader = file.read().range(span..3).build();
+    assert_eq!(reader.effective_len(), 0);
+    assert!(drain_reader(&mut reader).is_empty());
+}
+
+fn run_seek_script<M: WalkMode>(
+    mut reader: FileReader<TinyStore, M, TINY>,
+    data: &[u8],
+    label: &str,
+) {
+    let len = data.len();
+    let script = [
+        (0u64, 100usize),
+        (5000, 300),
+        (37, 64),
+        (len as u64 - 1, 50),
+        (0, 1),
+        (len as u64, 10),
+    ];
+    for (pos, want) in script {
+        reader.seek(pos).unwrap();
+        assert_eq!(reader.position(), pos, "{label}: position after seek");
+        let mut buf = vec![0u8; want];
+        let mut got = 0;
+        block_on(async {
+            loop {
+                let n = reader.read(&mut buf[got..]).await.unwrap();
+                if n == 0 {
+                    break;
+                }
+                got += n;
+            }
+        });
+        let expect_end = (pos as usize + want).min(len);
+        let expect = &data[(pos as usize).min(len)..expect_end];
+        assert_eq!(&buf[..got], expect, "{label}: seek {pos} read {want}");
+    }
+    // Past the effective length: typed, never clamped, reader survives.
+    let err = reader.seek(len as u64 + 1).unwrap_err();
+    assert_eq!(
+        err,
+        SeekPastEnd {
+            requested: len as u64 + 1,
+            effective_len: len as u64,
+        }
+    );
+    reader.seek(3).unwrap();
+    let mut buf = [0u8; 4];
+    block_on(async {
+        reader.read(&mut buf).await.unwrap();
+    });
+    assert_eq!(&buf[..], &data[3..7], "{label}: read after failed seek");
+}
+
+#[test]
+fn seek_reads_match_oracle_slices_both_widths() {
+    let data = fill(21 * TINY + 100);
+    let (plain_root, plain_store) = split::<TINY>(&data).unwrap();
+    let plain_file = block_on(File::<_, Plain, TINY>::open(plain_store, plain_root)).unwrap();
+    let (enc_root, enc_store) = split_encrypted::<TINY>(&data).unwrap();
+    let enc_file = block_on(File::<_, Encrypted, TINY>::open_encrypted(
+        enc_store, enc_root,
+    ))
+    .unwrap();
+
+    run_seek_script(plain_file.read().build(), &data, "plain");
+    run_seek_script(enc_file.read().build(), &data, "encrypted");
+}
+
+#[test]
+fn any_file_dispatches_on_the_wire_reference_width() {
+    let data = fill(9 * TINY + 5);
+    let (plain_root, plain_store) = split::<TINY>(&data).unwrap();
+    let (enc_root, enc_store) = split_encrypted::<TINY>(&data).unwrap();
+
+    let plain_entry = EntryRef::Plain(ChunkRef::new(plain_root));
+    let any = block_on(AnyFile::<_, TINY>::open(plain_store, plain_entry)).unwrap();
+    assert_eq!(any.mode(), Mode::Plain);
+    assert_eq!(any.len(), data.len() as u64);
+    assert_eq!(any.root(), &plain_root);
+    let AnyFile::Plain(file) = any else {
+        panic!("32-byte reference must open plain");
+    };
+    assert_eq!(drain_reader(&mut file.read().build()), data);
+
+    let enc_entry = EntryRef::from(enc_root);
+    let any = block_on(AnyFile::<_, TINY>::open(enc_store, enc_entry)).unwrap();
+    assert_eq!(any.mode(), Mode::Encrypted);
+    assert_eq!(any.len(), data.len() as u64);
+    let AnyFile::Encrypted(file) = any else {
+        panic!("64-byte reference must open encrypted");
+    };
+    assert_eq!(drain_reader(&mut file.read().build()), data);
+}
+
+#[test]
+fn stream_tiles_the_range_and_carries_reader_leftovers() {
+    let data = fill(13 * TINY + 40);
+    let (root, store) = split::<TINY>(&data).unwrap();
+    let file = block_on(File::<_, Plain, TINY>::open(store, root)).unwrap();
+
+    // Fresh stream over a mid-file range.
+    let range = 100u64..(11 * TINY) as u64;
+    let collected = block_on(async {
+        use futures::StreamExt;
+        let mut stream = file.read().range(range.clone()).stream();
+        let mut out = Vec::new();
+        while let Some(segment) = stream.next().await {
+            let segment: Bytes = segment.unwrap();
+            assert!(!segment.is_empty(), "no empty segments");
+            out.extend_from_slice(&segment);
+        }
+        out
+    });
+    assert_eq!(collected, &data[100..11 * TINY]);
+
+    // A partially consumed reader hands its leftover bytes to the stream.
+    let mut reader = file.read().build();
+    let mut buf = [0u8; 100];
+    block_on(async {
+        reader.read(&mut buf).await.unwrap();
+    });
+    let rest = block_on(async {
+        use futures::StreamExt;
+        let mut stream = reader.into_stream();
+        let mut out = Vec::new();
+        while let Some(segment) = stream.next().await {
+            out.extend_from_slice(&segment.unwrap());
+        }
+        out
+    });
+    assert_eq!(&buf[..], &data[..100]);
+    assert_eq!(rest, &data[100..]);
+}
+
+#[test]
+fn next_segment_is_gapless_and_zero_copy_sized() {
+    let data = fill(6 * TINY + 30);
+    let (root_ref, store) = split_encrypted::<TINY>(&data).unwrap();
+    let file = block_on(File::<_, Encrypted, TINY>::open_encrypted(store, root_ref)).unwrap();
+    let mut reader = file.read().build();
+    let collected = block_on(async {
+        let mut out = Vec::new();
+        while let Some(segment) = reader.next_segment().await {
+            out.extend_from_slice(&segment.unwrap());
+        }
+        out
+    });
+    assert_eq!(collected, data);
+    assert_eq!(reader.position(), data.len() as u64);
+}
+
+/// Seal one hand-built chunk for the tiny profile.
+fn seal(
+    content: ContentChunk<TINY>,
+) -> (
+    ChunkAddress,
+    Chunk<nectar_primitives::chunk::Verified, AnyChunkSet<TINY>>,
+) {
+    let address = *content.address();
+    let chunk = Chunk::from_envelope(AnyChunk::from(content)).unwrap();
+    (address, chunk)
+}
+
+/// Encrypt `span || body` by hand: the span rides counter `TINY / 32`, the
+/// body counter zero, padded with zeros to the full body.
+fn encrypt_node(key: &EncryptionKey, span: u64, body: &[u8]) -> Vec<u8> {
+    let mut wire = vec![0u8; 8 + TINY];
+    transcrypt(key, (TINY / 32) as u32, &span.to_le_bytes(), &mut wire[..8]).unwrap();
+    let mut padded = vec![0u8; TINY];
+    padded[..body.len()].copy_from_slice(body);
+    transcrypt(key, 0, &padded, &mut wire[8..]).unwrap();
+    wire
+}
+
+#[test]
+fn truncated_ciphertext_is_a_typed_decode_error() {
+    // A 40-byte chunk cannot be an encrypted node: ciphertexts are full-size.
+    let (short_addr, short_chunk) = seal(ContentChunk::<TINY>::new(fill(40)).unwrap());
+    let child_key = EncryptionKey::from([0x21; 32]);
+    let parent_key = EncryptionKey::from([0x42; 32]);
+
+    // Opening a short chunk as an encrypted root fails at open.
+    let store = TinyStore::from_chunks([short_chunk.clone()]);
+    let err = block_on(File::<_, Encrypted, TINY>::open_encrypted(
+        store,
+        EncryptedChunkRef::new(short_addr, parent_key.clone()),
+    ))
+    .unwrap_err();
+    assert!(matches!(
+        err,
+        OpenError::Decode(DecodeError::CiphertextLength {
+            len: 40,
+            expected: TINY
+        })
+    ));
+
+    // A valid encrypted parent referencing the short chunk fails mid-walk.
+    let span = 2 * TINY as u64;
+    let mut refs = Vec::new();
+    refs.extend_from_slice(&EncryptedChunkRef::new(short_addr, child_key.clone()).to_bytes());
+    refs.extend_from_slice(&EncryptedChunkRef::new(short_addr, child_key).to_bytes());
+    let parent_wire = encrypt_node(&parent_key, span, &refs);
+    let (parent_addr, parent_chunk) =
+        seal(ContentChunk::<TINY>::try_from(Bytes::from(parent_wire)).unwrap());
+    let store = TinyStore::from_chunks([short_chunk, parent_chunk]);
+
+    let file = block_on(File::<_, Encrypted, TINY>::open_encrypted(
+        store,
+        EncryptedChunkRef::new(parent_addr, parent_key),
+    ))
+    .unwrap();
+    assert_eq!(file.len(), span);
+    let mut reader = file.read().build();
+    let err = block_on(async {
+        let mut buf = [0u8; 16];
+        reader.read(&mut buf).await.unwrap_err()
+    });
+    assert!(matches!(
+        err,
+        WalkError::Decode {
+            offset: 0,
+            source: DecodeError::CiphertextLength {
+                len: 40,
+                expected: TINY
+            },
+        }
+    ));
+}
+
+#[test]
+fn debug_never_leaks_the_decryption_key() {
+    let data = fill(2 * TINY);
+    let key_free = |rendered: String| {
+        // The reader's Debug output must stay structural.
+        assert!(!rendered.contains("key"), "{rendered}");
+    };
+    let (root_ref, store) = split_encrypted::<TINY>(&data).unwrap();
+    let file = block_on(File::<_, Encrypted, TINY>::open_encrypted(store, root_ref)).unwrap();
+    key_free(std::format!("{file:?}"));
+    key_free(std::format!("{:?}", file.read()));
+    key_free(std::format!("{:?}", file.read().build()));
+}

--- a/crates/file/src/walk/engine.rs
+++ b/crates/file/src/walk/engine.rs
@@ -23,9 +23,8 @@ use crate::num::{fan_out, u64_from_u32, u64_from_usize};
 /// One pending tree node: where its bytes live and what fetches it.
 struct Node<M: WalkMode> {
     address: ChunkAddress,
-    /// Reference context routed with the node; the encrypted mode's body
-    /// decoder consumes it.
-    #[allow(dead_code, reason = "consumed once the encrypted decoder lands")]
+    /// Reference context routed with the node; the mode's body decoder
+    /// consumes it.
     context: M::Context,
     /// Absolute offset of the subtree's first byte.
     start: u64,
@@ -403,6 +402,11 @@ where
             });
         }
         let data = chunk.into_envelope().data().clone();
+        let data = M::decode_body(&node.context, B, self.plaintext_len(&node, leaf), data)
+            .map_err(|source| WalkError::Decode {
+                offset: node.start,
+                source,
+            })?;
         if leaf {
             let len = u64_from_usize(data.len());
             if len != node.span {
@@ -418,6 +422,20 @@ where
         } else {
             self.expand(&node, &data).map_err(WalkError::from)
         }
+    }
+
+    /// Plaintext bytes a node's body carries: a leaf's span, or an
+    /// intermediate's packed references, never past the profile's body.
+    fn plaintext_len(&self, node: &Node<M>, leaf: bool) -> usize {
+        let take = if leaf {
+            node.span
+        } else {
+            let sub = child_subspan(node.span, self.body, self.branches);
+            let ref_size = u64_from_u32(M::MODE.ref_size());
+            node.span.div_ceil(sub).saturating_mul(ref_size)
+        };
+        // take is capped at the body size, which is the usize B.
+        usize::try_from(take.min(self.body)).unwrap_or(B)
     }
 
     /// Expand an intermediate body into its overlapping children.

--- a/crates/file/src/walk/error.rs
+++ b/crates/file/src/walk/error.rs
@@ -24,6 +24,14 @@ pub enum WalkError<E> {
     /// The tree's bytes contradict its declared spans.
     #[error(transparent)]
     Shape(#[from] ShapeError),
+    /// A fetched body failed the mode's decode step.
+    #[error("body decode failed at {offset}")]
+    Decode {
+        /// Absolute offset of the failing node's first byte.
+        offset: u64,
+        /// Decode failure behind the error.
+        source: DecodeError,
+    },
     /// The engine could neither admit nor await work; a walk invariant is
     /// broken.
     #[error("walk stalled with {pending} pending nodes and occupancy {occupancy}")]
@@ -32,6 +40,20 @@ pub enum WalkError<E> {
         pending: usize,
         /// Leaf bodies held (in flight plus buffered).
         occupancy: usize,
+    },
+}
+
+/// A fetched body's bytes cannot be decoded under the mode's reference
+/// grammar.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum DecodeError {
+    /// An encrypted node must arrive as one full ciphertext body.
+    #[error("ciphertext body of {len} bytes where the profile demands {expected}")]
+    CiphertextLength {
+        /// Bytes the fetched body actually carries.
+        len: usize,
+        /// The profile's full body size.
+        expected: usize,
     },
 }
 

--- a/crates/file/src/walk/mod.rs
+++ b/crates/file/src/walk/mod.rs
@@ -33,8 +33,8 @@ mod tests;
 use bytes::Bytes;
 
 pub use engine::Walk;
-pub use error::{ShapeError, WalkError};
-pub use mode::{Plain, WalkMode};
+pub use error::{DecodeError, ShapeError, WalkError};
+pub use mode::{Encrypted, Plain, WalkMode};
 
 /// One delivered run of file bytes.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/file/src/walk/mode.rs
+++ b/crates/file/src/walk/mode.rs
@@ -1,16 +1,22 @@
-//! Reference grammar seam: how a walk reads child references.
+//! Reference grammar seam: how a walk reads child references and node
+//! bodies.
 
+use alloc::vec::Vec;
 use core::fmt::Debug;
 
+use bytes::Bytes;
 use nectar_primitives::chunk::ChunkAddress;
+use nectar_primitives::chunk::encryption::{EncryptedChunkRef, EncryptionKey, transcrypt_in_place};
 use nectar_primitives::store::{MaybeSend, MaybeSync};
 
+use super::error::DecodeError;
 use crate::geometry::Mode;
 
 /// Reference grammar of one tree profile.
 ///
-/// The engine stays mode-blind: a mode contributes its [`Mode`] geometry and
-/// the parser for one wire reference; the descent itself is shared.
+/// The engine stays mode-blind: a mode contributes its [`Mode`] geometry, the
+/// parser for one wire reference, and the body decoder; the descent itself is
+/// shared.
 pub trait WalkMode: MaybeSend + MaybeSync + 'static {
     /// Reference layout this mode walks.
     const MODE: Mode;
@@ -22,9 +28,20 @@ pub trait WalkMode: MaybeSend + MaybeSync + 'static {
     /// Read one reference off the front of `input`, advancing it past the
     /// consumed bytes; `None` when fewer than one reference remains.
     fn take_ref(input: &mut &[u8]) -> Option<(ChunkAddress, Self::Context)>;
+
+    /// Decode one fetched body into the plaintext the tree grammar reads:
+    /// `take` bytes (a leaf's span, or an intermediate's packed references)
+    /// out of a `body_size`-byte profile.
+    fn decode_body(
+        context: &Self::Context,
+        body_size: usize,
+        take: usize,
+        data: Bytes,
+    ) -> Result<Bytes, DecodeError>;
 }
 
-/// Plain mode: a reference is a bare chunk address.
+/// Plain mode: a reference is a bare chunk address and bodies arrive as
+/// plaintext.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct Plain;
 
@@ -37,5 +54,50 @@ impl WalkMode for Plain {
         let (address, rest) = input.split_first_chunk::<{ ChunkAddress::SIZE }>()?;
         *input = rest;
         Some((ChunkAddress::new(*address), ()))
+    }
+
+    fn decode_body(
+        _context: &(),
+        _body_size: usize,
+        _take: usize,
+        data: Bytes,
+    ) -> Result<Bytes, DecodeError> {
+        Ok(data)
+    }
+}
+
+/// Encrypted mode: a reference carries an address plus the decryption key of
+/// a keccak counter-mode ciphertext body.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Encrypted;
+
+impl WalkMode for Encrypted {
+    const MODE: Mode = Mode::Encrypted;
+
+    type Context = EncryptionKey;
+
+    fn take_ref(input: &mut &[u8]) -> Option<(ChunkAddress, EncryptionKey)> {
+        let (raw, rest) = input.split_first_chunk::<{ EncryptedChunkRef::SIZE }>()?;
+        *input = rest;
+        Some(EncryptedChunkRef::from_bytes(raw).into_parts())
+    }
+
+    /// A ciphertext body is always full-size (short leaves are padded), so
+    /// only the first `take` bytes are decrypted and returned.
+    fn decode_body(
+        context: &EncryptionKey,
+        body_size: usize,
+        take: usize,
+        data: Bytes,
+    ) -> Result<Bytes, DecodeError> {
+        if data.len() != body_size {
+            return Err(DecodeError::CiphertextLength {
+                len: data.len(),
+                expected: body_size,
+            });
+        }
+        let mut plain = Vec::from(data.slice(..take.min(body_size)).as_ref());
+        transcrypt_in_place(context, 0, &mut plain);
+        Ok(Bytes::from(plain))
     }
 }

--- a/crates/manifest/src/error.rs
+++ b/crates/manifest/src/error.rs
@@ -32,6 +32,15 @@ pub struct ValueTooLong {
     pub max: usize,
 }
 
+/// Entry-to-reference conversion rejected: an inline entry carries opaque
+/// bytes, not a chunk reference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("inline entry of {len} bytes carries no chunk reference")]
+pub struct NotAReference {
+    /// Inline value length in bytes.
+    pub len: usize,
+}
+
 /// Custom metadata key rejected.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum CustomKeyError {

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -111,7 +111,8 @@ pub use dx::FetchError;
 #[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
 pub use encryption::{EncryptedNode, EncryptedNodeGet, EncryptedNodePut, derive_key};
 pub use error::{
-    CustomKeyError, ForkPrefixEmpty, MetadataTooLong, PrefixTooLong, ValueTooLong, WeightOverBudget,
+    CustomKeyError, ForkPrefixEmpty, MetadataTooLong, NotAReference, PrefixTooLong, ValueTooLong,
+    WeightOverBudget,
 };
 pub use folder::{DirEntry, Listing, Served, Website};
 pub use fork::{Child, ForkPayload, ForkRecord, ForkTable};

--- a/crates/manifest/src/value.rs
+++ b/crates/manifest/src/value.rs
@@ -3,9 +3,9 @@
 use core::marker::PhantomData;
 
 use bytes::Bytes;
-use nectar_primitives::{ChunkAddress, ChunkRef, EncryptedChunkRef};
+use nectar_primitives::{ChunkAddress, ChunkRef, EncryptedChunkRef, EntryRef};
 
-use crate::error::ValueTooLong;
+use crate::error::{NotAReference, ValueTooLong};
 use crate::format::{Format, V1};
 
 /// An arbitrary-byte map key, ordered bytewise.
@@ -236,6 +236,29 @@ impl<F: Format> From<InlineValue<F>> for Entry<F> {
     }
 }
 
+impl<F: Format> From<EntryRef> for Entry<F> {
+    fn from(reference: EntryRef) -> Self {
+        match reference {
+            EntryRef::Plain(r) => Self::Ref32(r),
+            EntryRef::Encrypted(r) => Self::Ref64(r),
+        }
+    }
+}
+
+impl<F: Format> TryFrom<Entry<F>> for EntryRef {
+    type Error = NotAReference;
+
+    fn try_from(entry: Entry<F>) -> Result<Self, Self::Error> {
+        match entry {
+            Entry::Ref32(r) => Ok(Self::Plain(r)),
+            Entry::Ref64(r) => Ok(Self::Encrypted(r)),
+            Entry::Inline(value) => Err(NotAReference {
+                len: value.as_ref().len(),
+            }),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use nectar_primitives::EncryptionKey;
@@ -323,5 +346,27 @@ mod tests {
     fn entry_inline_rejects_over_vinline_max() {
         let err = Entry::<V1>::inline(Bytes::from(vec![0; V1::VINLINE_MAX + 1])).unwrap_err();
         assert_eq!(err.max, V1::VINLINE_MAX);
+    }
+
+    #[test]
+    fn entry_round_trips_entry_ref_both_widths() {
+        let plain = EntryRef::Plain(ChunkRef::new(address(0x33)));
+        let entry = Entry::<V1>::from(plain.clone());
+        assert_eq!(entry, Entry::Ref32(ChunkRef::new(address(0x33))));
+        assert_eq!(EntryRef::try_from(entry).unwrap(), plain);
+
+        let encrypted = EntryRef::Encrypted(EncryptedChunkRef::new(
+            address(0x44),
+            EncryptionKey::from([0x55; 32]),
+        ));
+        let entry = Entry::<V1>::from(encrypted.clone());
+        assert_eq!(EntryRef::try_from(entry).unwrap(), encrypted);
+    }
+
+    #[test]
+    fn inline_entry_is_not_a_reference() {
+        let entry: Entry = Entry::inline(Bytes::from(vec![0xAA; 3])).unwrap();
+        let err = EntryRef::try_from(entry).unwrap_err();
+        assert_eq!(err, NotAReference { len: 3 });
     }
 }

--- a/crates/mantaray/src/entry.rs
+++ b/crates/mantaray/src/entry.rs
@@ -104,6 +104,12 @@ impl Entry {
     }
 }
 
+impl From<EntryRef> for Entry {
+    fn from(reference: EntryRef) -> Self {
+        Self::new(reference)
+    }
+}
+
 impl From<ChunkAddress> for Entry {
     fn from(address: ChunkAddress) -> Self {
         Self::new(address)

--- a/crates/primitives/src/chunk/reference.rs
+++ b/crates/primitives/src/chunk/reference.rs
@@ -167,12 +167,12 @@ impl Reference for ChunkRef {
     }
 
     fn into_entry_ref(self) -> EntryRef {
-        EntryRef::Plain(self.into_address())
+        EntryRef::Plain(self)
     }
 
     fn from_entry_ref(entry: EntryRef) -> Result<Self, WrongRefKind> {
         match entry {
-            EntryRef::Plain(address) => Ok(Self::new(address)),
+            EntryRef::Plain(reference) => Ok(reference),
             EntryRef::Encrypted(_) => Err(WrongRefKind {
                 expected: Self::KIND,
                 got: RefKind::Encrypted,
@@ -236,7 +236,7 @@ mod tests {
         let addr = ChunkAddress::from(B256::repeat_byte(0x11));
         let reference = ChunkRef::new(addr);
         let entry = reference.into_entry_ref();
-        assert_eq!(entry, EntryRef::Plain(addr));
+        assert_eq!(entry, EntryRef::Plain(reference));
         assert_eq!(ChunkRef::from_entry_ref(entry).unwrap(), reference);
     }
 

--- a/crates/primitives/src/entry_ref.rs
+++ b/crates/primitives/src/entry_ref.rs
@@ -6,11 +6,12 @@ use crate::chunk::{ChunkAddress, ChunkRef};
 #[allow(deprecated)]
 use crate::file::error::FileError;
 
-/// A typed chunk reference: either a plain 32-byte address or an encrypted 64-byte ref.
+/// A typed chunk reference: either a plain 32-byte reference or an encrypted
+/// 64-byte reference.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EntryRef {
-    /// Plain 32-byte chunk address.
-    Plain(ChunkAddress),
+    /// Plain 32-byte chunk reference.
+    Plain(ChunkRef),
     /// Encrypted 64-byte reference (address + decryption key).
     Encrypted(EncryptedChunkRef),
 }
@@ -23,7 +24,7 @@ impl EntryRef {
     /// - [`EncryptedChunkRef::SIZE`] bytes → `Encrypted`
     pub fn try_from_bytes(bytes: &[u8]) -> Result<Self, FileError> {
         if let Ok(addr_bytes) = <[u8; ChunkRef::SIZE]>::try_from(bytes) {
-            return Ok(Self::Plain(ChunkAddress::from(addr_bytes)));
+            return Ok(Self::Plain(ChunkRef::new(ChunkAddress::from(addr_bytes))));
         }
         if bytes.len() == EncryptedChunkRef::SIZE {
             let enc_ref = EncryptedChunkRef::try_from(bytes)
@@ -36,15 +37,21 @@ impl EntryRef {
     /// The chunk address (first 32 bytes of any reference).
     pub const fn address(&self) -> &ChunkAddress {
         match self {
-            Self::Plain(addr) => addr,
+            Self::Plain(reference) => reference.address(),
             Self::Encrypted(enc) => enc.address(),
         }
     }
 }
 
+impl From<ChunkRef> for EntryRef {
+    fn from(reference: ChunkRef) -> Self {
+        Self::Plain(reference)
+    }
+}
+
 impl From<ChunkAddress> for EntryRef {
     fn from(addr: ChunkAddress) -> Self {
-        Self::Plain(addr)
+        Self::Plain(ChunkRef::new(addr))
     }
 }
 
@@ -57,7 +64,7 @@ impl From<EncryptedChunkRef> for EntryRef {
 impl From<&EntryRef> for Vec<u8> {
     fn from(entry_ref: &EntryRef) -> Self {
         match entry_ref {
-            EntryRef::Plain(addr) => addr.as_bytes().to_vec(),
+            EntryRef::Plain(reference) => reference.address().as_bytes().to_vec(),
             EntryRef::Encrypted(enc) => Self::from(enc),
         }
     }
@@ -75,7 +82,10 @@ mod tests {
     fn parses_and_reserializes_both_widths() {
         let plain_bytes = [0x11u8; ChunkRef::SIZE];
         let plain = EntryRef::try_from_bytes(&plain_bytes).unwrap();
-        assert!(matches!(plain, EntryRef::Plain(_)));
+        assert_eq!(
+            plain,
+            EntryRef::Plain(ChunkRef::new(ChunkAddress::from(plain_bytes)))
+        );
         assert_eq!(Vec::<u8>::from(&plain), plain_bytes);
 
         let mut enc_bytes = [0x22u8; EncryptedChunkRef::SIZE];
@@ -100,5 +110,14 @@ mod tests {
             let err = EntryRef::try_from_bytes(&bytes).unwrap_err();
             assert!(matches!(err, FileError::InvalidEntryRef { len: got } if got == len));
         }
+    }
+
+    #[test]
+    fn plain_variant_converts_from_address_and_reference() {
+        let addr = ChunkAddress::from([0x44u8; ChunkRef::SIZE]);
+        let from_addr = EntryRef::from(addr);
+        let from_ref = EntryRef::from(ChunkRef::new(addr));
+        assert_eq!(from_addr, from_ref);
+        assert_eq!(from_addr.address(), &addr);
     }
 }

--- a/crates/primitives/src/file/mod.rs
+++ b/crates/primitives/src/file/mod.rs
@@ -300,6 +300,8 @@ pub trait ChunkPutExt<const BODY_SIZE: usize>: ChunkPut<AnyChunkSet<BODY_SIZE>> 
     #[deprecated(
         note = "select encrypted mode through the reference type: an encrypted `ManifestBuilder::put_file`, or the `EncryptedParallelSplitter`/`split_encrypted` primitives directly"
     )]
+    // The body may keep calling its deprecated siblings until the module goes.
+    #[allow(deprecated)]
     fn write_encrypted_file<D: ReadAt + Sync>(
         &self,
         data: D,


### PR DESCRIPTION
## What

- `refactor(primitives)!`: `EntryRef::Plain` now carries a typed `ChunkRef` instead of a raw address; `ChunkRef`'s `Reference` impl round-trips through it, with `From<ChunkRef>`/`From<ChunkAddress>` constructors.
- `nectar-manifest` gains `Entry<F> <-> EntryRef` conversions: `From` for both reference widths, and `TryFrom` with a typed `NotAReference { len }` error for inline entries, exported from the crate root.
- `nectar-mantaray` gains `From<EntryRef> for Entry`.
- `feat(file)`: new std-gated `read` module in `nectar-file`:
  - `File<S, M, B>` with mode pinned at the type level; `open`/`open_encrypted` read or decrypt the span off the root with an address-equality check.
  - `AnyFile<S, B>` for runtime width dispatch from `EntryRef`, with `len`/`root`/`mode` accessors and `From` impls.
  - Infallible `ReadBuilder` (window, clip-semantics range).
  - `FileReader` with position/effective_len tracking and synchronous typed seek via `SeekPastEnd`.

## Why

Closes #332

## Testing

Independently verified branch `s323/22-file-facade` (tip `9c894e5e`) against base `origin/s323/30-splitter` (`67abb1ce`). Base ancestry confirmed. Diff: 18 files, +1226/-25, touching crates `file`, `manifest`, `mantaray`, `primitives`. Two commits, both authored and committed by mfw78 <mfw78@nxm.rs>.

Gates run (all green):
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --locked`: exit 0. Pre-existing warnings on base (primitives `use_self`, unused test macros, mantaray unused `Chunk` import) confirmed unchanged; zero new warnings in `nectar-file` or any new file (`read/`, `walk/`).
- `cargo nextest run` (nix devshell) for `nectar-file`, `nectar-manifest`, `nectar-mantaray`, `nectar-primitives`: pass.

Red-team review found no blocking bugs: the encrypted decode is correct because the keccak CTR keystream is derived per-block from `(key, init_ctr+i)` with no length dependence, so decrypting the first `take` bytes at counter 0 is byte-identical to full-body-then-truncate; the `EntryRef::Plain(ChunkAddress) -> ChunkRef` breaking change is rippled across every call site with a symmetric 32-byte wire round-trip.

## AI Assistance

Implementation by Fable, review by Opus, PR by Sonnet.

