### PR TITLE
fix(file): keep SplitError::PoolDropped ungated so cross-crate matches stay exhaustive

### DIFF
--- a/crates/file/src/split/error.rs
+++ b/crates/file/src/split/error.rs
@@ -45,13 +45,9 @@ pub enum SplitError<E> {
     #[error("poisoned by an earlier failure")]
     Poisoned,
     /// The pool dropped a leaf seal without replying; the worker panicked
-    /// or died.
-    #[cfg(all(
-        feature = "rayon",
-        not(target_arch = "wasm32"),
-        not(feature = "unsync")
-    ))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
+    /// or died. Only the rayon batch ingest raises it, but the variant is
+    /// always present so a cross-crate match over `SplitError` stays
+    /// exhaustive regardless of the file crate's feature resolution.
     #[error("hash pool dropped a leaf seal")]
     PoolDropped,
     /// The spine emptied without yielding a root; a split invariant is

--- a/crates/file/src/split/mod.rs
+++ b/crates/file/src/split/mod.rs
@@ -120,11 +120,6 @@ fn widen<E>(error: SplitError<Infallible>) -> SplitError<E> {
         SplitError::SpanOverflow { span, add } => SplitError::SpanOverflow { span, add },
         SplitError::Finished => SplitError::Finished,
         SplitError::Poisoned => SplitError::Poisoned,
-        #[cfg(all(
-            feature = "rayon",
-            not(target_arch = "wasm32"),
-            not(feature = "unsync")
-        ))]
         SplitError::PoolDropped => SplitError::PoolDropped,
         SplitError::SpineDepleted => SplitError::SpineDepleted,
     }

--- a/crates/manifest/src/builder.rs
+++ b/crates/manifest/src/builder.rs
@@ -620,6 +620,7 @@ where
         }
         SplitError::Finished => BuildError::Split(SplitError::Finished),
         SplitError::Poisoned => BuildError::Split(SplitError::Poisoned),
+        SplitError::PoolDropped => BuildError::Split(SplitError::PoolDropped),
         SplitError::SpineDepleted => BuildError::Split(SplitError::SpineDepleted),
     }
 }


### PR DESCRIPTION
## What

Make `SplitError::PoolDropped` an always-present variant instead of gating it on the file crate's `rayon` feature, and add the matching arm in the manifest's `SplitError` -> `BuildError` mapping.

## Why

`unit` (`test / swarm`) is red on `main` at fd4bd670 (#395's merge): `nectar-manifest` fails to compile with `error[E0004]: non-exhaustive patterns: SplitError::PoolDropped not covered`.

#395 added `PoolDropped` gated on `nectar-file`'s `rayon` feature and mirrored the arm inside the file crate, but a dependent crate cannot mirror that gate. `nectar-manifest` matches `SplitError` to fold it into `BuildError`, and a `--workspace` build unifies `nectar-file/rayon` on (pulled in by `postage-issuer`), so the variant is present while `manifest`, which declares no `rayon` feature, has no cfg it could put on an arm to track it. An unconditional arm would then break the non-rayon build, and a gated arm breaks the unified build: the presence of a dependency's cfg-gated variant is not observable from the dependent crate.

Un-gating removes the fragility at the source. The variant carries no data and is only ever constructed by the rayon batch ingest, so run-time behaviour is unchanged; only the compile-time surface is now stable across feature resolutions.

## Testing

- `cargo build --workspace --locked` (reproduces the failure via unified rayon): passes.
- `cargo build -p nectar-file --no-default-features --features std` (variant present, unconstructed): passes, no dead-variant warning.
- `cargo build -p nectar-file --features rayon,encryption` (construction site): passes.

## AI Assistance

Diagnosed and fixed with AI assistance.
