### PR TITLE
feat(file): add tokio async writer adapter

### DIFF
--- a/crates/file/src/lib.rs
+++ b/crates/file/src/lib.rs
@@ -71,13 +71,13 @@ pub mod tokio;
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod walk;
 
+#[cfg(feature = "tokio")]
+pub use self::tokio::{SeekOverflow, TokioReader};
 #[cfg(all(
     feature = "tokio",
     not(any(target_arch = "wasm32", feature = "unsync"))
 ))]
-pub use self::tokio::SpawnedReader;
-#[cfg(feature = "tokio")]
-pub use self::tokio::{SeekOverflow, TokioReader};
+pub use self::tokio::{SpawnedReader, TokioWriter};
 pub use config::{BranchBudget, PutWindow, Window};
 pub use geometry::{DEFAULT_BODY_SIZE, Mode, branches, max_depth};
 #[cfg(all(

--- a/crates/file/src/tokio/mod.rs
+++ b/crates/file/src/tokio/mod.rs
@@ -1,4 +1,4 @@
-//! Async io adapters over the poll-native read surface.
+//! Async io adapters over the poll-native read and write surfaces.
 //!
 //! [`TokioReader`] shims [`AsyncRead`](::tokio::io::AsyncRead) and
 //! [`AsyncSeek`](::tokio::io::AsyncSeek) straight over a
@@ -7,7 +7,9 @@
 //! created per call. [`SpawnedReader`] opts into a runtime task that keeps
 //! the walk advancing between reads. Positions are zero-based within the
 //! clipped range, so [`SeekFrom::End`] resolves against the effective
-//! length.
+//! length. [`TokioWriter`] shims [`AsyncWrite`](::tokio::io::AsyncWrite)
+//! over a [`Split`](crate::Split): `poll_shutdown` drives the finish and
+//! `into_inner` hands back the delivered root.
 //!
 //! Reading a byte range through the shim:
 //!
@@ -45,12 +47,18 @@ mod reader;
 mod spawned;
 #[cfg(test)]
 mod tests;
+// The writer maps split failures into `io::Error`, which boxes them
+// `Send + Sync`; the wasm32 and `unsync` error chains are not.
+#[cfg(not(any(target_arch = "wasm32", feature = "unsync")))]
+mod writer;
 
 use std::io::SeekFrom;
 
 pub use reader::TokioReader;
 #[cfg(not(any(target_arch = "wasm32", feature = "unsync")))]
 pub use spawned::SpawnedReader;
+#[cfg(not(any(target_arch = "wasm32", feature = "unsync")))]
+pub use writer::TokioWriter;
 
 /// A relative seek whose resolved target leaves the unsigned position
 /// space.

--- a/crates/file/src/tokio/tests.rs
+++ b/crates/file/src/tokio/tests.rs
@@ -1,5 +1,6 @@
 //! Adapter battery: differential reads over both drivers, seek semantics,
-//! typed-to-io error mapping and driver handover.
+//! typed-to-io error mapping, driver handover and the writer shim's
+//! shutdown-to-root path.
 #![allow(deprecated)]
 
 use std::io::{ErrorKind, SeekFrom};
@@ -9,11 +10,13 @@ use std::vec::Vec;
 
 use nectar_primitives::chunk::{AnyChunkSet, Chunk, ChunkAddress, Verified};
 use nectar_primitives::file::split;
-use nectar_primitives::store::{ChunkGet, ChunkStoreError, MemoryStore};
-use tokio::io::{AsyncReadExt, AsyncSeekExt};
+use nectar_primitives::store::{ChunkGet, ChunkPut, ChunkStoreError, MemoryStore};
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 
-use super::{SpawnedReader, TokioReader};
+use super::{SpawnedReader, TokioReader, TokioWriter};
+use crate::config::PutWindow;
 use crate::read::File;
+use crate::split::Split;
 use crate::walk::Plain;
 
 /// Tiny body size shared with the facade tests: fan-out 8, so small files
