### PR TITLE
feat(file): bounded collect, boxed store aliases, guest driver

### DIFF
--- a/crates/file/src/lib.rs
+++ b/crates/file/src/lib.rs
@@ -6,8 +6,9 @@
 //! engines drain against, the poll-native [`walk`] engine every read mode
 //! drains, the poll-native [`split`] engine every write mode feeds, the
 //! [`read`] facade that opens files by either reference width and drains the
-//! walk in file order, and the [`sink`] targets a restartable download
-//! writes into.
+//! walk in file order, the [`sink`] targets a restartable download writes
+//! into, the [`store`] erasure that makes file handles nameable, and the
+//! [`sync`] driver for Ready-only guests.
 
 #![no_std]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
@@ -45,6 +46,10 @@ pub mod sink;
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod split;
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+pub mod store;
+pub mod sync;
 #[cfg(feature = "tokio")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub mod tokio;
@@ -63,14 +68,16 @@ pub use config::{BranchBudget, PutWindow, Window};
 pub use geometry::{DEFAULT_BODY_SIZE, Mode, branches, max_depth};
 #[cfg(feature = "std")]
 pub use read::{
-    AnyFile, DownloadBuilder, DownloadError, File, FileFrames, FileReader, FileStream, OpenError,
-    Progress, ProgressFn, ReadBuilder, SeekPastEnd,
+    AnyFile, CollectError, DownloadBuilder, DownloadError, File, FileFrames, FileReader,
+    FileStream, OpenError, Progress, ProgressFn, ReadBuilder, SeekPastEnd,
 };
 #[cfg(feature = "std")]
 pub use sink::FsSink;
 pub use sink::{DataSink, MemSink, MemSinkError};
 #[cfg(feature = "std")]
 pub use split::{Sealed, Split, SplitError, SplitMode, SplitStats};
+#[cfg(feature = "std")]
+pub use store::{BoxedStore, BoxedStoreError, DynAnyFile, DynFile, DynFileReader, DynFileStream};
 #[cfg(feature = "std")]
 pub use walk::{
     DecodeError, Encrypted, Frame, Plain, ShapeError, Walk, WalkError, WalkMode, WalkStats,

--- a/crates/file/src/read/error.rs
+++ b/crates/file/src/read/error.rs
@@ -1,5 +1,7 @@
 //! Typed failures of the read facade.
 
+use alloc::collections::TryReserveError;
+
 use nectar_primitives::chunk::ChunkAddress;
 
 use crate::walk::{DecodeError, WalkError};
@@ -43,6 +45,25 @@ pub enum DownloadError<E, SE> {
         /// Sink error behind the failure.
         source: SE,
     },
+}
+
+/// Failure assembling a bounded in-memory read.
+#[derive(Debug, thiserror::Error)]
+pub enum CollectError<E> {
+    /// The clipped read exceeds the collect bound.
+    #[error("read of {len} bytes exceeds the collect bound {max}")]
+    TooLarge {
+        /// Bytes the clipped read covers.
+        len: u64,
+        /// Effective bound; saturates at the address width.
+        max: u64,
+    },
+    /// The assembly buffer reservation failed.
+    #[error("assembly buffer reservation failed")]
+    Reserve(#[from] TryReserveError),
+    /// The walk failed before the range was tiled.
+    #[error(transparent)]
+    Walk(#[from] WalkError<E>),
 }
 
 /// A seek past the reader's effective length; the reader never clamps.

--- a/crates/file/src/read/file.rs
+++ b/crates/file/src/read/file.rs
@@ -1,5 +1,6 @@
 //! File handles: one opened chunk tree, mode pinned or runtime-dispatched.
 
+use alloc::vec::Vec;
 use core::fmt;
 
 use nectar_primitives::chunk::encryption::{EncryptedChunkRef, EncryptionKey, transcrypt_in_place};
@@ -8,7 +9,7 @@ use nectar_primitives::store::TrustedGet;
 use nectar_primitives::{DEFAULT_BODY_SIZE, EntryRef};
 
 use super::download::DownloadBuilder;
-use super::error::OpenError;
+use super::error::{CollectError, OpenError};
 use super::reader::ReadBuilder;
 use crate::config::Window;
 use crate::geometry::Mode;
@@ -64,6 +65,17 @@ impl<S: Clone, M: WalkMode, const B: usize> File<S, M, B> {
             Window::DEFAULT,
             0..u64::MAX,
         )
+    }
+}
+
+impl<S, M, const B: usize> File<S, M, B>
+where
+    S: TrustedGet<AnyChunkSet<B>> + Clone + 'static,
+    M: WalkMode,
+{
+    /// Assemble the whole file in memory, at most `max` bytes.
+    pub async fn collect(&self, max: u64) -> Result<Vec<u8>, CollectError<S::Error>> {
+        self.read().collect(max).await
     }
 }
 
