### PR TITLE
ci: audit fuzz Cargo.lock in security workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -34,6 +34,7 @@ jobs:
           tool: cargo-audit
 
       - name: cargo audit
+        id: root-audit
         run: cargo audit
 
       # fuzz/ is a self-contained workspace with its own committed lockfile,
@@ -41,7 +42,7 @@ jobs:
       # .cargo/audit.toml applies to both lockfiles, and run even when the
       # root audit fails so one lockfile cannot mask the other.
       - name: cargo audit (fuzz lockfile)
-        if: '!cancelled()'
+        if: success() || steps.root-audit.outcome == 'failure'
         run: cargo audit --file fuzz/Cargo.lock
 
       - name: Open or update advisory issue
@@ -51,7 +52,7 @@ jobs:
         run: |
           title="Security audit found vulnerable dependencies"
           run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          body=$(printf 'The scheduled security audit failed: a RustSec advisory matches a dependency in Cargo.lock.\n\nFailed run: %s\n\nUpdate the affected dependency to a patched version shown in the run log.' "$run_url")
+          body=$(printf 'The scheduled security audit failed: a RustSec advisory matches a dependency in the root or fuzz Cargo.lock.\n\nFailed run: %s\n\nUpdate the affected dependency to a patched version shown in the run log.' "$run_url")
           existing=$(gh issue list --state open --search "in:title \"$title\"" --json number --jq '.[0].number')
           if [ -n "$existing" ]; then
             gh issue comment "$existing" --body "$body"

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -36,6 +36,14 @@ jobs:
       - name: cargo audit
         run: cargo audit
 
+      # fuzz/ is a self-contained workspace with its own committed lockfile,
+      # which a bare `cargo audit` never reads. Run from the repo root so
+      # .cargo/audit.toml applies to both lockfiles, and run even when the
+      # root audit fails so one lockfile cannot mask the other.
+      - name: cargo audit (fuzz lockfile)
+        if: '!cancelled()'
+        run: cargo audit --file fuzz/Cargo.lock
+
       - name: Open or update advisory issue
         if: failure() && github.event_name == 'schedule'
         env:


### PR DESCRIPTION
## What

Adds a second audit step to `.github/workflows/audit.yml`: `cargo audit --file fuzz/Cargo.lock`, run from the repo root so `.cargo/audit.toml` ignore handling applies to both lockfiles, guarded with `if: success() || steps.root-audit.outcome == 'failure'` so a root-lock failure cannot mask fuzz-lock advisories. The existing scheduled-run issue-opener step fires on either failure unchanged, and its body text is updated to mention both lockfiles. Workflow-only, 10 insertions / 1 deletion, no source or lockfile changes.

## Why

`fuzz/` is a self-contained cargo workspace with its own committed `Cargo.lock` that a bare `cargo audit` never reads, so fuzz-only dependency advisories were going undetected. Running from the repo root (rather than a fuzz/ working-directory run) is required per the issue comment's caveat, so `.cargo/audit.toml` ignore handling applies consistently to both lockfiles. This is the epic #443 Wave 1 fuzz-lockfile-audit item; it touches no oracle/generator rows and preserves rows 1-6 of the drift register.

## Testing

Verified in a fresh detached worktree under the repo-pinned toolchain (`nix develop`, rust 1.94): `cargo nextest run --workspace --locked --no-tests=warn --no-fail-fast` green (902 passed, 1 skipped); `cargo metadata --locked` clean at the root and in `fuzz/`; `actionlint` clean on the changed workflow. Since the only changed file is the workflow, the per-crate battery (clippy, per-crate nextest feature shapes, doctests, rv64 no_std) is vacuous, no `.rs`, `Cargo.toml`, or feature wiring changed. Behaviour smoke-tested locally with the installed `cargo-audit`: from the repo root, `cargo audit` and `cargo audit --file fuzz/Cargo.lock` both exit 0, the fuzz invocation scans `fuzz/Cargo.lock` (326 crate dependencies), and `.cargo/audit.toml` is picked up from the cwd for both runs.

## AI Assistance

Implemented and reviewed with Claude (Anthropic).

Closes #214
