### PR TITLE
feat(file): add frames sink and restartable download

### DIFF
--- a/crates/file/Cargo.toml
+++ b/crates/file/Cargo.toml
@@ -21,7 +21,7 @@ workspace = true
 bytes = { workspace = true, optional = true }
 futures-util = { workspace = true, optional = true }
 nectar-primitives = { workspace = true, optional = true }
-thiserror = { workspace = true, optional = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 futures.workspace = true
@@ -40,10 +40,9 @@ std = [
 	"dep:bytes",
 	"dep:futures-util",
 	"dep:nectar-primitives",
-	"dep:thiserror",
 	"futures-util?/std",
 	"nectar-primitives?/std",
-	"thiserror?/std",
+	"thiserror/std",
 ]
 
 # Async reader and writer adapters over the poll surface. Implies `std`.

--- a/crates/file/src/lib.rs
+++ b/crates/file/src/lib.rs
@@ -4,9 +4,10 @@
 //! This crate carries the pipeline's foundations: per-profile tree
 //! [`geometry`] pinned at compile time, the [`config`] admission budgets the
 //! engines drain against, the poll-native [`walk`] engine every read mode
-//! drains, the poll-native [`split`] engine every write mode feeds, and the
+//! drains, the poll-native [`split`] engine every write mode feeds, the
 //! [`read`] facade that opens files by either reference width and drains the
-//! walk in file order.
+//! walk in file order, and the [`sink`] targets a restartable download
+//! writes into.
 
 #![no_std]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
@@ -29,9 +30,8 @@
     )
 )]
 
-#[cfg(feature = "std")]
 extern crate alloc;
-#[cfg(test)]
+#[cfg(any(test, feature = "std"))]
 extern crate std;
 
 pub mod config;
@@ -41,6 +41,7 @@ mod num;
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod read;
+pub mod sink;
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod split;
@@ -51,7 +52,13 @@ pub mod walk;
 pub use config::{BranchBudget, PutWindow, Window};
 pub use geometry::{DEFAULT_BODY_SIZE, Mode, branches, max_depth};
 #[cfg(feature = "std")]
-pub use read::{AnyFile, File, FileReader, FileStream, OpenError, ReadBuilder, SeekPastEnd};
+pub use read::{
+    AnyFile, DownloadBuilder, DownloadError, File, FileFrames, FileReader, FileStream, OpenError,
+    Progress, ProgressFn, ReadBuilder, SeekPastEnd,
+};
+#[cfg(feature = "std")]
+pub use sink::FsSink;
+pub use sink::{DataSink, MemSink, MemSinkError};
 #[cfg(feature = "std")]
 pub use split::{Sealed, Split, SplitError, SplitMode, SplitStats};
 #[cfg(feature = "std")]

