### PR TITLE
feat(file): fan leaf sealing onto the pool behind a hash window

### DIFF
--- a/crates/file/Cargo.toml
+++ b/crates/file/Cargo.toml
@@ -54,8 +54,9 @@ std = [
 # Async reader and writer adapters over the poll surface. Implies `std`.
 tokio = [ "dep:tokio", "std" ]
 
-# Batch leaf hashing and read-at ingest. Implies `std`; rayon on wasm32 or
-# under `unsync` is a compile error, never a silent fallback.
+# Pool leaf hashing: the split hash window and the read-at ingest. Implies
+# `std`; rayon on wasm32 or under `unsync` is a compile error, never a
+# silent fallback.
 rayon = [ "dep:rayon", "std" ]
 
 # Split-side encrypted mode. Joining encrypted references stays unconditional.

--- a/crates/file/src/config.rs
+++ b/crates/file/src/config.rs
@@ -92,6 +92,47 @@ impl From<PutWindow> for NonZeroU16 {
     }
 }
 
+/// Hash window: leaf seals a split may hold in flight on the thread pool.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct HashWindow(NonZeroU16);
+
+impl HashWindow {
+    /// Default window of sixteen seal slots.
+    pub const DEFAULT: Self = Self(DEFAULT_SLOTS);
+
+    /// `None` when `slots` is zero; const twin of the `NonZeroU16`
+    /// conversion.
+    pub const fn new(slots: u16) -> Option<Self> {
+        match NonZeroU16::new(slots) {
+            Some(slots) => Some(Self(slots)),
+            None => None,
+        }
+    }
+
+    /// Window depth in slots.
+    pub const fn get(self) -> u16 {
+        self.0.get()
+    }
+}
+
+impl Default for HashWindow {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+impl From<NonZeroU16> for HashWindow {
+    fn from(slots: NonZeroU16) -> Self {
+        Self(slots)
+    }
+}
+
+impl From<HashWindow> for NonZeroU16 {
+    fn from(window: HashWindow) -> Self {
+        window.0
+    }
+}
+
 /// Branch budget: intermediate fetches a walk may hold in flight. Derived
 /// from the fetch window, never configured directly.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -138,6 +179,7 @@ mod tests {
     fn windows_reject_zero() {
         assert!(Window::new(0).is_none());
         assert!(PutWindow::new(0).is_none());
+        assert!(HashWindow::new(0).is_none());
     }
 
     #[test]
@@ -146,6 +188,8 @@ mod tests {
         assert_eq!(Window::default(), Window::DEFAULT);
         assert_eq!(PutWindow::DEFAULT.get(), 16);
         assert_eq!(PutWindow::default(), PutWindow::DEFAULT);
+        assert_eq!(HashWindow::DEFAULT.get(), 16);
+        assert_eq!(HashWindow::default(), HashWindow::DEFAULT);
     }
 
     #[test]
@@ -153,6 +197,7 @@ mod tests {
         let slots = NonZeroU16::new(5).unwrap();
         assert_eq!(NonZeroU16::from(Window::from(slots)), slots);
         assert_eq!(NonZeroU16::from(PutWindow::from(slots)), slots);
+        assert_eq!(NonZeroU16::from(HashWindow::from(slots)), slots);
     }
 
     #[test]

--- a/crates/file/src/lib.rs
+++ b/crates/file/src/lib.rs
@@ -8,7 +8,7 @@
 //! [`read`] facade that opens files by either reference width and drains the
 //! walk in file order, the [`sink`] targets a restartable download writes
 //! into, the [`store`] erasure that makes file handles nameable, the
-//! [`sync`] driver for Ready-only guests, and the `parallel` batch ingest
+//! [`sync`] driver for Ready-only guests, and the `parallel` read-at ingest
 //! over a random-access source (behind the `rayon` feature).
 //!
 //! # Exhibits
@@ -127,7 +127,7 @@ pub use self::tokio::{SeekOverflow, TokioReader};
     not(any(target_arch = "wasm32", feature = "unsync"))
 ))]
 pub use self::tokio::{SpawnedReader, TokioWriter};
-pub use config::{BranchBudget, PutWindow, Window};
+pub use config::{BranchBudget, HashWindow, PutWindow, Window};
 pub use geometry::{DEFAULT_BODY_SIZE, Mode, branches, max_depth};
 #[cfg(all(
     feature = "rayon",

--- a/crates/file/src/parallel/error.rs
+++ b/crates/file/src/parallel/error.rs
@@ -2,7 +2,7 @@
 
 use std::io;
 
-use crate::split::{SealError, SplitError};
+use crate::split::SplitError;
 
 /// Terminal read-at ingest failure.
 #[derive(Debug, thiserror::Error)]
@@ -39,46 +39,8 @@ pub enum ReadAtError<E> {
         /// Buffer bytes the read had to fill.
         capacity: usize,
     },
-    /// The split ascent failed.
+    /// The split ascent failed; a dropped pool seal arrives here as
+    /// [`SplitError::PoolDropped`].
     #[error(transparent)]
     Split(#[from] SplitError<E>),
-    /// The pool dropped a batch without replying; a worker died mid-job.
-    #[error("hash pool dropped a batch")]
-    PoolDropped,
-}
-
-/// A failure sealing one leaf on a pool worker; carried across the handoff.
-#[derive(Debug)]
-pub(super) enum LeafError {
-    /// Reading the leaf body failed.
-    Read { offset: u64, source: io::Error },
-    /// The source ended before the leaf filled.
-    Short { offset: u64, remaining: usize },
-    /// The source reported more bytes than the buffer holds.
-    Overrun {
-        offset: u64,
-        count: usize,
-        capacity: usize,
-    },
-    /// Sealing the leaf payload failed.
-    Seal(SealError),
-}
-
-impl<E> From<LeafError> for ReadAtError<E> {
-    fn from(error: LeafError) -> Self {
-        match error {
-            LeafError::Read { offset, source } => Self::Read { offset, source },
-            LeafError::Short { offset, remaining } => Self::ShortRead { offset, remaining },
-            LeafError::Overrun {
-                offset,
-                count,
-                capacity,
-            } => Self::ReadOverrun {
-                offset,
-                count,
-                capacity,
-            },
-            LeafError::Seal(source) => Self::Split(SplitError::Seal(source)),
-        }
-    }
 }

--- a/crates/file/src/parallel/mod.rs
+++ b/crates/file/src/parallel/mod.rs
@@ -1,55 +1,38 @@
-//! Thread-pool ingest: batch leaf hashing over a random-access source.
+//! Thread-pool ingest over a random-access source.
 //!
-//! [`split_read_at`] reads and seals leaves in pool-wide batches on the
-//! rayon pool and threads their references through the same bounded ascent
-//! as the streaming split, so roots and chunk sets are identical. Each
-//! batch is one queued pool job, so submission never blocks, and at most
-//! one batch hashes while the previous one drains through the put window:
-//! retained memory stays at two batches of leaf bodies plus the window.
+//! [`split_read_at`] reads leaf bodies in file order and feeds them through
+//! a hash-windowed [`Split`], so leaf sealing runs on the rayon pool while
+//! the ascent, intermediate sealing and put dispatch stay on the calling
+//! task. Retained memory stays at the hash window of leaf bodies plus the
+//! spine and the put window.
 
 mod error;
