### PR TITLE
fix(postage)!: carry the bucket-depth floor in the type

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,6 +48,10 @@ jobs:
             # disallowed-methods gate sees them.
             - name: cargo clippy (postage-usage surfaces)
               run: cargo clippy --workspace --all-targets --locked --features nectar-postage-usage/client,nectar-postage-usage/issuer
+            # The postage serde impls are off the default build, so the passes
+            # above never see them.
+            - name: cargo clippy (postage serde)
+              run: cargo clippy --locked --all-targets -p nectar-postage --features serde
             # `unused_crate_dependencies` is enforced per-library via `cargo
             # rustc` (not `[workspace.lints]`) so the flag applies only to each
             # crate's own lib target — never to benches/examples/tests (which

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -75,6 +75,13 @@ jobs:
                   cargo nextest run \
                     -p nectar-postage-usage --features issuer --locked \
                     --no-tests=warn --no-fail-fast
+            # The serde impls (and the bounded-newtype guards on their decode
+            # path) are off the default build; cover their tests here.
+            - name: Run postage serde tests
+              run: |
+                  cargo nextest run \
+                    -p nectar-postage --features serde --locked \
+                    --no-tests=warn --no-fail-fast
 
     wasm:
         # The postage-usage client facade is meant to run in a browser. The

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2156,6 +2156,7 @@ dependencies = [
  "rand 0.10.1",
  "rayon",
  "serde",
+ "serde_json",
  "thiserror",
  "web-time",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2156,7 +2156,6 @@ dependencies = [
  "rand 0.10.1",
  "rayon",
  "serde",
- "serde_json",
  "thiserror",
  "web-time",
 ]

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -149,6 +149,7 @@ sol! {
         function batchDepth(bytes32 batchId) external view returns (uint8);
         function batchBucketDepth(bytes32 batchId) external view returns (uint8);
         function remainingBalance(bytes32 batchId) external view returns (uint256);
+        function minimumBucketDepth() external view returns (uint8);
         function minimumInitialBalancePerChunk() external view returns (uint256);
         function batches(bytes32 batchId) external view returns (
             address owner,
@@ -476,6 +477,7 @@ mod tests {
         let _ = IPostageStamp::batchOwnerCall {
             batchId: [0u8; 32].into(),
         };
+        let _ = IPostageStamp::minimumBucketDepthCall {};
         let _ = IStakeRegistry::overlayOfAddressCall {
             owner: Address::ZERO,
         };

--- a/crates/postage-issuer/benches/sign.rs
+++ b/crates/postage-issuer/benches/sign.rs
@@ -20,7 +20,8 @@ use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
 use nectar_postage_issuer::{
-    BatchId, BatchStamper, MemoryIssuer, ShardedIssuer, SigningError, Stamper, sign_stamps_parallel,
+    BatchId, BatchStamper, BucketDepth, MemoryIssuer, ShardedIssuer, SigningError, Stamper,
+    sign_stamps_parallel,
 };
 use nectar_primitives::ChunkAddress;
 use rand::RngExt;
@@ -57,7 +58,7 @@ fn bench_stamper_mock(c: &mut Criterion) {
 
     group.bench_function("single", |b| {
         b.iter(|| {
-            let issuer = MemoryIssuer::new(BatchId::ZERO, 24, 16);
+            let issuer = MemoryIssuer::new(BatchId::ZERO, 24, BucketDepth::new(16).unwrap());
             let mut stamper = BatchStamper::new(issuer, MockSigner);
             let address = random_address();
             black_box(stamper.stamp(black_box(&address)))
@@ -69,7 +70,7 @@ fn bench_stamper_mock(c: &mut Criterion) {
 
     group.bench_function("throughput_1000", |b| {
         b.iter(|| {
-            let issuer = MemoryIssuer::new(BatchId::ZERO, 32, 16);
+            let issuer = MemoryIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
             let mut stamper = BatchStamper::new(issuer, MockSigner);
             for addr in &addresses {
                 black_box(stamper.stamp(addr).unwrap());
@@ -90,7 +91,7 @@ fn bench_ecdsa_sign_sequential(c: &mut Criterion) {
 
     group.bench_function("single", |b| {
         b.iter(|| {
-            let issuer = MemoryIssuer::new(BatchId::ZERO, 24, 16);
+            let issuer = MemoryIssuer::new(BatchId::ZERO, 24, BucketDepth::new(16).unwrap());
             let mut stamper = BatchStamper::new(issuer, &signer);
             let address = random_address();
             black_box(stamper.stamp(black_box(&address)))
@@ -101,7 +102,7 @@ fn bench_ecdsa_sign_sequential(c: &mut Criterion) {
 
     group.bench_function("throughput_100", |b| {
         b.iter(|| {
-            let issuer = MemoryIssuer::new(BatchId::ZERO, 32, 16);
+            let issuer = MemoryIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
             let mut stamper = BatchStamper::new(issuer, &signer);
             for addr in &addresses {
                 black_box(stamper.stamp(addr).unwrap());
@@ -131,7 +132,7 @@ fn bench_ecdsa_sign_parallel(c: &mut Criterion) {
     group.throughput(Throughput::Elements(100));
     group.bench_function("throughput_100", |b| {
         b.iter(|| {
-            let issuer = ShardedIssuer::new(BatchId::ZERO, 32, 16);
+            let issuer = ShardedIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
             black_box(sign_stamps_parallel(&issuer, &sign_fn, &addresses_100))
         })
     });
@@ -139,7 +140,7 @@ fn bench_ecdsa_sign_parallel(c: &mut Criterion) {
     group.throughput(Throughput::Elements(1000));
     group.bench_function("throughput_1000", |b| {
         b.iter(|| {
-            let issuer = ShardedIssuer::new(BatchId::ZERO, 32, 16);
+            let issuer = ShardedIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
             black_box(sign_stamps_parallel(&issuer, &sign_fn, &addresses_1000))
         })
     });
@@ -166,7 +167,7 @@ fn bench_sign_comparison(c: &mut Criterion) {
     // Sequential
     group.bench_function("sequential", |b| {
         b.iter(|| {
-            let issuer = MemoryIssuer::new(BatchId::ZERO, 32, 16);
+            let issuer = MemoryIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
             let mut stamper = BatchStamper::new(issuer, &signer);
             for addr in &addresses {
                 black_box(stamper.stamp(addr).unwrap());
@@ -177,7 +178,7 @@ fn bench_sign_comparison(c: &mut Criterion) {
     // Parallel
     group.bench_function("parallel", |b| {
         b.iter(|| {
-            let issuer = ShardedIssuer::new(BatchId::ZERO, 32, 16);
+            let issuer = ShardedIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
             black_box(sign_stamps_parallel(&issuer, &sign_fn, &addresses))
         })
     });

--- a/crates/postage-issuer/benches/upload_pipeline.rs
+++ b/crates/postage-issuer/benches/upload_pipeline.rs
@@ -31,7 +31,8 @@ use rand::{Rng, rng};
 
 use nectar_file::{Plain, PutWindow, ReadAt, Split, split_read_at};
 use nectar_postage_issuer::{
-    BatchId, BatchStamper, MemoryIssuer, ShardedIssuer, SigningError, Stamper, sign_stamps_parallel,
+    BatchId, BatchStamper, BucketDepth, MemoryIssuer, ShardedIssuer, SigningError, Stamper,
+    sign_stamps_parallel,
 };
 use nectar_primitives::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{AnyChunkSet, Chunk, ChunkAddress, Verified};
@@ -137,7 +138,7 @@ fn bench_pipeline_mock_sequential(c: &mut Criterion) {
                 let (root, chunks) = split_sequential(data);
 
                 // Stamp each chunk
-                let issuer = MemoryIssuer::new(BatchId::ZERO, 32, 16);
+                let issuer = MemoryIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
                 let mut stamper = BatchStamper::new(issuer, MockSigner);
 
                 let stamps: Vec<_> = chunks
@@ -169,7 +170,7 @@ fn bench_pipeline_mock_parallel_split(c: &mut Criterion) {
                 let (root, chunks) = split_parallel(source);
 
                 // Stamp each chunk (sequential)
-                let issuer = MemoryIssuer::new(BatchId::ZERO, 32, 16);
+                let issuer = MemoryIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
                 let mut stamper = BatchStamper::new(issuer, MockSigner);
 
                 let stamps: Vec<_> = chunks
@@ -204,7 +205,7 @@ fn bench_pipeline_ecdsa_sequential(c: &mut Criterion) {
                 let (root, chunks) = split_sequential(data);
 
                 // Stamp each chunk with real signatures
-                let issuer = MemoryIssuer::new(BatchId::ZERO, 32, 16);
+                let issuer = MemoryIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
                 let mut stamper = BatchStamper::new(issuer, &signer);
 
                 let stamps: Vec<_> = chunks
@@ -249,7 +250,7 @@ fn bench_pipeline_fully_parallel(c: &mut Criterion) {
                 let addresses: Vec<_> = chunks.iter().map(|c| *c.address()).collect();
 
                 // Parallel stamp signing
-                let issuer = ShardedIssuer::new(BatchId::ZERO, 32, 16);
+                let issuer = ShardedIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
                 let stamps = sign_stamps_parallel(&issuer, &sign_fn, &addresses);
 
                 black_box((root, stamps))
@@ -284,7 +285,7 @@ fn bench_pipeline_comparison(c: &mut Criterion) {
         b.iter(|| {
             let (root, chunks) = split_sequential(&data);
 
-            let issuer = MemoryIssuer::new(BatchId::ZERO, 32, 16);
+            let issuer = MemoryIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
             let mut stamper = BatchStamper::new(issuer, &signer);
 
             let stamps: Vec<_> = chunks
@@ -301,7 +302,7 @@ fn bench_pipeline_comparison(c: &mut Criterion) {
         b.iter(|| {
             let (root, chunks) = split_parallel(&source);
 
-            let issuer = MemoryIssuer::new(BatchId::ZERO, 32, 16);
+            let issuer = MemoryIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
             let mut stamper = BatchStamper::new(issuer, &signer);
 
             let stamps: Vec<_> = chunks
@@ -320,7 +321,7 @@ fn bench_pipeline_comparison(c: &mut Criterion) {
 
             let addresses: Vec<_> = chunks.iter().map(|c| *c.address()).collect();
 
-            let issuer = ShardedIssuer::new(BatchId::ZERO, 32, 16);
+            let issuer = ShardedIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
             let stamps = sign_stamps_parallel(&issuer, &sign_fn, &addresses);
 
             black_box((root, stamps))
@@ -363,7 +364,7 @@ fn bench_pipeline_stages(c: &mut Criterion) {
     // Stage 2: Stamp only (sequential)
     group.bench_function("2_stamp_sequential", |b| {
         b.iter(|| {
-            let issuer = MemoryIssuer::new(BatchId::ZERO, 32, 16);
+            let issuer = MemoryIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
             let mut stamper = BatchStamper::new(issuer, &signer);
             let stamps: Vec<_> = addresses
                 .iter()
@@ -382,7 +383,7 @@ fn bench_pipeline_stages(c: &mut Criterion) {
 
     group.bench_function("2_stamp_parallel", |b| {
         b.iter(|| {
-            let issuer = ShardedIssuer::new(BatchId::ZERO, 32, 16);
+            let issuer = ShardedIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
             black_box(sign_stamps_parallel(&issuer, &sign_fn, &addresses))
         });
     });

--- a/crates/postage-issuer/src/counter.rs
+++ b/crates/postage-issuer/src/counter.rs
@@ -31,6 +31,8 @@ extern crate alloc;
 use alloc::vec;
 use alloc::vec::Vec;
 
+use nectar_postage::BucketDepth;
+use nectar_primitives::{Mainnet, SwarmSpec};
 use thiserror::Error;
 
 /// Whether a [`CounterTable`] fills each bucket once or wraps it as a ring.
@@ -104,16 +106,39 @@ pub enum CounterError {
 /// answers whether a `(bucket, slot)` is protected, so a ring never re-emits a
 /// reserved slot. Fill mode ignores the predicate; nothing protects a fill
 /// watermark because it only ever moves forward.
-#[derive(Debug, Clone)]
-pub struct CounterTable {
+///
+/// The network is a type parameter and reaches the table through its
+/// [`BucketDepth`], so the bucket depth a table was built with is one the
+/// network accepts. [`CounterTable`] is the mainnet table.
+#[derive(Debug)]
+pub struct CounterTableFor<S: SwarmSpec = Mainnet> {
     depth: u8,
-    bucket_depth: u8,
+    bucket_depth: BucketDepth<S>,
     mode: CounterMode,
     counts: Vec<u32>,
     issued: u64,
 }
 
-impl PartialEq for CounterTable {
+/// The [`CounterTableFor`] of the mainnet spec.
+pub type CounterTable = CounterTableFor<Mainnet>;
+
+// The spec is a type-level tag, so the impls below carry no bound on `S` beyond
+// `SwarmSpec`; deriving would demand `S: Clone` and `S: Eq` of a marker type
+// that holds no data.
+
+impl<S: SwarmSpec> Clone for CounterTableFor<S> {
+    fn clone(&self) -> Self {
+        Self {
+            depth: self.depth,
+            bucket_depth: self.bucket_depth,
+            mode: self.mode,
+            counts: self.counts.clone(),
+            issued: self.issued,
+        }
+    }
+}
+
+impl<S: SwarmSpec> PartialEq for CounterTableFor<S> {
     fn eq(&self, other: &Self) -> bool {
         self.depth == other.depth
             && self.bucket_depth == other.bucket_depth
@@ -123,16 +148,16 @@ impl PartialEq for CounterTable {
     }
 }
 
-impl Eq for CounterTable {}
+impl<S: SwarmSpec> Eq for CounterTableFor<S> {}
 
-impl CounterTable {
+impl<S: SwarmSpec> CounterTableFor<S> {
     /// Creates an empty table for the given geometry and mode.
-    pub fn new(depth: u8, bucket_depth: u8, mode: CounterMode) -> Self {
+    pub fn new(depth: u8, bucket_depth: BucketDepth<S>, mode: CounterMode) -> Self {
         Self {
             depth,
             bucket_depth,
             mode,
-            counts: vec![0u32; 1usize << bucket_depth],
+            counts: vec![0u32; 1usize << bucket_depth.get()],
             issued: 0,
         }
     }
@@ -149,11 +174,11 @@ impl CounterTable {
     /// exceeds the bucket capacity.
     pub fn from_counts(
         depth: u8,
-        bucket_depth: u8,
+        bucket_depth: BucketDepth<S>,
         mode: CounterMode,
         counts: Vec<u32>,
     ) -> Result<Self, CounterError> {
-        let expected = 1usize << bucket_depth;
+        let expected = 1usize << bucket_depth.get();
         if counts.len() != expected {
             return Err(CounterError::CounterLength {
                 expected,
@@ -162,7 +187,7 @@ impl CounterTable {
         }
         // Batch geometry invariant: depth >= bucket_depth, enforced by callers.
         #[allow(clippy::arithmetic_side_effects)]
-        let capacity = 1u32 << (depth - bucket_depth);
+        let capacity = 1u32 << (depth - bucket_depth.get());
         let mut issued = 0u64;
         for (bucket, &count) in counts.iter().enumerate() {
             if count > capacity {
@@ -197,7 +222,7 @@ impl CounterTable {
     }
 
     /// Returns the bucket (uniformity) depth.
-    pub const fn bucket_depth(&self) -> u8 {
+    pub const fn bucket_depth(&self) -> BucketDepth<S> {
         self.bucket_depth
     }
 
@@ -208,14 +233,14 @@ impl CounterTable {
 
     /// Returns the number of collision buckets (`2^bucket_depth`).
     pub const fn bucket_count(&self) -> u32 {
-        1u32 << self.bucket_depth
+        1u32 << self.bucket_depth.get()
     }
 
     /// Returns the number of slots per bucket (`2^(depth - bucket_depth)`).
     // Batch geometry invariant: depth >= bucket_depth, enforced at construction.
     #[allow(clippy::arithmetic_side_effects)]
     pub const fn bucket_capacity(&self) -> u32 {
-        1u32 << (self.depth - self.bucket_depth)
+        1u32 << (self.depth - self.bucket_depth.get())
     }
 
     /// Returns the total batch capacity in slots (`2^depth`).
@@ -390,10 +415,15 @@ mod tests {
         false
     }
 
+    /// The mainnet bucket depth every fixture below is built at.
+    fn bucket_depth() -> BucketDepth {
+        BucketDepth::new(16).unwrap()
+    }
+
     #[test]
     fn fill_is_a_monotone_watermark_that_refuses_a_full_bucket() {
         // depth 17, bucket depth 16 gives 2 slots per bucket.
-        let mut table = CounterTable::new(17, 16, CounterMode::Fill);
+        let mut table = CounterTable::new(17, bucket_depth(), CounterMode::Fill);
         assert_eq!(table.record(5, never).unwrap(), 0);
         assert_eq!(table.record(5, never).unwrap(), 1);
         assert_eq!(
@@ -409,7 +439,7 @@ mod tests {
 
     #[test]
     fn ring_wraps_and_keeps_the_cursor_in_range() {
-        let mut table = CounterTable::new(17, 16, CounterMode::Ring);
+        let mut table = CounterTable::new(17, bucket_depth(), CounterMode::Ring);
         assert_eq!(table.record(5, never).unwrap(), 0);
         assert_eq!(table.record(5, never).unwrap(), 1);
         // The cursor sits at capacity, the deferred-wrap state.
@@ -422,7 +452,7 @@ mod tests {
     #[test]
     fn ring_skips_protected_slots() {
         // depth 18, bucket depth 16 gives 4 slots per bucket. Protect 1 and 3.
-        let mut table = CounterTable::new(18, 16, CounterMode::Ring);
+        let mut table = CounterTable::new(18, bucket_depth(), CounterMode::Ring);
         let protected = |slot: u32| slot == 1 || slot == 3;
         for _ in 0..20 {
             let slot = table.record(0, protected).unwrap();
@@ -432,7 +462,7 @@ mod tests {
 
     #[test]
     fn ring_exhausts_when_every_slot_is_protected() {
-        let mut table = CounterTable::new(17, 16, CounterMode::Ring);
+        let mut table = CounterTable::new(17, bucket_depth(), CounterMode::Ring);
         assert_eq!(
             table.record(0, |_| true),
             Err(CounterError::RingExhausted { bucket: 0 })
@@ -443,13 +473,14 @@ mod tests {
     fn from_counts_sums_and_rejects_overflow() {
         let mut counts = vec![0u32; 1usize << 16];
         counts[7] = 2;
-        let table = CounterTable::from_counts(17, 16, CounterMode::Fill, counts).unwrap();
+        let table =
+            CounterTable::from_counts(17, bucket_depth(), CounterMode::Fill, counts).unwrap();
         assert_eq!(table.total_issued(), 2);
 
         let mut over = vec![0u32; 1usize << 16];
         over[7] = 3;
         assert_eq!(
-            CounterTable::from_counts(17, 16, CounterMode::Fill, over),
+            CounterTable::from_counts(17, bucket_depth(), CounterMode::Fill, over),
             Err(CounterError::CounterOverflow {
                 bucket: 7,
                 count: 3,

--- a/crates/postage-issuer/src/dilute_handler.rs
+++ b/crates/postage-issuer/src/dilute_handler.rs
@@ -16,17 +16,21 @@
 use std::collections::HashMap;
 
 use crate::error::IssuerError;
-use crate::issuer::MemoryIssuer;
-use crate::sharded::ShardedIssuer;
+use crate::issuer::MemoryIssuerFor;
+use crate::sharded::ShardedIssuerFor;
 use nectar_postage::{BatchEvent, BatchEventHandler, BatchId};
+use nectar_primitives::SwarmSpec;
 
 /// An issuer whose per-bucket capacity can be grown by an on-chain dilution.
 ///
 /// This is the minimal surface the [`IssuerRegistry`] needs to drive a
 /// [`BatchEvent::DepthIncrease`] through to the right issuer. It is implemented
-/// for the fill-only issuers in this crate ([`MemoryIssuer`] and
-/// [`ShardedIssuer`]); a self-hosting ring issuer dilutes through its snapshot
+/// for the fill-only issuers in this crate ([`MemoryIssuerFor`] and
+/// [`ShardedIssuerFor`]); a self-hosting ring issuer dilutes through its snapshot
 /// in `nectar-postage-usage` and is not registered here.
+///
+/// The trait is spec-agnostic: it only reads scalar geometry, so one registry
+/// can hold issuers for different networks behind `dyn Dilutable`.
 pub trait Dilutable {
     /// Returns the batch ID this issuer issues stamps for.
     fn batch_id(&self) -> BatchId;
@@ -47,7 +51,7 @@ pub trait Dilutable {
     fn dilute(&mut self, new_depth: u8) -> Result<(), IssuerError>;
 }
 
-impl Dilutable for MemoryIssuer {
+impl<S: SwarmSpec> Dilutable for MemoryIssuerFor<S> {
     // The geometry accessors come from the StampIssuer trait, so they are named
     // explicitly to avoid resolving back into this Dilutable impl.
     fn batch_id(&self) -> BatchId {
@@ -67,7 +71,7 @@ impl Dilutable for MemoryIssuer {
     }
 }
 
-impl Dilutable for ShardedIssuer {
+impl<S: SwarmSpec> Dilutable for ShardedIssuerFor<S> {
     fn batch_id(&self) -> BatchId {
         Self::batch_id(self)
     }
@@ -170,6 +174,7 @@ impl BatchEventHandler for IssuerRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{MemoryIssuer, ShardedIssuer};
     use nectar_postage::BucketDepth;
 
     fn batch_id(byte: u8) -> BatchId {

--- a/crates/postage-issuer/src/dilute_handler.rs
+++ b/crates/postage-issuer/src/dilute_handler.rs
@@ -170,6 +170,7 @@ impl BatchEventHandler for IssuerRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nectar_postage::BucketDepth;
 
     fn batch_id(byte: u8) -> BatchId {
         BatchId::new([byte; 32])
@@ -180,7 +181,11 @@ mod tests {
         // depth=17, bucket_depth=16 gives 2 slots per bucket.
         let tracked = batch_id(0x11);
         let mut registry = IssuerRegistry::new();
-        registry.register(MemoryIssuer::new(tracked, 17, 16));
+        registry.register(MemoryIssuer::new(
+            tracked,
+            17,
+            BucketDepth::new(16).unwrap(),
+        ));
         assert_eq!(registry.get(&tracked).unwrap().bucket_capacity(), 2);
 
         registry
@@ -201,7 +206,11 @@ mod tests {
     fn depth_increase_grows_sharded_issuer_capacity() {
         let tracked = batch_id(0x22);
         let mut registry = IssuerRegistry::new();
-        registry.register(ShardedIssuer::new(tracked, 17, 16));
+        registry.register(ShardedIssuer::new(
+            tracked,
+            17,
+            BucketDepth::new(16).unwrap(),
+        ));
         assert_eq!(registry.get(&tracked).unwrap().bucket_capacity(), 2);
 
         registry
@@ -222,7 +231,11 @@ mod tests {
         let other = batch_id(0x44);
 
         let mut registry = IssuerRegistry::new();
-        registry.register(MemoryIssuer::new(tracked, 17, 16));
+        registry.register(MemoryIssuer::new(
+            tracked,
+            17,
+            BucketDepth::new(16).unwrap(),
+        ));
 
         // An event for a batch we do not track must not error and must leave
         // the tracked issuer untouched.
@@ -246,7 +259,11 @@ mod tests {
     fn non_depth_events_are_ignored() {
         let tracked = batch_id(0x55);
         let mut registry = IssuerRegistry::new();
-        registry.register(MemoryIssuer::new(tracked, 17, 16));
+        registry.register(MemoryIssuer::new(
+            tracked,
+            17,
+            BucketDepth::new(16).unwrap(),
+        ));
 
         registry
             .handle_event(BatchEvent::TopUp {
@@ -270,7 +287,11 @@ mod tests {
         // refuses it and the error propagates.
         let tracked = batch_id(0x66);
         let mut registry = IssuerRegistry::new();
-        registry.register(MemoryIssuer::new(tracked, 18, 16));
+        registry.register(MemoryIssuer::new(
+            tracked,
+            18,
+            BucketDepth::new(16).unwrap(),
+        ));
 
         let result = registry.handle_event(BatchEvent::DepthIncrease {
             batch_id: tracked,

--- a/crates/postage-issuer/src/factory.rs
+++ b/crates/postage-issuer/src/factory.rs
@@ -149,17 +149,18 @@ impl BatchFactory for MemoryBatchFactory {
 mod tests {
     use super::*;
     use alloy_primitives::Address;
+    use nectar_postage::BucketDepth;
 
     #[tokio::test]
     async fn test_memory_factory_create() {
         let factory = MemoryBatchFactory::new(100);
 
-        let params = BatchParams::new(Address::ZERO, 20, 16, 1000);
+        let params = BatchParams::new(Address::ZERO, 20, BucketDepth::new(16).unwrap(), 1000);
         let result = factory.create(params).await.unwrap();
 
         assert_eq!(result.batch.owner(), Address::ZERO);
         assert_eq!(result.batch.depth(), 20);
-        assert_eq!(result.batch.bucket_depth(), 16);
+        assert_eq!(result.batch.bucket_depth().get(), 16);
         assert_eq!(result.batch.value(), 1000);
         assert_eq!(result.batch.start(), 100);
         assert!(result.tx_hash.is_none());
@@ -169,7 +170,7 @@ mod tests {
     async fn test_memory_factory_unique_ids() {
         let factory = MemoryBatchFactory::new(0);
 
-        let params = BatchParams::new(Address::ZERO, 20, 16, 1000);
+        let params = BatchParams::new(Address::ZERO, 20, BucketDepth::new(16).unwrap(), 1000);
 
         let r1 = factory.create(params.clone()).await.unwrap();
         let r2 = factory.create(params.clone()).await.unwrap();
@@ -183,7 +184,8 @@ mod tests {
     async fn test_memory_factory_immutable() {
         let factory = MemoryBatchFactory::new(0);
 
-        let params = BatchParams::new(Address::ZERO, 20, 16, 1000).immutable(true);
+        let params = BatchParams::new(Address::ZERO, 20, BucketDepth::new(16).unwrap(), 1000)
+            .immutable(true);
         let result = factory.create(params).await.unwrap();
 
         assert!(result.batch.immutable());

--- a/crates/postage-issuer/src/factory.rs
+++ b/crates/postage-issuer/src/factory.rs
@@ -1,15 +1,42 @@
 //! Batch factory traits for creating batches.
 
-use nectar_postage::{Batch, BatchId, BatchParams};
+use core::marker::PhantomData;
 
-/// The result of creating a batch.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CreateResult {
+use nectar_postage::{Batch, BatchId, BatchParams};
+use nectar_primitives::{Mainnet, SwarmSpec};
+
+/// The result of creating a batch on the network `S`.
+#[derive(Debug)]
+pub struct CreateResultFor<S: SwarmSpec = Mainnet> {
     /// The created batch.
-    pub batch: Batch,
+    pub batch: Batch<S>,
     /// The transaction hash (if created on-chain).
     pub tx_hash: Option<alloy_primitives::B256>,
 }
+
+/// The [`CreateResultFor`] of the mainnet spec.
+pub type CreateResult = CreateResultFor<Mainnet>;
+
+// The spec is a type-level tag, so the impls below carry no bound on `S` beyond
+// `SwarmSpec`; deriving would demand `S: Clone` and `S: Eq` of a marker type
+// that holds no data.
+
+impl<S: SwarmSpec> Clone for CreateResultFor<S> {
+    fn clone(&self) -> Self {
+        Self {
+            batch: self.batch.clone(),
+            tx_hash: self.tx_hash,
+        }
+    }
+}
+
+impl<S: SwarmSpec> PartialEq for CreateResultFor<S> {
+    fn eq(&self, other: &Self) -> bool {
+        self.batch == other.batch && self.tx_hash == other.tx_hash
+    }
+}
+
+impl<S: SwarmSpec> Eq for CreateResultFor<S> {}
 
 /// A trait for creating postage batches.
 ///
@@ -18,6 +45,9 @@ pub struct CreateResult {
 pub trait BatchFactory {
     /// The error type returned by factory operations.
     type Error: std::error::Error;
+
+    /// The network the created batches belong to.
+    type Spec: SwarmSpec;
 
     /// Creates a new batch with the given parameters.
     ///
@@ -33,8 +63,8 @@ pub trait BatchFactory {
     /// A `CreateResult` containing the created batch and optional transaction hash.
     fn create(
         &self,
-        params: BatchParams,
-    ) -> impl std::future::Future<Output = Result<CreateResult, Self::Error>> + Send;
+        params: BatchParams<Self::Spec>,
+    ) -> impl std::future::Future<Output = Result<CreateResultFor<Self::Spec>, Self::Error>> + Send;
 
     /// Tops up a batch with additional funds.
     ///
@@ -72,20 +102,29 @@ pub trait BatchFactory {
 ///
 /// This implementation creates batches in memory without any blockchain
 /// interaction. Useful for unit tests and local development.
+///
+/// The network the batches are minted for is a type parameter;
+/// [`MemoryBatchFactory`] is the mainnet factory.
 #[derive(Debug)]
-pub struct MemoryBatchFactory {
+pub struct MemoryBatchFactoryFor<S: SwarmSpec = Mainnet> {
     /// Counter for generating unique batch IDs.
     next_id: std::sync::atomic::AtomicU64,
     /// The current block number (for start block).
     current_block: u64,
+    /// The network the minted batches belong to.
+    spec: PhantomData<fn() -> S>,
 }
 
-impl MemoryBatchFactory {
+/// The [`MemoryBatchFactoryFor`] of the mainnet spec.
+pub type MemoryBatchFactory = MemoryBatchFactoryFor<Mainnet>;
+
+impl<S: SwarmSpec> MemoryBatchFactoryFor<S> {
     /// Creates a new memory batch factory.
     pub const fn new(current_block: u64) -> Self {
         Self {
             next_id: std::sync::atomic::AtomicU64::new(0),
             current_block,
+            spec: PhantomData,
         }
     }
 
@@ -104,16 +143,17 @@ impl MemoryBatchFactory {
     }
 }
 
-impl Default for MemoryBatchFactory {
+impl<S: SwarmSpec> Default for MemoryBatchFactoryFor<S> {
     fn default() -> Self {
         Self::new(0)
     }
 }
 
-impl BatchFactory for MemoryBatchFactory {
+impl<S: SwarmSpec> BatchFactory for MemoryBatchFactoryFor<S> {
     type Error = std::convert::Infallible;
+    type Spec = S;
 
-    async fn create(&self, params: BatchParams) -> Result<CreateResult, Self::Error> {
+    async fn create(&self, params: BatchParams<S>) -> Result<CreateResultFor<S>, Self::Error> {
         let batch_id = self.generate_batch_id();
 
         let batch = Batch::new(
@@ -126,7 +166,7 @@ impl BatchFactory for MemoryBatchFactory {
             params.immutable,
         );
 
-        Ok(CreateResult {
+        Ok(CreateResultFor {
             batch,
             tx_hash: None,
         })

--- a/crates/postage-issuer/src/issuer.rs
+++ b/crates/postage-issuer/src/issuer.rs
@@ -2,7 +2,9 @@
 
 use crate::counter::{CounterMode, CounterTable};
 use crate::error::IssuerError;
-use nectar_postage::{Batch, BatchId, StampDigest, StampError, StampIndex, calculate_bucket};
+use nectar_postage::{
+    Batch, BatchId, BucketDepth, StampDigest, StampError, StampIndex, calculate_bucket,
+};
 use nectar_primitives::ChunkAddress;
 
 /// A trait for managing stamp issuance within a batch.
@@ -154,10 +156,10 @@ pub struct MemoryIssuer {
 
 impl MemoryIssuer {
     /// Creates a new fill-only memory issuer for the given batch geometry.
-    pub fn new(batch_id: BatchId, depth: u8, bucket_depth: u8) -> Self {
+    pub fn new(batch_id: BatchId, depth: u8, bucket_depth: BucketDepth) -> Self {
         Self {
             batch_id,
-            counters: CounterTable::new(depth, bucket_depth, CounterMode::Fill),
+            counters: CounterTable::new(depth, bucket_depth.get(), CounterMode::Fill),
         }
     }
 
@@ -277,7 +279,7 @@ mod tests {
     #[test]
     fn test_memory_issuer_basic() {
         let batch_id = BatchId::ZERO;
-        let issuer = MemoryIssuer::new(batch_id, 20, 16);
+        let issuer = MemoryIssuer::new(batch_id, 20, BucketDepth::new(16).unwrap());
 
         assert_eq!(issuer.batch_id(), batch_id);
         assert_eq!(issuer.batch_depth(), 20);
@@ -290,7 +292,7 @@ mod tests {
 
     #[test]
     fn test_memory_issuer_prepare_stamp() {
-        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 20, 16);
+        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
 
         let address = test_address(0xCBE5);
         let digest = issuer.prepare_stamp(&address, 12345).unwrap();
@@ -305,7 +307,7 @@ mod tests {
 
     #[test]
     fn test_memory_issuer_increments_index() {
-        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 20, 16);
+        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
 
         let address = test_address(0xCBE5);
 
@@ -322,7 +324,7 @@ mod tests {
     #[test]
     fn test_memory_issuer_bucket_full() {
         // depth=17, bucket_depth=16 gives 2 slots per bucket
-        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 17, 16);
+        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 17, BucketDepth::new(16).unwrap());
 
         let address = test_address(0xABCD);
 
@@ -343,7 +345,7 @@ mod tests {
 
     #[test]
     fn test_memory_issuer_bucket_utilization() {
-        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 20, 16);
+        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
 
         let addr1 = test_address(0x1234);
         let addr2 = test_address(0x5678);
@@ -360,7 +362,7 @@ mod tests {
     #[test]
     fn test_memory_issuer_capacity_check() {
         // depth=17, bucket_depth=16 gives 2 slots per bucket
-        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 17, 16);
+        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 17, BucketDepth::new(16).unwrap());
 
         let address = test_address(0x0001);
 
@@ -376,7 +378,7 @@ mod tests {
     #[test]
     fn test_memory_issuer_near_capacity() {
         // depth=18, bucket_depth=16 gives 4 slots per bucket
-        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 18, 16);
+        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 18, BucketDepth::new(16).unwrap());
 
         let address = test_address(0x0001);
 
@@ -402,7 +404,15 @@ mod tests {
         // A mutable batch must never yield an issuer: the obvious constructor
         // refuses it instead of handing back a reserved-blind ring that would
         // silently overwrite a self-hosted snapshot's own chunks.
-        let mutable = Batch::new(BatchId::ZERO, 0, 0, Default::default(), 20, 16, false);
+        let mutable = Batch::new(
+            BatchId::ZERO,
+            0,
+            0,
+            Default::default(),
+            20,
+            BucketDepth::new(16).unwrap(),
+            false,
+        );
 
         assert!(matches!(
             MemoryIssuer::from_batch(&mutable),
@@ -417,10 +427,18 @@ mod tests {
         // An immutable batch yields a fill-only issuer byte-for-byte identical
         // to `new` for the same geometry: same indices and the same digest.
         let batch_id = BatchId::new([0x11u8; 32]);
-        let immutable = Batch::new(batch_id, 0, 0, Default::default(), 17, 16, true);
+        let immutable = Batch::new(
+            batch_id,
+            0,
+            0,
+            Default::default(),
+            17,
+            BucketDepth::new(16).unwrap(),
+            true,
+        );
 
         let mut from_batch = MemoryIssuer::from_batch(&immutable).unwrap();
-        let mut from_new = MemoryIssuer::new(batch_id, 17, 16);
+        let mut from_new = MemoryIssuer::new(batch_id, 17, BucketDepth::new(16).unwrap());
 
         for ts in 0..2u64 {
             for leading in [0xCBE5u16, 0x0001, 0xABCD] {
@@ -443,7 +461,7 @@ mod tests {
     #[test]
     fn test_memory_issuer_dilute_grows_capacity_only() {
         // depth=17, bucket_depth=16 gives 2 slots per bucket.
-        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 17, 16);
+        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 17, BucketDepth::new(16).unwrap());
         let address = test_address(0xABCD);
 
         // Fill the bucket, then a dilution to depth 18 (4 slots) reopens it

--- a/crates/postage-issuer/src/issuer.rs
+++ b/crates/postage-issuer/src/issuer.rs
@@ -1,11 +1,11 @@
 //! Stamp issuer trait for tracking bucket utilization.
 
-use crate::counter::{CounterMode, CounterTable};
+use crate::counter::{CounterMode, CounterTableFor};
 use crate::error::IssuerError;
 use nectar_postage::{
     Batch, BatchId, BucketDepth, StampDigest, StampError, StampIndex, calculate_bucket,
 };
-use nectar_primitives::ChunkAddress;
+use nectar_primitives::{ChunkAddress, Mainnet, SwarmSpec};
 
 /// A trait for managing stamp issuance within a batch.
 ///
@@ -145,21 +145,39 @@ pub trait StampIssuer {
 /// issuance is intentionally absent from this crate; it requires reserved-slot
 /// awareness that lives in `nectar-postage-usage`. See the crate-root
 /// documentation for the steer toward `Snapshot::issuer` / `SnapshotIssuer`.
-#[derive(Debug, Clone)]
-pub struct MemoryIssuer {
+///
+/// The network is a type parameter and reaches the issuer through its
+/// [`BucketDepth`]; [`MemoryIssuer`] is the mainnet issuer.
+#[derive(Debug)]
+pub struct MemoryIssuerFor<S: SwarmSpec = Mainnet> {
     /// The batch ID.
     batch_id: BatchId,
     /// The shared per-bucket fill watermarks. `counts[b]` is the next unused
     /// slot, monotone and never above the capacity.
-    counters: CounterTable,
+    counters: CounterTableFor<S>,
 }
 
-impl MemoryIssuer {
+/// The [`MemoryIssuerFor`] of the mainnet spec.
+pub type MemoryIssuer = MemoryIssuerFor<Mainnet>;
+
+// The spec is a type-level tag, so this carries no bound on `S` beyond
+// `SwarmSpec`; deriving would demand `S: Clone` of a marker type that holds no
+// data.
+impl<S: SwarmSpec> Clone for MemoryIssuerFor<S> {
+    fn clone(&self) -> Self {
+        Self {
+            batch_id: self.batch_id,
+            counters: self.counters.clone(),
+        }
+    }
+}
+
+impl<S: SwarmSpec> MemoryIssuerFor<S> {
     /// Creates a new fill-only memory issuer for the given batch geometry.
-    pub fn new(batch_id: BatchId, depth: u8, bucket_depth: BucketDepth) -> Self {
+    pub fn new(batch_id: BatchId, depth: u8, bucket_depth: BucketDepth<S>) -> Self {
         Self {
             batch_id,
-            counters: CounterTable::new(depth, bucket_depth.get(), CounterMode::Fill),
+            counters: CounterTableFor::new(depth, bucket_depth, CounterMode::Fill),
         }
     }
 
@@ -194,7 +212,7 @@ impl MemoryIssuer {
     /// [`RingIssuer::external`](crate::RingIssuer::external) for external
     /// tracking, or [`RingIssuer::reserved`](crate::RingIssuer::reserved) for
     /// self-hosting, where the protected slots come from `nectar-postage-usage`.
-    pub fn from_batch(batch: &Batch) -> Result<Self, IssuerError> {
+    pub fn from_batch(batch: &Batch<S>) -> Result<Self, IssuerError> {
         if batch.immutable() {
             Ok(Self::new(batch.id(), batch.depth(), batch.bucket_depth()))
         } else {
@@ -203,13 +221,13 @@ impl MemoryIssuer {
     }
 }
 
-impl StampIssuer for MemoryIssuer {
+impl<S: SwarmSpec> StampIssuer for MemoryIssuerFor<S> {
     fn prepare_stamp(
         &mut self,
         address: &ChunkAddress,
         timestamp: u64,
     ) -> Result<StampDigest, StampError> {
-        let bucket = calculate_bucket(address, self.counters.bucket_depth());
+        let bucket = calculate_bucket(address, self.counters.bucket_depth().get());
         // Fill mode ignores the predicate; a monotone watermark never lands on a
         // reserved slot.
         let position =
@@ -237,7 +255,7 @@ impl StampIssuer for MemoryIssuer {
     }
 
     fn bucket_depth(&self) -> u8 {
-        self.counters.bucket_depth()
+        self.counters.bucket_depth().get()
     }
 
     fn max_bucket_utilization(&self) -> u32 {

--- a/crates/postage-issuer/src/lib.rs
+++ b/crates/postage-issuer/src/lib.rs
@@ -44,6 +44,27 @@
 //! self_hosting_sink(unreserved);
 //! ```
 //!
+//! # Networks
+//!
+//! An issuer is parameterized by the [`SwarmSpec`] its batch was built for, and
+//! carries it in the [`BucketDepth`] it is constructed from, so a depth the
+//! network refuses never reaches an issuer. The generic type takes the `...For`
+//! name ([`MemoryIssuerFor`], [`RingIssuerFor`], [`ShardedIssuerFor`],
+//! [`ShardedRingIssuerFor`], [`CounterTableFor`]) and the bare name is the
+//! mainnet alias, so ordinary call sites need no type annotation:
+//!
+//! ```
+//! use nectar_postage_issuer::{BatchId, BucketDepth, MemoryIssuer, MemoryIssuerFor, Testnet};
+//!
+//! let mainnet = MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16)?);
+//! let testnet = MemoryIssuerFor::<Testnet>::new(BatchId::ZERO, 20, BucketDepth::new(16)?);
+//! # Ok::<(), nectar_postage_issuer::StampError>(())
+//! ```
+//!
+//! [`StampIssuer`], [`Stamper`] and [`Dilutable`] stay spec-agnostic: they only
+//! read scalar geometry, so a `dyn Dilutable` registry can hold issuers for
+//! different networks.
+//!
 //! # Features
 //!
 //! - `std` (default) - Enables standard library support
@@ -98,28 +119,33 @@ mod stamper;
 // Re-export core types from nectar-postage (includes BatchEvent, BatchEventHandler)
 pub use nectar_postage::*;
 
+// The network specs the issuers are parameterized by.
+pub use nectar_primitives::{Mainnet, NetworkId, SwarmSpec, Testnet};
+
 // Errors (override nectar_postage::StampError with our own that includes signing)
 pub use error::{IssuerError, SigningError};
 
 // The shared per-bucket counter table behind every issuer and the snapshot.
-pub use counter::{CounterError, CounterMode, CounterTable};
+pub use counter::{CounterError, CounterMode, CounterTable, CounterTableFor};
 
 // Wiring on-chain depth-increase events through to issuer dilution (std only).
 #[cfg(feature = "std")]
 pub use dilute_handler::{Dilutable, IssuerRegistry};
 
 // Issuing
-pub use issuer::{MemoryIssuer, StampIssuer};
-pub use sharded::ShardedIssuer;
+pub use issuer::{MemoryIssuer, MemoryIssuerFor, StampIssuer};
+pub use sharded::{ShardedIssuer, ShardedIssuerFor};
 pub use stamper::{BatchStamper, Stamper};
 
 // Mutable (ring) issuing with a type-state reservation guard
-pub use ring::{Reservation, Reserved, RingIssuer, Unreserved};
-pub use sharded_ring::ShardedRingIssuer;
+pub use ring::{Reservation, Reserved, RingIssuer, RingIssuerFor, Unreserved};
+pub use sharded_ring::{ShardedRingIssuer, ShardedRingIssuerFor};
 
 // Factory (std only)
 #[cfg(feature = "std")]
-pub use factory::{BatchFactory, CreateResult, MemoryBatchFactory};
+pub use factory::{
+    BatchFactory, CreateResult, CreateResultFor, MemoryBatchFactory, MemoryBatchFactoryFor,
+};
 
 // Parallel signing (requires parallel feature)
 #[cfg(feature = "parallel")]

--- a/crates/postage-issuer/src/lib.rs
+++ b/crates/postage-issuer/src/lib.rs
@@ -33,11 +33,12 @@
 //!
 //! ```compile_fail
 //! use nectar_postage_issuer::{RingIssuer, Reserved, Unreserved};
-//! use nectar_postage::{Batch, BatchId};
+//! use nectar_postage::{Batch, BatchId, BucketDepth};
 //!
 //! fn self_hosting_sink(_ring: RingIssuer<Reserved>) {}
 //!
-//! let batch = Batch::new(BatchId::ZERO, 0, 0, Default::default(), 20, 16, false);
+//! let bucket_depth = BucketDepth::new(16).unwrap();
+//! let batch = Batch::new(BatchId::ZERO, 0, 0, Default::default(), 20, bucket_depth, false);
 //! let unreserved: RingIssuer<Unreserved> = RingIssuer::external(&batch).unwrap();
 //! // A reserved-blind ring is not a Reserved ring, and there is no conversion.
 //! self_hosting_sink(unreserved);

--- a/crates/postage-issuer/src/lib.rs
+++ b/crates/postage-issuer/src/lib.rs
@@ -52,12 +52,12 @@
 //! # Example
 //!
 //! ```ignore
-//! use nectar_postage_issuer::{BatchId, BatchStamper, MemoryIssuer, Stamper};
+//! use nectar_postage_issuer::{BatchId, BatchStamper, BucketDepth, MemoryIssuer, Stamper};
 //! use nectar_primitives::ChunkAddress;
 //! use alloy_signer_local::PrivateKeySigner;
 //!
 //! // Create an issuer for a batch
-//! let issuer = MemoryIssuer::new(BatchId::ZERO, 20, 16);
+//! let issuer = MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
 //!
 //! // Combine with any SignerSync implementation to create a stamper
 //! let signer = PrivateKeySigner::random();

--- a/crates/postage-issuer/src/ring.rs
+++ b/crates/postage-issuer/src/ring.rs
@@ -33,10 +33,10 @@ use alloc::vec::Vec;
 use nectar_postage::{
     Batch, BatchId, BucketDepth, StampDigest, StampError, StampIndex, calculate_bucket,
 };
-use nectar_primitives::ChunkAddress;
+use nectar_primitives::{ChunkAddress, Mainnet, SwarmSpec};
 
 use crate::StampIssuer;
-use crate::counter::{CounterError, CounterMode, CounterTable};
+use crate::counter::{CounterError, CounterMode, CounterTableFor};
 use crate::error::IssuerError;
 
 mod sealed {
@@ -134,13 +134,16 @@ impl Reservation for Reserved {
 /// Both constructors require a mutable batch. An immutable batch is refused
 /// with [`IssuerError::ImmutableNotSupported`]: immutable batches are fill-only
 /// and use [`MemoryIssuer`](crate::MemoryIssuer).
-#[derive(Debug, Clone)]
-pub struct RingIssuer<R = Unreserved> {
+///
+/// The network is the leading type parameter and reaches the ring through its
+/// [`BucketDepth`]; [`RingIssuer`] is the mainnet ring.
+#[derive(Debug)]
+pub struct RingIssuerFor<S: SwarmSpec = Mainnet, R = Unreserved> {
     /// The batch ID.
     batch_id: BatchId,
     /// The shared per-bucket ring cursors, in the `[0, capacity]` deferred-wrap
     /// representation. `counts[b] == capacity` means "wrap on the next write".
-    counters: CounterTable,
+    counters: CounterTableFor<S>,
     /// Whether each bucket has been written to capacity at least once.
     ///
     /// The wire representation defers each wrap, so once a bucket has wrapped its
@@ -158,7 +161,26 @@ pub struct RingIssuer<R = Unreserved> {
     reservation: R,
 }
 
-impl RingIssuer<Unreserved> {
+/// The [`RingIssuerFor`] of the mainnet spec.
+pub type RingIssuer<R = Unreserved> = RingIssuerFor<Mainnet, R>;
+
+// The spec is a type-level tag, so this carries no bound on `S` beyond
+// `SwarmSpec`; deriving would demand `S: Clone` of a marker type that holds no
+// data.
+impl<S: SwarmSpec, R: Clone> Clone for RingIssuerFor<S, R> {
+    fn clone(&self) -> Self {
+        Self {
+            batch_id: self.batch_id,
+            counters: self.counters.clone(),
+            saturated: self.saturated.clone(),
+            max_utilization: self.max_utilization,
+            stamps_issued: self.stamps_issued,
+            reservation: self.reservation.clone(),
+        }
+    }
+}
+
+impl<S: SwarmSpec> RingIssuerFor<S, Unreserved> {
     /// Builds an externally tracked ring for a mutable batch.
     ///
     /// The ring protects nothing: it wraps freely and may re-emit any slot. The
@@ -170,12 +192,12 @@ impl RingIssuer<Unreserved> {
     /// Returns [`IssuerError::ImmutableNotSupported`] if the batch is immutable;
     /// immutable batches are fill-only and use
     /// [`MemoryIssuer`](crate::MemoryIssuer).
-    pub fn external(batch: &Batch) -> Result<Self, IssuerError> {
+    pub fn external(batch: &Batch<S>) -> Result<Self, IssuerError> {
         Self::for_mutable_batch(batch, Unreserved)
     }
 }
 
-impl RingIssuer<Reserved> {
+impl<S: SwarmSpec> RingIssuerFor<S, Reserved> {
     /// Builds a self-hosting ring for a mutable batch with a set of protected
     /// slots.
     ///
@@ -189,16 +211,16 @@ impl RingIssuer<Reserved> {
     /// immutable batches are fill-only and use
     /// [`MemoryIssuer`](crate::MemoryIssuer).
     pub fn reserved(
-        batch: &Batch,
+        batch: &Batch<S>,
         slots: impl IntoIterator<Item = (u32, u32)>,
     ) -> Result<Self, IssuerError> {
         Self::for_mutable_batch(batch, Reserved::new(slots))
     }
 }
 
-impl<R: Reservation> RingIssuer<R> {
+impl<S: SwarmSpec, R: Reservation> RingIssuerFor<S, R> {
     /// Builds a ring for a mutable batch with the given reservation policy.
-    fn for_mutable_batch(batch: &Batch, reservation: R) -> Result<Self, IssuerError> {
+    fn for_mutable_batch(batch: &Batch<S>, reservation: R) -> Result<Self, IssuerError> {
         if batch.immutable() {
             return Err(IssuerError::ImmutableNotSupported);
         }
@@ -214,14 +236,13 @@ impl<R: Reservation> RingIssuer<R> {
     fn with_reservation(
         batch_id: BatchId,
         depth: u8,
-        bucket_depth: BucketDepth,
+        bucket_depth: BucketDepth<S>,
         reservation: R,
     ) -> Self {
-        let bucket_depth = bucket_depth.get();
-        let bucket_count = 1usize << bucket_depth;
+        let bucket_count = 1usize << bucket_depth.get();
         Self {
             batch_id,
-            counters: CounterTable::new(depth, bucket_depth, CounterMode::Ring),
+            counters: CounterTableFor::new(depth, bucket_depth, CounterMode::Ring),
             saturated: alloc::vec![false; bucket_count],
             max_utilization: 0,
             stamps_issued: 0,
@@ -295,7 +316,7 @@ impl<R: Reservation> RingIssuer<R> {
         address: &ChunkAddress,
         timestamp: u64,
     ) -> Result<StampDigest, IssuerError> {
-        let bucket = calculate_bucket(address, self.counters.bucket_depth());
+        let bucket = calculate_bucket(address, self.counters.bucket_depth().get());
         let position = self.next_slot(bucket)?;
 
         // Monotone u64 issuance counter; one increment per stamp cannot
@@ -327,7 +348,7 @@ impl<R: Reservation> RingIssuer<R> {
     }
 }
 
-impl<R: Reservation> StampIssuer for RingIssuer<R> {
+impl<S: SwarmSpec, R: Reservation> StampIssuer for RingIssuerFor<S, R> {
     fn prepare_stamp(
         &mut self,
         address: &ChunkAddress,
@@ -360,7 +381,7 @@ impl<R: Reservation> StampIssuer for RingIssuer<R> {
     }
 
     fn bucket_depth(&self) -> u8 {
-        self.counters.bucket_depth()
+        self.counters.bucket_depth().get()
     }
 
     fn max_bucket_utilization(&self) -> u32 {

--- a/crates/postage-issuer/src/ring.rs
+++ b/crates/postage-issuer/src/ring.rs
@@ -30,7 +30,9 @@ extern crate alloc;
 use alloc::collections::BTreeSet;
 use alloc::vec::Vec;
 
-use nectar_postage::{Batch, BatchId, StampDigest, StampError, StampIndex, calculate_bucket};
+use nectar_postage::{
+    Batch, BatchId, BucketDepth, StampDigest, StampError, StampIndex, calculate_bucket,
+};
 use nectar_primitives::ChunkAddress;
 
 use crate::StampIssuer;
@@ -209,7 +211,13 @@ impl<R: Reservation> RingIssuer<R> {
     }
 
     /// Builds a ring directly from geometry and a reservation policy.
-    fn with_reservation(batch_id: BatchId, depth: u8, bucket_depth: u8, reservation: R) -> Self {
+    fn with_reservation(
+        batch_id: BatchId,
+        depth: u8,
+        bucket_depth: BucketDepth,
+        reservation: R,
+    ) -> Self {
+        let bucket_depth = bucket_depth.get();
         let bucket_count = 1usize << bucket_depth;
         Self {
             batch_id,
@@ -412,7 +420,7 @@ mod tests {
             0,
             Default::default(),
             depth,
-            bucket_depth,
+            BucketDepth::new(bucket_depth).unwrap(),
             false,
         )
     }
@@ -424,7 +432,7 @@ mod tests {
             0,
             Default::default(),
             depth,
-            bucket_depth,
+            BucketDepth::new(bucket_depth).unwrap(),
             true,
         )
     }

--- a/crates/postage-issuer/src/sharded.rs
+++ b/crates/postage-issuer/src/sharded.rs
@@ -19,7 +19,7 @@ use crate::error::IssuerError;
 use nectar_postage::{
     Batch, BatchId, BucketDepth, StampDigest, StampError, StampIndex, calculate_bucket,
 };
-use nectar_primitives::ChunkAddress;
+use nectar_primitives::{ChunkAddress, Mainnet, SwarmSpec};
 
 #[cfg(feature = "parallel")]
 use {
@@ -99,6 +99,9 @@ impl BucketShard {
 ///
 /// # Example
 ///
+/// The network is a type parameter and reaches the issuer through its
+/// [`BucketDepth`]; [`ShardedIssuer`] is the mainnet issuer.
+///
 /// ```ignore
 /// use nectar_postage_issuer::{BatchId, BucketDepth, ShardedIssuer};
 ///
@@ -106,13 +109,13 @@ impl BucketShard {
 /// // Now safe to use from multiple threads via sign_stamps_parallel
 /// ```
 #[derive(Debug)]
-pub struct ShardedIssuer {
+pub struct ShardedIssuerFor<S: SwarmSpec = Mainnet> {
     /// The batch ID.
     batch_id: BatchId,
     /// The batch depth.
     depth: u8,
     /// The bucket depth.
-    bucket_depth: u8,
+    bucket_depth: BucketDepth<S>,
     /// The bucket capacity (2^(depth - bucket_depth)).
     bucket_capacity: u32,
     /// The shards containing bucket indices.
@@ -127,9 +130,12 @@ pub struct ShardedIssuer {
     stamps_issued: AtomicU64,
 }
 
-impl ShardedIssuer {
+/// The [`ShardedIssuerFor`] of the mainnet spec.
+pub type ShardedIssuer = ShardedIssuerFor<Mainnet>;
+
+impl<S: SwarmSpec> ShardedIssuerFor<S> {
     /// Creates a new sharded issuer with the default number of shards.
-    pub fn new(batch_id: BatchId, depth: u8, bucket_depth: BucketDepth) -> Self {
+    pub fn new(batch_id: BatchId, depth: u8, bucket_depth: BucketDepth<S>) -> Self {
         Self::with_shard_count(batch_id, depth, bucket_depth, DEFAULT_SHARD_COUNT)
     }
 
@@ -148,7 +154,7 @@ impl ShardedIssuer {
     pub fn with_shard_count(
         batch_id: BatchId,
         depth: u8,
-        bucket_depth: BucketDepth,
+        bucket_depth: BucketDepth<S>,
         shard_count: usize,
     ) -> Self {
         assert!(
@@ -156,9 +162,7 @@ impl ShardedIssuer {
             "shard_count must be a power of 2"
         );
 
-        let bucket_depth = bucket_depth.get();
-
-        let total_buckets = 1u32 << bucket_depth;
+        let total_buckets = 1u32 << bucket_depth.get();
         // `u32` always fits `usize` on the >=32-bit targets this crate supports.
         #[allow(clippy::as_conversions)]
         let shard_count = shard_count.min(total_buckets as usize);
@@ -167,12 +171,12 @@ impl ShardedIssuer {
         #[allow(clippy::as_conversions)]
         let shard_count_u32 = shard_count as u32;
         let buckets_per_shard = total_buckets / shard_count_u32;
-        let bucket_capacity = 1u32 << (depth - bucket_depth);
+        let bucket_capacity = 1u32 << (depth - bucket_depth.get());
 
         // Calculate shard_shift: how many bits to shift bucket to get shard index
         // For bucket_depth=16 and shard_count=16, we take top 4 bits: shift = 16 - 4 = 12
         let shard_bits = shard_count_u32.trailing_zeros();
-        let shard_shift = u32::from(bucket_depth) - shard_bits;
+        let shard_shift = u32::from(bucket_depth.get()) - shard_bits;
         let shard_mask = shard_count_u32 - 1;
 
         let shards: Vec<_> = (0..shard_count)
@@ -208,7 +212,7 @@ impl ShardedIssuer {
     /// external tracking, or
     /// [`ShardedRingIssuer::reserved`](crate::ShardedRingIssuer::reserved) for
     /// self-hosting, where the protected slots come from `nectar-postage-usage`.
-    pub fn from_batch(batch: &Batch) -> Result<Self, IssuerError> {
+    pub fn from_batch(batch: &Batch<S>) -> Result<Self, IssuerError> {
         if batch.immutable() {
             Ok(Self::new(batch.id(), batch.depth(), batch.bucket_depth()))
         } else {
@@ -241,7 +245,7 @@ impl ShardedIssuer {
         // batch geometry invariant), so the subtraction cannot underflow.
         #[allow(clippy::arithmetic_side_effects)]
         {
-            self.bucket_capacity = 1u32 << (new_depth - self.bucket_depth);
+            self.bucket_capacity = 1u32 << (new_depth - self.bucket_depth.get());
         }
         Ok(())
     }
@@ -263,7 +267,7 @@ impl ShardedIssuer {
         address: &ChunkAddress,
         timestamp: u64,
     ) -> Result<StampDigest, StampError> {
-        let bucket = calculate_bucket(address, self.bucket_depth);
+        let bucket = calculate_bucket(address, self.bucket_depth.get());
         let shard_idx = self.shard_index(bucket);
         // `shard_index` masks with `shard_mask = shards.len() - 1`, so the index
         // is always in range.
@@ -315,7 +319,7 @@ impl ShardedIssuer {
 
     /// Bucket depth.
     pub const fn bucket_depth(&self) -> u8 {
-        self.bucket_depth
+        self.bucket_depth.get()
     }
 
     /// Maximum bucket utilization observed across all buckets.
@@ -393,13 +397,14 @@ pub struct StampResult {
 /// let results = sign_stamps_parallel(&issuer, &signer_fn, &addresses);
 /// ```
 #[cfg(feature = "parallel")]
-pub fn sign_stamps_parallel<S, E>(
-    issuer: &ShardedIssuer,
-    signer: &S,
+pub fn sign_stamps_parallel<Sp, Sg, E>(
+    issuer: &ShardedIssuerFor<Sp>,
+    signer: &Sg,
     addresses: &[ChunkAddress],
 ) -> Vec<StampResult>
 where
-    S: Fn(&B256) -> Result<Signature, E> + Sync,
+    Sp: SwarmSpec + Sync,
+    Sg: Fn(&B256) -> Result<Signature, E> + Sync,
     E: Into<SigningError>,
 {
     use rayon::prelude::*;
@@ -417,13 +422,14 @@ where
 }
 
 #[cfg(feature = "parallel")]
-fn sign_stamp_internal<S, E>(
-    issuer: &ShardedIssuer,
-    signer: &S,
+fn sign_stamp_internal<Sp, Sg, E>(
+    issuer: &ShardedIssuerFor<Sp>,
+    signer: &Sg,
     address: &ChunkAddress,
 ) -> Result<Stamp, SigningError>
 where
-    S: Fn(&B256) -> Result<Signature, E>,
+    Sp: SwarmSpec,
+    Sg: Fn(&B256) -> Result<Signature, E>,
     E: Into<SigningError>,
 {
     let timestamp = current_timestamp();

--- a/crates/postage-issuer/src/sharded.rs
+++ b/crates/postage-issuer/src/sharded.rs
@@ -16,7 +16,9 @@
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 
 use crate::error::IssuerError;
-use nectar_postage::{Batch, BatchId, StampDigest, StampError, StampIndex, calculate_bucket};
+use nectar_postage::{
+    Batch, BatchId, BucketDepth, StampDigest, StampError, StampIndex, calculate_bucket,
+};
 use nectar_primitives::ChunkAddress;
 
 #[cfg(feature = "parallel")]
@@ -98,9 +100,9 @@ impl BucketShard {
 /// # Example
 ///
 /// ```ignore
-/// use nectar_postage_issuer::{BatchId, ShardedIssuer};
+/// use nectar_postage_issuer::{BatchId, BucketDepth, ShardedIssuer};
 ///
-/// let issuer = ShardedIssuer::new(BatchId::ZERO, 20, 16);
+/// let issuer = ShardedIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
 /// // Now safe to use from multiple threads via sign_stamps_parallel
 /// ```
 #[derive(Debug)]
@@ -127,7 +129,7 @@ pub struct ShardedIssuer {
 
 impl ShardedIssuer {
     /// Creates a new sharded issuer with the default number of shards.
-    pub fn new(batch_id: BatchId, depth: u8, bucket_depth: u8) -> Self {
+    pub fn new(batch_id: BatchId, depth: u8, bucket_depth: BucketDepth) -> Self {
         Self::with_shard_count(batch_id, depth, bucket_depth, DEFAULT_SHARD_COUNT)
     }
 
@@ -146,13 +148,15 @@ impl ShardedIssuer {
     pub fn with_shard_count(
         batch_id: BatchId,
         depth: u8,
-        bucket_depth: u8,
+        bucket_depth: BucketDepth,
         shard_count: usize,
     ) -> Self {
         assert!(
             shard_count.is_power_of_two(),
             "shard_count must be a power of 2"
         );
+
+        let bucket_depth = bucket_depth.get();
 
         let total_buckets = 1u32 << bucket_depth;
         // `u32` always fits `usize` on the >=32-bit targets this crate supports.
@@ -378,11 +382,11 @@ pub struct StampResult {
 /// # Example
 ///
 /// ```ignore
-/// use nectar_postage_issuer::{BatchId, ShardedIssuer, sign_stamps_parallel};
+/// use nectar_postage_issuer::{BatchId, BucketDepth, ShardedIssuer, sign_stamps_parallel};
 /// use alloy_primitives::B256;
 /// use alloy_signer::SignerSync;
 ///
-/// let issuer = ShardedIssuer::new(BatchId::ZERO, 20, 16);
+/// let issuer = ShardedIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
 /// let addresses: Vec<ChunkAddress> = /* ... */;
 /// // Use sign_message_sync for EIP-191 compatibility
 /// let signer_fn = |prehash: &B256| signer.sign_message_sync(prehash.as_slice());
@@ -449,7 +453,15 @@ mod tests {
         // The parallel constructor refuses a mutable batch for the same reason
         // as MemoryIssuer: a reserved-blind ring would silently overwrite a
         // self-hosted snapshot's own chunks.
-        let mutable = Batch::new(BatchId::ZERO, 0, 0, Default::default(), 20, 16, false);
+        let mutable = Batch::new(
+            BatchId::ZERO,
+            0,
+            0,
+            Default::default(),
+            20,
+            BucketDepth::new(16).unwrap(),
+            false,
+        );
         assert!(matches!(
             ShardedIssuer::from_batch(&mutable),
             Err(IssuerError::MutableNotSupported)
@@ -460,13 +472,21 @@ mod tests {
     fn test_sharded_issuer_from_batch_immutable_ok() {
         use nectar_postage::Batch;
 
-        let immutable = Batch::new(BatchId::ZERO, 0, 0, Default::default(), 20, 16, true);
+        let immutable = Batch::new(
+            BatchId::ZERO,
+            0,
+            0,
+            Default::default(),
+            20,
+            BucketDepth::new(16).unwrap(),
+            true,
+        );
         assert!(ShardedIssuer::from_batch(&immutable).is_ok());
     }
 
     #[test]
     fn test_sharded_issuer_basic() {
-        let issuer = ShardedIssuer::new(BatchId::ZERO, 20, 16);
+        let issuer = ShardedIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
 
         assert_eq!(issuer.batch_id(), BatchId::ZERO);
         assert_eq!(issuer.batch_depth(), 20);
@@ -477,7 +497,7 @@ mod tests {
 
     #[test]
     fn test_sharded_issuer_prepare_stamp() {
-        let issuer = ShardedIssuer::new(BatchId::ZERO, 20, 16);
+        let issuer = ShardedIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
         let address = ChunkAddress::from(B256::random());
 
         let digest = issuer.prepare_stamp(&address, 12345).unwrap();
@@ -490,7 +510,7 @@ mod tests {
     #[test]
     fn test_sharded_issuer_dilute_grows_capacity_only() {
         // depth=17, bucket_depth=16 gives 2 slots per bucket.
-        let mut issuer = ShardedIssuer::new(BatchId::ZERO, 17, 16);
+        let mut issuer = ShardedIssuer::new(BatchId::ZERO, 17, BucketDepth::new(16).unwrap());
         let address = ChunkAddress::from(B256::repeat_byte(0xAB));
         let bucket = calculate_bucket(&address, 16);
 
@@ -520,7 +540,11 @@ mod tests {
         use std::sync::Arc;
         use std::thread;
 
-        let issuer = Arc::new(ShardedIssuer::new(BatchId::ZERO, 24, 16));
+        let issuer = Arc::new(ShardedIssuer::new(
+            BatchId::ZERO,
+            24,
+            BucketDepth::new(16).unwrap(),
+        ));
         let num_threads = 8;
         let stamps_per_thread = 1000;
 
@@ -553,7 +577,7 @@ mod tests {
         use alloy_signer::SignerSync;
         use alloy_signer_local::PrivateKeySigner;
 
-        let issuer = ShardedIssuer::new(BatchId::ZERO, 24, 16);
+        let issuer = ShardedIssuer::new(BatchId::ZERO, 24, BucketDepth::new(16).unwrap());
         let signer = PrivateKeySigner::random();
 
         let addresses: Vec<_> = (0..100)

--- a/crates/postage-issuer/src/sharded_ring.rs
+++ b/crates/postage-issuer/src/sharded_ring.rs
@@ -17,7 +17,9 @@
 
 use std::sync::Mutex;
 
-use nectar_postage::{Batch, BatchId, StampDigest, StampError, StampIndex, calculate_bucket};
+use nectar_postage::{
+    Batch, BatchId, BucketDepth, StampDigest, StampError, StampIndex, calculate_bucket,
+};
 use nectar_primitives::ChunkAddress;
 
 use crate::error::IssuerError;
@@ -235,7 +237,7 @@ impl<R: Reservation> ShardedRingIssuer<R> {
     fn with_shard_count(
         batch_id: BatchId,
         depth: u8,
-        bucket_depth: u8,
+        bucket_depth: BucketDepth,
         shard_count: usize,
         make_reservation: impl Fn(u32, u32, usize) -> R,
     ) -> Self {
@@ -243,6 +245,8 @@ impl<R: Reservation> ShardedRingIssuer<R> {
             shard_count.is_power_of_two(),
             "shard_count must be a power of 2"
         );
+
+        let bucket_depth = bucket_depth.get();
 
         let total_buckets = 1u32 << bucket_depth;
         // `u32` always fits `usize` on the >=32-bit targets this crate supports.
@@ -438,7 +442,7 @@ mod tests {
             0,
             Default::default(),
             depth,
-            bucket_depth,
+            BucketDepth::new(bucket_depth).unwrap(),
             false,
         )
     }
@@ -450,7 +454,7 @@ mod tests {
             0,
             Default::default(),
             depth,
-            bucket_depth,
+            BucketDepth::new(bucket_depth).unwrap(),
             true,
         )
     }

--- a/crates/postage-issuer/src/sharded_ring.rs
+++ b/crates/postage-issuer/src/sharded_ring.rs
@@ -20,7 +20,7 @@ use std::sync::Mutex;
 use nectar_postage::{
     Batch, BatchId, BucketDepth, StampDigest, StampError, StampIndex, calculate_bucket,
 };
-use nectar_primitives::ChunkAddress;
+use nectar_primitives::{ChunkAddress, Mainnet, SwarmSpec};
 
 use crate::error::IssuerError;
 use crate::ring::{Reservation, Reserved, Unreserved};
@@ -147,14 +147,17 @@ fn alloc_zeroed_u32(count: usize) -> Vec<u32> {
 ///
 /// Both constructors require a mutable batch; an immutable batch is refused with
 /// [`IssuerError::ImmutableNotSupported`].
+///
+/// The network is the leading type parameter and reaches the ring through its
+/// [`BucketDepth`]; [`ShardedRingIssuer`] is the mainnet ring.
 #[derive(Debug)]
-pub struct ShardedRingIssuer<R = Unreserved> {
+pub struct ShardedRingIssuerFor<S: SwarmSpec = Mainnet, R = Unreserved> {
     /// The batch ID.
     batch_id: BatchId,
     /// The batch depth.
     depth: u8,
     /// The bucket depth.
-    bucket_depth: u8,
+    bucket_depth: BucketDepth<S>,
     /// The bucket capacity, `2^(depth - bucket_depth)`.
     bucket_capacity: u32,
     /// The shards, each owning a contiguous bucket range.
@@ -169,7 +172,10 @@ pub struct ShardedRingIssuer<R = Unreserved> {
     stamps_issued: Mutex<u64>,
 }
 
-impl ShardedRingIssuer<Unreserved> {
+/// The [`ShardedRingIssuerFor`] of the mainnet spec.
+pub type ShardedRingIssuer<R = Unreserved> = ShardedRingIssuerFor<Mainnet, R>;
+
+impl<S: SwarmSpec> ShardedRingIssuerFor<S, Unreserved> {
     /// Builds an externally tracked sharded ring for a mutable batch.
     ///
     /// The ring protects nothing. The caller tracks usage outside the batch.
@@ -177,12 +183,12 @@ impl ShardedRingIssuer<Unreserved> {
     /// # Errors
     ///
     /// Returns [`IssuerError::ImmutableNotSupported`] if the batch is immutable.
-    pub fn external(batch: &Batch) -> Result<Self, IssuerError> {
+    pub fn external(batch: &Batch<S>) -> Result<Self, IssuerError> {
         Self::for_mutable_batch(batch, |_, _, _| Unreserved)
     }
 }
 
-impl ShardedRingIssuer<Reserved> {
+impl<S: SwarmSpec> ShardedRingIssuerFor<S, Reserved> {
     /// Builds a self-hosting sharded ring for a mutable batch with a set of
     /// protected slots.
     ///
@@ -194,7 +200,7 @@ impl ShardedRingIssuer<Reserved> {
     ///
     /// Returns [`IssuerError::ImmutableNotSupported`] if the batch is immutable.
     pub fn reserved(
-        batch: &Batch,
+        batch: &Batch<S>,
         slots: impl IntoIterator<Item = (u32, u32)>,
     ) -> Result<Self, IssuerError> {
         let slots: Vec<(u32, u32)> = slots.into_iter().collect();
@@ -210,9 +216,9 @@ impl ShardedRingIssuer<Reserved> {
     }
 }
 
-impl<R: Reservation> ShardedRingIssuer<R> {
+impl<S: SwarmSpec, R: Reservation> ShardedRingIssuerFor<S, R> {
     fn for_mutable_batch(
-        batch: &Batch,
+        batch: &Batch<S>,
         make_reservation: impl Fn(u32, u32, usize) -> R,
     ) -> Result<Self, IssuerError> {
         if batch.immutable() {
@@ -237,7 +243,7 @@ impl<R: Reservation> ShardedRingIssuer<R> {
     fn with_shard_count(
         batch_id: BatchId,
         depth: u8,
-        bucket_depth: BucketDepth,
+        bucket_depth: BucketDepth<S>,
         shard_count: usize,
         make_reservation: impl Fn(u32, u32, usize) -> R,
     ) -> Self {
@@ -246,9 +252,7 @@ impl<R: Reservation> ShardedRingIssuer<R> {
             "shard_count must be a power of 2"
         );
 
-        let bucket_depth = bucket_depth.get();
-
-        let total_buckets = 1u32 << bucket_depth;
+        let total_buckets = 1u32 << bucket_depth.get();
         // `u32` always fits `usize` on the >=32-bit targets this crate supports.
         #[allow(clippy::as_conversions)]
         let shard_count = shard_count.min(total_buckets as usize);
@@ -257,10 +261,10 @@ impl<R: Reservation> ShardedRingIssuer<R> {
         #[allow(clippy::as_conversions)]
         let shard_count_u32 = shard_count as u32;
         let buckets_per_shard = total_buckets / shard_count_u32;
-        let bucket_capacity = 1u32 << (depth - bucket_depth);
+        let bucket_capacity = 1u32 << (depth - bucket_depth.get());
 
         let shard_bits = shard_count_u32.trailing_zeros();
-        let shard_shift = u32::from(bucket_depth) - shard_bits;
+        let shard_shift = u32::from(bucket_depth.get()) - shard_bits;
         let shard_mask = shard_count_u32 - 1;
 
         let shards: Vec<_> = (0..shard_count)
@@ -314,7 +318,7 @@ impl<R: Reservation> ShardedRingIssuer<R> {
         address: &ChunkAddress,
         timestamp: u64,
     ) -> Result<StampDigest, StampError> {
-        let bucket = calculate_bucket(address, self.bucket_depth);
+        let bucket = calculate_bucket(address, self.bucket_depth.get());
         // `shard_index` masks with `shard_mask = shards.len() - 1`, so the index
         // is always in range.
         #[allow(clippy::indexing_slicing)]
@@ -370,7 +374,7 @@ impl<R: Reservation> ShardedRingIssuer<R> {
 
     /// Returns the bucket depth.
     pub const fn bucket_depth(&self) -> u8 {
-        self.bucket_depth
+        self.bucket_depth.get()
     }
 
     /// Returns the bucket capacity, `2^(depth - bucket_depth)`.

--- a/crates/postage-issuer/src/stamper.rs
+++ b/crates/postage-issuer/src/stamper.rs
@@ -197,6 +197,7 @@ mod tests {
     use super::*;
     use crate::MemoryIssuer;
     use alloy_primitives::{B256, Signature, U256};
+    use nectar_postage::BucketDepth;
     use nectar_postage::StampIndex;
 
     /// A mock signer for testing that creates deterministic signatures.
@@ -218,7 +219,7 @@ mod tests {
 
     #[test]
     fn test_batch_stamper_basic() {
-        let issuer = MemoryIssuer::new(BatchId::ZERO, 20, 16);
+        let issuer = MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
         let mut stamper = BatchStamper::new(issuer, MockSigner);
 
         let address = ChunkAddress::new([0xAB; 32]);
@@ -231,7 +232,7 @@ mod tests {
 
     #[test]
     fn test_batch_stamper_increments_index() {
-        let issuer = MemoryIssuer::new(BatchId::ZERO, 20, 16);
+        let issuer = MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
         let mut stamper = BatchStamper::new(issuer, MockSigner);
 
         // Use same address to hit same bucket
@@ -256,7 +257,7 @@ mod tests {
 
         // Create an issuer with very small bucket capacity: depth=17, bucket_depth=16
         // This gives 2^(17-16) = 2 slots per bucket
-        let issuer = MemoryIssuer::new(BatchId::ZERO, 17, 16);
+        let issuer = MemoryIssuer::new(BatchId::ZERO, 17, BucketDepth::new(16).unwrap());
         let mut stamper = BatchStamper::new(issuer, MockSigner);
 
         let address = ChunkAddress::new([0xAB; 32]);
@@ -275,7 +276,7 @@ mod tests {
 
     #[test]
     fn test_batch_stamper_max_utilization() {
-        let issuer = MemoryIssuer::new(BatchId::ZERO, 20, 16);
+        let issuer = MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
         let mut stamper = BatchStamper::new(issuer, MockSigner);
 
         assert_eq!(stamper.max_bucket_utilization(), 0);

--- a/crates/postage-issuer/tests/non_mainnet.rs
+++ b/crates/postage-issuer/tests/non_mainnet.rs
@@ -1,0 +1,140 @@
+//! Issuing for a network other than mainnet, end to end.
+//!
+//! The spec parameter is load-bearing rather than decorative: a deployment that
+//! raises the collision-bucket floor above mainnet's refuses a depth mainnet
+//! accepts, and an issuer built for it stamps, fills, dilutes, and reserves at
+//! that geometry.
+
+// The crate-level `cfg_attr(test, ..)` exemption does not reach a separate test
+// binary, and a fixture that unwraps a known-good depth is setup, not shipped
+// surface. Nothing else in this file needs an exemption.
+#![allow(clippy::unwrap_used)]
+
+use alloy_signer_local::PrivateKeySigner;
+use nectar_postage_issuer::{
+    Batch, BatchId, BatchStamper, BucketDepth, IssuerError, Mainnet, MemoryIssuerFor, NetworkId,
+    Reserved, RingIssuerFor, ShardedIssuerFor, SigningError, StampError, StampIssuer, Stamper,
+    SwarmSpec, calculate_bucket,
+};
+use nectar_primitives::ChunkAddress;
+
+/// A deployment whose collision-bucket floor is deeper than mainnet's 16.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Deep;
+
+impl SwarmSpec for Deep {
+    const NETWORK_ID: NetworkId = NetworkId::TESTNET;
+    const MIN_BUCKET_DEPTH: u8 = 20;
+}
+
+/// The bucket depth `Deep` demands.
+fn deep() -> BucketDepth<Deep> {
+    BucketDepth::new(20).unwrap()
+}
+
+/// A `Deep` batch: 2^20 buckets of 2^(depth - 20) slots each.
+fn deep_batch(depth: u8, immutable: bool) -> Batch<Deep> {
+    Batch::new(
+        BatchId::ZERO,
+        0,
+        0,
+        Default::default(),
+        depth,
+        deep(),
+        immutable,
+    )
+}
+
+/// An address whose leading 20 bits select `bucket`.
+fn address_in(bucket: u32) -> ChunkAddress {
+    let mut bytes = [0u8; 32];
+    bytes[..4].copy_from_slice(&(bucket << 12).to_be_bytes());
+    ChunkAddress::new(bytes)
+}
+
+#[test]
+fn the_floor_is_the_deployments_own() {
+    // Mainnet's floor admits 16; `Deep` refuses it and demands 20.
+    assert!(BucketDepth::<Mainnet>::new(16).is_ok());
+    assert!(matches!(
+        BucketDepth::<Deep>::new(16),
+        Err(StampError::BucketDepthBelowMinimum {
+            bucket_depth: 16,
+            minimum: 20
+        })
+    ));
+    assert_eq!(BucketDepth::<Deep>::new(20).unwrap().get(), 20);
+}
+
+#[test]
+fn a_deep_issuer_stamps_through_a_batch_stamper() {
+    // depth 22 over bucket depth 20 gives 4 slots per bucket.
+    let batch = deep_batch(22, true);
+    let issuer = MemoryIssuerFor::from_batch(&batch).unwrap();
+    assert_eq!(issuer.bucket_depth(), 20);
+    assert_eq!(issuer.bucket_count(), 1 << 20);
+    assert_eq!(issuer.bucket_capacity(), 4);
+
+    let mut stamper = BatchStamper::new(issuer, PrivateKeySigner::random());
+    let address = address_in(0xABCDE);
+
+    for expected in 0..4u32 {
+        let stamp = stamper.stamp(&address).unwrap();
+        assert_eq!(stamp.bucket(), 0xABCDE);
+        assert_eq!(stamp.index(), expected);
+    }
+
+    // The fifth stamp exhausts the bucket at this geometry.
+    assert!(matches!(
+        stamper.stamp(&address),
+        Err(SigningError::Stamp(StampError::BucketFull {
+            bucket: 0xABCDE,
+            capacity: 4
+        }))
+    ));
+    assert_eq!(stamper.issuer().stamps_issued(), Some(4));
+}
+
+#[test]
+fn a_deep_issuer_dilutes_and_a_deep_sharded_issuer_stamps() {
+    let mut issuer = MemoryIssuerFor::<Deep>::new(BatchId::ZERO, 21, deep());
+    let address = address_in(1);
+    assert_eq!(issuer.prepare_stamp(&address, 1).unwrap().index.index(), 0);
+    assert_eq!(issuer.prepare_stamp(&address, 2).unwrap().index.index(), 1);
+    assert!(issuer.prepare_stamp(&address, 3).is_err());
+
+    issuer.dilute(22).unwrap();
+    assert_eq!(issuer.bucket_capacity(), 4);
+    assert_eq!(issuer.prepare_stamp(&address, 4).unwrap().index.index(), 2);
+    assert!(matches!(
+        issuer.dilute(21),
+        Err(IssuerError::DepthDecrease {
+            current: 22,
+            requested: 21
+        })
+    ));
+
+    let sharded = ShardedIssuerFor::from_batch(&deep_batch(22, true)).unwrap();
+    assert_eq!(sharded.bucket_depth(), 20);
+    let digest = sharded.prepare_stamp(&address, 5).unwrap();
+    assert_eq!(digest.index.bucket(), calculate_bucket(&address, 20));
+    assert_eq!(sharded.stamps_issued(), 1);
+}
+
+#[test]
+fn a_deep_reserved_ring_never_emits_a_reserved_slot() {
+    // depth 22 over bucket depth 20 gives 4 slots per bucket; reserve two.
+    let batch = deep_batch(22, false);
+    let address = address_in(0x0FEDC);
+    let bucket = calculate_bucket(&address, 20);
+    let mut ring: RingIssuerFor<Deep, Reserved> =
+        RingIssuerFor::reserved(&batch, [(bucket, 1), (bucket, 3)]).unwrap();
+
+    // Far past one wrap, so every wrap is exercised.
+    for timestamp in 0..40u64 {
+        let digest = ring.prepare_stamp(&address, timestamp).unwrap();
+        assert_eq!(digest.index.bucket(), bucket);
+        let slot = digest.index.index();
+        assert!(slot == 0 || slot == 2, "ring emitted reserved slot {slot}");
+    }
+}

--- a/crates/postage-issuer/tests/non_mainnet.rs
+++ b/crates/postage-issuer/tests/non_mainnet.rs
@@ -10,6 +10,8 @@
 // surface. Nothing else in this file needs an exemption.
 #![allow(clippy::unwrap_used)]
 
+use core::num::NonZeroU8;
+
 use alloy_signer_local::PrivateKeySigner;
 use nectar_postage_issuer::{
     Batch, BatchId, BatchStamper, BucketDepth, IssuerError, Mainnet, MemoryIssuerFor, NetworkId,
@@ -24,7 +26,7 @@ struct Deep;
 
 impl SwarmSpec for Deep {
     const NETWORK_ID: NetworkId = NetworkId::TESTNET;
-    const MIN_BUCKET_DEPTH: u8 = 20;
+    const MIN_BUCKET_DEPTH: NonZeroU8 = NonZeroU8::new(20).unwrap();
 }
 
 /// The bucket depth `Deep` demands.

--- a/crates/postage-usage/README.md
+++ b/crates/postage-usage/README.md
@@ -84,7 +84,7 @@ With `w > 0`, each leaf holds `B = floor(32768 / w)` buckets' deltas, MSB-first 
 
 A complete root payload, byte for byte, so the record structure can be reasoned about. This exact vector is pinned by `tests/vector.rs`, so the documentation cannot drift from the implementation.
 
-Scenario: batch id `0x42` repeated, owner `0x11` repeated, depth 12, bucket depth 8 (256 buckets of 16 slots). Counters follow the pattern `count(b) = 3 + (b mod 4)`, except bucket 200 (0xc8) which is completely full at 16. Persisting allocates the snapshot's own root chunk a slot: its address hashes into bucket 41 (0x29), bumping that counter from 4 to 5 and `total_issued` to 1166.
+Scenario: batch id `0x42` repeated, owner `0x11` repeated, depth 12, bucket depth 8 (256 buckets of 16 slots). The format supports bucket depths 1 to 16; which of them a batch may declare is the network's own floor (`SwarmSpec::MIN_BUCKET_DEPTH`, 16 on mainnet), so this small geometry belongs to a deployment with a lower floor and the vector is pinned for one. Counters follow the pattern `count(b) = 3 + (b mod 4)`, except bucket 200 (0xc8) which is completely full at 16. Persisting allocates the snapshot's own root chunk a slot: its address hashes into bucket 41 (0x29), bumping that counter from 4 to 5 and `total_issued` to 1166.
 
 The encoder picks `base = 3` and `w = 2` (deltas 0..=3 cover every bucket except the hot one, which becomes the single exception: 1 exception at 8 bytes beats widening 256 buckets to 4 bits). The packed table is 64 bytes and fits inline, so the whole snapshot is one 142-byte chunk:
 

--- a/crates/postage-usage/examples/roam_between_machines.rs
+++ b/crates/postage-usage/examples/roam_between_machines.rs
@@ -224,7 +224,12 @@ fn stale_persist_is_rejected(
     println!("----------------------------------------------");
 
     // A snapshot sitting at sequence 1 (its next persist would emit 2).
-    let table = UsageTable::new(batch_id, DEPTH, BUCKET_DEPTH, Mutability::Immutable)?;
+    let table = UsageTable::new(
+        batch_id,
+        DEPTH,
+        BucketDepth::new(BUCKET_DEPTH)?,
+        Mutability::Immutable,
+    )?;
     let mut snapshot = Snapshot::new(table);
     snapshot
         .revalidate(PublishedSequence::NONE)?

--- a/crates/postage-usage/examples/roam_between_machines.rs
+++ b/crates/postage-usage/examples/roam_between_machines.rs
@@ -43,7 +43,7 @@ use std::sync::{Arc, Mutex};
 use alloy_primitives::{Address, B256, hex};
 use alloy_signer_local::PrivateKeySigner;
 use bytes::Bytes;
-use nectar_postage::{Batch, BatchId};
+use nectar_postage::{Batch, BatchId, BucketDepth};
 use nectar_postage_usage::{
     BatchStamper, ChunkAddress, Mutability, PublishedSequence, SealedChunk, Snapshot, SnapshotSink,
     SnapshotSource, UsageError, UsageTable,
@@ -96,7 +96,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let signer = PrivateKeySigner::random();
     let owner: Address = signer.address();
     let batch_id = BatchId::new([0x42; 32]);
-    let batch = Batch::new(batch_id, 0, 0, owner, DEPTH, BUCKET_DEPTH, true);
+    let batch = Batch::new(
+        batch_id,
+        0,
+        0,
+        owner,
+        DEPTH,
+        BucketDepth::new(BUCKET_DEPTH)?,
+        true,
+    );
 
     println!("Postage batch usage: roaming between machines");
     println!("==============================================\n");

--- a/crates/postage-usage/src/client.rs
+++ b/crates/postage-usage/src/client.rs
@@ -34,12 +34,12 @@ use alloy_primitives::Address;
 use alloy_signer::SignerSync;
 use bytes::Bytes;
 use nectar_postage::{Batch, BatchId, StampIndex};
-use nectar_primitives::ChunkAddress;
+use nectar_primitives::{ChunkAddress, Mainnet, SwarmSpec};
 use thiserror::Error;
 
-use crate::codec::RootInfo;
+use crate::codec::RootInfoFor;
 use crate::seal::{SealError, SealedChunk, seal_plan};
-use crate::snapshot::{PublishedSequence, Snapshot};
+use crate::snapshot::{PublishedSequence, SnapshotFor};
 use crate::{UsageError, usage_chunk_address};
 
 /// Reads a chunk's payload from the network by its single-owner-chunk address.
@@ -143,13 +143,13 @@ where
 /// chunk address is derived from it and the batch id, so a second machine
 /// holding only the same key and batch id recovers the same state.
 #[derive(Debug)]
-pub struct BatchStamper<Sg, Src, Snk> {
+pub struct BatchStamperFor<Sg, Src, Snk, S: SwarmSpec = Mainnet> {
     signer: Sg,
     owner: Address,
     batch_id: BatchId,
     source: Src,
     sink: Snk,
-    snapshot: Snapshot,
+    snapshot: SnapshotFor<S>,
     /// Whether a persist has been emitted in this session. A clean snapshot that
     /// has already persisted once this session makes [`flush`](Self::flush) a
     /// no-op; a clean but never-persisted snapshot still flushes once so a fresh
@@ -157,11 +157,15 @@ pub struct BatchStamper<Sg, Src, Snk> {
     persisted_this_session: bool,
 }
 
-impl<Sg, Src, Snk> BatchStamper<Sg, Src, Snk>
+/// The [`BatchStamperFor`] of the mainnet spec.
+pub type BatchStamper<Sg, Src, Snk> = BatchStamperFor<Sg, Src, Snk, Mainnet>;
+
+impl<Sg, Src, Snk, S> BatchStamperFor<Sg, Src, Snk, S>
 where
     Sg: SignerSync + alloy_signer::Signer,
     Src: SnapshotSource,
     Snk: SnapshotSink,
+    S: SwarmSpec,
 {
     /// Opens a stamper for `batch`, recovering published state or starting fresh.
     ///
@@ -181,7 +185,7 @@ where
     ///   a published root.
     pub async fn open(
         signer: Sg,
-        batch: &Batch,
+        batch: &Batch<S>,
         source: Src,
         sink: Snk,
     ) -> Result<Self, ClientError<Src::Error, Snk::Error>> {
@@ -198,7 +202,7 @@ where
                 // A published root exists: recover its sequence and slots. Every
                 // committed leaf must be present; a missing leaf is corruption,
                 // not a reason to start over.
-                let root = RootInfo::parse(&root_bytes)?;
+                let root = RootInfoFor::<S>::parse(&root_bytes)?;
                 let mut leaves: Vec<Bytes> = Vec::with_capacity(usize::from(root.leaf_count()));
                 for leaf in 0..root.leaf_count() {
                     // `leaf < leaf_count() <= u16::MAX`, so the increment
@@ -218,7 +222,7 @@ where
                 root.assemble(&leaves)?
             }
             // The network confirms no published root: a genuinely fresh batch.
-            None => Snapshot::from_batch(batch)?,
+            None => SnapshotFor::from_batch(batch)?,
         };
 
         Ok(Self {
@@ -275,7 +279,7 @@ where
             .await
             .map_err(ClientError::Source)?
         {
-            Some(root_bytes) => PublishedSequence::from(&RootInfo::parse(&root_bytes)?),
+            Some(root_bytes) => PublishedSequence::from(&RootInfoFor::<S>::parse(&root_bytes)?),
             // The network confirms no published root: the floor is NONE.
             None => PublishedSequence::NONE,
         };
@@ -309,7 +313,7 @@ where
     }
 
     /// Returns the wrapped snapshot.
-    pub const fn snapshot(&self) -> &Snapshot {
+    pub const fn snapshot(&self) -> &SnapshotFor<S> {
         &self.snapshot
     }
 
@@ -342,7 +346,7 @@ mod tests {
     use alloy_signer_local::PrivateKeySigner;
 
     use super::*;
-    use crate::{Mutability, UsageTable};
+    use crate::{Mutability, Snapshot, UsageTable};
 
     /// A shared in-memory network backing both a [`SnapshotSource`] and a
     /// [`SnapshotSink`], keyed by single-owner-chunk address.
@@ -599,7 +603,13 @@ mod tests {
         // A stale machine B sitting at sequence 1: open it, but rewind its
         // snapshot to a sequence-1 state, then issue and flush. The live floor (2)
         // rejects the next sequence (2).
-        let table = UsageTable::new(batch.id(), 20, 16, Mutability::Immutable).unwrap();
+        let table = UsageTable::new(
+            batch.id(),
+            20,
+            BucketDepth::new(16).unwrap(),
+            Mutability::Immutable,
+        )
+        .unwrap();
         let mut stale = Snapshot::new(table);
         stale
             .revalidate(PublishedSequence::NONE)

--- a/crates/postage-usage/src/client.rs
+++ b/crates/postage-usage/src/client.rs
@@ -335,6 +335,7 @@ where
 #[allow(clippy::disallowed_methods)]
 mod tests {
     use alloc::collections::BTreeMap;
+    use nectar_postage::BucketDepth;
     use std::sync::Mutex;
 
     use alloy_primitives::B256;
@@ -444,7 +445,7 @@ mod tests {
             0,
             signer.address(),
             20,
-            16,
+            BucketDepth::new(16).unwrap(),
             immutable,
         )
     }

--- a/crates/postage-usage/src/codec.rs
+++ b/crates/postage-usage/src/codec.rs
@@ -866,6 +866,8 @@ impl<S: SwarmSpec> RootInfoFor<S> {
 
 #[cfg(test)]
 mod tests {
+    use core::num::NonZeroU8;
+
     use nectar_primitives::NetworkId;
 
     use super::*;
@@ -880,7 +882,7 @@ mod tests {
 
     impl SwarmSpec for Shallow {
         const NETWORK_ID: NetworkId = NetworkId::TESTNET;
-        const MIN_BUCKET_DEPTH: u8 = 1;
+        const MIN_BUCKET_DEPTH: NonZeroU8 = NonZeroU8::new(1).unwrap();
     }
 
     /// A bucket depth `Shallow` accepts but mainnet does not.

--- a/crates/postage-usage/src/codec.rs
+++ b/crates/postage-usage/src/codec.rs
@@ -7,11 +7,12 @@ use alloc::vec::Vec;
 
 use alloy_primitives::{B256, keccak256};
 use bytes::Bytes;
-use nectar_postage::BatchId;
+use nectar_postage::{BatchId, BucketDepth};
 use nectar_primitives::wire::{Cursor, FromCursor, ToWriter, Underrun, Writer};
+use nectar_primitives::{Mainnet, SwarmSpec};
 
-use crate::snapshot::Snapshot;
-use crate::table::{Mutability, UsageTable, validate_geometry};
+use crate::snapshot::SnapshotFor;
+use crate::table::{Mutability, UsageTableFor, checked_bucket_depth};
 use crate::{
     MAGIC, MAX_EXCEPTIONS, MAX_PAYLOAD_SIZE, MAX_WIDTH, ROOT_HEADER_SIZE, Result, UsageError,
 };
@@ -46,11 +47,15 @@ enum LeafSection {
 }
 
 /// A parsed root payload, ready to be assembled with its leaf payloads.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct RootInfo {
+///
+/// The network is a type parameter: the geometry on the wire is a bare depth
+/// byte, and parsing it as a snapshot of `S` is what re-establishes the
+/// [`BucketDepth`] proof. [`RootInfo`] is the mainnet root.
+#[derive(Debug)]
+pub struct RootInfoFor<S: SwarmSpec = Mainnet> {
     batch_id: BatchId,
     depth: u8,
-    bucket_depth: u8,
+    bucket_depth: BucketDepth<S>,
     mutable: bool,
     width: u8,
     sequence: u64,
@@ -60,6 +65,49 @@ pub struct RootInfo {
     slots: Vec<u32>,
     leaves: LeafSection,
 }
+
+/// The [`RootInfoFor`] of the mainnet spec.
+pub type RootInfo = RootInfoFor<Mainnet>;
+
+// The spec is a type-level tag, so the impls below carry no bound on `S` beyond
+// `SwarmSpec`; deriving would demand `S: Clone` and `S: Eq` of a marker type
+// that holds no data.
+
+impl<S: SwarmSpec> Clone for RootInfoFor<S> {
+    fn clone(&self) -> Self {
+        Self {
+            batch_id: self.batch_id,
+            depth: self.depth,
+            bucket_depth: self.bucket_depth,
+            mutable: self.mutable,
+            width: self.width,
+            sequence: self.sequence,
+            total_issued: self.total_issued,
+            base: self.base,
+            exceptions: self.exceptions.clone(),
+            slots: self.slots.clone(),
+            leaves: self.leaves.clone(),
+        }
+    }
+}
+
+impl<S: SwarmSpec> PartialEq for RootInfoFor<S> {
+    fn eq(&self, other: &Self) -> bool {
+        self.batch_id == other.batch_id
+            && self.depth == other.depth
+            && self.bucket_depth == other.bucket_depth
+            && self.mutable == other.mutable
+            && self.width == other.width
+            && self.sequence == other.sequence
+            && self.total_issued == other.total_issued
+            && self.base == other.base
+            && self.exceptions == other.exceptions
+            && self.slots == other.slots
+            && self.leaves == other.leaves
+    }
+}
+
+impl<S: SwarmSpec> Eq for RootInfoFor<S> {}
 
 /// The fixed root header, stated once in wire order. Multi-byte fields are
 /// big-endian; `README.md` gives the full layout.
@@ -365,7 +413,11 @@ fn select_width(counts: &[u32], base: u32, buckets: usize, allocated: usize) -> 
 // `width <= 32`, `exceptions <= MAX_EXCEPTIONS`, `allocated` at most the
 // chunk count), so every saturating operation below is exact.
 #[must_use = "the encoded payloads are the snapshot to publish; dropping them discards the encode"]
-pub(crate) fn encode(table: &UsageTable, sequence: u64, slots: &[u32]) -> Result<Encoded> {
+pub(crate) fn encode<S: SwarmSpec>(
+    table: &UsageTableFor<S>,
+    sequence: u64,
+    slots: &[u32],
+) -> Result<Encoded> {
     if slots.is_empty() {
         return Err(UsageError::Malformed("root slot not allocated"));
     }
@@ -427,7 +479,7 @@ pub(crate) fn encode(table: &UsageTable, sequence: u64, slots: &[u32]) -> Result
         magic: MAGIC,
         batch_id: table.batch_id(),
         depth: table.depth(),
-        bucket_depth: table.bucket_depth(),
+        bucket_depth: table.bucket_depth().get(),
         flags: if table.is_mutable() { 1 } else { 0 },
         width,
         sequence,
@@ -457,7 +509,7 @@ pub(crate) fn encode(table: &UsageTable, sequence: u64, slots: &[u32]) -> Result
     })
 }
 
-impl RootInfo {
+impl<S: SwarmSpec> RootInfoFor<S> {
     /// Parses and structurally validates a root payload.
     ///
     /// Untrusted input: every byte access goes through [`Cursor`], and the
@@ -478,7 +530,7 @@ impl RootInfo {
         if header.magic != MAGIC {
             return Err(UsageError::BadMagic);
         }
-        validate_geometry(header.depth, header.bucket_depth)
+        let bucket_depth = checked_bucket_depth::<S>(header.depth, header.bucket_depth)
             .map_err(UsageError::into_corruption)?;
         // Only bit 0 (mutable) is defined; any other bit set is rejected so a
         // future flag is never silently ignored by an older reader.
@@ -582,7 +634,7 @@ impl RootInfo {
         Ok(Self {
             batch_id: header.batch_id,
             depth: header.depth,
-            bucket_depth: header.bucket_depth,
+            bucket_depth,
             mutable,
             width,
             sequence: header.sequence,
@@ -610,7 +662,7 @@ impl RootInfo {
     }
 
     /// Returns the bucket depth.
-    pub const fn bucket_depth(&self) -> u8 {
+    pub const fn bucket_depth(&self) -> BucketDepth<S> {
         self.bucket_depth
     }
 
@@ -654,7 +706,7 @@ impl RootInfo {
         if usize::from(leaf) >= usize::from(self.leaf_count()) {
             return None;
         }
-        let buckets = 1usize << self.bucket_depth;
+        let buckets = 1usize << self.bucket_depth.get();
         let per_leaf = buckets_per_leaf(self.width);
         let start = usize::from(leaf) * per_leaf;
         let end = (start + per_leaf).min(buckets);
@@ -675,9 +727,9 @@ impl RootInfo {
     // `buckets <= 2^16` and `width <= 32`.
     #[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)]
     #[must_use = "the reassembled snapshot is the recovered state; dropping it discards the assemble"]
-    pub fn assemble<L: AsRef<[u8]>>(self, leaves: &[L]) -> Result<Snapshot> {
-        let buckets = 1usize << self.bucket_depth;
-        let capacity = 1u32 << (self.depth - self.bucket_depth);
+    pub fn assemble<L: AsRef<[u8]>>(self, leaves: &[L]) -> Result<SnapshotFor<S>> {
+        let buckets = 1usize << self.bucket_depth.get();
+        let capacity = 1u32 << (self.depth - self.bucket_depth.get());
         let width = self.width;
 
         let mut counts = vec![0u32; buckets];
@@ -798,7 +850,7 @@ impl RootInfo {
         // their corruption counterparts: reached from the decode path, they mean
         // the fetched bytes are bad, not a caller input that can be adjusted. A
         // direct `Snapshot::from_parts` caller still gets the caller-input variant.
-        let table = UsageTable::from_counts(
+        let table = UsageTableFor::from_counts(
             self.batch_id,
             self.depth,
             self.bucket_depth,
@@ -806,15 +858,40 @@ impl RootInfo {
             mutability,
         )
         .map_err(UsageError::into_corruption)?;
-        let parts = Snapshot::recovered_parts(table, self.sequence, self.slots)
+        let parts = SnapshotFor::recovered_parts(table, self.sequence, self.slots)
             .map_err(UsageError::into_corruption)?;
-        Snapshot::from_parts(parts).map_err(UsageError::into_corruption)
+        SnapshotFor::from_parts(parts).map_err(UsageError::into_corruption)
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use nectar_primitives::NetworkId;
+
     use super::*;
+    use crate::UsageTable;
+
+    /// A deployment whose bucket-depth floor is the format minimum. Mainnet
+    /// sets its floor at 16, which the format also caps, so a mainnet snapshot
+    /// has exactly 2^16 buckets; the fixtures below exercise the smaller
+    /// geometries the format supports for a network that allows them.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct Shallow;
+
+    impl SwarmSpec for Shallow {
+        const NETWORK_ID: NetworkId = NetworkId::TESTNET;
+        const MIN_BUCKET_DEPTH: u8 = 1;
+    }
+
+    /// A bucket depth `Shallow` accepts but mainnet does not.
+    fn shallow(depth: u8) -> BucketDepth<Shallow> {
+        BucketDepth::new(depth).unwrap()
+    }
+
+    /// The mainnet bucket depth, the only one mainnet and the format agree on.
+    fn mainnet() -> BucketDepth {
+        BucketDepth::new(16).unwrap()
+    }
 
     /// Reads a big-endian u32 at `offset`, for fixture verification.
     fn read_u32(buf: &[u8], offset: usize) -> u32 {
@@ -863,8 +940,13 @@ mod tests {
         // Encoding with no allocated slot has no root slot to serialize, so the
         // codec refuses it. The public path reaches encoding only through
         // `plan_persist`, which always allocates the root first.
-        let table =
-            UsageTable::new(BatchId::new([0x42; 32]), 20, 16, Mutability::Immutable).unwrap();
+        let table = UsageTable::new(
+            BatchId::new([0x42; 32]),
+            20,
+            mainnet(),
+            Mutability::Immutable,
+        )
+        .unwrap();
         assert_eq!(
             encode(&table, 0, &[]),
             Err(UsageError::Malformed("root slot not allocated")),
@@ -874,7 +956,8 @@ mod tests {
     #[test]
     fn flags_bit0_is_mutable_other_bits_rejected() {
         // Build a minimal valid mutable root: width 0, one slot, no exceptions.
-        let table = UsageTable::new(BatchId::new([0x42; 32]), 20, 16, Mutability::Mutable).unwrap();
+        let table =
+            UsageTable::new(BatchId::new([0x42; 32]), 20, mainnet(), Mutability::Mutable).unwrap();
         let encoded = encode(&table, 1, &[0]).unwrap();
         let mut root = encoded.root.to_vec();
         assert_eq!(root[38], 0x01, "mutable flag must be set");
@@ -907,10 +990,10 @@ mod tests {
         // A single full bucket becomes the lone exception; the rest stay at the
         // base so the encoder packs nothing inline.
         counts[5] = 16;
-        let table = UsageTable::from_counts(
+        let table = UsageTableFor::from_counts(
             BatchId::new([0x42; 32]),
             12,
-            8,
+            shallow(8),
             counts,
             Mutability::Immutable,
         )
@@ -930,7 +1013,7 @@ mod tests {
         let mut root = root_with_one_exception();
         // Push the exception bucket index past the 256-bucket range.
         root[ROOT_HEADER_SIZE..ROOT_HEADER_SIZE + 4].copy_from_slice(&300u32.to_be_bytes());
-        let err = RootInfo::parse(&root).unwrap_err();
+        let err = RootInfoFor::<Shallow>::parse(&root).unwrap_err();
         assert_eq!(err, UsageError::CorruptBucket { bucket: 300 });
         assert!(err.is_corruption());
         assert!(!err.is_recoverable());
@@ -941,7 +1024,7 @@ mod tests {
         let mut root = root_with_one_exception();
         // Push the exception counter past the per-bucket capacity of 16.
         root[ROOT_HEADER_SIZE + 4..ROOT_HEADER_SIZE + 8].copy_from_slice(&17u32.to_be_bytes());
-        let err = RootInfo::parse(&root).unwrap_err();
+        let err = RootInfoFor::<Shallow>::parse(&root).unwrap_err();
         assert_eq!(
             err,
             UsageError::CorruptCounter {
@@ -961,7 +1044,7 @@ mod tests {
         // bucket-depth byte (here past the supported maximum) is decode
         // corruption, not a caller-input error.
         root[37] = 17;
-        let err = RootInfo::parse(&root).unwrap_err();
+        let err = RootInfoFor::<Shallow>::parse(&root).unwrap_err();
         assert_eq!(
             err,
             UsageError::CorruptGeometry {
@@ -991,7 +1074,7 @@ mod tests {
         root[60..62].copy_from_slice(&1u16.to_be_bytes()); // allocated = 1
         // exceptions = 0, leaves = 0, base = 0, slot 0 already zeroed.
 
-        let err = RootInfo::parse(&root).unwrap_err();
+        let err = RootInfoFor::<Shallow>::parse(&root).unwrap_err();
         assert_eq!(
             err,
             UsageError::CorruptGeometry {
@@ -1008,7 +1091,7 @@ mod tests {
         let mut root = root_with_one_exception();
         // Push the allocated slot to the capacity bound (valid slots are < 16).
         root[ROOT_HEADER_SIZE + 8..ROOT_HEADER_SIZE + 12].copy_from_slice(&16u32.to_be_bytes());
-        let err = RootInfo::parse(&root).unwrap_err();
+        let err = RootInfoFor::<Shallow>::parse(&root).unwrap_err();
         assert_eq!(
             err,
             UsageError::CorruptSlot {
@@ -1025,17 +1108,19 @@ mod tests {
         // A table whose deltas span 0..16 packs inline at width 5 (no
         // exceptions): every count is within the capacity of 16.
         let counts: Vec<u32> = (0..256u32).map(|b| b % 17).collect();
-        let table = UsageTable::from_counts(
+        let table = UsageTableFor::from_counts(
             BatchId::new([0x42; 32]),
             12,
-            8,
+            shallow(8),
             counts,
             Mutability::Immutable,
         )
         .unwrap();
         let mut corrupt = encode(&table, 1, &[4]).unwrap().root.to_vec();
         assert_eq!(
-            RootInfo::parse(&corrupt).unwrap().leaf_count(),
+            RootInfoFor::<Shallow>::parse(&corrupt)
+                .unwrap()
+                .leaf_count(),
             0,
             "this geometry inlines the deltas"
         );
@@ -1046,7 +1131,7 @@ mod tests {
         let packed_start = ROOT_HEADER_SIZE + 4;
         corrupt[packed_start] |= 0b1111_1000;
 
-        let info = RootInfo::parse(&corrupt).unwrap();
+        let info = RootInfoFor::<Shallow>::parse(&corrupt).unwrap();
         let err = info.assemble::<&[u8]>(&[]).unwrap_err();
         assert_eq!(
             err,
@@ -1067,10 +1152,10 @@ mod tests {
         // caller can fix the counts it passed.
         let mut counts = vec![0u32; 256];
         counts[5] = 17; // capacity is 16
-        let err = UsageTable::from_counts(
+        let err = UsageTableFor::from_counts(
             BatchId::new([0x42; 32]),
             12,
-            8,
+            shallow(8),
             counts,
             Mutability::Immutable,
         )
@@ -1137,13 +1222,15 @@ mod tests {
     /// is pinned on stable without running the fuzzer. A persist may
     /// legitimately refuse to allocate a snapshot slot (a full immutable
     /// bucket, an exhausted capacity-1 ring), so those iterations are
-    /// skipped, but most generated snapshots must round-trip.
+    /// skipped, but most generated snapshots must round-trip. The generator
+    /// runs at `Shallow` so it spans the format's whole bucket-depth range
+    /// rather than the single geometry mainnet's floor admits.
     #[test]
     fn arbitrary_snapshot_persist_parse_assemble_round_trip() {
         use alloy_primitives::Address;
         use arbitrary::{Arbitrary, Unstructured};
 
-        use crate::{PublishedSequence, Snapshot};
+        use crate::{PublishedSequence, SnapshotFor};
 
         // Deterministic pseudo-random bytes (Knuth multiplicative hash).
         let raw: Vec<u8> = (0u32..8192)
@@ -1155,7 +1242,7 @@ mod tests {
 
         let mut round_trips = 0usize;
         for _ in 0..32 {
-            let mut snapshot = Snapshot::arbitrary(&mut u).unwrap();
+            let mut snapshot = SnapshotFor::<Shallow>::arbitrary(&mut u).unwrap();
             let plan = match snapshot
                 .revalidate(PublishedSequence::NONE)
                 .unwrap()
@@ -1165,7 +1252,8 @@ mod tests {
                 // A full bucket can legitimately refuse a snapshot slot.
                 Err(_) => continue,
             };
-            let root = RootInfo::parse(&plan.chunks[0].payload).expect("planned root must parse");
+            let root = RootInfoFor::<Shallow>::parse(&plan.chunks[0].payload)
+                .expect("planned root must parse");
             let leaves: Vec<_> = plan.chunks[1..]
                 .iter()
                 .map(|c| c.payload.as_ref())

--- a/crates/postage-usage/src/issuer.rs
+++ b/crates/postage-usage/src/issuer.rs
@@ -4,9 +4,9 @@
 use alloy_primitives::Address;
 use nectar_postage::{BatchId, StampDigest, StampError};
 use nectar_postage_issuer::StampIssuer;
-use nectar_primitives::ChunkAddress;
+use nectar_primitives::{ChunkAddress, Mainnet, SwarmSpec};
 
-use crate::Snapshot;
+use crate::SnapshotFor;
 use crate::error::UsageError;
 
 /// Maps a usage table error onto a stamp issuer error.
@@ -25,31 +25,46 @@ const fn map_usage_error(err: UsageError) -> StampError {
 /// slots so it never evicts the batch-state chunks. It owns the snapshot by
 /// value to drop into `BatchStamper::new`; recover it with
 /// [`into_snapshot`](Self::into_snapshot).
-#[derive(Debug, Clone)]
-pub struct SnapshotIssuer {
-    snapshot: Snapshot,
+#[derive(Debug)]
+pub struct SnapshotIssuerFor<S: SwarmSpec = Mainnet> {
+    snapshot: SnapshotFor<S>,
     owner: Address,
 }
 
-impl SnapshotIssuer {
+/// The [`SnapshotIssuerFor`] of the mainnet spec.
+pub type SnapshotIssuer = SnapshotIssuerFor<Mainnet>;
+
+// The spec is a type-level tag, so this carries no bound on `S` beyond
+// `SwarmSpec`; deriving would demand `S: Clone` of a marker type that holds no
+// data.
+impl<S: SwarmSpec> Clone for SnapshotIssuerFor<S> {
+    fn clone(&self) -> Self {
+        Self {
+            snapshot: self.snapshot.clone(),
+            owner: self.owner,
+        }
+    }
+}
+
+impl<S: SwarmSpec> SnapshotIssuerFor<S> {
     /// Wraps a snapshot and the batch owner address.
-    pub const fn new(snapshot: Snapshot, owner: Address) -> Self {
+    pub const fn new(snapshot: SnapshotFor<S>, owner: Address) -> Self {
         Self { snapshot, owner }
     }
 
     /// Returns a reference to the wrapped snapshot.
-    pub const fn snapshot(&self) -> &Snapshot {
+    pub const fn snapshot(&self) -> &SnapshotFor<S> {
         &self.snapshot
     }
 
     /// Returns a mutable reference to the wrapped snapshot, for example to plan
     /// a persist between batches of content stamping.
-    pub const fn snapshot_mut(&mut self) -> &mut Snapshot {
+    pub const fn snapshot_mut(&mut self) -> &mut SnapshotFor<S> {
         &mut self.snapshot
     }
 
     /// Consumes the adapter and returns the wrapped snapshot.
-    pub fn into_snapshot(self) -> Snapshot {
+    pub fn into_snapshot(self) -> SnapshotFor<S> {
         self.snapshot
     }
 
@@ -59,7 +74,7 @@ impl SnapshotIssuer {
     }
 }
 
-impl StampIssuer for SnapshotIssuer {
+impl<S: SwarmSpec> StampIssuer for SnapshotIssuerFor<S> {
     fn prepare_stamp(
         &mut self,
         address: &ChunkAddress,
@@ -86,7 +101,7 @@ impl StampIssuer for SnapshotIssuer {
     }
 
     fn bucket_depth(&self) -> u8 {
-        self.snapshot.table_ref().bucket_depth()
+        self.snapshot.table_ref().bucket_depth().get()
     }
 
     fn max_bucket_utilization(&self) -> u32 {

--- a/crates/postage-usage/src/lib.rs
+++ b/crates/postage-usage/src/lib.rs
@@ -145,7 +145,7 @@ pub use nectar_primitives::{ChunkAddress, SocId};
 /// Postage types re-exported so a downstream caller naming
 /// [`PlannedChunk::stamp_index`] or calling [`UsageTable::from_batch`] does not
 /// need a direct `nectar-postage` dependency.
-pub use nectar_postage::{Batch, BatchId, StampIndex};
+pub use nectar_postage::{Batch, BatchId, BucketDepth, StampIndex};
 
 use alloy_primitives::{Address, Keccak256};
 

--- a/crates/postage-usage/src/lib.rs
+++ b/crates/postage-usage/src/lib.rs
@@ -27,7 +27,8 @@
 //! ```
 //! use alloy_primitives::{Address, B256};
 //! use nectar_postage_usage::{
-//!     BatchId, Mutability, PublishedSequence, RootInfo, Snapshot, ChunkAddress, UsageTable,
+//!     BatchId, BucketDepth, ChunkAddress, Mutability, PublishedSequence, RootInfo, Snapshot,
+//!     UsageTable,
 //! };
 //!
 //! let batch_id = BatchId::new([0x42; 32]);
@@ -35,7 +36,8 @@
 //!
 //! // Issue a stamp for an uploaded chunk through the snapshot's issuing handle,
 //! // then plan a persist.
-//! let table = UsageTable::new(batch_id, 20, 16, Mutability::Immutable).unwrap();
+//! let table =
+//!     UsageTable::new(batch_id, 20, BucketDepth::new(16).unwrap(), Mutability::Immutable).unwrap();
 //! let mut snapshot = Snapshot::new(table);
 //! let address = ChunkAddress::from(B256::repeat_byte(0x99));
 //! snapshot.issuer(owner).record_address(&address).unwrap();
@@ -54,6 +56,21 @@
 //! let recovered = root.assemble(&leaves).unwrap();
 //! assert_eq!(recovered, snapshot);
 //! ```
+//!
+//! # Networks
+//!
+//! A snapshot is parameterized by the [`SwarmSpec`] of the batch it describes,
+//! and carries it in the [`BucketDepth`] its table was built from. The generic
+//! type takes the `...For` name ([`UsageTableFor`], [`SnapshotFor`],
+//! [`RootInfoFor`] and friends) and the bare name is the mainnet alias, so
+//! ordinary call sites need no type annotation. The floor is load-bearing on
+//! the wire too: [`RootInfo::parse`] rebuilds the bucket depth for the network
+//! asked of it, so a root whose geometry that network would never issue is
+//! refused as corrupt.
+//!
+//! The snapshot format supports bucket depths 1 to 16 and mainnet's floor is
+//! 16, so a mainnet snapshot always has exactly 2^16 buckets; the smaller
+//! geometries belong to deployments with a lower floor.
 //!
 //! # Recovery
 //!
@@ -124,23 +141,24 @@ mod issuer;
 #[cfg(feature = "seal")]
 mod seal;
 
-pub use codec::RootInfo;
+pub use codec::{RootInfo, RootInfoFor};
 pub use error::UsageError;
 pub use snapshot::{
-    Issuer, PersistPlan, PlannedChunk, PublishedSequence, Snapshot, SnapshotParts, Validated,
+    Issuer, IssuerFor, PersistPlan, PlannedChunk, PublishedSequence, Snapshot, SnapshotFor,
+    SnapshotParts, SnapshotPartsFor, Validated, ValidatedFor,
 };
-pub use table::{Mutability, TableView, UsageTable};
+pub use table::{Mutability, TableView, TableViewFor, UsageTable, UsageTableFor};
 
 #[cfg(feature = "issuer")]
-pub use issuer::SnapshotIssuer;
+pub use issuer::{SnapshotIssuer, SnapshotIssuerFor};
 
 #[cfg(feature = "seal")]
 pub use seal::{SealError, SealedChunk, seal_plan};
 
 #[cfg(feature = "client")]
-pub use client::{BatchStamper, ClientError, SnapshotSink, SnapshotSource};
+pub use client::{BatchStamper, BatchStamperFor, ClientError, SnapshotSink, SnapshotSource};
 
-pub use nectar_primitives::{ChunkAddress, SocId};
+pub use nectar_primitives::{ChunkAddress, Mainnet, NetworkId, SocId, SwarmSpec, Testnet};
 
 /// Postage types re-exported so a downstream caller naming
 /// [`PlannedChunk::stamp_index`] or calling [`UsageTable::from_batch`] does not

--- a/crates/postage-usage/src/seal.rs
+++ b/crates/postage-usage/src/seal.rs
@@ -4,10 +4,10 @@ use alloc::vec::Vec;
 
 use alloy_signer::SignerSync;
 use nectar_postage::{Stamp, StampDigest};
-use nectar_primitives::{ChunkOps, SingleOwnerChunk};
+use nectar_primitives::{ChunkOps, SingleOwnerChunk, SwarmSpec};
 use thiserror::Error;
 
-use crate::snapshot::{PersistPlan, Snapshot};
+use crate::snapshot::{PersistPlan, SnapshotFor};
 
 /// Errors produced while sealing a persist plan.
 #[non_exhaustive]
@@ -66,8 +66,8 @@ pub struct SealedChunk {
 /// holds across the whole persist/seal cycle without caller bookkeeping. `plan`
 /// must have been planned from `snapshot`.
 #[must_use = "the sealed chunks are the snapshot to upload; dropping them discards the seal"]
-pub fn seal_plan(
-    snapshot: &mut Snapshot,
+pub fn seal_plan<S: SwarmSpec>(
+    snapshot: &mut SnapshotFor<S>,
     plan: &PersistPlan,
     timestamp: u64,
     signer: &impl SignerSync,

--- a/crates/postage-usage/src/snapshot.rs
+++ b/crates/postage-usage/src/snapshot.rs
@@ -6,10 +6,10 @@ use alloc::vec::Vec;
 use alloy_primitives::Address;
 use bytes::Bytes;
 use nectar_postage::{Batch, BatchId, StampIndex, calculate_bucket};
-use nectar_primitives::{ChunkAddress, SocId};
+use nectar_primitives::{ChunkAddress, Mainnet, SocId, SwarmSpec};
 
-use crate::codec::{self, Encoded, RootInfo};
-use crate::table::{TableView, UsageTable};
+use crate::codec::{self, Encoded, RootInfoFor};
+use crate::table::{TableViewFor, UsageTableFor};
 use crate::{Result, UsageError, usage_chunk_address, usage_chunk_id};
 
 /// The published persist sequence at a snapshot's root chunk address, the floor
@@ -45,8 +45,8 @@ impl PublishedSequence {
     }
 }
 
-impl From<&RootInfo> for PublishedSequence {
-    fn from(r: &RootInfo) -> Self {
+impl<S: SwarmSpec> From<&RootInfoFor<S>> for PublishedSequence {
+    fn from(r: &RootInfoFor<S>) -> Self {
         Self(r.sequence())
     }
 }
@@ -54,9 +54,9 @@ impl From<&RootInfo> for PublishedSequence {
 /// A [`UsageTable`] together with the state needed to persist it inside its
 /// own batch: a monotone sequence number and the within-bucket slots
 /// allocated to the snapshot chunks themselves.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Snapshot {
-    table: UsageTable,
+#[derive(Debug)]
+pub struct SnapshotFor<S: SwarmSpec = Mainnet> {
+    table: UsageTableFor<S>,
     sequence: u64,
     slots: Vec<u32>,
     /// The counter sum ([`UsageTable::total_issued`]) captured at the last
@@ -76,6 +76,41 @@ pub struct Snapshot {
     #[cfg(feature = "seal")]
     last_seal_timestamp: Option<u64>,
 }
+
+/// The [`SnapshotFor`] of the mainnet spec.
+pub type Snapshot = SnapshotFor<Mainnet>;
+
+// The spec is a type-level tag, so the impls below (here and on
+// [`SnapshotParts`]) carry no bound on `S` beyond `SwarmSpec`; deriving would
+// demand `S: Clone` and `S: Eq` of a marker type that holds no data, and
+// [`Validated::plan_persist`] clones a snapshot generically.
+
+impl<S: SwarmSpec> Clone for SnapshotFor<S> {
+    fn clone(&self) -> Self {
+        Self {
+            table: self.table.clone(),
+            sequence: self.sequence,
+            slots: self.slots.clone(),
+            issued_at_persist: self.issued_at_persist,
+            #[cfg(feature = "seal")]
+            last_seal_timestamp: self.last_seal_timestamp,
+        }
+    }
+}
+
+impl<S: SwarmSpec> PartialEq for SnapshotFor<S> {
+    fn eq(&self, other: &Self) -> bool {
+        let equal = self.table == other.table
+            && self.sequence == other.sequence
+            && self.slots == other.slots
+            && self.issued_at_persist == other.issued_at_persist;
+        #[cfg(feature = "seal")]
+        let equal = equal && self.last_seal_timestamp == other.last_seal_timestamp;
+        equal
+    }
+}
+
+impl<S: SwarmSpec> Eq for SnapshotFor<S> {}
 
 /// One chunk of a persist plan: the payload to publish and the slot to
 /// stamp it with.
@@ -117,23 +152,44 @@ pub struct PlannedChunk {
 /// The accessors are read-only and for inspection only (logging a recovered
 /// sequence, say); rebuilding a usable snapshot goes through
 /// [`from_parts`](Snapshot::from_parts).
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 #[must_use = "dropping the parts discards the recovered sequence and slots; rebuild with Snapshot::from_parts"]
-pub struct SnapshotParts {
-    table: UsageTable,
+pub struct SnapshotPartsFor<S: SwarmSpec = Mainnet> {
+    table: UsageTableFor<S>,
     sequence: u64,
     slots: Vec<u32>,
 }
 
-impl SnapshotParts {
+/// The [`SnapshotPartsFor`] of the mainnet spec.
+pub type SnapshotParts = SnapshotPartsFor<Mainnet>;
+
+impl<S: SwarmSpec> Clone for SnapshotPartsFor<S> {
+    fn clone(&self) -> Self {
+        Self {
+            table: self.table.clone(),
+            sequence: self.sequence,
+            slots: self.slots.clone(),
+        }
+    }
+}
+
+impl<S: SwarmSpec> PartialEq for SnapshotPartsFor<S> {
+    fn eq(&self, other: &Self) -> bool {
+        self.table == other.table && self.sequence == other.sequence && self.slots == other.slots
+    }
+}
+
+impl<S: SwarmSpec> Eq for SnapshotPartsFor<S> {}
+
+impl<S: SwarmSpec> SnapshotPartsFor<S> {
     /// Returns a borrowed, read-only [`TableView`] onto the inert usage table.
     ///
     /// There is deliberately no owned-table accessor, and the view is neither
     /// [`Clone`]-to-owned nor a [`Deref`](core::ops::Deref) to the table: an owned
     /// bare table could be passed to [`Snapshot::new`] and reset to sequence 0, so
     /// `parts.table().clone()` must not yield one.
-    pub const fn table(&self) -> TableView<'_> {
-        TableView::new(&self.table)
+    pub const fn table(&self) -> TableViewFor<'_, S> {
+        TableViewFor::new(&self.table)
     }
 
     /// Returns the persist sequence carried by these parts.
@@ -169,7 +225,7 @@ pub struct PersistPlan {
     pub previous_timestamp: Option<u64>,
 }
 
-impl Snapshot {
+impl<S: SwarmSpec> SnapshotFor<S> {
     /// Wraps a table that has never been persisted, starting a fresh persist
     /// history at sequence 0 with no allocated slots.
     ///
@@ -195,7 +251,7 @@ impl Snapshot {
     /// *published* sequence needs a compare-and-swap against the live root chunk.
     /// Both are enforced by [`Snapshot::revalidate`]'s [`PublishedSequence`]
     /// floor.
-    pub const fn new(table: UsageTable) -> Self {
+    pub const fn new(table: UsageTableFor<S>) -> Self {
         Self {
             table,
             sequence: 0,
@@ -216,14 +272,14 @@ impl Snapshot {
     /// this is correct *only* for a genuinely new batch and starts the persist
     /// history at sequence 0 with no allocated slots; recovered or extracted state
     /// round-trips through [`from_parts`](Self::from_parts) instead.
-    pub fn from_batch(batch: &Batch) -> Result<Self> {
-        Ok(Self::new(UsageTable::from_batch(batch)?))
+    pub fn from_batch(batch: &Batch<S>) -> Result<Self> {
+        Ok(Self::new(UsageTableFor::from_batch(batch)?))
     }
 
     /// Validates the slots of a table/sequence/slots triple against the table
     /// geometry, the shared check behind [`from_parts`](Self::from_parts) and
     /// the codec's recovery path.
-    pub(crate) fn validate_parts(table: &UsageTable, slots: &[u32]) -> Result<()> {
+    pub(crate) fn validate_parts(table: &UsageTableFor<S>, slots: &[u32]) -> Result<()> {
         let capacity = table.bucket_capacity();
         if slots.len() > usize::from(u16::MAX) {
             return Err(UsageError::Malformed("too many allocated chunks"));
@@ -239,12 +295,12 @@ impl Snapshot {
     /// recovery through [`RootInfo::assemble`](crate::RootInfo::assemble), which
     /// flows through here, or through [`into_parts`](Self::into_parts).
     pub(crate) fn recovered_parts(
-        table: UsageTable,
+        table: UsageTableFor<S>,
         sequence: u64,
         slots: Vec<u32>,
-    ) -> Result<SnapshotParts> {
+    ) -> Result<SnapshotPartsFor<S>> {
         Self::validate_parts(&table, &slots)?;
-        Ok(SnapshotParts {
+        Ok(SnapshotPartsFor {
             table,
             sequence,
             slots,
@@ -263,8 +319,8 @@ impl Snapshot {
     /// automatically the moment you obtain an [`Issuer`] through
     /// [`issuer`](Self::issuer), which is the only way to advance a counter.
     /// Immutable batches issue without reserved state.
-    pub fn from_parts(parts: SnapshotParts) -> Result<Self> {
-        let SnapshotParts {
+    pub fn from_parts(parts: SnapshotPartsFor<S>) -> Result<Self> {
+        let SnapshotPartsFor {
             table,
             sequence,
             slots,
@@ -295,8 +351,8 @@ impl Snapshot {
     /// another borrowed view, never an owned table that [`new`](Self::new) would
     /// accept at sequence 0. This closes the in-memory clone route that would
     /// otherwise downgrade a recovered snapshot.
-    pub const fn table(&self) -> TableView<'_> {
-        TableView::new(&self.table)
+    pub const fn table(&self) -> TableViewFor<'_, S> {
+        TableViewFor::new(&self.table)
     }
 
     /// Returns the inner [`UsageTable`] by reference, for crate-internal callers
@@ -304,7 +360,7 @@ impl Snapshot {
     /// Never exposed publicly: a public `&UsageTable` would let
     /// `snapshot.table().clone()` reproduce an owned table for
     /// [`new`](Self::new).
-    pub(crate) const fn table_ref(&self) -> &UsageTable {
+    pub(crate) const fn table_ref(&self) -> &UsageTableFor<S> {
         &self.table
     }
 
@@ -321,7 +377,7 @@ impl Snapshot {
     /// Immutable only: rejects with [`MutableMerge`](UsageError::MutableMerge) if
     /// either table is mutable. The persistence state (sequence and slots) is
     /// untouched; only the counters and depth join.
-    pub fn merge_max(&mut self, other: &UsageTable) -> Result<()> {
+    pub fn merge_max(&mut self, other: &UsageTableFor<S>) -> Result<()> {
         self.table.merge_max(other)
     }
 
@@ -342,10 +398,10 @@ impl Snapshot {
     /// error:
     ///
     /// ```compile_fail
-    /// use alloy_primitives::B256;
-    /// use nectar_postage_usage::{Mutability, Snapshot, UsageTable};
+    /// use nectar_postage_usage::{BatchId, BucketDepth, Mutability, Snapshot, UsageTable};
     ///
-    /// let snapshot = Snapshot::new(UsageTable::new(B256::repeat_byte(0x42), 20, 16, Mutability::Immutable).unwrap());
+    /// let table = UsageTable::new(BatchId::new([0x42; 32]), 20, BucketDepth::new(16).unwrap(), Mutability::Immutable).unwrap();
+    /// let snapshot = Snapshot::new(table);
     /// // `into_table` no longer exists; only `into_parts` can consume a snapshot.
     /// let table = snapshot.into_table();
     /// ```
@@ -355,11 +411,12 @@ impl Snapshot {
     /// an owned table, so it cannot be moved into `Snapshot::new`:
     ///
     /// ```compile_fail
-    /// use alloy_primitives::{Address, B256};
-    /// use nectar_postage_usage::{Mutability, Snapshot, UsageTable};
+    /// use alloy_primitives::Address;
+    /// use nectar_postage_usage::{BatchId, BucketDepth, Mutability, Snapshot, UsageTable};
     ///
     /// let owner = Address::repeat_byte(0x11);
-    /// let snapshot = Snapshot::new(UsageTable::new(B256::repeat_byte(0x42), 20, 16, Mutability::Immutable).unwrap());
+    /// let table = UsageTable::new(BatchId::new([0x42; 32]), 20, BucketDepth::new(16).unwrap(), Mutability::Immutable).unwrap();
+    /// let snapshot = Snapshot::new(table);
     /// let parts = snapshot.into_parts();
     /// // The move/clone guard is what fails here: `parts.table` is private and
     /// // only a `TableView` is exposed, so `Snapshot::new(parts.table)` cannot
@@ -376,17 +433,17 @@ impl Snapshot {
     /// [`UsageTable`] for `Snapshot::new`:
     ///
     /// ```compile_fail
-    /// use alloy_primitives::B256;
-    /// use nectar_postage_usage::{Mutability, Snapshot, UsageTable};
+    /// use nectar_postage_usage::{BatchId, BucketDepth, Mutability, Snapshot, UsageTable};
     ///
-    /// let snapshot = Snapshot::new(UsageTable::new(B256::repeat_byte(0x42), 20, 16, Mutability::Immutable).unwrap());
+    /// let table = UsageTable::new(BatchId::new([0x42; 32]), 20, BucketDepth::new(16).unwrap(), Mutability::Immutable).unwrap();
+    /// let snapshot = Snapshot::new(table);
     /// // `table()` returns a `TableView`; cloning it yields another view, not a
     /// // `UsageTable`, so this does not type-check.
     /// let reset = Snapshot::new(snapshot.table().clone());
     /// ```
     #[must_use = "the parts carry the recovered sequence and slots; dropping them discards that state"]
-    pub fn into_parts(self) -> SnapshotParts {
-        SnapshotParts {
+    pub fn into_parts(self) -> SnapshotPartsFor<S> {
+        SnapshotPartsFor {
             table: self.table,
             sequence: self.sequence,
             slots: self.slots,
@@ -472,7 +529,7 @@ impl Snapshot {
     /// any write.
     pub fn reserved_stamp_indices(&self, owner: &Address) -> Vec<StampIndex> {
         let batch_id = self.table.batch_id();
-        let bucket_depth = self.table.bucket_depth();
+        let bucket_depth = self.table.bucket_depth().get();
         self.slots
             .iter()
             .enumerate()
@@ -550,9 +607,9 @@ impl Snapshot {
     /// sequence against a [`PublishedSequence`] floor and is the only route to a
     /// [`PersistPlan`], so a snapshot can issue but cannot persist without first
     /// clearing the floor.
-    pub fn issuer(&mut self, owner: Address) -> Issuer<'_> {
+    pub fn issuer(&mut self, owner: Address) -> IssuerFor<'_, S> {
         let reserved = self.reserved_slots(&owner);
-        Issuer {
+        IssuerFor {
             snapshot: self,
             owner,
             reserved,
@@ -576,8 +633,8 @@ impl Snapshot {
     /// bound to `owner`, so content stamping drops into a `BatchStamper` while
     /// persisting through the same table as snapshot allocation.
     #[cfg(feature = "issuer")]
-    pub const fn into_issuer(self, owner: Address) -> crate::SnapshotIssuer {
-        crate::SnapshotIssuer::new(self, owner)
+    pub const fn into_issuer(self, owner: Address) -> crate::SnapshotIssuerFor<S> {
+        crate::SnapshotIssuerFor::new(self, owner)
     }
 
     /// Encodes the snapshot with its current sequence number.
@@ -609,7 +666,7 @@ impl Snapshot {
     /// mutation. The floor is captured here, so keep the
     /// `revalidate` -> [`plan_persist`](Validated::plan_persist) window tight:
     /// the network floor may advance afterwards.
-    pub fn revalidate(&mut self, floor: PublishedSequence) -> Result<Validated<'_>> {
+    pub fn revalidate(&mut self, floor: PublishedSequence) -> Result<ValidatedFor<'_, S>> {
         let next = self
             .sequence
             .checked_add(1)
@@ -620,7 +677,7 @@ impl Snapshot {
                 floor: floor.get(),
             });
         }
-        Ok(Validated {
+        Ok(ValidatedFor {
             snapshot: self,
             floor: floor.get(),
         })
@@ -636,12 +693,15 @@ impl Snapshot {
 /// window tight, since the floor is captured at revalidate time and the network
 /// floor may advance afterwards.
 #[derive(Debug)]
-pub struct Validated<'s> {
-    snapshot: &'s mut Snapshot,
+pub struct ValidatedFor<'s, S: SwarmSpec = Mainnet> {
+    snapshot: &'s mut SnapshotFor<S>,
     floor: u64,
 }
 
-impl Validated<'_> {
+/// The [`ValidatedFor`] of the mainnet spec.
+pub type Validated<'s> = ValidatedFor<'s, Mainnet>;
+
+impl<S: SwarmSpec> ValidatedFor<'_, S> {
     /// Plans the next persist: bumps the sequence, allocates a slot for any
     /// snapshot chunk that lacks one (folding those stamps into the table), and
     /// encodes.
@@ -663,11 +723,11 @@ impl Validated<'_> {
     ///
     /// ```compile_fail
     /// # #![deny(unused_must_use)]
-    /// use alloy_primitives::{Address, B256};
-    /// use nectar_postage_usage::{Mutability, PublishedSequence, Snapshot, UsageTable};
+    /// use alloy_primitives::Address;
+    /// use nectar_postage_usage::{BatchId, BucketDepth, Mutability, PublishedSequence, Snapshot, UsageTable};
     ///
     /// let owner = Address::repeat_byte(0x11);
-    /// let table = UsageTable::new(B256::repeat_byte(0x42), 20, 16, Mutability::Immutable).unwrap();
+    /// let table = UsageTable::new(BatchId::new([0x42; 32]), 20, BucketDepth::new(16).unwrap(), Mutability::Immutable).unwrap();
     /// let mut snapshot = Snapshot::new(table);
     /// // Ignoring the plan is a compile error: the persist would be silently lost.
     /// snapshot.revalidate(PublishedSequence::NONE).unwrap().plan_persist(&owner);
@@ -695,7 +755,7 @@ impl Validated<'_> {
         }
 
         let batch_id = self.snapshot.table.batch_id();
-        let bucket_depth = self.snapshot.table.bucket_depth();
+        let bucket_depth = self.snapshot.table.bucket_depth().get();
         let previously_allocated = self.snapshot.slots.len();
         let previous_sequence = self.snapshot.sequence;
 
@@ -737,7 +797,7 @@ impl Validated<'_> {
             // carries the new sequence.
             work.sequence = sequence;
 
-            let allocate = |work: &mut Snapshot| -> Result<()> {
+            let allocate = |work: &mut SnapshotFor<S>| -> Result<()> {
                 // The allocation loop stops once the slots outnumber the
                 // leaves (at most the digests that fit a root chunk), far
                 // below u16::MAX.
@@ -831,15 +891,18 @@ impl Validated<'_> {
 /// that could wrap a mutable ring onto the snapshot's own chunks. It borrows the
 /// snapshot mutably, so persisting cannot run while issuance is live.
 #[derive(Debug)]
-pub struct Issuer<'s> {
-    snapshot: &'s mut Snapshot,
+pub struct IssuerFor<'s, S: SwarmSpec = Mainnet> {
+    snapshot: &'s mut SnapshotFor<S>,
     owner: Address,
     /// The `(bucket, index)` slots held by the snapshot's own chunks, installed
     /// at construction from the snapshot's allocated slots.
     reserved: BTreeSet<(u32, u32)>,
 }
 
-impl Issuer<'_> {
+/// The [`IssuerFor`] of the mainnet spec.
+pub type Issuer<'s> = IssuerFor<'s, Mainnet>;
+
+impl<S: SwarmSpec> IssuerFor<'_, S> {
     /// Assigns the next unused slot for a content chunk address and returns the
     /// resulting stamp index, skipping the snapshot's reserved slots.
     ///
@@ -868,7 +931,7 @@ impl Issuer<'_> {
         &mut self,
         address: &ChunkAddress,
     ) -> Result<(StampIndex, bool)> {
-        let bucket = calculate_bucket(address, self.snapshot.table.bucket_depth());
+        let bucket = calculate_bucket(address, self.snapshot.table.bucket_depth().get());
         // Decide before the write: afterwards the cursor has already advanced.
         let wrapped = self.will_wrap(bucket)?;
         let index = self.snapshot.record_bucket(bucket, &self.reserved)?;
@@ -959,12 +1022,14 @@ mod arbitrary_impls {
     use alloc::vec::Vec;
     use arbitrary::{Arbitrary, Result as ArbitraryResult, Unstructured};
 
-    use super::Snapshot;
-    use crate::UsageTable;
+    use nectar_primitives::SwarmSpec;
 
-    impl<'a> Arbitrary<'a> for Snapshot {
+    use super::SnapshotFor;
+    use crate::UsageTableFor;
+
+    impl<'a, S: SwarmSpec> Arbitrary<'a> for SnapshotFor<S> {
         fn arbitrary(u: &mut Unstructured<'a>) -> ArbitraryResult<Self> {
-            let table = UsageTable::arbitrary(u)?;
+            let table = UsageTableFor::<S>::arbitrary(u)?;
             // Leave headroom so revalidate/plan_persist can advance the
             // sequence without overflowing.
             let sequence = u.int_in_range(0..=u64::MAX - 1)?;

--- a/crates/postage-usage/src/table.rs
+++ b/crates/postage-usage/src/table.rs
@@ -2,8 +2,9 @@
 
 use alloc::vec::Vec;
 
-use nectar_postage::{Batch, BatchId};
-use nectar_postage_issuer::{CounterError, CounterMode, CounterTable};
+use nectar_postage::{Batch, BatchId, BucketDepth};
+use nectar_postage_issuer::{CounterError, CounterMode, CounterTableFor};
+use nectar_primitives::{Mainnet, SwarmSpec};
 
 use crate::{MAX_BUCKET_DEPTH, MAX_COUNTER_BITS, Result, UsageError};
 
@@ -58,6 +59,23 @@ pub(crate) const fn validate_geometry(depth: u8, bucket_depth: u8) -> Result<()>
     Ok(())
 }
 
+/// Validates a raw geometry against both the snapshot format and the network
+/// floor, yielding the proof-carrying bucket depth `S` accepts.
+///
+/// The wire carries a bare depth byte, so this is where a decoded geometry
+/// rejoins the type: a bucket depth the network would refuse never reaches a
+/// table.
+pub(crate) fn checked_bucket_depth<S: SwarmSpec>(
+    depth: u8,
+    bucket_depth: u8,
+) -> Result<BucketDepth<S>> {
+    validate_geometry(depth, bucket_depth)?;
+    BucketDepth::new(bucket_depth).map_err(|_| UsageError::InvalidGeometry {
+        depth,
+        bucket_depth,
+    })
+}
+
 /// Whether a usage table is an immutable fill watermark or a mutable ring.
 ///
 /// The fill-or-ring choice is a runtime flag, not a type parameter: the SBU1
@@ -80,7 +98,7 @@ impl Mutability {
     /// Picks the mutability from a batch: an immutable batch yields the fill
     /// watermark table, a mutable batch (`batch.immutable() == false`) yields the
     /// wrapping ring.
-    pub const fn from_batch(batch: &Batch) -> Self {
+    pub const fn from_batch<S: SwarmSpec>(batch: &Batch<S>) -> Self {
         if batch.immutable() {
             Self::Immutable
         } else {
@@ -129,32 +147,58 @@ impl Mutability {
 /// runtime check.
 ///
 /// ```compile_fail
-/// use nectar_postage_usage::{BatchId, Mutability, UsageTable};
+/// use nectar_postage_usage::{BatchId, BucketDepth, Mutability, UsageTable};
 ///
-/// let mut table = UsageTable::new(BatchId::new([0x42; 32]), 18, 16, Mutability::Mutable).unwrap();
+/// let bucket_depth = BucketDepth::new(16).unwrap();
+/// let mut table = UsageTable::new(BatchId::new([0x42; 32]), 18, bucket_depth, Mutability::Mutable).unwrap();
 /// // `record` no longer exists on the inert table.
 /// table.record(7).unwrap();
 /// ```
 ///
 /// ```compile_fail
 /// use alloy_primitives::B256;
-/// use nectar_postage_usage::{BatchId, Mutability, ChunkAddress, UsageTable};
+/// use nectar_postage_usage::{BatchId, BucketDepth, ChunkAddress, Mutability, UsageTable};
 ///
-/// let mut table = UsageTable::new(BatchId::new([0x42; 32]), 18, 16, Mutability::Mutable).unwrap();
+/// let bucket_depth = BucketDepth::new(16).unwrap();
+/// let mut table = UsageTable::new(BatchId::new([0x42; 32]), 18, bucket_depth, Mutability::Mutable).unwrap();
 /// // `record_address` no longer exists on the inert table.
 /// table.record_address(&ChunkAddress::from(B256::repeat_byte(0x99))).unwrap();
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct UsageTable {
+#[derive(Debug)]
+pub struct UsageTableFor<S: SwarmSpec = Mainnet> {
     pub(crate) batch_id: BatchId,
     /// The shared per-bucket counter table. It holds the counters, the issued
     /// sum, the geometry, and the fill-or-ring mode, in the same `[0, capacity]`
     /// representation the wire format serializes. The snapshot wraps this table
     /// rather than carrying its own copy of the counter logic.
-    pub(crate) counters: CounterTable,
+    pub(crate) counters: CounterTableFor<S>,
 }
 
-impl UsageTable {
+/// The [`UsageTableFor`] of the mainnet spec.
+pub type UsageTable = UsageTableFor<Mainnet>;
+
+// The spec is a type-level tag, so the impls below carry no bound on `S` beyond
+// `SwarmSpec`; deriving would demand `S: Clone` and `S: Eq` of a marker type
+// that holds no data.
+
+impl<S: SwarmSpec> Clone for UsageTableFor<S> {
+    fn clone(&self) -> Self {
+        Self {
+            batch_id: self.batch_id,
+            counters: self.counters.clone(),
+        }
+    }
+}
+
+impl<S: SwarmSpec> PartialEq for UsageTableFor<S> {
+    fn eq(&self, other: &Self) -> bool {
+        self.batch_id == other.batch_id && self.counters == other.counters
+    }
+}
+
+impl<S: SwarmSpec> Eq for UsageTableFor<S> {}
+
+impl<S: SwarmSpec> UsageTableFor<S> {
     /// Creates an empty table for a batch with the given geometry and
     /// [`Mutability`].
     ///
@@ -166,13 +210,13 @@ impl UsageTable {
     pub fn new(
         batch_id: BatchId,
         depth: u8,
-        bucket_depth: u8,
+        bucket_depth: BucketDepth<S>,
         mutability: Mutability,
     ) -> Result<Self> {
-        validate_geometry(depth, bucket_depth)?;
+        validate_geometry(depth, bucket_depth.get())?;
         Ok(Self {
             batch_id,
-            counters: CounterTable::new(depth, bucket_depth, mutability.mode()),
+            counters: CounterTableFor::new(depth, bucket_depth, mutability.mode()),
         })
     }
 
@@ -183,11 +227,11 @@ impl UsageTable {
     /// (`batch.immutable() == false`) yields a wrapping ring. This lets a caller
     /// holding a `Batch` build the matching table without restating the geometry
     /// or polarity by hand.
-    pub fn from_batch(batch: &Batch) -> Result<Self> {
+    pub fn from_batch(batch: &Batch<S>) -> Result<Self> {
         Self::new(
             batch.id(),
             batch.depth(),
-            batch.bucket_depth().get(),
+            batch.bucket_depth(),
             Mutability::from_batch(batch),
         )
     }
@@ -200,12 +244,12 @@ impl UsageTable {
     pub fn from_counts(
         batch_id: BatchId,
         depth: u8,
-        bucket_depth: u8,
+        bucket_depth: BucketDepth<S>,
         counts: Vec<u32>,
         mutability: Mutability,
     ) -> Result<Self> {
-        validate_geometry(depth, bucket_depth)?;
-        let counters = CounterTable::from_counts(depth, bucket_depth, mutability.mode(), counts)
+        validate_geometry(depth, bucket_depth.get())?;
+        let counters = CounterTableFor::from_counts(depth, bucket_depth, mutability.mode(), counts)
             .map_err(map_counter_error)?;
         Ok(Self { batch_id, counters })
     }
@@ -227,7 +271,7 @@ impl UsageTable {
     }
 
     /// Returns the bucket (uniformity) depth.
-    pub const fn bucket_depth(&self) -> u8 {
+    pub const fn bucket_depth(&self) -> BucketDepth<S> {
         self.counters.bucket_depth()
     }
 
@@ -285,13 +329,13 @@ impl UsageTable {
 
     /// Returns the shared counter table backing this usage table, for the
     /// snapshot's counter-advance and merge paths.
-    pub(crate) const fn counters(&self) -> &CounterTable {
+    pub(crate) const fn counters(&self) -> &CounterTableFor<S> {
         &self.counters
     }
 
     /// Returns a mutable reference to the shared counter table, the snapshot's
     /// single counter-advance handle.
-    pub(crate) const fn counters_mut(&mut self) -> &mut CounterTable {
+    pub(crate) const fn counters_mut(&mut self) -> &mut CounterTableFor<S> {
         &mut self.counters
     }
 
@@ -308,7 +352,7 @@ impl UsageTable {
                 requested: new_depth,
             });
         }
-        validate_geometry(new_depth, self.counters.bucket_depth())?;
+        validate_geometry(new_depth, self.counters.bucket_depth().get())?;
         // The geometry is validated against the snapshot format above, so the
         // shared table only needs to adopt the new depth.
         self.counters.set_depth(new_depth);
@@ -334,7 +378,7 @@ impl UsageTable {
             return Err(UsageError::BatchMismatch);
         }
         let depth = self.depth().max(other.depth());
-        validate_geometry(depth, self.bucket_depth())?;
+        validate_geometry(depth, self.bucket_depth().get())?;
         self.counters.merge_counts_max(other.counters(), depth);
         Ok(())
     }
@@ -354,13 +398,25 @@ impl UsageTable {
 /// snapshot.
 ///
 /// The view borrows the table, so it cannot outlive the snapshot it came from.
-#[derive(Debug, Clone, Copy)]
-pub struct TableView<'a> {
-    table: &'a UsageTable,
+#[derive(Debug)]
+pub struct TableViewFor<'a, S: SwarmSpec = Mainnet> {
+    table: &'a UsageTableFor<S>,
 }
 
-impl<'a> TableView<'a> {
-    pub(crate) const fn new(table: &'a UsageTable) -> Self {
+/// The [`TableViewFor`] of the mainnet spec.
+pub type TableView<'a> = TableViewFor<'a, Mainnet>;
+
+// A view is a shared borrow, so it copies whatever the spec marker does.
+impl<S: SwarmSpec> Clone for TableViewFor<'_, S> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<S: SwarmSpec> Copy for TableViewFor<'_, S> {}
+
+impl<'a, S: SwarmSpec> TableViewFor<'a, S> {
+    pub(crate) const fn new(table: &'a UsageTableFor<S>) -> Self {
         Self { table }
     }
 
@@ -381,7 +437,7 @@ impl<'a> TableView<'a> {
     }
 
     /// Returns the bucket (uniformity) depth.
-    pub const fn bucket_depth(&self) -> u8 {
+    pub const fn bucket_depth(&self) -> BucketDepth<S> {
         self.table.bucket_depth()
     }
 
@@ -441,9 +497,10 @@ impl<'a> TableView<'a> {
 mod arbitrary_impls {
     use alloc::vec;
     use arbitrary::{Arbitrary, Result as ArbitraryResult, Unstructured};
-    use nectar_postage::BatchId;
+    use nectar_postage::{BatchId, BucketDepth};
+    use nectar_primitives::SwarmSpec;
 
-    use super::{Mutability, UsageTable};
+    use super::{Mutability, UsageTableFor};
     use crate::{MAX_BUCKET_DEPTH, MAX_COUNTER_BITS};
 
     impl<'a> Arbitrary<'a> for Mutability {
@@ -456,15 +513,21 @@ mod arbitrary_impls {
         }
     }
 
-    impl<'a> Arbitrary<'a> for UsageTable {
+    impl<'a, S: SwarmSpec> Arbitrary<'a> for UsageTableFor<S> {
         fn arbitrary(u: &mut Unstructured<'a>) -> ArbitraryResult<Self> {
             let batch_id = BatchId::new(u.arbitrary::<[u8; 32]>()?);
             // `bucket_depth == 0` (a zero-width bucket) is invalid geometry:
             // `validate_geometry` rejects it because `nectar_postage::
             // calculate_bucket` shifts a u32 right by `32 - bucket_depth`, so
-            // depth 0 would overflow the shift. The range below is therefore
-            // exactly the format invariant, not a generator restriction.
-            let bucket_depth = u.int_in_range(1..=MAX_BUCKET_DEPTH)?;
+            // depth 0 would overflow the shift. The window below is therefore
+            // exactly the format invariant intersected with the network floor,
+            // not a generator restriction; a network whose floor exceeds the
+            // format maximum has no snapshot geometry at all.
+            let low = S::MIN_BUCKET_DEPTH.max(1);
+            if low > MAX_BUCKET_DEPTH {
+                return Err(arbitrary::Error::IncorrectFormat);
+            }
+            let bucket_depth = u.int_in_range(low..=MAX_BUCKET_DEPTH)?;
             let counter_bits = u.int_in_range(0..=MAX_COUNTER_BITS)?;
             // `bucket_depth <= 16` and `counter_bits <= 31`, so the u8 sum
             // is at most 47.
@@ -489,6 +552,8 @@ mod arbitrary_impls {
 
             // Cannot fail for the geometry and counters generated above; map
             // defensively rather than panicking inside the generator.
+            let bucket_depth =
+                BucketDepth::new(bucket_depth).map_err(|_| arbitrary::Error::IncorrectFormat)?;
             Self::from_counts(batch_id, depth, bucket_depth, counts, mutability)
                 .map_err(|_| arbitrary::Error::IncorrectFormat)
         }
@@ -498,9 +563,25 @@ mod arbitrary_impls {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{Address, b256};
-    use nectar_postage::{Batch, BucketDepth};
+    use nectar_postage::Batch;
+    use nectar_primitives::NetworkId;
 
     use super::*;
+
+    /// A deployment whose bucket-depth floor is the format minimum, for the
+    /// geometries mainnet's floor of 16 forbids.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct Shallow;
+
+    impl SwarmSpec for Shallow {
+        const NETWORK_ID: NetworkId = NetworkId::TESTNET;
+        const MIN_BUCKET_DEPTH: u8 = 1;
+    }
+
+    /// The mainnet bucket depth, the only one mainnet and the format agree on.
+    fn mainnet() -> BucketDepth {
+        BucketDepth::new(16).unwrap()
+    }
 
     fn batch_id() -> BatchId {
         BatchId::from(b256!(
@@ -527,12 +608,13 @@ mod tests {
     #[test]
     fn geometry_bounds() {
         let imm = Mutability::Immutable;
-        assert!(UsageTable::new(batch_id(), 20, 16, imm).is_ok());
-        assert!(UsageTable::new(batch_id(), 16, 16, imm).is_ok());
-        assert!(UsageTable::new(batch_id(), 47, 16, imm).is_ok());
-        assert!(UsageTable::new(batch_id(), 48, 16, imm).is_err());
-        assert!(UsageTable::new(batch_id(), 15, 16, imm).is_err());
-        assert!(UsageTable::new(batch_id(), 20, 17, imm).is_err());
+        assert!(UsageTable::new(batch_id(), 20, mainnet(), imm).is_ok());
+        assert!(UsageTable::new(batch_id(), 16, mainnet(), imm).is_ok());
+        assert!(UsageTable::new(batch_id(), 47, mainnet(), imm).is_ok());
+        assert!(UsageTable::new(batch_id(), 48, mainnet(), imm).is_err());
+        assert!(UsageTable::new(batch_id(), 15, mainnet(), imm).is_err());
+        // A bucket depth the network accepts but the format does not.
+        assert!(UsageTable::new(batch_id(), 20, BucketDepth::new(17).unwrap(), imm).is_err());
     }
 
     #[test]
@@ -549,19 +631,29 @@ mod tests {
                 })
             );
         }
-        // Both constructors go through the validator.
+        // The constructors cannot even be reached with one: no network, however
+        // low its floor, has a representable zero-width bucket depth.
+        assert!(BucketDepth::<Shallow>::new(0).is_err());
+        // The wire path rejoins the type here, so a decoded zero is refused.
         assert_eq!(
-            UsageTable::new(batch_id(), 20, 0, Mutability::Immutable),
+            checked_bucket_depth::<Shallow>(20, 0),
             Err(UsageError::InvalidGeometry {
                 depth: 20,
                 bucket_depth: 0,
             })
         );
+    }
+
+    #[test]
+    fn a_decoded_geometry_must_clear_the_network_floor() {
+        // The format supports bucket depth 8; mainnet does not, and the wire
+        // gate is where that is caught.
+        assert!(checked_bucket_depth::<Shallow>(12, 8).is_ok());
         assert_eq!(
-            UsageTable::from_counts(batch_id(), 5, 0, vec![0u32], Mutability::Immutable),
+            checked_bucket_depth::<Mainnet>(12, 8),
             Err(UsageError::InvalidGeometry {
-                depth: 5,
-                bucket_depth: 0,
+                depth: 12,
+                bucket_depth: 8,
             })
         );
     }
@@ -570,25 +662,30 @@ mod tests {
     fn mutability_enum_matches_old_constructors() {
         // The enum constructors produce the same tables the old `new`/`new_mutable`
         // pair did: an immutable table is a fill watermark, a mutable table a ring.
-        let immutable = UsageTable::new(batch_id(), 20, 16, Mutability::Immutable).unwrap();
+        let immutable = UsageTable::new(batch_id(), 20, mainnet(), Mutability::Immutable).unwrap();
         assert!(!immutable.is_mutable());
 
-        let mutable = UsageTable::new(batch_id(), 20, 16, Mutability::Mutable).unwrap();
+        let mutable = UsageTable::new(batch_id(), 20, mainnet(), Mutability::Mutable).unwrap();
         assert!(mutable.is_mutable());
 
         let from_counts_imm = UsageTable::from_counts(
             batch_id(),
             17,
-            16,
+            mainnet(),
             immutable_counts(),
             Mutability::Immutable,
         )
         .unwrap();
         assert!(!from_counts_imm.is_mutable());
 
-        let from_counts_mut =
-            UsageTable::from_counts(batch_id(), 17, 16, immutable_counts(), Mutability::Mutable)
-                .unwrap();
+        let from_counts_mut = UsageTable::from_counts(
+            batch_id(),
+            17,
+            mainnet(),
+            immutable_counts(),
+            Mutability::Mutable,
+        )
+        .unwrap();
         assert!(from_counts_mut.is_mutable());
     }
 
@@ -600,7 +697,7 @@ mod tests {
         assert!(!immutable_table.is_mutable());
         assert_eq!(immutable_table.batch_id(), batch_id());
         assert_eq!(immutable_table.depth(), 20);
-        assert_eq!(immutable_table.bucket_depth(), 16);
+        assert_eq!(immutable_table.bucket_depth().get(), 16);
 
         let mutable_batch = batch_with(20, 16, false);
         let mutable_table = UsageTable::from_batch(&mutable_batch).unwrap();
@@ -613,7 +710,8 @@ mod tests {
         let mut counts = vec![0u32; 1usize << 16];
         counts[7] = 2;
         let table =
-            UsageTable::from_counts(batch_id(), 17, 16, counts, Mutability::Immutable).unwrap();
+            UsageTable::from_counts(batch_id(), 17, mainnet(), counts, Mutability::Immutable)
+                .unwrap();
         assert_eq!(table.bucket_capacity(), 2);
         assert_eq!(table.total_issued(), 2);
         assert_eq!(table.max_count(), 2);
@@ -622,7 +720,7 @@ mod tests {
         let mut over = vec![0u32; 1usize << 16];
         over[7] = 3; // capacity is 2
         assert_eq!(
-            UsageTable::from_counts(batch_id(), 17, 16, over, Mutability::Immutable),
+            UsageTable::from_counts(batch_id(), 17, mainnet(), over, Mutability::Immutable),
             Err(UsageError::CounterOverflow {
                 bucket: 7,
                 count: 3,
@@ -636,7 +734,8 @@ mod tests {
         let mut counts = vec![0u32; 1usize << 16];
         counts[0] = 1;
         let mut table =
-            UsageTable::from_counts(batch_id(), 17, 16, counts, Mutability::Immutable).unwrap();
+            UsageTable::from_counts(batch_id(), 17, mainnet(), counts, Mutability::Immutable)
+                .unwrap();
         table.dilute(18).unwrap();
         assert_eq!(table.bucket_capacity(), 4);
         assert_eq!(table.count(0).unwrap(), 1);
@@ -657,9 +756,10 @@ mod tests {
         counts_b[0] = 1;
         counts_b[1] = 1;
         let mut a =
-            UsageTable::from_counts(batch_id(), 18, 16, counts_a, Mutability::Immutable).unwrap();
-        let b =
-            UsageTable::from_counts(batch_id(), 19, 16, counts_b, Mutability::Immutable).unwrap();
+            UsageTable::from_counts(batch_id(), 18, mainnet(), counts_a, Mutability::Immutable)
+                .unwrap();
+        let b = UsageTable::from_counts(batch_id(), 19, mainnet(), counts_b, Mutability::Immutable)
+            .unwrap();
         a.merge_max(&b).unwrap();
         assert_eq!(a.depth(), 19);
         assert_eq!(a.count(0).unwrap(), 2);
@@ -670,13 +770,16 @@ mod tests {
     #[test]
     fn merge_max_rejects_mutable() {
         let zero = || vec![0u32; 1usize << 16];
-        let mut a =
-            UsageTable::from_counts(batch_id(), 18, 16, zero(), Mutability::Mutable).unwrap();
-        let b = UsageTable::from_counts(batch_id(), 18, 16, zero(), Mutability::Immutable).unwrap();
+        let mut a = UsageTable::from_counts(batch_id(), 18, mainnet(), zero(), Mutability::Mutable)
+            .unwrap();
+        let b = UsageTable::from_counts(batch_id(), 18, mainnet(), zero(), Mutability::Immutable)
+            .unwrap();
         assert_eq!(a.merge_max(&b), Err(UsageError::MutableMerge));
         let mut c =
-            UsageTable::from_counts(batch_id(), 18, 16, zero(), Mutability::Immutable).unwrap();
-        let d = UsageTable::from_counts(batch_id(), 18, 16, zero(), Mutability::Mutable).unwrap();
+            UsageTable::from_counts(batch_id(), 18, mainnet(), zero(), Mutability::Immutable)
+                .unwrap();
+        let d = UsageTable::from_counts(batch_id(), 18, mainnet(), zero(), Mutability::Mutable)
+            .unwrap();
         assert_eq!(c.merge_max(&d), Err(UsageError::MutableMerge));
     }
 }

--- a/crates/postage-usage/src/table.rs
+++ b/crates/postage-usage/src/table.rs
@@ -187,7 +187,7 @@ impl UsageTable {
         Self::new(
             batch.id(),
             batch.depth(),
-            batch.bucket_depth(),
+            batch.bucket_depth().get(),
             Mutability::from_batch(batch),
         )
     }
@@ -498,7 +498,7 @@ mod arbitrary_impls {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{Address, b256};
-    use nectar_postage::Batch;
+    use nectar_postage::{Batch, BucketDepth};
 
     use super::*;
 
@@ -519,7 +519,7 @@ mod tests {
             0,
             Address::repeat_byte(0x11),
             depth,
-            bucket_depth,
+            BucketDepth::new(bucket_depth).unwrap(),
             immutable,
         )
     }

--- a/crates/postage-usage/src/table.rs
+++ b/crates/postage-usage/src/table.rs
@@ -516,14 +516,10 @@ mod arbitrary_impls {
     impl<'a, S: SwarmSpec> Arbitrary<'a> for UsageTableFor<S> {
         fn arbitrary(u: &mut Unstructured<'a>) -> ArbitraryResult<Self> {
             let batch_id = BatchId::new(u.arbitrary::<[u8; 32]>()?);
-            // `bucket_depth == 0` (a zero-width bucket) is invalid geometry:
-            // `validate_geometry` rejects it because `nectar_postage::
-            // calculate_bucket` shifts a u32 right by `32 - bucket_depth`, so
-            // depth 0 would overflow the shift. The window below is therefore
-            // exactly the format invariant intersected with the network floor,
-            // not a generator restriction; a network whose floor exceeds the
-            // format maximum has no snapshot geometry at all.
-            let low = S::MIN_BUCKET_DEPTH.max(1);
+            // The window is the format's cap intersected with the network
+            // floor, not a generator restriction; a network whose floor exceeds
+            // the format maximum has no snapshot geometry at all.
+            let low = S::MIN_BUCKET_DEPTH.get();
             if low > MAX_BUCKET_DEPTH {
                 return Err(arbitrary::Error::IncorrectFormat);
             }
@@ -562,6 +558,8 @@ mod arbitrary_impls {
 
 #[cfg(test)]
 mod tests {
+    use core::num::NonZeroU8;
+
     use alloy_primitives::{Address, b256};
     use nectar_postage::Batch;
     use nectar_primitives::NetworkId;
@@ -575,7 +573,7 @@ mod tests {
 
     impl SwarmSpec for Shallow {
         const NETWORK_ID: NetworkId = NetworkId::TESTNET;
-        const MIN_BUCKET_DEPTH: u8 = 1;
+        const MIN_BUCKET_DEPTH: NonZeroU8 = NonZeroU8::new(1).unwrap();
     }
 
     /// The mainnet bucket depth, the only one mainnet and the format agree on.
@@ -631,8 +629,8 @@ mod tests {
                 })
             );
         }
-        // The constructors cannot even be reached with one: no network, however
-        // low its floor, has a representable zero-width bucket depth.
+        // The constructors cannot even be reached with one: no network can
+        // declare a floor of zero, so the shallowest depth is 1.
         assert!(BucketDepth::<Shallow>::new(0).is_err());
         // The wire path rejoins the type here, so a decoded zero is refused.
         assert_eq!(

--- a/crates/postage-usage/tests/common/mod.rs
+++ b/crates/postage-usage/tests/common/mod.rs
@@ -1,0 +1,42 @@
+//! Shared helpers for the postage-usage integration tests.
+
+#![allow(dead_code)]
+
+use core::num::NonZeroU8;
+
+use alloy_primitives::Address;
+use nectar_postage_usage::{BatchId, BucketDepth, NetworkId, SwarmSpec};
+
+/// The bucket depth of every mainnet table below.
+pub(crate) const BUCKET_DEPTH: u8 = 16;
+
+/// The mainnet bucket depth of every table below, proof-carrying.
+pub(crate) fn bucket_depth() -> BucketDepth {
+    BucketDepth::new(BUCKET_DEPTH).unwrap()
+}
+
+/// The batch every table below belongs to.
+pub(crate) const fn batch_id() -> BatchId {
+    BatchId::new([0x42; 32])
+}
+
+/// The owner every table below is persisted by.
+pub(crate) const fn owner() -> Address {
+    Address::repeat_byte(0x11)
+}
+
+/// A deployment whose bucket-depth floor is the format minimum, for the
+/// geometries mainnet's floor of 16 forbids. The encoding does not depend on
+/// the spec: only which geometries a network admits does.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Shallow;
+
+impl SwarmSpec for Shallow {
+    const NETWORK_ID: NetworkId = NetworkId::TESTNET;
+    const MIN_BUCKET_DEPTH: NonZeroU8 = NonZeroU8::new(1).unwrap();
+}
+
+/// A bucket depth [`Shallow`] accepts.
+pub(crate) fn shallow(depth: u8) -> BucketDepth<Shallow> {
+    BucketDepth::new(depth).unwrap()
+}

--- a/crates/postage-usage/tests/common/mod.rs
+++ b/crates/postage-usage/tests/common/mod.rs
@@ -7,20 +7,20 @@ use core::num::NonZeroU8;
 use alloy_primitives::Address;
 use nectar_postage_usage::{BatchId, BucketDepth, NetworkId, SwarmSpec};
 
-/// The bucket depth of every mainnet table below.
+/// The mainnet bucket depth these tests build tables at.
 pub(crate) const BUCKET_DEPTH: u8 = 16;
 
-/// The mainnet bucket depth of every table below, proof-carrying.
+/// [`BUCKET_DEPTH`] in the proof-carrying type.
 pub(crate) fn bucket_depth() -> BucketDepth {
     BucketDepth::new(BUCKET_DEPTH).unwrap()
 }
 
-/// The batch every table below belongs to.
+/// The batch these tests' tables belong to.
 pub(crate) const fn batch_id() -> BatchId {
     BatchId::new([0x42; 32])
 }
 
-/// The owner every table below is persisted by.
+/// The owner these tests' tables are persisted by.
 pub(crate) const fn owner() -> Address {
     Address::repeat_byte(0x11)
 }

--- a/crates/postage-usage/tests/issuer.rs
+++ b/crates/postage-usage/tests/issuer.rs
@@ -15,7 +15,7 @@
     clippy::missing_panics_doc
 )]
 use alloy_primitives::Address;
-use nectar_postage::{BatchId, StampIndex, calculate_bucket};
+use nectar_postage::{BatchId, BucketDepth, StampIndex, calculate_bucket};
 use nectar_postage_issuer::StampIssuer;
 use nectar_postage_usage::{Mutability, PublishedSequence, Snapshot, SnapshotIssuer, UsageTable};
 use nectar_primitives::ChunkAddress;
@@ -220,7 +220,7 @@ fn shared_counter_table_backs_both_crates_identically() {
     // advances exactly like a bare MemoryIssuer.
     let table = UsageTable::new(batch_id, 20, BUCKET_DEPTH, Mutability::Immutable).unwrap();
     let mut snapshot = Snapshot::new(table);
-    let mut memory = MemoryIssuer::new(batch_id, 20, BUCKET_DEPTH);
+    let mut memory = MemoryIssuer::new(batch_id, 20, BucketDepth::new(BUCKET_DEPTH).unwrap());
 
     for bucket in [0x0001u32, 0x0001, 0xCBE5, 0x0001, 0xCBE5] {
         for salt in 0..3u8 {

--- a/crates/postage-usage/tests/issuer.rs
+++ b/crates/postage-usage/tests/issuer.rs
@@ -22,6 +22,11 @@ use nectar_primitives::ChunkAddress;
 
 const BUCKET_DEPTH: u8 = 16;
 
+/// The mainnet bucket depth of every table below, proof-carrying.
+fn bucket_depth() -> BucketDepth {
+    BucketDepth::new(BUCKET_DEPTH).unwrap()
+}
+
 const fn owner() -> Address {
     Address::repeat_byte(0x11)
 }
@@ -42,7 +47,7 @@ const fn content_address(bucket: u32, salt: u8) -> ChunkAddress {
 #[test]
 fn snapshot_issuer_issues_sequential_indices() {
     let batch_id = BatchId::new([0x42; 32]);
-    let table = UsageTable::new(batch_id, 18, BUCKET_DEPTH, Mutability::Immutable).unwrap();
+    let table = UsageTable::new(batch_id, 18, bucket_depth(), Mutability::Immutable).unwrap();
     // A fresh, never-persisted snapshot reserves no slots, so issuance fills the
     // bucket from index zero just as a bare table once did.
     let snapshot = Snapshot::new(table);
@@ -78,7 +83,8 @@ fn shared_table_immutable_never_collides_with_reserved_slots() {
     let batch_id = BatchId::new([0x42; 32]);
     let counts = vec![5u32; 1usize << BUCKET_DEPTH];
     let table =
-        UsageTable::from_counts(batch_id, 24, BUCKET_DEPTH, counts, Mutability::Immutable).unwrap();
+        UsageTable::from_counts(batch_id, 24, bucket_depth(), counts, Mutability::Immutable)
+            .unwrap();
     let mut snapshot = Snapshot::new(table);
 
     // Persist once, recording the snapshot's own reserved slots.
@@ -109,7 +115,7 @@ fn shared_table_mutable_skips_reserved_across_wraps() {
     // Capacity 4 per bucket; fill near-full so the ring wraps almost at once.
     let counts = vec![2u32; 1usize << BUCKET_DEPTH];
     let table =
-        UsageTable::from_counts(batch_id, 18, BUCKET_DEPTH, counts, Mutability::Mutable).unwrap();
+        UsageTable::from_counts(batch_id, 18, bucket_depth(), counts, Mutability::Mutable).unwrap();
     assert!(table.is_mutable());
     let mut snapshot = Snapshot::new(table);
 
@@ -161,7 +167,7 @@ fn sole_issuance_path_cannot_evict_snapshot_slots() {
     // wraps the ring and would land on the reserved slot under a naive issuer.
     let counts = vec![3u32; 1usize << BUCKET_DEPTH];
     let table =
-        UsageTable::from_counts(batch_id, 18, BUCKET_DEPTH, counts, Mutability::Mutable).unwrap();
+        UsageTable::from_counts(batch_id, 18, bucket_depth(), counts, Mutability::Mutable).unwrap();
     assert!(table.is_mutable());
 
     // `SnapshotIssuer` is the only `StampIssuer` this crate exposes. Persist
@@ -218,9 +224,9 @@ fn shared_counter_table_backs_both_crates_identically() {
     let batch_id = BatchId::new([0x42; 32]);
     // A fresh, never-persisted snapshot reserves no slots, so its fill watermark
     // advances exactly like a bare MemoryIssuer.
-    let table = UsageTable::new(batch_id, 20, BUCKET_DEPTH, Mutability::Immutable).unwrap();
+    let table = UsageTable::new(batch_id, 20, bucket_depth(), Mutability::Immutable).unwrap();
     let mut snapshot = Snapshot::new(table);
-    let mut memory = MemoryIssuer::new(batch_id, 20, BucketDepth::new(BUCKET_DEPTH).unwrap());
+    let mut memory = MemoryIssuer::new(batch_id, 20, bucket_depth());
 
     for bucket in [0x0001u32, 0x0001, 0xCBE5, 0x0001, 0xCBE5] {
         for salt in 0..3u8 {
@@ -250,7 +256,7 @@ fn snapshot_issuer_adapter_drives_a_batch_stamper_path() {
     let owner = signer.address();
     let batch_id = BatchId::new([0x77; 32]);
 
-    let table = UsageTable::new(batch_id, 20, BUCKET_DEPTH, Mutability::Mutable).unwrap();
+    let table = UsageTable::new(batch_id, 20, bucket_depth(), Mutability::Mutable).unwrap();
     let mut snapshot = Snapshot::new(table);
     snapshot
         .revalidate(PublishedSequence::NONE)

--- a/crates/postage-usage/tests/issuer.rs
+++ b/crates/postage-usage/tests/issuer.rs
@@ -14,22 +14,14 @@
     clippy::as_conversions,
     clippy::missing_panics_doc
 )]
-use alloy_primitives::Address;
-use nectar_postage::{BatchId, BucketDepth, StampIndex, calculate_bucket};
+use nectar_postage::{BatchId, StampIndex, calculate_bucket};
 use nectar_postage_issuer::StampIssuer;
 use nectar_postage_usage::{Mutability, PublishedSequence, Snapshot, SnapshotIssuer, UsageTable};
 use nectar_primitives::ChunkAddress;
 
-const BUCKET_DEPTH: u8 = 16;
+mod common;
 
-/// The mainnet bucket depth of every table below, proof-carrying.
-fn bucket_depth() -> BucketDepth {
-    BucketDepth::new(BUCKET_DEPTH).unwrap()
-}
-
-const fn owner() -> Address {
-    Address::repeat_byte(0x11)
-}
+use common::{BUCKET_DEPTH, batch_id, bucket_depth, owner};
 
 /// Returns a content chunk address whose top 16 bits select `bucket`, with
 /// `salt` mixed into lower bytes so distinct calls stay in the same bucket.
@@ -46,7 +38,7 @@ const fn content_address(bucket: u32, salt: u8) -> ChunkAddress {
 
 #[test]
 fn snapshot_issuer_issues_sequential_indices() {
-    let batch_id = BatchId::new([0x42; 32]);
+    let batch_id = batch_id();
     let table = UsageTable::new(batch_id, 18, bucket_depth(), Mutability::Immutable).unwrap();
     // A fresh, never-persisted snapshot reserves no slots, so issuance fills the
     // bucket from index zero just as a bare table once did.
@@ -80,7 +72,7 @@ fn snapshot_issuer_issues_sequential_indices() {
 
 #[test]
 fn shared_table_immutable_never_collides_with_reserved_slots() {
-    let batch_id = BatchId::new([0x42; 32]);
+    let batch_id = batch_id();
     let counts = vec![5u32; 1usize << BUCKET_DEPTH];
     let table =
         UsageTable::from_counts(batch_id, 24, bucket_depth(), counts, Mutability::Immutable)
@@ -111,7 +103,7 @@ fn shared_table_immutable_never_collides_with_reserved_slots() {
 
 #[test]
 fn shared_table_mutable_skips_reserved_across_wraps() {
-    let batch_id = BatchId::new([0x42; 32]);
+    let batch_id = batch_id();
     // Capacity 4 per bucket; fill near-full so the ring wraps almost at once.
     let counts = vec![2u32; 1usize << BUCKET_DEPTH];
     let table =
@@ -162,7 +154,7 @@ fn shared_table_mutable_skips_reserved_across_wraps() {
 /// not hold.
 #[test]
 fn sole_issuance_path_cannot_evict_snapshot_slots() {
-    let batch_id = BatchId::new([0x42; 32]);
+    let batch_id = batch_id();
     // A mutable bucket at capacity 4, pre-filled to 3 so the very next stamp
     // wraps the ring and would land on the reserved slot under a naive issuer.
     let counts = vec![3u32; 1usize << BUCKET_DEPTH];
@@ -221,7 +213,7 @@ fn sole_issuance_path_cannot_evict_snapshot_slots() {
 fn shared_counter_table_backs_both_crates_identically() {
     use nectar_postage_issuer::MemoryIssuer;
 
-    let batch_id = BatchId::new([0x42; 32]);
+    let batch_id = batch_id();
     // A fresh, never-persisted snapshot reserves no slots, so its fill watermark
     // advances exactly like a bare MemoryIssuer.
     let table = UsageTable::new(batch_id, 20, bucket_depth(), Mutability::Immutable).unwrap();

--- a/crates/postage-usage/tests/seal.rs
+++ b/crates/postage-usage/tests/seal.rs
@@ -16,17 +16,14 @@
 use alloy_primitives::Address;
 use alloy_signer_local::PrivateKeySigner;
 use nectar_postage_usage::{
-    BatchId, BucketDepth, Mutability, PublishedSequence, SealError, Snapshot, UsageTable,
-    seal_plan, usage_chunk_address,
+    BatchId, Mutability, PublishedSequence, SealError, Snapshot, UsageTable, seal_plan,
+    usage_chunk_address,
 };
 use nectar_primitives::ChunkOps;
 
-const BUCKET_DEPTH: u8 = 16;
+mod common;
 
-/// The mainnet bucket depth of every table below, proof-carrying.
-fn bucket_depth() -> BucketDepth {
-    BucketDepth::new(BUCKET_DEPTH).unwrap()
-}
+use common::{BUCKET_DEPTH, batch_id, bucket_depth};
 
 fn seeded_snapshot(owner: Address, batch_id: BatchId) -> Snapshot {
     // Seed one stamp in bucket 123 via the inert constructor; the table itself
@@ -49,7 +46,7 @@ fn seeded_snapshot(owner: Address, batch_id: BatchId) -> Snapshot {
 fn sealed_chunks_and_stamps_verify() {
     let signer = PrivateKeySigner::random();
     let owner = signer.address();
-    let batch_id = BatchId::new([0x42; 32]);
+    let batch_id = batch_id();
 
     let mut snapshot = seeded_snapshot(owner, batch_id);
     let plan = snapshot
@@ -105,7 +102,7 @@ fn sealed_chunks_and_stamps_verify() {
 fn non_increasing_seal_timestamp_is_rejected() {
     let signer = PrivateKeySigner::random();
     let owner = signer.address();
-    let batch_id = BatchId::new([0x42; 32]);
+    let batch_id = batch_id();
 
     let mut snapshot = seeded_snapshot(owner, batch_id);
 

--- a/crates/postage-usage/tests/seal.rs
+++ b/crates/postage-usage/tests/seal.rs
@@ -16,12 +16,17 @@
 use alloy_primitives::Address;
 use alloy_signer_local::PrivateKeySigner;
 use nectar_postage_usage::{
-    BatchId, Mutability, PublishedSequence, SealError, Snapshot, UsageTable, seal_plan,
-    usage_chunk_address,
+    BatchId, BucketDepth, Mutability, PublishedSequence, SealError, Snapshot, UsageTable,
+    seal_plan, usage_chunk_address,
 };
 use nectar_primitives::ChunkOps;
 
 const BUCKET_DEPTH: u8 = 16;
+
+/// The mainnet bucket depth of every table below, proof-carrying.
+fn bucket_depth() -> BucketDepth {
+    BucketDepth::new(BUCKET_DEPTH).unwrap()
+}
 
 fn seeded_snapshot(owner: Address, batch_id: BatchId) -> Snapshot {
     // Seed one stamp in bucket 123 via the inert constructor; the table itself
@@ -29,7 +34,8 @@ fn seeded_snapshot(owner: Address, batch_id: BatchId) -> Snapshot {
     let mut counts = vec![0u32; 1usize << BUCKET_DEPTH];
     counts[123] = 1;
     let table =
-        UsageTable::from_counts(batch_id, 20, BUCKET_DEPTH, counts, Mutability::Immutable).unwrap();
+        UsageTable::from_counts(batch_id, 20, bucket_depth(), counts, Mutability::Immutable)
+            .unwrap();
     let mut snapshot = Snapshot::new(table);
     let _ = snapshot
         .revalidate(PublishedSequence::NONE)

--- a/crates/postage-usage/tests/snapshot.rs
+++ b/crates/postage-usage/tests/snapshot.rs
@@ -13,30 +13,16 @@
     clippy::as_conversions,
     clippy::missing_panics_doc
 )]
-use core::num::NonZeroU8;
-
-use alloy_primitives::Address;
-use nectar_postage::{BucketDepth, calculate_bucket};
+use nectar_postage::calculate_bucket;
 use nectar_postage_usage::{
-    Batch, BatchId, MAGIC, Mutability, NetworkId, PersistPlan, PublishedSequence, RootInfo,
-    RootInfoFor, Snapshot, SnapshotFor, SwarmSpec, UsageError, UsageTable, UsageTableFor,
-    usage_chunk_address, usage_chunk_id,
+    Batch, MAGIC, Mutability, PersistPlan, PublishedSequence, RootInfo, RootInfoFor, Snapshot,
+    SnapshotFor, SwarmSpec, UsageError, UsageTable, UsageTableFor, usage_chunk_address,
+    usage_chunk_id,
 };
 
-const BUCKET_DEPTH: u8 = 16;
+mod common;
 
-/// The mainnet bucket depth of every table below, proof-carrying.
-fn bucket_depth() -> BucketDepth {
-    BucketDepth::new(BUCKET_DEPTH).unwrap()
-}
-
-const fn batch_id() -> BatchId {
-    BatchId::new([0x42; 32])
-}
-
-const fn owner() -> Address {
-    Address::repeat_byte(0x11)
-}
+use common::{BUCKET_DEPTH, Shallow, batch_id, bucket_depth, owner, shallow};
 
 /// Deterministic pseudo-random counters with the given spread.
 fn synthetic_counts(buckets: usize, base: u32, spread: u32) -> Vec<u32> {
@@ -61,16 +47,6 @@ fn roundtrip(plan: &PersistPlan) -> Snapshot {
     root.assemble(&leaves).unwrap()
 }
 
-/// A deployment whose bucket-depth floor is the format minimum, for the
-/// geometries mainnet's floor of 16 forbids.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct Shallow;
-
-impl SwarmSpec for Shallow {
-    const NETWORK_ID: NetworkId = NetworkId::TESTNET;
-    const MIN_BUCKET_DEPTH: NonZeroU8 = NonZeroU8::new(1).unwrap();
-}
-
 /// [`roundtrip`] for a snapshot of another network.
 fn roundtrip_for<S: SwarmSpec>(plan: &PersistPlan) -> SnapshotFor<S> {
     let root = RootInfoFor::<S>::parse(&plan.chunks[0].payload).unwrap();
@@ -86,7 +62,7 @@ fn batch(depth: u8, immutable: bool) -> Batch {
         0,
         owner(),
         depth,
-        BucketDepth::new(BUCKET_DEPTH).unwrap(),
+        bucket_depth(),
         immutable,
     )
 }
@@ -302,14 +278,9 @@ fn small_bucket_depth_inlines_in_the_root() {
     // 256 buckets at any width fit inline in the root.
     let counts = synthetic_counts(256, 1000, 4000);
     // Bucket depth 8 is below mainnet's floor, so this runs at `Shallow`.
-    let table = UsageTableFor::from_counts(
-        batch_id(),
-        21,
-        BucketDepth::<Shallow>::new(8).unwrap(),
-        counts,
-        Mutability::Immutable,
-    )
-    .unwrap();
+    let table =
+        UsageTableFor::from_counts(batch_id(), 21, shallow(8), counts, Mutability::Immutable)
+            .unwrap();
     let mut snapshot = SnapshotFor::new(table);
     let plan = snapshot
         .revalidate(PublishedSequence::NONE)
@@ -983,7 +954,7 @@ fn a_non_mainnet_snapshot_issues_reserves_and_recovers() {
     let table = UsageTableFor::from_counts(
         batch_id(),
         11,
-        BucketDepth::<Shallow>::new(8).unwrap(),
+        shallow(8),
         vec![0u32; 256],
         Mutability::Mutable,
     )

--- a/crates/postage-usage/tests/snapshot.rs
+++ b/crates/postage-usage/tests/snapshot.rs
@@ -14,7 +14,7 @@
     clippy::missing_panics_doc
 )]
 use alloy_primitives::Address;
-use nectar_postage::calculate_bucket;
+use nectar_postage::{BucketDepth, calculate_bucket};
 use nectar_postage_usage::{
     Batch, BatchId, MAGIC, Mutability, PersistPlan, PublishedSequence, RootInfo, Snapshot,
     UsageError, UsageTable, usage_chunk_address, usage_chunk_id,
@@ -53,14 +53,14 @@ fn roundtrip(plan: &PersistPlan) -> Snapshot {
     root.assemble(&leaves).unwrap()
 }
 
-const fn batch(depth: u8, immutable: bool) -> Batch {
+fn batch(depth: u8, immutable: bool) -> Batch {
     Batch::new(
         batch_id(),
         1_000,
         0,
         owner(),
         depth,
-        BUCKET_DEPTH,
+        BucketDepth::new(BUCKET_DEPTH).unwrap(),
         immutable,
     )
 }

--- a/crates/postage-usage/tests/snapshot.rs
+++ b/crates/postage-usage/tests/snapshot.rs
@@ -16,11 +16,17 @@
 use alloy_primitives::Address;
 use nectar_postage::{BucketDepth, calculate_bucket};
 use nectar_postage_usage::{
-    Batch, BatchId, MAGIC, Mutability, PersistPlan, PublishedSequence, RootInfo, Snapshot,
-    UsageError, UsageTable, usage_chunk_address, usage_chunk_id,
+    Batch, BatchId, MAGIC, Mutability, NetworkId, PersistPlan, PublishedSequence, RootInfo,
+    RootInfoFor, Snapshot, SnapshotFor, SwarmSpec, UsageError, UsageTable, UsageTableFor,
+    usage_chunk_address, usage_chunk_id,
 };
 
 const BUCKET_DEPTH: u8 = 16;
+
+/// The mainnet bucket depth of every table below, proof-carrying.
+fn bucket_depth() -> BucketDepth {
+    BucketDepth::new(BUCKET_DEPTH).unwrap()
+}
 
 const fn batch_id() -> BatchId {
     BatchId::new([0x42; 32])
@@ -53,6 +59,24 @@ fn roundtrip(plan: &PersistPlan) -> Snapshot {
     root.assemble(&leaves).unwrap()
 }
 
+/// A deployment whose bucket-depth floor is the format minimum, for the
+/// geometries mainnet's floor of 16 forbids.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Shallow;
+
+impl SwarmSpec for Shallow {
+    const NETWORK_ID: NetworkId = NetworkId::TESTNET;
+    const MIN_BUCKET_DEPTH: u8 = 1;
+}
+
+/// [`roundtrip`] for a snapshot of another network.
+fn roundtrip_for<S: SwarmSpec>(plan: &PersistPlan) -> SnapshotFor<S> {
+    let root = RootInfoFor::<S>::parse(&plan.chunks[0].payload).unwrap();
+    let leaves: Vec<_> = plan.chunks[1..].iter().map(|c| &c.payload).collect();
+    assert_eq!(usize::from(root.leaf_count()), leaves.len());
+    root.assemble(&leaves).unwrap()
+}
+
 fn batch(depth: u8, immutable: bool) -> Batch {
     Batch::new(
         batch_id(),
@@ -74,7 +98,7 @@ fn snapshot_from_batch_matches_batch_polarity() {
     assert!(!immutable.table().is_mutable());
     assert_eq!(immutable.table().batch_id(), batch_id());
     assert_eq!(immutable.table().depth(), 20);
-    assert_eq!(immutable.table().bucket_depth(), BUCKET_DEPTH);
+    assert_eq!(immutable.table().bucket_depth().get(), BUCKET_DEPTH);
     assert_eq!(immutable.sequence(), 0);
 
     let mutable = Snapshot::from_batch(&batch(22, false)).unwrap();
@@ -85,7 +109,7 @@ fn snapshot_from_batch_matches_batch_polarity() {
 
 #[test]
 fn empty_table_persists_as_a_single_small_root() {
-    let table = UsageTable::new(batch_id(), 20, BUCKET_DEPTH, Mutability::Immutable).unwrap();
+    let table = UsageTable::new(batch_id(), 20, bucket_depth(), Mutability::Immutable).unwrap();
     let mut snapshot = Snapshot::new(table);
     let plan = snapshot
         .revalidate(PublishedSequence::NONE)
@@ -113,9 +137,14 @@ fn uniform_spread_uses_leaves_and_round_trips() {
     // Counts in 64..=127: base 64, deltas need 6 bits. A leaf holds
     // floor(32768 / 6) = 5461 buckets, so 65536 buckets need 13 leaves.
     let counts = synthetic_counts(buckets, 64, 63);
-    let table =
-        UsageTable::from_counts(batch_id(), 24, BUCKET_DEPTH, counts, Mutability::Immutable)
-            .unwrap();
+    let table = UsageTable::from_counts(
+        batch_id(),
+        24,
+        bucket_depth(),
+        counts,
+        Mutability::Immutable,
+    )
+    .unwrap();
     let mut snapshot = Snapshot::new(table);
     let plan = snapshot
         .revalidate(PublishedSequence::NONE)
@@ -134,9 +163,14 @@ fn hot_bucket_becomes_an_exception_not_a_wider_table() {
     let buckets = 1usize << BUCKET_DEPTH;
     let mut counts = vec![0u32; buckets];
     counts[12345] = 200_000; // one hot bucket, everything else empty
-    let table =
-        UsageTable::from_counts(batch_id(), 34, BUCKET_DEPTH, counts, Mutability::Immutable)
-            .unwrap();
+    let table = UsageTable::from_counts(
+        batch_id(),
+        34,
+        bucket_depth(),
+        counts,
+        Mutability::Immutable,
+    )
+    .unwrap();
     let mut snapshot = Snapshot::new(table);
     let plan = snapshot
         .revalidate(PublishedSequence::NONE)
@@ -155,9 +189,14 @@ fn hot_bucket_becomes_an_exception_not_a_wider_table() {
 fn steady_state_persists_allocate_nothing_and_keep_slots() {
     let buckets = 1usize << BUCKET_DEPTH;
     let counts = synthetic_counts(buckets, 10, 15);
-    let table =
-        UsageTable::from_counts(batch_id(), 22, BUCKET_DEPTH, counts, Mutability::Immutable)
-            .unwrap();
+    let table = UsageTable::from_counts(
+        batch_id(),
+        22,
+        bucket_depth(),
+        counts,
+        Mutability::Immutable,
+    )
+    .unwrap();
     let mut snapshot = Snapshot::new(table);
 
     let first = snapshot
@@ -191,9 +230,14 @@ fn steady_state_persists_allocate_nothing_and_keep_slots() {
 fn snapshot_accounts_for_its_own_chunks() {
     let buckets = 1usize << BUCKET_DEPTH;
     let counts = synthetic_counts(buckets, 100, 90);
-    let table =
-        UsageTable::from_counts(batch_id(), 24, BUCKET_DEPTH, counts, Mutability::Immutable)
-            .unwrap();
+    let table = UsageTable::from_counts(
+        batch_id(),
+        24,
+        bucket_depth(),
+        counts,
+        Mutability::Immutable,
+    )
+    .unwrap();
     let issued_before = table.total_issued();
     let mut snapshot = Snapshot::new(table);
     let plan = snapshot
@@ -220,9 +264,14 @@ fn snapshot_accounts_for_its_own_chunks() {
 fn dilution_changes_no_leaf_bytes() {
     let buckets = 1usize << BUCKET_DEPTH;
     let counts = synthetic_counts(buckets, 5, 7);
-    let table =
-        UsageTable::from_counts(batch_id(), 20, BUCKET_DEPTH, counts, Mutability::Immutable)
-            .unwrap();
+    let table = UsageTable::from_counts(
+        batch_id(),
+        20,
+        bucket_depth(),
+        counts,
+        Mutability::Immutable,
+    )
+    .unwrap();
     let mut snapshot = Snapshot::new(table);
     let before = snapshot
         .revalidate(PublishedSequence::NONE)
@@ -250,15 +299,23 @@ fn dilution_changes_no_leaf_bytes() {
 fn small_bucket_depth_inlines_in_the_root() {
     // 256 buckets at any width fit inline in the root.
     let counts = synthetic_counts(256, 1000, 4000);
-    let table = UsageTable::from_counts(batch_id(), 21, 8, counts, Mutability::Immutable).unwrap();
-    let mut snapshot = Snapshot::new(table);
+    // Bucket depth 8 is below mainnet's floor, so this runs at `Shallow`.
+    let table = UsageTableFor::from_counts(
+        batch_id(),
+        21,
+        BucketDepth::<Shallow>::new(8).unwrap(),
+        counts,
+        Mutability::Immutable,
+    )
+    .unwrap();
+    let mut snapshot = SnapshotFor::new(table);
     let plan = snapshot
         .revalidate(PublishedSequence::NONE)
         .unwrap()
         .plan_persist(&owner())
         .unwrap();
     assert_eq!(plan.chunks.len(), 1);
-    assert_eq!(roundtrip(&plan), snapshot);
+    assert_eq!(roundtrip_for::<Shallow>(&plan), snapshot);
 }
 
 #[test]
@@ -270,9 +327,14 @@ fn full_capacity_counters_round_trip() {
     for c in counts.iter_mut().take(64) {
         *c = 0;
     }
-    let table =
-        UsageTable::from_counts(batch_id(), 17, BUCKET_DEPTH, counts, Mutability::Immutable)
-            .unwrap();
+    let table = UsageTable::from_counts(
+        batch_id(),
+        17,
+        bucket_depth(),
+        counts,
+        Mutability::Immutable,
+    )
+    .unwrap();
     let mut snapshot = Snapshot::new(table);
     match snapshot
         .revalidate(PublishedSequence::NONE)
@@ -294,9 +356,14 @@ fn full_capacity_counters_round_trip() {
 fn corruption_is_rejected() {
     let buckets = 1usize << BUCKET_DEPTH;
     let counts = synthetic_counts(buckets, 50, 40);
-    let table =
-        UsageTable::from_counts(batch_id(), 23, BUCKET_DEPTH, counts, Mutability::Immutable)
-            .unwrap();
+    let table = UsageTable::from_counts(
+        batch_id(),
+        23,
+        bucket_depth(),
+        counts,
+        Mutability::Immutable,
+    )
+    .unwrap();
     let mut snapshot = Snapshot::new(table);
     let plan = snapshot
         .revalidate(PublishedSequence::NONE)
@@ -351,9 +418,14 @@ fn corruption_is_rejected() {
 fn reserved_indices_match_planned_stamps_and_guard_reuse() {
     let buckets = 1usize << BUCKET_DEPTH;
     let counts = synthetic_counts(buckets, 10, 15);
-    let table =
-        UsageTable::from_counts(batch_id(), 22, BUCKET_DEPTH, counts, Mutability::Immutable)
-            .unwrap();
+    let table = UsageTable::from_counts(
+        batch_id(),
+        22,
+        bucket_depth(),
+        counts,
+        Mutability::Immutable,
+    )
+    .unwrap();
     let mut snapshot = Snapshot::new(table);
     let plan = snapshot
         .revalidate(PublishedSequence::NONE)
@@ -385,7 +457,8 @@ fn mutable_round_trips_and_decodes_as_mutable() {
     let buckets = 1usize << BUCKET_DEPTH;
     let counts = synthetic_counts(buckets, 10, 15);
     let table =
-        UsageTable::from_counts(batch_id(), 22, BUCKET_DEPTH, counts, Mutability::Mutable).unwrap();
+        UsageTable::from_counts(batch_id(), 22, bucket_depth(), counts, Mutability::Mutable)
+            .unwrap();
     assert!(table.is_mutable());
     let mut snapshot = Snapshot::new(table);
     let plan = snapshot
@@ -412,7 +485,8 @@ fn mutable_dilution_changes_no_cursor_or_leaf_bytes() {
     let buckets = 1usize << BUCKET_DEPTH;
     let counts = synthetic_counts(buckets, 5, 7);
     let table =
-        UsageTable::from_counts(batch_id(), 20, BUCKET_DEPTH, counts, Mutability::Mutable).unwrap();
+        UsageTable::from_counts(batch_id(), 20, bucket_depth(), counts, Mutability::Mutable)
+            .unwrap();
     let mut snapshot = Snapshot::new(table);
     let before = snapshot
         .revalidate(PublishedSequence::NONE)
@@ -448,7 +522,7 @@ fn merge_max_rejects_mutable() {
     let a = UsageTable::from_counts(
         batch_id(),
         20,
-        BUCKET_DEPTH,
+        bucket_depth(),
         synthetic_counts(buckets, 1, 2),
         Mutability::Mutable,
     )
@@ -456,7 +530,7 @@ fn merge_max_rejects_mutable() {
     let b = UsageTable::from_counts(
         batch_id(),
         20,
-        BUCKET_DEPTH,
+        bucket_depth(),
         synthetic_counts(buckets, 1, 2),
         Mutability::Immutable,
     )
@@ -474,9 +548,14 @@ fn recovered_mutable_issues_reserved_aware_through_the_handle() {
     let buckets = 1usize << BUCKET_DEPTH;
     // Fill the table close to full so cursors wrap fast.
     let counts = vec![3u32; buckets];
-    let table =
-        UsageTable::from_counts(batch_id(), depth, BUCKET_DEPTH, counts, Mutability::Mutable)
-            .unwrap();
+    let table = UsageTable::from_counts(
+        batch_id(),
+        depth,
+        bucket_depth(),
+        counts,
+        Mutability::Mutable,
+    )
+    .unwrap();
     let mut snapshot = Snapshot::new(table);
     let plan = snapshot
         .revalidate(PublishedSequence::NONE)
@@ -510,9 +589,14 @@ fn recovered_mutable_issues_reserved_aware_through_the_handle() {
 fn extract_then_rebuild_preserves_sequence_and_slots() {
     let buckets = 1usize << BUCKET_DEPTH;
     let counts = synthetic_counts(buckets, 10, 15);
-    let table =
-        UsageTable::from_counts(batch_id(), 22, BUCKET_DEPTH, counts, Mutability::Immutable)
-            .unwrap();
+    let table = UsageTable::from_counts(
+        batch_id(),
+        22,
+        bucket_depth(),
+        counts,
+        Mutability::Immutable,
+    )
+    .unwrap();
     let mut snapshot = Snapshot::new(table);
 
     // Persist a few times so the sequence climbs above 0 and slots are allocated.
@@ -568,9 +652,14 @@ fn extract_then_rebuild_preserves_sequence_and_slots() {
 fn recovered_snapshot_rebuilds_through_from_parts_without_regressing() {
     let buckets = 1usize << BUCKET_DEPTH;
     let counts = synthetic_counts(buckets, 64, 63);
-    let table =
-        UsageTable::from_counts(batch_id(), 24, BUCKET_DEPTH, counts, Mutability::Immutable)
-            .unwrap();
+    let table = UsageTable::from_counts(
+        batch_id(),
+        24,
+        bucket_depth(),
+        counts,
+        Mutability::Immutable,
+    )
+    .unwrap();
     let mut snapshot = Snapshot::new(table);
     snapshot
         .revalidate(PublishedSequence::NONE)
@@ -600,7 +689,7 @@ fn table_view_exposes_counts_and_geometry_without_yielding_an_owned_table() {
     let table = UsageTable::from_counts(
         batch_id(),
         24,
-        BUCKET_DEPTH,
+        bucket_depth(),
         counts.clone(),
         Mutability::Immutable,
     )
@@ -630,7 +719,7 @@ fn table_view_exposes_counts_and_geometry_without_yielding_an_owned_table() {
     // Geometry getters.
     assert_eq!(view.batch_id(), batch_id());
     assert_eq!(view.depth(), 24);
-    assert_eq!(view.bucket_depth(), BUCKET_DEPTH);
+    assert_eq!(view.bucket_depth().get(), BUCKET_DEPTH);
     assert_eq!(view.bucket_count(), buckets_u32);
     assert_eq!(view.bucket_capacity(), 1u32 << (24 - BUCKET_DEPTH));
     assert_eq!(view.total_capacity(), 1u64 << 24);
@@ -662,7 +751,7 @@ fn table_view_exposes_counts_and_geometry_without_yielding_an_owned_table() {
 /// `stamps_since_persist` counts the unpersisted stamps in immutable mode.
 #[test]
 fn is_dirty_and_stamps_since_persist_track_unpersisted_issuance() {
-    let table = UsageTable::new(batch_id(), 20, BUCKET_DEPTH, Mutability::Immutable).unwrap();
+    let table = UsageTable::new(batch_id(), 20, bucket_depth(), Mutability::Immutable).unwrap();
     let mut snapshot = Snapshot::new(table);
 
     // A fresh snapshot that has issued nothing is clean.
@@ -706,7 +795,7 @@ fn is_dirty_and_stamps_since_persist_track_unpersisted_issuance() {
 /// ring churn and clears on persist.
 #[test]
 fn mutable_is_dirty_tracks_churn_but_count_is_none() {
-    let table = UsageTable::new(batch_id(), 20, BUCKET_DEPTH, Mutability::Mutable).unwrap();
+    let table = UsageTable::new(batch_id(), 20, bucket_depth(), Mutability::Mutable).unwrap();
     let mut snapshot = Snapshot::new(table);
     assert!(snapshot.table().is_mutable());
 
@@ -740,7 +829,8 @@ fn mutable_ring_wrap_is_signalled() {
     let buckets = 1usize << BUCKET_DEPTH;
     let counts = vec![0u32; buckets];
     let table =
-        UsageTable::from_counts(batch_id(), 17, BUCKET_DEPTH, counts, Mutability::Mutable).unwrap();
+        UsageTable::from_counts(batch_id(), 17, bucket_depth(), counts, Mutability::Mutable)
+            .unwrap();
     let mut snapshot = Snapshot::new(table);
     let capacity = snapshot.table().bucket_capacity();
     assert_eq!(capacity, 2);
@@ -786,7 +876,7 @@ fn mutable_ring_wrap_is_signalled() {
 /// bucket fails rather than overwriting, so no eviction is ever signalled.
 #[test]
 fn immutable_never_wraps() {
-    let table = UsageTable::new(batch_id(), 17, BUCKET_DEPTH, Mutability::Immutable).unwrap();
+    let table = UsageTable::new(batch_id(), 17, bucket_depth(), Mutability::Immutable).unwrap();
     let mut snapshot = Snapshot::new(table);
     let content = address_in_bucket(0x1234);
     let bucket = calculate_bucket(&content, BUCKET_DEPTH);
@@ -810,9 +900,14 @@ fn immutable_never_wraps() {
 fn steady_state_persist_changes_only_the_sequence() {
     let buckets = 1usize << BUCKET_DEPTH;
     let counts = synthetic_counts(buckets, 10, 15);
-    let table =
-        UsageTable::from_counts(batch_id(), 22, BUCKET_DEPTH, counts, Mutability::Immutable)
-            .unwrap();
+    let table = UsageTable::from_counts(
+        batch_id(),
+        22,
+        bucket_depth(),
+        counts,
+        Mutability::Immutable,
+    )
+    .unwrap();
     let mut snapshot = Snapshot::new(table);
 
     // First persist allocates the snapshot's own slots.
@@ -848,9 +943,14 @@ fn failed_allocation_rolls_back_the_snapshot() {
     // immediately hits a full bucket.
     let buckets = 1usize << BUCKET_DEPTH;
     let counts = vec![1u32; buckets];
-    let table =
-        UsageTable::from_counts(batch_id(), 16, BUCKET_DEPTH, counts, Mutability::Immutable)
-            .unwrap();
+    let table = UsageTable::from_counts(
+        batch_id(),
+        16,
+        bucket_depth(),
+        counts,
+        Mutability::Immutable,
+    )
+    .unwrap();
     let mut snapshot = Snapshot::new(table);
     let counts_before = snapshot.table().counts().to_vec();
     let issued_before = snapshot.table().total_issued();
@@ -868,6 +968,79 @@ fn failed_allocation_rolls_back_the_snapshot() {
     assert!(snapshot.allocated_slots().is_empty());
     assert_eq!(snapshot.table().counts(), counts_before.as_slice());
     assert_eq!(snapshot.table().total_issued(), issued_before);
+}
+
+/// A whole issue-reserve-persist-recover cycle for a network other than
+/// mainnet, proving the spec parameter is load-bearing rather than decorative:
+/// bucket depth 8 is below mainnet's floor of 16, so none of this exists for a
+/// mainnet snapshot, and the same bytes are refused when parsed as one.
+#[test]
+fn a_non_mainnet_snapshot_issues_reserves_and_recovers() {
+    // Depth 11 over bucket depth 8 gives 8 slots per bucket, on a mutable ring
+    // so issuance wraps rather than filling.
+    let table = UsageTableFor::from_counts(
+        batch_id(),
+        11,
+        BucketDepth::<Shallow>::new(8).unwrap(),
+        vec![0u32; 256],
+        Mutability::Mutable,
+    )
+    .unwrap();
+    let mut snapshot = SnapshotFor::new(table);
+
+    // The first persist allocates the snapshot's own chunk, which is reserved
+    // from then on.
+    let first = snapshot
+        .revalidate(PublishedSequence::NONE)
+        .unwrap()
+        .plan_persist(&owner())
+        .unwrap();
+    assert_eq!(first.chunks.len(), 1);
+    let reserved = snapshot.reserved_stamp_indices(&owner());
+    assert_eq!(reserved.len(), 1);
+    let (root_bucket, root_slot) = (reserved[0].bucket(), reserved[0].index());
+
+    // Content stamped into the snapshot's own bucket wraps around its slot, far
+    // past one full ring cycle.
+    let address = address_in_bucket_at(root_bucket, 8);
+    let mut issuer = snapshot.issuer(owner());
+    for _ in 0..40 {
+        let index = issuer.record_address(&address).unwrap();
+        assert_eq!(index.bucket(), root_bucket);
+        assert_ne!(
+            index.index(),
+            root_slot,
+            "issuance evicted the snapshot's own chunk"
+        );
+    }
+
+    // The next persist recovers byte-for-byte through the same spec.
+    let plan = snapshot
+        .revalidate(PublishedSequence::from(
+            &RootInfoFor::<Shallow>::parse(&first.chunks[0].payload).unwrap(),
+        ))
+        .unwrap()
+        .plan_persist(&owner())
+        .unwrap();
+    assert_eq!(roundtrip_for::<Shallow>(&plan), snapshot);
+    assert!(snapshot.table().is_mutable());
+    assert_eq!(snapshot.table().bucket_depth().get(), 8);
+
+    // Mainnet refuses the very same payload: its floor is 16.
+    assert_eq!(
+        RootInfo::parse(&plan.chunks[0].payload),
+        Err(UsageError::CorruptGeometry {
+            depth: 11,
+            bucket_depth: 8,
+        })
+    );
+}
+
+/// Returns a chunk address whose top `bucket_depth` bits select `bucket`.
+fn address_in_bucket_at(bucket: u32, bucket_depth: u8) -> nectar_primitives::ChunkAddress {
+    let mut bytes = [0u8; 32];
+    bytes[..4].copy_from_slice(&(bucket << (32 - u32::from(bucket_depth))).to_be_bytes());
+    nectar_primitives::ChunkAddress::new(bytes)
 }
 
 /// Returns a chunk address whose top `BUCKET_DEPTH` bits select `bucket`.
@@ -888,7 +1061,7 @@ const fn address_in_bucket(bucket: u32) -> nectar_primitives::ChunkAddress {
 /// thing that can reject a forged sequence-0 persist against a published batch.
 #[test]
 fn fresh_construction_forgery_is_rejected_by_the_floor() {
-    let table = UsageTable::new(batch_id(), 20, BUCKET_DEPTH, Mutability::Immutable).unwrap();
+    let table = UsageTable::new(batch_id(), 20, bucket_depth(), Mutability::Immutable).unwrap();
     let mut snapshot = Snapshot::new(table);
     // The published root the consumer reads live already carries sequence 5, so
     // the floor is 5. A fresh snapshot would emit sequence 1, which does not
@@ -904,7 +1077,7 @@ fn fresh_construction_forgery_is_rejected_by_the_floor() {
 /// recovers it from the wire so it stands in for a snapshot loaded from a stale
 /// cache at sequence `n`.
 fn recovered_at_sequence(n: u64) -> Snapshot {
-    let table = UsageTable::new(batch_id(), 20, BUCKET_DEPTH, Mutability::Immutable).unwrap();
+    let table = UsageTable::new(batch_id(), 20, bucket_depth(), Mutability::Immutable).unwrap();
     let mut snapshot = Snapshot::new(table);
     let mut plan = None;
     for _ in 0..n {
@@ -959,7 +1132,7 @@ fn persist_above_the_floor_succeeds() {
 /// is 1 and `1 > 0`.
 #[test]
 fn none_floor_admits_the_first_persist() {
-    let table = UsageTable::new(batch_id(), 20, BUCKET_DEPTH, Mutability::Immutable).unwrap();
+    let table = UsageTable::new(batch_id(), 20, bucket_depth(), Mutability::Immutable).unwrap();
     let mut snapshot = Snapshot::new(table);
     let plan = snapshot
         .revalidate(PublishedSequence::NONE)
@@ -973,7 +1146,7 @@ fn none_floor_admits_the_first_persist() {
 /// live root chunk, the only sanctioned source of the floor value.
 #[test]
 fn published_sequence_reads_from_a_parsed_root() {
-    let table = UsageTable::new(batch_id(), 20, BUCKET_DEPTH, Mutability::Immutable).unwrap();
+    let table = UsageTable::new(batch_id(), 20, bucket_depth(), Mutability::Immutable).unwrap();
     let mut snapshot = Snapshot::new(table);
     // Publish twice so the live root carries sequence 2.
     snapshot

--- a/crates/postage-usage/tests/snapshot.rs
+++ b/crates/postage-usage/tests/snapshot.rs
@@ -13,6 +13,8 @@
     clippy::as_conversions,
     clippy::missing_panics_doc
 )]
+use core::num::NonZeroU8;
+
 use alloy_primitives::Address;
 use nectar_postage::{BucketDepth, calculate_bucket};
 use nectar_postage_usage::{
@@ -66,7 +68,7 @@ struct Shallow;
 
 impl SwarmSpec for Shallow {
     const NETWORK_ID: NetworkId = NetworkId::TESTNET;
-    const MIN_BUCKET_DEPTH: u8 = 1;
+    const MIN_BUCKET_DEPTH: NonZeroU8 = NonZeroU8::new(1).unwrap();
 }
 
 /// [`roundtrip`] for a snapshot of another network.

--- a/crates/postage-usage/tests/vector.rs
+++ b/crates/postage-usage/tests/vector.rs
@@ -21,11 +21,28 @@
     clippy::missing_panics_doc
 )]
 use alloy_primitives::{Address, hex};
-use nectar_postage::calculate_bucket;
+use nectar_postage::{BucketDepth, calculate_bucket};
 use nectar_postage_usage::{
-    BatchId, Mutability, PublishedSequence, RootInfo, Snapshot, UsageTable, usage_chunk_address,
-    usage_chunk_id,
+    BatchId, Mutability, NetworkId, PublishedSequence, RootInfo, RootInfoFor, Snapshot,
+    SnapshotFor, SwarmSpec, UsageTable, UsageTableFor, usage_chunk_address, usage_chunk_id,
 };
+
+/// The README's small worked example runs at bucket depth 8, which mainnet's
+/// floor of 16 forbids, so the vector is pinned for a deployment whose floor is
+/// the format minimum. The encoding does not depend on the spec: only which
+/// geometries a network admits does.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Shallow;
+
+impl SwarmSpec for Shallow {
+    const NETWORK_ID: NetworkId = NetworkId::TESTNET;
+    const MIN_BUCKET_DEPTH: u8 = 1;
+}
+
+/// A bucket depth `Shallow` accepts.
+fn shallow(depth: u8) -> BucketDepth<Shallow> {
+    BucketDepth::new(depth).unwrap()
+}
 
 /// The full root payload from the README worked example: depth 12, bucket
 /// depth 8, counts `3 + (b mod 4)` with bucket 200 full at 16, after one
@@ -41,8 +58,9 @@ fn readme_worked_example_vector() {
     let owner = Address::repeat_byte(0x11);
     let mut counts: Vec<u32> = (0..256u32).map(|b| 3 + (b & 3)).collect();
     counts[200] = 16;
-    let table = UsageTable::from_counts(batch_id, 12, 8, counts, Mutability::Immutable).unwrap();
-    let mut snapshot = Snapshot::new(table);
+    let table = UsageTableFor::from_counts(batch_id, 12, shallow(8), counts, Mutability::Immutable)
+        .unwrap();
+    let mut snapshot = SnapshotFor::new(table);
     let plan = snapshot
         .revalidate(PublishedSequence::NONE)
         .unwrap()
@@ -67,7 +85,7 @@ fn readme_worked_example_vector() {
     assert_eq!(hex::encode(&plan.chunks[0].payload), ROOT_PAYLOAD_HEX);
 
     // And the vector decodes back to the same snapshot.
-    let root = RootInfo::parse(&hex::decode(ROOT_PAYLOAD_HEX).unwrap()).unwrap();
+    let root = RootInfoFor::<Shallow>::parse(&hex::decode(ROOT_PAYLOAD_HEX).unwrap()).unwrap();
     let recovered = root.assemble::<&[u8]>(&[]).unwrap();
     assert_eq!(recovered, snapshot);
 }
@@ -87,7 +105,14 @@ fn readme_large_batch_multi_leaf_vector() {
     let mut counts: Vec<u32> = (0..65536u32).map(|b| 100 + (b % 50)).collect();
     counts[0x1234] = 5000;
     counts[0xCBE5] = 8192;
-    let table = UsageTable::from_counts(batch_id, 29, 16, counts, Mutability::Immutable).unwrap();
+    let table = UsageTable::from_counts(
+        batch_id,
+        29,
+        BucketDepth::new(16).unwrap(),
+        counts,
+        Mutability::Immutable,
+    )
+    .unwrap();
     let mut snapshot = Snapshot::new(table);
     let plan = snapshot
         .revalidate(PublishedSequence::NONE)
@@ -141,8 +166,9 @@ fn mutable_vector_flags_byte_and_round_trip() {
     let owner = Address::repeat_byte(0x11);
     let mut counts: Vec<u32> = (0..256u32).map(|b| 3 + (b & 3)).collect();
     counts[200] = 16;
-    let table = UsageTable::from_counts(batch_id, 12, 8, counts, Mutability::Mutable).unwrap();
-    let mut snapshot = Snapshot::new(table);
+    let table =
+        UsageTableFor::from_counts(batch_id, 12, shallow(8), counts, Mutability::Mutable).unwrap();
+    let mut snapshot = SnapshotFor::new(table);
     let plan = snapshot
         .revalidate(PublishedSequence::NONE)
         .unwrap()
@@ -160,7 +186,8 @@ fn mutable_vector_flags_byte_and_round_trip() {
     assert_eq!(hex::encode(&bytes), MUTABLE_ROOT_PAYLOAD_HEX);
 
     // It decodes back as mutable to the same snapshot.
-    let root = RootInfo::parse(&hex::decode(MUTABLE_ROOT_PAYLOAD_HEX).unwrap()).unwrap();
+    let root =
+        RootInfoFor::<Shallow>::parse(&hex::decode(MUTABLE_ROOT_PAYLOAD_HEX).unwrap()).unwrap();
     assert!(root.is_mutable());
     let recovered = root.assemble::<&[u8]>(&[]).unwrap();
     assert!(recovered.table().is_mutable());

--- a/crates/postage-usage/tests/vector.rs
+++ b/crates/postage-usage/tests/vector.rs
@@ -20,6 +20,8 @@
     clippy::as_conversions,
     clippy::missing_panics_doc
 )]
+use core::num::NonZeroU8;
+
 use alloy_primitives::{Address, hex};
 use nectar_postage::{BucketDepth, calculate_bucket};
 use nectar_postage_usage::{
@@ -36,7 +38,7 @@ struct Shallow;
 
 impl SwarmSpec for Shallow {
     const NETWORK_ID: NetworkId = NetworkId::TESTNET;
-    const MIN_BUCKET_DEPTH: u8 = 1;
+    const MIN_BUCKET_DEPTH: NonZeroU8 = NonZeroU8::new(1).unwrap();
 }
 
 /// A bucket depth `Shallow` accepts.

--- a/crates/postage-usage/tests/vector.rs
+++ b/crates/postage-usage/tests/vector.rs
@@ -20,31 +20,18 @@
     clippy::as_conversions,
     clippy::missing_panics_doc
 )]
-use core::num::NonZeroU8;
-
 use alloy_primitives::{Address, hex};
 use nectar_postage::{BucketDepth, calculate_bucket};
 use nectar_postage_usage::{
-    BatchId, Mutability, NetworkId, PublishedSequence, RootInfo, RootInfoFor, Snapshot,
-    SnapshotFor, SwarmSpec, UsageTable, UsageTableFor, usage_chunk_address, usage_chunk_id,
+    BatchId, Mutability, PublishedSequence, RootInfo, RootInfoFor, Snapshot, SnapshotFor,
+    UsageTable, UsageTableFor, usage_chunk_address, usage_chunk_id,
 };
 
-/// The README's small worked example runs at bucket depth 8, which mainnet's
-/// floor of 16 forbids, so the vector is pinned for a deployment whose floor is
-/// the format minimum. The encoding does not depend on the spec: only which
-/// geometries a network admits does.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct Shallow;
+mod common;
 
-impl SwarmSpec for Shallow {
-    const NETWORK_ID: NetworkId = NetworkId::TESTNET;
-    const MIN_BUCKET_DEPTH: NonZeroU8 = NonZeroU8::new(1).unwrap();
-}
-
-/// A bucket depth `Shallow` accepts.
-fn shallow(depth: u8) -> BucketDepth<Shallow> {
-    BucketDepth::new(depth).unwrap()
-}
+// The README's small worked example runs at bucket depth 8, which mainnet's
+// floor of 16 forbids, so those vectors are pinned for `Shallow`.
+use common::{Shallow, shallow};
 
 /// The full root payload from the README worked example: depth 12, bucket
 /// depth 8, counts `3 + (b mod 4)` with bucket 200 full at 16, after one

--- a/crates/postage/Cargo.toml
+++ b/crates/postage/Cargo.toml
@@ -44,7 +44,6 @@ alloy-signer-local = { workspace = true }
 alloy-primitives = { workspace = true, features = ["getrandom", "arbitrary"] }
 arbitrary = { workspace = true, features = ["derive"] }
 nectar-primitives = { workspace = true, features = ["arbitrary"] }
-serde_json = { workspace = true, features = ["std"] }
 
 [[bench]]
 name = "verify"

--- a/crates/postage/Cargo.toml
+++ b/crates/postage/Cargo.toml
@@ -44,6 +44,7 @@ alloy-signer-local = { workspace = true }
 alloy-primitives = { workspace = true, features = ["getrandom", "arbitrary"] }
 arbitrary = { workspace = true, features = ["derive"] }
 nectar-primitives = { workspace = true, features = ["arbitrary"] }
+serde_json = { workspace = true, features = ["std"] }
 
 [[bench]]
 name = "verify"

--- a/crates/postage/benches/verify.rs
+++ b/crates/postage/benches/verify.rs
@@ -20,7 +20,7 @@ use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
 use nectar_postage::{
-    Batch, BatchId, Stamp, StampBytes, StampDigest, StampIndex,
+    Batch, BatchId, BucketDepth, Stamp, StampBytes, StampDigest, StampIndex,
     parallel::{verify_stamps_parallel, verify_stamps_parallel_with_pubkey},
 };
 use nectar_primitives::ChunkAddress;
@@ -123,7 +123,15 @@ fn bench_stamp_index_roundtrip(c: &mut Criterion) {
 // Validation Benchmarks
 
 fn bench_validate_index(c: &mut Criterion) {
-    let batch = Batch::new(BatchId::ZERO, 0, 0, Address::ZERO, 20, 16, false);
+    let batch = Batch::new(
+        BatchId::ZERO,
+        0,
+        0,
+        Address::ZERO,
+        20,
+        BucketDepth::new(16).unwrap(),
+        false,
+    );
     let valid_index = StampIndex::new(1000, 10);
     let invalid_bucket = StampIndex::new(70000, 0);
 

--- a/crates/postage/src/batch.rs
+++ b/crates/postage/src/batch.rs
@@ -113,7 +113,9 @@ impl<'a> arbitrary::Arbitrary<'a> for BatchId {
 #[repr(transparent)]
 pub struct BucketDepth<S: SwarmSpec = Mainnet> {
     depth: u8,
-    spec: PhantomData<S>,
+    // `fn() -> S` rather than `S`: the tag carries no data, so the depth (and
+    // everything holding one) is `Send`/`Sync` whatever the spec marker is.
+    spec: PhantomData<fn() -> S>,
 }
 
 impl<S: SwarmSpec> BucketDepth<S> {
@@ -273,7 +275,7 @@ impl<'a, S: SwarmSpec> arbitrary::Arbitrary<'a> for BucketDepth<S> {
 }
 
 /// Parameters for creating a new batch on the network `S`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(bound(serialize = "", deserialize = "")))]
 pub struct BatchParams<S: SwarmSpec = Mainnet> {
@@ -292,6 +294,34 @@ pub struct BatchParams<S: SwarmSpec = Mainnet> {
     /// Initial amount to fund the batch.
     pub amount: u128,
 }
+
+// As for [`BucketDepth`] above: the spec is a type-level tag, so `Clone` and
+// equality carry no bound on `S` beyond `SwarmSpec`. Only `Debug` is derived,
+// following the marker's own.
+
+impl<S: SwarmSpec> Clone for BatchParams<S> {
+    fn clone(&self) -> Self {
+        Self {
+            owner: self.owner,
+            depth: self.depth,
+            bucket_depth: self.bucket_depth,
+            immutable: self.immutable,
+            amount: self.amount,
+        }
+    }
+}
+
+impl<S: SwarmSpec> PartialEq for BatchParams<S> {
+    fn eq(&self, other: &Self) -> bool {
+        self.owner == other.owner
+            && self.depth == other.depth
+            && self.bucket_depth == other.bucket_depth
+            && self.immutable == other.immutable
+            && self.amount == other.amount
+    }
+}
+
+impl<S: SwarmSpec> Eq for BatchParams<S> {}
 
 impl<S: SwarmSpec> BatchParams<S> {
     /// Creates new batch parameters.
@@ -355,7 +385,7 @@ const fn validate_depth<S: SwarmSpec>(
 ///
 /// The network is a type parameter, defaulting to [`Mainnet`], and reaches the
 /// batch through its [`BucketDepth`].
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(bound(serialize = "", deserialize = "")))]
 pub struct Batch<S: SwarmSpec = Mainnet> {
@@ -378,6 +408,34 @@ pub struct Batch<S: SwarmSpec = Mainnet> {
     /// bucket index with a later timestamp, replacing the previous chunk.
     immutable: bool,
 }
+
+impl<S: SwarmSpec> Clone for Batch<S> {
+    fn clone(&self) -> Self {
+        Self {
+            id: self.id,
+            value: self.value,
+            start: self.start,
+            owner: self.owner,
+            depth: self.depth,
+            bucket_depth: self.bucket_depth,
+            immutable: self.immutable,
+        }
+    }
+}
+
+impl<S: SwarmSpec> PartialEq for Batch<S> {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+            && self.value == other.value
+            && self.start == other.start
+            && self.owner == other.owner
+            && self.depth == other.depth
+            && self.bucket_depth == other.bucket_depth
+            && self.immutable == other.immutable
+    }
+}
+
+impl<S: SwarmSpec> Eq for Batch<S> {}
 
 impl<S: SwarmSpec> Batch<S> {
     /// Creates a new batch with the given parameters.

--- a/crates/postage/src/batch.rs
+++ b/crates/postage/src/batch.rs
@@ -83,6 +83,11 @@ impl<'a> arbitrary::Arbitrary<'a> for BatchId {
 /// Bounded to `1..=32` at construction: bucket selection shifts a `u32` right by
 /// `32 - depth`, so a depth outside that range names no bucket. Holding the
 /// bound in the type keeps the shift total wherever a depth reaches it.
+///
+/// The bound is what the shift can represent, not what a network accepts. The
+/// operative depth is a network constant, so a batch is only well-formed when
+/// its depth matches the one the spec fixes and leaves room for the batch
+/// depth above it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Display, Into)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
@@ -92,10 +97,12 @@ impl<'a> arbitrary::Arbitrary<'a> for BatchId {
 pub struct BucketDepth(u8);
 
 impl BucketDepth {
-    /// The smallest valid depth, two collision buckets.
+    /// The smallest representable depth, two collision buckets. A network
+    /// fixes a far higher operative depth; this is only the point below which
+    /// the bucket shift stops naming anything.
     pub const MIN: Self = Self(1);
 
-    /// The largest valid depth, the bit width of the bucket key.
+    /// The largest representable depth, the bit width of the bucket key.
     pub const MAX: Self = Self(32);
 
     /// Validates a raw depth against the `1..=32` bound.

--- a/crates/postage/src/batch.rs
+++ b/crates/postage/src/batch.rs
@@ -3,7 +3,7 @@
 use alloy_primitives::{Address, B256};
 use derive_more::{AsRef, Display, From, Into};
 use nectar_primitives::{
-    ChunkAddress,
+    ChunkAddress, SwarmSpec,
     wire::{Cursor, FromCursor, ToWriter, Underrun, Writer},
 };
 
@@ -84,10 +84,10 @@ impl<'a> arbitrary::Arbitrary<'a> for BatchId {
 /// `32 - depth`, so a depth outside that range names no bucket. Holding the
 /// bound in the type keeps the shift total wherever a depth reaches it.
 ///
-/// The bound is what the shift can represent, not what a network accepts. The
-/// operative depth is a network constant, so a batch is only well-formed when
-/// its depth matches the one the spec fixes and leaves room for the batch
-/// depth above it.
+/// The bound is what the shift can represent, not what a network accepts. A
+/// spec sets a minimum operative depth, so a batch is only well-formed when its
+/// bucket depth reaches that minimum and its batch depth leaves room above it;
+/// [`validate_geometry`] applies both.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Display, Into)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
@@ -97,9 +97,9 @@ impl<'a> arbitrary::Arbitrary<'a> for BatchId {
 pub struct BucketDepth(u8);
 
 impl BucketDepth {
-    /// The smallest representable depth, two collision buckets. A network
-    /// fixes a far higher operative depth; this is only the point below which
-    /// the bucket shift stops naming anything.
+    /// The smallest representable depth, two collision buckets. A network sets
+    /// a far higher minimum; this is only the point below which the bucket
+    /// shift stops naming anything.
     pub const MIN: Self = Self(1);
 
     /// The largest representable depth, the bit width of the bucket key.
@@ -160,6 +160,43 @@ impl<'a> arbitrary::Arbitrary<'a> for BucketDepth {
     }
 }
 
+/// Validates a batch geometry against the network `spec`.
+///
+/// Covers the two protocol bounds [`BucketDepth::new`] cannot: the bucket depth
+/// reaches [`SwarmSpec::min_bucket_depth`], and the batch depth leaves room
+/// above it. Takes the spec instead of binding one into every constructor, so
+/// building a depth stays free where no spec is at hand and the protocol check
+/// lands at the edge that has one.
+///
+/// # Errors
+///
+/// [`StampError::BucketDepthBelowMinimum`] when `bucket_depth` is under the
+/// spec minimum, [`StampError::DepthBelowBucketDepth`] when `depth` is under
+/// `bucket_depth`.
+pub fn validate_geometry<S>(
+    spec: &S,
+    depth: u8,
+    bucket_depth: BucketDepth,
+) -> Result<(), StampError>
+where
+    S: SwarmSpec + ?Sized,
+{
+    let minimum = spec.min_bucket_depth();
+    if bucket_depth.get() < minimum {
+        return Err(StampError::BucketDepthBelowMinimum {
+            bucket_depth: bucket_depth.get(),
+            minimum,
+        });
+    }
+    if depth < bucket_depth.get() {
+        return Err(StampError::DepthBelowBucketDepth {
+            depth,
+            bucket_depth: bucket_depth.get(),
+        });
+    }
+    Ok(())
+}
+
 /// Parameters for creating a new batch.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -197,6 +234,19 @@ impl BatchParams {
     pub const fn immutable(mut self, immutable: bool) -> Self {
         self.immutable = immutable;
         self
+    }
+
+    /// Validates the declared geometry against `spec`, per [`validate_geometry`].
+    ///
+    /// # Errors
+    ///
+    /// As [`validate_geometry`].
+    #[inline]
+    pub fn validate_geometry<S>(&self, spec: &S) -> Result<(), StampError>
+    where
+        S: SwarmSpec + ?Sized,
+    {
+        validate_geometry(spec, self.depth, self.bucket_depth)
     }
 }
 
@@ -350,6 +400,23 @@ impl Batch {
     // Validation methods
     // =========================================================================
 
+    /// Validates this batch's geometry against `spec`, per [`validate_geometry`].
+    ///
+    /// Dilution raises the batch depth, so a batch stays valid across a
+    /// [`set_depth`](Self::set_depth) only while the new depth clears the
+    /// bucket depth.
+    ///
+    /// # Errors
+    ///
+    /// As [`validate_geometry`].
+    #[inline]
+    pub fn validate_geometry<S>(&self, spec: &S) -> Result<(), StampError>
+    where
+        S: SwarmSpec + ?Sized,
+    {
+        validate_geometry(spec, self.depth, self.bucket_depth)
+    }
+
     /// Validates that an index is within the valid range for this batch.
     ///
     /// Checks that:
@@ -470,6 +537,79 @@ mod tests {
             BucketDepth::try_from(u8::MAX),
             Err(StampError::InvalidBucketDepth {
                 bucket_depth: u8::MAX
+            })
+        ));
+    }
+
+    #[test]
+    fn geometry_takes_the_bucket_depth_minimum_from_the_spec() {
+        let spec = nectar_primitives::MAINNET;
+        assert_eq!(spec.min_bucket_depth(), 16);
+
+        let depth = |d: u8| BucketDepth::new(d).unwrap();
+
+        // Below the minimum, at it, and deeper than it.
+        assert!(matches!(
+            validate_geometry(&spec, 24, depth(15)),
+            Err(StampError::BucketDepthBelowMinimum {
+                bucket_depth: 15,
+                minimum: 16
+            })
+        ));
+        assert!(validate_geometry(&spec, 24, depth(16)).is_ok());
+        assert!(validate_geometry(&spec, 24, depth(20)).is_ok());
+        // A batch exactly as deep as its buckets holds one slot each.
+        assert!(validate_geometry(&spec, 16, depth(16)).is_ok());
+
+        assert!(matches!(
+            validate_geometry(&spec, 15, depth(16)),
+            Err(StampError::DepthBelowBucketDepth {
+                depth: 15,
+                bucket_depth: 16
+            })
+        ));
+    }
+
+    #[test]
+    fn geometry_follows_a_deployment_that_raises_the_minimum() {
+        struct Deep;
+        impl SwarmSpec for Deep {
+            fn network_id(&self) -> nectar_primitives::NetworkId {
+                nectar_primitives::NetworkId::TESTNET
+            }
+            fn min_bucket_depth(&self) -> u8 {
+                20
+            }
+        }
+
+        let bucket_depth = BucketDepth::new(16).unwrap();
+        assert!(validate_geometry(&nectar_primitives::MAINNET, 24, bucket_depth).is_ok());
+        assert!(matches!(
+            validate_geometry(&Deep, 24, bucket_depth),
+            Err(StampError::BucketDepthBelowMinimum {
+                bucket_depth: 16,
+                minimum: 20
+            })
+        ));
+    }
+
+    #[test]
+    fn geometry_validates_through_batch_and_params() {
+        let spec = nectar_primitives::MAINNET;
+        let bucket_depth = BucketDepth::new(16).unwrap();
+
+        let params = BatchParams::new(Address::ZERO, 20, bucket_depth, 1000);
+        assert!(params.validate_geometry(&spec).is_ok());
+
+        let batch = Batch::new(BatchId::ZERO, 0, 0, Address::ZERO, 20, bucket_depth, false);
+        assert!(batch.validate_geometry(&spec).is_ok());
+
+        let shallow = Batch::new(BatchId::ZERO, 0, 0, Address::ZERO, 8, bucket_depth, false);
+        assert!(matches!(
+            shallow.validate_geometry(&spec),
+            Err(StampError::DepthBelowBucketDepth {
+                depth: 8,
+                bucket_depth: 16
             })
         ));
     }

--- a/crates/postage/src/batch.rs
+++ b/crates/postage/src/batch.rs
@@ -83,12 +83,11 @@ impl<'a> arbitrary::Arbitrary<'a> for BatchId {
 /// The number of leading chunk-address bits that select a collision bucket, as
 /// the network `S` accepts it.
 ///
-/// Two bounds hold at construction. The representable one is `1..=32`: bucket
-/// selection shifts a `u32` right by `32 - depth`, so a depth outside
-/// [`MIN`](Self::MIN)`..=`[`MAX`](Self::MAX) names no bucket, and holding it in
-/// the type keeps the shift total wherever a depth reaches it. The protocol one
-/// is [`SwarmSpec::MIN_BUCKET_DEPTH`], the floor the PostageStamp contract
-/// publishes as `minimumBucketDepth()`.
+/// Two bounds hold at construction: [`SwarmSpec::MIN_BUCKET_DEPTH`], the floor
+/// the PostageStamp contract publishes as `minimumBucketDepth()`, and
+/// [`MAX`](Self::MAX), the width of the bucket key. Bucket selection shifts a
+/// `u32` right by `32 - depth`; holding both bounds in the type keeps that
+/// shift total wherever a depth reaches it.
 ///
 /// The floor is a compile-time property: a `BucketDepth<Mainnet>` below 16 does
 /// not exist, and one network's depth does not type-check where another's is
@@ -116,29 +115,25 @@ pub struct BucketDepth<S: SwarmSpec = Mainnet> {
 }
 
 impl<S: SwarmSpec> BucketDepth<S> {
-    /// Smallest representable depth, below which the bucket shift names
-    /// nothing. The spec supplies the protocol floor, which is higher.
-    pub const MIN: u8 = 1;
-
     /// Largest representable depth, the bit width of the bucket key.
     pub const MAX: u8 = 32;
 
-    /// Validates a raw depth against the spec floor and the `1..=32` bound.
+    /// Validates a raw depth against the spec floor and [`MAX`](Self::MAX).
     ///
     /// # Errors
     ///
     /// [`StampError::BucketDepthBelowMinimum`] when `depth` is under
     /// [`SwarmSpec::MIN_BUCKET_DEPTH`], [`StampError::InvalidBucketDepth`] when
-    /// it is outside the representable range.
+    /// it is above [`MAX`](Self::MAX).
     #[inline]
     pub const fn new(depth: u8) -> Result<Self, StampError> {
-        if depth < S::MIN_BUCKET_DEPTH {
+        if depth < S::MIN_BUCKET_DEPTH.get() {
             return Err(StampError::BucketDepthBelowMinimum {
                 bucket_depth: depth,
-                minimum: S::MIN_BUCKET_DEPTH,
+                minimum: S::MIN_BUCKET_DEPTH.get(),
             });
         }
-        if depth < Self::MIN || depth > Self::MAX {
+        if depth > Self::MAX {
             return Err(StampError::InvalidBucketDepth {
                 bucket_depth: depth,
             });
@@ -261,9 +256,9 @@ impl<'de, S: SwarmSpec> serde::Deserialize<'de> for BucketDepth<S> {
 #[cfg(any(test, feature = "arbitrary"))]
 impl<'a, S: SwarmSpec> arbitrary::Arbitrary<'a> for BucketDepth<S> {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let low = S::MIN_BUCKET_DEPTH.max(Self::MIN);
+        let low = S::MIN_BUCKET_DEPTH.get();
         if low > Self::MAX {
-            // A spec whose floor is unrepresentable admits no depth at all.
+            // A spec whose floor is past the bucket-key width admits no depth.
             return Err(arbitrary::Error::IncorrectFormat);
         }
         Self::new(u.int_in_range(low..=Self::MAX)?).map_err(|_| arbitrary::Error::IncorrectFormat)
@@ -669,6 +664,8 @@ impl<'a, S: SwarmSpec> arbitrary::Arbitrary<'a> for Batch<S> {
 
 #[cfg(test)]
 mod tests {
+    use core::num::NonZeroU8;
+
     use super::*;
 
     #[test]
@@ -687,7 +684,16 @@ mod tests {
 
     impl SwarmSpec for Deep {
         const NETWORK_ID: nectar_primitives::NetworkId = nectar_primitives::NetworkId::TESTNET;
-        const MIN_BUCKET_DEPTH: u8 = 20;
+        const MIN_BUCKET_DEPTH: NonZeroU8 = NonZeroU8::new(20).unwrap();
+    }
+
+    /// A deployment whose floor is the lowest a spec can declare.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct Shallow;
+
+    impl SwarmSpec for Shallow {
+        const NETWORK_ID: nectar_primitives::NetworkId = nectar_primitives::NetworkId::TESTNET;
+        const MIN_BUCKET_DEPTH: NonZeroU8 = NonZeroU8::new(1).unwrap();
     }
 
     #[test]
@@ -722,18 +728,18 @@ mod tests {
                 bucket_depth: u8::MAX
             })
         ));
+    }
 
-        // A spec that lowers the floor still cannot name a zero-bit bucket.
-        struct Floorless;
-        impl SwarmSpec for Floorless {
-            const NETWORK_ID: nectar_primitives::NetworkId = nectar_primitives::NetworkId::TESTNET;
-            const MIN_BUCKET_DEPTH: u8 = 0;
-        }
+    #[test]
+    fn the_lowest_floor_admits_a_one_bit_bucket() {
+        assert_eq!(BucketDepth::<Shallow>::new(1).unwrap().get(), 1);
         assert!(matches!(
-            BucketDepth::<Floorless>::new(0),
-            Err(StampError::InvalidBucketDepth { bucket_depth: 0 })
+            BucketDepth::<Shallow>::new(0),
+            Err(StampError::BucketDepthBelowMinimum {
+                bucket_depth: 0,
+                minimum: 1
+            })
         ));
-        assert_eq!(BucketDepth::<Floorless>::new(1).unwrap().get(), 1);
     }
 
     #[test]

--- a/crates/postage/src/batch.rs
+++ b/crates/postage/src/batch.rs
@@ -78,6 +78,81 @@ impl<'a> arbitrary::Arbitrary<'a> for BatchId {
     }
 }
 
+/// The number of leading chunk-address bits that select a collision bucket.
+///
+/// Bounded to `1..=32` at construction: bucket selection shifts a `u32` right by
+/// `32 - depth`, so a depth outside that range names no bucket. Holding the
+/// bound in the type keeps the shift total wherever a depth reaches it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Display, Into)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
+#[display("{_0}")]
+#[into(u8)]
+#[repr(transparent)]
+pub struct BucketDepth(u8);
+
+impl BucketDepth {
+    /// The smallest valid depth, two collision buckets.
+    pub const MIN: Self = Self(1);
+
+    /// The largest valid depth, the bit width of the bucket key.
+    pub const MAX: Self = Self(32);
+
+    /// Validates a raw depth against the `1..=32` bound.
+    ///
+    /// # Errors
+    ///
+    /// [`StampError::InvalidBucketDepth`] when `depth` is zero or above 32.
+    #[inline]
+    pub const fn new(depth: u8) -> Result<Self, StampError> {
+        if depth < Self::MIN.0 || depth > Self::MAX.0 {
+            return Err(StampError::InvalidBucketDepth {
+                bucket_depth: depth,
+            });
+        }
+        Ok(Self(depth))
+    }
+
+    /// Returns the depth as a bit count.
+    #[inline]
+    pub const fn get(self) -> u8 {
+        self.0
+    }
+
+    /// Returns the number of collision buckets, `2^depth`.
+    ///
+    /// Widened to `u64` because depth 32 overflows a `u32` count by one.
+    #[inline]
+    pub const fn bucket_count(self) -> u64 {
+        1u64 << self.0
+    }
+
+    /// Returns whether a bucket index is one this depth addresses.
+    #[inline]
+    pub const fn contains_bucket(self, bucket: u32) -> bool {
+        // At the maximum depth every `u32` is a bucket, and the count no longer
+        // fits the `u32` shift used below.
+        self.0 == Self::MAX.0 || bucket < (1u32 << self.0)
+    }
+}
+
+impl TryFrom<u8> for BucketDepth {
+    type Error = StampError;
+
+    #[inline]
+    fn try_from(depth: u8) -> Result<Self, StampError> {
+        Self::new(depth)
+    }
+}
+
+#[cfg(any(test, feature = "arbitrary"))]
+impl<'a> arbitrary::Arbitrary<'a> for BucketDepth {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Self::new(u.int_in_range(Self::MIN.0..=Self::MAX.0)?)
+            .map_err(|_| arbitrary::Error::IncorrectFormat)
+    }
+}
+
 /// Parameters for creating a new batch.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -87,7 +162,7 @@ pub struct BatchParams {
     /// The depth of the batch (total capacity = 2^depth chunks).
     pub depth: u8,
     /// The bucket depth for collision bucket uniformity.
-    pub bucket_depth: u8,
+    pub bucket_depth: BucketDepth,
     /// Whether the batch is immutable.
     ///
     /// Immutable batches cannot be diluted (depth increased) and chunks cannot
@@ -100,7 +175,7 @@ pub struct BatchParams {
 
 impl BatchParams {
     /// Creates new batch parameters.
-    pub const fn new(owner: Address, depth: u8, bucket_depth: u8, amount: u128) -> Self {
+    pub const fn new(owner: Address, depth: u8, bucket_depth: BucketDepth, amount: u128) -> Self {
         Self {
             owner,
             depth,
@@ -137,7 +212,7 @@ pub struct Batch {
     /// The depth of the batch, determining total capacity (2^depth chunks).
     depth: u8,
     /// The bucket depth for collision bucket uniformity.
-    bucket_depth: u8,
+    bucket_depth: BucketDepth,
     /// Whether the batch is immutable.
     ///
     /// Immutable batches cannot be diluted (depth increased) and chunks cannot
@@ -155,7 +230,7 @@ impl Batch {
         start: u64,
         owner: Address,
         depth: u8,
-        bucket_depth: u8,
+        bucket_depth: BucketDepth,
         immutable: bool,
     ) -> Self {
         Self {
@@ -205,7 +280,7 @@ impl Batch {
     ///
     /// This controls the uniformity of chunk distribution across collision buckets.
     #[inline]
-    pub const fn bucket_depth(&self) -> u8 {
+    pub const fn bucket_depth(&self) -> BucketDepth {
         self.bucket_depth
     }
 
@@ -219,21 +294,25 @@ impl Batch {
         self.immutable
     }
 
-    /// Returns the maximum number of chunks per bucket.
+    /// Returns the maximum number of chunks per bucket, `2^(depth - bucket_depth)`.
     ///
-    /// This is equal to 2^(depth - bucket_depth).
+    /// Yields a single slot for a batch shallower than its bucket depth, and
+    /// saturates at [`u32::MAX`] for a slot count wider than a `u32`.
     #[inline]
-    #[allow(clippy::arithmetic_side_effects)] // batch geometry invariant: depth >= bucket_depth (capacity is 2^(depth - bucket_depth) chunks per bucket)
     pub const fn bucket_upper_bound(&self) -> u32 {
-        1u32 << (self.depth - self.bucket_depth)
+        let slots = self.depth.saturating_sub(self.bucket_depth.get());
+        // `BucketDepth::MAX` is the bit width of the count, so a wider slot
+        // count has no `u32` to land in.
+        if slots >= BucketDepth::MAX.get() {
+            return u32::MAX;
+        }
+        1u32 << slots
     }
 
-    /// Returns the number of collision buckets.
-    ///
-    /// This is equal to 2^bucket_depth.
+    /// Returns the number of collision buckets, `2^bucket_depth`.
     #[inline]
-    pub const fn bucket_count(&self) -> u32 {
-        1u32 << self.bucket_depth
+    pub const fn bucket_count(&self) -> u64 {
+        self.bucket_depth.bucket_count()
     }
 
     /// Updates the batch value (for top-up operations).
@@ -275,7 +354,7 @@ impl Batch {
     /// `Ok(())` if the index is valid, or `Err(StampError::InvalidIndex)` otherwise.
     pub const fn validate_index(&self, index: &StampIndex) -> Result<(), StampError> {
         // Check bucket is within range
-        if index.bucket() >= self.bucket_count() {
+        if !self.bucket_depth.contains_bucket(index.bucket()) {
             return Err(StampError::InvalidIndex);
         }
 
@@ -293,7 +372,7 @@ impl Batch {
     /// chunk address, interpreted as a big-endian unsigned integer.
     #[inline]
     pub fn bucket_for_address(&self, address: &ChunkAddress) -> u32 {
-        calculate_bucket(address, self.bucket_depth)
+        calculate_bucket(address, self.bucket_depth.get())
     }
 
     /// Checks if a chunk address matches the expected bucket for a stamp index.
@@ -321,7 +400,8 @@ impl<'a> arbitrary::Arbitrary<'a> for BatchParams {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         // Generate valid depth values (bucket_depth must be <= depth)
         let depth: u8 = u.int_in_range(1..=32)?;
-        let bucket_depth: u8 = u.int_in_range(1..=depth)?;
+        let bucket_depth = BucketDepth::new(u.int_in_range(1..=depth)?)
+            .map_err(|_| arbitrary::Error::IncorrectFormat)?;
 
         Ok(Self {
             owner: Address::arbitrary(u)?,
@@ -338,7 +418,8 @@ impl<'a> arbitrary::Arbitrary<'a> for Batch {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         // Generate valid depth values (bucket_depth must be <= depth)
         let depth: u8 = u.int_in_range(1..=32)?;
-        let bucket_depth: u8 = u.int_in_range(1..=depth)?;
+        let bucket_depth = BucketDepth::new(u.int_in_range(1..=depth)?)
+            .map_err(|_| arbitrary::Error::IncorrectFormat)?;
 
         Ok(Self::new(
             BatchId::arbitrary(u)?,
@@ -367,22 +448,119 @@ mod tests {
     }
 
     #[test]
+    fn bucket_depth_accepts_only_one_to_thirty_two() {
+        assert!(matches!(
+            BucketDepth::new(0),
+            Err(StampError::InvalidBucketDepth { bucket_depth: 0 })
+        ));
+        assert_eq!(BucketDepth::new(1).unwrap(), BucketDepth::MIN);
+        assert_eq!(BucketDepth::new(32).unwrap(), BucketDepth::MAX);
+        assert!(matches!(
+            BucketDepth::new(33),
+            Err(StampError::InvalidBucketDepth { bucket_depth: 33 })
+        ));
+        assert!(matches!(
+            BucketDepth::try_from(u8::MAX),
+            Err(StampError::InvalidBucketDepth {
+                bucket_depth: u8::MAX
+            })
+        ));
+    }
+
+    #[test]
+    fn bucket_geometry_holds_at_the_bounds() {
+        let min = Batch::new(
+            BatchId::ZERO,
+            0,
+            0,
+            Address::ZERO,
+            1,
+            BucketDepth::MIN,
+            false,
+        );
+        assert_eq!(min.bucket_count(), 2);
+        assert_eq!(min.bucket_for_address(&ChunkAddress::new([0xFF; 32])), 1);
+
+        let max = Batch::new(
+            BatchId::ZERO,
+            0,
+            0,
+            Address::ZERO,
+            u8::MAX,
+            BucketDepth::MAX,
+            false,
+        );
+        assert_eq!(max.bucket_count(), 1 << 32);
+        assert_eq!(
+            max.bucket_for_address(&ChunkAddress::new([0xFF; 32])),
+            u32::MAX
+        );
+        // Every `u32` is a bucket at the maximum depth, and the per-bucket slot
+        // count saturates rather than overflowing its shift.
+        assert!(max.validate_index(&StampIndex::new(u32::MAX, 0)).is_ok());
+        assert_eq!(max.bucket_upper_bound(), u32::MAX);
+    }
+
+    #[test]
+    fn bucket_upper_bound_holds_for_a_batch_shallower_than_its_buckets() {
+        let batch = Batch::new(
+            BatchId::ZERO,
+            0,
+            0,
+            Address::ZERO,
+            8,
+            BucketDepth::MAX,
+            false,
+        );
+        assert_eq!(batch.bucket_upper_bound(), 1);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_rejects_an_out_of_range_bucket_depth() {
+        use serde::{Deserialize, de::IntoDeserializer, de::value::Error};
+
+        let decode =
+            |raw: u8| BucketDepth::deserialize(IntoDeserializer::<Error>::into_deserializer(raw));
+
+        assert_eq!(decode(16).unwrap(), BucketDepth::new(16).unwrap());
+        assert!(decode(0).is_err());
+        assert!(decode(33).is_err());
+    }
+
+    #[test]
     fn test_batch_creation() {
         let id = BatchId::ZERO;
-        let batch = Batch::new(id, 1000, 100, Address::ZERO, 18, 16, false);
+        let batch = Batch::new(
+            id,
+            1000,
+            100,
+            Address::ZERO,
+            18,
+            BucketDepth::new(16).unwrap(),
+            false,
+        );
 
         assert_eq!(batch.id(), id);
         assert_eq!(batch.value(), 1000);
         assert_eq!(batch.start(), 100);
         assert_eq!(batch.owner(), Address::ZERO);
         assert_eq!(batch.depth(), 18);
-        assert_eq!(batch.bucket_depth(), 16);
+        assert_eq!(batch.bucket_depth().get(), 16);
         assert!(!batch.immutable());
     }
 
     #[test]
     fn test_bucket_calculations() {
-        let batch = Batch::new(BatchId::ZERO, 0, 0, Address::ZERO, 18, 16, false);
+        let batch = Batch::new(
+            BatchId::ZERO,
+            0,
+            0,
+            Address::ZERO,
+            18,
+            BucketDepth::new(16).unwrap(),
+            false,
+        );
 
         // 2^(18-16) = 2^2 = 4 chunks per bucket
         assert_eq!(batch.bucket_upper_bound(), 4);
@@ -392,7 +570,15 @@ mod tests {
 
     #[test]
     fn test_batch_expiry() {
-        let batch = Batch::new(BatchId::ZERO, 1000, 0, Address::ZERO, 18, 16, false);
+        let batch = Batch::new(
+            BatchId::ZERO,
+            1000,
+            0,
+            Address::ZERO,
+            18,
+            BucketDepth::new(16).unwrap(),
+            false,
+        );
 
         assert!(!batch.is_expired(999));
         assert!(batch.is_expired(1000));
@@ -401,7 +587,15 @@ mod tests {
 
     #[test]
     fn test_batch_usability() {
-        let batch = Batch::new(BatchId::ZERO, 1000, 100, Address::ZERO, 18, 16, false);
+        let batch = Batch::new(
+            BatchId::ZERO,
+            1000,
+            100,
+            Address::ZERO,
+            18,
+            BucketDepth::new(16).unwrap(),
+            false,
+        );
 
         assert!(!batch.is_usable(100, 10)); // Same block
         assert!(!batch.is_usable(109, 10)); // Not enough confirmations
@@ -411,11 +605,12 @@ mod tests {
 
     #[test]
     fn test_batch_params_builder() {
-        let params = BatchParams::new(Address::ZERO, 20, 16, 1000).immutable(true);
+        let params = BatchParams::new(Address::ZERO, 20, BucketDepth::new(16).unwrap(), 1000)
+            .immutable(true);
 
         assert_eq!(params.owner, Address::ZERO);
         assert_eq!(params.depth, 20);
-        assert_eq!(params.bucket_depth, 16);
+        assert_eq!(params.bucket_depth.get(), 16);
         assert_eq!(params.amount, 1000);
         assert!(params.immutable);
     }

--- a/crates/postage/src/batch.rs
+++ b/crates/postage/src/batch.rs
@@ -90,15 +90,12 @@ impl<'a> arbitrary::Arbitrary<'a> for BatchId {
 /// is [`SwarmSpec::MIN_BUCKET_DEPTH`], the floor the PostageStamp contract
 /// publishes as `minimumBucketDepth()`.
 ///
-/// The spec is a type parameter, so the floor is a compile-time property of the
-/// depth rather than something a caller must remember to check: a
-/// `BucketDepth<Mainnet>` below 16 does not exist, and a depth built for one
-/// network does not type-check where another's is wanted. Every constructor
-/// funnels through [`new`](Self::new), including the serde and `Arbitrary`
-/// paths.
+/// The floor is a compile-time property: a `BucketDepth<Mainnet>` below 16 does
+/// not exist, and one network's depth does not type-check where another's is
+/// wanted. Every constructor funnels through [`new`](Self::new), including the
+/// serde and `Arbitrary` paths.
 ///
-/// A depth carries the network it was built for, so the following does not
-/// compile:
+/// A depth carries its network, so this does not compile:
 ///
 /// ```compile_fail
 /// use nectar_postage::{Batch, BatchId, BucketDepth};
@@ -119,12 +116,11 @@ pub struct BucketDepth<S: SwarmSpec = Mainnet> {
 }
 
 impl<S: SwarmSpec> BucketDepth<S> {
-    /// The smallest representable depth, two collision buckets. A network sets
-    /// a far higher floor; this is only the point below which the bucket shift
-    /// stops naming anything.
+    /// Smallest representable depth, below which the bucket shift names
+    /// nothing. The spec supplies the protocol floor, which is higher.
     pub const MIN: u8 = 1;
 
-    /// The largest representable depth, the bit width of the bucket key.
+    /// Largest representable depth, the bit width of the bucket key.
     pub const MAX: u8 = 32;
 
     /// Validates a raw depth against the spec floor and the `1..=32` bound.

--- a/crates/postage/src/batch.rs
+++ b/crates/postage/src/batch.rs
@@ -844,18 +844,16 @@ mod tests {
 
     #[cfg(feature = "serde")]
     #[test]
-    fn serde_round_trips_a_depth_and_enforces_the_floor() {
+    fn serde_decodes_a_depth_and_enforces_the_floor() {
         use serde::{Deserialize, de::IntoDeserializer, de::value::Error};
 
         fn decode<S: SwarmSpec>(raw: u8) -> Result<BucketDepth<S>, Error> {
             BucketDepth::deserialize(IntoDeserializer::<Error>::into_deserializer(raw))
         }
 
-        let depth = BucketDepth::<Mainnet>::new(16).unwrap();
-        assert_eq!(decode::<Mainnet>(16).unwrap(), depth);
         assert_eq!(
-            serde_json::to_string(&depth).unwrap(),
-            serde_json::to_string(&16u8).unwrap()
+            decode::<Mainnet>(16).unwrap(),
+            BucketDepth::<Mainnet>::new(16).unwrap()
         );
 
         // The floor and the representable bound both survive the wire.
@@ -865,12 +863,6 @@ mod tests {
         // and is refused on a deployment that asks for 20.
         assert!(decode::<Deep>(16).is_err());
         assert!(decode::<Deep>(20).is_ok());
-
-        // A batch decodes through the same gate.
-        let batch: Batch = Batch::new(BatchId::ZERO, 0, 0, Address::ZERO, 20, depth, false);
-        let json = serde_json::to_string(&batch).unwrap();
-        assert_eq!(serde_json::from_str::<Batch>(&json).unwrap(), batch);
-        assert!(serde_json::from_str::<Batch<Deep>>(&json).is_err());
     }
 
     #[test]

--- a/crates/postage/src/batch.rs
+++ b/crates/postage/src/batch.rs
@@ -1,9 +1,11 @@
 //! Postage batch types.
 
+use core::{fmt, marker::PhantomData};
+
 use alloy_primitives::{Address, B256};
 use derive_more::{AsRef, Display, From, Into};
 use nectar_primitives::{
-    ChunkAddress, SwarmSpec,
+    ChunkAddress, Mainnet, SwarmSpec,
     wire::{Cursor, FromCursor, ToWriter, Underrun, Writer},
 };
 
@@ -78,52 +80,81 @@ impl<'a> arbitrary::Arbitrary<'a> for BatchId {
     }
 }
 
-/// The number of leading chunk-address bits that select a collision bucket.
+/// The number of leading chunk-address bits that select a collision bucket, as
+/// the network `S` accepts it.
 ///
-/// Bounded to `1..=32` at construction: bucket selection shifts a `u32` right by
-/// `32 - depth`, so a depth outside that range names no bucket. Holding the
-/// bound in the type keeps the shift total wherever a depth reaches it.
+/// Two bounds hold at construction. The representable one is `1..=32`: bucket
+/// selection shifts a `u32` right by `32 - depth`, so a depth outside
+/// [`MIN`](Self::MIN)`..=`[`MAX`](Self::MAX) names no bucket, and holding it in
+/// the type keeps the shift total wherever a depth reaches it. The protocol one
+/// is [`SwarmSpec::MIN_BUCKET_DEPTH`], the floor the PostageStamp contract
+/// publishes as `minimumBucketDepth()`.
 ///
-/// The bound is what the shift can represent, not what a network accepts. A
-/// spec sets a minimum operative depth, so a batch is only well-formed when its
-/// bucket depth reaches that minimum and its batch depth leaves room above it;
-/// [`validate_geometry`] applies both.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Display, Into)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
-#[display("{_0}")]
-#[into(u8)]
+/// The spec is a type parameter, so the floor is a compile-time property of the
+/// depth rather than something a caller must remember to check: a
+/// `BucketDepth<Mainnet>` below 16 does not exist, and a depth built for one
+/// network does not type-check where another's is wanted. Every constructor
+/// funnels through [`new`](Self::new), including the serde and `Arbitrary`
+/// paths.
+///
+/// A depth carries the network it was built for, so the following does not
+/// compile:
+///
+/// ```compile_fail
+/// use nectar_postage::{Batch, BatchId, BucketDepth};
+/// use nectar_primitives::Testnet;
+///
+/// let bucket_depth = BucketDepth::<Testnet>::new(16).unwrap();
+/// // `Batch` without a spec argument is a mainnet batch.
+/// let batch: Batch = Batch::new(
+///     BatchId::ZERO, 0, 0, Default::default(), 20, bucket_depth, false,
+/// );
+/// ```
 #[repr(transparent)]
-pub struct BucketDepth(u8);
+pub struct BucketDepth<S: SwarmSpec = Mainnet> {
+    depth: u8,
+    spec: PhantomData<S>,
+}
 
-impl BucketDepth {
+impl<S: SwarmSpec> BucketDepth<S> {
     /// The smallest representable depth, two collision buckets. A network sets
-    /// a far higher minimum; this is only the point below which the bucket
-    /// shift stops naming anything.
-    pub const MIN: Self = Self(1);
+    /// a far higher floor; this is only the point below which the bucket shift
+    /// stops naming anything.
+    pub const MIN: u8 = 1;
 
     /// The largest representable depth, the bit width of the bucket key.
-    pub const MAX: Self = Self(32);
+    pub const MAX: u8 = 32;
 
-    /// Validates a raw depth against the `1..=32` bound.
+    /// Validates a raw depth against the spec floor and the `1..=32` bound.
     ///
     /// # Errors
     ///
-    /// [`StampError::InvalidBucketDepth`] when `depth` is zero or above 32.
+    /// [`StampError::BucketDepthBelowMinimum`] when `depth` is under
+    /// [`SwarmSpec::MIN_BUCKET_DEPTH`], [`StampError::InvalidBucketDepth`] when
+    /// it is outside the representable range.
     #[inline]
     pub const fn new(depth: u8) -> Result<Self, StampError> {
-        if depth < Self::MIN.0 || depth > Self::MAX.0 {
+        if depth < S::MIN_BUCKET_DEPTH {
+            return Err(StampError::BucketDepthBelowMinimum {
+                bucket_depth: depth,
+                minimum: S::MIN_BUCKET_DEPTH,
+            });
+        }
+        if depth < Self::MIN || depth > Self::MAX {
             return Err(StampError::InvalidBucketDepth {
                 bucket_depth: depth,
             });
         }
-        Ok(Self(depth))
+        Ok(Self {
+            depth,
+            spec: PhantomData,
+        })
     }
 
     /// Returns the depth as a bit count.
     #[inline]
     pub const fn get(self) -> u8 {
-        self.0
+        self.depth
     }
 
     /// Returns the number of collision buckets, `2^depth`.
@@ -131,7 +162,7 @@ impl BucketDepth {
     /// Widened to `u64` because depth 32 overflows a `u32` count by one.
     #[inline]
     pub const fn bucket_count(self) -> u64 {
-        1u64 << self.0
+        1u64 << self.depth
     }
 
     /// Returns whether a bucket index is one this depth addresses.
@@ -139,11 +170,68 @@ impl BucketDepth {
     pub const fn contains_bucket(self, bucket: u32) -> bool {
         // At the maximum depth every `u32` is a bucket, and the count no longer
         // fits the `u32` shift used below.
-        self.0 == Self::MAX.0 || bucket < (1u32 << self.0)
+        self.depth == Self::MAX || bucket < (1u32 << self.depth)
     }
 }
 
-impl TryFrom<u8> for BucketDepth {
+// The spec is a type-level tag, so the manual impls below carry no bound on
+// `S` beyond `SwarmSpec`; deriving would demand `S: Clone`, `S: Eq` and the
+// rest of a marker type that holds no data.
+
+impl<S: SwarmSpec> Clone for BucketDepth<S> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<S: SwarmSpec> Copy for BucketDepth<S> {}
+
+impl<S: SwarmSpec> fmt::Debug for BucketDepth<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("BucketDepth").field(&self.depth).finish()
+    }
+}
+
+impl<S: SwarmSpec> fmt::Display for BucketDepth<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.depth, f)
+    }
+}
+
+impl<S: SwarmSpec> PartialEq for BucketDepth<S> {
+    fn eq(&self, other: &Self) -> bool {
+        self.depth == other.depth
+    }
+}
+
+impl<S: SwarmSpec> Eq for BucketDepth<S> {}
+
+impl<S: SwarmSpec> PartialOrd for BucketDepth<S> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<S: SwarmSpec> Ord for BucketDepth<S> {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.depth.cmp(&other.depth)
+    }
+}
+
+impl<S: SwarmSpec> core::hash::Hash for BucketDepth<S> {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.depth.hash(state);
+    }
+}
+
+impl<S: SwarmSpec> From<BucketDepth<S>> for u8 {
+    #[inline]
+    fn from(depth: BucketDepth<S>) -> Self {
+        depth.depth
+    }
+}
+
+impl<S: SwarmSpec> TryFrom<u8> for BucketDepth<S> {
     type Error = StampError;
 
     #[inline]
@@ -152,61 +240,49 @@ impl TryFrom<u8> for BucketDepth {
     }
 }
 
+/// Serializes as the bare depth byte.
+#[cfg(feature = "serde")]
+impl<S: SwarmSpec> serde::Serialize for BucketDepth<S> {
+    fn serialize<Z: serde::Serializer>(&self, serializer: Z) -> Result<Z::Ok, Z::Error> {
+        serializer.serialize_u8(self.depth)
+    }
+}
+
+/// Deserializes through [`BucketDepth::new`], so a stored depth below the spec
+/// floor is refused rather than reconstructed.
+#[cfg(feature = "serde")]
+impl<'de, S: SwarmSpec> serde::Deserialize<'de> for BucketDepth<S> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let depth = u8::deserialize(deserializer)?;
+        Self::new(depth).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Draws from the spec's accepted window, so every generated depth is one the
+/// network accepts.
 #[cfg(any(test, feature = "arbitrary"))]
-impl<'a> arbitrary::Arbitrary<'a> for BucketDepth {
+impl<'a, S: SwarmSpec> arbitrary::Arbitrary<'a> for BucketDepth<S> {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        Self::new(u.int_in_range(Self::MIN.0..=Self::MAX.0)?)
-            .map_err(|_| arbitrary::Error::IncorrectFormat)
+        let low = S::MIN_BUCKET_DEPTH.max(Self::MIN);
+        if low > Self::MAX {
+            // A spec whose floor is unrepresentable admits no depth at all.
+            return Err(arbitrary::Error::IncorrectFormat);
+        }
+        Self::new(u.int_in_range(low..=Self::MAX)?).map_err(|_| arbitrary::Error::IncorrectFormat)
     }
 }
 
-/// Validates a batch geometry against the network `spec`.
-///
-/// Covers the two protocol bounds [`BucketDepth::new`] cannot: the bucket depth
-/// reaches [`SwarmSpec::min_bucket_depth`], and the batch depth leaves room
-/// above it. Takes the spec instead of binding one into every constructor, so
-/// building a depth stays free where no spec is at hand and the protocol check
-/// lands at the edge that has one.
-///
-/// # Errors
-///
-/// [`StampError::BucketDepthBelowMinimum`] when `bucket_depth` is under the
-/// spec minimum, [`StampError::DepthBelowBucketDepth`] when `depth` is under
-/// `bucket_depth`.
-pub fn validate_geometry<S>(
-    spec: &S,
-    depth: u8,
-    bucket_depth: BucketDepth,
-) -> Result<(), StampError>
-where
-    S: SwarmSpec + ?Sized,
-{
-    let minimum = spec.min_bucket_depth();
-    if bucket_depth.get() < minimum {
-        return Err(StampError::BucketDepthBelowMinimum {
-            bucket_depth: bucket_depth.get(),
-            minimum,
-        });
-    }
-    if depth < bucket_depth.get() {
-        return Err(StampError::DepthBelowBucketDepth {
-            depth,
-            bucket_depth: bucket_depth.get(),
-        });
-    }
-    Ok(())
-}
-
-/// Parameters for creating a new batch.
+/// Parameters for creating a new batch on the network `S`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct BatchParams {
+#[cfg_attr(feature = "serde", serde(bound(serialize = "", deserialize = "")))]
+pub struct BatchParams<S: SwarmSpec = Mainnet> {
     /// The owner's Ethereum address.
     pub owner: Address,
     /// The depth of the batch (total capacity = 2^depth chunks).
     pub depth: u8,
     /// The bucket depth for collision bucket uniformity.
-    pub bucket_depth: BucketDepth,
+    pub bucket_depth: BucketDepth<S>,
     /// Whether the batch is immutable.
     ///
     /// Immutable batches cannot be diluted (depth increased) and chunks cannot
@@ -217,9 +293,14 @@ pub struct BatchParams {
     pub amount: u128,
 }
 
-impl BatchParams {
+impl<S: SwarmSpec> BatchParams<S> {
     /// Creates new batch parameters.
-    pub const fn new(owner: Address, depth: u8, bucket_depth: BucketDepth, amount: u128) -> Self {
+    pub const fn new(
+        owner: Address,
+        depth: u8,
+        bucket_depth: BucketDepth<S>,
+        amount: u128,
+    ) -> Self {
         Self {
             owner,
             depth,
@@ -236,18 +317,34 @@ impl BatchParams {
         self
     }
 
-    /// Validates the declared geometry against `spec`, per [`validate_geometry`].
+    /// Validates that the batch depth leaves room above the bucket depth.
+    ///
+    /// The bucket depth clears the network floor by construction; this is the
+    /// one geometry bound left to check, because `depth` is a plain `u8` the
+    /// type system cannot relate to it.
     ///
     /// # Errors
     ///
-    /// As [`validate_geometry`].
+    /// [`StampError::DepthBelowBucketDepth`] when `depth` is under the bucket
+    /// depth.
     #[inline]
-    pub fn validate_geometry<S>(&self, spec: &S) -> Result<(), StampError>
-    where
-        S: SwarmSpec + ?Sized,
-    {
-        validate_geometry(spec, self.depth, self.bucket_depth)
+    pub const fn validate_depth(&self) -> Result<(), StampError> {
+        validate_depth(self.depth, self.bucket_depth)
     }
+}
+
+/// Validates that a batch depth leaves room above its bucket depth.
+const fn validate_depth<S: SwarmSpec>(
+    depth: u8,
+    bucket_depth: BucketDepth<S>,
+) -> Result<(), StampError> {
+    if depth < bucket_depth.get() {
+        return Err(StampError::DepthBelowBucketDepth {
+            depth,
+            bucket_depth: bucket_depth.get(),
+        });
+    }
+    Ok(())
 }
 
 /// A postage batch represents a prepaid storage allocation in the Swarm network.
@@ -255,9 +352,13 @@ impl BatchParams {
 /// Batches are created by sending BZZ tokens to the postage stamp contract.
 /// Each batch has a depth that determines the maximum number of chunks it can stamp,
 /// and a bucket depth that controls the uniformity of chunk distribution.
+///
+/// The network is a type parameter, defaulting to [`Mainnet`], and reaches the
+/// batch through its [`BucketDepth`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Batch {
+#[cfg_attr(feature = "serde", serde(bound(serialize = "", deserialize = "")))]
+pub struct Batch<S: SwarmSpec = Mainnet> {
     /// The unique identifier for this batch.
     id: BatchId,
     /// The normalized balance of the batch (value per chunk).
@@ -269,7 +370,7 @@ pub struct Batch {
     /// The depth of the batch, determining total capacity (2^depth chunks).
     depth: u8,
     /// The bucket depth for collision bucket uniformity.
-    bucket_depth: BucketDepth,
+    bucket_depth: BucketDepth<S>,
     /// Whether the batch is immutable.
     ///
     /// Immutable batches cannot be diluted (depth increased) and chunks cannot
@@ -278,7 +379,7 @@ pub struct Batch {
     immutable: bool,
 }
 
-impl Batch {
+impl<S: SwarmSpec> Batch<S> {
     /// Creates a new batch with the given parameters.
     #[inline]
     pub const fn new(
@@ -287,7 +388,7 @@ impl Batch {
         start: u64,
         owner: Address,
         depth: u8,
-        bucket_depth: BucketDepth,
+        bucket_depth: BucketDepth<S>,
         immutable: bool,
     ) -> Self {
         Self {
@@ -337,7 +438,7 @@ impl Batch {
     ///
     /// This controls the uniformity of chunk distribution across collision buckets.
     #[inline]
-    pub const fn bucket_depth(&self) -> BucketDepth {
+    pub const fn bucket_depth(&self) -> BucketDepth<S> {
         self.bucket_depth
     }
 
@@ -360,7 +461,7 @@ impl Batch {
         let slots = self.depth.saturating_sub(self.bucket_depth.get());
         // `BucketDepth::MAX` is the bit width of the count, so a wider slot
         // count has no `u32` to land in.
-        if slots >= BucketDepth::MAX.get() {
+        if slots >= BucketDepth::<S>::MAX {
             return u32::MAX;
         }
         1u32 << slots
@@ -400,21 +501,21 @@ impl Batch {
     // Validation methods
     // =========================================================================
 
-    /// Validates this batch's geometry against `spec`, per [`validate_geometry`].
+    /// Validates that the batch depth leaves room above the bucket depth.
     ///
-    /// Dilution raises the batch depth, so a batch stays valid across a
-    /// [`set_depth`](Self::set_depth) only while the new depth clears the
-    /// bucket depth.
+    /// The bucket depth clears the network floor by construction; this is the
+    /// one geometry bound left to check, because `depth` is a plain `u8` the
+    /// type system cannot relate to it. [`set_depth`](Self::set_depth) takes a
+    /// bare depth for a dilution, so a batch stays well-formed across one only
+    /// while the new depth clears the bucket depth.
     ///
     /// # Errors
     ///
-    /// As [`validate_geometry`].
+    /// [`StampError::DepthBelowBucketDepth`] when `depth` is under the bucket
+    /// depth.
     #[inline]
-    pub fn validate_geometry<S>(&self, spec: &S) -> Result<(), StampError>
-    where
-        S: SwarmSpec + ?Sized,
-    {
-        validate_geometry(spec, self.depth, self.bucket_depth)
+    pub const fn validate_depth(&self) -> Result<(), StampError> {
+        validate_depth(self.depth, self.bucket_depth)
     }
 
     /// Validates that an index is within the valid range for this batch.
@@ -469,13 +570,21 @@ impl Batch {
 
 // Arbitrary implementations for property-based testing
 
+/// Draws a bucket depth the network accepts, then a batch depth at or above
+/// it, so the generated geometry satisfies both bounds.
 #[cfg(any(test, feature = "arbitrary"))]
-impl<'a> arbitrary::Arbitrary<'a> for BatchParams {
+fn arbitrary_geometry<S: SwarmSpec>(
+    u: &mut arbitrary::Unstructured<'_>,
+) -> arbitrary::Result<(u8, BucketDepth<S>)> {
+    let bucket_depth = <BucketDepth<S> as arbitrary::Arbitrary>::arbitrary(u)?;
+    let depth = u.int_in_range(bucket_depth.get()..=BucketDepth::<S>::MAX)?;
+    Ok((depth, bucket_depth))
+}
+
+#[cfg(any(test, feature = "arbitrary"))]
+impl<'a, S: SwarmSpec> arbitrary::Arbitrary<'a> for BatchParams<S> {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        // Generate valid depth values (bucket_depth must be <= depth)
-        let depth: u8 = u.int_in_range(1..=32)?;
-        let bucket_depth = BucketDepth::new(u.int_in_range(1..=depth)?)
-            .map_err(|_| arbitrary::Error::IncorrectFormat)?;
+        let (depth, bucket_depth) = arbitrary_geometry::<S>(u)?;
 
         Ok(Self {
             owner: Address::arbitrary(u)?,
@@ -488,12 +597,9 @@ impl<'a> arbitrary::Arbitrary<'a> for BatchParams {
 }
 
 #[cfg(any(test, feature = "arbitrary"))]
-impl<'a> arbitrary::Arbitrary<'a> for Batch {
+impl<'a, S: SwarmSpec> arbitrary::Arbitrary<'a> for Batch<S> {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        // Generate valid depth values (bucket_depth must be <= depth)
-        let depth: u8 = u.int_in_range(1..=32)?;
-        let bucket_depth = BucketDepth::new(u.int_in_range(1..=depth)?)
-            .map_err(|_| arbitrary::Error::IncorrectFormat)?;
+        let (depth, bucket_depth) = arbitrary_geometry::<S>(u)?;
 
         Ok(Self::new(
             BatchId::arbitrary(u)?,
@@ -521,120 +627,134 @@ mod tests {
         assert_eq!(BatchId::from(bytes), id);
     }
 
-    #[test]
-    fn bucket_depth_accepts_only_one_to_thirty_two() {
-        assert!(matches!(
-            BucketDepth::new(0),
-            Err(StampError::InvalidBucketDepth { bucket_depth: 0 })
-        ));
-        assert_eq!(BucketDepth::new(1).unwrap(), BucketDepth::MIN);
-        assert_eq!(BucketDepth::new(32).unwrap(), BucketDepth::MAX);
-        assert!(matches!(
-            BucketDepth::new(33),
-            Err(StampError::InvalidBucketDepth { bucket_depth: 33 })
-        ));
-        assert!(matches!(
-            BucketDepth::try_from(u8::MAX),
-            Err(StampError::InvalidBucketDepth {
-                bucket_depth: u8::MAX
-            })
-        ));
+    /// A deployment that raises the bucket-depth floor above mainnet's.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct Deep;
+
+    impl SwarmSpec for Deep {
+        const NETWORK_ID: nectar_primitives::NetworkId = nectar_primitives::NetworkId::TESTNET;
+        const MIN_BUCKET_DEPTH: u8 = 20;
     }
 
     #[test]
-    fn geometry_takes_the_bucket_depth_minimum_from_the_spec() {
-        let spec = nectar_primitives::MAINNET;
-        assert_eq!(spec.min_bucket_depth(), 16);
-
-        let depth = |d: u8| BucketDepth::new(d).unwrap();
-
-        // Below the minimum, at it, and deeper than it.
+    fn bucket_depth_takes_its_floor_from_the_spec() {
+        // Below the mainnet floor, at it, and deeper than it.
         assert!(matches!(
-            validate_geometry(&spec, 24, depth(15)),
+            BucketDepth::<Mainnet>::new(15),
             Err(StampError::BucketDepthBelowMinimum {
                 bucket_depth: 15,
                 minimum: 16
             })
         ));
-        assert!(validate_geometry(&spec, 24, depth(16)).is_ok());
-        assert!(validate_geometry(&spec, 24, depth(20)).is_ok());
-        // A batch exactly as deep as its buckets holds one slot each.
-        assert!(validate_geometry(&spec, 16, depth(16)).is_ok());
-
-        assert!(matches!(
-            validate_geometry(&spec, 15, depth(16)),
-            Err(StampError::DepthBelowBucketDepth {
-                depth: 15,
-                bucket_depth: 16
-            })
-        ));
+        assert_eq!(BucketDepth::<Mainnet>::new(16).unwrap().get(), 16);
+        assert_eq!(BucketDepth::<Mainnet>::new(20).unwrap().get(), 20);
+        assert_eq!(
+            BucketDepth::<Mainnet>::new(BucketDepth::<Mainnet>::MAX)
+                .unwrap()
+                .get(),
+            32
+        );
     }
 
     #[test]
-    fn geometry_follows_a_deployment_that_raises_the_minimum() {
-        struct Deep;
-        impl SwarmSpec for Deep {
-            fn network_id(&self) -> nectar_primitives::NetworkId {
-                nectar_primitives::NetworkId::TESTNET
-            }
-            fn min_bucket_depth(&self) -> u8 {
-                20
-            }
-        }
-
-        let bucket_depth = BucketDepth::new(16).unwrap();
-        assert!(validate_geometry(&nectar_primitives::MAINNET, 24, bucket_depth).is_ok());
+    fn bucket_depth_rejects_an_unrepresentable_depth() {
         assert!(matches!(
-            validate_geometry(&Deep, 24, bucket_depth),
+            BucketDepth::<Mainnet>::new(33),
+            Err(StampError::InvalidBucketDepth { bucket_depth: 33 })
+        ));
+        assert!(matches!(
+            BucketDepth::<Mainnet>::try_from(u8::MAX),
+            Err(StampError::InvalidBucketDepth {
+                bucket_depth: u8::MAX
+            })
+        ));
+
+        // A spec that lowers the floor still cannot name a zero-bit bucket.
+        struct Floorless;
+        impl SwarmSpec for Floorless {
+            const NETWORK_ID: nectar_primitives::NetworkId = nectar_primitives::NetworkId::TESTNET;
+            const MIN_BUCKET_DEPTH: u8 = 0;
+        }
+        assert!(matches!(
+            BucketDepth::<Floorless>::new(0),
+            Err(StampError::InvalidBucketDepth { bucket_depth: 0 })
+        ));
+        assert_eq!(BucketDepth::<Floorless>::new(1).unwrap().get(), 1);
+    }
+
+    #[test]
+    fn a_raised_floor_refuses_a_depth_mainnet_accepts() {
+        assert!(BucketDepth::<Mainnet>::new(16).is_ok());
+        assert!(matches!(
+            BucketDepth::<Deep>::new(16),
             Err(StampError::BucketDepthBelowMinimum {
                 bucket_depth: 16,
                 minimum: 20
             })
         ));
+        assert!(BucketDepth::<Deep>::new(20).is_ok());
     }
 
     #[test]
-    fn geometry_validates_through_batch_and_params() {
-        let spec = nectar_primitives::MAINNET;
-        let bucket_depth = BucketDepth::new(16).unwrap();
+    fn depth_below_bucket_depth_is_rejected_through_batch_and_params() {
+        let bucket_depth = BucketDepth::<Mainnet>::new(16).unwrap();
 
         let params = BatchParams::new(Address::ZERO, 20, bucket_depth, 1000);
-        assert!(params.validate_geometry(&spec).is_ok());
+        assert!(params.validate_depth().is_ok());
 
         let batch = Batch::new(BatchId::ZERO, 0, 0, Address::ZERO, 20, bucket_depth, false);
-        assert!(batch.validate_geometry(&spec).is_ok());
+        assert!(batch.validate_depth().is_ok());
+
+        // A batch exactly as deep as its buckets holds one slot each.
+        let flat = Batch::new(BatchId::ZERO, 0, 0, Address::ZERO, 16, bucket_depth, false);
+        assert!(flat.validate_depth().is_ok());
 
         let shallow = Batch::new(BatchId::ZERO, 0, 0, Address::ZERO, 8, bucket_depth, false);
         assert!(matches!(
-            shallow.validate_geometry(&spec),
+            shallow.validate_depth(),
             Err(StampError::DepthBelowBucketDepth {
                 depth: 8,
                 bucket_depth: 16
             })
         ));
+        assert!(matches!(
+            BatchParams::new(Address::ZERO, 8, bucket_depth, 1000).validate_depth(),
+            Err(StampError::DepthBelowBucketDepth {
+                depth: 8,
+                bucket_depth: 16
+            })
+        ));
+
+        // Dilution moves the depth, so the check survives a `set_depth`.
+        let mut diluted = batch;
+        diluted.set_depth(15);
+        assert!(diluted.validate_depth().is_err());
     }
 
     #[test]
     fn bucket_geometry_holds_at_the_bounds() {
-        let min = Batch::new(
+        let min: Batch = Batch::new(
             BatchId::ZERO,
             0,
             0,
             Address::ZERO,
-            1,
-            BucketDepth::MIN,
+            16,
+            BucketDepth::new(16).unwrap(),
             false,
         );
-        assert_eq!(min.bucket_count(), 2);
-        assert_eq!(min.bucket_for_address(&ChunkAddress::new([0xFF; 32])), 1);
+        assert_eq!(min.bucket_count(), 65536);
+        assert_eq!(
+            min.bucket_for_address(&ChunkAddress::new([0xFF; 32])),
+            65535
+        );
 
-        let max = Batch::new(
+        let max: Batch = Batch::new(
             BatchId::ZERO,
             0,
             0,
             Address::ZERO,
             u8::MAX,
-            BucketDepth::MAX,
+            BucketDepth::new(BucketDepth::<Mainnet>::MAX).unwrap(),
             false,
         );
         assert_eq!(max.bucket_count(), 1 << 32);
@@ -650,13 +770,13 @@ mod tests {
 
     #[test]
     fn bucket_upper_bound_holds_for_a_batch_shallower_than_its_buckets() {
-        let batch = Batch::new(
+        let batch: Batch = Batch::new(
             BatchId::ZERO,
             0,
             0,
             Address::ZERO,
             8,
-            BucketDepth::MAX,
+            BucketDepth::new(BucketDepth::<Mainnet>::MAX).unwrap(),
             false,
         );
         assert_eq!(batch.bucket_upper_bound(), 1);
@@ -664,21 +784,39 @@ mod tests {
 
     #[cfg(feature = "serde")]
     #[test]
-    fn serde_rejects_an_out_of_range_bucket_depth() {
+    fn serde_round_trips_a_depth_and_enforces_the_floor() {
         use serde::{Deserialize, de::IntoDeserializer, de::value::Error};
 
-        let decode =
-            |raw: u8| BucketDepth::deserialize(IntoDeserializer::<Error>::into_deserializer(raw));
+        fn decode<S: SwarmSpec>(raw: u8) -> Result<BucketDepth<S>, Error> {
+            BucketDepth::deserialize(IntoDeserializer::<Error>::into_deserializer(raw))
+        }
 
-        assert_eq!(decode(16).unwrap(), BucketDepth::new(16).unwrap());
-        assert!(decode(0).is_err());
-        assert!(decode(33).is_err());
+        let depth = BucketDepth::<Mainnet>::new(16).unwrap();
+        assert_eq!(decode::<Mainnet>(16).unwrap(), depth);
+        assert_eq!(
+            serde_json::to_string(&depth).unwrap(),
+            serde_json::to_string(&16u8).unwrap()
+        );
+
+        // The floor and the representable bound both survive the wire.
+        assert!(decode::<Mainnet>(15).is_err());
+        assert!(decode::<Mainnet>(33).is_err());
+        // And the floor is the spec's, not a constant: 16 decodes on mainnet
+        // and is refused on a deployment that asks for 20.
+        assert!(decode::<Deep>(16).is_err());
+        assert!(decode::<Deep>(20).is_ok());
+
+        // A batch decodes through the same gate.
+        let batch: Batch = Batch::new(BatchId::ZERO, 0, 0, Address::ZERO, 20, depth, false);
+        let json = serde_json::to_string(&batch).unwrap();
+        assert_eq!(serde_json::from_str::<Batch>(&json).unwrap(), batch);
+        assert!(serde_json::from_str::<Batch<Deep>>(&json).is_err());
     }
 
     #[test]
     fn test_batch_creation() {
         let id = BatchId::ZERO;
-        let batch = Batch::new(
+        let batch: Batch = Batch::new(
             id,
             1000,
             100,
@@ -699,7 +837,7 @@ mod tests {
 
     #[test]
     fn test_bucket_calculations() {
-        let batch = Batch::new(
+        let batch: Batch = Batch::new(
             BatchId::ZERO,
             0,
             0,
@@ -717,7 +855,7 @@ mod tests {
 
     #[test]
     fn test_batch_expiry() {
-        let batch = Batch::new(
+        let batch: Batch = Batch::new(
             BatchId::ZERO,
             1000,
             0,
@@ -734,7 +872,7 @@ mod tests {
 
     #[test]
     fn test_batch_usability() {
-        let batch = Batch::new(
+        let batch: Batch = Batch::new(
             BatchId::ZERO,
             1000,
             100,
@@ -752,8 +890,9 @@ mod tests {
 
     #[test]
     fn test_batch_params_builder() {
-        let params = BatchParams::new(Address::ZERO, 20, BucketDepth::new(16).unwrap(), 1000)
-            .immutable(true);
+        let params: BatchParams =
+            BatchParams::new(Address::ZERO, 20, BucketDepth::new(16).unwrap(), 1000)
+                .immutable(true);
 
         assert_eq!(params.owner, Address::ZERO);
         assert_eq!(params.depth, 20);

--- a/crates/postage/src/error.rs
+++ b/crates/postage/src/error.rs
@@ -33,6 +33,24 @@ pub enum StampError {
         bucket_depth: u8,
     },
 
+    /// The bucket depth is below the minimum the network spec sets.
+    #[error("bucket depth {bucket_depth} below the spec minimum {minimum}")]
+    BucketDepthBelowMinimum {
+        /// The rejected bucket depth.
+        bucket_depth: u8,
+        /// The minimum the spec sets.
+        minimum: u8,
+    },
+
+    /// The batch depth leaves no room above the bucket depth.
+    #[error("batch depth {depth} below bucket depth {bucket_depth}")]
+    DepthBelowBucketDepth {
+        /// The rejected batch depth.
+        depth: u8,
+        /// The bucket depth it has to reach.
+        bucket_depth: u8,
+    },
+
     /// The batch was not found.
     #[error("batch not found: {0}")]
     BatchNotFound(BatchId),

--- a/crates/postage/src/error.rs
+++ b/crates/postage/src/error.rs
@@ -26,6 +26,13 @@ pub enum StampError {
     #[error("bucket mismatch: chunk address doesn't belong to stamp bucket")]
     BucketMismatch,
 
+    /// The bucket depth is outside the range a bucket key can address.
+    #[error("invalid bucket depth {bucket_depth}: must be in 1..=32")]
+    InvalidBucketDepth {
+        /// The rejected bucket depth.
+        bucket_depth: u8,
+    },
+
     /// The batch was not found.
     #[error("batch not found: {0}")]
     BatchNotFound(BatchId),

--- a/crates/postage/src/events.rs
+++ b/crates/postage/src/events.rs
@@ -82,6 +82,7 @@ pub trait BatchEventHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::BucketDepth;
     use alloy_primitives::Address;
 
     #[test]
@@ -92,7 +93,7 @@ mod tests {
             100,
             Address::ZERO,
             20,
-            16,
+            BucketDepth::new(16).unwrap(),
             false,
         );
         let batch_id = batch.id();

--- a/crates/postage/src/generators.rs
+++ b/crates/postage/src/generators.rs
@@ -16,7 +16,7 @@ use alloy_signer::SignerSync;
 use arbitrary::Unstructured;
 use nectar_primitives::{AnyChunkSet, Chunk, ChunkAddress, Verified};
 
-use crate::{Batch, BatchId, Stamp, StampDigest, StampIndex, StampedChunk};
+use crate::{Batch, BatchId, BucketDepth, Stamp, StampDigest, StampIndex, StampedChunk};
 
 /// A batch with valid depth invariants and the given owner.
 ///
@@ -24,7 +24,8 @@ use crate::{Batch, BatchId, Stamp, StampDigest, StampIndex, StampedChunk};
 /// per-bucket capacity both stay within `u32`.
 pub fn batch(u: &mut Unstructured<'_>, owner: Address) -> arbitrary::Result<Batch> {
     let depth: u8 = u.int_in_range(1..=32)?;
-    let bucket_depth: u8 = u.int_in_range(1..=depth.min(31))?;
+    let bucket_depth = BucketDepth::new(u.int_in_range(1..=depth.min(31))?)
+        .map_err(|_| arbitrary::Error::IncorrectFormat)?;
     Ok(Batch::new(
         BatchId::from(u.arbitrary::<[u8; 32]>()?),
         u.arbitrary()?,

--- a/crates/postage/src/generators.rs
+++ b/crates/postage/src/generators.rs
@@ -14,17 +14,19 @@
 use alloy_primitives::Address;
 use alloy_signer::SignerSync;
 use arbitrary::Unstructured;
-use nectar_primitives::{AnyChunkSet, Chunk, ChunkAddress, Verified};
+use nectar_primitives::{AnyChunkSet, Chunk, ChunkAddress, Mainnet, SwarmSpec, Verified};
 
 use crate::{Batch, BatchId, BucketDepth, Stamp, StampDigest, StampIndex, StampedChunk};
 
 /// A batch with valid depth invariants and the given owner.
 ///
-/// `bucket_depth` is drawn in `1..=min(depth, 31)`, so bucket count and
-/// per-bucket capacity both stay within `u32`.
+/// `bucket_depth` is drawn in `MIN_BUCKET_DEPTH..=min(depth, 31)`: it clears
+/// the mainnet floor, and bucket count and per-bucket capacity both stay within
+/// `u32`.
 pub fn batch(u: &mut Unstructured<'_>, owner: Address) -> arbitrary::Result<Batch> {
-    let depth: u8 = u.int_in_range(1..=32)?;
-    let bucket_depth = BucketDepth::new(u.int_in_range(1..=depth.min(31))?)
+    let floor = Mainnet::MIN_BUCKET_DEPTH;
+    let depth: u8 = u.int_in_range(floor..=32)?;
+    let bucket_depth = BucketDepth::new(u.int_in_range(floor..=depth.min(31))?)
         .map_err(|_| arbitrary::Error::IncorrectFormat)?;
     Ok(Batch::new(
         BatchId::from(u.arbitrary::<[u8; 32]>()?),

--- a/crates/postage/src/generators.rs
+++ b/crates/postage/src/generators.rs
@@ -24,7 +24,7 @@ use crate::{Batch, BatchId, BucketDepth, Stamp, StampDigest, StampIndex, Stamped
 /// the mainnet floor, and bucket count and per-bucket capacity both stay within
 /// `u32`.
 pub fn batch(u: &mut Unstructured<'_>, owner: Address) -> arbitrary::Result<Batch> {
-    let floor = Mainnet::MIN_BUCKET_DEPTH;
+    let floor = Mainnet::MIN_BUCKET_DEPTH.get();
     let depth: u8 = u.int_in_range(floor..=32)?;
     let bucket_depth = BucketDepth::new(u.int_in_range(floor..=depth.min(31))?)
         .map_err(|_| arbitrary::Error::IncorrectFormat)?;

--- a/crates/postage/src/lib.rs
+++ b/crates/postage/src/lib.rs
@@ -10,6 +10,7 @@
 //!
 //! - [`Batch`]: A postage batch representing prepaid storage
 //! - [`BucketDepth`]: A collision-bucket depth validated to `1..=32`
+//! - [`validate_geometry`]: Check a batch geometry against a network spec
 //! - [`Stamp`]: A postage stamp proving payment for chunk storage
 //! - [`StampIndex`]: The bucket and position index within a stamp
 //! - [`StampDigest`]: The data to be signed when creating a stamp
@@ -83,7 +84,7 @@ mod store;
 pub mod parallel;
 
 // Core types
-pub use batch::{Batch, BatchId, BatchParams, BucketDepth};
+pub use batch::{Batch, BatchId, BatchParams, BucketDepth, validate_geometry};
 pub use error::StampError;
 pub use stamp::{STAMP_SIZE, Stamp, StampBytes, StampDigest, StampIndex};
 pub use stamped::StampedChunk;

--- a/crates/postage/src/lib.rs
+++ b/crates/postage/src/lib.rs
@@ -9,8 +9,8 @@
 //! # Core Types
 //!
 //! - [`Batch`]: A postage batch representing prepaid storage
-//! - [`BucketDepth`]: A collision-bucket depth validated to `1..=32`
-//! - [`validate_geometry`]: Check a batch geometry against a network spec
+//! - [`BucketDepth`]: A collision-bucket depth a network accepts, checked
+//!   against the [`SwarmSpec`](nectar_primitives::SwarmSpec) it is built for
 //! - [`Stamp`]: A postage stamp proving payment for chunk storage
 //! - [`StampIndex`]: The bucket and position index within a stamp
 //! - [`StampDigest`]: The data to be signed when creating a stamp
@@ -84,7 +84,7 @@ mod store;
 pub mod parallel;
 
 // Core types
-pub use batch::{Batch, BatchId, BatchParams, BucketDepth, validate_geometry};
+pub use batch::{Batch, BatchId, BatchParams, BucketDepth};
 pub use error::StampError;
 pub use stamp::{STAMP_SIZE, Stamp, StampBytes, StampDigest, StampIndex};
 pub use stamped::StampedChunk;

--- a/crates/postage/src/lib.rs
+++ b/crates/postage/src/lib.rs
@@ -9,6 +9,7 @@
 //! # Core Types
 //!
 //! - [`Batch`]: A postage batch representing prepaid storage
+//! - [`BucketDepth`]: A collision-bucket depth validated to `1..=32`
 //! - [`Stamp`]: A postage stamp proving payment for chunk storage
 //! - [`StampIndex`]: The bucket and position index within a stamp
 //! - [`StampDigest`]: The data to be signed when creating a stamp
@@ -82,7 +83,7 @@ mod store;
 pub mod parallel;
 
 // Core types
-pub use batch::{Batch, BatchId, BatchParams};
+pub use batch::{Batch, BatchId, BatchParams, BucketDepth};
 pub use error::StampError;
 pub use stamp::{STAMP_SIZE, Stamp, StampBytes, StampDigest, StampIndex};
 pub use stamped::StampedChunk;

--- a/crates/postage/src/validation.rs
+++ b/crates/postage/src/validation.rs
@@ -230,7 +230,7 @@ mod tests {
 
     #[test]
     fn test_validate_index_valid() {
-        let batch = Batch::new(
+        let batch: Batch = Batch::new(
             BatchId::ZERO,
             0,
             0,
@@ -247,7 +247,7 @@ mod tests {
 
     #[test]
     fn test_validate_index_bucket_out_of_range() {
-        let batch = Batch::new(
+        let batch: Batch = Batch::new(
             BatchId::ZERO,
             0,
             0,
@@ -267,7 +267,7 @@ mod tests {
 
     #[test]
     fn test_validate_index_position_out_of_range() {
-        let batch = Batch::new(
+        let batch: Batch = Batch::new(
             BatchId::ZERO,
             0,
             0,
@@ -287,7 +287,7 @@ mod tests {
 
     #[test]
     fn test_bucket_for_address() {
-        let batch = Batch::new(
+        let batch: Batch = Batch::new(
             BatchId::ZERO,
             0,
             0,
@@ -307,7 +307,7 @@ mod tests {
 
     #[test]
     fn test_validate_bucket_match() {
-        let batch = Batch::new(
+        let batch: Batch = Batch::new(
             BatchId::ZERO,
             0,
             0,
@@ -328,7 +328,7 @@ mod tests {
 
     #[test]
     fn test_validate_bucket_mismatch() {
-        let batch = Batch::new(
+        let batch: Batch = Batch::new(
             BatchId::ZERO,
             0,
             0,

--- a/crates/postage/src/validation.rs
+++ b/crates/postage/src/validation.rs
@@ -225,11 +225,20 @@ impl<S: BatchStore> StoreValidator<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::BucketDepth;
     use alloy_primitives::Address;
 
     #[test]
     fn test_validate_index_valid() {
-        let batch = Batch::new(BatchId::ZERO, 0, 0, Address::ZERO, 18, 16, false);
+        let batch = Batch::new(
+            BatchId::ZERO,
+            0,
+            0,
+            Address::ZERO,
+            18,
+            BucketDepth::new(16).unwrap(),
+            false,
+        );
 
         // Valid: bucket < 2^16, index < 2^(18-16) = 4
         let index = StampIndex::new(1000, 3);
@@ -238,7 +247,15 @@ mod tests {
 
     #[test]
     fn test_validate_index_bucket_out_of_range() {
-        let batch = Batch::new(BatchId::ZERO, 0, 0, Address::ZERO, 18, 16, false);
+        let batch = Batch::new(
+            BatchId::ZERO,
+            0,
+            0,
+            Address::ZERO,
+            18,
+            BucketDepth::new(16).unwrap(),
+            false,
+        );
 
         // Invalid: bucket >= 2^16 = 65536
         let index = StampIndex::new(70000, 0);
@@ -250,7 +267,15 @@ mod tests {
 
     #[test]
     fn test_validate_index_position_out_of_range() {
-        let batch = Batch::new(BatchId::ZERO, 0, 0, Address::ZERO, 18, 16, false);
+        let batch = Batch::new(
+            BatchId::ZERO,
+            0,
+            0,
+            Address::ZERO,
+            18,
+            BucketDepth::new(16).unwrap(),
+            false,
+        );
 
         // Invalid: index >= 2^(18-16) = 4
         let index = StampIndex::new(1000, 5);
@@ -262,7 +287,15 @@ mod tests {
 
     #[test]
     fn test_bucket_for_address() {
-        let batch = Batch::new(BatchId::ZERO, 0, 0, Address::ZERO, 18, 16, false);
+        let batch = Batch::new(
+            BatchId::ZERO,
+            0,
+            0,
+            Address::ZERO,
+            18,
+            BucketDepth::new(16).unwrap(),
+            false,
+        );
 
         let address = ChunkAddress::new([
             0xCB, 0xE5, 0x00, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -274,7 +307,15 @@ mod tests {
 
     #[test]
     fn test_validate_bucket_match() {
-        let batch = Batch::new(BatchId::ZERO, 0, 0, Address::ZERO, 18, 16, false);
+        let batch = Batch::new(
+            BatchId::ZERO,
+            0,
+            0,
+            Address::ZERO,
+            18,
+            BucketDepth::new(16).unwrap(),
+            false,
+        );
 
         let address = ChunkAddress::new([
             0xCB, 0xE5, 0x00, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -287,7 +328,15 @@ mod tests {
 
     #[test]
     fn test_validate_bucket_mismatch() {
-        let batch = Batch::new(BatchId::ZERO, 0, 0, Address::ZERO, 18, 16, false);
+        let batch = Batch::new(
+            BatchId::ZERO,
+            0,
+            0,
+            Address::ZERO,
+            18,
+            BucketDepth::new(16).unwrap(),
+            false,
+        );
 
         let address = ChunkAddress::new([
             0xCB, 0xE5, 0x00, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -91,7 +91,7 @@ pub use network_id::NetworkId;
 pub use nonce::Nonce;
 pub use overlay::compute_overlay;
 pub use proximity_order::{ProximityOrder, ProximityOrderError};
-pub use spec::{MAINNET, StaticSpec, SwarmSpec, TESTNET};
+pub use spec::{Mainnet, SwarmSpec, Testnet};
 pub use timestamp::{Timestamp, TimestampError};
 pub use xor_metric::{EXTENDED_PO, MAX_PO, XorMetric};
 

--- a/crates/primitives/src/neighborhood_depth.rs
+++ b/crates/primitives/src/neighborhood_depth.rs
@@ -9,9 +9,9 @@ use crate::Bin;
 /// Recompute the neighborhood depth from per-bin connected-peer counts.
 ///
 /// `connected_per_bin[i]` is the count of currently-connected peers in bin `i`.
-/// `saturation` is the target saturation per bin (typically `SwarmSpec::saturation_peers()`).
+/// `saturation` is the target saturation per bin (typically `SwarmSpec::SATURATION_PEERS`).
 /// `low_watermark` is the minimum cumulative count of peers in the deepest bins
-/// to anchor the neighborhood (typically `SwarmSpec::neighborhood_low_watermark()`).
+/// to anchor the neighborhood (typically `SwarmSpec::NEIGHBORHOOD_LOW_WATERMARK`).
 ///
 /// Algorithm - port of bee `kademlia.go:896-920`:
 /// 1. Walk bins shallow → deep. The depth candidate is the **shallowest bin

--- a/crates/primitives/src/neighborhood_depth.rs
+++ b/crates/primitives/src/neighborhood_depth.rs
@@ -1,6 +1,6 @@
 //! Canonical neighborhood-depth recomputation.
 //!
-//! Pure function port of bee `pkg/topology/kademlia/kademlia.go:896-920`
+//! Neighborhood depth from per-bin peer counts.
 //! (`recalcDepth`). The wrapper type (`NeighborhoodDepth`) stays in the
 //! routing layer of each downstream impl; nectar only owns the math.
 
@@ -13,7 +13,7 @@ use crate::Bin;
 /// `low_watermark` is the minimum cumulative count of peers in the deepest bins
 /// to anchor the neighborhood (typically `SwarmSpec::NEIGHBORHOOD_LOW_WATERMARK`).
 ///
-/// Algorithm - port of bee `kademlia.go:896-920`:
+/// Algorithm:
 /// 1. Walk bins shallow → deep. The depth candidate is the **shallowest bin
 ///    whose count is below `saturation`**.
 /// 2. From that candidate, sum populations of the deepest bins until the
@@ -65,7 +65,7 @@ pub fn recompute_neighborhood_depth(
     }
     if !found_unsaturated {
         // Every bin is saturated: depth is the deepest occupied bin.
-        // Bee returns `MaxPO` here, but the conservative interpretation is
+        // The reference client returns `MaxPO` here; the conservative reading is
         // that the neighborhood extends to the deepest bin we actually have
         // peers in - fall through and use the watermark anchor instead.
         candidate = crate::MAX_PO;

--- a/crates/primitives/src/spec.rs
+++ b/crates/primitives/src/spec.rs
@@ -1,17 +1,8 @@
-//! Canonical Swarm network spec - `NETWORK_ID`, kademlia tuning, defaults.
+//! Canonical Swarm network knobs: network id, kademlia tuning, postage floors.
 //!
-//! Every Swarm node implementation needs a small set of canonical knobs:
-//! the network ID, the kademlia saturation thresholds, the bootnode-mode
-//! over-saturation cap, the neighborhood-depth low-watermark, the clock-skew
-//! tolerance used during handshake, the postage minimum bucket depth. Bee
-//! hard-codes these in `pkg/topology/kademlia/kademlia.go:54-56` and
-//! `pkg/bzz/timestamp.go`.
-//!
-//! The spec is a type, not a value: every knob is an associated const, so a
-//! network is named as a type parameter ([`Mainnet`], [`Testnet`]) and a knob
-//! is read without an instance in hand. A type parameterized by a spec (a
-//! postage bucket depth, say) can then refuse a value the network would refuse
-//! at compile time instead of at a validation call.
+//! Knobs are associated consts, so a network is a type ([`Mainnet`],
+//! [`Testnet`]) and a spec-parameterized value rejects an out-of-range one at
+//! compile time rather than at a validation call.
 
 use core::time::Duration;
 
@@ -19,13 +10,9 @@ use crate::{Bin, NetworkId, ProximityOrder};
 
 /// Canonical Swarm network spec.
 ///
-/// Const defaults mirror bee's hard-coded constants. Implementors only have to
-/// give [`NETWORK_ID`](Self::NETWORK_ID); they may override any of the others
-/// to customise a deployment (e.g. a dense testnet with tighter saturation).
-///
-/// Trait can grow with defaulted consts without breaking implementors -
-/// `#[non_exhaustive]` is not a valid attribute on traits in Rust, but the
-/// default-value discipline gives equivalent backward-compatibility.
+/// Only [`NETWORK_ID`](Self::NETWORK_ID) is required; the rest default to the
+/// reference client's values and may be overridden per deployment. Defaulted
+/// consts can be added without breaking implementors.
 pub trait SwarmSpec {
     /// Network identifier used in [`compute_overlay`](crate::compute_overlay)
     /// and the BzzAddress sign-data.
@@ -34,32 +21,26 @@ pub trait SwarmSpec {
     /// Maximum proximity order (= number of bins minus one).
     const MAX_PROXIMITY_ORDER: ProximityOrder = ProximityOrder::MAX;
 
-    /// Minimum desired peers per bin before the bin is considered saturated.
-    /// Bee default: 8 (`defaultSaturationPeers`).
+    /// Peers per bin before the bin counts as saturated.
     const SATURATION_PEERS: u8 = 8;
 
-    /// Soft cap: above this, non-bootnode peers reject further inbound dials.
-    /// Bee default: 18 (`defaultOverSaturationPeers`).
+    /// Soft cap above which a non-bootnode rejects further inbound dials.
     const OVER_SATURATION_PEERS: u8 = 18;
 
-    /// Soft cap for **bootnode** mode (higher than regular).
-    /// Bee default: 20 (`defaultBootNodeOverSaturationPeers`).
+    /// Soft cap in bootnode mode.
     const BOOTNODE_OVER_SATURATION_PEERS: u8 = 20;
 
-    /// Minimum peers required in the deepest bins to maintain neighborhood
-    /// depth (bee default: 2 - `nnLowWatermark`).
+    /// Peers needed in the deepest bins to anchor neighborhood depth.
     const NEIGHBORHOOD_LOW_WATERMARK: u8 = 2;
 
-    /// Maximum clock skew permitted between local and remote timestamps
-    /// during handshake / hive verification. Bee's `bzz/timestamp.go`
-    /// hard-codes 5s but operational deployments commonly relax to minutes
-    /// or hours; this default is 6h to match what was previously embedded
-    /// in vertex.
+    /// Clock skew tolerated between local and remote timestamps during
+    /// handshake and hive verification. Deployments commonly relax this well
+    /// past the reference client's 5s.
     const CLOCK_SKEW_TOLERANCE: Duration = Duration::from_secs(6 * 60 * 60);
 
-    /// Minimum collision-bucket depth a postage batch may declare, mirroring
-    /// the PostageStamp contract's `minimumBucketDepth()` (16 on mainnet).
-    /// A floor rather than a fixed width: a batch may declare a deeper one.
+    /// Minimum collision-bucket depth a postage batch may declare, from the
+    /// PostageStamp contract's `minimumBucketDepth()`. A floor, not a fixed
+    /// width.
     const MIN_BUCKET_DEPTH: u8 = 16;
 
     /// Convenience: the deepest bin, derived from
@@ -94,7 +75,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn defaults_match_bee() {
+    fn defaults_match_the_reference_client() {
         assert_eq!(Mainnet::NETWORK_ID, NetworkId::MAINNET);
         assert_eq!(Mainnet::MAX_PROXIMITY_ORDER, ProximityOrder::MAX);
         assert_eq!(Mainnet::SATURATION_PEERS, 8);

--- a/crates/primitives/src/spec.rs
+++ b/crates/primitives/src/spec.rs
@@ -9,7 +9,7 @@
 //!
 //! The spec is a type, not a value: every knob is an associated const, so a
 //! network is named as a type parameter ([`Mainnet`], [`Testnet`]) and a knob
-//! is read without an instance in hand. A type parameterised by a spec (a
+//! is read without an instance in hand. A type parameterized by a spec (a
 //! postage bucket depth, say) can then refuse a value the network would refuse
 //! at compile time instead of at a validation call.
 

--- a/crates/primitives/src/spec.rs
+++ b/crates/primitives/src/spec.rs
@@ -65,6 +65,13 @@ pub trait SwarmSpec {
         Duration::from_secs(6 * 60 * 60)
     }
 
+    /// Minimum collision-bucket depth a postage batch may declare, mirroring
+    /// the PostageStamp contract's `minimumBucketDepth()` (16 on mainnet).
+    /// A floor rather than a fixed width: a batch may declare a deeper one.
+    fn min_bucket_depth(&self) -> u8 {
+        16
+    }
+
     /// Convenience: the routing-table bin count (`max_proximity_order() + 1`).
     #[allow(clippy::arithmetic_side_effects)] // max_proximity_order() <= MAX_PO (31), so + 1 cannot overflow usize
     fn bin_count(&self) -> usize {
@@ -118,6 +125,7 @@ mod tests {
         assert_eq!(s.bootnode_over_saturation_peers(), 20);
         assert_eq!(s.neighborhood_low_watermark(), 2);
         assert_eq!(s.clock_skew_tolerance(), Duration::from_secs(21600));
+        assert_eq!(s.min_bucket_depth(), 16);
         assert_eq!(s.bin_count(), 32);
         assert_eq!(s.max_bin(), Bin::MAX);
     }

--- a/crates/primitives/src/spec.rs
+++ b/crates/primitives/src/spec.rs
@@ -1,115 +1,93 @@
-//! Canonical Swarm network spec - `network_id`, kademlia tuning, defaults.
+//! Canonical Swarm network spec - `NETWORK_ID`, kademlia tuning, defaults.
 //!
 //! Every Swarm node implementation needs a small set of canonical knobs:
 //! the network ID, the kademlia saturation thresholds, the bootnode-mode
 //! over-saturation cap, the neighborhood-depth low-watermark, the clock-skew
-//! tolerance used during handshake. Bee hard-codes these in
-//! `pkg/topology/kademlia/kademlia.go:54-56` and `pkg/bzz/timestamp.go`.
+//! tolerance used during handshake, the postage minimum bucket depth. Bee
+//! hard-codes these in `pkg/topology/kademlia/kademlia.go:54-56` and
+//! `pkg/bzz/timestamp.go`.
 //!
-//! This trait surfaces them on the spec object so vertex / apiarist /
-//! reth-swarm derive them from one place instead of duplicating consts.
+//! The spec is a type, not a value: every knob is an associated const, so a
+//! network is named as a type parameter ([`Mainnet`], [`Testnet`]) and a knob
+//! is read without an instance in hand. A type parameterised by a spec (a
+//! postage bucket depth, say) can then refuse a value the network would refuse
+//! at compile time instead of at a validation call.
 
-use std::time::Duration;
+use core::time::Duration;
 
 use crate::{Bin, NetworkId, ProximityOrder};
 
 /// Canonical Swarm network spec.
 ///
-/// Default-method bodies mirror bee's hard-coded constants. Implementors only
-/// have to provide `network_id`; they may override any of the others to
-/// customise a deployment (e.g. a dense testnet with tighter saturation).
+/// Const defaults mirror bee's hard-coded constants. Implementors only have to
+/// give [`NETWORK_ID`](Self::NETWORK_ID); they may override any of the others
+/// to customise a deployment (e.g. a dense testnet with tighter saturation).
 ///
-/// Trait can grow with default methods without breaking implementors -
+/// Trait can grow with defaulted consts without breaking implementors -
 /// `#[non_exhaustive]` is not a valid attribute on traits in Rust, but the
-/// default-method discipline gives equivalent backward-compatibility.
+/// default-value discipline gives equivalent backward-compatibility.
 pub trait SwarmSpec {
     /// Network identifier used in [`compute_overlay`](crate::compute_overlay)
     /// and the BzzAddress sign-data.
-    fn network_id(&self) -> NetworkId;
+    const NETWORK_ID: NetworkId;
 
     /// Maximum proximity order (= number of bins minus one).
-    fn max_proximity_order(&self) -> ProximityOrder {
-        ProximityOrder::MAX
-    }
+    const MAX_PROXIMITY_ORDER: ProximityOrder = ProximityOrder::MAX;
 
     /// Minimum desired peers per bin before the bin is considered saturated.
     /// Bee default: 8 (`defaultSaturationPeers`).
-    fn saturation_peers(&self) -> u8 {
-        8
-    }
+    const SATURATION_PEERS: u8 = 8;
 
     /// Soft cap: above this, non-bootnode peers reject further inbound dials.
     /// Bee default: 18 (`defaultOverSaturationPeers`).
-    fn over_saturation_peers(&self) -> u8 {
-        18
-    }
+    const OVER_SATURATION_PEERS: u8 = 18;
 
     /// Soft cap for **bootnode** mode (higher than regular).
     /// Bee default: 20 (`defaultBootNodeOverSaturationPeers`).
-    fn bootnode_over_saturation_peers(&self) -> u8 {
-        20
-    }
+    const BOOTNODE_OVER_SATURATION_PEERS: u8 = 20;
 
     /// Minimum peers required in the deepest bins to maintain neighborhood
     /// depth (bee default: 2 - `nnLowWatermark`).
-    fn neighborhood_low_watermark(&self) -> u8 {
-        2
-    }
+    const NEIGHBORHOOD_LOW_WATERMARK: u8 = 2;
 
     /// Maximum clock skew permitted between local and remote timestamps
     /// during handshake / hive verification. Bee's `bzz/timestamp.go`
     /// hard-codes 5s but operational deployments commonly relax to minutes
     /// or hours; this default is 6h to match what was previously embedded
     /// in vertex.
-    fn clock_skew_tolerance(&self) -> Duration {
-        Duration::from_secs(6 * 60 * 60)
-    }
+    const CLOCK_SKEW_TOLERANCE: Duration = Duration::from_secs(6 * 60 * 60);
 
     /// Minimum collision-bucket depth a postage batch may declare, mirroring
     /// the PostageStamp contract's `minimumBucketDepth()` (16 on mainnet).
     /// A floor rather than a fixed width: a batch may declare a deeper one.
-    fn min_bucket_depth(&self) -> u8 {
-        16
-    }
+    const MIN_BUCKET_DEPTH: u8 = 16;
 
-    /// Convenience: the routing-table bin count (`max_proximity_order() + 1`).
-    #[allow(clippy::arithmetic_side_effects)] // max_proximity_order() <= MAX_PO (31), so + 1 cannot overflow usize
-    fn bin_count(&self) -> usize {
-        usize::from(self.max_proximity_order().get()) + 1
-    }
+    /// Convenience: the deepest bin, derived from
+    /// [`MAX_PROXIMITY_ORDER`](Self::MAX_PROXIMITY_ORDER).
+    const MAX_BIN: Bin = Bin::new_unchecked(Self::MAX_PROXIMITY_ORDER.get());
 
-    /// Convenience: the deepest bin, derived from `max_proximity_order`.
-    fn max_bin(&self) -> Bin {
-        // PO is range-validated; the conversion is total.
-        Bin::from(self.max_proximity_order())
-    }
-}
-
-/// Concrete static spec used when callers just need to plug a `network_id`
-/// into the canonical defaults.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct StaticSpec {
-    network_id: NetworkId,
-}
-
-impl StaticSpec {
-    /// Construct a spec for `network_id` with all default knobs.
-    pub const fn new(network_id: NetworkId) -> Self {
-        Self { network_id }
-    }
-}
-
-impl SwarmSpec for StaticSpec {
-    fn network_id(&self) -> NetworkId {
-        self.network_id
-    }
+    /// Convenience: the routing-table bin count
+    /// (`MAX_PROXIMITY_ORDER` + 1).
+    // A PO is range-validated to `MAX_PO` (31), so the saturating step never
+    // saturates; it is the const-callable form of the increment.
+    const BIN_COUNT: usize = Self::MAX_BIN.as_index().saturating_add(1);
 }
 
 /// Canonical mainnet spec ([`NetworkId::MAINNET`]).
-pub const MAINNET: StaticSpec = StaticSpec::new(NetworkId::MAINNET);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Mainnet;
+
+impl SwarmSpec for Mainnet {
+    const NETWORK_ID: NetworkId = NetworkId::MAINNET;
+}
 
 /// Canonical testnet (Sepolia) spec ([`NetworkId::TESTNET`]).
-pub const TESTNET: StaticSpec = StaticSpec::new(NetworkId::TESTNET);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Testnet;
+
+impl SwarmSpec for Testnet {
+    const NETWORK_ID: NetworkId = NetworkId::TESTNET;
+}
 
 #[cfg(test)]
 mod tests {
@@ -117,36 +95,42 @@ mod tests {
 
     #[test]
     fn defaults_match_bee() {
-        let s = MAINNET;
-        assert_eq!(s.network_id(), NetworkId::MAINNET);
-        assert_eq!(s.max_proximity_order(), ProximityOrder::MAX);
-        assert_eq!(s.saturation_peers(), 8);
-        assert_eq!(s.over_saturation_peers(), 18);
-        assert_eq!(s.bootnode_over_saturation_peers(), 20);
-        assert_eq!(s.neighborhood_low_watermark(), 2);
-        assert_eq!(s.clock_skew_tolerance(), Duration::from_secs(21600));
-        assert_eq!(s.min_bucket_depth(), 16);
-        assert_eq!(s.bin_count(), 32);
-        assert_eq!(s.max_bin(), Bin::MAX);
+        assert_eq!(Mainnet::NETWORK_ID, NetworkId::MAINNET);
+        assert_eq!(Mainnet::MAX_PROXIMITY_ORDER, ProximityOrder::MAX);
+        assert_eq!(Mainnet::SATURATION_PEERS, 8);
+        assert_eq!(Mainnet::OVER_SATURATION_PEERS, 18);
+        assert_eq!(Mainnet::BOOTNODE_OVER_SATURATION_PEERS, 20);
+        assert_eq!(Mainnet::NEIGHBORHOOD_LOW_WATERMARK, 2);
+        assert_eq!(Mainnet::CLOCK_SKEW_TOLERANCE, Duration::from_secs(21600));
+        assert_eq!(Mainnet::MIN_BUCKET_DEPTH, 16);
+        assert_eq!(Mainnet::BIN_COUNT, 32);
+        assert_eq!(Mainnet::MAX_BIN, Bin::MAX);
     }
 
     #[test]
     fn testnet_distinct_from_mainnet() {
-        assert_ne!(MAINNET.network_id(), TESTNET.network_id());
+        assert_ne!(Mainnet::NETWORK_ID, Testnet::NETWORK_ID);
     }
 
     #[test]
     fn override_saturation_via_custom_impl() {
         struct Tight;
         impl SwarmSpec for Tight {
-            fn network_id(&self) -> NetworkId {
-                NetworkId::TESTNET
-            }
-            fn saturation_peers(&self) -> u8 {
-                4
-            }
+            const NETWORK_ID: NetworkId = NetworkId::TESTNET;
+            const SATURATION_PEERS: u8 = 4;
         }
-        assert_eq!(Tight.saturation_peers(), 4);
-        assert_eq!(Tight.over_saturation_peers(), 18); // default unchanged
+        assert_eq!(Tight::SATURATION_PEERS, 4);
+        assert_eq!(Tight::OVER_SATURATION_PEERS, 18); // default unchanged
+    }
+
+    #[test]
+    fn bin_geometry_follows_a_lowered_proximity_order() {
+        struct Shallow;
+        impl SwarmSpec for Shallow {
+            const NETWORK_ID: NetworkId = NetworkId::TESTNET;
+            const MAX_PROXIMITY_ORDER: ProximityOrder = ProximityOrder::new_unchecked(7);
+        }
+        assert_eq!(Shallow::MAX_BIN, Bin::new(7).unwrap());
+        assert_eq!(Shallow::BIN_COUNT, 8);
     }
 }

--- a/crates/primitives/src/spec.rs
+++ b/crates/primitives/src/spec.rs
@@ -4,7 +4,7 @@
 //! [`Testnet`]) and a spec-parameterized value rejects an out-of-range one at
 //! compile time rather than at a validation call.
 
-use core::time::Duration;
+use core::{num::NonZeroU8, time::Duration};
 
 use crate::{Bin, NetworkId, ProximityOrder};
 
@@ -40,8 +40,8 @@ pub trait SwarmSpec {
 
     /// Minimum collision-bucket depth a postage batch may declare, from the
     /// PostageStamp contract's `minimumBucketDepth()`. A floor, not a fixed
-    /// width.
-    const MIN_BUCKET_DEPTH: u8 = 16;
+    /// width, and never zero: the bucket shift needs at least one bit.
+    const MIN_BUCKET_DEPTH: NonZeroU8 = NonZeroU8::new(16).unwrap();
 
     /// Convenience: the deepest bin, derived from
     /// [`MAX_PROXIMITY_ORDER`](Self::MAX_PROXIMITY_ORDER).
@@ -83,7 +83,7 @@ mod tests {
         assert_eq!(Mainnet::BOOTNODE_OVER_SATURATION_PEERS, 20);
         assert_eq!(Mainnet::NEIGHBORHOOD_LOW_WATERMARK, 2);
         assert_eq!(Mainnet::CLOCK_SKEW_TOLERANCE, Duration::from_secs(21600));
-        assert_eq!(Mainnet::MIN_BUCKET_DEPTH, 16);
+        assert_eq!(Mainnet::MIN_BUCKET_DEPTH.get(), 16);
         assert_eq!(Mainnet::BIN_COUNT, 32);
         assert_eq!(Mainnet::MAX_BIN, Bin::MAX);
     }

--- a/fuzz/fuzz_targets/usage_snapshot_roundtrip.rs
+++ b/fuzz/fuzz_targets/usage_snapshot_roundtrip.rs
@@ -19,6 +19,8 @@
 
 #![no_main]
 
+use core::num::NonZeroU8;
+
 use alloy_primitives::Address;
 use libfuzzer_sys::fuzz_target;
 use nectar_postage_usage::{NetworkId, PublishedSequence, RootInfoFor, SnapshotFor, SwarmSpec};
@@ -29,7 +31,7 @@ struct Shallow;
 
 impl SwarmSpec for Shallow {
     const NETWORK_ID: NetworkId = NetworkId::TESTNET;
-    const MIN_BUCKET_DEPTH: u8 = 1;
+    const MIN_BUCKET_DEPTH: NonZeroU8 = NonZeroU8::new(1).unwrap();
 }
 
 fuzz_target!(|snapshot: SnapshotFor<Shallow>| {

--- a/fuzz/fuzz_targets/usage_snapshot_roundtrip.rs
+++ b/fuzz/fuzz_targets/usage_snapshot_roundtrip.rs
@@ -9,6 +9,10 @@
 //! full immutable bucket, an exhausted capacity-1 ring), so a `plan_persist`
 //! error skips the input; every other failure is a codec bug.
 //!
+//! The generator runs at `Shallow`, a spec whose collision-bucket floor is the
+//! format minimum, so the inputs span the format's whole bucket-depth range
+//! rather than the single geometry mainnet's floor of 16 admits.
+//!
 //! The same property is pinned on stable by
 //! `arbitrary_snapshot_persist_parse_assemble_round_trip` in
 //! `crates/postage-usage/src/codec.rs`.
@@ -17,9 +21,18 @@
 
 use alloy_primitives::Address;
 use libfuzzer_sys::fuzz_target;
-use nectar_postage_usage::{PublishedSequence, RootInfo, Snapshot};
+use nectar_postage_usage::{NetworkId, PublishedSequence, RootInfoFor, SnapshotFor, SwarmSpec};
 
-fuzz_target!(|snapshot: Snapshot| {
+/// A deployment whose bucket-depth floor is the format minimum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Shallow;
+
+impl SwarmSpec for Shallow {
+    const NETWORK_ID: NetworkId = NetworkId::TESTNET;
+    const MIN_BUCKET_DEPTH: u8 = 1;
+}
+
+fuzz_target!(|snapshot: SnapshotFor<Shallow>| {
     let mut snapshot = snapshot;
     let owner = Address::repeat_byte(0x11);
 
@@ -35,7 +48,8 @@ fuzz_target!(|snapshot: Snapshot| {
         Err(_) => return,
     };
 
-    let root = RootInfo::parse(&plan.chunks[0].payload).expect("planned root must parse");
+    let root =
+        RootInfoFor::<Shallow>::parse(&plan.chunks[0].payload).expect("planned root must parse");
     let leaves: Vec<&[u8]> = plan.chunks[1..]
         .iter()
         .map(|c| c.payload.as_ref())


### PR DESCRIPTION
## What

A bucket depth that violates the network minimum is now a type error rather than something a caller must remember to validate. `SwarmSpec` becomes a compile-time trait of associated consts with per-network marker types (`Mainnet`, `Testnet`), and `BucketDepth<S: SwarmSpec = Mainnet>` reads its floor from `S::MIN_BUCKET_DEPTH` at construction, so a non-compliant value cannot be built for that spec.

The floor itself is real and sourced, not invented: the PostageStamp contract on Gnosis mainnet exposes `minimumBucketDepth()`, which returns 16 today. It is a floor rather than a fixed width, so a batch may declare a deeper one. `IPostageStamp` gains the binding so the value is readable rather than assumed. The associated const is a `NonZeroU8`, so a spec cannot declare a floor of zero and the type carries exactly one minimum.

`Batch` and `BatchParams` carry the parameter, defaulted to `Mainnet`. The `depth >= bucket_depth` half of the geometry contract survives as `validate_depth`, because the type cannot express it: `depth` is a separate field and `set_depth` can invalidate the relation after construction through dilution.

## Why

`Batch::new` and `BatchParams::new` stored `bucket_depth` unchecked, so a zero value reached `calculate_bucket` and its `>> 32` shift. The companion `validate_geometry` from #138 lives in `nectar-postage-usage`, which the issuer path never goes through, so the check did not apply where it was needed.

An earlier revision of this branch fixed that with a runtime `validate_geometry(spec, ..)` call. That was the wrong shape: a separate validation step is one a caller can forget, which is the entire class of error worth eliminating rather than merely narrowing. Holding the floor in the type removes the class.

Two design notes worth recording. A const generic over the minimum (`BucketDepth<const M: u8>`) cannot take `M` from the spec on stable Rust, since generic parameters may not be used in const operations without `generic_const_exprs`; and had the caller written the literal, the mistake would have been relocated rather than removed. Parameterising by the spec type and reading an associated const does work on stable, which is the form used here.

The compile-time form also closes a hole the runtime form could not. Serde's derive cannot consult a runtime spec, so a deserialized `BucketDepth` would have arrived unchecked and the honest runtime fix was to drop `Deserialize` entirely. Because `impl<S: SwarmSpec> TryFrom<u8>` still reads `S::MIN_BUCKET_DEPTH`, deserialization is spec-checked by construction and the impl stays.

Verifying at runtime that the compiled-in spec matches the deployment it is pointed at is deliberately out of scope and tracked as #429.

## Testing

`423` tests pass across primitives, contracts, postage, postage-issuer and postage-usage, plus `58` under the `serde` feature, `76` for postage-usage under `--all-features`, and the doctests. Clippy is clean on all five crates and on `--workspace --all-targets`, with one pre-existing `use_self` warning in `chunk/type_tag.rs` that this branch does not touch. Zero clippy allows were added and two were removed, one on the old `bin_count()` and one on the bucket arithmetic that the typed bound made total.

The floor is proven load-bearing rather than decorative: a `Deep` spec raising the minimum to 20 refuses a depth of 16 that `Mainnet` accepts, and it refuses it through the serde path as well as the constructor. A `compile_fail` doctest pins that a `BucketDepth<Testnet>` will not build a mainnet `Batch`, and it was checked to fail for the right reason by flipping the spec and watching it go red. A `Shallow` spec sitting at the lowest declarable floor accepts a depth of 1 and refuses 0, which pins the bottom of the range now that no spec can open it further.

The serde test drives `Deserialize` directly through `serde::de::value`, so it needs no data format and this crate gains no JSON dependency: the deserializer under test is the impl itself rather than a JSON decoder in front of it. Asserting the serialized byte form would have needed a format, and the `Serialize` impl is a single `serialize_u8`, so that assertion was dropped rather than paid for.

## Notes for review

`nectar-postage-issuer` and `nectar-postage-usage` needed no changes: 60 `BucketDepth::new` sites, 14 `Batch::new` sites and 47 signature positions all resolve through the default parameter because the receiving types are concrete. The cost was 16 type annotations inside this crate's own tests, where both sides of a `let` are generic.

The consequence is that those two crates are now typed to `Mainnet`. A non-mainnet deployment could not hand them a `Batch<Testnet>` without parameterising them too, which is not done here because no caller needs it and it would force an explicit spec at every one of those call sites.

The postage-usage integration tests gained `tests/common/mod.rs`, following the existing `crates/manifest/tests/common/mod.rs` precedent, absorbing the bucket-depth constant, the batch and owner fixtures and the `Shallow` spec that the four test binaries had been repeating. The per-file `#![allow(clippy::..)]` blocks stay where they are: they are inner attributes and each integration test file is its own crate root, so no module can supply them.

`BucketDepth` exposes `MAX` but no `MIN`. An earlier revision carried both, and the pair had to be reconciled at every use (`S::MIN_BUCKET_DEPTH.max(Self::MIN)`), which is the tell that one of them was wrong. `MIN` existed only to defend the shift against a spec declaring a floor of zero, so typing the spec's floor as `NonZeroU8` removes the case rather than checking it. `MAX` survives because the bucket-key width is a property of the format, not of any network. It is `u8` rather than `Self`, which as `Self` would itself have been a public route to a sub-floor value.

## AI Assistance

Designed, red-teamed and implemented with AI assistance.

Closes #145
Closes #428
