### PR TITLE
chore(deps): bump anyhow to 1.0.104 for RUSTSEC-2026-0190

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,9 +459,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"


### PR DESCRIPTION
## What

Bump `anyhow` from 1.0.102 to 1.0.104 in `Cargo.lock` via `cargo update -p anyhow`. The diff is exactly 2 lines (version + checksum); no manifest or source changes anywhere in the workspace.

## Why

RUSTSEC-2026-0190 documents unsoundness in `anyhow::Error::downcast_mut()`, patched in >= 1.0.103. Our lockfile pinned 1.0.102, which was genuinely affected. No nectar crate declares `anyhow` directly; it only reaches the lock transitively through the wit-bindgen stack (`wasm-metadata`, `wit-bindgen-{core,rust,rust-macro}`, `wit-component`, `wit-parser`) behind `cfg(target_env = "p2"/"p3")`, and `downcast_mut` is called nowhere in the workspace, so this is a hygiene bump rather than a live vulnerability fix. Bumping to 1.0.104 clears the advisory and keeps `cargo audit` clean.

## Testing

- `nix develop -c cargo audit`: exits 0, RUSTSEC-2026-0190 no longer present; only the 2 pre-existing allowed warnings (bitcoin-io, bitcoin_hashes) remain, unchanged by this branch.
- `cargo metadata --format-version=1 --all-features --filter-platform x86_64-unknown-linux-gnu --locked`: exits 0, lock is self-consistent.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --locked`: no errors (one pre-existing warning on `origin/main`, untouched by this lockfile-only diff).
- `cargo nextest run --workspace --locked --no-fail-fast`: 885 passed, 1 skipped.
- `cargo tree -i anyhow --locked --target all --all-features -e normal,build,dev`: confirms anyhow is lockfile-only (no direct workspace dependency).

## AI Assistance

Implemented and verified with Claude Code.

Closes #129