-mod handoff;
 mod source;
 #[cfg(test)]
 mod tests;
 
 use alloc::vec;
-use alloc::vec::Vec;
 use core::future::poll_fn;
-use core::task::Poll;
 
-use std::sync::Arc;
-
-use bytes::Bytes;
-use nectar_primitives::bmt::SPAN_SIZE;
-use nectar_primitives::chunk::{AnyChunkSet, Chunk, Verified};
+use nectar_primitives::chunk::AnyChunkSet;
 use nectar_primitives::store::ChunkPut;
-use rayon::prelude::*;
 
 pub use error::ReadAtError;
 pub use source::ReadAt;
 
-use self::error::LeafError;
-use self::handoff::Handoff;
-use crate::config::PutWindow;
+use crate::config::{HashWindow, PutWindow};
 use crate::num::u64_from_usize;
 use crate::split::{Split, SplitMode};
 
-/// One leaf sealed on a pool worker, awaiting admission to the ascent.
-struct SealedLeaf<M: SplitMode, const B: usize> {
-    chunk: Chunk<Verified, AnyChunkSet<B>>,
-    reference: M::Ref,
-    span: u64,
-}
-
-/// Split `source` into the tree under `store`, hashing leaves in pool-wide
-/// batches on the rayon pool; the mode `M` picks the reference grammar.
+/// Split `source` into the tree under `store`, sealing leaves on the rayon
+/// pool; the mode `M` picks the reference grammar.
 ///
-/// The root and chunk set equal the streaming split of the same bytes. The
-/// mode is default-constructed once and cloned across the ascent and pool
-/// workers, so a key-sourcing mode draws every key from one stream.
-/// Dropping the future abandons in-flight puts; a batch already queued on
-/// the pool finishes and is discarded.
+/// For deterministic modes the root and chunk set equal the streaming split
+/// of the same bytes. The mode is default-constructed once and cloned onto
+/// the pool workers; a key-drawing mode draws its keys on the workers in
+/// completion order, so its output is round-trip-verified rather than
+/// byte-reproducible. Dropping the future abandons in-flight puts; a leaf
+/// seal already queued on the pool finishes and is discarded.
 ///
 /// ```
 /// use nectar_file::{Plain, PutWindow, split_read_at};
@@ -71,134 +54,44 @@ pub async fn split_read_at<R, S, M, const B: usize>(
     window: PutWindow,
 ) -> Result<M::Root, ReadAtError<S::Error>>
 where