@@ -148,6 +160,14 @@ where
             EntryRef::Encrypted(reference) => File::open_encrypted(store, reference)
                 .await
                 .map(Self::Encrypted),
+        }
+    }
+
+    /// Assemble the whole file in memory, at most `max` bytes.
+    pub async fn collect(&self, max: u64) -> Result<Vec<u8>, CollectError<S::Error>> {
+        match self {
+            Self::Plain(file) => file.collect(max).await,
+            Self::Encrypted(file) => file.collect(max).await,
         }
     }
 }

--- a/crates/file/src/read/mod.rs
+++ b/crates/file/src/read/mod.rs
@@ -7,6 +7,8 @@
 //! out-of-file bounds shrink the read instead of failing, and the clipped
 //! length is readable as [`FileReader::effective_len`]. Only
 //! [`FileReader::seek`] is typed-strict: it never clamps.
+//! [`ReadBuilder::collect`] assembles a bounded in-memory copy, typed
+//! [`CollectError::TooLarge`] past its bound.
 
 mod download;
 mod error;
@@ -17,7 +19,7 @@ mod reader;
 mod tests;
 
 pub use download::{DownloadBuilder, Progress, ProgressFn};
-pub use error::{DownloadError, OpenError, SeekPastEnd};
+pub use error::{CollectError, DownloadError, OpenError, SeekPastEnd};
 pub use file::{AnyFile, File};
 pub use frames::FileFrames;
 pub use reader::{FileReader, FileStream, ReadBuilder};

--- a/crates/file/src/read/reader.rs
+++ b/crates/file/src/read/reader.rs
@@ -1,5 +1,6 @@
 //! Ordered reader and stream over one walk.
 
+use alloc::vec::Vec;
 use core::fmt;
 use core::future::poll_fn;
 use core::mem;
@@ -13,7 +14,7 @@ use nectar_primitives::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{AnyChunkSet, ChunkAddress};
 use nectar_primitives::store::TrustedGet;
 
-use super::error::SeekPastEnd;
+use super::error::{CollectError, SeekPastEnd};
 use super::frames::FileFrames;
 use crate::config::Window;
 use crate::num::u64_from_usize;
@@ -112,6 +113,35 @@ where
             self.range,
             self.window,
         ))
+    }
+
+    /// Assemble the clipped range in memory, at most `max` bytes.
+    ///
+    /// The buffer is reserved up front with `try_reserve_exact`, so an
+    /// oversized range fails typed before any fetch; the bound saturates at
+    /// the address width.
+    pub async fn collect(self, max: u64) -> Result<Vec<u8>, CollectError<S::Error>> {
+        let mut walk: Walk<S, M, B> = Walk::new(
+            self.store,
+            self.root,
+            self.context,
+            self.span,
+            self.range,
+            self.window,
+        );
+        let clipped = walk.range();
+        let len = clipped.end.saturating_sub(clipped.start);
+        let bound = max.min(u64_from_usize(usize::MAX));
+        let capacity = match usize::try_from(len) {
+            Ok(capacity) if len <= bound => capacity,
+            _ => return Err(CollectError::TooLarge { len, max: bound }),
+        };
+        let mut out = Vec::new();
+        out.try_reserve_exact(capacity)?;
+        while let Some(frame) = poll_fn(|cx| walk.poll_next_ordered(cx)).await {
+            out.extend_from_slice(&frame?.data);
+        }
+        Ok(out)
     }
 }
 

