### PR TITLE
feat(file): add rayon batch ingest over read-at sources

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,6 +34,10 @@ jobs:
             # default-features pass above.
             - name: cargo clippy (tokio adapters)
               run: cargo clippy --locked -p nectar-file --features tokio
+            # The batch ingest sits behind the rayon feature, likewise
+            # outside the default-features pass.
+            - name: cargo clippy (rayon ingest)
+              run: cargo clippy --locked -p nectar-file --features rayon
             # `unused_crate_dependencies` is enforced per-library via `cargo
             # rustc` (not `[workspace.lints]`) so the flag applies only to each
             # crate's own lib target — never to benches/examples/tests (which

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -49,6 +49,15 @@ jobs:
                     --no-tests=warn --no-fail-fast
             - name: Run tokio adapter doctests
               run: cargo test --doc -p nectar-file --features tokio --locked
+            # The batch ingest is likewise feature-gated off the default
+            # build; cover its tests and doctest here.
+            - name: Run rayon ingest tests
+              run: |
+                  cargo nextest run \
+                    -p nectar-file --features rayon --locked \
+                    --no-tests=warn --no-fail-fast
+            - name: Run rayon ingest doctests
+              run: cargo test --doc -p nectar-file --features rayon --locked
 
     wasm:
         # The postage-usage client facade is meant to run in a browser. The

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2066,6 +2066,7 @@ dependencies = [
  "futures",
  "futures-util",
  "nectar-primitives",
+ "rayon",
  "thiserror",
  "tokio",
 ]

--- a/crates/file/Cargo.toml
+++ b/crates/file/Cargo.toml
@@ -62,6 +62,8 @@ encryption = [ "nectar-primitives?/encryption" ]
 # lockstep with the primitives store traits.
 unsync = [ "nectar-primitives?/unsync" ]
 
+# `rayon` and `unsync` are mutually exclusive, so the doc build lists
+# features explicitly rather than enabling all at once.
 [package.metadata.docs.rs]
-all-features = true
+features = ["std", "tokio", "rayon", "encryption"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/file/Cargo.toml
+++ b/crates/file/Cargo.toml
@@ -21,6 +21,7 @@ workspace = true
 bytes = { workspace = true, optional = true }
 futures-util = { workspace = true, optional = true }
 nectar-primitives = { workspace = true, optional = true }
+rayon = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"], optional = true }
 
@@ -50,9 +51,9 @@ std = [
 # Async reader and writer adapters over the poll surface. Implies `std`.
 tokio = [ "dep:tokio", "std" ]
 
-# Batch leaf hashing and read-at ingest. Implies `std`; rayon on wasm32 is a
-# compile error, never a silent fallback.
-rayon = [ "std" ]
+# Batch leaf hashing and read-at ingest. Implies `std`; rayon on wasm32 or
+# under `unsync` is a compile error, never a silent fallback.
+rayon = [ "dep:rayon", "std" ]
 
 # Split-side encrypted mode. Joining encrypted references stays unconditional.
 encryption = [ "nectar-primitives?/encryption" ]

--- a/crates/file/src/lib.rs
+++ b/crates/file/src/lib.rs
@@ -7,8 +7,9 @@
 //! drains, the poll-native [`split`] engine every write mode feeds, the
 //! [`read`] facade that opens files by either reference width and drains the
 //! walk in file order, the [`sink`] targets a restartable download writes
-//! into, the [`store`] erasure that makes file handles nameable, and the
-//! [`sync`] driver for Ready-only guests.
+//! into, the [`store`] erasure that makes file handles nameable, the
+//! [`sync`] driver for Ready-only guests, and the `parallel` batch ingest
+//! over a random-access source (behind the `rayon` feature).
 
 #![no_std]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
@@ -35,10 +36,23 @@ extern crate alloc;
 #[cfg(any(test, feature = "std"))]
 extern crate std;
 
+#[cfg(all(feature = "rayon", target_arch = "wasm32"))]
+compile_error!("feature `rayon` needs a native thread pool; wasm32 builds must disable it");
+
+#[cfg(all(feature = "rayon", feature = "unsync"))]
+compile_error!("feature `rayon` needs `Send` chunks and errors; it excludes the `unsync` escape");
+
 pub mod config;
 pub mod geometry;
 #[cfg(feature = "std")]
 mod num;
+#[cfg(all(
+    feature = "rayon",
+    not(target_arch = "wasm32"),
+    not(feature = "unsync")
+))]
+#[cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
+pub mod parallel;
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod read;
@@ -66,6 +80,12 @@ pub use self::tokio::SpawnedReader;
 pub use self::tokio::{SeekOverflow, TokioReader};
 pub use config::{BranchBudget, PutWindow, Window};
 pub use geometry::{DEFAULT_BODY_SIZE, Mode, branches, max_depth};