-    R: ReadAt + Send + Sync + 'static,
+    R: ReadAt,
     S: ChunkPut<AnyChunkSet<B>> + Clone + 'static,
     M: SplitMode + Default + Clone,
     M::Ref: Send,
 {
-    let source = Arc::new(source);
     let size = source
         .len()
         .map_err(|source| ReadAtError::Length { source })?;
-    let mode = M::default();
-    let mut split = Split::<S, M, B>::with_mode(store, mode.clone(), window);
-    let leaves = size.div_ceil(u64_from_usize(B));
-    let batch = rayon::current_num_threads().max(1);
-    let mut next = 0u64;
-    let mut inflight = None;
-    if next < leaves {
-        let count = batch_len(leaves, next, batch);
-        inflight = Some(submit_batch::<R, M, B>(
-            &source,
-            mode.clone(),
-            next,
-            count,
-            size,
-        ));
-        next = next.saturating_add(u64_from_usize(count));
-    }
-    while let Some(mut handoff) = inflight.take() {
-        // Collect the hashed batch while the put window keeps draining.
-        let outcome = poll_fn(|cx| {
-            if let Err(error) = split.pump(cx) {
-                return Poll::Ready(Err(error));
-            }
-            handoff.poll_recv(cx).map(Ok)
-        })
-        .await;
-        let sealed = match outcome {
-            Ok(Some(sealed)) => sealed?,
-            Ok(None) => return Err(ReadAtError::PoolDropped),
-            Err(error) => return Err(error.into()),
+    let mut split = Split::<S, M, B>::with_mode(store, M::default(), window)
+        .with_hash_window(HashWindow::DEFAULT);
+    let mut buf = vec![0u8; B];
+    let mut offset = 0u64;
+    while offset < size {
+        // The remainder is capped by the body size, so the narrowing is
+        // lossless, and `take` never exceeds the buffer length.
+        let take = usize::try_from(size.saturating_sub(offset).min(u64_from_usize(B))).unwrap_or(B);
+        let Some((body, _)) = buf.split_at_mut_checked(take) else {
+            break;
         };
-        // Queue the next batch first, so it hashes while this one drains.
-        if next < leaves {
-            let count = batch_len(leaves, next, batch);
-            inflight = Some(submit_batch::<R, M, B>(
-                &source,
-                mode.clone(),
-                next,
-                count,
-                size,
-            ));
-            next = next.saturating_add(u64_from_usize(count));
+        read_full(&source, offset, body)?;
+        let mut piece = buf.get(..take).unwrap_or_default();
+        while !piece.is_empty() {
+            let n = poll_fn(|cx| split.poll_write(cx, piece)).await?;
+            piece = piece.get(n..).unwrap_or_default();
         }
-        for leaf in sealed {
-            poll_fn(|cx| split.poll_admit(cx)).await?;
-            split.push_sealed(leaf.chunk, leaf.reference, leaf.span)?;
-        }
+        offset = offset.saturating_add(u64_from_usize(take));
     }
     poll_fn(|cx| split.poll_finish(cx))
         .await
         .map_err(ReadAtError::from)
 }
 
-/// Leaves in the batch starting at `next`; capped by `batch`, so the
-/// narrowing is lossless.
-fn batch_len(leaves: u64, next: u64, batch: usize) -> usize {
-    let remaining = leaves.saturating_sub(next);
-    usize::try_from(remaining.min(u64_from_usize(batch))).unwrap_or(batch)
-}
-
-/// Queue one batch of leaf reads and seals on the pool.
-fn submit_batch<R, M, const B: usize>(
-    source: &Arc<R>,
-    mode: M,
-    start: u64,
-    count: usize,
-    size: u64,
-) -> Handoff<Result<Vec<SealedLeaf<M, B>>, LeafError>>
-where
-    R: ReadAt + Send + Sync + 'static,
-    M: SplitMode,
-    M::Ref: Send,
-{
-    let source = Arc::clone(source);
-    handoff::submit(move || {
-        (0..count)
-            .into_par_iter()
-            .map(|item| {
-                let index = start.saturating_add(u64_from_usize(item));
-                seal_leaf::<R, M, B>(source.as_ref(), &mode, index, size)
-            })
-            .collect()
-    })
-}
-
-/// Read and seal the leaf at `index`; its span is its byte length.
-fn seal_leaf<R, M, const B: usize>(
-    source: &R,
-    mode: &M,
-    index: u64,
-    size: u64,
-) -> Result<SealedLeaf<M, B>, LeafError>
-where
-    R: ReadAt + ?Sized,
-    M: SplitMode,
-{
-    let body = u64_from_usize(B);
-    let offset = index.saturating_mul(body);
-    let span = size.saturating_sub(offset).min(body);
-    // The span is capped by the body size, so the narrowing is lossless.
-    let take = usize::try_from(span).unwrap_or(B);
-    let mut data = vec![0u8; take];
-    read_full(source, offset, &mut data)?;
-    let mut payload = Vec::with_capacity(SPAN_SIZE.saturating_add(take));
-    payload.extend_from_slice(&span.to_le_bytes());
-    payload.extend_from_slice(&data);
-    let (chunk, reference) = mode
-        .seal::<B>(Bytes::from(payload))
-        .map_err(LeafError::Seal)?;
-    Ok(SealedLeaf {
-        chunk,
-        reference,
-        span,
-    })
-}
-
 /// Fill `buf` from `offset`, looping over short reads; running out of
 /// source is an error, never a silent truncation.
-fn read_full<R: ReadAt + ?Sized>(source: &R, offset: u64, buf: &mut [u8]) -> Result<(), LeafError> {
+fn read_full<R, E>(source: &R, offset: u64, buf: &mut [u8]) -> Result<(), ReadAtError<E>>
+where
+    R: ReadAt + ?Sized,
+{
     let mut filled = 0usize;
     while filled < buf.len() {
         let at = offset.saturating_add(u64_from_usize(filled));
@@ -208,15 +101,15 @@ fn read_full<R: ReadAt + ?Sized>(source: &R, offset: u64, buf: &mut [u8]) -> Res
         let capacity = rest.len();
         let count = source
             .read_at(at, rest)
-            .map_err(|source| LeafError::Read { offset: at, source })?;
+            .map_err(|source| ReadAtError::Read { offset: at, source })?;
         if count == 0 {
-            return Err(LeafError::Short {
+            return Err(ReadAtError::ShortRead {
                 offset: at,
                 remaining: capacity,
             });
         }
         if count > capacity {
-            return Err(LeafError::Overrun {
+            return Err(ReadAtError::ReadOverrun {
                 offset: at,
                 count,
                 capacity,

--- a/crates/file/src/split/engine.rs
+++ b/crates/file/src/split/engine.rs
@@ -18,8 +18,32 @@ use nectar_primitives::chunk::{AnyChunkSet, Chunk, ChunkAddress, Verified};
 use nectar_primitives::store::ChunkPut;
 
 use super::SplitStats;
+#[cfg(all(
+    feature = "rayon",
+    not(target_arch = "wasm32"),
+    not(feature = "unsync")
+))]
+use super::error::SealError;
 use super::error::SplitError;
+#[cfg(all(
+    feature = "rayon",
+    not(target_arch = "wasm32"),
+    not(feature = "unsync")
+))]
+use super::handoff::{self, Handoff};
+#[cfg(all(
+    feature = "rayon",
+    not(target_arch = "wasm32"),
+    not(feature = "unsync")
+))]
+use super::mode::Sealed;
 use super::mode::SplitMode;
+#[cfg(all(
+    feature = "rayon",
+    not(target_arch = "wasm32"),
+    not(feature = "unsync")
+))]
+use crate::config::HashWindow;
 use crate::config::PutWindow;
 use crate::num::{fan_out, u64_from_u32, u64_from_usize};
 
@@ -35,6 +59,47 @@ type BoxPut<E> = Pin<Box<dyn Future<Output = PutDone<E>> + Send>>;
 /// and under the `unsync` feature.
 #[cfg(any(target_arch = "wasm32", feature = "unsync"))]
 type BoxPut<E> = Pin<Box<dyn Future<Output = PutDone<E>>>>;
+
+/// Handoff carrying one pool leaf seal back to the engine.
+#[cfg(all(
+    feature = "rayon",
+    not(target_arch = "wasm32"),
+    not(feature = "unsync")
+))]
+type SealHandoff<M, const B: usize> = Handoff<Result<Sealed<M, B>, SealError>>;
+
+/// Submitter queueing one leaf payload on the pool.
+#[cfg(all(
+    feature = "rayon",
+    not(target_arch = "wasm32"),
+    not(feature = "unsync")
+))]
+type SealSubmit<M, const B: usize> = Box<dyn Fn(Bytes) -> SealHandoff<M, B> + Send + Sync>;
+
+/// One leaf seal in flight on the pool: its span and the handoff its sealed
+/// chunk arrives on.
+#[cfg(all(
+    feature = "rayon",
+    not(target_arch = "wasm32"),
+    not(feature = "unsync")
+))]
+struct PendingSeal<M: SplitMode, const B: usize> {
+    span: u64,
+    handoff: SealHandoff<M, B>,
+}
+
+/// Pool fan-out for leaf seals: a bounded deque of in-flight jobs and the
+/// submitter that queues one payload.
+#[cfg(all(
+    feature = "rayon",
+    not(target_arch = "wasm32"),
+    not(feature = "unsync")
+))]
+struct HashFan<M: SplitMode, const B: usize> {
+    window: usize,
+    submit: SealSubmit<M, B>,
+    seals: VecDeque<PendingSeal<M, B>>,
+}
 
 /// One spine level: references awaiting a close and the bytes they span.
 struct Level<M: SplitMode> {
@@ -90,6 +155,13 @@ where
     /// Sealed chunks awaiting a put slot; bounded by the spine height.
     pending: VecDeque<Chunk<Verified, AnyChunkSet<B>>>,
     in_flight: FuturesUnordered<BoxPut<S::Error>>,
+    /// Pool fan-out for leaf seals; `None` keeps sealing inline.
+    #[cfg(all(
+        feature = "rayon",
+        not(target_arch = "wasm32"),
+        not(feature = "unsync")
+    ))]
+    hash: Option<HashFan<M, B>>,
     phase: Phase,
     root: Option<M::Root>,
     stats: SplitStats,
@@ -136,10 +208,65 @@ where
             spine: Vec::new(),
             pending: VecDeque::new(),
             in_flight: FuturesUnordered::new(),
+            #[cfg(all(
+                feature = "rayon",
+                not(target_arch = "wasm32"),
+                not(feature = "unsync")
+            ))]
+            hash: None,
             phase: Phase::Writing,
             root: None,
             stats: SplitStats::default(),
         }