--- a/crates/file/src/read/tests.rs
+++ b/crates/file/src/read/tests.rs
@@ -18,7 +18,7 @@ use nectar_primitives::file::{ChunkGetExt, join, split, split_encrypted};
 use nectar_primitives::store::{ChunkStoreError, MemoryStore, TrustedGet};
 use nectar_primitives::{EntryRef, transcrypt};
 
-use super::{AnyFile, File, FileReader, OpenError, SeekPastEnd};
+use super::{AnyFile, CollectError, File, FileReader, OpenError, SeekPastEnd};
 use crate::config::Window;
 use crate::geometry::Mode;
 use crate::walk::{DecodeError, Encrypted, Plain, WalkError, WalkMode};
@@ -531,6 +531,141 @@ fn range_download_writes_range_relative_offsets() {
     let written = block_on(file.download().range(500..u64::MAX).run(&mut sink)).unwrap();
     assert_eq!(written, data.len() as u64 - 500);
     assert_eq!(sink.as_ref(), &data[500..]);
+}
+
+#[test]
+fn collect_assembles_the_clipped_range_both_widths() {
+    let data = fill(9 * TINY + 21);
+    let (plain_root, plain_store) = split::<TINY>(&data).unwrap();
+    let (enc_root, enc_store) = split_encrypted::<TINY>(&data).unwrap();
+    let plain_file = block_on(File::<_, Plain, TINY>::open(
+        plain_store.clone(),
+        plain_root,
+    ))
+    .unwrap();
+    let enc_file = block_on(File::<_, Encrypted, TINY>::open_encrypted(
+        enc_store, enc_root,
+    ))
+    .unwrap();
+
+    // The bound is inclusive: max equal to the length succeeds.
+    assert_eq!(
+        block_on(plain_file.collect(data.len() as u64)).unwrap(),
+        data
+    );
+    assert_eq!(block_on(enc_file.collect(u64::MAX)).unwrap(), data);
+
+    // The runtime-dispatched file collects through the same bound.
+    let entry = EntryRef::Plain(ChunkRef::new(plain_root));
+    let any = block_on(AnyFile::<_, TINY>::open(plain_store, entry)).unwrap();
+    assert_eq!(block_on(any.collect(u64::MAX)).unwrap(), data);
+
+    // A range collect bounds the clipped length, not the file length.
+    let range = 100u64..(5 * TINY) as u64;
+    let got = block_on(
+        plain_file
+            .read()
+            .range(range.clone())
+            .collect(range.end - range.start),
+    )
+    .unwrap();
+    assert_eq!(got, &data[100..5 * TINY]);
+
+    // An empty file collects empty under a zero bound.
+    let (root, store) = split::<TINY>(&[]).unwrap();
+    let empty = block_on(File::<_, Plain, TINY>::open(store, root)).unwrap();
+    assert!(block_on(empty.collect(0)).unwrap().is_empty());
+}
+
+/// Store counting every fetch it serves.
+#[derive(Clone)]
+struct CountingStore {
+    inner: std::sync::Arc<TinyStore>,
+    gets: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+}
+
+impl nectar_primitives::store::ChunkGet<AnyChunkSet<TINY>> for CountingStore {
+    type Trust = nectar_primitives::chunk::Verified;
+    type Error = ChunkStoreError;
+
+    async fn get(
+        &self,
+        address: &ChunkAddress,
+    ) -> Result<Chunk<nectar_primitives::chunk::Verified, AnyChunkSet<TINY>>, ChunkStoreError> {
+        self.gets.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        nectar_primitives::store::ChunkGet::get(self.inner.as_ref(), address).await
+    }
+}
+
+#[test]
+fn collect_past_the_bound_is_typed_and_fetches_nothing() {
+    let data = fill(4 * TINY);
+    let (root, store) = split::<TINY>(&data).unwrap();
+    let gets = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let store = CountingStore {
+        inner: std::sync::Arc::new(store),
+        gets: std::sync::Arc::clone(&gets),
+    };
+
+    let file = block_on(File::<_, Plain, TINY>::open(store, root)).unwrap();
+    let after_open = gets.load(std::sync::atomic::Ordering::Relaxed);
+    let err = block_on(file.collect(data.len() as u64 - 1)).unwrap_err();
+    assert!(matches!(
+        err,
+        CollectError::TooLarge { len, max }
+            if len == data.len() as u64 && max == data.len() as u64 - 1
+    ));
+    assert_eq!(
+        gets.load(std::sync::atomic::Ordering::Relaxed),
+        after_open,
+        "a failed bound must not fetch"
+    );
+}
+
+#[test]
+fn boxed_store_erases_behind_nameable_aliases() {
+    use crate::store::{BoxedStore, DynAnyFile, DynFile, DynFileReader, DynFileStream};
+
+    /// Struct-field nameability: no store type parameter anywhere.
+    struct Held {
+        file: DynFile<Plain, TINY>,
+    }
+
+    let data = fill(7 * TINY + 13);
+    let (root, store) = split::<TINY>(&data).unwrap();
+    let boxed = BoxedStore::<TINY>::new(store);
+
+    let file = block_on(DynFile::<Plain, TINY>::open(boxed.clone(), root)).unwrap();
+    let held = Held { file };
+    assert_eq!(block_on(held.file.collect(u64::MAX)).unwrap(), data);
+
+    // The erased reader and stream are nameable and drain the same bytes.
+    let mut reader: DynFileReader<Plain, TINY> = held.file.read().build();
+    let mut buf = [0u8; 64];
+    block_on(async {
+        reader.read(&mut buf).await.unwrap();
+    });
+    assert_eq!(&buf[..], &data[..64]);
+    let _stream: DynFileStream<Plain, TINY> = reader.into_stream();
+
+    let any: DynAnyFile<TINY> = block_on(AnyFile::open(
+        boxed.clone(),
+        EntryRef::Plain(ChunkRef::new(root)),
+    ))
+    .unwrap();
+    assert_eq!(block_on(any.collect(u64::MAX)).unwrap(), data);
+
+    // The concrete store error survives as the source of the erased error.
+    let missing = ChunkAddress::from([0x5a; 32]);
+    let err = block_on(DynFile::<Plain, TINY>::open(boxed, missing)).unwrap_err();
+    let OpenError::Fetch { source, .. } = err else {
+        panic!("a missing root must fail the fetch");
+    };
+    let source = std::error::Error::source(&source).expect("erased source retained");
+    assert!(matches!(
+        source.downcast_ref::<ChunkStoreError>(),
+        Some(ChunkStoreError::NotFound(address)) if *address == missing
+    ));
 }
 
 /// Store failing exactly one fetch (the countdown-th), healthy afterwards.

