### PR TITLE
ci: select nectar-mantaray by manifest path in the unused-deps and no_std gates

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,14 +50,17 @@ jobs:
             # that also covers non-lib targets.
             - name: unused lib dependencies
               run: |
-                  # nectar-mantaray is version-qualified: the editor's differential
-                  # gate pins nectar-mantaray 0.3.0 as an oracle, so a bare spec is
-                  # ambiguous against the workspace's 0.4.0.
-                  for crate in nectar-primitives nectar-mantaray@0.4.0 nectar-postage \
+                  for crate in nectar-primitives nectar-postage \
                                nectar-postage-issuer nectar-postage-usage \
                                nectar-swarms nectar-contracts nectar-file; do
                       cargo rustc --locked -p "$crate" --lib -- -D unused_crate_dependencies
                   done
+                  # nectar-mantaray by path: the editor's differential gate pins a
+                  # second nectar-mantaray (0.3.0) as an oracle, so a bare -p spec is
+                  # ambiguous. The manifest path selects the workspace member
+                  # regardless of version, so this needs no revisiting when the oracle
+                  # is removed or the workspace version bumps.
+                  cargo rustc --locked --manifest-path crates/mantaray/Cargo.toml --lib -- -D unused_crate_dependencies
 
     unused-deps:
         name: unused-deps (machete)

--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -38,9 +38,15 @@ jobs:
               run: |
                   cargo check --locked \
                     -p nectar-swarms -p nectar-contracts -p nectar-file \
-                    -p nectar-mantaray@0.4.0 \
                     --no-default-features \
                     --target ${{ matrix.target }}
+                  # nectar-mantaray by path: the editor's differential gate pins a
+                  # second nectar-mantaray (0.3.0), so a bare -p spec is ambiguous.
+                  # The manifest path selects the workspace member independent of
+                  # version, so nothing here needs revisiting when the oracle is
+                  # removed or the workspace version bumps.
+                  cargo check --locked --manifest-path crates/mantaray/Cargo.toml \
+                    --no-default-features --target ${{ matrix.target }}
             # nectar-primitives does not yet build bare-metal, so the
             # single-thread send escape (the unsync feature) and its
             # !Send-store compile proof are checked for the host inside the


### PR DESCRIPTION
## What
Select `nectar-mantaray` by manifest path in both lint workflows that pin it by version:
- `.github/workflows/lint.yml` (`unused lib dependencies` step): drop `-p nectar-mantaray@0.4.0` from the loop, run a separate `cargo rustc --manifest-path crates/mantaray/Cargo.toml` invocation.
- `.github/workflows/nostd.yml` (no_std `cargo check` step): drop `-p nectar-mantaray@0.4.0` from the multi-crate line, run a separate `cargo check --manifest-path crates/mantaray/Cargo.toml` per target (a multi-crate `-p` line cannot take `--manifest-path`).

## Why
The `@0.4.0` pins were transitional debt. They existed only because the editor's differential gate pins a second `nectar-mantaray` (the `mantaray-old` 0.3.0 oracle) in the workspace, making a bare `-p nectar-mantaray` spec ambiguous. Pinning to `@0.4.0` couples both gates to the oracle's presence and the current workspace version, so they break when the oracle is removed or the version bumps past 0.4.0. Selecting by `--manifest-path crates/mantaray/Cargo.toml` picks the workspace member regardless of version, removing both couplings.

## Testing
- `cargo rustc --locked --manifest-path crates/mantaray/Cargo.toml --lib -- -D unused_crate_dependencies` (pinned toolchain via `nix develop`): compiles, no unused-dep error.
- `cargo check --locked --manifest-path crates/mantaray/Cargo.toml --no-default-features` (host sanity check for the no_std invocation): resolves and checks cleanly, no package-spec/ambiguity error. Cross-target rv64/wasm32 checks run in CI.
- `actionlint .github/workflows/nostd.yml .github/workflows/lint.yml`: clean.

## AI Assistance
CI fix drafted with AI assistance.