+    }
+
+    /// Fan leaf sealing onto the rayon pool, holding at most `window` seals
+    /// in flight; sealed leaves are admitted in leaf order, so a
+    /// deterministic mode's chunk stream matches the serial engine.
+    /// Configure before the first write.
+    ///
+    /// ```
+    /// use core::future::poll_fn;
+    /// use nectar_file::{HashWindow, Plain, PutWindow, Split};
+    /// use nectar_primitives::chunk::AnyChunkSet;
+    /// use nectar_primitives::store::MemoryStore;
+    ///
+    /// # futures::executor::block_on(async {
+    /// let store = MemoryStore::<AnyChunkSet<4096>>::new();
+    /// let mut split = Split::<_, Plain, 4096>::new(store, PutWindow::DEFAULT)
+    ///     .with_hash_window(HashWindow::DEFAULT);
+    /// let data = vec![7u8; 10_000];
+    /// let mut buf = data.as_slice();
+    /// while !buf.is_empty() {
+    ///     let n = poll_fn(|cx| split.poll_write(cx, buf)).await.unwrap();
+    ///     buf = &buf[n..];
+    /// }
+    /// let root = poll_fn(|cx| split.poll_finish(cx)).await.unwrap();
+    /// assert_eq!(root.as_bytes().len(), 32);
+    /// # });
+    /// ```
+    #[cfg(all(
+        feature = "rayon",
+        not(target_arch = "wasm32"),
+        not(feature = "unsync")
+    ))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
+    #[must_use]
+    pub fn with_hash_window(mut self, window: HashWindow) -> Self
+    where
+        M: Clone,
+        M::Ref: Send,
+    {
+        let mode = self.mode.clone();
+        self.hash = Some(HashFan {
+            window: usize::from(window.get()),
+            submit: Box::new(move |payload| {
+                let mode = mode.clone();
+                handoff::submit(move || mode.seal::<B>(payload))
+            }),
+            seals: VecDeque::new(),
+        });
+        self
     }
 
     /// Occupancy witnesses accumulated so far.
@@ -155,8 +282,9 @@ where
     /// Consume bytes from `buf`, sealing and spilling as leaves fill; at
     /// most one leaf body is consumed per call.
     ///
-    /// Cancel-safe: a put slot is secured before any byte is consumed, so a
-    /// poll that returns `Pending` has consumed nothing.
+    /// Cancel-safe: a put slot (or a hash slot when the pool fan-out is on)
+    /// is secured before any byte is consumed, so a poll that returns
+    /// `Pending` has consumed nothing.
     pub fn poll_write(
         &mut self,
         cx: &mut Context<'_>,
@@ -175,7 +303,15 @@ where
         if let Err(error) = self.step_puts(cx) {
             return Poll::Ready(Err(self.poison(error)));
         }
-        if !self.pending.is_empty() || self.in_flight.len() >= self.window {
+        #[cfg(all(
+            feature = "rayon",
+            not(target_arch = "wasm32"),
+            not(feature = "unsync")
+        ))]
+        if let Err(error) = self.drain_seals(cx) {
+            return Poll::Ready(Err(self.poison(error)));
+        }
+        if self.write_gate_blocked() {
             return Poll::Pending;
         }
         let take = buf.len().min(B.saturating_sub(self.leaf_len()));
@@ -211,6 +347,22 @@ where
                 Phase::Writing | Phase::Closing => {
                     if let Err(error) = self.step_puts(cx) {
                         return Poll::Ready(Err(self.poison(error)));
+                    }
+                    // Every pool leaf seal must land before the tail seals
+                    // and the spine closes, so the ascent stays in leaf
+                    // order.
+                    #[cfg(all(
+                        feature = "rayon",
+                        not(target_arch = "wasm32"),
+                        not(feature = "unsync")
+                    ))]
+                    {
+                        if let Err(error) = self.drain_seals(cx) {
+                            return Poll::Ready(Err(self.poison(error)));
+                        }
+                        if self.seals_queued() > 0 {
+                            return Poll::Pending;
+                        }
                     }
                     if !self.pending.is_empty() || self.in_flight.len() >= self.window {
                         return Poll::Pending;
@@ -390,17 +542,94 @@ where
         }
     }
 
-    /// Patch the span into a finished leaf payload, seal it and thread its
-    /// reference into the spine.
+    /// Patch the span into a finished leaf payload, seal it (inline or on
+    /// the pool) and thread its reference into the spine.
     fn spill_leaf(&mut self, mut payload: Vec<u8>) -> Result<(), SplitError<S::Error>> {
         let span = u64_from_usize(payload.len().saturating_sub(SPAN_SIZE));
         if let Some((head, _)) = payload.split_first_chunk_mut::<SPAN_SIZE>() {
             *head = span.to_le_bytes();
         }
+        #[cfg(all(
+            feature = "rayon",
+            not(target_arch = "wasm32"),
+            not(feature = "unsync")
+        ))]
+        if let Some(fan) = &mut self.hash {
+            let handoff = (fan.submit)(Bytes::from(payload));
+            fan.seals.push_back(PendingSeal { span, handoff });
+            self.stats.peak_hash_in_flight = self.stats.peak_hash_in_flight.max(fan.seals.len());
+            return Ok(());
+        }
         let (chunk, reference) = self.mode.seal::<B>(Bytes::from(payload))?;
         self.stats.leaves = self.stats.leaves.saturating_add(1);
         self.enqueue(chunk)?;
         self.push_ref(0, reference, span)
+    }
+
+    /// Whether the write gate refuses bytes this poll: a full hash window
+    /// when the fan-out is on, otherwise the serial put gate.
+    fn write_gate_blocked(&self) -> bool {
+        #[cfg(all(
+            feature = "rayon",
+            not(target_arch = "wasm32"),
+            not(feature = "unsync")
+        ))]
+        if let Some(fan) = &self.hash {
+            return fan.seals.len() >= fan.window;
+        }
+        !self.pending.is_empty() || self.in_flight.len() >= self.window
+    }
+
+    /// Admit pool-sealed leaves in leaf order while put capacity allows.
+    ///
+    /// Only the front handoff is ever polled, so ascent order, intermediate
+    /// sealing and put dispatch order match the serial engine; out-of-order
+    /// completions park in their slots. `Ok` with jobs still queued means
+    /// the front is not ready or the put gate is shut, and a waker is
+    /// registered either way: every admission loops back through
+    /// `step_puts`, so a put dispatched here is re-polled with the caller's
+    /// waker before any return.
+    #[cfg(all(
+        feature = "rayon",
+        not(target_arch = "wasm32"),
+        not(feature = "unsync")
+    ))]
+    fn drain_seals(&mut self, cx: &mut Context<'_>) -> Result<(), SplitError<S::Error>> {
+        loop {
+            self.step_puts(cx)?;
+            if !self.pending.is_empty() || self.in_flight.len() >= self.window {
+                return Ok(());
+            }
+            let Some(fan) = self.hash.as_mut() else {
+                return Ok(());
+            };
+            let Some(front) = fan.seals.front_mut() else {
+                return Ok(());
+            };
+            let (span, sealed) = match front.handoff.poll_recv(cx) {
+                Poll::Pending => return Ok(()),
+                Poll::Ready(None) => return Err(SplitError::PoolDropped),
+                Poll::Ready(Some(result)) => {
+                    let span = front.span;
+                    fan.seals.pop_front();
+                    (span, result?)
+                }
+            };
+            let (chunk, reference) = sealed;
+            self.stats.leaves = self.stats.leaves.saturating_add(1);
+            self.enqueue(chunk)?;
+            self.push_ref(0, reference, span)?;
+        }
+    }
+
+    /// Leaf seals still on the pool; zero when the fan-out is off.
+    #[cfg(all(
+        feature = "rayon",
+        not(target_arch = "wasm32"),
+        not(feature = "unsync")
+    ))]
+    fn seals_queued(&self) -> usize {
+        self.hash.as_ref().map_or(0, |fan| fan.seals.len())
     }
 
     /// Thread a reference into the spine at `at`, closing and spilling