--- a/crates/file/src/store.rs
+++ b/crates/file/src/store.rs
@@ -1,0 +1,107 @@
+//! Erased chunk store and the nameable file aliases built on it.
+//!
+//! [`BoxedStore`] hides the concrete store type behind one cheap-to-clone
+//! handle, so the [`DynFile`] family fits struct fields without a store
+//! parameter.
+
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use core::fmt;
+use core::future::Future;
+use core::pin::Pin;
+
+use nectar_primitives::DEFAULT_BODY_SIZE;
+use nectar_primitives::chunk::{AnyChunkSet, Chunk, ChunkAddress, Verified};
+use nectar_primitives::store::{BoxedError, ChunkGet, MaybeSend, MaybeSync, TrustedGet};
+
+use crate::read::{AnyFile, File, FileReader, FileStream};
+use crate::walk::Plain;
+
+/// Fetch failure behind an erased store; the concrete error survives as the
+/// source.
+#[derive(Debug, thiserror::Error)]
+#[error("erased store fetch failed")]
+pub struct BoxedStoreError(#[source] BoxedError);
+
+/// Boxed erased fetch future: `Send` on multi-threaded targets, unbounded on
+/// wasm32 and under the `unsync` feature.
+#[cfg(not(any(target_arch = "wasm32", feature = "unsync")))]
+type BoxGet<const B: usize> =
+    Pin<Box<dyn Future<Output = Result<Chunk<Verified, AnyChunkSet<B>>, BoxedStoreError>> + Send>>;
+/// Boxed erased fetch future: `Send` on multi-threaded targets, unbounded on
+/// wasm32 and under the `unsync` feature.
+#[cfg(any(target_arch = "wasm32", feature = "unsync"))]
+type BoxGet<const B: usize> =
+    Pin<Box<dyn Future<Output = Result<Chunk<Verified, AnyChunkSet<B>>, BoxedStoreError>>>>;
+
+/// Object-safe fetch surface the adapter erases stores through.
+trait ErasedGet<const B: usize>: MaybeSend + MaybeSync {
+    fn get(&self, address: ChunkAddress) -> BoxGet<B>;
+}
+
+impl<S, const B: usize> ErasedGet<B> for S
+where
+    S: TrustedGet<AnyChunkSet<B>> + Clone + 'static,
+{
+    fn get(&self, address: ChunkAddress) -> BoxGet<B> {
+        let store = self.clone();
+        Box::pin(async move {
+            store
+                .get(&address)
+                .await
+                .map_err(|source| BoxedStoreError(Box::new(source)))
+        })
+    }
+}
+
+/// A trusted store with its type erased; cloning shares the same backend.
+pub struct BoxedStore<const B: usize = DEFAULT_BODY_SIZE>(Arc<dyn ErasedGet<B>>);
+
+impl<const B: usize> BoxedStore<B> {
+    /// Erase a trusted store behind one nameable handle.
+    pub fn new<S>(store: S) -> Self
+    where
+        S: TrustedGet<AnyChunkSet<B>> + Clone + 'static,
+    {
+        Self(Arc::new(store))
+    }
+}
+
+impl<const B: usize> Clone for BoxedStore<B> {
+    fn clone(&self) -> Self {
+        Self(Arc::clone(&self.0))
+    }
+}
+
+impl<const B: usize> fmt::Debug for BoxedStore<B> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BoxedStore").finish_non_exhaustive()
+    }
+}
+
+impl<const B: usize> ChunkGet<AnyChunkSet<B>> for BoxedStore<B> {
+    type Trust = Verified;
+    type Error = BoxedStoreError;
+
+    fn get(
+        &self,
+        address: &ChunkAddress,
+    ) -> impl Future<Output = Result<Chunk<Verified, AnyChunkSet<B>>, Self::Error>> + MaybeSend
+    {
+        self.0.get(*address)
+    }
+}
+
+/// Erased-store file; nameable as a struct field.
+pub type DynFile<M = Plain, const B: usize = DEFAULT_BODY_SIZE> = File<BoxedStore<B>, M, B>;
+
+/// Erased-store file of either reference width.
+pub type DynAnyFile<const B: usize = DEFAULT_BODY_SIZE> = AnyFile<BoxedStore<B>, B>;
+
+/// Erased-store ordered reader.
+pub type DynFileReader<M = Plain, const B: usize = DEFAULT_BODY_SIZE> =
+    FileReader<BoxedStore<B>, M, B>;
+
+/// Erased-store ordered stream.
+pub type DynFileStream<M = Plain, const B: usize = DEFAULT_BODY_SIZE> =
+    FileStream<BoxedStore<B>, M, B>;

