### PR TITLE
perf(file): drain collect through the unordered frame path

### DIFF
--- a/crates/file/src/read/reader.rs
+++ b/crates/file/src/read/reader.rs
@@ -9,7 +9,7 @@ use core::pin::Pin;
 use core::task::{Context, Poll};
 
 use bytes::Bytes;
-use futures_util::stream::Stream;
+use futures_util::stream::{Stream, StreamExt};
 use nectar_primitives::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{AnyChunkSet, ChunkAddress};
 use nectar_primitives::store::TrustedGet;
@@ -119,17 +119,12 @@ where
     ///
     /// The buffer is reserved up front with `try_reserve_exact`, so an
     /// oversized range fails typed before any fetch; the bound saturates at
-    /// the address width.
+    /// the address width. Frames land at their range-relative offsets in
+    /// completion order, tiling the buffer exactly once with no reorder
+    /// buffering.
     pub async fn collect(self, max: u64) -> Result<Vec<u8>, CollectError<S::Error>> {
-        let mut walk: Walk<S, M, B> = Walk::new(
-            self.store,
-            self.root,
-            self.context,
-            self.span,
-            self.range,
-            self.window,
-        );
-        let clipped = walk.range();
+        let mut frames = self.frames();
+        let clipped = frames.range();
         let len = clipped.end.saturating_sub(clipped.start);
         let bound = max.min(u64_from_usize(usize::MAX));
         let capacity = match usize::try_from(len) {
@@ -138,8 +133,14 @@ where
         };
         let mut out = Vec::new();
         out.try_reserve_exact(capacity)?;
-        while let Some(frame) = poll_fn(|cx| walk.poll_next_ordered(cx)).await {
-            out.extend_from_slice(&frame?.data);
+        out.resize(capacity, 0);
+        while let Some(frame) = frames.next().await {
+            let frame = frame?;
+            let offset = frame.offset.saturating_sub(clipped.start);
+            let start = usize::try_from(offset).unwrap_or(usize::MAX);
+            for (slot, byte) in out.iter_mut().skip(start).zip(frame.data.as_ref()) {
+                *slot = *byte;
+            }
         }
         Ok(out)
     }

--- a/crates/file/tests/membound.rs
+++ b/crates/file/tests/membound.rs
@@ -4,7 +4,8 @@
 //! retains one body, a read holds at most the fetch window in leaf bodies
 //! plus the derived branch budget, buffered leaf references stay within the
 //! window plus twice the fan-out, a bounded collect refuses an oversized
-//! range before any fetch, and a write holds at most the put window in
+//! range before any fetch and tiles its buffer whatever the completion
+//! order, and a write holds at most the put window in
 //! flight with spill bounded by the spine height. Peaks are read off the
 //! engines' stats and off a gauge store metering concurrent operations
 //! independently of the engines' own accounting. The bounds are witnessed
@@ -540,6 +541,29 @@ fn collect_refuses_an_oversized_range_before_any_fetch() {
     let store = built.fresh(0);
     let file = open_plain(store, root);
     assert!(block_on(file.collect(0)).unwrap().is_empty());
+}
+
+#[test]
+fn collect_assembles_out_of_order_within_the_window() {
+    // The head leaf resolves last among the fetches the window admits, so
+    // frames land far from file order; the ranged buffer is still tiled
+    // exactly once at range-relative offsets, within the window.
+    let size = 40 * TINY + 13;
+    let data = fill(size);
+    let (root, built, _) = split_plain(&data, 8, 0);
+    let head = built.first_put();
+    let window = 4u16;
+    let store = built.fresh(3).parked(head, usize::from(window) - 1);
+    let file = open_plain(store.clone(), root);
+    let out = block_on(
+        file.read()
+            .window(Window::new(window).unwrap())
+            .range(100..size as u64 - 7)
+            .collect(size as u64),
+    )
+    .unwrap();
+    assert_eq!(out, &data[100..size - 7]);
+    assert!(store.gets.peak() <= usize::from(window) + budget(window, BRANCHES as u32));
 }
 
 #[test]


### PR DESCRIPTION
## What

Reroutes `ReadBuilder::collect` through the unordered `frames()` drain (`poll_next_any` via `FileFrames`) instead of the ordered `Walk::poll_next_ordered` path. The output buffer is pre-sized with `try_reserve_exact`, zero-filled, then each completed frame is written to its range-relative offset (`frame.offset - clipped.start`) using the total `iter_mut().skip().zip()` pattern already established by `MemSink::write_at`. This removes the reorder queue and its head-of-line stalls from `collect`.

## Why

`collect` no longer needs frames in order since it writes directly to absolute offsets in a pre-allocated buffer, so draining completion-order (the `DownloadBuilder::run` pattern) avoids blocking on a slow head chunk. The pre-fetch `TooLarge` refusal and `try_reserve_exact` sizing are unchanged. Ordered delivery is preserved elsewhere (`FileReader`, `FileStream`, the io adapters) since only `collect` is touched.

Closes #388

## Testing

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --locked`: zero warnings on `nectar-file`; only pre-existing `use_self` warning in `crates/primitives/src/chunk/type_tag.rs` (untouched by this diff).
- Added `collect_assembles_out_of_order_within_the_window` to `crates/file/tests/membound.rs`: parks the head leaf to force adversarial completion order against a ranged `collect` call (nonzero clipped start), asserting byte-exact assembly within the window/budget fetch bound.
- Verified no reachable panics in the diff: bounded `try_from` with `unwrap_or` fallback, no indexing/slicing/`as`-conversions, no allow-with-comment lints.

## AI Assistance

Implementation by Fable, review by Opus, PR by Sonnet.

