### PR TITLE
refactor(file): replace the hand-rolled handoff with a oneshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2081,6 +2081,7 @@ dependencies = [
  "bytes",
  "codspeed-criterion-compat",
  "futures",
+ "futures-channel",
  "futures-util",
  "nectar-mantaray 0.4.0",
  "nectar-primitives 0.4.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ rayon = "1.10"
 
 # Core dependencies
 bytes = { version = "1.11", default-features = false }
+futures-channel = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 # race::OnceBox: lazy statics without std synchronization
 once_cell = { version = "1.21", default-features = false, features = ["race", "alloc"] }

--- a/crates/file/Cargo.toml
+++ b/crates/file/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 
 [dependencies]
 bytes = { workspace = true, optional = true }
+futures-channel = { workspace = true, optional = true }
 futures-util = { workspace = true, optional = true }
 nectar-primitives = { workspace = true, optional = true }
 rayon = { workspace = true, optional = true }
@@ -58,7 +59,7 @@ tokio = [ "dep:tokio", "std" ]
 # Pool leaf hashing: the split hash window and the read-at ingest. Implies
 # `std`; rayon on wasm32 or under `unsync` is a compile error, never a
 # silent fallback.
-rayon = [ "dep:rayon", "std" ]
+rayon = [ "dep:futures-channel", "dep:rayon", "std" ]
 
 # Split-side encrypted mode. Joining encrypted references stays unconditional.
 encryption = [ "nectar-primitives?/encryption" ]

--- a/crates/file/src/split/handoff.rs
+++ b/crates/file/src/split/handoff.rs
@@ -1,101 +1,44 @@
 //! Bounded handoff from the thread pool back to the polling future.
 
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::future::Future;
+use core::pin::Pin;
 use core::task::{Context, Poll};
 
 use std::panic::{AssertUnwindSafe, catch_unwind};
-use std::sync::{Arc, Mutex, PoisonError};
 
-use futures_util::task::AtomicWaker;
-
-/// Reply slot shared between one pool job and its receiver.
-struct Slot<T> {
-    value: Mutex<Option<T>>,
-    waker: AtomicWaker,
-    /// Raised by the reply half before it wakes, so a receiver that reads it
-    /// unset is guaranteed a later wake.
-    done: AtomicBool,
-}
-
-impl<T> Slot<T> {
-    /// The slot contents, riding out lock poisoning: the slot holds plain
-    /// data, so a poisoned lock leaves it intact.
-    fn value(&self) -> std::sync::MutexGuard<'_, Option<T>> {
-        self.value.lock().unwrap_or_else(PoisonError::into_inner)
-    }
-}
+use futures_channel::oneshot;
 
 /// Receiving half of one submitted job; polled by the split engine.
 pub(super) struct Handoff<T> {
-    slot: Arc<Slot<T>>,
+    rx: oneshot::Receiver<T>,
 }
 
 impl<T> Handoff<T> {
     /// Ready with the reply, or `None` when the job finished without one:
     /// the job panicked, or the pool dropped it.
-    ///
-    /// The waker is registered before the slot is checked, so a reply
-    /// landing between the two is never missed.
     pub(super) fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
-        self.slot.waker.register(cx.waker());
-        if let Some(value) = self.slot.value().take() {
-            return Poll::Ready(Some(value));
-        }
-        if self.slot.done.load(Ordering::Acquire) {
-            // The reply half is gone, but it may have written its value
-            // between the take above and this load; re-check so that
-            // ordering never turns a delivered reply into a spurious drop.
-            return Poll::Ready(self.slot.value().take());
-        }
-        Poll::Pending
+        Pin::new(&mut self.rx).poll(cx).map(Result::ok)
     }
-}
-
-/// Sending half held by the pool job; waking on drop covers both delivery
-/// and a job that finished without replying.
-struct Reply<T> {
-    slot: Arc<Slot<T>>,
-}
-
-impl<T> Drop for Reply<T> {
-    fn drop(&mut self) {
-        self.slot.done.store(true, Ordering::Release);
-        self.slot.waker.wake();
-    }
-}
-
-/// Both halves of one fresh slot.
-fn pair<T>() -> (Handoff<T>, Reply<T>) {
-    let slot = Arc::new(Slot {
-        value: Mutex::new(None),
-        waker: AtomicWaker::new(),
-        done: AtomicBool::new(false),
-    });
-    let reply = Reply {
-        slot: Arc::clone(&slot),
-    };
-    (Handoff { slot }, reply)
 }
 
 /// Queue `job` on the pool, returning the handoff its reply arrives on.
 ///
 /// Submission only enqueues, so neither building nor polling the caller's