@@ -526,73 +755,6 @@ where
                 Ok(())
             }
         }
-    }
-
-    /// Drive the put window without consuming input.
-    #[cfg(all(
-        feature = "rayon",
-        not(target_arch = "wasm32"),
-        not(feature = "unsync")
-    ))]
-    pub(crate) fn pump(&mut self, cx: &mut Context<'_>) -> Result<(), SplitError<S::Error>> {
-        if matches!(self.phase, Phase::Poisoned) {
-            return Err(SplitError::Poisoned);
-        }
-        self.step_puts(cx).map_err(|error| self.poison(error))
-    }
-
-    /// Secure admission for one externally sealed leaf: pending drained and
-    /// a put slot free. `Pending` admits nothing.
-    #[cfg(all(
-        feature = "rayon",
-        not(target_arch = "wasm32"),
-        not(feature = "unsync")
-    ))]
-    pub(crate) fn poll_admit(
-        &mut self,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<(), SplitError<S::Error>>> {
-        match self.phase {
-            Phase::Writing => {}
-            Phase::Poisoned => return Poll::Ready(Err(SplitError::Poisoned)),
-            Phase::Closing | Phase::Draining | Phase::Finished => {
-                return Poll::Ready(Err(SplitError::Finished));
-            }
-        }
-        if let Err(error) = self.step_puts(cx) {
-            return Poll::Ready(Err(self.poison(error)));
-        }
-        if !self.pending.is_empty() || self.in_flight.len() >= self.window {
-            return Poll::Pending;
-        }
-        Poll::Ready(Ok(()))
-    }
-
-    /// Thread one externally sealed leaf into the ascent; the caller has
-    /// secured capacity through `poll_admit`.
-    #[cfg(all(
-        feature = "rayon",
-        not(target_arch = "wasm32"),
-        not(feature = "unsync")
-    ))]
-    pub(crate) fn push_sealed(
-        &mut self,
-        chunk: Chunk<Verified, AnyChunkSet<B>>,
-        reference: M::Ref,
-        span: u64,
-    ) -> Result<(), SplitError<S::Error>> {
-        match self.phase {
-            Phase::Writing => {}
-            Phase::Poisoned => return Err(SplitError::Poisoned),
-            Phase::Closing | Phase::Draining | Phase::Finished => {
-                return Err(SplitError::Finished);
-            }
-        }
-        self.stats.bytes = self.stats.bytes.saturating_add(span);
-        self.stats.leaves = self.stats.leaves.saturating_add(1);
-        self.enqueue(chunk)
-            .and_then(|()| self.push_ref(0, reference, span))
-            .map_err(|error| self.poison(error))
     }
 
     /// Fold completed puts back in and admit pending chunks; a failed put

--- a/crates/file/src/split/error.rs
+++ b/crates/file/src/split/error.rs
@@ -44,6 +44,16 @@ pub enum SplitError<E> {
     /// An earlier failure fused the split shut.
     #[error("poisoned by an earlier failure")]
     Poisoned,
+    /// The pool dropped a leaf seal without replying; the worker panicked
+    /// or died.
+    #[cfg(all(
+        feature = "rayon",
+        not(target_arch = "wasm32"),
+        not(feature = "unsync")
+    ))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
+    #[error("hash pool dropped a leaf seal")]
+    PoolDropped,
     /// The spine emptied without yielding a root; a split invariant is
     /// broken.
     #[error("spine depleted without a root")]

--- a/crates/file/src/split/handoff.rs
+++ b/crates/file/src/split/handoff.rs
@@ -1,8 +1,9 @@
 //! Bounded handoff from the thread pool back to the polling future.
 
-use std::sync::{Arc, Mutex, PoisonError};
-
 use core::task::{Context, Poll};
+
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::{Arc, Mutex, PoisonError};
 
 use futures_util::task::AtomicWaker;
 
@@ -20,14 +21,14 @@ impl<T> Slot<T> {
     }
 }
 
-/// Receiving half of one submitted job; polled by the ingest future.
+/// Receiving half of one submitted job; polled by the split engine.
 pub(super) struct Handoff<T> {
     slot: Arc<Slot<T>>,
 }
 
 impl<T> Handoff<T> {
-    /// Ready with the reply, or `None` when the pool dropped the job
-    /// without replying (a worker died mid-job).
+    /// Ready with the reply, or `None` when the job finished without one:
+    /// the job panicked, or the pool dropped it.
     ///
     /// The waker is registered before the slot is checked, so a reply
     /// landing between the two is never missed.
@@ -39,7 +40,7 @@ impl<T> Handoff<T> {
         if Arc::strong_count(&self.slot) == 1 {
             // The reply half is gone, but it may have written its value
             // before dropping; re-check so that ordering never turns a
-            // delivered batch into a spurious drop.
+            // delivered reply into a spurious drop.
             return Poll::Ready(self.slot.value().take());
         }
         Poll::Pending
@@ -47,7 +48,7 @@ impl<T> Handoff<T> {
 }
 
 /// Sending half held by the pool job; waking on drop covers both delivery
-/// and a job that unwinds before replying.
+/// and a job that finished without replying.
 struct Reply<T> {
     slot: Arc<Slot<T>>,
 }
@@ -61,7 +62,9 @@ impl<T> Drop for Reply<T> {
 /// Queue `job` on the pool, returning the handoff its reply arrives on.
 ///
 /// Submission only enqueues, so neither building nor polling the caller's
-/// future ever blocks on the pool.
+/// future ever blocks on the pool. A panicking job is caught here and leaves
+/// its slot empty, so the receiver sees a dropped job instead of a process
+/// abort.
 pub(super) fn submit<T, F>(job: F) -> Handoff<T>
 where
     T: Send + 'static,
@@ -75,7 +78,9 @@ where
         slot: Arc::clone(&slot),
     };
     rayon::spawn(move || {
-        *reply.slot.value() = Some(job());
+        if let Ok(value) = catch_unwind(AssertUnwindSafe(job)) {
+            *reply.slot.value() = Some(value);
+        }
         drop(reply);
     });
     Handoff { slot }

--- a/crates/file/src/split/mod.rs
+++ b/crates/file/src/split/mod.rs
@@ -1,10 +1,11 @@
 //! Poll-native split engine: the one bounded ascent building a chunk tree.
 //!
 //! Every write mode feeds this engine, and only its ascent seals
-//! intermediates; the batch ingest pre-seals leaves but threads them through
-//! this same ascent. The engine is push-driven and io-free (no spawns, channels or
-//! timers), all state lives in the [`Split`], and sealed chunks flow to the
-//! store through a bounded put window.
+//! intermediates; the optional hash window fans leaf seals onto the rayon
+//! pool and admits them in leaf order through this same ascent. The engine
+//! is push-driven and io-free (no spawns, channels or timers, beyond the
+//! opt-in pool handoff), all state lives in the [`Split`], and sealed chunks
+//! flow to the store through a bounded put window.
 //!
 //! Normative invariants, each pinned by a test:
 //!
@@ -22,11 +23,21 @@
 //!    store seam.
 //! 5. Fused finish: `poll_finish` is cancel-safe and re-callable; after the
 //!    root is delivered every later call returns the same root.
+//! 6. Bounded hash window: pool leaf seals in flight never exceed the
+//!    [`HashWindow`](crate::HashWindow), and sealed leaves are admitted in
+//!    leaf order, so a deterministic mode's chunk stream matches the serial
+//!    engine.
 
 #[cfg(feature = "encryption")]
 mod encrypted;
 mod engine;
 mod error;
+#[cfg(all(
+    feature = "rayon",
+    not(target_arch = "wasm32"),
+    not(feature = "unsync")
+))]
+mod handoff;
 mod mode;
 #[cfg(test)]
 mod tests;
