### PR TITLE
feat(mantaray): no_std flip, rand key seam, legacy fence

### DIFF
--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -38,7 +38,7 @@ jobs:
               run: |
                   cargo check --locked \
                     -p nectar-swarms -p nectar-contracts -p nectar-file \
-                    -p nectar-mantaray -p nectar-nostd-spike \
+                    -p nectar-mantaray@0.4.0 -p nectar-nostd-spike \
                     --no-default-features \
                     --target ${{ matrix.target }}
             # nectar-primitives does not yet build bare-metal, so the

--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -38,7 +38,7 @@ jobs:
               run: |
                   cargo check --locked \
                     -p nectar-swarms -p nectar-contracts -p nectar-file \
-                    -p nectar-nostd-spike \
+                    -p nectar-mantaray -p nectar-nostd-spike \
                     --no-default-features \
                     --target ${{ matrix.target }}
             # nectar-primitives does not yet build bare-metal, so the

--- a/crates/mantaray/Cargo.toml
+++ b/crates/mantaray/Cargo.toml
@@ -18,13 +18,13 @@ categories = ["data-structures"]
 workspace = true
 
 [dependencies]
-alloy-primitives = { workspace = true, features = ["map"] }
-bitflags.workspace = true
-bytes.workspace = true
-futures.workspace = true
-nectar-primitives = { workspace = true }
-thiserror.workspace = true
-serde_json.workspace = true
+alloy-primitives = { workspace = true, features = ["map"], optional = true }
+bitflags = { workspace = true, optional = true }
+bytes = { workspace = true, optional = true }
+futures = { workspace = true, optional = true }
+nectar-primitives = { workspace = true, optional = true }
+thiserror = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 arbitrary = { workspace = true, features = ["derive"], optional = true }
 rand = { workspace = true, optional = true }
 
@@ -47,26 +47,37 @@ harness = false
 required-features = ["hazmat"]
 
 [features]
-default = [ "std" ]
+default = [ "rand", "std" ]
+# The trie modules ride this feature until the primitives core builds
+# bare-metal; without it only the metadata keys and the obfuscation key
+# remain.
 std = [
-	"alloy-primitives/std",
-	"nectar-primitives/std",
-	"rand",
-	"serde_json/std",
-	"thiserror/std",
+	"alloy-primitives?/std",
+	"dep:alloy-primitives",
+	"dep:bitflags",
+	"dep:bytes",
+	"dep:futures",
+	"dep:nectar-primitives",
+	"dep:serde_json",
+	"dep:thiserror",
+	"nectar-primitives?/std",
+	"serde_json?/std",
+	"thiserror?/std",
 ]
+# Random obfuscation-key generation for encrypted manifests. Implies `std`.
+rand = [ "dep:rand", "std" ]
 # Valid-by-construction `arbitrary::Arbitrary` impls for `Node`, `Fork`,
 # `Prefix`, `NodeType`, and `ObfuscationKey`, for structured (round-trip)
 # fuzz targets.
 arbitrary = [
-	"alloy-primitives/arbitrary",
+	"alloy-primitives?/arbitrary",
 	"dep:arbitrary",
-	"nectar-primitives/arbitrary",
+	"nectar-primitives?/arbitrary",
 	"std",
 ]
-encryption = [ "nectar-primitives/encryption" ]
+encryption = [ "nectar-primitives?/encryption" ]
 # Raw node internals (the `hazmat` module) for fuzz harnesses and benches.
-hazmat = []
+hazmat = [ "std" ]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/mantaray/src/constants.rs
+++ b/crates/mantaray/src/constants.rs
@@ -19,7 +19,9 @@ pub mod metadata {
 }
 
 // Path separator used in Swarm manifests.
+#[cfg(feature = "std")]
 pub(crate) const PATH_SEPARATOR: &str = "/";
 
 // Maximum prefix length in a fork (constrained by the 32-byte pre-reference region).
+#[cfg(feature = "std")]
 pub(crate) const PREFIX_MAX_LEN: usize = 30;

