### PR TITLE
perf(file): reuse in-flight set to halve plain join allocs

### DIFF
--- a/crates/file/src/inflight.rs
+++ b/crates/file/src/inflight.rs
@@ -1,0 +1,83 @@
+//! Bounded set of in-flight futures, polled without a per-future task node.
+
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::future::Future;
+use core::pin::Pin;
+use core::task::{Context, Poll};
+
+/// Boxed future held in the set: `Send` on multi-threaded targets, unbounded
+/// on wasm32 and under the `unsync` feature.
+#[cfg(not(any(target_arch = "wasm32", feature = "unsync")))]
+pub(crate) type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
+/// Boxed future held in the set: `Send` on multi-threaded targets, unbounded
+/// on wasm32 and under the `unsync` feature.
+#[cfg(any(target_arch = "wasm32", feature = "unsync"))]
+pub(crate) type BoxFuture<T> = Pin<Box<dyn Future<Output = T>>>;
+
+/// A fixed-membership set of outstanding futures.
+///
+/// Concurrency is capped by the caller's window, so the slot vector grows to
+/// the peak once and is then reused: a completed future vacates its slot and
+/// the next admission refills it, so the set holds no per-future task node.
+/// One boxed future per admission remains, because a store future borrows its
+/// store and is not nameable as a slab element.
+///
+/// [`poll`](Self::poll) scans the live slots and returns one completion per
+/// call, so a caller drives it in a loop; before it reports `Pending` every
+/// outstanding future has been polled with the current context, so no wakeup
+/// is lost.
+pub(crate) struct InFlight<T> {
+    slots: Vec<Option<BoxFuture<T>>>,
+    live: usize,
+}
+
+impl<T> InFlight<T> {
+    /// An empty set.
+    pub(crate) const fn new() -> Self {
+        Self {
+            slots: Vec::new(),
+            live: 0,
+        }
+    }
+
+    /// Futures currently outstanding.
+    pub(crate) const fn len(&self) -> usize {
+        self.live
+    }
+
+    /// Whether no future is outstanding.
+    pub(crate) const fn is_empty(&self) -> bool {
+        self.live == 0
+    }
+
+    /// Admit one future, reusing a vacated slot before growing the vector.
+    pub(crate) fn push(&mut self, future: BoxFuture<T>) {
+        self.live = self.live.saturating_add(1);
+        for slot in &mut self.slots {
+            if slot.is_none() {
+                *slot = Some(future);
+                return;
+            }
+        }
+        self.slots.push(Some(future));
+    }
+
+    /// Poll for one completion: `Ready(Some(_))` retires the first ready
+    /// future, `Ready(None)` reports the set empty, and `Pending` means every
+    /// outstanding future is pending with the current context registered.
+    pub(crate) fn poll(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
+        if self.live == 0 {
+            return Poll::Ready(None);
+        }
+        for slot in &mut self.slots {
+            let Some(future) = slot else { continue };
+            if let Poll::Ready(output) = future.as_mut().poll(cx) {
+                *slot = None;
+                self.live = self.live.saturating_sub(1);
+                return Poll::Ready(Some(output));
+            }
+        }
+        Poll::Pending
+    }
+}

--- a/crates/file/src/lib.rs
+++ b/crates/file/src/lib.rs
@@ -92,6 +92,8 @@ compile_error!("feature `rayon` needs `Send` chunks and errors; it excludes the 
 pub mod config;
 pub mod geometry;
 #[cfg(feature = "std")]
+mod inflight;
+#[cfg(feature = "std")]
 mod num;
 #[cfg(all(
     feature = "rayon",

--- a/crates/file/src/split/engine.rs
+++ b/crates/file/src/split/engine.rs
@@ -11,7 +11,6 @@ use core::pin::Pin;
 use core::task::{Context, Poll, Waker};
 
 use bytes::Bytes;
-use futures_util::stream::{FuturesUnordered, Stream};
 use nectar_primitives::DEFAULT_BODY_SIZE;
 use nectar_primitives::bmt::SPAN_SIZE;
 use nectar_primitives::chunk::{AnyChunkSet, Chunk, ChunkAddress, Verified};
@@ -45,6 +44,7 @@ use super::mode::SplitMode;
 ))]
 use crate::config::HashWindow;
 use crate::config::PutWindow;