@@ -109,6 +120,12 @@ fn widen<E>(error: SplitError<Infallible>) -> SplitError<E> {
         SplitError::SpanOverflow { span, add } => SplitError::SpanOverflow { span, add },
         SplitError::Finished => SplitError::Finished,
         SplitError::Poisoned => SplitError::Poisoned,
+        #[cfg(all(
+            feature = "rayon",
+            not(target_arch = "wasm32"),
+            not(feature = "unsync")
+        ))]
+        SplitError::PoolDropped => SplitError::PoolDropped,
         SplitError::SpineDepleted => SplitError::SpineDepleted,
     }
 }
@@ -178,6 +195,9 @@ pub struct SplitStats {
     pub puts: u64,
     /// Peak puts in flight.
     pub peak_put_in_flight: usize,
+    /// Peak leaf seals in flight on the hash pool; zero on the serial
+    /// engine.
+    pub peak_hash_in_flight: usize,
     /// Peak sealed chunks awaiting a put slot.
     pub peak_pending: usize,
     /// Spine levels touched.

--- a/crates/file/src/split/tests.rs
+++ b/crates/file/src/split/tests.rs
@@ -699,6 +699,49 @@ mod encrypted {
         assert_eq!(sorted(first_store.log()), sorted(second_store.log()));
     }
 
+    /// Keys are drawn on the workers, so only the round trip is pinned:
+    /// pooled encrypted output is not byte-reproducible.
+    #[cfg(all(
+        feature = "rayon",
+        not(target_arch = "wasm32"),
+        not(feature = "unsync")
+    ))]
+    #[test]
+    fn pooled_encrypted_split_round_trips() {
+        use crate::config::HashWindow;
+
+        let size = 17 * TINY + 43;
+        let data = fill(size);
+        let store = TestStore::<TINY>::new(0);
+        let mut split: Split<TestStore<TINY>, Encrypted<RandomKeys>, TINY> =
+            Split::new(store.clone(), PutWindow::new(4).unwrap())
+                .with_hash_window(HashWindow::new(4).unwrap());
+        let root = block_on(async {
+            let mut buf = data.as_slice();
+            while !buf.is_empty() {
+                let n = poll_fn(|cx| split.poll_write(cx, buf)).await.unwrap();
+                buf = &buf[n..];
+            }
+            poll_fn(|cx| split.poll_finish(cx)).await.unwrap()
+        });
+        let mut walk: Walk<TestStore<TINY>, Encrypted, TINY> = Walk::new(
+            store,
+            *root.address(),
+            root.key().clone(),
+            size as u64,
+            0..u64::MAX,
+            Window::new(4).unwrap(),
+        );
+        let plaintext = block_on(async {
+            let mut bytes = Vec::new();
+            while let Some(frame) = poll_fn(|cx| walk.poll_next_ordered(cx)).await {
+                bytes.extend_from_slice(&frame.unwrap().data);
+            }
+            bytes
+        });
+        assert_eq!(plaintext, data);
+    }
+
     #[test]
     fn an_exhausted_key_source_poisons_the_split() {
         let data = fill(3 * TINY);
@@ -736,6 +779,284 @@ mod encrypted {
             split.poll_finish(&mut cx),
             core::task::Poll::Ready(Err(SplitError::Poisoned))
         ));