@@ -225,4 +228,113 @@ async fn walk_failures_surface_as_io_errors_on_both_drivers() {
         .await
         .unwrap_err();
     assert_eq!(error.kind(), ErrorKind::Other);
+}
+
+/// Store refusing every put.
+#[derive(Clone)]
+struct RejectPuts;
+
+impl ChunkPut<AnyChunkSet<TINY>> for RejectPuts {
+    type Error = ChunkStoreError;
+
+    async fn put(&self, _chunk: Chunk<Verified, AnyChunkSet<TINY>>) -> Result<(), ChunkStoreError> {
+        Err(ChunkStoreError::Other("outage".to_string().into()))
+    }
+}
+
+/// Shared store handle: clones share one map, unlike the snapshot-cloning
+/// memory store.
+#[derive(Clone, Default)]
+struct SharedStore(Arc<TinyStore>);
+
+impl ChunkPut<AnyChunkSet<TINY>> for SharedStore {
+    type Error = std::convert::Infallible;
+
+    async fn put(
+        &self,
+        chunk: Chunk<Verified, AnyChunkSet<TINY>>,
+    ) -> Result<(), std::convert::Infallible> {
+        ChunkPut::put(self.0.as_ref(), chunk).await
+    }
+}
+
+impl ChunkGet<AnyChunkSet<TINY>> for SharedStore {
+    type Trust = Verified;
+    type Error = ChunkStoreError;
+
+    async fn get(
+        &self,
+        address: &ChunkAddress,
+    ) -> Result<Chunk<Verified, AnyChunkSet<TINY>>, ChunkStoreError> {
+        ChunkGet::get(self.0.as_ref(), address).await
+    }
+}
+
+fn writer(store: SharedStore) -> TokioWriter<SharedStore, Plain, TINY> {
+    TokioWriter::from(Split::new(store, PutWindow::new(2).unwrap()))
+}
+
+#[tokio::test]
+async fn writer_roots_match_the_legacy_split() {
+    for len in [
+        0usize,
+        1,
+        TINY - 1,
+        TINY,
+        TINY + 1,
+        8 * TINY,
+        33 * TINY + 17,
+    ] {
+        let data = fill(len);
+        let store = SharedStore::default();
+        let mut writer = writer(store.clone());
+        writer.write_all(&data).await.unwrap();
+        writer.flush().await.unwrap();
+        writer.shutdown().await.unwrap();
+        assert!(writer.is_finished());
+        assert_eq!(writer.stats().bytes, len as u64);
+        let root = writer.into_inner().unwrap();
+        let (expected, _) = split::<TINY>(&data).unwrap();
+        assert_eq!(root, expected, "diverged at {len}");
+
+        let file = File::<_, Plain, TINY>::open(store, root).await.unwrap();
+        let mut out = Vec::new();
+        TokioReader::from(file.read().build())
+            .read_to_end(&mut out)
+            .await
+            .unwrap();
+        assert_eq!(out, data, "read back diverged at {len}");
+    }
+}
+
+#[tokio::test]
+async fn writer_shutdown_is_fused_and_later_writes_fail() {
+    let data = fill(3 * TINY + 7);
+    assert!(writer(SharedStore::default()).into_inner().is_none());
+
+    let mut writer = writer(SharedStore::default());
+    writer.write_all(&data).await.unwrap();
+    writer.shutdown().await.unwrap();
+    writer.shutdown().await.unwrap();
+
+    let error = writer.write_all(b"late").await.unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::Other);
+
+    let (expected, _) = split::<TINY>(&data).unwrap();
+    assert_eq!(writer.into_inner().unwrap(), expected);
+}
+
+#[tokio::test]
+async fn writer_put_failures_surface_as_io_errors() {
+    let mut writer =
+        TokioWriter::from(Split::<_, Plain, TINY>::new(RejectPuts, PutWindow::DEFAULT));
+    let data = fill(2 * TINY);
+    let error = async {
+        writer.write_all(&data).await?;
+        writer.shutdown().await
+    }
+    .await
+    .unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::Other);
+    assert!(writer.into_inner().is_none());
 }