+use crate::inflight::InFlight;
 use crate::num::{fan_out, u64_from_u32, u64_from_usize};
 
 /// Completion payload; the future carries the chunk's address back for the
@@ -154,7 +154,7 @@ where
     spine: Vec<Level<M>>,
     /// Sealed chunks awaiting a put slot; bounded by the spine height.
     pending: VecDeque<Chunk<Verified, AnyChunkSet<B>>>,
-    in_flight: FuturesUnordered<BoxPut<S::Error>>,
+    in_flight: InFlight<PutDone<S::Error>>,
     /// Pool fan-out for leaf seals; `None` keeps sealing inline.
     #[cfg(all(
         feature = "rayon",
@@ -207,7 +207,7 @@ where
             leaf: Vec::new(),
             spine: Vec::new(),
             pending: VecDeque::new(),
-            in_flight: FuturesUnordered::new(),
+            in_flight: InFlight::new(),
             #[cfg(all(
                 feature = "rayon",
                 not(target_arch = "wasm32"),
@@ -765,7 +765,7 @@ where
             if self.in_flight.is_empty() {
                 return Ok(());
             }
-            match Pin::new(&mut self.in_flight).poll_next(cx) {
+            match self.in_flight.poll(cx) {
                 Poll::Ready(Some((address, result))) => {
                     result.map_err(|source| SplitError::Put { address, source })?;
                 }

--- a/crates/file/src/walk/engine.rs
+++ b/crates/file/src/walk/engine.rs
@@ -9,7 +9,6 @@ use core::pin::Pin;
 use core::task::{Context, Poll};
 
 use bytes::{Bytes, BytesMut};
-use futures_util::stream::{FuturesUnordered, Stream};
 use nectar_primitives::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{AnyChunkSet, Chunk, ChunkAddress, ChunkOps, Verified};
 use nectar_primitives::store::TrustedGet;
@@ -18,6 +17,7 @@ use super::error::{ShapeError, WalkError};
 use super::mode::WalkMode;
 use super::{Frame, WalkStats};
 use crate::config::{BranchBudget, Window};
+use crate::inflight::InFlight;
 use crate::num::{fan_out, u64_from_u32, u64_from_usize};
 
 /// One pending tree node: where its bytes live and what fetches it.
@@ -84,7 +84,7 @@ where
     /// Discovered intermediates awaiting descent, ascending by key; the
     /// flattened frame stack of the serial walk.
     branch_frontier: VecDeque<Node<M>>,
-    in_flight: FuturesUnordered<BoxFetch<M, S::Error, B>>,
+    in_flight: InFlight<Fetched<M, S::Error, B>>,
     /// Keys of in-flight leaf fetches, counted per key.
     leaf_keys: BTreeMap<u64, usize>,
     /// Keys of in-flight branch fetches, counted per key.
@@ -142,7 +142,7 @@ where
             branch_budget: usize::try_from(budget.get()).unwrap_or(usize::MAX),
             leaf_frontier: VecDeque::new(),
             branch_frontier: VecDeque::new(),
-            in_flight: FuturesUnordered::new(),
+            in_flight: InFlight::new(),
             leaf_keys: BTreeMap::new(),
             branch_keys: BTreeMap::new(),
             leaf_in_flight: 0,
@@ -212,7 +212,7 @@ where
             if let Some(frame) = self.take_ready(drain) {
                 return Poll::Ready(Some(Ok(frame)));
             }
-            match Pin::new(&mut self.in_flight).poll_next(cx) {
+            match self.in_flight.poll(cx) {
                 Poll::Ready(Some((node, fetched))) => {
                     if let Err(error) = self.absorb(node, fetched) {
                         self.done = true;

--- a/crates/file/tests/plain_alloc_probe.rs
+++ b/crates/file/tests/plain_alloc_probe.rs
@@ -1,0 +1,150 @@
+//! Allocation probe over the real plain read path.
+//!
+//! Splits a file through the plain splitter into a `MemoryStore`, then reads
+//! it back through `File::open` under a counting allocator. Plain bodies pass
+//! through undecoded, so no body-sized allocation lands per fetched node, and
+//! the walk holds outstanding fetches in a reusable in-flight set, so the
+//! per-fetch allocation count stays below the boxed-future-plus-task-node
+//! pair that a `FuturesUnordered` charged: one boxed store future per fetch
+//! plus a chunk-independent remainder, never two.
+// Integration-test code: unwraps, direct indexing, casts, and assertions are
+// setup and illustration, not shipped surface.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::panic,
+    clippy::as_conversions,
+    clippy::missing_panics_doc
+)]
+
+use core::future::poll_fn;
+use core::sync::atomic::{AtomicU64, Ordering};
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::Arc;
+
+use futures::executor::block_on;
+use nectar_file::{File, Plain, PutWindow, Split};
+use nectar_primitives::chunk::{AnyChunkSet, ChunkAddress};
+use nectar_primitives::store::MemoryStore;
+
+/// Body size of the default profile.
+const BODY: usize = nectar_primitives::DEFAULT_BODY_SIZE;
+
+/// Allocator calls observed so far.
+static CALLS: AtomicU64 = AtomicU64::new(0);
+/// Allocator calls of at least one body size.
+static BODY_CALLS: AtomicU64 = AtomicU64::new(0);
+
+fn note(size: usize) {
+    CALLS.fetch_add(1, Ordering::Relaxed);
+    if size >= BODY {
+        BODY_CALLS.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// System allocator wrapper counting calls by size class.
+struct Counting;
+
+// SAFETY: delegates to `System` unchanged; the counters are side effects.
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        note(layout.size());
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        note(new_size);
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: Counting = Counting;
+
+type Store = Arc<MemoryStore<AnyChunkSet<BODY>>>;
+
+/// Distinct byte per position so every chunk address is unique.
+fn fill(len: usize) -> Vec<u8> {
+    (0..len as u64)
+        .map(|i| ((i.wrapping_mul(2_654_435_761) >> 11) & 0xff) as u8)
+        .collect()
+}
+
+/// Stream `data` through a plain split into a fresh memory store.
+fn split_plain(data: &[u8]) -> (ChunkAddress, Store) {
+    let store: Store = Arc::new(MemoryStore::new());
+    let mut split: Split<Store, Plain, BODY> = Split::new(Arc::clone(&store), PutWindow::DEFAULT);
+    let root = block_on(async {
+        let mut buf = data;
+        while !buf.is_empty() {
+            let n = poll_fn(|cx| split.poll_write(cx, buf)).await.unwrap();
+            buf = &buf[n..];
+        }
+        poll_fn(|cx| split.poll_finish(cx)).await.unwrap()
+    });
+    (root, store)
+}
+
+/// Full read of `leaves` body-sized leaves; returns the calls, body-sized
+/// calls, and fetches the open-plus-drain made.
+fn probe(leaves: usize) -> (u64, u64, u64) {
+    let data = fill(leaves * BODY);
+    let (root, store) = split_plain(&data);
+
+    let calls = CALLS.load(Ordering::Relaxed);
+    let body_calls = BODY_CALLS.load(Ordering::Relaxed);
+    let (read, fetches) = block_on(async {
+        let file: File<Store, Plain, BODY> = File::open(store, root).await.unwrap();
+        let mut reader = file.read().build();
+        let mut read = 0usize;
+        while let Some(segment) = reader.next_segment().await {
+            read += segment.unwrap().len();
+        }
+        (read, reader.stats().fetches)
+    });
+    let calls = CALLS.load(Ordering::Relaxed) - calls;
+    let body_calls = BODY_CALLS.load(Ordering::Relaxed) - body_calls;
+
+    assert_eq!(read, data.len(), "plaintext short at {leaves} leaves");
+    (calls, body_calls, fetches)
+}
+
+#[test]
+fn plain_read_allocations_stay_below_two_per_fetch() {
+    // Plain fan-out 128: 128 leaves sit under one root; 512 leaves add four
+    // intermediates, so the fetch count scales while the peaks do not.
+    let (small_calls, small_body, small_fetches) = probe(128);
+    let (large_calls, large_body, large_fetches) = probe(512);
+    println!("128 leaves: {small_calls} calls, {small_body} body-sized, {small_fetches} fetches");
+    println!("512 leaves: {large_calls} calls, {large_body} body-sized, {large_fetches} fetches");
+
+    // Plain bodies pass through undecoded, so the only body-sized allocations
+    // are the reader's own staging, independent of the chunk count; one body
+    // per fetch would be 129 and 517.
+    assert!(
+        small_body <= 16,
+        "128-leaf read made {small_body} body-sized allocations"
+    );
+    assert!(
+        large_body <= 16,
+        "512-leaf read made {large_body} body-sized allocations"
+    );
+
+    // The reusable in-flight set holds one boxed store future per fetch and
+    // no per-push task node, so total allocations stay below two per fetch; a
+    // `FuturesUnordered` charged two (box plus `Arc<Task>`).
+    assert!(
+        large_calls * 2 < large_fetches * 3,
+        "512-leaf read made {large_calls} allocations over {large_fetches} fetches, at or above 1.5 per fetch"
+    );
+    assert!(
+        small_calls * 2 < small_fetches * 3,
+        "128-leaf read made {small_calls} allocations over {small_fetches} fetches, at or above 1.5 per fetch"
+    );
+}


### PR DESCRIPTION
## What

Replace the plain join walk engine's `FuturesUnordered` in-flight set with a reusable bounded `InFlight<T>` slot vector (new `crates/file/src/inflight.rs`). The slot `Vec` grows to the window once and is reused: a completed future vacates its slot and the next admission refills it, with no per-future task node. `poll` scans live slots, returns one completion per call, and before reporting `Pending` polls every outstanding future with the current context so no wakeup is lost. Admission counts, fetch order, decode and wire output are unchanged.

## Why

The plain join path allocated exactly 2.00 heap calls per fetch: `Box::pin` of the fetch future plus the `Arc<Task>` that `FuturesUnordered::push` mints. `Plain::decode_body` returns the body `Bytes` unchanged, so there is no per-frame plaintext buffer to pool, and PR #392's scratch cannot apply (the 2.00 rather than 3.00 factor proves it). Removing the task node sheds one of the two allocations, taking the path from 2.00 to roughly 1.0 allocs per fetch. The surviving box is the store future itself: `ChunkGet::get` returns a borrowing, non-`'static impl Future` that cannot live unboxed in a slot, so full legacy parity needs a nameable store future type, left as a follow-up noted on the issue.

## Testing

`nix develop --command cargo` for fmt, clippy (`--workspace --all-targets`, zero new warnings), `nextest run --workspace` (876 passed, 1 skipped), and the `nectar-file` tokio/rayon/encryption feature matrices. New `tests/plain_alloc_probe.rs` pins body-sized allocations chunk-independent (1 to 2) and total below 1.5 per fetch (fails at the old 2.0). The two-budget admission invariants in `membound.rs` stay green and wire output is asserted byte-identical to the join input at every size.

Plain join allocator calls (memprofile, streaming):

| payload | fetches | before | after | after/fetch |
|---|---|---|---|---|
| 1 MiB | 260 | 533 | 278 | 1.07 |
| 32 MiB | 8258 | 16,533 | 8,404 | 1.018 |
| 128 MiB | 33,028 | 66,077 | 33,560 | 1.016 |

Encrypted join allocator calls (streaming):

| payload | fetches | before | after | after/fetch |
|---|---|---|---|---|
| 1 MiB | 262 | 539 | 286 | 1.09 |
| 32 MiB | 8324 | 16,670 | 8,601 | 1.033 |

Both paths shed exactly the task node: 2.00 to roughly 1.0 allocs per fetch, count halved.

## AI Assistance

Implementation Fable, review Opus, PR Sonnet.

Closes #397