--- a/crates/file/src/read/download.rs
+++ b/crates/file/src/read/download.rs
@@ -1,0 +1,144 @@
+//! Restartable download: drain completion-order frames into a data sink.
+
+use alloc::boxed::Box;
+use core::fmt;
+use core::ops::Range;
+
+use futures_util::stream::StreamExt;
+use nectar_primitives::DEFAULT_BODY_SIZE;
+use nectar_primitives::chunk::{AnyChunkSet, ChunkAddress};
+use nectar_primitives::store::TrustedGet;
+
+use super::error::DownloadError;
+use super::frames::FileFrames;
+use crate::config::Window;
+use crate::num::u64_from_usize;
+use crate::sink::DataSink;
+use crate::walk::{Walk, WalkMode};
+
+/// Progress snapshot delivered after each frame lands in the sink.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Progress {
+    /// Bytes written so far.
+    pub written: u64,
+    /// Bytes the clipped download covers.
+    pub total: u64,
+}
+
+/// Boxed progress callback: `Send` on multi-threaded targets, unbounded on
+/// wasm32 and under the `unsync` feature.
+#[cfg(not(any(target_arch = "wasm32", feature = "unsync")))]
+pub type ProgressFn = Box<dyn FnMut(Progress) + Send>;
+/// Boxed progress callback: `Send` on multi-threaded targets, unbounded on
+/// wasm32 and under the `unsync` feature.
+#[cfg(any(target_arch = "wasm32", feature = "unsync"))]
+pub type ProgressFn = Box<dyn FnMut(Progress)>;
+
+/// Builder of one download; construction is infallible.
+///
+/// Ranges use clip semantics like a read, and sink offsets are relative to
+/// the clipped range start. A download is restartable, not resumable: after
+/// a failure, run it again in full; the sink's idempotent overwrites make
+/// the re-run safe.
+pub struct DownloadBuilder<S, M: WalkMode, const B: usize = DEFAULT_BODY_SIZE> {
+    store: S,
+    root: ChunkAddress,
+    context: M::Context,
+    span: u64,
+    window: Window,
+    range: Range<u64>,
+    progress: Option<ProgressFn>,
+}
+
+impl<S, M: WalkMode, const B: usize> DownloadBuilder<S, M, B> {
+    pub(super) const fn new(
+        store: S,
+        root: ChunkAddress,
+        context: M::Context,
+        span: u64,
+        window: Window,
+        range: Range<u64>,
+    ) -> Self {
+        Self {
+            store,
+            root,
+            context,
+            span,
+            window,
+            range,
+            progress: None,
+        }
+    }
+
+    /// Fetch window the download drains against.
+    #[must_use]
+    pub const fn window(mut self, window: Window) -> Self {
+        self.window = window;
+        self
+    }
+
+    /// Absolute byte range to download, clipped to the file.
+    #[must_use]
+    pub const fn range(mut self, range: Range<u64>) -> Self {
+        self.range = range;
+        self
+    }
+
+    /// Report progress after each frame lands in the sink.
+    #[must_use]
+    pub fn progress(mut self, callback: ProgressFn) -> Self {
+        self.progress = Some(callback);
+        self
+    }
+}
+
+impl<S, M, const B: usize> DownloadBuilder<S, M, B>
+where
+    S: TrustedGet<AnyChunkSet<B>> + Clone + 'static,
+    M: WalkMode,
+{
+    /// Run the download to completion, returning the bytes written.
+    ///
+    /// Frames land in completion order, each written once at its
+    /// range-relative offset; any error is terminal for this run.
+    pub async fn run<K: DataSink>(
+        self,
+        sink: &mut K,
+    ) -> Result<u64, DownloadError<S::Error, K::Error>> {
+        let mut frames: FileFrames<S, M, B> = FileFrames::new(Walk::new(
+            self.store,
+            self.root,
+            self.context,
+            self.span,
+            self.range,
+            self.window,
+        ));
+        let clipped = frames.range();
+        let total = clipped.end.saturating_sub(clipped.start);
+        let mut callback = self.progress;
+        let mut written = 0u64;
+        while let Some(frame) = frames.next().await {
+            let frame = frame?;
+            let offset = frame.offset.saturating_sub(clipped.start);
+            sink.write_at(offset, frame.data.as_ref())
+                .map_err(|source| DownloadError::Sink { offset, source })?;
+            written = written.saturating_add(u64_from_usize(frame.data.len()));
+            if let Some(callback) = callback.as_mut() {
+                callback(Progress { written, total });
+            }
+        }
+        Ok(written)
+    }
+}
+
+impl<S, M: WalkMode, const B: usize> fmt::Debug for DownloadBuilder<S, M, B> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DownloadBuilder")
+            .field("root", &self.root)
+            .field("span", &self.span)
+            .field("window", &self.window)
+            .field("range", &self.range)
+            .field("progress", &self.progress.is_some())
+            .finish_non_exhaustive()
+    }
+}

--- a/crates/file/src/read/error.rs
+++ b/crates/file/src/read/error.rs
@@ -2,7 +2,7 @@
 
 use nectar_primitives::chunk::ChunkAddress;
 
-use crate::walk::DecodeError;
+use crate::walk::{DecodeError, WalkError};
 
 /// Failure opening a file at its root chunk.
 #[derive(Debug, thiserror::Error)]
