### PR TITLE
fix(manifest): flatten the whole child-only chain when re-compacting an edge

### DIFF
--- a/crates/manifest/src/apply.rs
+++ b/crates/manifest/src/apply.rs
@@ -535,6 +535,11 @@ where
 
 /// Merge a child-only `edge` into its lone child fork (index byte `first` plus
 /// `record`), emitting the compacted fork a from-scratch build would produce.
+///
+/// The lone child may itself head a child-only chain, so the whole run is
+/// flattened before re-segmenting: stopping after one link would re-split a
+/// short run and dangle the chain's tail as a separate hop, diverging from a
+/// build.
 async fn compact<S, F>(
     store: &S,
     edge: &[u8],
@@ -547,17 +552,45 @@ where
     F: Format,
 {
     let mut merged = edge.to_vec();
-    merged.push(first);
-    merged.extend_from_slice(record.tail().as_bytes());
+    let terminal = flatten_run(&mut merged, first, record);
     chain(
         store,
         &merged,
-        record.payload().clone(),
-        record.metadata().cloned(),
-        record.child_count(),
+        terminal.payload().clone(),
+        terminal.metadata().cloned(),
+        terminal.child_count(),
         stats,
     )
     .await
+}
+
+/// Flatten a child-only single-fork chain rooted at (`first`, `record`) into
+/// `run`, appending every edge byte the collapsed run spans, and return the
+/// terminal fork whose payload the run carries.
+///
+/// The walk descends while a fork has no terminal value and exactly one
+/// embedded continuation: the shape a from-scratch build fuses into one
+/// `PLEN_MAX`-segmented run. It stops at a terminal value, a branch, or a
+/// referenced child, the boundaries a build keeps.
+fn flatten_run<'r, F: Format>(
+    run: &mut Vec<u8>,
+    mut first: u8,
+    mut record: &'r ForkRecord<F>,
+) -> &'r ForkRecord<F> {
+    loop {
+        run.push(first);
+        run.extend_from_slice(record.tail().as_bytes());
+        if record.entry().is_none()
+            && let Some(Child::Embedded(table)) = record.child()
+            && table.len() == 1
+            && let Some((next_first, next_record)) = table.iter().next()
+        {
+            first = next_first;
+            record = next_record;
+            continue;
+        }
+        return record;
+    }
 }
 
 /// A fork record over `prefix`, split into a `PLEN_MAX`-capped chain of
@@ -852,6 +885,56 @@ mod tests {
         cs.put(Key::from(&branched[..]), entry(2), None);
         let out = block_on(apply(&store, &root, &cs)).unwrap();
         assert_eq!(out, rebuilt(&[(&base[..], 1), (&branched[..], 2)]));
+    }
+
+    #[test]
+    fn a_split_above_a_multi_fork_chain_recompacts_like_a_rebuild() {
+        let store = MemoryStore::default();
+        // A 511-byte key sits behind a PLEN_MAX(255) chain of three forks
+        // (255 + 255 + 1). Inserting its one-byte prefix branches at the head,
+        // leaving a 510-byte continuation run whose canonical shape is a
+        // 255 + 255 chain, not the 255 + 254 + 1 a single-level re-compaction
+        // stops at.
+        let long = vec![0xffu8; 511];
+        let prefix = [0xffu8];
+        let root = build(&store, &[(&long[..], 1)]);
+        let mut cs = Changeset::<V1>::new();
+        cs.put(Key::from(&prefix[..]), entry(2), None);
+        let out = block_on(apply(&store, &root, &cs)).unwrap();
+        assert_eq!(out, rebuilt(&[(&long[..], 1), (&prefix[..], 2)]));
+    }
+
+    #[test]
+    fn a_split_above_a_deep_chain_recompacts_like_a_rebuild() {
+        let store = MemoryStore::default();
+        // A 766-byte key is a four-fork chain (255 + 255 + 255 + 1); branching
+        // at its head must re-segment the whole 765-byte run, not just the top
+        // link.
+        let long = vec![0xffu8; 766];
+        let prefix = [0xffu8];
+        let root = build(&store, &[(&long[..], 1)]);
+        let mut cs = Changeset::<V1>::new();
+        cs.put(Key::from(&prefix[..]), entry(2), None);
+        let out = block_on(apply(&store, &root, &cs)).unwrap();
+        assert_eq!(out, rebuilt(&[(&long[..], 1), (&prefix[..], 2)]));
+    }
+
+    #[test]
+    fn a_remove_beside_a_recapped_chain_insert_equals_a_rebuild() {
+        let store = MemoryStore::default();
+        // Removing the only key while inserting a 257-byte sibling splits the
+        // shared first byte, and the re-capped PLEN_MAX(255) chain boundary
+        // lands one byte earlier than the inserted subtree's own cap: the tail
+        // beyond the new boundary must merge into one edge rather than keep
+        // the stale one-byte chain hop.
+        let root = build(&store, &[(&[0u8, 0][..], 1)]);
+        let mut long = vec![0u8, 1];
+        long.extend(std::iter::repeat_n(0u8, 255));
+        let mut cs = Changeset::<V1>::new();
+        cs.remove(Key::from(&[0u8, 0][..]));
+        cs.put(Key::from(&long[..]), entry(2), None);
+        let out = block_on(apply(&store, &root, &cs)).unwrap();
+        assert_eq!(out, rebuilt(&[(&long[..], 2)]));
     }
 
     #[test]