--- a/crates/file/src/sync.rs
+++ b/crates/file/src/sync.rs
@@ -1,0 +1,72 @@
+//! Ready-only driver for single-threaded guests.
+//!
+//! [`drive`] polls a future exactly once with a no-op waker: over a
+//! synchronous store every await resolves inside that poll, and a
+//! [`Pending`] return is terminal because nothing in the guest can wake the
+//! future again.
+
+use core::future::Future;
+use core::pin::pin;
+use core::task::{Context, Poll, Waker};
+
+/// The driven future returned `Poll::Pending`; a Ready-only guest holds no
+/// waker that could resume it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("future pended under the ready-only driver")]
+pub struct Pending;
+
+/// Run `future` to completion in a single poll.
+///
+/// Never re-polls after a `Pending` (no wake can arrive), so the driver
+/// cannot livelock.
+///
+/// # Examples
+///
+/// ```
+/// assert_eq!(nectar_file::sync::drive(async { 7u8 }), Ok(7));
+/// ```
+pub fn drive<F: Future>(future: F) -> Result<F::Output, Pending> {
+    let future = pin!(future);
+    let mut cx = Context::from_waker(Waker::noop());
+    match future.poll(&mut cx) {
+        Poll::Ready(output) => Ok(output),
+        Poll::Pending => Err(Pending),
+    }
+}
+
+#[cfg(test)]
+#[allow(deprecated)]
+mod tests {
+    use std::vec::Vec;
+
+    use nectar_primitives::file::split;
+
+    use super::*;
+    use crate::read::File;
+    use crate::walk::Plain;
+
+    #[test]
+    fn ready_future_completes_in_one_poll() {
+        assert_eq!(drive(async { 7u8 }), Ok(7));
+    }
+
+    #[test]
+    fn pending_future_is_a_typed_error() {
+        assert_eq!(drive(core::future::pending::<()>()), Err(Pending));
+    }
+
+    #[test]
+    fn whole_file_read_is_ready_only_over_a_synchronous_store() {
+        const TINY: usize = 256;
+        let data: Vec<u8> = (0..(9 * TINY + 21) as u64)
+            .map(|i| (i % 251) as u8)
+            .collect();
+        let (root, store) = split::<TINY>(&data).unwrap();
+        let bytes = drive(async move {
+            let file = File::<_, Plain, TINY>::open(store, root).await.unwrap();
+            file.collect(u64::MAX).await.unwrap()
+        })
+        .unwrap();
+        assert_eq!(bytes, data);
+    }
+}