@@ -27,6 +27,22 @@ pub enum OpenError<E> {
     /// The root body cannot be decoded under the mode's reference grammar.
     #[error(transparent)]
     Decode(#[from] DecodeError),
+}
+
+/// Terminal failure of one download run; a full re-run restarts it.
+#[derive(Debug, thiserror::Error)]
+pub enum DownloadError<E, SE> {
+    /// The walk failed before the range was tiled.
+    #[error(transparent)]
+    Walk(#[from] WalkError<E>),
+    /// The sink rejected a write.
+    #[error("sink write failed at {offset}")]
+    Sink {
+        /// Range-relative offset of the failed write.
+        offset: u64,
+        /// Sink error behind the failure.
+        source: SE,
+    },
 }
 
 /// A seek past the reader's effective length; the reader never clamps.

--- a/crates/file/src/read/file.rs
+++ b/crates/file/src/read/file.rs
@@ -7,6 +7,7 @@ use nectar_primitives::chunk::{AnyChunkSet, ChunkAddress, ChunkOps};
 use nectar_primitives::store::TrustedGet;
 use nectar_primitives::{DEFAULT_BODY_SIZE, EntryRef};
 
+use super::download::DownloadBuilder;
 use super::error::OpenError;
 use super::reader::ReadBuilder;
 use crate::config::Window;
@@ -44,6 +45,18 @@ impl<S: Clone, M: WalkMode, const B: usize> File<S, M, B> {
     /// Start building an ordered, seekable read over the whole file.
     pub fn read(&self) -> ReadBuilder<S, M, B> {
         ReadBuilder::new(
+            self.store.clone(),
+            self.root,
+            self.context.clone(),
+            self.span,
+            Window::DEFAULT,
+            0..u64::MAX,
+        )
+    }
+
+    /// Start building a restartable download of the whole file.
+    pub fn download(&self) -> DownloadBuilder<S, M, B> {
+        DownloadBuilder::new(
             self.store.clone(),
             self.root,
             self.context.clone(),

--- a/crates/file/src/read/frames.rs
+++ b/crates/file/src/read/frames.rs
@@ -1,0 +1,76 @@
+//! Completion-order frames drain over one walk.
+
+use core::fmt;
+use core::ops::Range;
+use core::pin::Pin;
+use core::task::{Context, Poll};
+
+use futures_util::stream::Stream;
+use nectar_primitives::DEFAULT_BODY_SIZE;
+use nectar_primitives::chunk::AnyChunkSet;
+use nectar_primitives::store::TrustedGet;
+
+use crate::walk::{Frame, Walk, WalkError, WalkMode, WalkStats};
+
+/// Offset-tagged frames of one clipped range in completion order: the
+/// frames tile the range exactly once, in no particular order.
+pub struct FileFrames<S, M, const B: usize = DEFAULT_BODY_SIZE>
+where
+    S: TrustedGet<AnyChunkSet<B>>,
+    M: WalkMode,
+{
+    walk: Walk<S, M, B>,
+}
+
+impl<S, M, const B: usize> FileFrames<S, M, B>
+where
+    S: TrustedGet<AnyChunkSet<B>> + Clone + 'static,
+    M: WalkMode,
+{
+    pub(super) const fn new(walk: Walk<S, M, B>) -> Self {
+        Self { walk }
+    }
+
+    /// Clipped absolute byte range the frames tile.
+    pub const fn range(&self) -> Range<u64> {
+        self.walk.range()
+    }
+
+    /// Occupancy witnesses of the underlying walk.
+    pub const fn stats(&self) -> WalkStats {
+        self.walk.stats()
+    }
+}
+
+/// Movable regardless of the store or context types: the drain owns plain
+/// state and boxed futures, never a self-reference.
+impl<S, M, const B: usize> Unpin for FileFrames<S, M, B>
+where
+    S: TrustedGet<AnyChunkSet<B>>,
+    M: WalkMode,
+{
+}
+
+impl<S, M, const B: usize> Stream for FileFrames<S, M, B>
+where
+    S: TrustedGet<AnyChunkSet<B>> + Clone + 'static,
+    M: WalkMode,
+{
+    type Item = Result<Frame, WalkError<S::Error>>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.get_mut().walk.poll_next_any(cx)
+    }
+}
+
+impl<S, M, const B: usize> fmt::Debug for FileFrames<S, M, B>
+where
+    S: TrustedGet<AnyChunkSet<B>>,
+    M: WalkMode,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FileFrames")
+            .field("walk", &self.walk)
+            .finish_non_exhaustive()
+    }
+}

--- a/crates/file/src/read/mod.rs
+++ b/crates/file/src/read/mod.rs
@@ -3,17 +3,21 @@
 //!
 //! [`File`] pins the mode at the type level; [`AnyFile`] dispatches it at
 //! runtime from an [`EntryRef`](nectar_primitives::EntryRef) wire reference.
-//! [`ReadBuilder`] ranges use clip semantics: out-of-file bounds shrink the
-//! read instead of failing, and the clipped length is readable as
-//! [`FileReader::effective_len`]. Only [`FileReader::seek`] is typed-strict:
-//! it never clamps.
+//! [`ReadBuilder`] and [`DownloadBuilder`] ranges use clip semantics:
+//! out-of-file bounds shrink the read instead of failing, and the clipped
+//! length is readable as [`FileReader::effective_len`]. Only
+//! [`FileReader::seek`] is typed-strict: it never clamps.
 
+mod download;
 mod error;
 mod file;
+mod frames;
 mod reader;
 #[cfg(test)]
 mod tests;
 
-pub use error::{OpenError, SeekPastEnd};
+pub use download::{DownloadBuilder, Progress, ProgressFn};
+pub use error::{DownloadError, OpenError, SeekPastEnd};
 pub use file::{AnyFile, File};
+pub use frames::FileFrames;
 pub use reader::{FileReader, FileStream, ReadBuilder};

--- a/crates/file/src/read/reader.rs
+++ b/crates/file/src/read/reader.rs
@@ -14,6 +14,7 @@ use nectar_primitives::chunk::{AnyChunkSet, ChunkAddress};
 use nectar_primitives::store::TrustedGet;
 
 use super::error::SeekPastEnd;
+use super::frames::FileFrames;
 use crate::config::Window;
 use crate::num::u64_from_usize;
 use crate::walk::{Walk, WalkError, WalkMode, WalkStats};
@@ -99,6 +100,18 @@ where
     /// Build the ordered stream directly.
     pub fn stream(self) -> FileStream<S, M, B> {
         self.build().into_stream()
+    }
+
+    /// Build the completion-order frames drain.
+    pub fn frames(self) -> FileFrames<S, M, B> {
+        FileFrames::new(Walk::new(
+            self.store,
+            self.root,
+            self.context,
+            self.span,
+            self.range,
+            self.window,
+        ))
     }
 }
 

--- a/crates/file/src/read/tests.rs
+++ b/crates/file/src/read/tests.rs
@@ -3,7 +3,8 @@
 //! runtime width dispatch.
 #![allow(deprecated)]
 
-use std::string::String;
+use std::boxed::Box;
+use std::string::{String, ToString};
 use std::vec;
 use std::vec::Vec;
 
@@ -418,4 +419,190 @@ fn debug_never_leaks_the_decryption_key() {
     key_free(std::format!("{file:?}"));
     key_free(std::format!("{:?}", file.read()));
     key_free(std::format!("{:?}", file.read().build()));
+    key_free(std::format!("{:?}", file.read().frames()));
+    key_free(std::format!("{:?}", file.download()));
+}
+
+fn collect_frames<S, M>(mut frames: super::FileFrames<S, M, TINY>) -> Vec<crate::walk::Frame>
+where
+    S: TrustedGet<AnyChunkSet<TINY>, Error = ChunkStoreError> + Clone + 'static,
+    M: WalkMode,
+{
+    block_on(async {
+        use futures::StreamExt;
+        let mut out = Vec::new();
+        while let Some(frame) = frames.next().await {
+            out.push(frame.unwrap());
+        }
+        out
+    })
+}
+
+#[test]
+fn frames_tile_the_clipped_range_exactly_once() {
+    let data = fill(17 * TINY + 29);
+    let (root, store) = split::<TINY>(&data).unwrap();
+    let file = block_on(File::<_, Plain, TINY>::open(store, root)).unwrap();
+
+    let range = 100u64..(13 * TINY + 7) as u64;
+    let builder = file
+        .read()
+        .range(range.clone())
+        .window(Window::new(3).unwrap());
+    let mut frames = collect_frames(builder.frames());
+    frames.sort_by_key(|frame| frame.offset);
+
+    let mut expect = range.start;
+    let mut assembled = Vec::new();
+    for frame in &frames {
+        assert_eq!(frame.offset, expect, "frames must tile without overlap");
+        assert!(!frame.data.is_empty(), "no empty frames");
+        assembled.extend_from_slice(&frame.data);
+        expect += frame.data.len() as u64;
+    }
+    assert_eq!(expect, range.end);
+    assert_eq!(assembled, &data[100..13 * TINY + 7]);
+}
+
+#[test]
+fn download_fills_a_sink_and_reports_progress_both_widths() {
+    use std::sync::{Arc, Mutex};
+
+    use crate::sink::{DataSink as _, MemSink};
+
+    let data = fill(11 * TINY + 63);
+    let (plain_root, plain_store) = split::<TINY>(&data).unwrap();
+    let (enc_root, enc_store) = split_encrypted::<TINY>(&data).unwrap();
+    let plain_file = block_on(File::<_, Plain, TINY>::open(plain_store, plain_root)).unwrap();
+    let enc_file = block_on(File::<_, Encrypted, TINY>::open_encrypted(
+        enc_store, enc_root,
+    ))
+    .unwrap();
+
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let log = Arc::clone(&seen);
+    let mut sink = MemSink::new();
+    let written = block_on(
+        plain_file
+            .download()
+            .window(Window::new(4).unwrap())
+            .progress(Box::new(move |progress| log.lock().unwrap().push(progress)))
+            .run(&mut sink),
+    )
+    .unwrap();
+    assert_eq!(written, data.len() as u64);
+    assert_eq!(sink.as_ref(), data);
+
+    let seen = seen.lock().unwrap();
+    assert!(!seen.is_empty());
+    for pair in seen.windows(2) {
+        assert!(pair[0].written < pair[1].written, "monotone progress");
+    }
+    for progress in seen.iter() {
+        assert_eq!(progress.total, data.len() as u64);
+    }
+    assert_eq!(seen.last().unwrap().written, data.len() as u64);
+
+    // The encrypted width lands the same bytes, and a sink pre-filled with
+    // garbage is fully overwritten (idempotent full re-run semantics).
+    let mut sink = MemSink::new();
+    sink.write_at(0, &vec![0xa5; data.len()]).unwrap();
+    let written = block_on(enc_file.download().run(&mut sink)).unwrap();
+    assert_eq!(written, data.len() as u64);
+    assert_eq!(sink.as_ref(), data);
+}
+
+#[test]
+fn range_download_writes_range_relative_offsets() {
+    use crate::sink::MemSink;
+
+    let data = fill(9 * TINY + 11);
+    let (root, store) = split::<TINY>(&data).unwrap();
+    let file = block_on(File::<_, Plain, TINY>::open(store, root)).unwrap();
+
+    let range = 300u64..(5 * TINY) as u64;
+    let mut sink = MemSink::new();
+    let written = block_on(file.download().range(range.clone()).run(&mut sink)).unwrap();
+    assert_eq!(written, range.end - range.start);
+    assert_eq!(sink.as_ref(), &data[300..5 * TINY]);
+
+    // Clip semantics: an out-of-file range shrinks instead of failing.
+    let mut sink = MemSink::new();
+    let written = block_on(file.download().range(500..u64::MAX).run(&mut sink)).unwrap();
+    assert_eq!(written, data.len() as u64 - 500);
+    assert_eq!(sink.as_ref(), &data[500..]);
+}
+
+/// Store failing exactly one fetch (the countdown-th), healthy afterwards.
+#[derive(Clone)]
+struct FailOnce {
+    inner: std::sync::Arc<TinyStore>,
+    countdown: std::sync::Arc<std::sync::Mutex<Option<usize>>>,
+}
+
+impl nectar_primitives::store::ChunkGet<AnyChunkSet<TINY>> for FailOnce {
+    type Trust = nectar_primitives::chunk::Verified;
+    type Error = ChunkStoreError;
+
+    async fn get(
+        &self,
+        address: &ChunkAddress,
+    ) -> Result<Chunk<nectar_primitives::chunk::Verified, AnyChunkSet<TINY>>, ChunkStoreError> {
+        let fail = {
+            let mut slot = self.countdown.lock().unwrap();
+            match slot.as_mut() {
+                Some(0) => {
+                    *slot = None;
+                    true
+                }
+                Some(left) => {
+                    *left -= 1;
+                    false
+                }
+                None => false,
+            }
+        };
+        if fail {
+            return Err(ChunkStoreError::Other(
+                "transient outage".to_string().into(),
+            ));
+        }
+        nectar_primitives::store::ChunkGet::get(self.inner.as_ref(), address).await
+    }
+}
+
+#[test]
+fn download_restart_after_transient_failure_is_idempotent() {
+    use super::DownloadError;
+    use crate::sink::MemSink;
+
+    let data = fill(19 * TINY + 41);
+    let (root, store) = split::<TINY>(&data).unwrap();
+    let store = FailOnce {
+        inner: std::sync::Arc::new(store),
+        // Let several leaves land before the outage so the failed run
+        // leaves partial bytes behind.
+        countdown: std::sync::Arc::new(std::sync::Mutex::new(Some(9))),
+    };
+
+    let mut sink = MemSink::new();
+    let file = block_on(File::<_, Plain, TINY>::open(store, root)).unwrap();
+    let err = block_on(
+        file.download()
+            .window(Window::new(2).unwrap())
+            .run(&mut sink),
+    )
+    .unwrap_err();
+    assert!(matches!(err, DownloadError::Walk(WalkError::Fetch { .. })));
+    assert!(
+        !sink.is_empty() && sink.len() < data.len(),
+        "the failed run must stop partway ({} of {})",
+        sink.len(),
+        data.len(),
+    );
+
+    // Restart: the full re-run overwrites the partial bytes idempotently.
+    let written = block_on(file.download().run(&mut sink)).unwrap();
+    assert_eq!(written, data.len() as u64);
+    assert_eq!(sink.as_ref(), data);
 }

--- a/crates/file/src/sink/fs.rs
+++ b/crates/file/src/sink/fs.rs
@@ -1,0 +1,53 @@
+//! Filesystem sink over a seekable file handle.
+
+use std::fs::{File, OpenOptions};
+use std::io::{Seek, SeekFrom, Write};
+use std::path::Path;
+
+use super::DataSink;
+
+/// Positional sink over an open file: each write seeks then writes, so the
+/// handle needs no platform positional-write support.
+#[derive(Debug)]
+pub struct FsSink {
+    file: File,
+}
+
+impl FsSink {
+    /// Create the file at `path`, truncating any existing content.
+    pub fn create(path: impl AsRef<Path>) -> std::io::Result<Self> {
+        File::create(path.as_ref()).map(Self::from)
+    }
+
+    /// Open (or create) the file at `path` without truncating, keeping any
+    /// partially downloaded bytes for an idempotent re-run.
+    pub fn open(path: impl AsRef<Path>) -> std::io::Result<Self> {
+        OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(path.as_ref())
+            .map(Self::from)
+    }
+}
+
+impl From<File> for FsSink {
+    fn from(file: File) -> Self {
+        Self { file }
+    }
+}
+
+impl From<FsSink> for File {
+    fn from(sink: FsSink) -> Self {
+        sink.file
+    }
+}
+
+impl DataSink for FsSink {
+    type Error = std::io::Error;
+
+    fn write_at(&mut self, offset: u64, data: &[u8]) -> std::io::Result<()> {
+        self.file.seek(SeekFrom::Start(offset))?;
+        self.file.write_all(data)
+    }
+}

--- a/crates/file/src/sink/mod.rs
+++ b/crates/file/src/sink/mod.rs
@@ -1,0 +1,102 @@
+//! Data sinks: positional byte targets a download writes into.
+//!
+//! Writes are idempotent overwrites: rewriting a region with the same bytes
+//! leaves the sink unchanged, so a failed download is recovered by running
+//! it again in full. A resumable sink reporting persisted progress is a
+//! future subtrait, not part of this contract.
+
+use alloc::collections::TryReserveError;
+use alloc::vec::Vec;
+
+#[cfg(feature = "std")]
+mod fs;
+#[cfg(test)]
+mod tests;
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+pub use fs::FsSink;
+
+/// Positional byte target with idempotent overwrite semantics.
+pub trait DataSink {
+    /// Typed write failure.
+    type Error;
+
+    /// Write `data` at absolute byte `offset`, growing the sink as needed;
+    /// rewriting a region with the same bytes must be idempotent.
+    fn write_at(&mut self, offset: u64, data: &[u8]) -> Result<(), Self::Error>;
+}
+
+/// Growable in-memory sink; unwritten gaps below the highest written end
+/// read as zero.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct MemSink {
+    data: Vec<u8>,
+}
+
+impl MemSink {
+    /// Create an empty sink.
+    pub const fn new() -> Self {
+        Self { data: Vec::new() }
+    }
+
+    /// Highest written end in bytes.
+    pub const fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Whether nothing has been written.
+    pub const fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+}
+
+impl AsRef<[u8]> for MemSink {
+    fn as_ref(&self) -> &[u8] {
+        &self.data
+    }
+}
+
+impl From<MemSink> for Vec<u8> {
+    fn from(sink: MemSink) -> Self {
+        sink.data
+    }
+}
+
+/// Typed in-memory write failures.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum MemSinkError {
+    /// The write's end offset does not fit the address space.
+    #[error("write of {len} bytes at {offset} overflows the address space")]
+    EndOverflow {
+        /// Requested write offset.
+        offset: u64,
+        /// Bytes the write carries.
+        len: usize,
+    },
+    /// The backing buffer could not grow.
+    #[error(transparent)]
+    Reserve(#[from] TryReserveError),
+}
+
+impl DataSink for MemSink {
+    type Error = MemSinkError;
+
+    fn write_at(&mut self, offset: u64, data: &[u8]) -> Result<(), MemSinkError> {
+        let overflow = MemSinkError::EndOverflow {
+            offset,
+            len: data.len(),
+        };
+        let start = usize::try_from(offset).map_err(|_| overflow.clone())?;
+        let end = start.checked_add(data.len()).ok_or(overflow)?;
+        if end > self.data.len() {
+            let grow = end.saturating_sub(self.data.len());
+            self.data.try_reserve(grow)?;
+            self.data.resize(end, 0);
+        }
+        for (slot, byte) in self.data.iter_mut().skip(start).zip(data) {
+            *slot = *byte;
+        }
+        Ok(())
+    }
+}

