### PR TITLE
feat(file): encrypted split mode via KeySource

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,6 +38,10 @@ jobs:
             # outside the default-features pass.
             - name: cargo clippy (rayon ingest)
               run: cargo clippy --locked -p nectar-file --features rayon
+            # The encrypted split mode sits behind the encryption feature,
+            # likewise outside the default-features pass.
+            - name: cargo clippy (encrypted split)
+              run: cargo clippy --locked -p nectar-file --features encryption
             # `unused_crate_dependencies` is enforced per-library via `cargo
             # rustc` (not `[workspace.lints]`) so the flag applies only to each
             # crate's own lib target — never to benches/examples/tests (which

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -50,14 +50,24 @@ jobs:
             - name: Run tokio adapter doctests
               run: cargo test --doc -p nectar-file --features tokio --locked
             # The batch ingest is likewise feature-gated off the default
-            # build; cover its tests and doctest here.
+            # build; cover its tests and doctest here, with the encrypted
+            # mode enabled so the pooled encrypted ingest runs too.
             - name: Run rayon ingest tests
               run: |
                   cargo nextest run \
-                    -p nectar-file --features rayon --locked \
+                    -p nectar-file --features rayon,encryption --locked \
                     --no-tests=warn --no-fail-fast
             - name: Run rayon ingest doctests
-              run: cargo test --doc -p nectar-file --features rayon --locked
+              run: cargo test --doc -p nectar-file --features rayon,encryption --locked
+            # The encrypted split mode sits behind the encryption feature;
+            # cover its tests and doctest here.
+            - name: Run encrypted split tests
+              run: |
+                  cargo nextest run \
+                    -p nectar-file --features encryption --locked \
+                    --no-tests=warn --no-fail-fast
+            - name: Run encrypted split doctests
+              run: cargo test --doc -p nectar-file --features encryption --locked
 
     wasm:
         # The postage-usage client facade is meant to run in a browser. The