--- a/crates/file/src/tokio/writer.rs
+++ b/crates/file/src/tokio/writer.rs
@@ -1,0 +1,148 @@
+//! Shim writer: the caller's polls feed the split directly.
+
+use core::fmt;
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use std::io;
+
+use nectar_primitives::DEFAULT_BODY_SIZE;
+use nectar_primitives::chunk::AnyChunkSet;
+use nectar_primitives::store::ChunkPut;
+use tokio::io::AsyncWrite;
+
+use crate::split::{Split, SplitMode, SplitStats};
+
+/// [`AsyncWrite`] over one [`Split`].
+///
+/// Every poll feeds the split's ascent in place, so the put window stays in
+/// flight across polls and no future is created per call. `poll_shutdown`
+/// drives the finish to the root, which [`into_inner`](Self::into_inner)
+/// then hands back.
+///
+/// ```
+/// use nectar_file::{Plain, PutWindow, Split, TokioWriter};
+/// use nectar_primitives::chunk::AnyChunkSet;
+/// use nectar_primitives::store::MemoryStore;
+/// use tokio::io::AsyncWriteExt;
+///
+/// # #[tokio::main(flavor = "current_thread")]
+/// # async fn main() {
+/// let store = MemoryStore::<AnyChunkSet<4096>>::new();
+/// let split = Split::<_, Plain, 4096>::new(store, PutWindow::DEFAULT);
+/// let mut writer = TokioWriter::from(split);
+/// writer.write_all(&vec![7u8; 10_000]).await.unwrap();
+/// writer.shutdown().await.unwrap();
+/// let root = writer.into_inner().unwrap();
+/// assert_eq!(root.as_bytes().len(), 32);
+/// # }
+/// ```
+pub struct TokioWriter<S, M, const B: usize = DEFAULT_BODY_SIZE>
+where
+    S: ChunkPut<AnyChunkSet<B>>,
+    M: SplitMode,
+{
+    inner: Split<S, M, B>,
+    root: Option<M::Root>,
+}
+
+impl<S, M, const B: usize> TokioWriter<S, M, B>
+where
+    S: ChunkPut<AnyChunkSet<B>> + Clone + 'static,
+    M: SplitMode,
+{
+    /// Occupancy witnesses accumulated so far.
+    pub const fn stats(&self) -> SplitStats {
+        self.inner.stats()
+    }
+
+    /// Whether the split has delivered its root or failed.
+    pub const fn is_finished(&self) -> bool {
+        self.inner.is_finished()
+    }
+
+    /// The delivered root; `None` until `poll_shutdown` has completed.
+    pub fn into_inner(self) -> Option<M::Root> {
+        self.root
+    }
+}
+
+impl<S, M, const B: usize> From<Split<S, M, B>> for TokioWriter<S, M, B>
+where
+    S: ChunkPut<AnyChunkSet<B>>,
+    M: SplitMode,
+{
+    fn from(inner: Split<S, M, B>) -> Self {
+        Self { inner, root: None }
+    }
+}
+
+impl<S, M, const B: usize> From<TokioWriter<S, M, B>> for Split<S, M, B>
+where
+    S: ChunkPut<AnyChunkSet<B>>,
+    M: SplitMode,
+{
+    fn from(writer: TokioWriter<S, M, B>) -> Self {
+        writer.inner
+    }
+}
+
+/// Movable regardless of the store or context types: the shim owns plain
+/// state and boxed futures, never a self-reference.
+impl<S, M, const B: usize> Unpin for TokioWriter<S, M, B>
+where
+    S: ChunkPut<AnyChunkSet<B>>,
+    M: SplitMode,
+{
+}
+
+impl<S, M, const B: usize> AsyncWrite for TokioWriter<S, M, B>
+where
+    S: ChunkPut<AnyChunkSet<B>> + Clone + 'static,
+    S::Error: std::error::Error + Send + Sync + 'static,
+    M: SplitMode,
+{
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        self.get_mut()
+            .inner
+            .poll_write(cx, buf)
+            .map_err(io::Error::other)
+    }
+
+    /// The shim buffers nothing: sealed chunks stream to the store as write
+    /// and shutdown polls drive them, and a partial leaf seals only at the
+    /// finish.
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    /// Drives the split's finish; the fused root lands in the shim for
+    /// [`into_inner`](Self::into_inner).
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        match this.inner.poll_finish(cx) {
+            Poll::Ready(Ok(root)) => {
+                this.root = Some(root);
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Err(error)) => Poll::Ready(Err(io::Error::other(error))),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl<S, M, const B: usize> fmt::Debug for TokioWriter<S, M, B>
+where
+    S: ChunkPut<AnyChunkSet<B>>,
+    M: SplitMode,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TokioWriter")
+            .field("inner", &self.inner)
+            .field("root", &self.root)
+            .finish()
+    }
+}


### PR DESCRIPTION
## What

Adds `TokioWriter` (`crates/file/src/tokio/writer.rs`): an `AsyncWrite` shim over the `Split` poll surface.

- `poll_write` delegates to `Split::poll_write` (cancel-safe, typed errors mapped via `io::Error::other`).
- `poll_shutdown` drives `Split::poll_finish` and stashes the fused root; `into_inner` hands the delivered root back (`None` until shutdown completes).
- `poll_flush` is a documented no-op: the shim buffers nothing, a partial leaf seals only at finish.
- `From` impls convert `Split <-> TokioWriter` both ways; `stats()`/`is_finished()` pass through.
- Cfg-gated off `wasm32` and the `unsync` feature (mirroring `SpawnedReader`), since `SplitError` wraps `PrimitivesError` whose boxed error chain drops `Send + Sync` there, which `io::Error::other` requires.

## Why

Gives `nectar-file` a tokio `AsyncWrite` adapter over `Split` so callers can drive writes through the standard tokio IO traits instead of the raw poll surface.

Closes #340

## Testing

- Root differential vs the legacy splitter at `{0, 1, B-1, B, B+1, 8B, 33B+17}`, plus read-back through the same store.
- Fused double-shutdown with write-after-finish.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --locked`: no warnings attributable to `nectar-file`; only pre-existing warnings in untouched crates (`nectar-primitives`, `nectar-mantaray`).
- 63 unit tests pass, 3 doctests pass under `--features tokio`.
- `unsync`/`wasm32` gating compiles with the writer correctly excluded, consistent with the `SpawnedReader` gate.

## AI Assistance

Implementation by Fable, review by Opus, PR description by Sonnet.

