### PR TITLE
fix(manifest): recanonicalize a re-capped chain tail so apply matches rebuild

### DIFF
--- a/crates/manifest/src/apply.rs
+++ b/crates/manifest/src/apply.rs
@@ -577,6 +577,15 @@ where
     F: Format,
 {
     if prefix.len() <= F::PLEN_MAX {
+        // Re-capping a chain moves the edge boundary, which can leave the tail
+        // as a child-only fork over a single embedded fork: merge that run into
+        // one edge, as a from-scratch build at the new boundary would.
+        if let ForkPayload::Child(Child::Embedded(table)) = &payload
+            && table.len() == 1
+            && let Some((first, record)) = table.iter().next()
+        {
+            return Box::pin(compact(store, prefix, first, record, stats)).await;
+        }
         return make_fork(prefix, payload, meta, child_count);
     }
     let head = prefix.get(..F::PLEN_MAX).ok_or(ApplyError::Internal)?;
@@ -852,6 +861,24 @@ mod tests {
         cs.put(Key::from(&branched[..]), entry(2), None);
         let out = block_on(apply(&store, &root, &cs)).unwrap();
         assert_eq!(out, rebuilt(&[(&base[..], 1), (&branched[..], 2)]));
+    }
+
+    #[test]
+    fn a_remove_beside_a_recapped_chain_insert_equals_a_rebuild() {
+        let store = MemoryStore::default();
+        // Removing the only key while inserting a 257-byte sibling splits the
+        // shared first byte, and the re-capped PLEN_MAX(255) chain boundary
+        // lands one byte earlier than the inserted subtree's own cap: the tail
+        // beyond the new boundary must merge into one edge rather than keep
+        // the stale one-byte chain hop.
+        let root = build(&store, &[(&[0u8, 0][..], 1)]);
+        let mut long = vec![0u8, 1];
+        long.extend(std::iter::repeat_n(0u8, 255));
+        let mut cs = Changeset::<V1>::new();
+        cs.remove(Key::from(&[0u8, 0][..]));
+        cs.put(Key::from(&long[..]), entry(2), None);
+        let out = block_on(apply(&store, &root, &cs)).unwrap();
+        assert_eq!(out, rebuilt(&[(&long[..], 2)]));
     }
 
     #[test]

--- a/crates/manifest/tests/apply.proptest-regressions
+++ b/crates/manifest/tests/apply.proptest-regressions
@@ -7,3 +7,4 @@
 cc f940676ff3c129a82784c35dac784b59de63b6aacf785fc03467e86d40c0e397 # shrinks to base = [([4, 2, 0], (false, 0, [], false)), ([4, 2], (false, 0, [], false))], changes = [([4, 2], None)]
 cc 1cb7761c5940b43f1ba16ee5d2964e105e2eae954c71502e25633f15858b588a # shrinks to base = [([1, 3, 4, 1], (false, 0, [], false))], changes = [([1], Some((false, 0, [], false))), ([1, 3, 4, 1], None)]
 cc 8e84fef34381739f0e73eaa5df42392f44fdc2538285a0eaa29cc51ed8f1c992 # shrinks to base = [([2, 2, 1, 1, 4], (false, 0, [], false))], changes = [([2, 0, 0, 0, 4], None), ([2, 2, 1, 1], Some((false, 0, [], false)))]
+cc f4a05b32307a56b322ea29e18cfd8396749df177a140cf39d9236e70c53da374 # shrinks to base = [([0, 0], (false, 0, [], false))], changes = [([0, 0], None), ([0, 1, then 255 zeros], Some((false, 0, [], false)))]


### PR DESCRIPTION
## What

Recompact the tail emitted by chain()'s base case in apply.rs. When compact() merges an outer edge with a chain-head record built at a deeper boundary, the re-capped PLEN_MAX boundary can land earlier than the boundary the record's embedded child was built at; the base case previously emitted the stale payload verbatim, leaving a one-byte chain hop that a from-scratch build merges into a single edge. The recompaction recurses through any number of stale boundary levels, so the applied root is byte-identical to the rebuilt root.

## Why

Manifests are history-independent by contract: applying a changeset to a persisted root must produce the same root as rebuilding from the merged key set. The divergence was found by the apply-vs-rebuild property (proptest seed committed) and reproduced by the fuzz battery; long chained keys crossing the prefix cap after a remove-and-insert pair triggered it.

Closes #320

## Testing

- New fixed-vector unit test a_remove_beside_a_recapped_chain_insert_equals_a_rebuild (257-byte chained key beside a removed sibling).
- The failing proptest seed cc f4a05b32... is committed to apply.proptest-regressions and replays green through apply_equals_rebuild_over_long_keys.
- cargo nextest -p nectar-manifest: 211 passed; clippy --all-targets and fmt clean.

## AI Assistance

Implementation and diagnosis Fable, conducted review; filed by the session conductor.