--- a/crates/file/src/lib.rs
+++ b/crates/file/src/lib.rs
@@ -94,8 +94,11 @@ pub use read::{
 #[cfg(feature = "std")]
 pub use sink::FsSink;
 pub use sink::{DataSink, MemSink, MemSinkError};
+#[cfg(all(feature = "std", feature = "encryption"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
+pub use split::{KeyError, KeySource, RandomKeys};
 #[cfg(feature = "std")]
-pub use split::{Sealed, Split, SplitError, SplitMode, SplitStats};
+pub use split::{SealError, Sealed, Split, SplitError, SplitMode, SplitStats};
 #[cfg(feature = "std")]
 pub use store::{BoxedStore, BoxedStoreError, DynAnyFile, DynFile, DynFileReader, DynFileStream};
 #[cfg(feature = "std")]

--- a/crates/file/src/parallel/error.rs
+++ b/crates/file/src/parallel/error.rs
@@ -2,9 +2,7 @@
 
 use std::io;
 
-use nectar_primitives::PrimitivesError;
-
-use crate::split::SplitError;
+use crate::split::{SealError, SplitError};
 
 /// Terminal read-at ingest failure.
 #[derive(Debug, thiserror::Error)]
@@ -63,7 +61,7 @@ pub(super) enum LeafError {
         capacity: usize,
     },
     /// Sealing the leaf payload failed.
-    Seal(PrimitivesError),
+    Seal(SealError),
 }
 
 impl<E> From<LeafError> for ReadAtError<E> {

--- a/crates/file/src/parallel/mod.rs
+++ b/crates/file/src/parallel/mod.rs
@@ -45,7 +45,9 @@ struct SealedLeaf<M: SplitMode, const B: usize> {
 /// Split `source` into the tree under `store`, hashing leaves in pool-wide
 /// batches on the rayon pool; the mode `M` picks the reference grammar.
 ///
-/// The root and chunk set equal the streaming split of the same bytes.
+/// The root and chunk set equal the streaming split of the same bytes. The
+/// mode is default-constructed once and cloned across the ascent and pool
+/// workers, so a key-sourcing mode draws every key from one stream.
 /// Dropping the future abandons in-flight puts; a batch already queued on
 /// the pool finishes and is discarded.
 ///
@@ -71,21 +73,28 @@ pub async fn split_read_at<R, S, M, const B: usize>(
 where
     R: ReadAt + Send + Sync + 'static,
     S: ChunkPut<AnyChunkSet<B>> + Clone + 'static,
-    M: SplitMode,
+    M: SplitMode + Default + Clone,
     M::Ref: Send,
 {
     let source = Arc::new(source);
     let size = source
         .len()
         .map_err(|source| ReadAtError::Length { source })?;
-    let mut split = Split::<S, M, B>::new(store, window);
+    let mode = M::default();
+    let mut split = Split::<S, M, B>::with_mode(store, mode.clone(), window);
     let leaves = size.div_ceil(u64_from_usize(B));
     let batch = rayon::current_num_threads().max(1);
     let mut next = 0u64;
     let mut inflight = None;
     if next < leaves {
         let count = batch_len(leaves, next, batch);
-        inflight = Some(submit_batch::<R, M, B>(&source, next, count, size));
+        inflight = Some(submit_batch::<R, M, B>(
+            &source,
+            mode.clone(),
+            next,
+            count,
+            size,
+        ));
         next = next.saturating_add(u64_from_usize(count));
     }
     while let Some(mut handoff) = inflight.take() {
@@ -105,7 +114,13 @@ where
         // Queue the next batch first, so it hashes while this one drains.
         if next < leaves {
             let count = batch_len(leaves, next, batch);
-            inflight = Some(submit_batch::<R, M, B>(&source, next, count, size));
+            inflight = Some(submit_batch::<R, M, B>(
+                &source,
+                mode.clone(),
+                next,
+                count,
+                size,
+            ));
             next = next.saturating_add(u64_from_usize(count));
         }
         for leaf in sealed {
@@ -128,6 +143,7 @@ fn batch_len(leaves: u64, next: u64, batch: usize) -> usize {
 /// Queue one batch of leaf reads and seals on the pool.
 fn submit_batch<R, M, const B: usize>(
     source: &Arc<R>,
+    mode: M,
     start: u64,
     count: usize,
     size: u64,
@@ -143,7 +159,7 @@ where
             .into_par_iter()
             .map(|item| {
                 let index = start.saturating_add(u64_from_usize(item));
-                seal_leaf::<R, M, B>(source.as_ref(), index, size)
+                seal_leaf::<R, M, B>(source.as_ref(), &mode, index, size)
             })
             .collect()
     })
@@ -152,6 +168,7 @@ where
 /// Read and seal the leaf at `index`; its span is its byte length.
 fn seal_leaf<R, M, const B: usize>(
     source: &R,
+    mode: &M,
     index: u64,
     size: u64,
 ) -> Result<SealedLeaf<M, B>, LeafError>
@@ -169,7 +186,9 @@ where
     let mut payload = Vec::with_capacity(SPAN_SIZE.saturating_add(take));
     payload.extend_from_slice(&span.to_le_bytes());
     payload.extend_from_slice(&data);
-    let (chunk, reference) = M::seal::<B>(Bytes::from(payload)).map_err(LeafError::Seal)?;
+    let (chunk, reference) = mode
+        .seal::<B>(Bytes::from(payload))
+        .map_err(LeafError::Seal)?;
     Ok(SealedLeaf {
         chunk,
         reference,

--- a/crates/file/src/parallel/tests.rs
+++ b/crates/file/src/parallel/tests.rs
@@ -224,6 +224,47 @@ fn put_window_bounds_concurrent_puts() {
     }
 }
 
+/// The legacy joiner reads the shared chunk map, so the pooled encrypted
+/// ingest is checked end to end.
+#[cfg(feature = "encryption")]
+impl<const B: usize> nectar_primitives::store::ChunkGet<AnyChunkSet<B>> for TestStore<B> {
+    type Trust = Verified;
+    type Error = ChunkStoreError;
+
+    async fn get(
+        &self,
+        address: &ChunkAddress,
+    ) -> Result<Chunk<Verified, AnyChunkSet<B>>, ChunkStoreError> {
+        self.chunks
+            .lock()
+            .unwrap()
+            .get(address)
+            .cloned()
+            .ok_or_else(|| ChunkStoreError::not_found(address))
+    }
+}
+
+/// The pooled encrypted ingest hands the legacy joiner a readable root.
+#[cfg(feature = "encryption")]
+#[test]
+fn encrypted_ingest_joins_through_the_legacy_joiner() {
+    use nectar_primitives::file::join;
+
+    use crate::split::RandomKeys;
+    use crate::walk::Encrypted;
+
+    let data = fill(17 * TINY + 43);
+    let store = TestStore::<TINY>::new(0);
+    let root = block_on(split_read_at::<_, _, Encrypted<RandomKeys>, TINY>(
+        data.clone(),
+        store.clone(),
+        PutWindow::DEFAULT,
+    ))
+    .unwrap();
+    let plaintext = block_on(join(&store, root)).unwrap();
+    assert_eq!(plaintext, data);
+}
+
 #[test]
 fn bytes_and_slice_sources_agree() {
     let data = fill(11 * TINY + 7);

--- a/crates/file/src/split/encrypted.rs
+++ b/crates/file/src/split/encrypted.rs
@@ -1,0 +1,93 @@
+//! Split-side encrypted sealing: keccak counter-mode bodies keyed through a
+//! [`KeySource`]. Joining encrypted references stays unconditional; only
+//! this encoding side sits behind the `encryption` feature.
+
+use alloc::vec::Vec;
+
+use bytes::Bytes;
+use nectar_primitives::chunk::encryption::{ChunkEncrypt, EncryptedChunkRef, EncryptionKey};
+use nectar_primitives::chunk::{AnyChunkSet, ContentChunk};
+use nectar_primitives::store::{MaybeSend, MaybeSync};
+
+use super::error::SealError;
+use super::mode::{Sealed, SplitMode};
+use crate::geometry::Mode;
+use crate::walk::Encrypted;
+
+/// Key supply for the encrypted split; one fresh key seals one chunk.
+///
+/// Sources are shared handles: a clone draws from the same stream, so keys
+/// stay unique across the streaming ascent and pool workers.
+pub trait KeySource: MaybeSend + MaybeSync + 'static {
+    /// The key sealing the next chunk.
+    fn next_key(&self) -> Result<EncryptionKey, KeyError>;
+}
+
+/// Typed key-supply failure.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum KeyError {
+    /// A finite source ran out of keys.
+    #[error("key source exhausted after {issued} keys")]
+    Exhausted {
+        /// Keys issued before the supply ran out.
+        issued: u64,
+    },
+}
+
+/// Default source: an independent random key per chunk.
+///
+/// ```
+/// use core::future::poll_fn;
+/// use nectar_file::{Encrypted, PutWindow, RandomKeys, Split};
+/// use nectar_primitives::chunk::AnyChunkSet;
+/// use nectar_primitives::store::MemoryStore;
+///
+/// # futures::executor::block_on(async {
+/// let store = MemoryStore::<AnyChunkSet<4096>>::new();
+/// let mut split = Split::<_, Encrypted<RandomKeys>, 4096>::new(store, PutWindow::DEFAULT);
+/// let mut buf = &b"secret"[..];
+/// while !buf.is_empty() {
+///     let n = poll_fn(|cx| split.poll_write(cx, buf)).await.unwrap();
+///     buf = &buf[n..];
+/// }
+/// let root = poll_fn(|cx| split.poll_finish(cx)).await.unwrap();
+/// assert_eq!(root.to_bytes().len(), 64);
+/// # });
+/// ```
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RandomKeys;
+
+impl KeySource for RandomKeys {
+    fn next_key(&self) -> Result<EncryptionKey, KeyError> {
+        Ok(EncryptionKey::generate())
+    }
+}
+
+/// Encrypted split: each payload is sealed under a fresh key from the
+/// source, and a reference carries the ciphertext address plus that key.
+impl<K: KeySource> SplitMode for Encrypted<K> {
+    const MODE: Mode = Mode::Encrypted;
+
+    type Ref = EncryptedChunkRef;
+    type Root = EncryptedChunkRef;
+
+    fn data_slots(branches: u64) -> u64 {
+        branches
+    }
+
+    fn seal<const B: usize>(&self, payload: Bytes) -> Result<Sealed<Self, B>, SealError> {
+        let key = self.source().next_key()?;
+        let (chunk, reference) = ContentChunk::<B>::try_from(payload)?
+            .encrypt_with(&key)?
+            .into_parts();
+        Ok((chunk.seal::<AnyChunkSet<B>>(), reference))
+    }
+
+    fn write_ref(reference: &EncryptedChunkRef, out: &mut Vec<u8>) {
+        out.extend_from_slice(&reference.to_bytes());
+    }
+
+    fn into_root(reference: EncryptedChunkRef) -> EncryptedChunkRef {
+        reference
+    }
+}

--- a/crates/file/src/split/engine.rs
+++ b/crates/file/src/split/engine.rs
@@ -77,6 +77,7 @@ where
     M: SplitMode,
 {
     store: S,
+    mode: M,
     /// Data-carrying reference slots per intermediate, from the mode.
     slots: u64,
     window: usize,
@@ -110,13 +111,23 @@ where
 
     /// Split a byte stream into the tree under `store`, holding at most
     /// `window` puts in flight.
-    pub fn new(store: S, window: PutWindow) -> Self {
+    pub fn new(store: S, window: PutWindow) -> Self
+    where
+        M: Default,
+    {
+        Self::with_mode(store, M::default(), window)
+    }
+
+    /// Split through an explicitly constructed `mode` (a keyed encrypted
+    /// mode); otherwise identical to [`new`](Self::new).
+    pub fn with_mode(store: S, mode: M, window: PutWindow) -> Self {
         const { Self::PROFILE };
         let branches = fan_out(u64_from_usize(B), u64_from_u32(M::MODE.ref_size()));
         // A close must shrink its level, so the seam floors at two slots.
         let slots = M::data_slots(branches).max(2);
         Self {
             store,
+            mode,
             slots,
             window: usize::from(window.get()),
             leaf: Vec::new(),
@@ -296,7 +307,7 @@ where
         let mut payload = Vec::with_capacity(SPAN_SIZE.saturating_add(data.len()));
         payload.extend_from_slice(&span.to_le_bytes());
         payload.extend_from_slice(&data);
-        let (chunk, reference) = M::seal::<B>(Bytes::from(payload))?;
+        let (chunk, reference) = self.mode.seal::<B>(Bytes::from(payload))?;
         self.stats.leaves = self.stats.leaves.saturating_add(1);
         self.enqueue(chunk);
         self.push_ref(0, reference, span)
@@ -369,7 +380,7 @@ where
         for reference in refs {
             M::write_ref(reference, &mut payload);
         }
-        let (chunk, reference) = M::seal::<B>(Bytes::from(payload))?;
+        let (chunk, reference) = self.mode.seal::<B>(Bytes::from(payload))?;
         self.stats.intermediates = self.stats.intermediates.saturating_add(1);
         self.enqueue(chunk);
         Ok(reference)

--- a/crates/file/src/split/error.rs
+++ b/crates/file/src/split/error.rs
@@ -3,6 +3,18 @@
 use nectar_primitives::PrimitivesError;
 use nectar_primitives::chunk::ChunkAddress;
 
+/// Failure sealing one payload into a chunk.
+#[derive(Debug, thiserror::Error)]
+pub enum SealError {
+    /// Chunk construction or encryption rejected the payload.
+    #[error("chunk construction failed")]
+    Chunk(#[from] PrimitivesError),
+    /// The key source yielded no key for the chunk.
+    #[cfg(feature = "encryption")]
+    #[error("key source failed")]
+    Key(#[from] super::encrypted::KeyError),
+}
+
 /// Terminal split failure.
 #[derive(Debug, thiserror::Error)]
 pub enum SplitError<E> {
@@ -16,7 +28,7 @@ pub enum SplitError<E> {
     },
     /// Sealing a payload into a chunk failed.
     #[error("seal failed")]
-    Seal(#[from] PrimitivesError),
+    Seal(#[from] SealError),
     /// Accumulated child spans overflowed the `u64` length domain.
     #[error("span overflow adding {add} to {span}")]
     SpanOverflow {

--- a/crates/file/src/split/mod.rs
+++ b/crates/file/src/split/mod.rs
@@ -23,14 +23,19 @@
 //! 5. Fused finish: `poll_finish` is cancel-safe and re-callable; after the
 //!    root is delivered every later call returns the same root.
 
+#[cfg(feature = "encryption")]
+mod encrypted;
 mod engine;
 mod error;
 mod mode;
 #[cfg(test)]
 mod tests;
 
+#[cfg(feature = "encryption")]
+#[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
+pub use encrypted::{KeyError, KeySource, RandomKeys};
 pub use engine::Split;
-pub use error::SplitError;
+pub use error::{SealError, SplitError};
 pub use mode::{Sealed, SplitMode};
 
 /// Occupancy witnesses of one split.

--- a/crates/file/src/split/mode.rs
+++ b/crates/file/src/split/mode.rs
@@ -4,10 +4,10 @@ use alloc::vec::Vec;
 use core::fmt::Debug;
 
 use bytes::Bytes;
-use nectar_primitives::PrimitivesError;
 use nectar_primitives::chunk::{AnyChunkSet, Chunk, ChunkAddress, ContentChunk, Verified};
 use nectar_primitives::store::{MaybeSend, MaybeSync};
 
+use super::error::SealError;
 use crate::geometry::Mode;
 use crate::walk::Plain;
 
@@ -37,7 +37,7 @@ pub trait SplitMode: MaybeSend + MaybeSync + 'static {
     ///
     /// The payload is the chunk's wire body: a little-endian `u64` span
     /// followed by the spanned content (leaf bytes or packed references).
-    fn seal<const B: usize>(payload: Bytes) -> Result<Sealed<Self, B>, PrimitivesError>;
+    fn seal<const B: usize>(&self, payload: Bytes) -> Result<Sealed<Self, B>, SealError>;
 
     /// Append one reference's wire bytes to a parent payload under build.
     fn write_ref(reference: &Self::Ref, out: &mut Vec<u8>);
@@ -58,7 +58,7 @@ impl SplitMode for Plain {
         branches
     }
 
-    fn seal<const B: usize>(payload: Bytes) -> Result<Sealed<Self, B>, PrimitivesError> {
+    fn seal<const B: usize>(&self, payload: Bytes) -> Result<Sealed<Self, B>, SealError> {
         let chunk = ContentChunk::<B>::try_from(payload)?.seal::<AnyChunkSet<B>>();
         let address = *chunk.address();
         Ok((chunk, address))

--- a/crates/file/src/split/tests.rs
+++ b/crates/file/src/split/tests.rs
@@ -397,6 +397,239 @@ fn finish_is_fused_and_recallable() {
     assert_eq!(root, legacy_root);
 }
 
+/// Encrypted-mode oracles: legacy joiner and splitter differentials, walk
+/// round trip, per-mode geometry witnesses, key-source injection and
+/// exhaustion.
+#[cfg(feature = "encryption")]
+mod encrypted {
+    use core::future::poll_fn;
+    use core::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::Arc;
+    use std::vec::Vec;
+
+    use futures::executor::block_on;
+    use nectar_primitives::chunk::encryption::{EncryptedChunkRef, EncryptionKey};
+    use nectar_primitives::file::{EncryptedParallelSplitter, join};
+
+    use super::{BRANCHES, TINY, TestStore, fill, sorted};
+    use crate::config::{PutWindow, Window};
+    use crate::geometry::{Mode, branches, max_depth};
+    use crate::split::{KeyError, KeySource, RandomKeys, SealError, Split, SplitError, SplitStats};
+    use crate::walk::{Encrypted, Walk};
+
+    /// Encrypted fan-out at the tiny body: four 64-byte references.
+    const ENC_BRANCHES: usize = 4;
+
+    /// Deterministic source: counter keys starting at one, shared across
+    /// clones.
+    #[derive(Debug, Clone, Default)]
+    struct SeqKeys(Arc<AtomicU64>);
+
+    impl KeySource for SeqKeys {
+        fn next_key(&self) -> Result<EncryptionKey, KeyError> {
+            let n = self.0.fetch_add(1, Ordering::Relaxed) + 1;
+            let mut bytes = [0u8; EncryptionKey::SIZE];
+            bytes[..8].copy_from_slice(&n.to_le_bytes());
+            Ok(EncryptionKey::from(bytes))
+        }
+    }
+
+    /// Finite source: refuses every key past `limit`.
+    #[derive(Debug, Clone)]
+    struct LimitedKeys {
+        limit: u64,
+        issued: Arc<AtomicU64>,
+    }
+
+    impl KeySource for LimitedKeys {
+        fn next_key(&self) -> Result<EncryptionKey, KeyError> {
+            let n = self.issued.fetch_add(1, Ordering::Relaxed);
+            if n >= self.limit {
+                return Err(KeyError::Exhausted { issued: self.limit });
+            }
+            let mut bytes = [0u8; EncryptionKey::SIZE];
+            bytes[..8].copy_from_slice(&(n + 1).to_le_bytes());
+            Ok(EncryptionKey::from(bytes))
+        }
+    }
+
+    /// Stream `data` through a fresh encrypted split in `step`-byte writes.
+    fn stream_split_encrypted<K: KeySource>(
+        data: &[u8],
+        mode: Encrypted<K>,
+        step: usize,
+    ) -> (EncryptedChunkRef, TestStore<TINY>, SplitStats) {
+        let store = TestStore::<TINY>::new(1);
+        let mut split: Split<TestStore<TINY>, Encrypted<K>, TINY> =
+            Split::with_mode(store.clone(), mode, PutWindow::new(4).unwrap());
+        let root = block_on(async {
+            for piece in data.chunks(step.max(1)) {
+                let mut buf = piece;
+                while !buf.is_empty() {
+                    let n = poll_fn(|cx| split.poll_write(cx, buf)).await.unwrap();
+                    buf = &buf[n..];
+                }
+            }
+            poll_fn(|cx| split.poll_finish(cx)).await.unwrap()
+        });
+        let stats = split.stats();
+        (root, store, stats)
+    }
+
+    /// Depth-boundary sizes for the encrypted fan-out.
+    fn sizes() -> Vec<usize> {
+        let b = TINY;
+        let kb = ENC_BRANCHES * b;
+        let k2b = ENC_BRANCHES * kb;
+        std::vec![
+            0,
+            1,
+            b - 1,
+            b,
+            b + 1,
+            kb - 1,
+            kb,
+            kb + 1,
+            k2b - 1,
+            k2b,
+            k2b + 1,
+            3 * kb + 517,
+        ]
+    }
+
+    #[test]
+    fn encrypted_roots_join_through_the_legacy_joiner() {
+        for size in sizes() {
+            let data = fill(size);
+            // The rand-gated default source through the `Default` mode.
+            let store = TestStore::<TINY>::new(1);
+            let mut split: Split<TestStore<TINY>, Encrypted<RandomKeys>, TINY> =
+                Split::new(store.clone(), PutWindow::new(4).unwrap());
+            let root = block_on(async {
+                let mut buf = data.as_slice();
+                while !buf.is_empty() {
+                    let n = poll_fn(|cx| split.poll_write(cx, buf)).await.unwrap();
+                    buf = &buf[n..];
+                }
+                poll_fn(|cx| split.poll_finish(cx)).await.unwrap()
+            });
+            let plaintext = block_on(join(&store, root)).unwrap();
+            assert_eq!(plaintext, data, "plaintext diverged at {size}");
+
+            // The tree shape matches the legacy encrypted splitter.
+            let (_, legacy_chunks) =
+                EncryptedParallelSplitter::<TINY>::split_to_vec(&data).unwrap();
+            let stats = split.stats();
+            assert_eq!(
+                stats.puts as usize,
+                legacy_chunks.len(),
+                "chunk count diverged at {size}"
+            );
+            assert_eq!(stats.bytes, size as u64);
+            assert_eq!(stats.leaves + stats.intermediates, stats.puts);
+        }
+    }
+
+    #[test]
+    fn encrypted_split_then_walk_round_trips() {
+        let size = 13 * TINY + 29;
+        let data = fill(size);
+        let (root, store, _) =
+            stream_split_encrypted(&data, Encrypted::new(SeqKeys::default()), 719);
+        let mut walk: Walk<TestStore<TINY>, Encrypted, TINY> = Walk::new(
+            store,
+            *root.address(),
+            root.key().clone(),
+            size as u64,
+            0..u64::MAX,
+            Window::new(4).unwrap(),
+        );
+        let bytes = block_on(async {
+            let mut bytes = Vec::new();
+            while let Some(frame) = poll_fn(|cx| walk.poll_next_ordered(cx)).await {
+                bytes.extend_from_slice(&frame.unwrap().data);
+            }
+            bytes
+        });
+        assert_eq!(bytes, data);
+    }
+
+    #[test]
+    fn per_mode_geometry_diverges_at_the_shared_body() {
+        let body = TINY as u32;
+        assert_eq!(branches(body, Mode::Plain), BRANCHES as u32);
+        assert_eq!(branches(body, Mode::Encrypted), ENC_BRANCHES as u32);
+        assert_eq!(max_depth(body, Mode::Plain), 20);
+        assert_eq!(max_depth(body, Mode::Encrypted), 29);
+
+        // Sixty-four leaves: a two-level plain tree against a three-level
+        // encrypted tree over the same bytes.
+        let data = fill(64 * TINY);
+        let (_, _, plain_stats) = super::stream_split::<TINY>(&data, 4, 719, 1);
+        assert_eq!(plain_stats.leaves, 64);
+        assert_eq!(plain_stats.intermediates, 9);
+        assert_eq!(plain_stats.peak_spine, 3);
+
+        let (_, _, enc_stats) =
+            stream_split_encrypted(&data, Encrypted::new(SeqKeys::default()), 719);
+        assert_eq!(enc_stats.leaves, 64);
+        assert_eq!(enc_stats.intermediates, 21);
+        assert_eq!(enc_stats.peak_spine, 4);
+    }
+
+    #[test]
+    fn a_deterministic_source_pins_the_padless_tree() {
+        // Every node is full at this size, so no random padding enters the
+        // ciphertexts and the whole tree is a function of the key stream.
+        let data = fill(16 * TINY);
+        let (first_root, first_store, _) =
+            stream_split_encrypted(&data, Encrypted::new(SeqKeys::default()), 719);
+        let (second_root, second_store, _) =
+            stream_split_encrypted(&data, Encrypted::new(SeqKeys::default()), 97);
+        assert_eq!(first_root, second_root);
+        assert_eq!(sorted(first_store.log()), sorted(second_store.log()));
+    }
+
+    #[test]
+    fn an_exhausted_key_source_poisons_the_split() {
+        let data = fill(3 * TINY);
+        let source = LimitedKeys {
+            limit: 2,
+            issued: Arc::new(AtomicU64::new(0)),
+        };
+        let store = TestStore::<TINY>::new(0);
+        let mut split: Split<TestStore<TINY>, Encrypted<LimitedKeys>, TINY> =
+            Split::with_mode(store, Encrypted::new(source), PutWindow::new(4).unwrap());
+        let error = block_on(async {
+            let mut buf = data.as_slice();
+            loop {
+                match poll_fn(|cx| split.poll_write(cx, buf)).await {
+                    Ok(n) => buf = &buf[n..],
+                    Err(error) => break error,
+                }
+                if buf.is_empty() {
+                    break poll_fn(|cx| split.poll_finish(cx)).await.unwrap_err();
+                }
+            }
+        });
+        assert!(
+            matches!(
+                error,
+                SplitError::Seal(SealError::Key(KeyError::Exhausted { issued: 2 }))
+            ),
+            "got {error:?}"
+        );
+
+        // The fuse is shut for good.
+        let waker = futures::task::noop_waker();
+        let mut cx = core::task::Context::from_waker(&waker);
+        assert!(matches!(
+            split.poll_finish(&mut cx),
+            core::task::Poll::Ready(Err(SplitError::Poisoned))
+        ));
+    }
+}
+
 /// Nightly gate: a stream past the `u32` span boundary keeps root equality
 /// with the legacy splitter while memory stays bounded.
 #[test]

--- a/crates/file/src/walk/mode.rs
+++ b/crates/file/src/walk/mode.rs
@@ -68,10 +68,28 @@ impl WalkMode for Plain {
 
 /// Encrypted mode: a reference carries an address plus the decryption key of
 /// a keccak counter-mode ciphertext body.
+///
+/// Joining needs no keys beyond the references, so the default `K = ()`
+/// serves every read path; the split side instantiates `K` with a key
+/// source behind the `encryption` feature.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct Encrypted;
+pub struct Encrypted<K = ()> {
+    source: K,
+}
 
-impl WalkMode for Encrypted {
+impl<K> Encrypted<K> {
+    /// Wrap a split-side key source; `Encrypted::default()` covers reads.
+    pub const fn new(source: K) -> Self {
+        Self { source }
+    }
+
+    /// The wrapped key source.
+    pub const fn source(&self) -> &K {
+        &self.source
+    }
+}
+
+impl<K: MaybeSend + MaybeSync + 'static> WalkMode for Encrypted<K> {
     const MODE: Mode = Mode::Encrypted;
 
     type Context = EncryptionKey;


### PR DESCRIPTION
## What

- `walk::Encrypted` becomes `Encrypted<K = ()>`: bare `Encrypted` still serves the unconditional decrypt path, while `K` is instantiated with a `KeySource` on the split side under the `encryption` feature.
- New `split/encrypted.rs`: `KeySource` trait (`next_key -> Result<EncryptionKey, KeyError>`, shared-handle contract so clones draw from one stream), `KeyError::Exhausted { issued }`, rand-gated `RandomKeys` default, and `impl SplitMode for Encrypted<K>` sealing each payload via `encrypt_with` into an `EncryptedChunkRef`.
- `SplitMode::seal` changes from an associated function to `&self`-taking, and returns the new `SealError` (`Chunk` from `PrimitivesError`, feature-gated `Key` from `KeyError`) instead of `PrimitivesError` directly; `split::mod` re-exports `SealError`.
- `Split` now holds its `mode: M`; `new` requires `M: Default` and delegates to a new `with_mode(store, mode, window)` for keyed construction.
- `parallel::split_read_at` requires `M: Default + Clone`, constructs the mode once via `with_mode`, and clones it into each batch so a key-sourcing mode draws from one stream across pool workers; `parallel::error` reworked to carry `SealError` instead of `PrimitivesError`.
- CI: lint workflow adds a `cargo clippy --features encryption` job; unit workflow runs rayon tests/doctests with `rayon,encryption` and adds dedicated encrypted-split test/doctest jobs.
- Tests: `split/tests.rs` gains encrypted-mode coverage (chunk-count differentials, geometry witnesses, exhaustion, determinism); `parallel/tests.rs` gains pooled encrypted-ingest coverage.

## Why

Closes #338

## Testing

- `cargo nextest run -p nectar-file --features encryption`
- `cargo nextest run -p nectar-file --features rayon,encryption`
- `cargo test --doc -p nectar-file --features encryption`
- `cargo clippy --all-targets -p nectar-file` (warning-clean)
- Adversarial red-team pass: no correctness bugs found; encrypted split output validated retrievable through both the legacy joiner and the new walk, cancel-safety, Send/Sync bounds, and the `Encrypted<()>` read path all hold.

## AI Assistance

Implementation by Fable, review by Opus, PR by Sonnet.