--- a/crates/mantaray/src/editor.rs
+++ b/crates/mantaray/src/editor.rs
@@ -95,7 +95,8 @@ impl<S, const BS: usize> ManifestEditor<S, ChunkRef, BS> {
 
 impl<S, const BS: usize> ManifestEditor<S, nectar_primitives::EncryptedChunkRef, BS> {
     /// Editor over an empty encrypted manifest with a random obfuscation key.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "rand")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
     pub fn new_encrypted(store: S) -> Self {
         let trie = Node {
             obfuscation_key: crate::obfuscation::ObfuscationKey::generate(),

--- a/crates/mantaray/src/legacy/builder.rs
+++ b/crates/mantaray/src/legacy/builder.rs
@@ -11,6 +11,7 @@
 //! silently.
 //!
 //! ```
+//! # #![allow(deprecated)]
 //! # use nectar_mantaray::{ManifestBuilder, DefaultMemoryStore};
 //! # use nectar_primitives::chunk::ChunkAddress;
 //! # futures::executor::block_on(async {
@@ -45,8 +46,8 @@ use nectar_primitives::chunk::{ChunkAddress, ChunkRef, Reference};
 use nectar_primitives::file::{ChunkPutExt, ReadAt};
 use nectar_primitives::store::{ChunkPut, MaybeSend, TrustedGet};
 
+use super::manifest::Manifest;
 use crate::entry::Entry;
-use crate::manifest::Manifest;
 use crate::{MantarayError, Result};
 
 /// Staging buffer for a mantaray manifest whose `save` consumes the builder.
@@ -54,6 +55,7 @@ use crate::{MantarayError, Result};
 /// The reference type parameter `R` fixes what `add` accepts and what `save`
 /// returns (a plain [`ChunkAddress`] or an encrypted
 /// [`ManifestRef`](crate::ManifestRef)), mirroring [`Manifest`].
+#[deprecated(note = "superseded by ManifestEditor; removal is gated on the manifest 1.0 store")]
 #[derive(Debug)]
 pub struct ManifestBuilder<S, R: Reference = ChunkRef, const BS: usize = DEFAULT_BODY_SIZE> {
     manifest: Manifest<S, R, BS>,
@@ -68,7 +70,7 @@ impl<S, const BS: usize> ManifestBuilder<S, ChunkRef, BS> {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "rand")]
 impl<S, const BS: usize> ManifestBuilder<S, nectar_primitives::EncryptedChunkRef, BS> {
     /// Create a new encrypted builder (random obfuscation key, 64-byte refs).
     pub fn new_encrypted(store: S) -> Self {
@@ -306,7 +308,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "rand")]
     #[test]
     fn encrypted_builder_round_trips_the_reference() {
         use nectar_primitives::file::EntryRef;
@@ -328,7 +330,7 @@ mod tests {
         assert_eq!(entry.reference(), Some(&EntryRef::Encrypted(eref)));
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "rand")]
     #[test]
     fn encrypted_builder_rejects_root_metadata() {
         use nectar_primitives::{EncryptedChunkRef, EncryptionKey};

--- a/crates/mantaray/src/legacy/manifest.rs
+++ b/crates/mantaray/src/legacy/manifest.rs
@@ -18,6 +18,7 @@ use crate::{MantarayError, Result, metadata};
 ///
 /// Matches the file joiner's async width, balancing round-trip overlap against
 /// peak in-flight store load.
+#[deprecated(note = "superseded by the Cursor window")]
 pub const DEFAULT_LIST_CONCURRENCY: usize = 8;
 
 /// High-level mantaray manifest backed by a typed chunk store.
@@ -26,6 +27,9 @@ pub const DEFAULT_LIST_CONCURRENCY: usize = 8;
 /// - What reference types `add()` accepts (compile-time enforcement)
 /// - The reference byte size via `R::SIZE`
 /// - What `save()` returns (specialized per entry type)
+#[deprecated(
+    note = "superseded by Reader, Cursor, and ManifestEditor; removal is gated on the manifest 1.0 store"
+)]
 #[derive(Debug)]
 pub struct Manifest<S, R: Reference = ChunkRef, const BS: usize = DEFAULT_BODY_SIZE> {
     trie: Node<R>,
@@ -48,7 +52,7 @@ impl<S, const BS: usize> Manifest<S, ChunkRef, BS> {
 
 impl<S, const BS: usize> Manifest<S, nectar_primitives::EncryptedChunkRef, BS> {
     /// Create a new encrypted manifest (random obfuscation key, 64-byte refs).
-    #[cfg(feature = "std")]
+    #[cfg(feature = "rand")]
     pub fn new_encrypted(store: S) -> Self {
         use crate::obfuscation::ObfuscationKey;
         let trie = Node {
@@ -206,7 +210,7 @@ impl<S: TrustedGet<AnyChunkSet<BS>>, R: Reference + MaybeSend, const BS: usize> 
     /// Collect all value entries, fetching sibling forks concurrently.
     ///
     /// Walks the trie level by level, keeping up to `concurrency` node loads in
-    /// flight through the shared [`ChunkGet`]. Where [`entries`](Self::entries)
+    /// flight through the shared [`ChunkGet`](crate::ChunkGet). Where [`entries`](Self::entries)
     /// fetches one node per `await` in depth-first order, this fans out each
     /// level's sibling forks at once, collapsing a folder's N sequential round
     /// trips into ceil(N / concurrency) batched ones.
@@ -457,6 +461,7 @@ impl<S: TrustedGet<AnyChunkSet<BS>> + ChunkPut<AnyChunkSet<BS>>, const BS: usize
 /// the trie is exclusively borrowed (`&'a mut Node`) for the iterator's
 /// lifetime, and `BTreeMap` values are stable (we never insert into or remove
 /// from a parent's fork map during iteration).
+#[deprecated(note = "superseded by Cursor")]
 pub struct ManifestIter<'a, S, R: Reference = ChunkRef, const BS: usize = DEFAULT_BODY_SIZE> {
     trie: &'a mut Node<R>,
     store: &'a S,

--- a/crates/mantaray/src/legacy/mod.rs
+++ b/crates/mantaray/src/legacy/mod.rs
@@ -1,0 +1,28 @@
+//! Deprecated lazy-trie manifest surface, superseded by the streaming
+//! modules. Removal is gated on the manifest 1.0 key-value store replacing
+//! this crate's manifest surface. The trie substrate the editor replays
+//! (node add, remove, and load) is not legacy and stays with the editor.
+//!
+//! # Migration
+//!
+//! | Legacy | Replacement |
+//! |---|---|
+//! | `Manifest::get`, `Manifest::lookup` | [`Reader::get`](crate::Reader::get) |
+//! | `Manifest::has_prefix` | [`Reader::has_prefix`](crate::Reader::has_prefix) |
+//! | `Manifest::add`, `add_with_metadata`, `remove` | [`ManifestEditor::put`](crate::ManifestEditor::put), `put_with_metadata`, `remove` |
+//! | `Manifest::save` | [`ManifestEditor::commit`](crate::ManifestEditor) |
+//! | `Manifest::set_index_document`, `set_error_document` | the [`ManifestEditor`](crate::ManifestEditor) twins |
+//! | `Manifest::entries`, `entries_concurrent`, `stream`, `walk` | [`Cursor`](crate::Cursor) |
+//! | `Manifest::iterate_addresses` | [`AddressStream`](crate::AddressStream) |
+//! | `Manifest::read`, `ManifestBuilder::put_file` | [`Reader::get`](crate::Reader::get) plus the file pipeline |
+//! | `ManifestIter` | [`Cursor`](crate::Cursor) |
+//! | `ManifestBuilder` | [`ManifestEditor`](crate::ManifestEditor) |
+
+#![allow(deprecated)]
+
+mod builder;
+mod manifest;
+mod node;
+
+pub use builder::ManifestBuilder;
+pub use manifest::{DEFAULT_LIST_CONCURRENCY, Manifest, ManifestIter};

--- a/crates/mantaray/src/legacy/node.rs
+++ b/crates/mantaray/src/legacy/node.rs
@@ -1,0 +1,321 @@
+//! Trie traversal and save machinery serving only the deprecated
+//! [`Manifest`](super::manifest::Manifest) surface; removed with it.
+
+use bytes::Bytes;
+use nectar_primitives::chunk::{ChunkOps, ContentChunk, Reference};
+use nectar_primitives::store::{ChunkPut, TrustedGet};
+use nectar_primitives::{AnyChunkSet, Chunk};
+
+use crate::error::{MantarayError, Result};
+use crate::node::{Node, NodeState, StoredReference, common_prefix_len};
+
+impl<R: Reference> Node<R> {
+    /// Look up the node at the given path, loading from storage as needed.
+    #[allow(clippy::indexing_slicing)] // `rest` is checked non-empty before `rest[0]`; `c <= rest.len()` from common_prefix_len
+    pub(crate) async fn lookup_node<S: TrustedGet<AnyChunkSet<BS>>, const BS: usize>(
+        &mut self,
+        path: &[u8],
+        store: &S,
+    ) -> Result<&mut Self> {
+        // Iterative descent: reborrow `current` to the chosen child each step.
+        let mut current = self;
+        let mut rest = path;
+        loop {
+            current.ensure_loaded(store).await?;
+
+            if rest.is_empty() {
+                return Ok(current);
+            }
+
+            let first = rest[0];
+            let reference = current.reference().map(|r| *r.address());
+            let fork = current
+                .forks
+                .get_mut(&first)
+                .ok_or(MantarayError::NoForkFound { reference })?;
+
+            let c = common_prefix_len(&fork.prefix, rest);
+            if c != fork.prefix.len() {
+                return Err(MantarayError::NoForkFound { reference });
+            }
+
+            current = &mut fork.node;
+            rest = &rest[c..];
+        }
+    }
+
+    /// Resolve the node at `path` over owned clones, loading on demand.
+    ///
+    /// Shared-read counterpart to [`lookup_node`](Self::lookup_node): borrows
+    /// `&self` and clones each descended fork, so reading a persisted manifest
+    /// leaves the trie untouched. Returns `None` for an absent path.
+    #[allow(clippy::indexing_slicing)] // `rest` is checked non-empty before `rest[0]`; `c <= rest.len()` from common_prefix_len
+    pub(crate) async fn get_node<S: TrustedGet<AnyChunkSet<BS>>, const BS: usize>(
+        &self,
+        path: &[u8],
+        store: &S,
+    ) -> Result<Option<Self>> {
+        let mut current = self.clone();
+        let mut rest = path;
+        loop {
+            current.ensure_loaded(store).await?;
+
+            if rest.is_empty() {
+                return Ok(Some(current));
+            }
+
+            let first = rest[0];
+            let Some(fork) = current.forks.get(&first) else {
+                return Ok(None);
+            };
+
+            let c = common_prefix_len(&fork.prefix, rest);
+            if c != fork.prefix.len() {
+                return Ok(None);
+            }
+
+            let child = fork.node.clone();
+            rest = &rest[c..];
+            current = child;
+        }
+    }
+
+    /// Look up the entry at the given path, loading from storage as needed.
+    #[cfg(test)]
+    pub(crate) async fn lookup<S: TrustedGet<AnyChunkSet<BS>>, const BS: usize>(
+        &mut self,
+        path: &[u8],
+        store: &S,
+    ) -> Result<Option<&R>> {
+        let node = self.lookup_node(path, store).await?;
+        if !node.is_value() && !path.is_empty() {
+            return Err(MantarayError::NoEntryFound {
+                reference: node.reference().map(|r| *r.address()),
+            });
+        }
+        Ok(node.entry.as_ref())
+    }
+
+    /// Test whether a prefix exists in the trie, loading from storage as needed.
+    #[allow(clippy::indexing_slicing)] // `rest` is checked non-empty before `rest[0]`; `c <= rest.len()` from common_prefix_len
+    pub(crate) async fn has_prefix<S: TrustedGet<AnyChunkSet<BS>>, const BS: usize>(
+        &mut self,
+        path: &[u8],
+        store: &S,
+    ) -> Result<bool> {
+        // Iterative descent: reborrow `current` to the chosen child each step.
+        let mut current = self;
+        let mut rest = path;
+        loop {
+            if rest.is_empty() {
+                return Ok(true);
+            }
+
+            current.ensure_loaded(store).await?;
+
+            let fork = match current.forks.get_mut(&rest[0]) {
+                Some(f) => f,
+                None => return Ok(false),
+            };
+
+            let c = common_prefix_len(&fork.prefix, rest);
+
+            if c == fork.prefix.len() {
+                current = &mut fork.node;
+                rest = &rest[c..];
+                continue;
+            }
+
+            if fork.prefix.starts_with(rest) {
+                return Ok(true);
+            }
+
+            return Ok(false);
+        }
+    }
+
+    /// Save this node and all children to storage in post-order.
+    ///
+    /// Uses BMT content-addressing via `ContentChunk`. An explicit stack avoids
+    /// recursion: each frame visits its forks (pushing unsaved children) before
+    /// the node itself is encoded and put.
+    #[allow(clippy::arithmetic_side_effects)] // the only arithmetic is the fork-cursor `key_idx += 1`, bounded by keys.len() <= 256
+    pub(crate) async fn save<S: ChunkPut<AnyChunkSet<BS>>, const BS: usize>(
+        &mut self,
+        store: &S,
+    ) -> Result<()>
+    where
+        R: StoredReference,
+    {
+        if self.reference().is_some() {
+            return Ok(());
+        }
+
+        struct SaveFrame<R: Reference> {
+            /// Node owned by an ancestor's fork map, valid for this call.
+            node: *mut Node<R>,
+            /// Fork keys still to descend into.
+            keys: Vec<u8>,
+            /// Index into `keys`.
+            key_idx: usize,
+        }
+
+        let mut stack: Vec<SaveFrame<R>> = vec![SaveFrame {
+            node: core::ptr::from_mut(self),
+            keys: self.forks.keys().copied().collect(),
+            key_idx: 0,
+        }];
+
+        while let Some(frame) = stack.last_mut() {
+            // SAFETY: every frame's node points into the exclusively borrowed
+            // trie. Children are only pushed once, then their parent waits in
+            // the stack below them, so no two frames alias the same node.
+            let node = unsafe { &mut *frame.node };
+
+            if frame.key_idx < frame.keys.len() {
+                #[allow(clippy::indexing_slicing)] // key_idx < keys.len() checked above
+                let key = frame.keys[frame.key_idx];
+                frame.key_idx += 1;
+                #[allow(clippy::expect_used)]
+                // key was collected from this node's fork map, which is not mutated while the frame is live
+                let child = node.forks.get_mut(&key).expect("key from this node");
+                if child.node.reference().is_none() {
+                    let child_ptr = core::ptr::from_mut(&mut child.node);
+                    let child_keys = child.node.forks.keys().copied().collect();
+                    stack.push(SaveFrame {
+                        node: child_ptr,
+                        keys: child_keys,
+                        key_idx: 0,
+                    });
+                }
+                continue;
+            }
+
+            // All children saved; encode and put this node, then pop.
+            let data = node.encode()?;
+            let chunk = ContentChunk::<BS>::new(Bytes::from(data))?;
+            let address = *chunk.address();
+            let sealed: Chunk<_, AnyChunkSet<BS>> = Chunk::from_envelope(chunk.into())?;
+            store
+                .put(sealed)
+                .await
+                .map_err(|e| MantarayError::StorePut {
+                    source: alloc::sync::Arc::new(e),
+                })?;
+            // Persist the reference and drop the now-redundant forks: the node
+            // becomes a stub, reloaded on demand.
+            node.state = NodeState::Stub(R::from_stored(address));
+            node.forks.clear();
+            stack.pop();
+        }
+
+        Ok(())
+    }
+
+    /// Walk all nodes depth-first, calling `f` for each node with its path.
+    pub(crate) async fn walk<S: TrustedGet<AnyChunkSet<BS>>, const BS: usize, F>(
+        &mut self,
+        store: &S,
+        f: &mut F,
+    ) -> Result<()>
+    where
+        F: FnMut(&[u8], &Self) -> Result<()>,
+    {
+        let mut path_buf = Vec::new();
+        walk_inner(&mut path_buf, self, store, f).await
+    }
+
+    /// Walk the subtree at `root`, calling `f` for each node.
+    pub(crate) async fn walk_from<S: TrustedGet<AnyChunkSet<BS>>, const BS: usize, F>(
+        &mut self,
+        root: &[u8],
+        store: &S,
+        f: &mut F,
+    ) -> Result<()>
+    where
+        F: FnMut(&[u8], &Self) -> Result<()>,
+    {
+        let mut path_buf = root.to_vec();
+        if root.is_empty() {
+            return walk_inner(&mut path_buf, self, store, f).await;
+        }
+
+        let target = self.lookup_node(root, store).await?;
+        walk_inner(&mut path_buf, target, store, f).await
+    }
+}
+
+/// Pre-order DFS visitor over a loaded-on-demand trie via an explicit stack.
+///
+/// The visitor `f` only reads loaded nodes, so it stays a synchronous `FnMut`.
+#[allow(clippy::arithmetic_side_effects)] // the only arithmetic is the fork-cursor `key_idx += 1`, bounded by keys.len() <= 256
+async fn walk_inner<R: Reference, S: TrustedGet<AnyChunkSet<BS>>, const BS: usize, F>(
+    path_buf: &mut Vec<u8>,
+    node: &mut Node<R>,
+    store: &S,
+    f: &mut F,
+) -> Result<()>
+where
+    F: FnMut(&[u8], &Node<R>) -> Result<()>,
+{
+    struct WalkFrame {
+        /// Node visited at this level (raw pointer into the exclusive borrow).
+        node: *mut (),
+        /// Length of `path_buf` before this frame's prefix was appended.
+        path_len_before: usize,
+        /// Sorted fork keys for this node.
+        keys: Vec<u8>,
+        /// Index into `keys`.
+        key_idx: usize,
+    }
+
+    node.ensure_loaded(store).await?;
+    f(path_buf, node)?;
+
+    let mut stack: Vec<WalkFrame> = vec![WalkFrame {
+        node: core::ptr::from_mut(node).cast::<()>(),
+        path_len_before: path_buf.len(),
+        keys: node.forks.keys().copied().collect(),
+        key_idx: 0,
+    }];
+
+    while let Some(frame) = stack.last_mut() {
+        if frame.key_idx >= frame.keys.len() {
+            path_buf.truncate(frame.path_len_before);
+            stack.pop();
+            continue;
+        }
+
+        #[allow(clippy::indexing_slicing)] // key_idx < keys.len() checked above
+        let key = frame.keys[frame.key_idx];
+        frame.key_idx += 1;
+
+        // SAFETY: frame.node points into the exclusively borrowed trie. Each
+        // node appears in exactly one frame and is only dereferenced while at
+        // the top of the stack, so no two live references alias.
+        let parent = unsafe { &mut *frame.node.cast::<Node<R>>() };
+        let reference = parent.reference().map(|r| *r.address());
+        let fork = parent
+            .forks
+            .get_mut(&key)
+            .ok_or(MantarayError::NoForkFound { reference })?;
+
+        let prev_len = path_buf.len();
+        path_buf.extend_from_slice(&fork.prefix);
+
+        let child = &mut fork.node;
+        child.ensure_loaded(store).await?;
+        f(path_buf, child)?;
+
+        let child_ptr = core::ptr::from_mut(child).cast::<()>();
+        let child_keys = child.forks.keys().copied().collect();
+        stack.push(WalkFrame {
+            node: child_ptr,
+            path_len_before: prev_len,
+            keys: child_keys,
+            key_idx: 0,
+        });
+    }
+
+    Ok(())
+}

--- a/crates/mantaray/src/lib.rs
+++ b/crates/mantaray/src/lib.rs
@@ -8,43 +8,39 @@
 //! It supports XOR obfuscation, versioned binary serialization (v0.1 and v0.2),
 //! and metadata per path.
 //!
-//! # Efficient Partial Updates
+//! # Streaming Surface
 //!
-//! The trie uses lazy loading and dirty-reference tracking so that updating a
-//! single path in a million-entry manifest only re-serializes O(depth) nodes:
+//! Three complementary handles over a typed chunk store cover the manifest
+//! lifecycle:
 //!
-//! 1. [`Manifest::add`] lazily loads only the affected path branch.
-//! 2. Modified nodes have their reference cleared (dirty flag).
-//! 3. [`Manifest::save`] skips nodes with non-empty references (unmodified).
-//! 4. After save, child forks are dropped from memory.
-//! 5. The next operation lazily reloads from the new state.
-//!
-//! # Unified Store
-//!
-//! Manifest operations use the async typed chunk store traits from
-//! `nectar_primitives`: [`ChunkGet`](nectar_primitives::store::ChunkGet) for
-//! loading and [`ChunkPut`](nectar_primitives::store::ChunkPut) for saving.
-//! This means a single [`MemoryStore`] can hold both file chunks and manifest
-//! trie nodes.
+//! - [`Reader`]: depth-guarded point lookups ([`Reader::get`],
+//!   [`Reader::has_prefix`]) with `Ok(None)` on a miss.
+//! - [`Cursor`] and [`AddressStream`]: ordered listing with bounded
+//!   read-ahead.
+//! - [`ManifestEditor`]: records puts and removes, then commits them in
+//!   submission order with a bounded number of puts in flight.
 //!
 //! ```no_run
-//! # use nectar_mantaray::{PlainManifest, Entry, DefaultMemoryStore};
-//! let store = DefaultMemoryStore::new();
-//! let mut manifest: PlainManifest<_> = PlainManifest::new(store);
+//! # use nectar_mantaray::{ManifestEditor, DefaultMemoryStore};
+//! let mut editor: ManifestEditor<_> = ManifestEditor::new(DefaultMemoryStore::new());
 //! ```
+//!
+//! The store traits come from `nectar_primitives` ([`ChunkGet`],
+//! [`ChunkPut`]), so a single [`MemoryStore`] can hold both file chunks and
+//! manifest trie nodes.
+//!
+//! The former lazy-trie surface lives in [`legacy`] with a migration table;
+//! its removal is gated on the manifest 1.0 key-value store replacing it.
 //!
 //! # Website Manifests
 //!
 //! Configure index and error documents for Swarm-hosted websites:
 //!
 //! ```no_run
-//! # use nectar_mantaray::{PlainManifest, Entry, metadata, DefaultMemoryStore};
-//! # let store = DefaultMemoryStore::new();
-//! # let mut manifest = PlainManifest::new(store);
-//! # futures::executor::block_on(async {
-//! manifest.set_index_document("index.html").await.unwrap();
-//! manifest.set_error_document("404.html").await.unwrap();
-//! # });
+//! # use nectar_mantaray::{ManifestEditor, DefaultMemoryStore};
+//! let mut editor: ManifestEditor<_> = ManifestEditor::new(DefaultMemoryStore::new());
+//! editor.set_index_document("index.html");
+//! editor.set_error_document("404.html");
 //! ```
 //!
 //! # Metadata Constants
@@ -58,15 +54,14 @@
 //!
 //! # Raw encode containment
 //!
-//! Node bytes are produced only inside [`Manifest::save`] and consumed only
-//! on load; a node handed out by [`Manifest::root`], [`Manifest::walk`], or
-//! [`Manifest::into_parts`] carries no public encode:
+//! Node bytes are produced only inside a save or commit and consumed only on
+//! load; no public handle carries an encode:
 //!
 //! ```compile_fail
-//! use nectar_mantaray::{DefaultMemoryStore, PlainManifest};
+//! use nectar_mantaray::{DefaultMemoryStore, ManifestEditor};
 //!
-//! let manifest: PlainManifest<_> = PlainManifest::new(DefaultMemoryStore::new());
-//! let bytes: Vec<u8> = Vec::try_from(manifest.root()).unwrap();
+//! let editor: ManifestEditor<_> = ManifestEditor::new(DefaultMemoryStore::new());
+//! let bytes: Vec<u8> = Vec::try_from(editor).unwrap();
 //! ```
 //!
 //! The raw node internals exist only under the `hazmat` feature, for fuzz
@@ -91,6 +86,8 @@
 //! number should be removed. Run `git grep -n BEE-WORKAROUND` to enumerate
 //! them.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(
     test,
     allow(
@@ -105,46 +102,83 @@
         clippy::panic_in_result_fn
     )
 )]
+// The in-crate tests drive the deprecated legacy surface as the differential
+// oracle for the streaming modules.
+#![cfg_attr(test, allow(deprecated))]
 
 // `alloc` backs the fork maps (`BTreeMap`) and shared error sources (`Arc`).
-// `nectar-primitives`, a hard dependency, already requires an allocator.
+// `nectar-primitives`, a hard dependency of the trie modules, already
+// requires an allocator.
+#[cfg(feature = "std")]
 extern crate alloc;
 
+#[cfg(feature = "std")]
 use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
+#[cfg(feature = "std")]
 use nectar_primitives::chunk::ChunkRef;
 
-pub mod builder;
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod codec;
 mod constants;
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod cursor;
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod editor;
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod entry;
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod error;
+#[cfg(feature = "std")]
 mod format;
-pub mod manifest;
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+#[deprecated(note = "superseded by Reader, Cursor, and ManifestEditor")]
+pub mod legacy;
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod manifest_ref;
+#[cfg(feature = "std")]
 mod node;
 pub mod obfuscation;
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod reader;
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod view;
 
 // Re-export constants.
 pub use constants::metadata;
+#[cfg(feature = "std")]
 pub(crate) use constants::*;
 
 // Re-export public types.
-pub use builder::ManifestBuilder;
+#[cfg(feature = "std")]
 pub use cursor::{AddressStream, Cursor, Window};
+#[cfg(feature = "std")]
 pub use editor::{DEFAULT_PUT_WIDTH, ManifestEditor, Op};
+#[cfg(feature = "std")]
 pub use entry::Entry;
+#[cfg(feature = "std")]
 pub use error::{
     CursorError, DecodeError, DecodeResult, EditorError, MantarayError, ReaderError, Result,
 };
-pub use manifest::{Manifest, ManifestIter};
+#[allow(deprecated)]
+#[cfg(feature = "std")]
+pub use legacy::{DEFAULT_LIST_CONCURRENCY, Manifest, ManifestBuilder, ManifestIter};
+#[cfg(feature = "std")]
 pub use manifest_ref::ManifestRef;
+#[cfg(feature = "std")]
 pub use node::NodeType;
 pub use obfuscation::ObfuscationKey;
+#[cfg(feature = "std")]
 pub use reader::{DEFAULT_MAX_DEPTH, Reader};
+#[cfg(feature = "std")]
 pub use view::{ForkView, NodeView, RefWidth, Version};
 
 /// Raw node internals for fuzz harnesses and benches only.
@@ -171,15 +205,26 @@ pub mod hazmat {
 }
 
 // Re-export typed storage traits from primitives.
+#[cfg(feature = "std")]
 pub use nectar_primitives::DefaultMemoryStore;
+#[cfg(feature = "std")]
 pub use nectar_primitives::store::{ChunkGet, ChunkHas, ChunkPut, MemoryStore, TrustedGet};
 
 /// Default manifest type using [`DEFAULT_BODY_SIZE`] and plain mode.
+#[allow(deprecated)]
+#[deprecated(note = "superseded by ManifestEditor and Reader")]
+#[cfg(feature = "std")]
 pub type DefaultManifest<S> = PlainManifest<S, DEFAULT_BODY_SIZE>;
 
 /// Plain manifest: 32-byte refs, no obfuscation.
+#[allow(deprecated)]
+#[deprecated(note = "superseded by ManifestEditor and Reader")]
+#[cfg(feature = "std")]
 pub type PlainManifest<S, const BS: usize = DEFAULT_BODY_SIZE> = Manifest<S, ChunkRef, BS>;
 
 /// Encrypted manifest: 64-byte refs, random obfuscation key.
+#[allow(deprecated)]
+#[deprecated(note = "superseded by ManifestEditor and Reader")]
+#[cfg(feature = "std")]
 pub type EncryptedManifest<S, const BS: usize = DEFAULT_BODY_SIZE> =
     Manifest<S, nectar_primitives::EncryptedChunkRef, BS>;

--- a/crates/mantaray/src/node.rs
+++ b/crates/mantaray/src/node.rs
@@ -7,11 +7,10 @@ use core::pin::Pin;
 use crate::error::{DecodeError, DecodeResult, MantarayError, Result};
 use crate::obfuscation::ObfuscationKey;
 use crate::{PATH_SEPARATOR, PREFIX_MAX_LEN};
-use bytes::Bytes;
-use nectar_primitives::chunk::{ChunkAddress, ChunkOps, ChunkRef, ContentChunk, Reference};
-use nectar_primitives::store::{ChunkPut, MaybeSend, TrustedGet};
+use nectar_primitives::chunk::{ChunkAddress, ChunkOps, ChunkRef, Reference};
+use nectar_primitives::store::{MaybeSend, TrustedGet};
 use nectar_primitives::wire::{Cursor, FromCursor, ToWriter, Writer};
-use nectar_primitives::{AnyChunkSet, Chunk, EncryptedChunkRef, EncryptionKey};
+use nectar_primitives::{AnyChunkSet, EncryptedChunkRef, EncryptionKey};
 
 /// Boxed recursion future: `Send` on native, unbounded on wasm32 so `!Send`
 /// browser stores stay usable. `MaybeSend` cannot appear in a `dyn` bound
@@ -278,7 +277,7 @@ impl<R: Reference> Fork<R> {
 }
 
 /// Return the length of the common prefix of two byte slices.
-fn common_prefix_len(a: &[u8], b: &[u8]) -> usize {
+pub(crate) fn common_prefix_len(a: &[u8], b: &[u8]) -> usize {
     a.iter().zip(b.iter()).take_while(|(x, y)| x == y).count()
 }
 
@@ -397,7 +396,7 @@ impl<R: Reference> Node<R> {
     }
 
     /// Load forks from storage if the node hasn't been loaded yet.
-    async fn ensure_loaded<S: TrustedGet<AnyChunkSet<BS>>, const BS: usize>(
+    pub(crate) async fn ensure_loaded<S: TrustedGet<AnyChunkSet<BS>>, const BS: usize>(
         &mut self,
         store: &S,
     ) -> Result<()> {
@@ -434,92 +433,6 @@ impl<R: Reference> Node<R> {
         loaded.metadata = core::mem::take(&mut self.metadata);
         *self = loaded;
         Ok(())
-    }
-
-    /// Look up the node at the given path, loading from storage as needed.
-    #[allow(clippy::indexing_slicing)] // `rest` is checked non-empty before `rest[0]`; `c <= rest.len()` from common_prefix_len
-    pub(crate) async fn lookup_node<S: TrustedGet<AnyChunkSet<BS>>, const BS: usize>(
-        &mut self,
-        path: &[u8],
-        store: &S,
-    ) -> Result<&mut Self> {
-        // Iterative descent: reborrow `current` to the chosen child each step.
-        let mut current = self;
-        let mut rest = path;
-        loop {
-            current.ensure_loaded(store).await?;
-
-            if rest.is_empty() {
-                return Ok(current);
-            }
-
-            let first = rest[0];
-            let reference = current.reference().map(|r| *r.address());
-            let fork = current
-                .forks
-                .get_mut(&first)
-                .ok_or(MantarayError::NoForkFound { reference })?;
-
-            let c = common_prefix_len(&fork.prefix, rest);
-            if c != fork.prefix.len() {
-                return Err(MantarayError::NoForkFound { reference });
-            }
-
-            current = &mut fork.node;
-            rest = &rest[c..];
-        }
-    }
-
-    /// Resolve the node at `path` over owned clones, loading on demand.
-    ///
-    /// Shared-read counterpart to [`lookup_node`](Self::lookup_node): borrows
-    /// `&self` and clones each descended fork, so reading a persisted manifest
-    /// leaves the trie untouched. Returns `None` for an absent path.
-    #[allow(clippy::indexing_slicing)] // `rest` is checked non-empty before `rest[0]`; `c <= rest.len()` from common_prefix_len
-    pub(crate) async fn get_node<S: TrustedGet<AnyChunkSet<BS>>, const BS: usize>(
-        &self,
-        path: &[u8],
-        store: &S,
-    ) -> Result<Option<Self>> {
-        let mut current = self.clone();
-        let mut rest = path;
-        loop {
-            current.ensure_loaded(store).await?;
-
-            if rest.is_empty() {
-                return Ok(Some(current));
-            }
-
-            let first = rest[0];
-            let Some(fork) = current.forks.get(&first) else {
-                return Ok(None);
-            };
-
-            let c = common_prefix_len(&fork.prefix, rest);
-            if c != fork.prefix.len() {
-                return Ok(None);
-            }
-
-            let child = fork.node.clone();
-            rest = &rest[c..];
-            current = child;
-        }
-    }
-
-    /// Look up the entry at the given path, loading from storage as needed.
-    #[cfg(test)]
-    pub(crate) async fn lookup<S: TrustedGet<AnyChunkSet<BS>>, const BS: usize>(
-        &mut self,
-        path: &[u8],
-        store: &S,
-    ) -> Result<Option<&R>> {
-        let node = self.lookup_node(path, store).await?;
-        if !node.is_value() && !path.is_empty() {
-            return Err(MantarayError::NoEntryFound {
-                reference: node.reference().map(|r| *r.address()),
-            });
-        }
-        Ok(node.entry.as_ref())
     }
 
     /// Add an entry at the given path with optional metadata, loading from storage as needed.
@@ -714,229 +627,6 @@ impl<R: Reference> Node<R> {
             result
         })
     }
-
-    /// Test whether a prefix exists in the trie, loading from storage as needed.
-    #[allow(clippy::indexing_slicing)] // `rest` is checked non-empty before `rest[0]`; `c <= rest.len()` from common_prefix_len
-    pub(crate) async fn has_prefix<S: TrustedGet<AnyChunkSet<BS>>, const BS: usize>(
-        &mut self,
-        path: &[u8],
-        store: &S,
-    ) -> Result<bool> {
-        // Iterative descent: reborrow `current` to the chosen child each step.
-        let mut current = self;
-        let mut rest = path;
-        loop {
-            if rest.is_empty() {
-                return Ok(true);
-            }
-
-            current.ensure_loaded(store).await?;
-
-            let fork = match current.forks.get_mut(&rest[0]) {
-                Some(f) => f,
-                None => return Ok(false),
-            };
-
-            let c = common_prefix_len(&fork.prefix, rest);
-
-            if c == fork.prefix.len() {
-                current = &mut fork.node;
-                rest = &rest[c..];
-                continue;
-            }
-
-            if fork.prefix.starts_with(rest) {
-                return Ok(true);
-            }
-
-            return Ok(false);
-        }
-    }
-
-    /// Save this node and all children to storage in post-order.
-    ///
-    /// Uses BMT content-addressing via `ContentChunk`. An explicit stack avoids
-    /// recursion: each frame visits its forks (pushing unsaved children) before
-    /// the node itself is encoded and put.
-    #[allow(clippy::arithmetic_side_effects)] // the only arithmetic is the fork-cursor `key_idx += 1`, bounded by keys.len() <= 256
-    pub(crate) async fn save<S: ChunkPut<AnyChunkSet<BS>>, const BS: usize>(
-        &mut self,
-        store: &S,
-    ) -> Result<()>
-    where
-        R: StoredReference,
-    {
-        if self.reference().is_some() {
-            return Ok(());
-        }
-
-        struct SaveFrame<R: Reference> {
-            /// Node owned by an ancestor's fork map, valid for this call.
-            node: *mut Node<R>,
-            /// Fork keys still to descend into.
-            keys: Vec<u8>,
-            /// Index into `keys`.
-            key_idx: usize,
-        }
-
-        let mut stack: Vec<SaveFrame<R>> = vec![SaveFrame {
-            node: core::ptr::from_mut(self),
-            keys: self.forks.keys().copied().collect(),
-            key_idx: 0,
-        }];
-
-        while let Some(frame) = stack.last_mut() {
-            // SAFETY: every frame's node points into the exclusively borrowed
-            // trie. Children are only pushed once, then their parent waits in
-            // the stack below them, so no two frames alias the same node.
-            let node = unsafe { &mut *frame.node };
-
-            if frame.key_idx < frame.keys.len() {
-                #[allow(clippy::indexing_slicing)] // key_idx < keys.len() checked above
-                let key = frame.keys[frame.key_idx];
-                frame.key_idx += 1;
-                #[allow(clippy::expect_used)]
-                // key was collected from this node's fork map, which is not mutated while the frame is live
-                let child = node.forks.get_mut(&key).expect("key from this node");
-                if child.node.reference().is_none() {
-                    let child_ptr = core::ptr::from_mut(&mut child.node);
-                    let child_keys = child.node.forks.keys().copied().collect();
-                    stack.push(SaveFrame {
-                        node: child_ptr,
-                        keys: child_keys,
-                        key_idx: 0,
-                    });
-                }
-                continue;
-            }
-
-            // All children saved; encode and put this node, then pop.
-            let data = node.encode()?;
-            let chunk = ContentChunk::<BS>::new(Bytes::from(data))?;
-            let address = *chunk.address();
-            let sealed: Chunk<_, AnyChunkSet<BS>> = Chunk::from_envelope(chunk.into())?;
-            store
-                .put(sealed)
-                .await
-                .map_err(|e| MantarayError::StorePut {
-                    source: alloc::sync::Arc::new(e),
-                })?;
-            // Persist the reference and drop the now-redundant forks: the node
-            // becomes a stub, reloaded on demand.
-            node.state = NodeState::Stub(R::from_stored(address));
-            node.forks.clear();
-            stack.pop();
-        }
-
-        Ok(())
-    }
-
-    /// Walk all nodes depth-first, calling `f` for each node with its path.
-    pub(crate) async fn walk<S: TrustedGet<AnyChunkSet<BS>>, const BS: usize, F>(
-        &mut self,
-        store: &S,
-        f: &mut F,
-    ) -> Result<()>
-    where
-        F: FnMut(&[u8], &Self) -> Result<()>,
-    {
-        let mut path_buf = Vec::new();
-        walk_inner(&mut path_buf, self, store, f).await
-    }
-
-    /// Walk the subtree at `root`, calling `f` for each node.
-    pub(crate) async fn walk_from<S: TrustedGet<AnyChunkSet<BS>>, const BS: usize, F>(
-        &mut self,
-        root: &[u8],
-        store: &S,
-        f: &mut F,
-    ) -> Result<()>
-    where
-        F: FnMut(&[u8], &Self) -> Result<()>,
-    {
-        let mut path_buf = root.to_vec();
-        if root.is_empty() {
-            return walk_inner(&mut path_buf, self, store, f).await;
-        }
-
-        let target = self.lookup_node(root, store).await?;
-        walk_inner(&mut path_buf, target, store, f).await
-    }
-}
-
-/// Pre-order DFS visitor over a loaded-on-demand trie via an explicit stack.
-///
-/// The visitor `f` only reads loaded nodes, so it stays a synchronous `FnMut`.
-#[allow(clippy::arithmetic_side_effects)] // the only arithmetic is the fork-cursor `key_idx += 1`, bounded by keys.len() <= 256
-async fn walk_inner<R: Reference, S: TrustedGet<AnyChunkSet<BS>>, const BS: usize, F>(
-    path_buf: &mut Vec<u8>,
-    node: &mut Node<R>,
-    store: &S,
-    f: &mut F,
-) -> Result<()>
-where
-    F: FnMut(&[u8], &Node<R>) -> Result<()>,
-{
-    struct WalkFrame {
-        /// Node visited at this level (raw pointer into the exclusive borrow).
-        node: *mut (),
-        /// Length of `path_buf` before this frame's prefix was appended.
-        path_len_before: usize,
-        /// Sorted fork keys for this node.
-        keys: Vec<u8>,
-        /// Index into `keys`.
-        key_idx: usize,
-    }
-
-    node.ensure_loaded(store).await?;
-    f(path_buf, node)?;
-
-    let mut stack: Vec<WalkFrame> = vec![WalkFrame {
-        node: core::ptr::from_mut(node).cast::<()>(),
-        path_len_before: path_buf.len(),
-        keys: node.forks.keys().copied().collect(),
-        key_idx: 0,
-    }];
-
-    while let Some(frame) = stack.last_mut() {
-        if frame.key_idx >= frame.keys.len() {
-            path_buf.truncate(frame.path_len_before);
-            stack.pop();
-            continue;
-        }
-
-        #[allow(clippy::indexing_slicing)] // key_idx < keys.len() checked above
-        let key = frame.keys[frame.key_idx];
-        frame.key_idx += 1;
-
-        // SAFETY: frame.node points into the exclusively borrowed trie. Each
-        // node appears in exactly one frame and is only dereferenced while at
-        // the top of the stack, so no two live references alias.
-        let parent = unsafe { &mut *frame.node.cast::<Node<R>>() };
-        let reference = parent.reference().map(|r| *r.address());
-        let fork = parent
-            .forks
-            .get_mut(&key)
-            .ok_or(MantarayError::NoForkFound { reference })?;
-
-        let prev_len = path_buf.len();
-        path_buf.extend_from_slice(&fork.prefix);
-
-        let child = &mut fork.node;
-        child.ensure_loaded(store).await?;
-        f(path_buf, child)?;
-
-        let child_ptr = core::ptr::from_mut(child).cast::<()>();
-        let child_keys = child.forks.keys().copied().collect();
-        stack.push(WalkFrame {
-            node: child_ptr,
-            path_len_before: prev_len,
-            keys: child_keys,
-            key_idx: 0,
-        });
-    }
-
-    Ok(())
 }
 
 /// `Arbitrary` implementations that generate *valid* mantaray values: every
@@ -1064,10 +754,13 @@ mod arbitrary_impls {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use nectar_primitives::StandardChunkSet;
+    use bytes::Bytes;
     use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
-    use nectar_primitives::store::{MemoryStore, NullLoader};
+    use nectar_primitives::chunk::ContentChunk;
+    use nectar_primitives::store::{ChunkPut, MemoryStore, NullLoader};
+    use nectar_primitives::{Chunk, StandardChunkSet};
+
+    use super::*;
 
     struct TestCase {
         _name: &'static str,

--- a/crates/mantaray/src/obfuscation.rs
+++ b/crates/mantaray/src/obfuscation.rs
@@ -17,7 +17,8 @@ impl ObfuscationKey {
     }
 
     /// Generate a random obfuscation key.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "rand")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
     pub fn generate() -> Self {
         use rand::RngExt;
         let mut bytes = [0u8; 32];


### PR DESCRIPTION
## What

- Flips `nectar-mantaray` toward `no_std`: `crates/mantaray/src/lib.rs` gains `cfg_attr(not(feature = "std"), no_std)` plus `docsrs` `doc_cfg` attributes.
- Reworks `Cargo.toml` so primitives-dependent deps are optional and ride a `std` feature (mirroring `nectar-file`, since `nectar-primitives` does not yet build bare-metal).
- Adds a `rand` feature (`dep:rand`, implies `std`; `default = [rand, std]`) gating `ObfuscationKey::generate` and the new `new_encrypted` constructors on `Manifest`, `ManifestBuilder`, and `ManifestEditor`.
- Moves `manifest.rs` and `builder.rs` to `src/legacy/` (git renames) and adds `src/legacy/node.rs`, holding the `Manifest`-only `Node` machinery (`lookup_node`, `get_node`, `lookup`, `has_prefix`, `save`).
- Adds `nectar-mantaray` to the rv64/wasm32 lanes in `.github/workflows/nostd.yml`.
- Fixes a pre-existing `-p nectar-mantaray` package-spec ambiguity (against the `mantaray-old` 0.3.0 differential dev-dep) in `nostd.yml` and `lint.yml`.

## Why

The bare no_std surface is `constants::metadata` plus `ObfuscationKey`; everything else stays behind `std`/`rand` so downstream no_std consumers can pull in only what they need, and legacy `Manifest` node machinery is fenced off from the production `Reader`/`Cursor`/editor path.

Closes #346

## Testing

- no_std builds clean on riscv64 and wasm32.
- `rand` feature gating verified complete; plain `--features std` builds without `rand`.
- zepter, clippy, rustdoc, and the 177-test suite all pass.
- CI package-spec fix verified with the exact CI commands via `act`.

## AI Assistance

Implementation: Fable. Review: Opus. PR: Sonnet.