+#[cfg(all(
+    feature = "rayon",
+    not(target_arch = "wasm32"),
+    not(feature = "unsync")
+))]
+pub use parallel::{ReadAt, ReadAtError, split_read_at};
 #[cfg(feature = "std")]
 pub use read::{
     AnyFile, CollectError, DownloadBuilder, DownloadError, File, FileFrames, FileReader,

--- a/crates/file/src/parallel/error.rs
+++ b/crates/file/src/parallel/error.rs
@@ -1,0 +1,86 @@
+//! Typed ingest failures; every error is terminal.
+
+use std::io;
+
+use nectar_primitives::PrimitivesError;
+
+use crate::split::SplitError;
+
+/// Terminal read-at ingest failure.
+#[derive(Debug, thiserror::Error)]
+pub enum ReadAtError<E> {
+    /// Sizing the source failed.
+    #[error("source length unavailable")]
+    Length {
+        /// Io error behind the failure.
+        source: io::Error,
+    },
+    /// Reading a leaf body from the source failed.
+    #[error("read failed at offset {offset}")]
+    Read {
+        /// Offset of the failed read.
+        offset: u64,
+        /// Io error behind the failure.
+        source: io::Error,
+    },
+    /// The source reported its end before a leaf filled.
+    #[error("short read at offset {offset}: {remaining} bytes missing")]
+    ShortRead {
+        /// Offset of the zero-length read.
+        offset: u64,
+        /// Leaf bytes still unread.
+        remaining: usize,
+    },
+    /// The source reported more bytes than the read buffer holds.
+    #[error("read overrun at offset {offset}: {count} bytes into {capacity}")]
+    ReadOverrun {
+        /// Offset of the overlong read.
+        offset: u64,
+        /// Byte count the source reported.
+        count: usize,
+        /// Buffer bytes the read had to fill.
+        capacity: usize,
+    },
+    /// The split ascent failed.
+    #[error(transparent)]
+    Split(#[from] SplitError<E>),
+    /// The pool dropped a batch without replying; a worker died mid-job.
+    #[error("hash pool dropped a batch")]
+    PoolDropped,
+}
+
+/// A failure sealing one leaf on a pool worker; carried across the handoff.
+#[derive(Debug)]
+pub(super) enum LeafError {
+    /// Reading the leaf body failed.
+    Read { offset: u64, source: io::Error },
+    /// The source ended before the leaf filled.
+    Short { offset: u64, remaining: usize },
+    /// The source reported more bytes than the buffer holds.
+    Overrun {
+        offset: u64,
+        count: usize,
+        capacity: usize,
+    },
+    /// Sealing the leaf payload failed.
+    Seal(PrimitivesError),
+}
+
+impl<E> From<LeafError> for ReadAtError<E> {
+    fn from(error: LeafError) -> Self {
+        match error {
+            LeafError::Read { offset, source } => Self::Read { offset, source },
+            LeafError::Short { offset, remaining } => Self::ShortRead { offset, remaining },
+            LeafError::Overrun {
+                offset,
+                count,
+                capacity,
+            } => Self::ReadOverrun {
+                offset,
+                count,
+                capacity,
+            },
+            LeafError::Seal(source) => Self::Split(SplitError::Seal(source)),
+        }
+    }
+}

--- a/crates/file/src/parallel/handoff.rs
+++ b/crates/file/src/parallel/handoff.rs
@@ -1,0 +1,79 @@
+//! Bounded handoff from the thread pool back to the polling future.
+
+use std::sync::{Arc, Mutex, PoisonError};
+
+use core::task::{Context, Poll};
+
+use futures_util::task::AtomicWaker;
+
+/// Reply slot shared between one pool job and its receiver.
+struct Slot<T> {
+    value: Mutex<Option<T>>,
+    waker: AtomicWaker,
+}
+
+impl<T> Slot<T> {
+    /// The slot contents, riding out lock poisoning: the slot holds plain
+    /// data, so a poisoned lock leaves it intact.
+    fn value(&self) -> std::sync::MutexGuard<'_, Option<T>> {
+        self.value.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+/// Receiving half of one submitted job; polled by the ingest future.
+pub(super) struct Handoff<T> {
+    slot: Arc<Slot<T>>,
+}
+
+impl<T> Handoff<T> {
+    /// Ready with the reply, or `None` when the pool dropped the job
+    /// without replying (a worker died mid-job).
+    ///
+    /// The waker is registered before the slot is checked, so a reply
+    /// landing between the two is never missed.
+    pub(super) fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
+        self.slot.waker.register(cx.waker());
+        if let Some(value) = self.slot.value().take() {
+            return Poll::Ready(Some(value));
+        }
+        if Arc::strong_count(&self.slot) == 1 {
+            return Poll::Ready(None);
+        }
+        Poll::Pending
+    }
+}
+
+/// Sending half held by the pool job; waking on drop covers both delivery
+/// and a job that unwinds before replying.
+struct Reply<T> {
+    slot: Arc<Slot<T>>,
+}
+
+impl<T> Drop for Reply<T> {
+    fn drop(&mut self) {
+        self.slot.waker.wake();
+    }
+}
+
+/// Queue `job` on the pool, returning the handoff its reply arrives on.
+///
+/// Submission only enqueues, so neither building nor polling the caller's
+/// future ever blocks on the pool.
+pub(super) fn submit<T, F>(job: F) -> Handoff<T>
+where
+    T: Send + 'static,
+    F: FnOnce() -> T + Send + 'static,
+{
+    let slot = Arc::new(Slot {
+        value: Mutex::new(None),
+        waker: AtomicWaker::new(),
+    });
+    let reply = Reply {
+        slot: Arc::clone(&slot),
+    };
+    rayon::spawn(move || {
+        *reply.slot.value() = Some(job());
+        drop(reply);
+    });
+    Handoff { slot }
+}

--- a/crates/file/src/parallel/handoff.rs
+++ b/crates/file/src/parallel/handoff.rs
@@ -37,7 +37,10 @@ impl<T> Handoff<T> {
             return Poll::Ready(Some(value));
         }
         if Arc::strong_count(&self.slot) == 1 {
-            return Poll::Ready(None);
+            // The reply half is gone, but it may have written its value
+            // before dropping; re-check so that ordering never turns a
+            // delivered batch into a spurious drop.
+            return Poll::Ready(self.slot.value().take());
         }
         Poll::Pending
     }

--- a/crates/file/src/parallel/mod.rs
+++ b/crates/file/src/parallel/mod.rs
@@ -1,0 +1,209 @@
+//! Thread-pool ingest: batch leaf hashing over a random-access source.
+//!
+//! [`split_read_at`] reads and seals leaves in pool-wide batches on the
+//! rayon pool and threads their references through the same bounded ascent
+//! as the streaming split, so roots and chunk sets are identical. Each
+//! batch is one queued pool job, so submission never blocks, and at most
+//! one batch hashes while the previous one drains through the put window:
+//! retained memory stays at two batches of leaf bodies plus the window.
+
+mod error;
+mod handoff;
+mod source;
+#[cfg(test)]
+mod tests;
+
+use alloc::vec;
+use alloc::vec::Vec;
+use core::future::poll_fn;
+use core::task::Poll;
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use nectar_primitives::bmt::SPAN_SIZE;
+use nectar_primitives::chunk::{AnyChunkSet, Chunk, Verified};
+use nectar_primitives::store::ChunkPut;
+use rayon::prelude::*;
+
+pub use error::ReadAtError;
+pub use source::ReadAt;
+
+use self::error::LeafError;
+use self::handoff::Handoff;
+use crate::config::PutWindow;
+use crate::num::u64_from_usize;
+use crate::split::{Split, SplitMode};
+
+/// One leaf sealed on a pool worker, awaiting admission to the ascent.
+struct SealedLeaf<M: SplitMode, const B: usize> {
+    chunk: Chunk<Verified, AnyChunkSet<B>>,
+    reference: M::Ref,
+    span: u64,
+}
+
+/// Split `source` into the tree under `store`, hashing leaves in pool-wide
+/// batches on the rayon pool; the mode `M` picks the reference grammar.
+///
+/// The root and chunk set equal the streaming split of the same bytes.
+/// Dropping the future abandons in-flight puts; a batch already queued on
+/// the pool finishes and is discarded.
+///
+/// ```
+/// use nectar_file::{Plain, PutWindow, split_read_at};
+/// use nectar_primitives::chunk::AnyChunkSet;
+/// use nectar_primitives::store::MemoryStore;
+///
+/// # futures::executor::block_on(async {
+/// let data = vec![7u8; 10_000];
+/// let store = MemoryStore::<AnyChunkSet<4096>>::new();
+/// let root = split_read_at::<_, _, Plain, 4096>(data, store, PutWindow::DEFAULT)
+///     .await
+///     .unwrap();
+/// assert_eq!(root.as_bytes().len(), 32);
+/// # });
+/// ```
+pub async fn split_read_at<R, S, M, const B: usize>(
+    source: R,
+    store: S,
+    window: PutWindow,
+) -> Result<M::Root, ReadAtError<S::Error>>
+where
+    R: ReadAt + Send + Sync + 'static,
+    S: ChunkPut<AnyChunkSet<B>> + Clone + 'static,
+    M: SplitMode,
+    M::Ref: Send,
+{
+    let source = Arc::new(source);
+    let size = source
+        .len()
+        .map_err(|source| ReadAtError::Length { source })?;
+    let mut split = Split::<S, M, B>::new(store, window);
+    let leaves = size.div_ceil(u64_from_usize(B));
+    let batch = rayon::current_num_threads().max(1);
+    let mut next = 0u64;
+    let mut inflight = None;
+    if next < leaves {
+        let count = batch_len(leaves, next, batch);
+        inflight = Some(submit_batch::<R, M, B>(&source, next, count, size));
+        next = next.saturating_add(u64_from_usize(count));
+    }
+    while let Some(mut handoff) = inflight.take() {
+        // Collect the hashed batch while the put window keeps draining.
+        let outcome = poll_fn(|cx| {
+            if let Err(error) = split.pump(cx) {
+                return Poll::Ready(Err(error));
+            }
+            handoff.poll_recv(cx).map(Ok)
+        })
+        .await;
+        let sealed = match outcome {
+            Ok(Some(sealed)) => sealed?,
+            Ok(None) => return Err(ReadAtError::PoolDropped),
+            Err(error) => return Err(error.into()),
+        };
+        // Queue the next batch first, so it hashes while this one drains.
+        if next < leaves {
+            let count = batch_len(leaves, next, batch);
+            inflight = Some(submit_batch::<R, M, B>(&source, next, count, size));
+            next = next.saturating_add(u64_from_usize(count));
+        }
+        for leaf in sealed {
+            poll_fn(|cx| split.poll_admit(cx)).await?;
+            split.push_sealed(leaf.chunk, leaf.reference, leaf.span)?;
+        }
+    }
+    poll_fn(|cx| split.poll_finish(cx))
+        .await
+        .map_err(ReadAtError::from)
+}
+
+/// Leaves in the batch starting at `next`; capped by `batch`, so the
+/// narrowing is lossless.
+fn batch_len(leaves: u64, next: u64, batch: usize) -> usize {
+    let remaining = leaves.saturating_sub(next);
+    usize::try_from(remaining.min(u64_from_usize(batch))).unwrap_or(batch)
+}
+
+/// Queue one batch of leaf reads and seals on the pool.
+fn submit_batch<R, M, const B: usize>(
+    source: &Arc<R>,
+    start: u64,
+    count: usize,
+    size: u64,
+) -> Handoff<Result<Vec<SealedLeaf<M, B>>, LeafError>>
+where
+    R: ReadAt + Send + Sync + 'static,
+    M: SplitMode,
+    M::Ref: Send,
+{
+    let source = Arc::clone(source);
+    handoff::submit(move || {
+        (0..count)
+            .into_par_iter()
+            .map(|item| {
+                let index = start.saturating_add(u64_from_usize(item));
+                seal_leaf::<R, M, B>(source.as_ref(), index, size)
+            })
+            .collect()
+    })
+}
+
+/// Read and seal the leaf at `index`; its span is its byte length.
+fn seal_leaf<R, M, const B: usize>(
+    source: &R,
+    index: u64,
+    size: u64,
+) -> Result<SealedLeaf<M, B>, LeafError>
+where
+    R: ReadAt + ?Sized,
+    M: SplitMode,
+{
+    let body = u64_from_usize(B);
+    let offset = index.saturating_mul(body);
+    let span = size.saturating_sub(offset).min(body);
+    // The span is capped by the body size, so the narrowing is lossless.
+    let take = usize::try_from(span).unwrap_or(B);
+    let mut data = vec![0u8; take];
+    read_full(source, offset, &mut data)?;
+    let mut payload = Vec::with_capacity(SPAN_SIZE.saturating_add(take));
+    payload.extend_from_slice(&span.to_le_bytes());
+    payload.extend_from_slice(&data);
+    let (chunk, reference) = M::seal::<B>(Bytes::from(payload)).map_err(LeafError::Seal)?;
+    Ok(SealedLeaf {
+        chunk,
+        reference,
+        span,
+    })
+}
+
+/// Fill `buf` from `offset`, looping over short reads; running out of
+/// source is an error, never a silent truncation.
+fn read_full<R: ReadAt + ?Sized>(source: &R, offset: u64, buf: &mut [u8]) -> Result<(), LeafError> {
+    let mut filled = 0usize;
+    while filled < buf.len() {
+        let at = offset.saturating_add(u64_from_usize(filled));
+        let Some(rest) = buf.get_mut(filled..) else {
+            return Ok(());
+        };
+        let capacity = rest.len();
+        let count = source
+            .read_at(at, rest)
+            .map_err(|source| LeafError::Read { offset: at, source })?;
+        if count == 0 {
+            return Err(LeafError::Short {
+                offset: at,
+                remaining: capacity,
+            });
+        }
+        if count > capacity {
+            return Err(LeafError::Overrun {
+                offset: at,
+                count,
+                capacity,
+            });
+        }
+        filled = filled.saturating_add(count);
+    }
+    Ok(())
+}

--- a/crates/file/src/parallel/source.rs
+++ b/crates/file/src/parallel/source.rs
@@ -1,0 +1,98 @@
+//! Random-access byte sources for the batch ingest.
+
+use alloc::vec::Vec;
+
+use std::io;
+
+use bytes::Bytes;
+
+use crate::num::u64_from_usize;
+
+/// Random-access byte source; reads at distinct offsets may run
+/// concurrently from pool workers.
+pub trait ReadAt {
+    /// Read into `buf` at `offset`, returning the bytes read; zero at or
+    /// past the end.
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> io::Result<usize>;
+
+    /// Total source length in bytes.
+    fn len(&self) -> io::Result<u64>;
+
+    /// Whether the source has no bytes.
+    fn is_empty(&self) -> io::Result<bool> {
+        Ok(self.len()? == 0)
+    }
+}
+
+impl ReadAt for [u8] {
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> io::Result<usize> {
+        let Ok(offset) = usize::try_from(offset) else {
+            return Ok(0);
+        };
+        let Some(tail) = self.get(offset..) else {
+            return Ok(0);
+        };
+        let take = tail.len().min(buf.len());
+        let (Some(src), Some((dst, _))) = (tail.get(..take), buf.split_at_mut_checked(take)) else {
+            return Ok(0);
+        };
+        dst.copy_from_slice(src);
+        Ok(take)
+    }
+
+    fn len(&self) -> io::Result<u64> {
+        Ok(u64_from_usize(<[u8]>::len(self)))
+    }
+}
+
+impl ReadAt for Vec<u8> {
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> io::Result<usize> {
+        self.as_slice().read_at(offset, buf)
+    }
+
+    fn len(&self) -> io::Result<u64> {
+        ReadAt::len(self.as_slice())
+    }
+}
+
+impl ReadAt for Bytes {
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> io::Result<usize> {
+        <[u8] as ReadAt>::read_at(self.as_ref(), offset, buf)
+    }
+
+    fn len(&self) -> io::Result<u64> {
+        <[u8] as ReadAt>::len(self.as_ref())
+    }
+}
+
+impl<T: ReadAt + ?Sized> ReadAt for &T {
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> io::Result<usize> {
+        (**self).read_at(offset, buf)
+    }
+
+    fn len(&self) -> io::Result<u64> {
+        (**self).len()
+    }
+}
+
+#[cfg(unix)]
+impl ReadAt for std::fs::File {
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> io::Result<usize> {
+        std::os::unix::fs::FileExt::read_at(self, buf, offset)
+    }
+
+    fn len(&self) -> io::Result<u64> {
+        self.metadata().map(|metadata| metadata.len())
+    }
+}
+
+#[cfg(windows)]
+impl ReadAt for std::fs::File {
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> io::Result<usize> {
+        std::os::windows::fs::FileExt::seek_read(self, buf, offset)
+    }
+
+    fn len(&self) -> io::Result<u64> {
+        self.metadata().map(|metadata| metadata.len())
+    }
+}

--- a/crates/file/src/parallel/tests.rs
+++ b/crates/file/src/parallel/tests.rs
@@ -1,0 +1,421 @@
+//! Ingest oracles: root and chunk-set differentials against the legacy
+//! buffered splitter, put-window witnesses, and typed failure paths.
+
+#![allow(deprecated)]
+
+use core::future::Future;
+use core::pin::Pin;
+use std::collections::HashMap;
+use std::format;
+use std::io::Write as _;
+use std::string::ToString;
+use std::sync::{Arc, Mutex};
+use std::vec;
+use std::vec::Vec;
+
+use futures::executor::block_on;
+use nectar_primitives::chunk::{AnyChunkSet, Chunk, ChunkAddress, ChunkOps, Verified};
+use nectar_primitives::file::Splitter;
+use nectar_primitives::store::{ChunkPut, ChunkStoreError};
+
+use super::{ReadAt, ReadAtError, split_read_at};
+use crate::config::PutWindow;
+use crate::split::SplitError;
+use crate::walk::Plain;
+
+/// Tiny body size: fan-out 8, so a few dozen leaves already build a deep
+/// tree.
+const TINY: usize = 256;
+const BRANCHES: usize = 8;
+
+/// Distinct byte per file position so every node address is unique.
+fn fill(len: usize) -> Vec<u8> {
+    (0..len as u64).map(pattern).collect()
+}
+
+/// The byte at absolute file position `i`.
+fn pattern(i: u64) -> u8 {
+    (i.wrapping_mul(2_654_435_761) >> 11) as u8
+}
+
+/// Shared put store: logs accepted puts, resolves after `delay` yields,
+/// tracks peak concurrent puts, refuses puts past `fail_after`.
+struct TestStore<const B: usize> {
+    chunks: Arc<Mutex<HashMap<ChunkAddress, Chunk<Verified, AnyChunkSet<B>>>>>,
+    log: Arc<Mutex<Vec<ChunkAddress>>>,
+    active: Arc<Mutex<(usize, usize)>>,
+    delay: usize,
+    fail_after: Option<usize>,
+}
+
+impl<const B: usize> Clone for TestStore<B> {
+    fn clone(&self) -> Self {
+        Self {
+            chunks: Arc::clone(&self.chunks),
+            log: Arc::clone(&self.log),
+            active: Arc::clone(&self.active),
+            delay: self.delay,
+            fail_after: self.fail_after,
+        }
+    }
+}
+
+impl<const B: usize> TestStore<B> {
+    fn new(delay: usize) -> Self {
+        Self {
+            chunks: Arc::new(Mutex::new(HashMap::new())),
+            log: Arc::new(Mutex::new(Vec::new())),
+            active: Arc::new(Mutex::new((0, 0))),
+            delay,
+            fail_after: None,
+        }
+    }
+
+    fn failing_after(fail_after: usize) -> Self {
+        Self {
+            fail_after: Some(fail_after),
+            ..Self::new(0)
+        }
+    }
+
+    fn log(&self) -> Vec<ChunkAddress> {
+        self.log.lock().unwrap().clone()
+    }
+
+    fn peak_active(&self) -> usize {
+        self.active.lock().unwrap().1
+    }
+}
+
+/// A self-waking yield: `Pending` once with an immediate wake, so
+/// `block_on` keeps polling.
+fn yield_now() -> impl Future<Output = ()> {
+    struct YieldNow(bool);
+    impl Future for YieldNow {
+        type Output = ();
+        fn poll(
+            mut self: Pin<&mut Self>,
+            cx: &mut core::task::Context<'_>,
+        ) -> core::task::Poll<()> {
+            if self.0 {
+                core::task::Poll::Ready(())
+            } else {
+                self.0 = true;
+                cx.waker().wake_by_ref();
+                core::task::Poll::Pending
+            }
+        }
+    }
+    YieldNow(false)
+}
+
+impl<const B: usize> ChunkPut<AnyChunkSet<B>> for TestStore<B> {
+    type Error = ChunkStoreError;
+
+    async fn put(&self, chunk: Chunk<Verified, AnyChunkSet<B>>) -> Result<(), ChunkStoreError> {
+        {
+            let mut active = self.active.lock().unwrap();
+            active.0 += 1;
+            active.1 = active.1.max(active.0);
+        }
+        for _ in 0..self.delay {
+            yield_now().await;
+        }
+        self.active.lock().unwrap().0 -= 1;
+        if let Some(limit) = self.fail_after
+            && self.log.lock().unwrap().len() >= limit
+        {
+            return Err(ChunkStoreError::Other("put refused".to_string().into()));
+        }
+        let address = *chunk.address();
+        self.log.lock().unwrap().push(address);
+        self.chunks.lock().unwrap().insert(address, chunk);
+        Ok(())
+    }
+}
+
+/// The legacy buffered splitter as the oracle: root plus every produced
+/// chunk address.
+fn legacy_split<const B: usize>(data: &[u8]) -> (ChunkAddress, Vec<ChunkAddress>) {
+    let mut splitter = Splitter::<B>::new(data.len() as u64);
+    splitter.write_all(data).unwrap();
+    let (root, chunks) = splitter.finish().unwrap();
+    let addresses = chunks.iter().map(|chunk| *chunk.address()).collect();
+    (root, addresses)
+}
+
+fn ingest<const B: usize>(
+    data: Vec<u8>,
+    window: u16,
+    delay: usize,
+) -> (ChunkAddress, TestStore<B>) {
+    let store = TestStore::<B>::new(delay);
+    let root = block_on(split_read_at::<_, _, Plain, B>(
+        data,
+        store.clone(),
+        PutWindow::new(window).unwrap(),
+    ))
+    .unwrap();
+    (root, store)
+}
+
+fn sorted(mut addresses: Vec<ChunkAddress>) -> Vec<ChunkAddress> {
+    addresses.sort();
+    addresses
+}
+
+#[test]
+fn roots_and_chunk_sets_match_the_legacy_splitter() {
+    let b = TINY;
+    let kb = BRANCHES * b;
+    let k2b = BRANCHES * kb;
+    let sizes = [
+        0,
+        1,
+        b - 1,
+        b,
+        b + 1,
+        kb - 1,
+        kb,
+        kb + 1,
+        k2b - 1,
+        k2b,
+        k2b + 1,
+        3 * kb + 517,
+    ];
+    for size in sizes {
+        let data = fill(size);
+        let (legacy_root, legacy_chunks) = legacy_split::<TINY>(&data);
+        let (root, store) = ingest::<TINY>(data, 4, 1);
+        assert_eq!(root, legacy_root, "root diverged at {size}");
+        assert_eq!(
+            sorted(store.log()),
+            sorted(legacy_chunks),
+            "chunk set diverged at {size}"
+        );
+    }
+}
+
+#[test]
+fn default_profile_roots_match_the_legacy_splitter() {
+    const B: usize = nectar_primitives::DEFAULT_BODY_SIZE;
+    let sizes = [0, 1, B - 1, B, B + 1, 5 * B + 123];
+    for size in sizes {
+        let data = fill(size);
+        let (legacy_root, _) = legacy_split::<B>(&data);
+        let (root, _) = ingest::<B>(data, 8, 0);
+        assert_eq!(root, legacy_root, "root diverged at {size}");
+    }
+}
+
+#[test]
+fn put_window_bounds_concurrent_puts() {
+    let data = fill(200 * TINY + 63);
+    for window in [1u16, 4, 16] {
+        let (legacy_root, legacy_chunks) = legacy_split::<TINY>(&data);
+        let (root, store) = ingest::<TINY>(data.clone(), window, 3);
+        assert_eq!(root, legacy_root);
+        assert_eq!(store.log().len(), legacy_chunks.len());
+        assert!(
+            store.peak_active() <= usize::from(window),
+            "puts in flight {} exceeded window {window}",
+            store.peak_active()
+        );
+    }
+}
+
+#[test]
+fn bytes_and_slice_sources_agree() {
+    let data = fill(11 * TINY + 7);
+    let (from_vec, _) = ingest::<TINY>(data.clone(), 4, 0);
+    let store = TestStore::<TINY>::new(0);
+    let from_bytes = block_on(split_read_at::<_, _, Plain, TINY>(
+        bytes::Bytes::from(data),
+        store,
+        PutWindow::DEFAULT,
+    ))
+    .unwrap();
+    assert_eq!(from_vec, from_bytes);
+}
+
+#[cfg(unix)]
+#[test]
+fn a_filesystem_source_matches_the_buffer_path() {
+    let data = fill(23 * TINY + 91);
+    let path =
+        std::env::temp_dir().join(format!("nectar-file-read-at-{}-{TINY}", std::process::id()));
+    std::fs::write(&path, &data).unwrap();
+    let file = std::fs::File::open(&path).unwrap();
+    let store = TestStore::<TINY>::new(0);
+    let root = block_on(split_read_at::<_, _, Plain, TINY>(
+        file,
+        store,
+        PutWindow::DEFAULT,
+    ))
+    .unwrap();
+    std::fs::remove_file(&path).unwrap();
+    let (expected, _) = ingest::<TINY>(data, 4, 0);
+    assert_eq!(root, expected);
+}
+
+/// Source failing every read at or past `fail_at`.
+struct FailingSource {
+    data: Vec<u8>,
+    fail_at: u64,
+}
+
+impl ReadAt for FailingSource {
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> std::io::Result<usize> {
+        if offset >= self.fail_at {
+            return Err(std::io::Error::other("device gone"));
+        }
+        self.data.read_at(offset, buf)
+    }
+
+    fn len(&self) -> std::io::Result<u64> {
+        ReadAt::len(&self.data)
+    }
+}
+
+#[test]
+fn a_read_failure_is_typed_with_its_offset() {
+    // A single failing leaf, so the parallel batch surfaces one offset.
+    let source = FailingSource {
+        data: fill(2 * TINY),
+        fail_at: u64::try_from(TINY).unwrap(),
+    };
+    let store = TestStore::<TINY>::new(0);
+    let error = block_on(split_read_at::<_, _, Plain, TINY>(
+        source,
+        store,
+        PutWindow::DEFAULT,
+    ))
+    .unwrap_err();
+    let ReadAtError::Read { offset, .. } = error else {
+        panic!("expected a read error, got {error:?}");
+    };
+    assert_eq!(offset, u64::try_from(TINY).unwrap());
+}
+
+/// Source claiming more bytes than it can deliver.
+struct LyingSource {
+    data: Vec<u8>,
+    claimed: u64,
+}
+
+impl ReadAt for LyingSource {
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.data.read_at(offset, buf)
+    }
+
+    fn len(&self) -> std::io::Result<u64> {
+        Ok(self.claimed)
+    }
+}
+
+#[test]
+fn a_source_ending_early_is_a_short_read() {
+    let source = LyingSource {
+        data: fill(TINY + 100),
+        claimed: u64::try_from(2 * TINY).unwrap(),
+    };
+    let store = TestStore::<TINY>::new(0);
+    let error = block_on(split_read_at::<_, _, Plain, TINY>(
+        source,
+        store,
+        PutWindow::DEFAULT,
+    ))
+    .unwrap_err();
+    let ReadAtError::ShortRead { offset, remaining } = error else {
+        panic!("expected a short read, got {error:?}");
+    };
+    assert_eq!(offset, u64::try_from(TINY + 100).unwrap());
+    assert_eq!(remaining, TINY - 100);
+}
+
+/// Source reporting more bytes than the buffer holds.
+struct OverrunSource;
+
+impl ReadAt for OverrunSource {
+    fn read_at(&self, _offset: u64, buf: &mut [u8]) -> std::io::Result<usize> {
+        Ok(buf.len() + 1)
+    }
+
+    fn len(&self) -> std::io::Result<u64> {
+        Ok(u64::try_from(TINY).unwrap())
+    }
+}
+
+#[test]
+fn an_overlong_read_count_is_refused() {
+    let store = TestStore::<TINY>::new(0);
+    let error = block_on(split_read_at::<_, _, Plain, TINY>(
+        OverrunSource,
+        store,
+        PutWindow::DEFAULT,
+    ))
+    .unwrap_err();
+    assert!(
+        matches!(error, ReadAtError::ReadOverrun { count, capacity, .. }
+            if count == TINY + 1 && capacity == TINY),
+        "got {error:?}"
+    );
+}
+
+/// Source whose sizing itself fails.
+struct UnsizedSource;
+
+impl ReadAt for UnsizedSource {
+    fn read_at(&self, _offset: u64, _buf: &mut [u8]) -> std::io::Result<usize> {
+        Ok(0)
+    }
+
+    fn len(&self) -> std::io::Result<u64> {
+        Err(std::io::Error::other("no metadata"))
+    }
+}
+
+#[test]
+fn a_sizing_failure_is_typed() {
+    let store = TestStore::<TINY>::new(0);
+    let error = block_on(split_read_at::<_, _, Plain, TINY>(
+        UnsizedSource,
+        store,
+        PutWindow::DEFAULT,
+    ))
+    .unwrap_err();
+    assert!(matches!(error, ReadAtError::Length { .. }), "got {error:?}");
+}
+
+#[test]
+fn a_failed_put_surfaces_as_a_split_error() {
+    let store = TestStore::<TINY>::failing_after(0);
+    let error = block_on(split_read_at::<_, _, Plain, TINY>(
+        fill(6 * TINY),
+        store,
+        PutWindow::new(2).unwrap(),
+    ))
+    .unwrap_err();
+    assert!(
+        matches!(error, ReadAtError::Split(SplitError::Put { .. })),
+        "got {error:?}"
+    );
+}
+
+#[test]
+fn read_at_sources_honour_offsets_and_ends() {
+    let data = fill(100);
+    let slice: &[u8] = &data;
+    let mut buf = vec![0u8; 40];
+    assert_eq!(slice.read_at(0, &mut buf).unwrap(), 40);
+    assert_eq!(buf, data[..40]);
+    assert_eq!(slice.read_at(80, &mut buf).unwrap(), 20);
+    assert_eq!(buf[..20], data[80..]);
+    assert_eq!(slice.read_at(100, &mut buf).unwrap(), 0);
+    assert_eq!(slice.read_at(u64::MAX, &mut buf).unwrap(), 0);
+    assert_eq!(ReadAt::len(slice).unwrap(), 100);
+    let owned = bytes::Bytes::from(data.clone());
+    assert_eq!(owned.read_at(60, &mut buf).unwrap(), 40);
+    assert_eq!(buf, data[60..]);
+    assert_eq!(ReadAt::len(&owned).unwrap(), 100);
+}

