### PR TITLE
docs(file): add the six exhibit doctests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2066,6 +2066,7 @@ dependencies = [
  "codspeed-criterion-compat",
  "futures",
  "futures-util",
+ "nectar-mantaray",
  "nectar-primitives",
  "rayon",
  "thiserror",

--- a/crates/file/Cargo.toml
+++ b/crates/file/Cargo.toml
@@ -28,6 +28,8 @@ tokio = { workspace = true, features = ["sync"], optional = true }
 [dev-dependencies]
 criterion.workspace = true
 futures.workspace = true
+# The manifest-edit exhibit publishes a file root under a path.
+nectar-mantaray.workspace = true
 # The differential oracles split and join through the legacy read paths,
 # including the encrypted width.
 nectar-primitives = { workspace = true, features = ["std", "encryption"] }

--- a/crates/file/src/lib.rs
+++ b/crates/file/src/lib.rs
@@ -10,6 +10,41 @@
 //! into, the [`store`] erasure that makes file handles nameable, the
 //! [`sync`] driver for Ready-only guests, and the `parallel` batch ingest
 //! over a random-access source (behind the `rayon` feature).
+//!
+//! # Exhibits
+//!
+//! Runnable exhibits sit on their surfaces: http range serving on the
+//! `tokio` adapter module, streaming upload on `TokioWriter`, restartable
+//! download on [`DownloadBuilder`], the executor-agnostic stream on
+//! [`FileStream`], and a whole-file guest read under [`sync::drive`].
+//! Publishing a root under a manifest path rides the legacy mantaray edit
+//! surface:
+//!
+//! ```
+//! # #![allow(deprecated)]
+//! use nectar_file::AnyFile;
+//! use nectar_mantaray::Manifest;
+//!
+//! # futures::executor::block_on(async {
+//! let data = b"hello swarm".to_vec();
+//! # let (root, store) = nectar_primitives::file::split::<4096>(&data).unwrap();
+//! let mut manifest = Manifest::new(store);
+//! manifest.add("hello.txt", root).await.unwrap();
+//! manifest.add("stale.txt", root).await.unwrap();
+//! manifest.remove("stale.txt").await.unwrap();
+//! let manifest_root = manifest.save().await.unwrap();
+//!
+//! let (_, store) = manifest.into_parts();
+//! let manifest = Manifest::open(manifest_root, store);
+//! assert!(manifest.get("stale.txt").await.unwrap().is_none());
+//! let entry = manifest.get("hello.txt").await.unwrap().unwrap();
+//! let (_, store) = manifest.into_parts();
+//! let file = AnyFile::open(store, entry.reference().unwrap().clone())
+//!     .await
+//!     .unwrap();
+//! assert_eq!(file.collect(u64::MAX).await.unwrap(), data);
+//! # });
+//! ```
 
 #![no_std]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]

--- a/crates/file/src/read/download.rs
+++ b/crates/file/src/read/download.rs
@@ -40,6 +40,31 @@ pub type ProgressFn = Box<dyn FnMut(Progress)>;
 /// the clipped range start. A download is restartable, not resumable: after
 /// a failure, run it again in full; the sink's idempotent overwrites make
 /// the re-run safe.
+///
+/// ```
+/// # #![allow(deprecated)]
+/// use nectar_file::{File, MemSink};
+///
+/// # futures::executor::block_on(async {
+/// let data: Vec<u8> = (0u32..40_000)
+///     .map(|i| u8::try_from(i % 251).unwrap())
+///     .collect();
+/// # let (root, store) = nectar_primitives::file::split::<4096>(&data).unwrap();
+/// let file = File::open(store, root).await.unwrap();
+/// let mut sink = MemSink::new();
+/// let written = file
+///     .download()
+///     .range(8_192..24_576)
+///     .progress(Box::new(|progress| {
+///         assert!(progress.written <= progress.total);
+///     }))
+///     .run(&mut sink)
+///     .await
+///     .unwrap();
+/// assert_eq!(written, 16_384);
+/// assert_eq!(sink.as_ref(), &data[8_192..24_576]);
+/// # });
+/// ```
 pub struct DownloadBuilder<S, M: WalkMode, const B: usize = DEFAULT_BODY_SIZE> {
     store: S,
     root: ChunkAddress,

--- a/crates/file/src/read/reader.rs
+++ b/crates/file/src/read/reader.rs
@@ -355,6 +355,29 @@ where
 
 /// Ordered stream of byte runs over one clipped range; consecutive items
 /// tile the range gaplessly.
+///
+/// Runtime-free: no spawns, threads or timers, so the stream drains under
+/// any single-threaded executor, wasm32 included.
+///
+/// ```
+/// # #![allow(deprecated)]
+/// use futures::StreamExt;
+/// use nectar_file::File;
+///
+/// # futures::executor::block_on(async {
+/// let data: Vec<u8> = (0u32..20_000)
+///     .map(|i| u8::try_from(i % 251).unwrap())
+///     .collect();
+/// # let (root, store) = nectar_primitives::file::split::<4096>(&data).unwrap();
+/// let file = File::open(store, root).await.unwrap();
+/// let mut stream = file.read().range(4_096..12_288).stream();
+/// let mut out = Vec::new();
+/// while let Some(run) = stream.next().await {
+///     out.extend_from_slice(&run.unwrap());
+/// }
+/// assert_eq!(out, &data[4_096..12_288]);
+/// # });
+/// ```
 pub struct FileStream<S, M, const B: usize = DEFAULT_BODY_SIZE>
 where
     S: TrustedGet<AnyChunkSet<B>>,

--- a/crates/file/src/sync.rs
+++ b/crates/file/src/sync.rs
@@ -22,8 +22,21 @@ pub struct Pending;
 ///
 /// # Examples
 ///
+/// A whole-file read over a synchronous store completes in the single poll:
+///
 /// ```
-/// assert_eq!(nectar_file::sync::drive(async { 7u8 }), Ok(7));
+/// # #![allow(deprecated)]
+/// use nectar_file::File;
+/// use nectar_file::sync::drive;
+///
+/// let data = b"guest payload".to_vec();
+/// # let (root, store) = nectar_primitives::file::split::<4096>(&data).unwrap();
+/// let bytes = drive(async {
+///     let file = File::open(store, root).await.unwrap();
+///     file.collect(u64::MAX).await.unwrap()
+/// })
+/// .unwrap();
+/// assert_eq!(bytes, data);
 /// ```
 pub fn drive<F: Future>(future: F) -> Result<F::Output, Pending> {
     let future = pin!(future);

--- a/crates/file/src/tokio/writer.rs
+++ b/crates/file/src/tokio/writer.rs
@@ -19,7 +19,11 @@ use crate::split::{Split, SplitMode, SplitStats};
 /// drives the finish to the root, which [`into_inner`](Self::into_inner)
 /// then hands back.
 ///
+/// Streaming an upload from any [`AsyncRead`](::tokio::io::AsyncRead)
+/// source:
+///
 /// ```
+/// # #![allow(deprecated)]
 /// use nectar_file::{Plain, PutWindow, Split, TokioWriter};
 /// use nectar_primitives::chunk::AnyChunkSet;
 /// use nectar_primitives::store::MemoryStore;
@@ -27,13 +31,18 @@ use crate::split::{Split, SplitMode, SplitStats};
 ///
 /// # #[tokio::main(flavor = "current_thread")]
 /// # async fn main() {
+/// let data: Vec<u8> = (0u32..100_000)
+///     .map(|i| u8::try_from(i % 251).unwrap())
+///     .collect();
 /// let store = MemoryStore::<AnyChunkSet<4096>>::new();
 /// let split = Split::<_, Plain, 4096>::new(store, PutWindow::DEFAULT);
 /// let mut writer = TokioWriter::from(split);
-/// writer.write_all(&vec![7u8; 10_000]).await.unwrap();
+/// let mut source = &data[..];
+/// tokio::io::copy(&mut source, &mut writer).await.unwrap();
 /// writer.shutdown().await.unwrap();
 /// let root = writer.into_inner().unwrap();
-/// assert_eq!(root.as_bytes().len(), 32);
+/// # let (expected, _) = nectar_primitives::file::split::<4096>(&data).unwrap();
+/// assert_eq!(root, expected);
 /// # }
 /// ```
 pub struct TokioWriter<S, M, const B: usize = DEFAULT_BODY_SIZE>

--- a/crates/mantaray/src/builder.rs
+++ b/crates/mantaray/src/builder.rs
@@ -38,12 +38,12 @@
 
 use alloc::collections::BTreeMap;
 
+use nectar_primitives::AnyChunkSet;
 use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{ChunkAddress, ChunkRef, Reference};
 #[allow(deprecated)]
 use nectar_primitives::file::{ChunkPutExt, ReadAt};
 use nectar_primitives::store::{ChunkPut, MaybeSend, TrustedGet};
-use nectar_primitives::{AnyChunkSet, Chunk};
 
 use crate::entry::Entry;
 use crate::manifest::Manifest;
@@ -176,6 +176,7 @@ impl<S: TrustedGet<AnyChunkSet<BS>> + ChunkPut<AnyChunkSet<BS>>, const BS: usize
     /// `data` is dropped before the first store await, mirroring `write_file`,
     /// so the returned future never holds the source across a suspension point.
     pub async fn put_file<D: ReadAt + Sync>(&mut self, path: &str, data: D) -> Result<()> {
+        use nectar_primitives::Chunk;
         use nectar_primitives::file::{EncryptedParallelSplitter, FileError};
         let (root, chunks) = EncryptedParallelSplitter::<BS>::split_to_vec(&data)?;
         drop(data);


### PR DESCRIPTION
## What

Adds/repairs six doctested exhibits in `nectar-file` covering the read/write surfaces, plus an "Exhibits" index in the crate docs:

- range read: the `tokio` module's `AsyncRead` + `AsyncSeek` doctest, seeking and reading a byte range through the shim, now indexed.
- download: new `DownloadBuilder` doctest exercising a ranged download with progress into `MemSink`.
- stream upload: `TokioWriter` doctest widened to `tokio::io::copy` from an async source, with a legacy-split root-equality check.
- wasm: new `FileStream` doctest with a runtime-free note and a hidden `block_on` executor.
- mantaray edit: new crate-docs doctest via the legacy `nectar_mantaray::Manifest` add/remove/save/get surface, read back through `AnyFile::open` on the entry's `EntryRef`, legacy noted in one line.
- guest drive: `sync::drive` doctest upgraded to a whole-file open+collect in a single poll.

All doctests hide executor lines per the async house pattern. `nectar-mantaray` is added as a `nectar-file` dev-dependency (`Cargo.toml`, `Cargo.lock`). One necessary import move in `crates/mantaray/src/builder.rs` (`AnyChunkSet` import split from `Chunk`, `Chunk` moved to a local `use` inside `put_file`).

## Why

Runnable, doctested exhibits give each surface (range read, download, stream, wasm, mantaray edit, guest read) a concrete, regression-catching example under workspace lints, indexed from the crate docs.

Closes #348

## Testing

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --locked`: no warnings in touched crates (`nectar-file`, `nectar-mantaray`); pre-existing warnings in untouched `nectar-primitives` are outside the diff.
- `cargo nextest run -p nectar-file -p nectar-mantaray --locked`: 190 passed, 1 skipped, 0 failed.
- `cargo test --doc -p nectar-file --features std,tokio,rayon,encryption --locked`: 8 passed.
- Red-team pass found no bugs, no spec misses, no house-rule violations; all exhibits are differential doctests with concrete equality assertions that fail on regression (e.g. download: `written == 16384` and `sink == data[8192..24576]`; stream: `out == data[4096..12288]`; sync guest: single-poll `bytes == payload`).

## AI Assistance

Implementation Fable, review Opus, PR Sonnet.