-/// future ever blocks on the pool. A panicking job is caught here and leaves
-/// its slot empty, so the receiver sees a dropped job instead of a process
-/// abort.
+/// future ever blocks on the pool. A panicking job is caught here and drops
+/// its sender unsent, so the receiver sees a dropped job instead of a
+/// process abort.
 pub(super) fn submit<T, F>(job: F) -> Handoff<T>
 where
     T: Send + 'static,
     F: FnOnce() -> T + Send + 'static,
 {
-    let (handoff, reply) = pair();
+    let (tx, rx) = oneshot::channel();
     rayon::spawn(move || {
         if let Ok(value) = catch_unwind(AssertUnwindSafe(job)) {
-            *reply.slot.value() = Some(value);
+            drop(tx.send(value));
         }
-        drop(reply);
     });
-    handoff
+    Handoff { rx }
 }
 
 #[cfg(test)]
@@ -104,6 +47,7 @@ mod tests {
 
     use core::task::Waker;
     use core::time::Duration;
+    use std::sync::Arc;
     use std::task::Wake;
     use std::thread::{self, Thread};
     use std::time::Instant;
@@ -135,28 +79,25 @@ mod tests {
         }
     }
 
-    /// Waking after the completion flag is raised is what keeps a receiver that
-    /// parks mid-drop from sleeping for good, so hammer that interleaving.
+    /// A sender dropped unsent must always wake the receiver, whatever the
+    /// interleaving against the poll that registered the waker.
     #[test]
-    fn a_reply_dropped_without_a_value_always_wakes_the_receiver() {
+    fn a_sender_dropped_without_a_value_always_wakes_the_receiver() {
         for _ in 0..1_000 {
-            let (handoff, reply) = pair::<u32>();
-            let sender = thread::spawn(move || drop(reply));
-            assert_eq!(recv_before(handoff, Duration::from_secs(10)), None);
+            let (tx, rx) = oneshot::channel::<u32>();
+            let sender = thread::spawn(move || drop(tx));
+            assert_eq!(recv_before(Handoff { rx }, Duration::from_secs(10)), None);
             sender.join().unwrap();
         }
     }
 
-    /// A value stored before the drop is delivered, never read as a drop.
+    /// A value sent before the drop is delivered, never read as a drop.
     #[test]
-    fn a_reply_carrying_a_value_delivers_it() {
+    fn a_sender_carrying_a_value_delivers_it() {
         for _ in 0..1_000 {
-            let (handoff, reply) = pair::<u32>();
-            let sender = thread::spawn(move || {
-                *reply.slot.value() = Some(7);
-                drop(reply);
-            });
-            assert_eq!(recv_before(handoff, Duration::from_secs(10)), Some(7));
+            let (tx, rx) = oneshot::channel::<u32>();
+            let sender = thread::spawn(move || tx.send(7).unwrap());
+            assert_eq!(recv_before(Handoff { rx }, Duration::from_secs(10)), Some(7));
             sender.join().unwrap();
         }
     }


### PR DESCRIPTION
## What

Replace the hand-rolled pool handoff with `futures_channel::oneshot`, and delete the slot mutex, the atomic waker and the ordering that guarded them.

## Why

Follow-up to #430. That fix was correct but minimal: it swapped one hand-written completion signal for a better one. The module underneath is a oneshot channel with sender-drop detection written out by hand, and that hand-written completion signal is what produced the lost wake in the first place.

`oneshot` is exactly this abstraction. A sender dropped unsent resolves the receiver to `Canceled`, which is precisely the dropped-job case the engine already reads as `PoolDropped`, so the mapping is direct and the ordering comes from a primitive that gets it right by construction rather than from an invariant we have to keep restating. It removes the failure mode rather than fixing one instance of it.

Production code in `handoff.rs` goes from 99 lines to 42. The receiver keeps its poll shape, so `engine.rs` is untouched.

The dependency is already compiled in the tree, via `futures-util` and the `futures` dev-dependency, at the same 0.3.32 family version, so no new third-party code enters the build. The edge is gated behind `rayon`, which implies `std`, so bare-metal builds never see it.

## Testing

`cargo nextest run -p nectar-file --features rayon,encryption` green at 113 of 113, including the worker-panic path and the deterministic lost-wake regression test carried over from #430 unchanged in intent: one thousand rounds of a sender dropped unsent on another thread, receiver driven off wakes alone, with a deadline that fails loudly instead of hanging.

`cargo clippy -p nectar-file --features rayon,encryption --all-targets` clean, leaving only the pre-existing `clippy::use_self` warning in `nectar-primitives`. `cargo check -p nectar-swarms -p nectar-contracts -p nectar-file --no-default-features --target riscv64imac-unknown-none-elf` green, confirming the new edge stays out of the no_std build. `Cargo.lock` is committed and resolves under CI's exact `--locked` invocation.

Not measured: throughput or allocation on the split hot path. Both versions allocate a single `Arc` per leaf seal so I expect parity, but this change is not justified on performance grounds and no bench was run.

## AI Assistance

Claude Code was used to identify the hand-rolled primitive, carry out the replacement and verify it.