--- a/crates/file/src/split/engine.rs
+++ b/crates/file/src/split/engine.rs
@@ -405,6 +405,73 @@ where
         self.stats.peak_put_in_flight = self.stats.peak_put_in_flight.max(self.in_flight.len());
     }
 
+    /// Drive the put window without consuming input.
+    #[cfg(all(
+        feature = "rayon",
+        not(target_arch = "wasm32"),
+        not(feature = "unsync")
+    ))]
+    pub(crate) fn pump(&mut self, cx: &mut Context<'_>) -> Result<(), SplitError<S::Error>> {
+        if matches!(self.phase, Phase::Poisoned) {
+            return Err(SplitError::Poisoned);
+        }
+        self.step_puts(cx).map_err(|error| self.poison(error))
+    }
+
+    /// Secure admission for one externally sealed leaf: pending drained and
+    /// a put slot free. `Pending` admits nothing.
+    #[cfg(all(
+        feature = "rayon",
+        not(target_arch = "wasm32"),
+        not(feature = "unsync")
+    ))]
+    pub(crate) fn poll_admit(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), SplitError<S::Error>>> {
+        match self.phase {
+            Phase::Writing => {}
+            Phase::Poisoned => return Poll::Ready(Err(SplitError::Poisoned)),
+            Phase::Closing | Phase::Draining | Phase::Finished => {
+                return Poll::Ready(Err(SplitError::Finished));
+            }
+        }
+        if let Err(error) = self.step_puts(cx) {
+            return Poll::Ready(Err(self.poison(error)));
+        }
+        if !self.pending.is_empty() || self.in_flight.len() >= self.window {
+            return Poll::Pending;
+        }
+        Poll::Ready(Ok(()))
+    }
+
+    /// Thread one externally sealed leaf into the ascent; the caller has
+    /// secured capacity through `poll_admit`.
+    #[cfg(all(
+        feature = "rayon",
+        not(target_arch = "wasm32"),
+        not(feature = "unsync")
+    ))]
+    pub(crate) fn push_sealed(
+        &mut self,
+        chunk: Chunk<Verified, AnyChunkSet<B>>,
+        reference: M::Ref,
+        span: u64,
+    ) -> Result<(), SplitError<S::Error>> {
+        match self.phase {
+            Phase::Writing => {}
+            Phase::Poisoned => return Err(SplitError::Poisoned),
+            Phase::Closing | Phase::Draining | Phase::Finished => {
+                return Err(SplitError::Finished);
+            }
+        }
+        self.stats.bytes = self.stats.bytes.saturating_add(span);
+        self.stats.leaves = self.stats.leaves.saturating_add(1);
+        self.enqueue(chunk);
+        self.push_ref(0, reference, span)
+            .map_err(|error| self.poison(error))
+    }
+
     /// Fold completed puts back in and admit pending chunks; a failed put
     /// is terminal.
     fn step_puts(&mut self, cx: &mut Context<'_>) -> Result<(), SplitError<S::Error>> {

--- a/crates/file/src/split/mod.rs
+++ b/crates/file/src/split/mod.rs
@@ -1,7 +1,8 @@
 //! Poll-native split engine: the one bounded ascent building a chunk tree.
 //!
-//! Every write mode feeds this engine; nothing else in the crate seals tree
-//! nodes. The engine is push-driven and io-free (no spawns, channels or
+//! Every write mode feeds this engine, and only its ascent seals
+//! intermediates; the batch ingest pre-seals leaves but threads them through
+//! this same ascent. The engine is push-driven and io-free (no spawns, channels or
 //! timers), all state lives in the [`Split`], and sealed chunks flow to the
 //! store through a bounded put window.
 //!


### PR DESCRIPTION
## What

Adds a `parallel` module to `nectar-file` behind the `rayon` feature. `split_read_at` ingests a random-access source by reading and sealing leaves in pool-wide ordered batches on the rayon pool, then threads the pre-sealed leaves through the existing `Split` ascent via new crate-private `poll_admit`/`push_sealed`/`pump` seams. A new fallible `ReadAt` trait is implemented for slices, `Vec`, `Bytes`, references, and (unix) `fs::File`.

## Why

Closes #339

## Testing

All independent gates pass; see below.

- Differential tests against the legacy buffered splitter across 12 sizes on both tiny and default profiles confirm roots and chunk sets are byte-identical between the parallel and streaming split paths.
- A peak-active test with delayed puts confirms the pool handoff (one queued job per batch over an `AtomicWaker` reply slot) keeps the put window genuinely bounded: submission never blocks, at most one batch hashes while the previous drains the put window, and the put window keeps pumping while awaiting the pool.
- Typed failure paths are exercised.
- Deny-lint compliance holds in non-test code (saturating arithmetic, `try_from`, total slice patterns; no `unwrap`/`expect`/`panic`/`as`).

## AI Assistance

Implementation by Fable, review by Opus, PR by Sonnet.

