### PR TITLE
feat(manifest): stream file splitting through the file-crate Split engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2078,6 +2078,7 @@ dependencies = [
  "alloy-primitives",
  "bytes",
  "futures",
+ "nectar-file",
  "nectar-primitives",
  "proptest",
  "thiserror",

--- a/crates/manifest/Cargo.toml
+++ b/crates/manifest/Cargo.toml
@@ -21,6 +21,7 @@ workspace = true
 alloy-primitives = { workspace = true }
 bytes.workspace = true
 futures.workspace = true
+nectar-file = { workspace = true }
 nectar-primitives = { workspace = true }
 thiserror.workspace = true
 
@@ -40,6 +41,7 @@ encryption = []
 std = [
 	"alloy-primitives/std",
 	"bytes/std",
+	"nectar-file/std",
 	"nectar-primitives/std",
 	"thiserror/std",
 ]

--- a/crates/manifest/src/builder.rs
+++ b/crates/manifest/src/builder.rs
@@ -7,15 +7,15 @@
 //! key set enters through a sorted map, so the published tree is a pure function
 //! of the keys, identical whatever order the caller streamed them in.
 
-use std::collections::BTreeMap;
-use std::io::Write;
+use core::convert::Infallible;
+use core::future::poll_fn;
+use std::collections::{BTreeMap, VecDeque};
+use std::sync::{Arc, Mutex, PoisonError};
 
 use bytes::Bytes;
+use nectar_file::{Plain, PutWindow, Split, SplitError};
 use nectar_primitives::store::{BoxedError, ChunkPut, MaybeSend, MaybeSync};
-#[allow(deprecated)]
-use nectar_primitives::{
-    Chunk, ChunkAddress, ChunkRef, ContentChunk, DefaultSplitter, FileError, PrimitivesError,
-};
+use nectar_primitives::{Chunk, ChunkAddress, ChunkRef, ContentChunk, PrimitivesError};
 
 use crate::bounded::{Prefix, SegmentWeight};
 use crate::codec::{
@@ -40,13 +40,10 @@ pub enum BuildError {
     /// here as an encode error.
     #[error(transparent)]
     Store(#[from] StoreError),
-    /// Splitting a file into BMT chunks failed.
-    #[allow(deprecated)]
+    /// Splitting a file into BMT chunks failed. The relay put is infallible,
+    /// so every failure here is an engine or seal error.
     #[error("split file")]
-    Split(#[source] FileError),
-    /// Buffering a file for splitting failed.
-    #[error("buffer file")]
-    Buffer(#[source] std::io::Error),
+    Split(#[from] SplitError<Infallible>),
     /// Sealing a file chunk failed.
     #[error("seal file chunk")]
     Seal(#[source] PrimitivesError),
@@ -596,29 +593,79 @@ where
     Ok(address)
 }
 
-/// Split `data` through BMT, spill its chunks to `store`, and return its plain
-/// root reference. Reuses the primitives splitter, so the BMT is shared.
-#[allow(deprecated)]
+/// Shared put queue bridging the borrowed caller store to the owned-handle
+/// store the splitter clones per put: puts land here synchronously and
+/// [`drain`] forwards them between polls, so the splitter never parks and its
+/// memory bound carries over.
+#[derive(Clone, Debug, Default)]
+struct Relay {
+    queue: Arc<Mutex<VecDeque<Chunk>>>,
+}
+
+impl Relay {
+    /// The oldest queued chunk; a poisoned lock hands back its inner queue,
+    /// which a single push or pop cannot leave inconsistent.
+    fn pop(&self) -> Option<Chunk> {
+        self.queue
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .pop_front()
+    }
+}
+
+impl ChunkPut for Relay {
+    type Error = Infallible;
+
+    async fn put(&self, chunk: Chunk) -> Result<(), Self::Error> {
+        self.queue
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .push_back(chunk);
+        Ok(())
+    }
+}
+
+/// Forward every queued chunk to the caller's store in seal order.
+async fn drain<S>(relay: &Relay, store: &S) -> Result<(), BuildError>
+where
+    S: ChunkPut + MaybeSync,
+{
+    while let Some(chunk) = relay.pop() {
+        store.put(chunk).await.map_err(BuildError::backend)?;
+    }
+    Ok(())
+}
+
+/// Split `data` through the streaming splitter, forwarding each sealed chunk
+/// to `store` as it spills, and return the file's plain root reference.
 async fn split_file<S>(store: &S, data: &[u8]) -> Result<ChunkRef, BuildError>
 where
     S: ChunkPut + MaybeSync,
 {
-    let span = u64::try_from(data.len()).map_err(|_| BuildError::Internal)?;
-    let mut splitter = DefaultSplitter::new(span);
-    splitter.write_all(data).map_err(BuildError::Buffer)?;
-    let (root, chunks) = splitter.finish().map_err(BuildError::Split)?;
-    for chunk in chunks {
-        let sealed = Chunk::from_envelope(chunk.into()).map_err(BuildError::Seal)?;
-        store.put(sealed).await.map_err(BuildError::backend)?;
+    let relay = Relay::default();
+    let mut split: Split<Relay, Plain> = Split::new(relay.clone(), PutWindow::DEFAULT);
+    let mut rest = data;
+    while !rest.is_empty() {
+        // Relay puts complete in place, so the splitter always accepts bytes
+        // and every sealed chunk is forwarded before more bytes go in.
+        let taken = poll_fn(|cx| split.poll_write(cx, rest)).await?;
+        rest = match rest.split_at_checked(taken) {
+            Some((consumed, tail)) if !consumed.is_empty() => tail,
+            _ => return Err(BuildError::Internal),
+        };
+        drain(&relay, store).await?;
     }
+    let root = poll_fn(|cx| split.poll_finish(cx)).await?;
+    drain(&relay, store).await?;
     Ok(ChunkRef::new(root))
 }
 
 /// Stream files through BMT into one published manifest.
 ///
-/// Each `(key, file)` pair is split into content chunks, stored, and bound to
-/// the file's root reference; the manifest is then assembled and published. The
-/// iteration order does not affect the published root.
+/// Each `(key, file)` pair streams through the bounded splitter into stored
+/// content chunks and binds to the file's root reference; the manifest is then
+/// assembled and published. The iteration order does not affect the published
+/// root.
 ///
 /// ```
 /// use nectar_manifest::{build_files, Key};

--- a/crates/manifest/tests/bridge.rs
+++ b/crates/manifest/tests/bridge.rs
@@ -1,0 +1,126 @@
+//! Byte pin of the streaming build bridge against the legacy split path.
+//!
+//! For a battery of boundary sizes, `build_files` must publish the same
+//! manifest root as a build over the legacy whole-buffer splitter's
+//! references, and the stored chunk address set must match exactly. Chunks
+//! are content-addressed, so address equality pins the stored bytes.
+
+// Bench, example, and integration-test code: unwraps, direct indexing,
+// casts, and assertions are setup and illustration, not shipped surface.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::as_conversions,
+    clippy::missing_panics_doc
+)]
+// The legacy whole-buffer splitter is the differential oracle here.
+#![allow(deprecated)]
+
+use std::error::Error;
+
+use bytes::Bytes;
+use futures::executor::block_on;
+use nectar_manifest::{Builder, Entry, Key, Reader, build_files};
+use nectar_primitives::{ChunkRef, DEFAULT_BODY_SIZE, MemoryStore, split};
+
+type TestResult = Result<(), Box<dyn Error>>;
+
+/// A fallible assertion: Result-returning tests report failures as errors.
+fn ensure(cond: bool, what: &str) -> TestResult {
+    if cond { Ok(()) } else { Err(what.into()) }
+}
+
+/// A fallible equality assertion.
+fn ensure_eq<T: PartialEq + core::fmt::Debug>(left: T, right: T, what: &str) -> TestResult {
+    if left == right {
+        Ok(())
+    } else {
+        Err(format!("{what}: {left:?} != {right:?}").into())
+    }
+}
+
+const B: usize = DEFAULT_BODY_SIZE;
+/// Reference fan-out of one intermediate chunk at the default body size.
+const FAN: usize = B / 32;
+
+/// Boundary sizes: empty, single byte, the leaf edges, one full intermediate
+/// level and its neighbours, and a two-level interior point.
+const SIZES: &[usize] = &[
+    0,
+    1,
+    B - 1,
+    B,
+    B + 1,
+    2 * B + 37,
+    FAN * B - 1,
+    FAN * B,
+    FAN * B + 1,
+    2 * FAN * B + 3,
+];
+
+/// Non-uniform bytes so leaf boundaries cut through varying content.
+fn pattern(size: usize) -> Bytes {
+    Bytes::from((0..size).map(|i| (i % 251) as u8).collect::<Vec<u8>>())
+}
+
+#[test]
+fn streaming_bridge_pins_the_legacy_split_bytes() -> TestResult {
+    for &size in SIZES {
+        let data = pattern(size);
+        let key = Key::from(&b"file"[..]);
+
+        let store = MemoryStore::default();
+        let built = block_on(build_files(&store, [(key.clone(), data.clone())]))?;
+
+        // The prior bridge: the same manifest over the legacy splitter's
+        // reference, with the legacy chunk set as the file bytes oracle.
+        let (legacy_root, legacy_chunks) = split::<DEFAULT_BODY_SIZE>(&data)?;
+        let node_store = MemoryStore::default();
+        let mut builder: Builder = Builder::new();
+        builder.insert(key, Entry::from(ChunkRef::new(legacy_root)), None);
+        let legacy_built = block_on(builder.build(&node_store))?;
+        ensure_eq(built.root(), legacy_built.root(), "manifest root")?;
+
+        let legacy = legacy_chunks.into_chunks();
+        let nodes = node_store.into_chunks();
+        for address in legacy.keys() {
+            ensure(store.get(address).is_some(), "legacy chunk stored")?;
+        }
+        // Exact set equality: with the file chunks and manifest nodes both
+        // pinned, no other chunk may appear.
+        for address in store.into_chunks().keys() {
+            ensure(
+                legacy.contains_key(address) || nodes.contains_key(address),
+                "no chunk beyond the legacy set and the manifest nodes",
+            )?;
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn bridged_files_round_trip_byte_exact() -> TestResult {
+    let store = MemoryStore::default();
+    let big = pattern(FAN * B + 5);
+    let files = [
+        (Key::from(&b"a/big"[..]), big.clone()),
+        (Key::from(&b"a/small"[..]), Bytes::from_static(b"x")),
+    ];
+    let root = *block_on(build_files(&store, files))?.root();
+
+    let reader: Reader<_> = Reader::new(&store);
+    ensure_eq(
+        block_on(reader.fetch(&root, &Key::from(&b"a/big"[..])))?,
+        Some(big),
+        "deep file round trip",
+    )?;
+    ensure_eq(
+        block_on(reader.fetch(&root, &Key::from(&b"a/small"[..])))?,
+        Some(Bytes::from_static(b"x")),
+        "single-leaf round trip",
+    )
+}

--- a/crates/manifest/tests/bridge.rs
+++ b/crates/manifest/tests/bridge.rs
@@ -5,18 +5,6 @@
 //! references, and the stored chunk address set must match exactly. Chunks
 //! are content-addressed, so address equality pins the stored bytes.
 
-// Bench, example, and integration-test code: unwraps, direct indexing,
-// casts, and assertions are setup and illustration, not shipped surface.
-#![allow(
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::indexing_slicing,
-    clippy::arithmetic_side_effects,
-    clippy::panic,
-    clippy::panic_in_result_fn,
-    clippy::as_conversions,
-    clippy::missing_panics_doc
-)]
 // The legacy whole-buffer splitter is the differential oracle here.
 #![allow(deprecated)]
 
@@ -62,9 +50,11 @@ const SIZES: &[usize] = &[
     2 * FAN * B + 3,
 ];
 
-/// Non-uniform bytes so leaf boundaries cut through varying content.
+/// Non-uniform bytes so leaf boundaries cut through varying content. The
+/// 251-byte cycle is coprime with the body size, so no two leaves repeat.
 fn pattern(size: usize) -> Bytes {
-    Bytes::from((0..size).map(|i| (i % 251) as u8).collect::<Vec<u8>>())
+    let cycle = (0u16..251).map(|byte| u8::try_from(byte).unwrap_or_default());
+    Bytes::from(cycle.cycle().take(size).collect::<Vec<u8>>())
 }
 
 #[test]

--- a/crates/manifest/tests/builder.rs
+++ b/crates/manifest/tests/builder.rs
@@ -4,7 +4,7 @@
 //! buffers track the trie depth rather than the key count, and the files path
 //! splits through BMT and references the stored roots.
 
-// The legacy splitter seeds fixtures until the nectar-file bridge lands.
+// The legacy splitter is the differential oracle for the streaming bridge.
 #![allow(deprecated)]
 
 use std::error::Error;

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1913,6 +1913,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "nectar-file"
+version = "0.4.0"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "nectar-primitives",
+ "thiserror",
+]
+
+[[package]]
 name = "nectar-fuzz"
 version = "0.0.0"
 dependencies = [
@@ -1935,6 +1945,8 @@ version = "0.4.0"
 dependencies = [
  "alloy-primitives",
  "bytes",
+ "futures",
+ "nectar-file",
  "nectar-primitives",
  "thiserror",
 ]
@@ -2011,6 +2023,7 @@ dependencies = [
  "hybrid-array",
  "js-sys",
  "keccak-batch",
+ "once_cell",
  "parking_lot",
  "rand 0.10.2",
  "rayon",

--- a/zepter.yaml
+++ b/zepter.yaml
@@ -16,6 +16,10 @@ workflows:
         # (transcrypt, keccak, the ref types), so the feature deliberately
         # enables no primitives feature.
         "--ignore-missing-propagate=nectar-manifest/encryption:nectar-primitives/encryption",
+        # Manifest encryption is node-level; the build bridge splits files in
+        # plain mode only, so it deliberately leaves the file crate's
+        # encrypted split mode off.
+        "--ignore-missing-propagate=nectar-manifest/encryption:nectar-file/encryption",
         "--workspace",
         "--show-path",
         "--quiet",


### PR DESCRIPTION
## What

Ports `nectar-manifest`'s `split_file`/`build_files` onto `nectar-file`'s streaming `Split` engine. `split_file` now drives `Split<Relay, Plain>` via `poll_fn`: a private `Relay` (`Arc<Mutex<VecDeque<Chunk>>>`, infallible `ChunkPut`) receives the engine's puts synchronously, and `drain()` forwards them to the caller's borrowed store between polls. This preserves the existing `&S` public API and the splitter's memory bound, since the engine requires an owned `Clone + 'static` store handle that a borrowed store cannot satisfy directly, and `MemoryStore`'s deep `Clone` would silently lose chunks.

Removed the deprecated `DefaultSplitter` path and the `BuildError::Buffer` variant; `BuildError::Split` now carries `SplitError<Infallible>` via `#[from]`.

Added `crates/manifest/tests/bridge.rs`: a round-trip byte pin over boundary sizes (0, 1, B-1, B, B+1, 2B+37, FAN*B-1, FAN*B, FAN*B+1, 2*FAN*B+3) proving the streamed manifest root and stored chunks are identical to the legacy path.

Closes #347

## Why

Aligns `nectar-manifest`'s file splitting with the memory-bounded streaming engine in `nectar-file`, dropping the deprecated buffering splitter while keeping the public API and memory-bound guarantees intact.

## Testing

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --locked`: succeeds; the diff's crates (`nectar-manifest`, `nectar-file`) compile warning-free (pre-existing warnings in `nectar-primitives`/`nectar-mantaray` are untouched by this change).
- `cargo nextest run -p nectar-manifest --locked`: 214 passed, 0 skipped, including the new differential-oracle tests in `bridge.rs`.
- Independent review verified end-to-end with no source changes needed after the lint fix in `e41d1f6f` (restriction-lint allow removed from `tests/bridge.rs`, matching the `builder.rs` convention).

## AI Assistance

Implementation Fable, review Opus, PR Sonnet.