--- a/crates/file/src/sink/tests.rs
+++ b/crates/file/src/sink/tests.rs
@@ -1,0 +1,98 @@
+//! Sink oracles: out-of-order assembly, idempotent overwrite, growth edges.
+
+use std::vec::Vec;
+
+#[cfg(feature = "std")]
+use super::FsSink;
+use super::{DataSink, MemSink, MemSinkError};
+
+#[test]
+fn mem_sink_assembles_out_of_order_writes() {
+    let mut sink = MemSink::new();
+    sink.write_at(6, b"world").unwrap();
+    sink.write_at(0, b"hello ").unwrap();
+    assert_eq!(sink.as_ref(), b"hello world");
+    assert_eq!(sink.len(), 11);
+    assert!(!sink.is_empty());
+    assert_eq!(Vec::from(sink), b"hello world");
+}
+
+#[test]
+fn mem_sink_overwrites_are_idempotent() {
+    let mut sink = MemSink::new();
+    sink.write_at(0, b"abcdef").unwrap();
+    let before = sink.clone();
+    // Rewriting the same bytes at the same offsets changes nothing.
+    sink.write_at(2, b"cd").unwrap();
+    sink.write_at(0, b"abcdef").unwrap();
+    assert_eq!(sink, before);
+    // A genuine overwrite replaces exactly the covered region.
+    sink.write_at(2, b"XY").unwrap();
+    assert_eq!(sink.as_ref(), b"abXYef");
+}
+
+#[test]
+fn mem_sink_zero_fills_gaps() {
+    let mut sink = MemSink::new();
+    sink.write_at(4, b"z").unwrap();
+    assert_eq!(sink.as_ref(), b"\0\0\0\0z");
+    // An empty write past the end still marks the extent.
+    sink.write_at(8, b"").unwrap();
+    assert_eq!(sink.len(), 8);
+}
+
+#[test]
+fn mem_sink_rejects_end_overflow() {
+    let mut sink = MemSink::new();
+    let err = sink.write_at(u64::MAX, b"x").unwrap_err();
+    assert_eq!(
+        err,
+        MemSinkError::EndOverflow {
+            offset: u64::MAX,
+            len: 1,
+        }
+    );
+    assert!(sink.is_empty(), "a rejected write must leave no trace");
+}
+
+/// Temp file path unique to this process; removed by the returned guard.
+#[cfg(feature = "std")]
+struct TempPath(std::path::PathBuf);
+
+#[cfg(feature = "std")]
+impl Drop for TempPath {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+#[cfg(feature = "std")]
+fn temp_path(name: &str) -> TempPath {
+    let mut path = std::env::temp_dir();
+    path.push(std::format!(
+        "nectar-file-sink-{}-{name}",
+        std::process::id()
+    ));
+    TempPath(path)
+}
+
+#[cfg(feature = "std")]
+#[test]
+fn fs_sink_assembles_and_overwrites_like_mem_sink() {
+    let path = temp_path("assemble");
+    let mut sink = FsSink::create(&path.0).unwrap();
+    sink.write_at(6, b"world").unwrap();
+    sink.write_at(0, b"hello ").unwrap();
+    sink.write_at(0, b"hello ").unwrap();
+    assert_eq!(std::fs::read(&path.0).unwrap(), b"hello world");
+
+    // Reopening without truncation keeps the bytes for a re-run.
+    let mut sink = FsSink::open(&path.0).unwrap();
+    sink.write_at(6, b"world").unwrap();
+    assert_eq!(std::fs::read(&path.0).unwrap(), b"hello world");
+
+    // Create truncates.
+    let sink = FsSink::create(&path.0).unwrap();
+    let file: std::fs::File = sink.into();
+    assert_eq!(file.metadata().unwrap().len(), 0);
+}


### PR DESCRIPTION
## What

- `FileFrames`: completion-order drain over `Walk::poll_next_any`, offset-tagged, `Stream + Unpin`, with range/stats witnesses (`read/frames.rs`).
- `DownloadBuilder`: `File::download`, clip-semantics range, window, boxed progress callback (`ProgressFn`, a single `Send`/unsync cfg-gated alias), `run(sink)` returning bytes written, range-relative sink offsets, typed `DownloadError` with `Walk` and `Sink` variants (`read/download.rs`).
- `DataSink` trait, idempotent-overwrite semantics: `MemSink` (no_std+alloc, `try_reserve` growth, typed `EndOverflow`/`Reserve` errors, zero-filled gaps) and std-gated `FsSink` (create/open constructors, `From<File>` conversions, seek + write_all) (`sink/mod.rs`, `sink/fs.rs`).
- Downloads are restartable, not resumable; a `ResumableSink` subtrait is noted as future work, not implemented here.
- `sink` module no_std wiring: `extern crate alloc` made unconditional, `thiserror` made a non-optional default-features-off dependency (`Cargo.toml`, `lib.rs`).
- Tests: frames tiling oracle, download fill/progress for both plain and encrypted widths, sink round-trip tests (`read/tests.rs`, `sink/tests.rs`).

## Why

Closes #333

## Testing

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --locked`: exit 0, zero new warnings in touched crate (nectar-file).
- `cargo nextest run -p nectar-file --locked`: 50 passed, 1 skipped.
- no_std riscv64 check: passes.
- zepter: passes.

## AI Assistance

Implementation by Fable, review by Opus, PR description by Sonnet.

