### PR TITLE
perf(file): bounded split hot-path optimization

### DIFF
--- a/crates/file/src/split/engine.rs
+++ b/crates/file/src/split/engine.rs
@@ -8,7 +8,7 @@ use core::future::Future;
 use core::future::poll_fn;
 use core::mem;
 use core::pin::Pin;
-use core::task::{Context, Poll};
+use core::task::{Context, Poll, Waker};
 
 use bytes::Bytes;
 use futures_util::stream::{FuturesUnordered, Stream};
@@ -82,7 +82,8 @@ where
     /// Data-carrying reference slots per intermediate, from the mode.
     slots: u64,
     window: usize,
-    /// Partial tail leaf, always shorter than the body.
+    /// Tail leaf payload under build: the span placeholder, then content
+    /// shorter than one body; empty between leaves.
     leaf: Vec<u8>,
     /// Spine frontier: per-level references awaiting a close, bottom up.
     spine: Vec<Level<M>>,
@@ -177,15 +178,16 @@ where
         if !self.pending.is_empty() || self.in_flight.len() >= self.window {
             return Poll::Pending;
         }
-        let take = buf.len().min(B.saturating_sub(self.leaf.len()));
+        let take = buf.len().min(B.saturating_sub(self.leaf_len()));
         let Some((bytes, _)) = buf.split_at_checked(take) else {
             return Poll::Ready(Ok(0));
         };
+        self.begin_leaf();
         self.leaf.extend_from_slice(bytes);
         self.stats.bytes = self.stats.bytes.saturating_add(u64_from_usize(take));
-        if self.leaf.len() == B {
-            let data = mem::take(&mut self.leaf);
-            if let Err(error) = self.spill_leaf(data) {
+        if self.leaf_len() == B {
+            let payload = mem::take(&mut self.leaf);
+            if let Err(error) = self.spill_leaf(payload) {
                 return Poll::Ready(Err(self.poison(error)));
             }
         }
@@ -322,11 +324,29 @@ where
     /// closing phase.
     fn flush_tail(&mut self) -> Result<(), SplitError<S::Error>> {
         if !self.leaf.is_empty() || self.stats.bytes == 0 {
-            let data = mem::take(&mut self.leaf);
-            self.spill_leaf(data)?;
+            self.begin_leaf();
+            let mut payload = mem::take(&mut self.leaf);
+            // The tail rarely fills the reserved body; give the slack back
+            // before the payload is pinned inside the sealed chunk.
+            payload.shrink_to_fit();
+            self.spill_leaf(payload)?;
         }
         self.phase = Phase::Closing;
         Ok(())
+    }
+
+    /// Content bytes in the tail leaf, behind its span placeholder.
+    const fn leaf_len(&self) -> usize {
+        self.leaf.len().saturating_sub(SPAN_SIZE)
+    }
+
+    /// Reserve one payload and lay down the span placeholder; a no-op once
+    /// the leaf is started.
+    fn begin_leaf(&mut self) {
+        if self.leaf.is_empty() {
+            self.leaf.reserve_exact(SPAN_SIZE.saturating_add(B));
+            self.leaf.extend_from_slice(&[0u8; SPAN_SIZE]);
+        }
     }
 
     /// Close the lowest occupied level: carry a lone reference up for free,
@@ -370,15 +390,16 @@ where
         }
     }
 
-    /// Seal one leaf payload and thread its reference into the spine.
-    fn spill_leaf(&mut self, data: Vec<u8>) -> Result<(), SplitError<S::Error>> {
-        let span = u64_from_usize(data.len());
-        let mut payload = Vec::with_capacity(SPAN_SIZE.saturating_add(data.len()));
-        payload.extend_from_slice(&span.to_le_bytes());
-        payload.extend_from_slice(&data);
+    /// Patch the span into a finished leaf payload, seal it and thread its
+    /// reference into the spine.
+    fn spill_leaf(&mut self, mut payload: Vec<u8>) -> Result<(), SplitError<S::Error>> {
+        let span = u64_from_usize(payload.len().saturating_sub(SPAN_SIZE));
+        if let Some((head, _)) = payload.split_first_chunk_mut::<SPAN_SIZE>() {
+            *head = span.to_le_bytes();
+        }
         let (chunk, reference) = self.mode.seal::<B>(Bytes::from(payload))?;
         self.stats.leaves = self.stats.leaves.saturating_add(1);
-        self.enqueue(chunk);
+        self.enqueue(chunk)?;
         self.push_ref(0, reference, span)
     }
 
@@ -451,38 +472,60 @@ where
         }
         let (chunk, reference) = self.mode.seal::<B>(Bytes::from(payload))?;
         self.stats.intermediates = self.stats.intermediates.saturating_add(1);