+    }
+}
+
+/// Pooled-seal oracles: chunk streams identical to the serial engine,
+/// hash-window bounds, backpressure, drop and worker-panic paths.
+#[cfg(all(
+    feature = "rayon",
+    not(target_arch = "wasm32"),
+    not(feature = "unsync")
+))]
+mod pooled {
+    use core::future::poll_fn;
+    use core::task::{Context, Poll};
+    use core::time::Duration;
+    use std::sync::{Arc, Mutex};
+    use std::vec::Vec;
+
+    use bytes::Bytes;
+    use futures::executor::block_on;
+    use futures::task::noop_waker;
+    use nectar_primitives::chunk::{ChunkAddress, ContentChunk};
+
+    use super::{BRANCHES, TINY, TestStore, fill, sorted, stream_split, tree_chunks};
+    use crate::config::{HashWindow, PutWindow};
+    use crate::geometry::Mode;
+    use crate::split::{SealError, Sealed, Split, SplitError, SplitMode, SplitStats};
+    use crate::walk::Plain;
+
+    /// Stream `data` through a hash-windowed split in `step`-byte writes.
+    fn pooled_split(
+        data: &[u8],
+        put_window: u16,
+        hash_window: u16,
+        step: usize,
+        delay: usize,
+    ) -> (ChunkAddress, TestStore<TINY>, SplitStats) {
+        let store = TestStore::<TINY>::new(delay);
+        let mut split: Split<TestStore<TINY>, Plain, TINY> =
+            Split::new(store.clone(), PutWindow::new(put_window).unwrap())
+                .with_hash_window(HashWindow::new(hash_window).unwrap());
+        let root = block_on(async {
+            for piece in data.chunks(step.max(1)) {
+                let mut buf = piece;
+                while !buf.is_empty() {
+                    let n = poll_fn(|cx| split.poll_write(cx, buf)).await.unwrap();
+                    buf = &buf[n..];
+                }
+            }
+            poll_fn(|cx| split.poll_finish(cx)).await.unwrap()
+        });
+        let stats = split.stats();
+        (root, store, stats)
+    }
+
+    #[test]
+    fn pooled_chunk_streams_are_byte_identical_to_serial() {
+        let b = TINY;
+        let kb = BRANCHES * b;
+        let k2b = BRANCHES * kb;
+        let sizes = [
+            0,
+            1,
+            b - 1,
+            b,
+            b + 1,
+            kb - 1,
+            kb,
+            kb + 1,
+            k2b - 1,
+            k2b,
+            k2b + 1,
+            3 * kb + 517,
+        ];
+        for size in sizes {
+            let data = fill(size);
+            // Zero put delay settles every put at dispatch, so the ordered
+            // log is the dispatch order: the wire chunk stream itself.
+            let (serial_root, serial_store, serial_stats) = stream_split::<TINY>(&data, 4, 719, 0);
+            let (root, store, stats) = pooled_split(&data, 4, 4, 719, 0);
+            assert_eq!(root, serial_root, "root diverged at {size}");
+            assert_eq!(
+                store.log(),
+                serial_store.log(),
+                "chunk stream diverged at {size}"
+            );
+            assert_eq!(stats.puts, serial_stats.puts);
+            assert_eq!(stats.bytes, size as u64);
+            assert_eq!(stats.leaves + stats.intermediates, stats.puts);
+            assert_eq!(stats.puts, tree_chunks(size, TINY, BRANCHES));
+        }
+    }
+
+    #[test]
+    fn pooled_bounds_hold_under_a_slow_store() {
+        let data = fill(200 * TINY + 63);
+        let (serial_root, serial_store, _) = stream_split::<TINY>(&data, 4, 719, 1);
+        for put_window in [1u16, 4] {
+            for hash_window in [1u16, 2, 8] {
+                let (root, store, stats) = pooled_split(&data, put_window, hash_window, 997, 3);
+                assert_eq!(root, serial_root);
+                assert_eq!(sorted(store.log()), sorted(serial_store.log()));
+                assert!(
+                    stats.peak_hash_in_flight <= usize::from(hash_window),
+                    "seals in flight {} exceeded the hash window {hash_window}",
+                    stats.peak_hash_in_flight
+                );
+                assert!(
+                    stats.peak_put_in_flight <= usize::from(put_window),
+                    "puts in flight {} exceeded the put window {put_window}",
+                    stats.peak_put_in_flight
+                );
+                assert!(
+                    stats.peak_pending <= stats.peak_spine,
+                    "pending {} exceeded the spine height {}",
+                    stats.peak_pending,
+                    stats.peak_spine
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn pooled_write_backpressure_consumes_nothing_when_full() {
+        let gate = Arc::new(Mutex::new(false));
+        let store = TestStore::<TINY>::gated(Arc::clone(&gate));
+        let mut split: Split<TestStore<TINY>, Plain, TINY> =
+            Split::new(store, PutWindow::new(1).unwrap())
+                .with_hash_window(HashWindow::new(1).unwrap());
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let data = fill(4 * TINY);
+
+        // Two leaves fit: one behind the parked put, one on the pool.
+        let mut consumed = 0usize;
+        for _ in 0..100_000 {
+            match split.poll_write(&mut cx, &data[consumed..]) {
+                Poll::Ready(Ok(n)) => consumed += n,
+                Poll::Ready(Err(error)) => panic!("write failed: {error:?}"),
+                Poll::Pending => std::thread::sleep(Duration::from_micros(50)),
+            }
+            if consumed == 2 * TINY {
+                break;
+            }
+        }
+        assert_eq!(consumed, 2 * TINY, "backpressure engaged early");
+
+        // Let the second seal land: the front is then ready but the put
+        // window is full, so the deque stays occupied and every further
+        // poll consumes nothing.
+        std::thread::sleep(Duration::from_millis(20));
+        for _ in 0..100 {
+            assert!(split.poll_write(&mut cx, &data[consumed..]).is_pending());
+            assert_eq!(split.stats().bytes, (2 * TINY) as u64);
+        }
+
+        // Opening the gate drains the chain and the split finishes.
+        *gate.lock().unwrap() = true;
+        let root = block_on(async {
+            let mut buf = &data[consumed..];
+            while !buf.is_empty() {
+                let n = poll_fn(|cx| split.poll_write(cx, buf)).await.unwrap();
+                buf = &buf[n..];
+            }
+            poll_fn(|cx| split.poll_finish(cx)).await.unwrap()
+        });
+        let (serial_root, _, _) = stream_split::<TINY>(&data, 4, 719, 0);
+        assert_eq!(root, serial_root);
+        assert_eq!(split.stats().bytes, (4 * TINY) as u64);
+    }
+
+    /// Mode whose seal panics on the worker; the split must survive it.
+    #[derive(Clone, Copy, Debug, Default)]
+    struct PanicMode;
+
+    impl SplitMode for PanicMode {
+        const MODE: Mode = Mode::Plain;
+
+        type Ref = ChunkAddress;
+        type Root = ChunkAddress;
+
+        fn data_slots(branches: u64) -> u64 {
+            branches
+        }
+
+        fn seal<const B: usize>(&self, _payload: Bytes) -> Result<Sealed<Self, B>, SealError> {
+            panic!("seal panicked on the worker")
+        }
+
+        fn write_ref(reference: &ChunkAddress, out: &mut Vec<u8>) {
+            out.extend_from_slice(reference.as_bytes());
+        }
+
+        fn into_root(reference: ChunkAddress) -> ChunkAddress {
+            reference
+        }
+    }
+
+    #[test]
+    fn a_worker_panic_is_a_typed_error_not_an_abort() {
+        let store = TestStore::<TINY>::new(0);
+        let mut split: Split<TestStore<TINY>, PanicMode, TINY> =
+            Split::new(store, PutWindow::DEFAULT).with_hash_window(HashWindow::new(2).unwrap());
+        let data = fill(TINY);
+        let error = block_on(async {
+            let mut buf = data.as_slice();
+            while !buf.is_empty() {
+                match poll_fn(|cx| split.poll_write(cx, buf)).await {
+                    Ok(n) => buf = &buf[n..],
+                    Err(error) => return error,
+                }
+            }
+            poll_fn(|cx| split.poll_finish(cx)).await.unwrap_err()
+        });
+        assert!(matches!(error, SplitError::PoolDropped), "got {error:?}");
+
+        // The fuse is shut for good.
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        assert!(matches!(
+            split.poll_finish(&mut cx),
+            Poll::Ready(Err(SplitError::Poisoned))
+        ));
+    }
+
+    /// Plain sealing behind a worker-side stall, so drops race live jobs.
+    #[derive(Clone, Copy, Debug, Default)]
+    struct SlowMode;
+
+    impl SplitMode for SlowMode {
+        const MODE: Mode = Mode::Plain;
+
+        type Ref = ChunkAddress;
+        type Root = ChunkAddress;
+
+        fn data_slots(branches: u64) -> u64 {
+            branches
+        }
+
+        fn seal<const B: usize>(&self, payload: Bytes) -> Result<Sealed<Self, B>, SealError> {
+            std::thread::sleep(Duration::from_millis(10));
+            let chunk = ContentChunk::<B>::try_from(payload)?
+                .seal::<nectar_primitives::chunk::AnyChunkSet<B>>();
+            let address = *chunk.address();
+            Ok((chunk, address))
+        }
+
+        fn write_ref(reference: &ChunkAddress, out: &mut Vec<u8>) {
+            out.extend_from_slice(reference.as_bytes());
+        }
+
+        fn into_root(reference: ChunkAddress) -> ChunkAddress {
+            reference
+        }
+    }
+
+    #[test]
+    fn dropping_a_pooled_split_abandons_live_jobs() {
+        let store = TestStore::<TINY>::new(0);
+        let mut split: Split<TestStore<TINY>, SlowMode, TINY> =
+            Split::new(store, PutWindow::DEFAULT).with_hash_window(HashWindow::new(4).unwrap());
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let data = fill(4 * TINY);
+        let mut consumed = 0usize;
+        for _ in 0..1_000 {
+            match split.poll_write(&mut cx, &data[consumed..]) {
+                Poll::Ready(Ok(n)) => consumed += n,
+                Poll::Ready(Err(error)) => panic!("write failed: {error:?}"),
+                Poll::Pending => {}
+            }
+            if consumed == data.len() {
+                break;
+            }
+        }
+        // Seals are still running on the pool; the drop must orphan them
+        // harmlessly (each writes into its dead slot and wakes a no-op).
+        drop(split);
+        std::thread::sleep(Duration::from_millis(60));
     }
 }
 

--- a/crates/file/tests/membound.rs
+++ b/crates/file/tests/membound.rs
@@ -730,12 +730,14 @@ mod encrypted {
     }
 }
 
-/// The batch ingest pre-seals leaves on the pool but drains the same put
-/// window; the write-side bound survives the parallel path.
+/// The pooled paths seal leaves on the pool but drain the same put window;
+/// the write-side bounds survive the fan-out, plus the hash window's own.
 #[cfg(feature = "rayon")]
 mod batch {
+    use core::future::poll_fn;
+
     use futures::executor::block_on;
-    use nectar_file::{Plain, PutWindow, split_read_at};
+    use nectar_file::{HashWindow, Plain, PutWindow, Split, split_read_at};
 
     use super::{BRANCHES, GaugeStore, TINY, fill, split_plain};
 
@@ -758,6 +760,48 @@ mod batch {
                 "{} concurrent puts exceeded window {window}",
                 store.puts.peak()
             );
+            assert_eq!(store.chunk_count(), streamed_store.chunk_count());
+        }
+    }
+
+    #[test]
+    fn pooled_writer_holds_all_three_windows() {
+        let size = BRANCHES * BRANCHES * TINY + 999;
+        let data = fill(size);
+        let (streamed_root, streamed_store, _) = split_plain(&data, 4, 0);
+        for (put_window, hash_window) in [(1u16, 1u16), (2, 4), (16, 8)] {
+            let store = GaugeStore::<TINY>::new(2);
+            let mut split: Split<GaugeStore<TINY>, Plain, TINY> =
+                Split::new(store.clone(), PutWindow::new(put_window).unwrap())
+                    .with_hash_window(HashWindow::new(hash_window).unwrap());
+            let root = block_on(async {
+                let mut buf = data.as_slice();
+                while !buf.is_empty() {
+                    let n = poll_fn(|cx| split.poll_write(cx, buf)).await.unwrap();
+                    buf = &buf[n..];
+                }
+                poll_fn(|cx| split.poll_finish(cx)).await.unwrap()
+            });
+            let stats = split.stats();
+            assert_eq!(root, streamed_root, "pooled root diverged at {put_window}");
+            assert!(
+                store.puts.peak() <= usize::from(put_window),
+                "{} concurrent puts exceeded window {put_window}",
+                store.puts.peak()
+            );
+            assert!(
+                stats.peak_put_in_flight <= usize::from(put_window),
+                "in flight {} exceeded window {put_window}",
+                stats.peak_put_in_flight
+            );
+            assert!(
+                stats.peak_hash_in_flight <= usize::from(hash_window),
+                "seals in flight {} exceeded the hash window {hash_window}",
+                stats.peak_hash_in_flight
+            );
+            assert!(stats.peak_pending <= stats.peak_spine);
+            assert_eq!(stats.bytes, size as u64);
+            assert_eq!(stats.puts, stats.leaves + stats.intermediates);
             assert_eq!(store.chunk_count(), streamed_store.chunk_count());
         }
     }


### PR DESCRIPTION
## What

Adds `HashWindow`, a bounded pool of in-flight leaf-hashing jobs, to the split engine. `Split::with_hash_window(HashWindow)` fans per-leaf sealing onto the rayon pool while keeping ascent order, intermediate sealing, and put dispatch order byte-identical to the serial engine in deterministic modes. `split_read_at` is rebased onto the same hash-windowed engine, dropping the old batch double-buffer, `pump`/`poll_admit`/`push_sealed`, `LeafError`, and `ReadAtError::PoolDropped`.

Closes #394

## Why

Leaf hashing was serial on the calling task even with the rayon pool available, leaving throughput on the table for large uploads. Profiling (issue #387) showed the serial split is ~90 percent single-threaded keccak, so the deleted legacy splitter reached its numbers by hashing across chunks in parallel. Bounding the number of in-flight hash jobs behind a window recovers that parallelism on the one streaming surface while the ascent/seal/put path stays deterministic and cancel-safe, so the parallel and serial engines produce the same roots. Native targets only; wasm32/`unsync` stay serial.

## Testing

- fmt: clean.
- clippy `--workspace --all-targets` + tokio/rayon/encryption/rayon,encryption lanes: 0 warnings from this change (one pre-existing `use_self` in nectar-primitives `type_tag.rs`, untouched).
- nextest: workspace 875/875; nectar-file tokio 82/82; rayon,encryption 107/107 (includes all new tests); encryption 87/87. Doctests: workspace + all three feature lanes pass (including the new `with_hash_window` doctest). Roots byte-identical across serial, hash-windowed and rebased read-at paths (parity-asserted in tests).
- no_std: `--no-default-features` check green on `riscv64imac-unknown-none-elf` and `wasm32-unknown-unknown` (swarms, contracts, file, mantaray@0.4.0, nostd-spike). `nectar-file --features unsync` checks.
- fuzz workspace: `cargo check` green. Membound suite green.

Benchmark (same-run criterion medians, `MemoryStore`, 8C/16T avx512, on the standalone `benches-intrinsic` rig where the deleted legacy splitter is still present as the baseline; roots parity-asserted across serial, concurrent and read-at):

| Split | Serial streaming | Legacy | Streaming concurrent | `split_read_at` |
|---|---|---|---|---|
| 1 MiB | 2.266 ms | 0.772 ms | 0.801 ms | 0.747 ms |
| 32 MiB | 82.5 ms | 39.1 ms | 26.089 ms (1286 MiB/s) | 25.272 ms |

The hash-windowed streaming split reaches legacy parity at 1 MiB (within the spawn/window constant) and beats it 1.50x at 32 MiB (1286 vs 858 MiB/s), converging on the `split_read_at` bulk ceiling. A hash-window sweep on a 64 MiB payload confirms the scaling: serial 2.24 ms/MiB, hw=4 1.80, hw=8 1.05, hw=16 (default) 0.586, hw=32 0.583 (~3.8x over serial at the default window).

## AI Assistance

Implementation Fable, review Opus, PR Sonnet.