### PR DESCRIPTION
## What

- `ReadBuilder::collect(max)` (plus `File::collect` / `AnyFile::collect` conveniences) that reserves via `try_reserve_exact` and returns a typed `CollectError::TooLarge { len, max }` before any fetch, with the bound saturating at address width.
- `BoxedStore<B>`: a boxed-store adapter with a private object-safe `ErasedGet` behind `Arc`, a cfg-forked `BoxGet` future alias reusing the existing wasm32/unsync mechanism, and `BoxedStoreError` retaining the concrete source error.
- `DynFile` / `DynAnyFile` / `DynFileReader` / `DynFileStream` aliases for struct-field nameability over the boxed store.
- `sync::drive()`: a Ready-only guest driver in a new unconditional no_std `sync` module, single poll with `Waker::noop()`, typed `Pending` error, never re-polls.

## Why

Closes #334

## Testing

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --locked`: zero new warnings on `nectar-file` (ambient 1.92 and flake-pinned 1.94 toolchains); remaining warnings are pre-existing in nectar-primitives/nectar-mantaray, outside this diff.
- `cargo nextest run -p nectar-file --locked`: 56 passed, 1 skipped, including new collect differential tests (both address widths), `AnyFile` dispatch, range clip, empty file, and a counting store proving a failed bound dispatches zero fetches.
- No Cargo.toml/CI/manifest/postage changes, so zepter/actionlint/wasm gates are not applicable.

## AI Assistance

Implementation by Fable, review by Opus, PR by Sonnet.