-        self.enqueue(chunk);
+        self.enqueue(chunk)?;
         Ok(reference)
     }
 
     /// Queue a sealed chunk for the put window, admitting what fits.
-    fn enqueue(&mut self, chunk: Chunk<Verified, AnyChunkSet<B>>) {
+    fn enqueue(
+        &mut self,
+        chunk: Chunk<Verified, AnyChunkSet<B>>,
+    ) -> Result<(), SplitError<S::Error>> {
         self.pending.push_back(chunk);
-        self.admit();
+        self.admit()?;
         self.stats.peak_pending = self.stats.peak_pending.max(self.pending.len());
+        Ok(())
     }
 
-    /// Move pending chunks into the put window while slots are free.
-    fn admit(&mut self) {
+    /// Move pending chunks into the put window while slots are free; a put
+    /// that fails on its opening poll is terminal.
+    fn admit(&mut self) -> Result<(), SplitError<S::Error>> {
         while self.in_flight.len() < self.window {
             let Some(chunk) = self.pending.pop_front() else {
-                return;
+                return Ok(());
             };
-            self.dispatch(chunk);
+            self.dispatch(chunk)?;
         }
+        Ok(())
     }
 
     /// Start one put, moving the chunk into its future; the completion
     /// carries the address back.
-    fn dispatch(&mut self, chunk: Chunk<Verified, AnyChunkSet<B>>) {
+    ///
+    /// The future is polled once on the spot: a put that finishes
+    /// synchronously never occupies the window, and a pending one parks
+    /// there to be driven with the caller's waker.
+    fn dispatch(
+        &mut self,
+        chunk: Chunk<Verified, AnyChunkSet<B>>,
+    ) -> Result<(), SplitError<S::Error>> {
         let store = self.store.clone();
-        let put: BoxPut<S::Error> = Box::pin(async move {
+        let mut put: BoxPut<S::Error> = Box::pin(async move {
             let address = *chunk.address();
             (address, store.put(chunk).await)
         });
-        self.in_flight.push(put);
         self.stats.puts = self.stats.puts.saturating_add(1);
-        self.stats.peak_put_in_flight = self.stats.peak_put_in_flight.max(self.in_flight.len());
+        match put.as_mut().poll(&mut Context::from_waker(Waker::noop())) {
+            Poll::Ready((address, result)) => {
+                result.map_err(|source| SplitError::Put { address, source })
+            }
+            Poll::Pending => {
+                self.in_flight.push(put);
+                self.stats.peak_put_in_flight =
+                    self.stats.peak_put_in_flight.max(self.in_flight.len());
+                Ok(())
+            }
+        }
     }
 
     /// Drive the put window without consuming input.
@@ -547,16 +590,19 @@ where
         }
         self.stats.bytes = self.stats.bytes.saturating_add(span);
         self.stats.leaves = self.stats.leaves.saturating_add(1);
-        self.enqueue(chunk);
-        self.push_ref(0, reference, span)
+        self.enqueue(chunk)
+            .and_then(|()| self.push_ref(0, reference, span))
             .map_err(|error| self.poison(error))
     }
 
     /// Fold completed puts back in and admit pending chunks; a failed put
-    /// is terminal.
+    /// is terminal. An empty window skips the poll machinery entirely.
     fn step_puts(&mut self, cx: &mut Context<'_>) -> Result<(), SplitError<S::Error>> {
         loop {
-            self.admit();
+            self.admit()?;
+            if self.in_flight.is_empty() {
+                return Ok(());
+            }
             match Pin::new(&mut self.in_flight).poll_next(cx) {
                 Poll::Ready(Some((address, result))) => {
                     result.map_err(|source| SplitError::Put { address, source })?;
@@ -577,7 +623,7 @@ where
             .field("phase", &self.phase)
             .field("window", &self.window)
             .field("slots", &self.slots)
-            .field("leaf_len", &self.leaf.len())
+            .field("leaf_len", &self.leaf.len().saturating_sub(SPAN_SIZE))
             .field("spine_levels", &self.spine.len())
             .field("pending", &self.pending.len())
             .field("in_flight", &self.in_flight.len())

--- a/crates/file/src/split/tests.rs
+++ b/crates/file/src/split/tests.rs
@@ -356,6 +356,17 @@ fn put_window_witnesses_hold() {
 }
 
 #[test]
+fn a_synchronous_store_never_occupies_the_put_window() {
+    // Every put settles on its opening poll, so no chunk is ever parked: the
+    // whole tree is sealed and stored with an empty window throughout.
+    let data = fill(200 * TINY + 63);
+    let (_, store, stats) = stream_split::<TINY>(&data, 8, 997, 0);
+    assert_eq!(stats.peak_put_in_flight, 0, "a settled put occupied a slot");
+    assert_eq!(stats.leaves + stats.intermediates, stats.puts);
+    assert_eq!(store.log().len() as u64, stats.puts);
+}
+
+#[test]
 fn write_secures_capacity_before_consuming() {
     let gate = Arc::new(Mutex::new(false));
     let store = TestStore::<TINY>::gated(Arc::clone(&gate));

--- a/crates/primitives/src/chunk/bmt_body.rs
+++ b/crates/primitives/src/chunk/bmt_body.rs
@@ -66,11 +66,16 @@ impl<const BODY_SIZE: usize> BmtBody<BODY_SIZE> {
 
     /// Append the body wire bytes (`span || payload`) to `out`.
     ///
-    /// The sole body encoder: the span is serialised little-endian here so the
-    /// standalone [`Bytes`] conversion and the chunk carrier share one copy.
+    /// The sole body encoder: the standalone [`Bytes`] conversion and the
+    /// chunk carrier share one copy.
     pub(crate) fn encode(&self, out: &mut BytesMut) {
-        out.extend_from_slice(&self.span.to_le_bytes());
+        out.extend_from_slice(&self.span_bytes());
         out.extend_from_slice(self.data.as_ref());
+    }
+
+    /// The span half of the body wire encoding, serialised little-endian.
+    pub(crate) const fn span_bytes(&self) -> [u8; SPAN_SIZE] {
+        self.span.to_le_bytes()
     }
 
     /// Compute the BMT hash of this body

--- a/crates/primitives/src/chunk/content.rs
+++ b/crates/primitives/src/chunk/content.rs
@@ -197,8 +197,12 @@ impl<const BODY_SIZE: usize> super::encryption::ChunkEncrypt for ContentChunk<BO
         &self,
         key: &super::encryption::EncryptionKey,
     ) -> Result<EncryptedContentChunk<BODY_SIZE>> {
-        let raw: Bytes = self.clone().into(); // span || data
-        let ciphertext = super::encryption::encrypt_chunk::<BODY_SIZE>(&raw, key)?;
+        let body = self.body();
+        let ciphertext = super::encryption::encrypt_chunk::<BODY_SIZE>(
+            &body.span_bytes(),
+            body.data().as_ref(),
+            key,
+        )?;
         let encrypted_chunk = Self::try_from(Bytes::from(ciphertext))?;
         let encrypted_ref =
             super::encryption::EncryptedChunkRef::new(*encrypted_chunk.address(), key.clone());

--- a/crates/primitives/src/chunk/encryption/chunk.rs
+++ b/crates/primitives/src/chunk/encryption/chunk.rs
@@ -20,34 +20,27 @@ const fn span_ctr(body_size: usize) -> u32 {
     (body_size / EncryptionKey::SIZE) as u32
 }
 
-/// Encrypt chunk data (span + body) with the given key, returning ciphertext.
+/// Encrypt chunk wire data (`span || data`, taken apart so callers never
+/// assemble a contiguous copy) with the given key, returning ciphertext.
 ///
 /// The output is always `SPAN_SIZE + BODY_SIZE` bytes: the span is encrypted
 /// with `init_ctr = BODY_SIZE / EncryptionKey::SIZE`, and the data is encrypted with
 /// `init_ctr = 0` and padded to `BODY_SIZE` with random bytes.
 ///
-/// `chunk_data` must be `SPAN_SIZE..=SPAN_SIZE + BODY_SIZE` bytes.
+/// `data` must be at most `BODY_SIZE` bytes.
 #[cfg(feature = "encryption")]
-#[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)] // SPAN_SIZE + BODY_SIZE and SPAN_SIZE + data.len() sum small constants; the length checks above bound chunk_data, and output is allocated SPAN_SIZE + BODY_SIZE bytes
+#[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)] // SPAN_SIZE + BODY_SIZE and SPAN_SIZE + data.len() sum small constants; the length check above bounds data, and output is allocated SPAN_SIZE + BODY_SIZE bytes
 pub(crate) fn encrypt_chunk<const BODY_SIZE: usize>(
-    chunk_data: &[u8],
+    span: &[u8; SPAN_SIZE],
+    data: &[u8],
     key: &EncryptionKey,
 ) -> Result<Vec<u8>, EncryptionError> {
-    if chunk_data.len() < SPAN_SIZE {
-        return Err(EncryptionError::DataTooShort {
-            len: chunk_data.len(),
-            min: SPAN_SIZE,
-        });
-    }
-    if chunk_data.len() > SPAN_SIZE + BODY_SIZE {
+    if data.len() > BODY_SIZE {
         return Err(EncryptionError::DataTooLong {
-            len: chunk_data.len(),
+            len: SPAN_SIZE + data.len(),
             max: SPAN_SIZE + BODY_SIZE,
         });
     }
-
-    let span = &chunk_data[..SPAN_SIZE];
-    let data = &chunk_data[SPAN_SIZE..];
 
     let mut output = vec![0u8; SPAN_SIZE + BODY_SIZE];
 
@@ -152,7 +145,8 @@ mod tests {
         }
 
         let key = EncryptionKey::generate();
-        let encrypted = encrypt_chunk::<DEFAULT_BODY_SIZE>(&chunk_data, &key).unwrap();
+        let (span, data) = chunk_data.split_first_chunk::<SPAN_SIZE>().unwrap();
+        let encrypted = encrypt_chunk::<DEFAULT_BODY_SIZE>(span, data, &key).unwrap();
         assert_eq!(encrypted.len(), SPAN_SIZE + DEFAULT_BODY_SIZE);
         assert_ne!(&encrypted[..], &chunk_data[..]);
 
@@ -172,7 +166,8 @@ mod tests {
         }
 
         let key = EncryptionKey::generate();
-        let encrypted = encrypt_chunk::<DEFAULT_BODY_SIZE>(&chunk_data, &key).unwrap();
+        let (span, data) = chunk_data.split_first_chunk::<SPAN_SIZE>().unwrap();
+        let encrypted = encrypt_chunk::<DEFAULT_BODY_SIZE>(span, data, &key).unwrap();
         assert_eq!(encrypted.len(), SPAN_SIZE + DEFAULT_BODY_SIZE);
 
         let decrypted =
@@ -185,7 +180,7 @@ mod tests {
     fn roundtrip_span_only() {
         let chunk_data = 0u64.to_le_bytes().to_vec();
         let key = EncryptionKey::generate();
-        let encrypted = encrypt_chunk::<DEFAULT_BODY_SIZE>(&chunk_data, &key).unwrap();
+        let encrypted = encrypt_chunk::<DEFAULT_BODY_SIZE>(&0u64.to_le_bytes(), &[], &key).unwrap();
         assert_eq!(encrypted.len(), SPAN_SIZE + DEFAULT_BODY_SIZE);
 
         let decrypted = decrypt_chunk_data::<DEFAULT_BODY_SIZE>(&encrypted, &key, 0).unwrap();
@@ -203,7 +198,8 @@ mod tests {
         }
 
         let key = EncryptionKey::generate();
-        let encrypted = encrypt_chunk::<DEFAULT_BODY_SIZE>(&chunk_data, &key).unwrap();
+        let (span, data) = chunk_data.split_first_chunk::<SPAN_SIZE>().unwrap();
+        let encrypted = encrypt_chunk::<DEFAULT_BODY_SIZE>(span, data, &key).unwrap();
 
         // Decrypt into a pre-allocated buffer
         let mut buf = vec![0u8; SPAN_SIZE + data_len];
@@ -213,14 +209,12 @@ mod tests {
 
     #[cfg(feature = "encryption")]
     #[test]
-    fn encrypt_too_short() {
-        let short = [0u8; 4];
+    fn encrypt_too_long() {
+        let span = [0u8; SPAN_SIZE];
+        let long = [0u8; DEFAULT_BODY_SIZE + 1];
         let key = EncryptionKey::generate();
-        let err = encrypt_chunk::<DEFAULT_BODY_SIZE>(&short, &key).unwrap_err();
-        assert!(matches!(
-            err,
-            EncryptionError::DataTooShort { len: 4, min: 8 }
-        ));
+        let err = encrypt_chunk::<DEFAULT_BODY_SIZE>(&span, &long, &key).unwrap_err();
+        assert!(matches!(err, EncryptionError::DataTooLong { .. }));
     }
 
     #[test]


### PR DESCRIPTION
## What

Profiling-led bounded optimization of the streaming split hot path (`crates/file/src/split/engine.rs`) plus supporting in-place encryption changes in `crates/primitives` that back it:

- Leaf payloads are now built in place around a span placeholder, saving one 4 KiB copy + alloc per leaf (leaf length accounting via `leaf_len`/`begin_leaf`/`spill_leaf` using `split_first_chunk_mut`).
- `put` is polled once inline at dispatch with a noop waker, so a synchronously-settling store never occupies the put window.
- Encryption chunk wire-part assembly (`bmt_body.rs`, `content.rs`, `encryption/chunk.rs`) reworked to avoid reassembly.
- New split test: `a_synchronous_store_never_occupies_the_put_window`.

## Why

perf + criterion micro-profiling disproves the premise of #387 on this machine class: one 4 KiB BMT hash costs 7.5 us (`bmt_hash/4096`) while the streaming split spends 8.2 us/chunk end to end, so ~90% of split runtime is the inherent single-threaded keccak floor (`keccak_batch` 63-65% self, ~80% cumulative; hasher-internal memset/memmove ~12%; engine machinery <5%). The legacy splitter's 683 us/1 MiB is below the 1.93 ms hash floor for 257 chunks, so its advantage must have come from parallel hashing; single-threaded parity is unreachable by engine work alone, and the shipped rayon `split_read_at` ingest is the parity path. This PR lands the safe, bounded wins available in the engine and encryption hot paths without chasing that unreachable parity.

Closes #387

## Testing

- `cargo fmt --all -- --check` — clean.
- `cargo clippy --workspace --all-targets --locked` and `cargo clippy -p nectar-primitives --all-targets --features encryption --locked` — no new warnings (one pre-existing `use_self` in the unchanged `type_tag.rs`).
- `cargo nextest run -p nectar-file -p nectar-primitives --locked` — 324 passed; `-p nectar-primitives --features encryption` — 26 passed (new `encrypt_too_long`, `roundtrip_span_only`; new split test `a_synchronous_store_never_occupies_the_put_window`).
- `cargo test --doc -p nectar-primitives --features encryption --locked` — pass (incl. `encrypt_with` doctest).
- no_std: `cargo check -p nectar-file --no-default-features --target {riscv64imac-unknown-none-elf,wasm32-unknown-unknown}` — both pass.
- N/A this diff: zepter (no Cargo.toml change), actionlint (no workflow change), manifest/postage-usage wasm.

## AI Assistance

Implementation by Fable, review by Opus, PR by Sonnet.