--- a/crates/manifest/tests/apply.rs
+++ b/crates/manifest/tests/apply.rs
@@ -84,12 +84,13 @@ fn change_set() -> impl Strategy<Value = Vec<(Vec<u8>, Option<Parts>)>> {
     prop::collection::vec((key_bytes(), prop::option::of(value_parts())), 0..=40)
 }
 
-/// A long, low-entropy key: a binary alphabet over up to 400 bytes, so pairs
-/// share prefixes past the 255-byte bound while the two-way fanout keeps every
-/// node within budget. Chains form, and a split above a chain boundary
-/// re-compacts into a `PLEN_MAX`-capped chain rather than one over-long edge.
+/// A long, low-entropy key: a binary alphabet over up to 800 bytes, so pairs
+/// share prefixes across several `PLEN_MAX` links while the two-way fanout keeps
+/// every node within budget. The ceiling clears 510 bytes so a shared run spans
+/// a chain of three or more forks, and a split above such a chain re-compacts
+/// into a `PLEN_MAX`-capped chain rather than stopping one link short.
 fn long_key_bytes() -> impl Strategy<Value = Vec<u8>> {
-    prop::collection::vec(0u8..2, 1..=400)
+    prop::collection::vec(0u8..2, 1..=800)
 }
 
 /// A base key set of long keys.


### PR DESCRIPTION
## What

Fix `apply` over-fragmenting a long shared key path, so an incremental apply no longer diverges from a from-scratch rebuild. `compact` now flattens the entire child-only single-fork chain into one run (via a new `flatten_run` helper) before `chain` re-segments it, instead of folding only the first link and dangling the rest.

Widen the `apply_equals_rebuild_over_long_keys` proptest generator from 400 to 800 byte keys so a shared run reaches a three-fork chain, and add two deterministic regression tests pinning the minimal 511- and 766-byte cases.

## Why

The `manifest_apply_rebuild` fuzz target was flaking `main` red (#414). A key of 511 bytes builds a `PLEN_MAX`-capped chain of three child-only forks (255 + 255 + 1). Inserting its one-byte prefix branches at the head, and `compact` re-split only the first 509 bytes of the 510-byte continuation, leaving the terminal fork dangling as a separate hop (255 + 254 + 1) rather than the canonical 255 + 255. A different fork topology gives different node hashes and so a different root, breaking mantaray 1.0 history-independence (`apply(build(base), delta) == build(base <+ delta)`).

The existing long-key proptest already covered this property, but capped keys at 400 bytes, one link short of the three-fork region, so it never generated the triggering input. The unbounded fuzzer did. Raising the ceiling past 510 bytes lets proptest reach and shrink the same class.

The defect predates the current perf train: the manifest crate is byte-identical across it (`git diff c23a1fa7 origin/main -- crates/manifest/` is empty).

## Testing

- Two new deterministic unit tests (`a_split_above_a_multi_fork_chain_recompacts_like_a_rebuild`, `a_split_above_a_deep_chain_recompacts_like_a_rebuild`) fail before the fix and pass after.
- Widened long-key proptest (800-byte keys, 256 cases) passes with the fix and, confirmed against the pre-fix code, fails and shrinks to a minimal case.
- Full `nectar-manifest` suite green; clippy clean; `Cargo.lock` unchanged.
- `cargo +nightly fuzz run manifest_apply_rebuild` for 180s: 816,504 executions, no crash, no artifacts.

## AI Assistance

Diagnosed, minimised, and fixed with AI assistance.



Supersedes #390, which fixed the same defect via `chain`/`compact` mutual recursion. This PR flattens the run explicitly instead, absorbs #390's re-capped-tail regression test, and carries the widened proptest generator. Verified equivalent: each fix passes the other's regression case.

Closes #414
Closes #320