### PR TITLE
test(manifest): replace TestResult with anyhow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2096,6 +2096,7 @@ name = "nectar-manifest"
 version = "0.4.0"
 dependencies = [
  "alloy-primitives",
+ "anyhow",
  "bytes",
  "futures",
  "nectar-file",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 
 # For tests and examples
+anyhow = "1"
 arbitrary = "1.4"
 criterion = { package = "codspeed-criterion-compat", version = "2.10.1" }
 proptest = "1"

--- a/crates/manifest/Cargo.toml
+++ b/crates/manifest/Cargo.toml
@@ -26,6 +26,7 @@ nectar-primitives = { workspace = true }
 thiserror.workspace = true
 
 [dev-dependencies]
+anyhow.workspace = true
 nectar-testing.workspace = true
 proptest.workspace = true
 

--- a/crates/manifest/tests/bridge.rs
+++ b/crates/manifest/tests/bridge.rs
@@ -5,13 +5,14 @@
 //! and the stored chunk address set must match exactly. Chunks are
 //! content-addressed, so address equality pins the stored bytes.
 
+use anyhow::{Result, anyhow, ensure};
 use bytes::Bytes;
 use nectar_manifest::{Builder, Entry, Key, Reader, build_files};
 use nectar_primitives::{ChunkRef, DEFAULT_BODY_SIZE, MemoryStore};
 use nectar_testing::run;
 
 mod common;
-use common::{TestResult, ensure, ensure_eq, split_whole};
+use common::split_whole;
 
 const B: usize = DEFAULT_BODY_SIZE;
 /// Reference fan-out of one intermediate chunk at the default body size.
@@ -40,7 +41,7 @@ fn pattern(size: usize) -> Bytes {
 }
 
 #[test]
-fn streaming_bridge_pins_the_direct_split_bytes() -> TestResult {
+fn streaming_bridge_pins_the_direct_split_bytes() -> Result<()> {
     for &size in SIZES {
         let data = pattern(size);
         let key = Key::from(&b"file"[..]);
@@ -50,32 +51,32 @@ fn streaming_bridge_pins_the_direct_split_bytes() -> TestResult {
 
         // The reference bridge: the same manifest over a direct split's
         // reference, with the direct chunk set as the file bytes oracle.
-        let (direct_root, direct_store) = run(split_whole(&data))?;
+        let (direct_root, direct_store) = run(split_whole(&data)).map_err(|e| anyhow!("{e}"))?;
         let node_store = MemoryStore::default();
         let mut builder: Builder = Builder::new();
         builder.insert(key, Entry::from(ChunkRef::new(direct_root)), None);
         let direct_built = run(builder.build(&node_store))?;
-        ensure_eq(built.root(), direct_built.root(), "manifest root")?;
+        ensure!(built.root() == direct_built.root(), "manifest root");
 
         let direct = direct_store.into_chunks();
         let nodes = node_store.into_chunks();
         for address in direct.keys() {
-            ensure(store.get(address).is_some(), "direct-split chunk stored")?;
+            ensure!(store.get(address).is_some(), "direct-split chunk stored");
         }
         // Exact set equality: with the file chunks and manifest nodes both
         // pinned, no other chunk may appear.
         for address in store.into_chunks().keys() {
-            ensure(
+            ensure!(
                 direct.contains_key(address) || nodes.contains_key(address),
                 "no chunk beyond the direct split set and the manifest nodes",
-            )?;
+            );
         }
     }
     Ok(())
 }
 
 #[test]
-fn bridged_files_round_trip_byte_exact() -> TestResult {
+fn bridged_files_round_trip_byte_exact() -> Result<()> {
     let store = MemoryStore::default();
     let big = pattern(FAN * B + 5);
     let files = [
@@ -85,14 +86,13 @@ fn bridged_files_round_trip_byte_exact() -> TestResult {
     let root = *run(build_files(&store, files))?.root();
 
     let reader: Reader<_> = Reader::new(store);
-    ensure_eq(
-        run(reader.fetch(&root, &Key::from(&b"a/big"[..])))?,
-        Some(big),
+    ensure!(
+        run(reader.fetch(&root, &Key::from(&b"a/big"[..])))? == Some(big),
         "deep file round trip",
-    )?;
-    ensure_eq(
-        run(reader.fetch(&root, &Key::from(&b"a/small"[..])))?,
-        Some(Bytes::from_static(b"x")),
+    );
+    ensure!(
+        run(reader.fetch(&root, &Key::from(&b"a/small"[..])))? == Some(Bytes::from_static(b"x")),
         "single-leaf round trip",
-    )
+    );
+    Ok(())
 }

--- a/crates/manifest/tests/builder.rs
+++ b/crates/manifest/tests/builder.rs
@@ -4,8 +4,7 @@
 //! buffers track the trie depth rather than the key count, and the files path
 //! splits through BMT and references the stored roots.
 
-use std::error::Error;
-
+use anyhow::{Context, Result, anyhow, ensure};
 use bytes::Bytes;
 use nectar_manifest::{
     BuildStats, Builder, Child, Entry, ForkPayload, ForkTable, Key, KeyId, Metadata, Node, NodeGet,
@@ -15,20 +14,20 @@ use nectar_primitives::{ChunkAddress, ChunkOps, ChunkRef, MemoryStore};
 use nectar_testing::run;
 
 mod common;
-use common::{TestResult, ensure, ensure_eq, split_whole};
+use common::split_whole;
 
 const fn ref32(byte: u8) -> ChunkRef {
     ChunkRef::new(ChunkAddress::new([byte; 32]))
 }
 
-fn content_type(value: &'static [u8]) -> Result<Metadata, Box<dyn Error>> {
+fn content_type(value: &'static [u8]) -> Result<Metadata> {
     Ok(Metadata::new(
         KeyId::ContentType,
         Bytes::from_static(value),
     )?)
 }
 
-fn website_index() -> Result<Metadata, Box<dyn Error>> {
+fn website_index() -> Result<Metadata> {
     Ok(Metadata::new(
         KeyId::WebsiteIndexDocument,
         Bytes::from_static(b"index.html"),
@@ -37,7 +36,7 @@ fn website_index() -> Result<Metadata, Box<dyn Error>> {
 
 // The spec's worked example, built manually: a two-file website behind one
 // shared embedded child, the same node the codec conformance pins to 150 bytes.
-fn worked_example_node() -> Result<Node, Box<dyn Error>> {
+fn worked_example_node() -> Result<Node> {
     let mut child = ForkTable::new();
     child.insert(
         Prefix::try_from(&b"mg/logo.png"[..])?,
@@ -64,7 +63,7 @@ fn worked_example_node() -> Result<Node, Box<dyn Error>> {
 }
 
 #[test]
-fn builds_the_worked_example_byte_for_byte() -> TestResult {
+fn builds_the_worked_example_byte_for_byte() -> Result<()> {
     let store = MemoryStore::default();
     let mut builder: Builder = Builder::new();
     builder
@@ -83,23 +82,23 @@ fn builds_the_worked_example_byte_for_byte() -> TestResult {
     let built = run(builder.build(&store))?;
 
     // The shared child is inlined, so the whole manifest is one chunk.
-    ensure_eq(built.stats().nodes_written(), 1, "one node written")?;
-    ensure_eq(built.stats().nodes_embedded(), 1, "one child embedded")?;
+    ensure!(built.stats().nodes_written() == 1, "one node written");
+    ensure!(built.stats().nodes_embedded() == 1, "one child embedded");
 
-    let chunk = store.get(built.root()).ok_or("root not stored")?;
+    let chunk = store.get(built.root()).context("root not stored")?;
     let expected = worked_example_node()?.encode()?;
-    ensure_eq(expected.len(), 150, "worked example is 150 bytes")?;
-    ensure_eq(
-        chunk.envelope().data().as_ref(),
-        expected.as_slice(),
+    ensure!(expected.len() == 150, "worked example is 150 bytes");
+    ensure!(
+        chunk.envelope().data().as_ref() == expected.as_slice(),
         "root payload",
-    )?;
+    );
 
     let decoded: Node = run(store.get_node(built.root()))?;
-    ensure_eq(decoded, worked_example_node()?, "decoded root")
+    ensure!(decoded == worked_example_node()?, "decoded root");
+    Ok(())
 }
 
-fn root_of(order: &[(&[u8], u8)]) -> Result<ChunkAddress, Box<dyn Error>> {
+fn root_of(order: &[(&[u8], u8)]) -> Result<ChunkAddress> {
     let store = MemoryStore::default();
     let mut builder: Builder = Builder::new();
     for (key, fill) in order {
@@ -109,7 +108,7 @@ fn root_of(order: &[(&[u8], u8)]) -> Result<ChunkAddress, Box<dyn Error>> {
 }
 
 #[test]
-fn the_published_root_is_history_independent() -> TestResult {
+fn the_published_root_is_history_independent() -> Result<()> {
     // A key set that exercises a terminating-and-continuing fork ("a" under
     // "about"), a nested shared edge ("about-us"), and a shared directory
     // ("img/").
@@ -125,14 +124,15 @@ fn the_published_root_is_history_independent() -> TestResult {
 
     let mut reversed = order;
     reversed.reverse();
-    ensure_eq(root_of(&reversed)?, forward, "reversed order")?;
+    ensure!(root_of(&reversed)? == forward, "reversed order");
 
     let mut rotated = order;
     rotated.rotate_left(3);
-    ensure_eq(root_of(&rotated)?, forward, "rotated order")
+    ensure!(root_of(&rotated)? == forward, "rotated order");
+    Ok(())
 }
 
-fn two_level_stats(store: &MemoryStore, fan: u16, width: u8) -> Result<BuildStats, Box<dyn Error>> {
+fn two_level_stats(store: &MemoryStore, fan: u16, width: u8) -> Result<BuildStats> {
     let mut builder: Builder<V1> = Builder::new();
     for hi in 0..fan {
         let hi = u8::try_from(hi)?;
@@ -144,7 +144,7 @@ fn two_level_stats(store: &MemoryStore, fan: u16, width: u8) -> Result<BuildStat
 }
 
 #[test]
-fn peak_node_buffers_track_depth_not_key_count() -> TestResult {
+fn peak_node_buffers_track_depth_not_key_count() -> Result<()> {
     // Two two-level manifests whose second level is wide enough that each child
     // spills to its own chunk. The narrow build has 8 subtrees, the wide one 64;
     // the wide build stores many more nodes, yet both keep the same tiny number
@@ -155,41 +155,42 @@ fn peak_node_buffers_track_depth_not_key_count() -> TestResult {
     let wide_stats = two_level_stats(&wide, 64, 80)?;
 
     // Root plus one open child: never a whole level or frontier.
-    ensure_eq(narrow_stats.peak_open_nodes(), 2, "narrow peak")?;
-    ensure_eq(wide_stats.peak_open_nodes(), 2, "wide peak")?;
+    ensure!(narrow_stats.peak_open_nodes() == 2, "narrow peak");
+    ensure!(wide_stats.peak_open_nodes() == 2, "wide peak");
 
     // The children are spilled, not embedded, so work scales with the fan.
-    ensure_eq(narrow_stats.nodes_embedded(), 0, "narrow spills all")?;
-    ensure_eq(narrow_stats.nodes_written(), 9, "narrow node count")?;
-    ensure_eq(wide_stats.nodes_written(), 65, "wide node count")?;
+    ensure!(narrow_stats.nodes_embedded() == 0, "narrow spills all");
+    ensure!(narrow_stats.nodes_written() == 9, "narrow node count");
+    ensure!(wide_stats.nodes_written() == 65, "wide node count");
 
     // Eight times the keys, eight times the stored nodes, identical peak.
-    ensure(
+    ensure!(
         wide_stats.nodes_written() > narrow_stats.nodes_written().saturating_mul(7),
         "work scales with keys",
-    )?;
-    ensure_eq(
-        narrow_stats.peak_open_nodes(),
-        wide_stats.peak_open_nodes(),
+    );
+    ensure!(
+        narrow_stats.peak_open_nodes() == wide_stats.peak_open_nodes(),
         "peak is key-count independent",
-    )
+    );
+    Ok(())
 }
 
 #[test]
-fn the_empty_builder_publishes_the_empty_root() -> TestResult {
+fn the_empty_builder_publishes_the_empty_root() -> Result<()> {
     let store = MemoryStore::default();
     let builder: Builder = Builder::new();
     let built = run(builder.build(&store))?;
 
-    ensure_eq(built.stats().peak_open_nodes(), 1, "one open node")?;
-    ensure_eq(built.stats().nodes_written(), 1, "one node written")?;
+    ensure!(built.stats().peak_open_nodes() == 1, "one open node");
+    ensure!(built.stats().nodes_written() == 1, "one node written");
 
     let node: Node = run(store.get_node(built.root()))?;
-    ensure(node.is_empty(), "root is the empty map")
+    ensure!(node.is_empty(), "root is the empty map");
+    Ok(())
 }
 
 #[test]
-fn build_files_splits_through_bmt_and_references_the_stored_roots() -> TestResult {
+fn build_files_splits_through_bmt_and_references_the_stored_roots() -> Result<()> {
     let store = MemoryStore::default();
     let logo = Bytes::from(vec![0x42u8; 12_000]); // several chunks
     let page = Bytes::from_static(b"<h1>hello</h1>");
@@ -207,23 +208,23 @@ fn build_files_splits_through_bmt_and_references_the_stored_roots() -> TestResul
         (b'i', &b"ndex.html"[..], page),
         (b'l', &b"ogo.png"[..], logo),
     ] {
-        let record = node.forks().get(first).ok_or("missing fork")?;
-        ensure_eq(record.tail().as_bytes(), tail, "fork tail")?;
+        let record = node.forks().get(first).context("missing fork")?;
+        ensure!(record.tail().as_bytes() == tail, "fork tail");
         let address = record
             .entry()
-            .ok_or("fork has no entry")?
+            .context("fork has no entry")?
             .address()
-            .ok_or("entry is not a reference")?;
+            .context("entry is not a reference")?;
 
-        let (expected_root, _) = run(split_whole(&data))?;
-        ensure_eq(address, &expected_root, "file root reference")?;
-        ensure(store.get(address).is_some(), "file root stored")?;
+        let (expected_root, _) = run(split_whole(&data)).map_err(|e| anyhow!("{e}"))?;
+        ensure!(address == &expected_root, "file root reference");
+        ensure!(store.get(address).is_some(), "file root stored");
     }
     Ok(())
 }
 
 #[test]
-fn a_key_that_prefixes_another_shares_a_fork() -> TestResult {
+fn a_key_that_prefixes_another_shares_a_fork() -> Result<()> {
     let store = MemoryStore::default();
     let mut builder: Builder = Builder::new();
     builder
@@ -232,16 +233,16 @@ fn a_key_that_prefixes_another_shares_a_fork() -> TestResult {
     let built = run(builder.build(&store))?;
 
     let node: Node = run(store.get_node(built.root()))?;
-    let record = node.forks().get(b'a').ok_or("missing fork a")?;
-    ensure(record.tail().is_empty(), "single-byte edge")?;
+    let record = node.forks().get(b'a').context("missing fork a")?;
+    ensure!(record.tail().is_empty(), "single-byte edge");
     // "a" terminates here and the trie continues to "ab".
-    ensure(
+    ensure!(
         matches!(record.payload(), ForkPayload::Both { .. }),
         "fork is entry-and-child",
-    )?;
-    ensure_eq(
-        record.entry(),
-        Some(&Entry::from(ref32(1))),
+    );
+    ensure!(
+        record.entry() == Some(&Entry::from(ref32(1))),
         "terminating value",
-    )
+    );
+    Ok(())
 }

--- a/crates/manifest/tests/common/mod.rs
+++ b/crates/manifest/tests/common/mod.rs
@@ -8,27 +8,6 @@ use std::sync::Arc;
 use nectar_file::{Plain, Split};
 use nectar_primitives::{ChunkAddress, DEFAULT_BODY_SIZE, MemoryStore};
 
-/// The result type the Result-returning integration tests report through.
-pub(crate) type TestResult = Result<(), Box<dyn Error>>;
-
-/// A fallible assertion: Result-returning tests report failures as errors.
-pub(crate) fn ensure(cond: bool, what: &str) -> TestResult {
-    if cond { Ok(()) } else { Err(what.into()) }
-}
-
-/// A fallible equality assertion.
-pub(crate) fn ensure_eq<T: PartialEq + core::fmt::Debug>(
-    left: T,
-    right: T,
-    what: &str,
-) -> TestResult {
-    if left == right {
-        Ok(())
-    } else {
-        Err(format!("{what}: {left:?} != {right:?}").into())
-    }
-}
-
 /// Split `data` whole through the streaming engine into a fresh store,
 /// returning the root and the split store.
 pub(crate) async fn split_whole(

--- a/crates/manifest/tests/common/mod.rs
+++ b/crates/manifest/tests/common/mod.rs
@@ -1,7 +1,5 @@
 //! Shared helpers for the manifest integration tests.
 
-#![allow(dead_code)]
-
 use std::error::Error;
 use std::sync::Arc;
 

--- a/crates/manifest/tests/conformance.rs
+++ b/crates/manifest/tests/conformance.rs
@@ -3,9 +3,9 @@
 //! the canonical-or-reject bijection between logical trees and byte strings.
 
 use std::collections::HashSet;
-use std::error::Error;
 
 use alloy_primitives::{b256, keccak256};
+use anyhow::{Context, Result, ensure};
 use bytes::Bytes;
 use nectar_manifest::{
     Child, CustomKeyError, DecodeError, Domain, Entry, ForkPayload, ForkTable, Format, KeyId,
@@ -13,9 +13,6 @@ use nectar_manifest::{
     segment,
 };
 use nectar_primitives::{ChunkAddress, ChunkRef, EncryptedChunkRef, EncryptionKey};
-
-mod common;
-use common::{TestResult, ensure, ensure_eq};
 
 const fn ref32(byte: u8) -> ChunkRef {
     ChunkRef::new(ChunkAddress::new([byte; 32]))
@@ -28,7 +25,7 @@ fn ref64(addr: u8, key: u8) -> EncryptedChunkRef {
     )
 }
 
-fn prefix(bytes: &[u8]) -> Result<Prefix, Box<dyn Error>> {
+fn prefix(bytes: &[u8]) -> Result<Prefix> {
     Ok(Prefix::try_from(bytes)?)
 }
 
@@ -56,24 +53,23 @@ fn record32(byte: u8) -> Vec<u8> {
 
 // The empty-map root payload is the five bytes 6D 01 00 00 00.
 #[test]
-fn empty_map_root_is_the_frozen_five_byte_vector() -> TestResult {
+fn empty_map_root_is_the_frozen_five_byte_vector() -> Result<()> {
     let node: Node = Node::empty();
     let image = node.encode()?;
-    ensure_eq(
-        image.as_slice(),
-        [0x6D, 0x01, 0x00, 0x00, 0x00].as_slice(),
+    ensure!(
+        image.as_slice() == [0x6D, 0x01, 0x00, 0x00, 0x00].as_slice(),
         "empty-map root payload",
-    )?;
+    );
 
     let decoded: Node = Node::decode(&image)?;
-    ensure(decoded.is_empty(), "decoded root must be empty")?;
-    ensure_eq(&decoded.encode()?, &image, "re-encode")?;
+    ensure!(decoded.is_empty(), "decoded root must be empty");
+    ensure!(decoded.encode()? == image, "re-encode");
     Ok(())
 }
 
 // The worked example: a two-file website in one 150-byte payload.
 #[test]
-fn worked_two_file_example_is_bit_exact() -> TestResult {
+fn worked_two_file_example_is_bit_exact() -> Result<()> {
     let ref_a = [0xAA; 32]; // "index.html" content
     let ref_b = [0xBB; 32]; // "img/logo.png" content
 
@@ -135,14 +131,14 @@ fn worked_two_file_example_is_bit_exact() -> TestResult {
     expected.extend_from_slice(&ref_a); // 104
     expected.extend_from_slice(&[0x0C, 0x00, 0x01, 0x09, 0x00]); // 136: mlen = 12; content-type
     expected.extend_from_slice(b"text/html");
-    ensure_eq(expected.len(), 150, "vector length")?;
+    ensure!(expected.len() == 150, "vector length");
 
     let image = node.encode()?;
-    ensure_eq(&image, &expected, "worked example payload")?;
+    ensure!(image == expected, "worked example payload");
 
     let decoded: Node = Node::decode(&image)?;
-    ensure_eq(&decoded, &node, "round trip")?;
-    ensure_eq(&decoded.encode()?, &image, "re-encode")?;
+    ensure!(decoded == node, "round trip");
+    ensure!(decoded.encode()? == image, "re-encode");
     Ok(())
 }
 
@@ -170,7 +166,7 @@ fn h64_anchors_match_the_spec() {
 // Each row pins H64(P), the w * CUT_SCALE threshold, and the hash-cut bit;
 // the partition run pins the segmentation itself.
 #[test]
-fn worked_leaf_partition_reproduces_the_spec_trace() -> TestResult {
+fn worked_leaf_partition_reproduces_the_spec_trace() -> Result<()> {
     // (fork key, record weight w, H64 of the one-byte prefix, hash cut)
     let rows: [(u8, u64, u64, bool); 8] = [
         (b'a', 207, 0x1242_f58d_1625_c23a, true),
@@ -198,27 +194,25 @@ fn worked_leaf_partition_reproduces_the_spec_trace() -> TestResult {
 
     for ((key, w, hash, hash_cut), threshold) in rows.into_iter().zip(thresholds) {
         let name = char::from(key);
-        ensure_eq(h64(&[key]), hash, &format!("H64({name})"))?;
-        ensure_eq(
-            w.checked_mul(V1::CUT_SCALE),
-            Some(threshold),
-            &format!("threshold of {name}"),
-        )?;
-        ensure(w < seg_target, "every worked weight is below SEG_TARGET")?;
-        ensure_eq(hash < threshold, hash_cut, &format!("cut bit of {name}"))?;
+        ensure!(h64(&[key]) == hash, "H64({name})");
+        ensure!(
+            w.checked_mul(V1::CUT_SCALE) == Some(threshold),
+            "threshold of {name}",
+        );
+        ensure!(w < seg_target, "every worked weight is below SEG_TARGET");
+        ensure!((hash < threshold) == hash_cut, "cut bit of {name}");
         // Below SEG_TARGET the real predicate reduces to the hash comparison.
-        ensure_eq(
-            cut::<V1>(&[key], usize::try_from(w)?),
-            hash_cut,
-            &format!("cut predicate of {name}"),
-        )?;
+        ensure!(
+            cut::<V1>(&[key], usize::try_from(w)?) == hash_cut,
+            "cut predicate of {name}",
+        );
     }
 
     // The real leaf partition over (fork-relative prefix, weight), CAP_FORK.
     let forks: Vec<(Prefix, SegmentWeight)> = rows
         .into_iter()
         .map(|(key, w, _, _)| {
-            Ok::<_, Box<dyn Error>>((prefix(&[key])?, SegmentWeight::new(usize::try_from(w)?)?))
+            Ok::<_, anyhow::Error>((prefix(&[key])?, SegmentWeight::new(usize::try_from(w)?)?))
         })
         .collect::<Result<_, _>>()?;
     let ranges = segment::<V1>(&forks, SegmentKind::Leaf);
@@ -228,20 +222,19 @@ fn worked_leaf_partition_reproduces_the_spec_trace() -> TestResult {
     for range in &ranges {
         let mut group: Vec<u8> = Vec::new();
         for i in range.clone() {
-            let (key, ..) = *rows.get(i).ok_or("segment index out of range")?;
+            let (key, ..) = *rows.get(i).context("segment index out of range")?;
             group.push(key);
         }
         segments.push(group);
     }
 
     let expected = [b"abc".to_vec(), b"defg".to_vec(), b"h".to_vec()];
-    ensure_eq(segments.as_slice(), expected.as_slice(), "segments")?;
+    ensure!(segments.as_slice() == expected.as_slice(), "segments");
     let first_keys: Vec<u8> = segments.iter().filter_map(|s| s.first().copied()).collect();
-    ensure_eq(
-        first_keys.as_slice(),
-        [0x61, 0x64, 0x68].as_slice(),
+    ensure!(
+        first_keys.as_slice() == [0x61, 0x64, 0x68].as_slice(),
         "directory first keys",
-    )?;
+    );
     Ok(())
 }
 
@@ -274,30 +267,30 @@ fn cut_thresholds_are_exact_integer_comparisons() {
 // and shares its parent's encryption domain. The worked example's shared
 // child is a 123-byte plaintext body, so it embeds (its ilen is 123 there).
 #[test]
-fn child_embedding_gates_on_inline_max_and_domain() -> TestResult {
-    ensure(
+fn child_embedding_gates_on_inline_max_and_domain() -> Result<()> {
+    ensure!(
         embed::<V1>(123, Domain::Plain, Domain::Plain),
         "the worked child within INLINE_MAX embeds",
-    )?;
-    ensure(
+    );
+    ensure!(
         embed::<V1>(V1::INLINE_MAX, Domain::Plain, Domain::Plain),
         "a body at INLINE_MAX embeds",
-    )?;
-    ensure(
+    );
+    ensure!(
         !embed::<V1>(V1::INLINE_MAX + 1, Domain::Plain, Domain::Plain),
         "a body over INLINE_MAX spills",
-    )?;
-    ensure(
+    );
+    ensure!(
         !embed::<V1>(123, Domain::Plain, Domain::Encrypted),
         "a cross-domain child spills",
-    )?;
+    );
     Ok(())
 }
 
 /// The bijection family: pairwise-distinct logical trees, including the
 /// near-miss pairs (absent value against empty value, the all-zero
 /// reference as a legal value, not a sentinel).
-fn tree_family() -> Result<Vec<Node>, Box<dyn Error>> {
+fn tree_family() -> Result<Vec<Node>> {
     let mut family: Vec<Node> = vec![Node::empty()];
 
     // Root extension variants: the empty inline value is a value, distinct
@@ -343,7 +336,7 @@ fn tree_family() -> Result<Vec<Node>, Box<dyn Error>> {
             Some(Entry::inline(Bytes::new())?),
             Some(Child::from(ref32(0x33))),
         )
-        .ok_or("empty payload")?,
+        .context("empty payload")?,
         None,
     )?;
     family.push(Node::new(None, forks));
@@ -378,17 +371,17 @@ fn tree_family() -> Result<Vec<Node>, Box<dyn Error>> {
 // One logical tree, one byte string: every family member round-trips to
 // itself, re-encodes to the same bytes, and no two members share an image.
 #[test]
-fn bijection_holds_over_the_tree_family() -> TestResult {
+fn bijection_holds_over_the_tree_family() -> Result<()> {
     let family = tree_family()?;
     let mut images: HashSet<Vec<u8>> = HashSet::new();
     for node in &family {
         let image = node.encode()?;
         let decoded: Node = Node::decode(&image)?;
-        ensure_eq(&decoded, node, "round trip")?;
-        ensure_eq(&decoded.encode()?, &image, "re-encode")?;
-        ensure(images.insert(image), "two trees share one byte string")?;
+        ensure!(&decoded == node, "round trip");
+        ensure!(decoded.encode()? == image, "re-encode");
+        ensure!(images.insert(image), "two trees share one byte string");
     }
-    ensure_eq(images.len(), family.len(), "family image count")?;
+    ensure!(images.len() == family.len(), "family image count");
     Ok(())
 }
 

--- a/crates/manifest/tests/counted.rs
+++ b/crates/manifest/tests/counted.rs
@@ -3,15 +3,11 @@
 //! the same root a from-scratch build produces, with counts maintained
 //! throughout.
 
-use std::error::Error;
-
+use anyhow::{Result, ensure};
 use bytes::Bytes;
 use nectar_manifest::{Builder, Changeset, Entry, Key, Reader, V1, apply};
 use nectar_primitives::{ChunkAddress, ChunkRef, MemoryStore};
 use nectar_testing::run;
-
-mod common;
-use common::{TestResult, ensure};
 
 fn ref_entry<F: nectar_manifest::Format>(fill: u8) -> Entry<F> {
     Entry::from(ChunkRef::new(ChunkAddress::new([fill; 32])))
@@ -29,7 +25,7 @@ fn keys() -> Vec<(Key, u8)> {
     out
 }
 
-fn build<F: nectar_manifest::Format>(order: &[(Key, u8)]) -> Result<ChunkAddress, Box<dyn Error>> {
+fn build<F: nectar_manifest::Format>(order: &[(Key, u8)]) -> Result<ChunkAddress> {
     let store = MemoryStore::default();
     let mut builder = Builder::<F>::new();
     for (key, fill) in order {
@@ -39,18 +35,18 @@ fn build<F: nectar_manifest::Format>(order: &[(Key, u8)]) -> Result<ChunkAddress
 }
 
 #[test]
-fn counted_canonical_bytes_are_stable_under_shuffled_build_order() -> TestResult {
+fn counted_canonical_bytes_are_stable_under_shuffled_build_order() -> Result<()> {
     let forward = keys();
     let mut reversed = forward.clone();
     reversed.reverse();
     let a = build::<V1>(&forward)?;
     let b = build::<V1>(&reversed)?;
-    ensure(a == b, "counted root must not depend on insertion order")?;
+    ensure!(a == b, "counted root must not depend on insertion order");
     Ok(())
 }
 
 #[test]
-fn build_then_read_round_trips_every_key() -> TestResult {
+fn build_then_read_round_trips_every_key() -> Result<()> {
     let store = MemoryStore::default();
     let all = keys();
     let mut builder = Builder::<V1>::new();
@@ -62,17 +58,17 @@ fn build_then_read_round_trips_every_key() -> TestResult {
     let reader = Reader::<MemoryStore, V1>::new(store);
     for (key, fill) in &all {
         let got = run(reader.get(&root, key))?;
-        ensure(got == Some(ref_entry::<V1>(*fill)), "read value mismatch")?;
+        ensure!(got == Some(ref_entry::<V1>(*fill)), "read value mismatch");
     }
-    ensure(
+    ensure!(
         run(reader.get(&root, &Key::from(&b"absent"[..])))?.is_none(),
         "absent key must read as None",
-    )?;
+    );
     Ok(())
 }
 
 #[test]
-fn apply_matches_a_from_scratch_build() -> TestResult {
+fn apply_matches_a_from_scratch_build() -> Result<()> {
     let all = keys();
     let split = all.len() * 3 / 4;
 
@@ -90,12 +86,12 @@ fn apply_matches_a_from_scratch_build() -> TestResult {
     let applied = run(apply(&store, &base_root, &changeset))?;
 
     let scratch = build::<V1>(&all)?;
-    ensure(applied == scratch, "apply must match a from-scratch build")?;
+    ensure!(applied == scratch, "apply must match a from-scratch build");
     Ok(())
 }
 
 #[test]
-fn an_inline_value_round_trips() -> TestResult {
+fn an_inline_value_round_trips() -> Result<()> {
     let store = MemoryStore::default();
     let mut builder = Builder::<V1>::new();
     let value = Entry::<V1>::inline(Bytes::from_static(b"<h1>hi</h1>"))?;
@@ -104,6 +100,6 @@ fn an_inline_value_round_trips() -> TestResult {
 
     let reader = Reader::<MemoryStore, V1>::new(store);
     let got = run(reader.get(&root, &Key::from(&b"index.html"[..])))?;
-    ensure(got == Some(value), "inline value must round-trip")?;
+    ensure!(got == Some(value), "inline value must round-trip");
     Ok(())
 }

--- a/crates/manifest/tests/determinism.rs
+++ b/crates/manifest/tests/determinism.rs
@@ -9,15 +9,13 @@
 use core::ops::Range;
 use std::collections::BTreeMap;
 
+use anyhow::{Context, Result, ensure};
 use nectar_manifest::{
     Domain, Entry, ForkTable, Format, Node, Prefix, SegmentKind, SegmentWeight, V1, cut, h64,
     segment, spill,
 };
 use nectar_primitives::{ChunkAddress, ChunkRef};
 use proptest::prelude::*;
-
-mod common;
-use common::{TestResult, ensure, ensure_eq};
 
 const fn ref32(byte: u8) -> ChunkRef {
     ChunkRef::new(ChunkAddress::new([byte; 32]))
@@ -227,20 +225,20 @@ proptest! {
 // The frozen boundary anchors: CUT_SCALE is 2^53 and divides the 64-bit hash
 // space by SEG_TARGET exactly, so the window product never overflows a u64.
 #[test]
-fn cut_scale_is_frozen() -> TestResult {
-    ensure_eq(V1::CUT_SCALE, 1u64 << 53, "CUT_SCALE")?;
+fn cut_scale_is_frozen() -> Result<()> {
+    ensure!(V1::CUT_SCALE == 1u64 << 53, "CUT_SCALE");
     let seg_target = u128::try_from(V1::SEG_TARGET)?;
     let product = u128::from(V1::CUT_SCALE)
         .checked_mul(seg_target)
-        .ok_or("window product overflowed")?;
-    ensure_eq(product, 1u128 << 64, "CUT_SCALE * SEG_TARGET")?;
+        .context("window product overflowed")?;
+    ensure!(product == 1u128 << 64, "CUT_SCALE * SEG_TARGET");
     Ok(())
 }
 
 // Termination at V1: the widest fork record fits a leaf segment with a margin
 // wider than the cut-suppression window, so packing always makes progress.
 #[test]
-fn termination_bounds_hold_at_v1() -> TestResult {
+fn termination_bounds_hold_at_v1() -> Result<()> {
     // The worst record by the codec's layout: index slot (key byte + u16
     // offset), fork flags, prefix-length byte, the longest tail, the largest
     // inline entry, the largest embedded child, and the largest metadata block.
@@ -255,18 +253,18 @@ fn termination_bounds_hold_at_v1() -> TestResult {
         .saturating_add(entry)
         .saturating_add(child)
         .saturating_add(metadata);
-    ensure_eq(worst, 2952, "worst fork record")?;
-    ensure(
+    ensure!(worst == 2952, "worst fork record");
+    ensure!(
         worst <= V1::CAP_FORK,
         "the worst record fits a leaf segment",
-    )?;
+    );
 
     let margin = V1::CAP_FORK.saturating_sub(worst);
-    ensure_eq(margin, 1139, "forced-cut margin")?;
-    ensure(
+    ensure!(margin == 1139, "forced-cut margin");
+    ensure!(
         margin >= V1::SEG_MIN,
         "the margin covers the suppression window",
-    )?;
+    );
     Ok(())
 }
 
@@ -274,7 +272,7 @@ fn termination_bounds_hold_at_v1() -> TestResult {
 // heavy enough to force its own leaf. It splits across exactly two levels, and
 // one top directory still routes every group.
 #[test]
-fn spill_of_a_full_radix_table_stays_depth_two() -> TestResult {
+fn spill_of_a_full_radix_table_stays_depth_two() -> Result<()> {
     let mut forks = Vec::with_capacity(V1::FORKS_MAX);
     for first in 0u8..=u8::MAX {
         forks.push((
@@ -283,11 +281,11 @@ fn spill_of_a_full_radix_table_stays_depth_two() -> TestResult {
         ));
     }
     let dir = spill::<V1>(&forks, Domain::Plain);
-    ensure_eq(dir.leaves().len(), V1::FORKS_MAX, "one leaf per fork")?;
-    ensure_eq(dir.depth(), 2, "a full table needs two levels")?;
+    ensure!(dir.leaves().len() == V1::FORKS_MAX, "one leaf per fork");
+    ensure!(dir.depth() == 2, "a full table needs two levels");
 
     let route = 5usize.saturating_add(ChunkRef::SIZE);
     let top = dir.dirs().len().saturating_mul(route);
-    ensure(top <= V1::CAP_DIR, "one top directory routes every group")?;
+    ensure!(top <= V1::CAP_DIR, "one top directory routes every group");
     Ok(())
 }

--- a/crates/manifest/tests/membound.rs
+++ b/crates/manifest/tests/membound.rs
@@ -7,9 +7,9 @@
 //! pin the single-chunk-node invariant: no node the builder emits exceeds one
 //! chunk body.
 
-use std::error::Error;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use anyhow::{Result, ensure};
 use bytes::Bytes;
 use nectar_manifest::{
     ApplyError, BuildStats, Builder, Changeset, Entry, Key, KeyId, Metadata, Reader, V1, apply,
@@ -21,9 +21,6 @@ use nectar_primitives::{
 };
 use nectar_testing::run;
 use proptest::prelude::*;
-
-mod common;
-use common::{TestResult, ensure};
 
 /// A reference-valued entry keyed on one byte.
 fn entry(byte: u8) -> Entry<V1> {
@@ -75,28 +72,28 @@ fn fill_radix(builder: &mut Builder<V1>, radix: u8, remaining: u32, key: &mut Ve
 
 /// Build every `radix`-ary key of length `len` into `store`, returning the build
 /// stats.
-fn build_radix(store: &MemoryStore, radix: u8, len: u32) -> Result<BuildStats, Box<dyn Error>> {
+fn build_radix(store: &MemoryStore, radix: u8, len: u32) -> Result<BuildStats> {
     let mut builder = Builder::<V1>::new();
     fill_radix(&mut builder, radix, len, &mut Vec::new(), 0x11);
-    let built = run(builder.build(store)).map_err(|e| e.to_string())?;
+    let built = run(builder.build(store))?;
     Ok(*built.stats())
 }
 
 /// Assert every stored node fits one chunk body: the single-chunk-node
 /// invariant, checked over the whole emitted set.
-fn assert_single_chunk_nodes(store: &MemoryStore) -> TestResult {
+fn assert_single_chunk_nodes(store: &MemoryStore) -> Result<()> {
     for chunk in store.clone().into_chunks().into_values() {
         let len = chunk.envelope().data().len();
-        ensure(
+        ensure!(
             len <= DEFAULT_BODY_SIZE,
-            &format!("emitted node is {len} bytes, over one chunk body"),
-        )?;
+            "emitted node is {len} bytes, over one chunk body",
+        );
     }
     Ok(())
 }
 
 #[test]
-fn peak_open_nodes_tracks_depth_not_width() -> TestResult {
+fn peak_open_nodes_tracks_depth_not_width() -> Result<()> {
     // radix 10, depth 2 is 100 keys two nodes deep.
     let shallow_narrow = build_radix(&MemoryStore::default(), 10, 2)?;
     // radix 60, depth 2 is 3_600 keys, still two deep but far wider per level.
@@ -105,36 +102,33 @@ fn peak_open_nodes_tracks_depth_not_width() -> TestResult {
     let deep = build_radix(&MemoryStore::default(), 10, 4)?;
 
     // Same depth, very different width: identical peak, whatever the fan.
-    ensure(
+    ensure!(
         shallow_narrow.peak_open_nodes() == shallow_wide.peak_open_nodes(),
-        &format!(
-            "peak {} != {} across widths at equal depth",
-            shallow_narrow.peak_open_nodes(),
-            shallow_wide.peak_open_nodes(),
-        ),
-    )?;
+        "peak {} != {} across widths at equal depth",
+        shallow_narrow.peak_open_nodes(),
+        shallow_wide.peak_open_nodes(),
+    );
     // Greater depth raises the peak; width alone never does.
-    ensure(
+    ensure!(
         deep.peak_open_nodes() > shallow_wide.peak_open_nodes(),
-        &format!(
-            "deeper build peak {} did not exceed shallow peak {}",
-            deep.peak_open_nodes(),
-            shallow_wide.peak_open_nodes(),
-        ),
-    )?;
+        "deeper build peak {} did not exceed shallow peak {}",
+        deep.peak_open_nodes(),
+        shallow_wide.peak_open_nodes(),
+    );
     // The wide build writes far more nodes than its peak: work is O(tree), the
     // retained frontier is O(depth).
-    ensure(
+    ensure!(
         shallow_wide.nodes_written() > shallow_wide.peak_open_nodes().saturating_mul(10),
         "wide build node count is not far above its peak",
-    )
+    );
+    Ok(())
 }
 
 /// Stream a byte-keyed profile into the builder: the first two key positions
 /// range over all 256 byte values and the third over `0..tail`, so every level-0
 /// and level-1 node is a full radix-256 fork table that overruns one chunk and
 /// must spill. `tail = 16` yields `256*256*16 = 1_048_576` keys.
-fn fill_radix256(builder: &mut Builder<V1>, tail: u16, fill: u8) -> Result<(), Box<dyn Error>> {
+fn fill_radix256(builder: &mut Builder<V1>, tail: u16, fill: u8) -> Result<()> {
     let mut key = [0u8; 3];
     for a in 0u16..256 {
         key[0] = u8::try_from(a)?;
@@ -150,7 +144,7 @@ fn fill_radix256(builder: &mut Builder<V1>, tail: u16, fill: u8) -> Result<(), B
 }
 
 #[test]
-fn a_million_key_manifest_is_depth_bounded() -> TestResult {
+fn a_million_key_manifest_is_depth_bounded() -> Result<()> {
     // A byte-keyed radix-256 profile: 256*256*16 = 1_048_576 keys three nodes
     // deep, whose level-0 and level-1 nodes are full 256-fork tables that a
     // naive encoder would reject as over-budget. Spill packs each into a segment
@@ -160,26 +154,22 @@ fn a_million_key_manifest_is_depth_bounded() -> TestResult {
     let inner = MemoryStore::default();
     let mut builder = Builder::<V1>::new();
     fill_radix256(&mut builder, 16, 0x22)?;
-    let built = run(builder.build(&inner)).map_err(|e| e.to_string())?;
+    let built = run(builder.build(&inner))?;
     let stats = *built.stats();
     let root = *built.root();
 
-    ensure(
+    ensure!(
         stats.peak_open_nodes() <= 8,
-        &format!(
-            "peak {} open nodes is not O(depth) at 10^6 keys",
-            stats.peak_open_nodes(),
-        ),
-    )?;
+        "peak {} open nodes is not O(depth) at 10^6 keys",
+        stats.peak_open_nodes(),
+    );
     // The tree is spilled across many chunks, orders of magnitude above the
     // peak, so the bound is a genuine streaming bound, not a small tree.
-    ensure(
+    ensure!(
         stats.nodes_written() > stats.peak_open_nodes().saturating_mul(100),
-        &format!(
-            "only {} nodes written, no wider than the peak",
-            stats.nodes_written(),
-        ),
-    )?;
+        "only {} nodes written, no wider than the peak",
+        stats.nodes_written(),
+    );
     // Every emitted node fits one chunk body, checked at 10^6-key scale over a
     // profile whose interior nodes are all spilled.
     assert_single_chunk_nodes(&inner)?;
@@ -195,22 +185,20 @@ fn a_million_key_manifest_is_depth_bounded() -> TestResult {
     let reader: Reader<_> = Reader::new(&store);
     for probe in [[0u8, 0, 0], [255, 255, 15], [128, 64, 8], [7, 200, 3]] {
         store.gets.store(0, Ordering::Relaxed);
-        let value = run(reader.get(&root, &Key::from(&probe[..]))).map_err(|e| e.to_string())?;
-        ensure(
-            value == Some(entry(0x22)),
-            &format!("missing key {probe:?}"),
-        )?;
+        let value = run(reader.get(&root, &Key::from(&probe[..])))?;
+        ensure!(value == Some(entry(0x22)), "missing key {probe:?}");
         // Three levels, each at most a segmented node and its covering segments.
-        ensure(
+        ensure!(
             store.gets() <= 24,
-            &format!("lookup fetched {} nodes, not O(depth)", store.gets()),
-        )?;
+            "lookup fetched {} nodes, not O(depth)",
+            store.gets(),
+        );
     }
     Ok(())
 }
 
 #[test]
-fn a_full_radix_256_node_of_heavy_records_packs_and_reads() -> TestResult {
+fn a_full_radix_256_node_of_heavy_records_packs_and_reads() -> Result<()> {
     // A single node holding all 256 first-byte forks, each carrying a heavy
     // metadata block: a ~9.5 KB fork table that far overruns one chunk. The
     // builder spills it into a segment directory; every emitted chunk still fits
@@ -219,33 +207,31 @@ fn a_full_radix_256_node_of_heavy_records_packs_and_reads() -> TestResult {
     let mut builder = Builder::<V1>::new();
     for first in 0u16..256 {
         let byte = u8::try_from(first)?;
-        let meta = Metadata::new(KeyId::ContentType, Bytes::from(vec![b'a'; 900]))
-            .map_err(|e| e.to_string())?;
+        let meta = Metadata::new(KeyId::ContentType, Bytes::from(vec![b'a'; 900]))?;
         builder.insert(Key::from(vec![byte]), entry(byte), Some(meta));
     }
-    let built = run(builder.build(&store)).map_err(|e| e.to_string())?;
+    let built = run(builder.build(&store))?;
 
     // The node did not fit one chunk, so it was spilled across several.
-    ensure(
+    ensure!(
         built.stats().nodes_written() > 1,
         "a full radix-256 heavy node must spill into several chunks",
-    )?;
+    );
     assert_single_chunk_nodes(&store)?;
 
     let reader: Reader<_> = Reader::new(&store);
     for first in [0u8, 1, 127, 200, 255] {
-        let value =
-            run(reader.get(built.root(), &Key::from(vec![first]))).map_err(|e| e.to_string())?;
-        ensure(
+        let value = run(reader.get(built.root(), &Key::from(vec![first])))?;
+        ensure!(
             value == Some(entry(first)),
-            &format!("missing key {first} after spill"),
-        )?;
+            "missing key {first} after spill",
+        );
     }
     Ok(())
 }
 
 #[test]
-fn every_spilled_chunk_re_encodes_to_its_own_bytes() -> TestResult {
+fn every_spilled_chunk_re_encodes_to_its_own_bytes() -> Result<()> {
     // The canonical-form check (spec 6.2) over a whole spilled node set: decode
     // each stored chunk and re-encode it, and the bytes must match, plain node,
     // segmented node and segment alike. This is the build-roundtrip fuzz oracle
@@ -254,20 +240,19 @@ fn every_spilled_chunk_re_encodes_to_its_own_bytes() -> TestResult {
     let mut builder = Builder::<V1>::new();
     for first in 0u16..256 {
         let byte = u8::try_from(first)?;
-        let meta = Metadata::new(KeyId::ContentType, Bytes::from(vec![b'a'; 700]))
-            .map_err(|e| e.to_string())?;
+        let meta = Metadata::new(KeyId::ContentType, Bytes::from(vec![b'a'; 700]))?;
         builder.insert(Key::from(vec![byte]), entry(byte), Some(meta));
     }
-    run(builder.build(&store)).map_err(|e| e.to_string())?;
+    run(builder.build(&store))?;
 
     let mut saw_segment = false;
     for chunk in store.into_chunks().into_values() {
         let payload = chunk.envelope().data();
-        let reencoded = recanonicalize::<V1>(payload.as_ref()).map_err(|e| e.to_string())?;
-        ensure(
+        let reencoded = recanonicalize::<V1>(payload.as_ref())?;
+        ensure!(
             reencoded.as_slice() == payload.as_ref(),
             "a stored chunk did not re-encode to its own bytes",
-        )?;
+        );
         // The flags byte follows the two preamble bytes; a set SEGMENTED or
         // SEGMENT bit witnesses that spill actually fired.
         if payload
@@ -278,12 +263,12 @@ fn every_spilled_chunk_re_encodes_to_its_own_bytes() -> TestResult {
             saw_segment = true;
         }
     }
-    ensure(saw_segment, "the heavy set did not spill into segments")?;
+    ensure!(saw_segment, "the heavy set did not spill into segments");
     Ok(())
 }
 
 #[test]
-fn apply_over_a_spilled_node_matches_a_from_scratch_build() -> TestResult {
+fn apply_over_a_spilled_node_matches_a_from_scratch_build() -> Result<()> {
     // History independence across the spill boundary: folding a changeset into a
     // base whose root node spills must reach the exact root a from-scratch build
     // of the merged key set reaches, byte for byte. This drives the whole
@@ -295,51 +280,37 @@ fn apply_over_a_spilled_node_matches_a_from_scratch_build() -> TestResult {
     let mut base_builder = Builder::<V1>::new();
     for first in 0u16..200 {
         let byte = u8::try_from(first)?;
-        base_builder.insert(
-            Key::from(vec![byte]),
-            entry(byte),
-            Some(heavy().map_err(|e| e.to_string())?),
-        );
+        base_builder.insert(Key::from(vec![byte]), entry(byte), Some(heavy()?));
     }
-    let base = run(base_builder.build(&base_store)).map_err(|e| e.to_string())?;
-    ensure(
+    let base = run(base_builder.build(&base_store))?;
+    ensure!(
         base.stats().nodes_written() > 1,
         "the base root node must spill",
-    )?;
+    );
 
     // The changeset overwrites the tail of the base and extends past it, so the
     // merged key set is 0..256.
     let mut changeset = Changeset::<V1>::new();
     for first in 150u16..256 {
         let byte = u8::try_from(first)?;
-        changeset.put(
-            Key::from(vec![byte]),
-            entry(byte),
-            Some(heavy().map_err(|e| e.to_string())?),
-        );
+        changeset.put(Key::from(vec![byte]), entry(byte), Some(heavy()?));
     }
-    let applied = run(apply(&base_store, base.root(), &changeset)).map_err(|e| e.to_string())?;
+    let applied = run(apply(&base_store, base.root(), &changeset))?;
 
     // A from-scratch build of the merged key set.
     let scratch_store = MemoryStore::default();
     let mut scratch_builder = Builder::<V1>::new();
     for first in 0u16..256 {
         let byte = u8::try_from(first)?;
-        scratch_builder.insert(
-            Key::from(vec![byte]),
-            entry(byte),
-            Some(heavy().map_err(|e| e.to_string())?),
-        );
+        scratch_builder.insert(Key::from(vec![byte]), entry(byte), Some(heavy()?));
     }
-    let scratch = run(scratch_builder.build(&scratch_store)).map_err(|e| e.to_string())?;
+    let scratch = run(scratch_builder.build(&scratch_store))?;
 
-    ensure(
+    ensure!(
         applied == *scratch.root(),
-        &format!(
-            "apply root {applied:?} diverged from the from-scratch root {:?}",
-            scratch.root()
-        ),
-    )?;
+        "apply root {applied:?} diverged from the from-scratch root {:?}",
+        scratch.root(),
+    );
     Ok(())
 }
 

--- a/crates/manifest/tests/order.rs
+++ b/crates/manifest/tests/order.rs
@@ -3,16 +3,13 @@
 //! returns the same slice as `iter().skip(offset).take(limit)`; and the offset
 //! seek costs O(depth), not O(offset), witnessed through a fetch-counting store.
 
-use std::error::Error;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use anyhow::{Context, Result, ensure};
 use nectar_manifest::{Builder, Entry, Key, Reader, V1};
 use nectar_primitives::store::{ChunkGet, MemoryStore};
 use nectar_primitives::{Chunk, ChunkAddress, ChunkRef, StandardChunkSet, Verified};
 use nectar_testing::run;
-
-mod common;
-use common::{TestResult, ensure};
 
 /// A key set paired with the value each key carries.
 type KeySet = Vec<(Key, u8)>;
@@ -94,49 +91,47 @@ fn wide_keys() -> KeySet {
     out
 }
 
-fn build(store: &MemoryStore, keys: &[(Key, u8)]) -> Result<ChunkAddress, Box<dyn Error>> {
+fn build(store: &MemoryStore, keys: &[(Key, u8)]) -> Result<ChunkAddress> {
     let mut builder = Builder::<V1>::new();
     for (key, fill) in keys {
         builder.insert(key.clone(), entry(*fill), None);
     }
-    Ok(*run(builder.build(store)).map_err(|e| e.to_string())?.root())
+    Ok(*run(builder.build(store))?.root())
 }
 
 /// The ground-truth ordering: every `(key, value)` a full walk yields.
-fn oracle(reader: &Reader<MemoryStore, V1>, root: &ChunkAddress) -> Result<Pairs, Box<dyn Error>> {
+fn oracle(reader: &Reader<MemoryStore, V1>, root: &ChunkAddress) -> Result<Pairs> {
     let mut out = Vec::new();
-    let mut cursor = run(reader.iter(root)).map_err(|e| e.to_string())?;
-    while let Some(pair) = run(cursor.next()).map_err(|e| e.to_string())? {
+    let mut cursor = run(reader.iter(root))?;
+    while let Some(pair) = run(cursor.next())? {
         out.push(pair);
     }
     Ok(out)
 }
 
 #[test]
-fn rank_select_count_agree_with_a_full_walk_oracle() -> TestResult {
+fn rank_select_count_agree_with_a_full_walk_oracle() -> Result<()> {
     let store = MemoryStore::default();
     let keys = radix_keys(12, 3);
     let root = build(&store, &keys)?;
     let reader = Reader::<MemoryStore, V1>::new(store);
     let all = oracle(&reader, &root)?;
-    ensure(all.len() == keys.len(), "oracle lost keys")?;
+    ensure!(all.len() == keys.len(), "oracle lost keys");
 
     // select(i) is the i-th key; one past the end is None.
     for (i, (key, value)) in all.iter().enumerate() {
         let index = u64::try_from(i)?;
-        let got = run(reader.select(&root, index)).map_err(|e| e.to_string())?;
-        ensure(
+        let got = run(reader.select(&root, index))?;
+        ensure!(
             got.as_ref() == Some(&(key.clone(), value.clone())),
-            &format!("select({i}) mismatch"),
-        )?;
+            "select({i}) mismatch",
+        );
     }
     let end = u64::try_from(all.len())?;
-    ensure(
-        run(reader.select(&root, end))
-            .map_err(|e| e.to_string())?
-            .is_none(),
+    ensure!(
+        run(reader.select(&root, end))?.is_none(),
         "select past the end must be None",
-    )?;
+    );
 
     // rank(key) is the count of strictly-smaller keys, checked at present keys
     // and at the absent points that bracket, precede and follow the key set.
@@ -153,11 +148,8 @@ fn rank_select_count_agree_with_a_full_walk_oracle() -> TestResult {
     ];
     for probe in &probes {
         let expected = u64::try_from(all.iter().filter(|(k, _)| k < probe).count())?;
-        let got = run(reader.rank(&root, probe)).map_err(|e| e.to_string())?;
-        ensure(
-            got == expected,
-            &format!("rank mismatch: {got} != {expected}"),
-        )?;
+        let got = run(reader.rank(&root, probe))?;
+        ensure!(got == expected, "rank mismatch: {got} != {expected}");
     }
 
     // count(lo, hi) is the size of the half-open window.
@@ -168,17 +160,14 @@ fn rank_select_count_agree_with_a_full_walk_oracle() -> TestResult {
         (Key::from(&[9u8][..]), Key::from(&[3u8][..])),
     ] {
         let expected = u64::try_from(all.iter().filter(|(k, _)| lo <= *k && *k < hi).count())?;
-        let got = run(reader.count(&root, &lo, &hi)).map_err(|e| e.to_string())?;
-        ensure(
-            got == expected,
-            &format!("count mismatch: {got} != {expected}"),
-        )?;
+        let got = run(reader.count(&root, &lo, &hi))?;
+        ensure!(got == expected, "count mismatch: {got} != {expected}");
     }
     Ok(())
 }
 
 #[test]
-fn spilled_node_order_statistics_agree_with_the_oracle() -> TestResult {
+fn spilled_node_order_statistics_agree_with_the_oracle() -> Result<()> {
     // A corpus whose root is a segmented node, so every query routes the root's
     // segment directory by seg_count before descending a referenced child.
     let store = MemoryStore::default();
@@ -186,21 +175,21 @@ fn spilled_node_order_statistics_agree_with_the_oracle() -> TestResult {
     let root = build(&store, &keys)?;
     let reader = Reader::<MemoryStore, V1>::new(store);
     let all = oracle(&reader, &root)?;
-    ensure(all.len() == keys.len(), "oracle lost keys")?;
+    ensure!(all.len() == keys.len(), "oracle lost keys");
 
     // Sampled select and its inverse rank agree with the oracle across the whole
     // spilled listing, including both ends.
     let last = all.len().saturating_sub(1);
     for i in (0..all.len()).step_by(311).chain([last]) {
-        let (key, value) = all.get(i).ok_or("oracle index out of range")?;
+        let (key, value) = all.get(i).context("oracle index out of range")?;
         let index = u64::try_from(i)?;
-        let got = run(reader.select(&root, index)).map_err(|e| e.to_string())?;
-        ensure(
+        let got = run(reader.select(&root, index))?;
+        ensure!(
             got.as_ref() == Some(&(key.clone(), value.clone())),
-            &format!("spilled select({i}) mismatch"),
-        )?;
-        let rank = run(reader.rank(&root, key)).map_err(|e| e.to_string())?;
-        ensure(rank == index, &format!("spilled rank at {i} mismatch"))?;
+            "spilled select({i}) mismatch",
+        );
+        let rank = run(reader.rank(&root, key))?;
+        ensure!(rank == index, "spilled rank at {i} mismatch");
     }
 
     // Windows spanning several segments count exactly.
@@ -210,27 +199,26 @@ fn spilled_node_order_statistics_agree_with_the_oracle() -> TestResult {
         (Key::empty(), Key::from(&[255u8, 255][..])),
     ] {
         let expected = u64::try_from(all.iter().filter(|(k, _)| lo <= *k && *k < hi).count())?;
-        let got = run(reader.count(&root, &lo, &hi)).map_err(|e| e.to_string())?;
-        ensure(
+        let got = run(reader.count(&root, &lo, &hi))?;
+        ensure!(
             got == expected,
-            &format!("spilled count mismatch: {got} != {expected}"),
-        )?;
+            "spilled count mismatch: {got} != {expected}"
+        );
     }
 
     // A page deep in the spilled listing is the matching oracle slice.
     let mut got = Vec::new();
-    let mut cursor =
-        run(reader.paginate_prefix(&root, &Key::empty(), 9000, 25)).map_err(|e| e.to_string())?;
-    while let Some(pair) = run(cursor.next()).map_err(|e| e.to_string())? {
+    let mut cursor = run(reader.paginate_prefix(&root, &Key::empty(), 9000, 25))?;
+    while let Some(pair) = run(cursor.next())? {
         got.push(pair);
     }
     let want: Vec<_> = all.iter().skip(9000).take(25).cloned().collect();
-    ensure(got == want, "spilled paginate mismatch")?;
+    ensure!(got == want, "spilled paginate mismatch");
     Ok(())
 }
 
 #[test]
-fn order_statistics_are_stable_under_shuffled_build_order() -> TestResult {
+fn order_statistics_are_stable_under_shuffled_build_order() -> Result<()> {
     let forward = radix_keys(10, 3);
     let mut reversed = forward.clone();
     reversed.reverse();
@@ -239,21 +227,21 @@ fn order_statistics_are_stable_under_shuffled_build_order() -> TestResult {
     let a = build(&a_store, &forward)?;
     let b_store = MemoryStore::default();
     let b = build(&b_store, &reversed)?;
-    ensure(a == b, "shuffled build must root identically")?;
+    ensure!(a == b, "shuffled build must root identically");
 
     let reader = Reader::<MemoryStore, V1>::new(a_store);
     // A shuffled build is the same tree, so every rank and select is unchanged.
     for index in [0u64, 1, 250, 500, 999] {
-        let got = run(reader.select(&a, index)).map_err(|e| e.to_string())?;
-        let (key, _) = got.ok_or("select fell off the shuffled build")?;
-        let rank = run(reader.rank(&a, &key)).map_err(|e| e.to_string())?;
-        ensure(rank == index, &format!("rank/select disagree at {index}"))?;
+        let got = run(reader.select(&a, index))?;
+        let (key, _) = got.context("select fell off the shuffled build")?;
+        let rank = run(reader.rank(&a, &key))?;
+        ensure!(rank == index, "rank/select disagree at {index}");
     }
     Ok(())
 }
 
 #[test]
-fn paginate_matches_iter_skip_take() -> TestResult {
+fn paginate_matches_iter_skip_take() -> Result<()> {
     let store = MemoryStore::default();
     let keys = radix_keys(10, 3);
     let root = build(&store, &keys)?;
@@ -263,17 +251,13 @@ fn paginate_matches_iter_skip_take() -> TestResult {
     // Whole-manifest pagination is exactly iter().skip(offset).take(limit).
     for (offset, limit) in [(0u64, 7usize), (13, 20), (500, 33), (995, 50), (2000, 4)] {
         let mut got = Vec::new();
-        let mut cursor = run(reader.paginate_prefix(&root, &Key::empty(), offset, limit))
-            .map_err(|e| e.to_string())?;
-        while let Some(pair) = run(cursor.next()).map_err(|e| e.to_string())? {
+        let mut cursor = run(reader.paginate_prefix(&root, &Key::empty(), offset, limit))?;
+        while let Some(pair) = run(cursor.next())? {
             got.push(pair);
         }
         let start = usize::try_from(offset)?;
         let want: Vec<_> = all.iter().skip(start).take(limit).cloned().collect();
-        ensure(
-            got == want,
-            &format!("paginate_prefix({offset}, {limit}) mismatch"),
-        )?;
+        ensure!(got == want, "paginate_prefix({offset}, {limit}) mismatch");
     }
 
     // Range pagination is the same over the range's own slice.
@@ -286,23 +270,19 @@ fn paginate_matches_iter_skip_take() -> TestResult {
         .collect();
     for (offset, limit) in [(0u64, 10usize), (25, 40), (300, 12)] {
         let mut got = Vec::new();
-        let mut cursor =
-            run(reader.paginate(&root, &lo, &hi, offset, limit)).map_err(|e| e.to_string())?;
-        while let Some(pair) = run(cursor.next()).map_err(|e| e.to_string())? {
+        let mut cursor = run(reader.paginate(&root, &lo, &hi, offset, limit))?;
+        while let Some(pair) = run(cursor.next())? {
             got.push(pair);
         }
         let start = usize::try_from(offset)?;
         let want: Vec<_> = window.iter().skip(start).take(limit).cloned().collect();
-        ensure(
-            got == want,
-            &format!("paginate({offset}, {limit}) mismatch"),
-        )?;
+        ensure!(got == want, "paginate({offset}, {limit}) mismatch");
     }
     Ok(())
 }
 
 #[test]
-fn the_offset_seek_costs_depth_not_offset() -> TestResult {
+fn the_offset_seek_costs_depth_not_offset() -> Result<()> {
     // A wide, spilled corpus: a full first-byte spread forces the root to spill
     // into a segment directory, so the seek must route by seg_count.
     let inner = MemoryStore::default();
@@ -320,40 +300,35 @@ fn the_offset_seek_costs_depth_not_offset() -> TestResult {
     let mut costs = Vec::new();
     for index in [0u64, total / 2, total.saturating_sub(1)] {
         reader.store().reset();
-        let got = run(reader.select(&root, index)).map_err(|e| e.to_string())?;
-        ensure(got.is_some(), &format!("select({index}) fell off"))?;
+        let got = run(reader.select(&root, index))?;
+        ensure!(got.is_some(), "select({index}) fell off");
         costs.push(reader.store().gets());
     }
     for cost in &costs {
-        ensure(
-            *cost <= 32,
-            &format!("select fetched {cost} nodes, not O(depth)"),
-        )?;
+        ensure!(*cost <= 32, "select fetched {cost} nodes, not O(depth)");
     }
 
     // Paginating at a large offset fetches no more than at offset zero plus the
     // page and its read-ahead: the offset itself is free.
     reader.store().reset();
-    let mut head =
-        run(reader.paginate_prefix(&root, &Key::empty(), 0, 5)).map_err(|e| e.to_string())?;
-    while run(head.next()).map_err(|e| e.to_string())?.is_some() {}
+    let mut head = run(reader.paginate_prefix(&root, &Key::empty(), 0, 5))?;
+    while run(head.next())?.is_some() {}
     let head_cost = reader.store().gets();
 
     reader.store().reset();
     let deep_offset = total.saturating_sub(5);
-    let mut deep = run(reader.paginate_prefix(&root, &Key::empty(), deep_offset, 5))
-        .map_err(|e| e.to_string())?;
-    while run(deep.next()).map_err(|e| e.to_string())?.is_some() {}
+    let mut deep = run(reader.paginate_prefix(&root, &Key::empty(), deep_offset, 5))?;
+    while run(deep.next())?.is_some() {}
     let deep_cost = reader.store().gets();
 
     // The deep page pays for its own depth and window, not the offset it skipped.
-    ensure(
+    ensure!(
         deep_cost <= head_cost.saturating_mul(2).saturating_add(32),
-        &format!("deep page fetched {deep_cost} vs head {head_cost}: offset is not free"),
-    )?;
-    ensure(
+        "deep page fetched {deep_cost} vs head {head_cost}: offset is not free",
+    );
+    ensure!(
         u64::try_from(deep_cost)? < deep_offset,
-        &format!("deep page fetched {deep_cost}, proportional to the offset"),
-    )?;
+        "deep page fetched {deep_cost}, proportional to the offset",
+    );
     Ok(())
 }

--- a/crates/manifest/tests/read_profile.rs
+++ b/crates/manifest/tests/read_profile.rs
@@ -3,15 +3,11 @@
 //! inlines a subtree that V1 would reference, so the same key set resolves
 //! through fewer chunks under `V1Read`.
 
-use std::error::Error;
-
+use anyhow::{Result, ensure};
 use bytes::Bytes;
 use nectar_manifest::{Builder, Changeset, Entry, Key, Reader, V1, V1Read, apply};
 use nectar_primitives::{ChunkAddress, ChunkRef, MemoryStore};
 use nectar_testing::run;
-
-mod common;
-use common::{TestResult, ensure};
 
 fn ref_entry<F: nectar_manifest::Format>(fill: u8) -> Entry<F> {
     Entry::from(ChunkRef::new(ChunkAddress::new([fill; 32])))
@@ -27,7 +23,7 @@ fn windowed_keys() -> Vec<(Key, u8)> {
 
 /// Build the windowed key set under `F`, returning the root and the number of
 /// distinct chunks the build stored.
-fn build_windowed<F: nectar_manifest::Format>() -> Result<(ChunkAddress, usize), Box<dyn Error>> {
+fn build_windowed<F: nectar_manifest::Format>() -> Result<(ChunkAddress, usize)> {
     let store = MemoryStore::default();
     let mut builder = Builder::<F>::new();
     for (key, fill) in windowed_keys() {
@@ -38,32 +34,32 @@ fn build_windowed<F: nectar_manifest::Format>() -> Result<(ChunkAddress, usize),
 }
 
 #[test]
-fn the_read_profile_stores_fewer_chunks_for_a_windowed_subtree() -> TestResult {
+fn the_read_profile_stores_fewer_chunks_for_a_windowed_subtree() -> Result<()> {
     let (_, v1_chunks) = build_windowed::<V1>()?;
     let (_, read_chunks) = build_windowed::<V1Read>()?;
     // The sub-node is referenced under V1 (its own chunk) but embedded under
     // the read profile (folded into the root), so the read build stores fewer.
-    ensure(
+    ensure!(
         read_chunks < v1_chunks,
         "read profile must store fewer chunks than V1 for the windowed subtree",
-    )?;
+    );
     Ok(())
 }
 
 #[test]
-fn the_read_profile_and_v1_produce_distinct_roots() -> TestResult {
+fn the_read_profile_and_v1_produce_distinct_roots() -> Result<()> {
     let (v1_root, _) = build_windowed::<V1>()?;
     let (read_root, _) = build_windowed::<V1Read>()?;
     // A distinct wire version and a distinct shape: byte-distinct manifests.
-    ensure(
+    ensure!(
         v1_root != read_root,
-        "the two profiles must root differently",
-    )?;
+        "the two profiles must root differently"
+    );
     Ok(())
 }
 
 #[test]
-fn build_then_read_round_trips_every_key_under_the_read_profile() -> TestResult {
+fn build_then_read_round_trips_every_key_under_the_read_profile() -> Result<()> {
     let store = MemoryStore::default();
     let mut builder = Builder::<V1Read>::new();
     for (key, fill) in windowed_keys() {
@@ -74,21 +70,21 @@ fn build_then_read_round_trips_every_key_under_the_read_profile() -> TestResult 
     let reader = Reader::<MemoryStore, V1Read>::new(store);
     for (key, fill) in windowed_keys() {
         let got = run(reader.get(&root, &key))?;
-        ensure(
+        ensure!(
             got == Some(ref_entry::<V1Read>(fill)),
-            "read value mismatch",
-        )?;
+            "read value mismatch"
+        );
     }
     // An absent key still reads as absent under the profile.
-    ensure(
+    ensure!(
         run(reader.get(&root, &Key::from(&b"absent"[..])))?.is_none(),
         "absent key must read as None",
-    )?;
+    );
     Ok(())
 }
 
 #[test]
-fn apply_matches_a_from_scratch_build_under_the_read_profile() -> TestResult {
+fn apply_matches_a_from_scratch_build_under_the_read_profile() -> Result<()> {
     let all = windowed_keys();
     let split = 40usize;
 
@@ -109,25 +105,25 @@ fn apply_matches_a_from_scratch_build_under_the_read_profile() -> TestResult {
     // A from-scratch build of the merged key set lands on the same root, byte
     // for byte: history independence holds under the read profile too.
     let (scratch_root, _) = build_windowed::<V1Read>()?;
-    ensure(
+    ensure!(
         applied == scratch_root,
         "apply must match a from-scratch build under the read profile",
-    )?;
+    );
 
     // The applied manifest reads back the full key set.
     let reader = Reader::<MemoryStore, V1Read>::new(store);
     for (key, fill) in &all {
         let got = run(reader.get(&applied, key))?;
-        ensure(
+        ensure!(
             got == Some(ref_entry::<V1Read>(*fill)),
             "applied value mismatch",
-        )?;
+        );
     }
     Ok(())
 }
 
 #[test]
-fn an_inline_value_round_trips_under_the_read_profile() -> TestResult {
+fn an_inline_value_round_trips_under_the_read_profile() -> Result<()> {
     let store = MemoryStore::default();
     let mut builder = Builder::<V1Read>::new();
     let value = Entry::<V1Read>::inline(Bytes::from_static(b"<h1>hi</h1>"))?;
@@ -136,6 +132,6 @@ fn an_inline_value_round_trips_under_the_read_profile() -> TestResult {
 
     let reader = Reader::<MemoryStore, V1Read>::new(store);
     let got = run(reader.get(&root, &Key::from(&b"index.html"[..])))?;
-    ensure(got == Some(value), "inline value must round-trip")?;
+    ensure!(got == Some(value), "inline value must round-trip");
     Ok(())
 }

--- a/crates/manifest/tests/reader.rs
+++ b/crates/manifest/tests/reader.rs
@@ -2,17 +2,14 @@
 //! node, so a lookup down a wide manifest fetches O(depth) nodes and never a
 //! whole level. A counting store witnesses the bound directly.
 
-use std::error::Error;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use anyhow::{Result, ensure};
 use bytes::Bytes;
 use nectar_manifest::{Builder, Child, Entry, ForkTable, Key, Node, NodePut, Prefix, Reader, V1};
 use nectar_primitives::store::{ChunkGet, MemoryStore};
 use nectar_primitives::{Chunk, ChunkAddress, ChunkRef, StandardChunkSet, Verified};
 use nectar_testing::run;
-
-mod common;
-use common::{TestResult, ensure, ensure_eq};
 
 /// A trusted store that counts every `get`, so a test can read off how many
 /// nodes a lookup fetched.
@@ -48,7 +45,7 @@ fn entry(byte: u8) -> Entry {
 /// Build a deliberately wide two-level manifest: a root whose fork table holds
 /// one referenced leaf per first byte, each leaf terminating a single key. The
 /// second level is `width` chunks wide, but any one key sits two nodes deep.
-fn wide_manifest(store: &MemoryStore, width: u16) -> Result<ChunkAddress, Box<dyn Error>> {
+fn wide_manifest(store: &MemoryStore, width: u16) -> Result<ChunkAddress> {
     let mut forks = ForkTable::<V1>::new();
     for first in 0..width {
         let first = u8::try_from(first)?;
@@ -65,7 +62,7 @@ fn wide_manifest(store: &MemoryStore, width: u16) -> Result<ChunkAddress, Box<dy
 }
 
 #[test]
-fn a_lookup_fetches_depth_nodes_not_the_wide_level() -> TestResult {
+fn a_lookup_fetches_depth_nodes_not_the_wide_level() -> Result<()> {
     // Wide enough to dwarf the depth-2 path, yet inside one root chunk (a
     // radix-full root spills to a directory, which is a later car's concern).
     let width = 100u16;
@@ -73,7 +70,7 @@ fn a_lookup_fetches_depth_nodes_not_the_wide_level() -> TestResult {
     let root = wide_manifest(&memory, width)?;
 
     // The whole manifest is one root plus `width` leaves.
-    ensure_eq(memory.len(), usize::from(width) + 1, "stored node count")?;
+    ensure!(memory.len() == usize::from(width) + 1, "stored node count");
 
     let store = CountingStore {
         inner: memory,
@@ -84,26 +81,27 @@ fn a_lookup_fetches_depth_nodes_not_the_wide_level() -> TestResult {
     // Look up one key: first byte 0x2A, then the leaf's 0xFF fork.
     let key = Key::from(&[0x2Au8, 0xFF][..]);
     let value = run(reader.get(&root, &key))?;
-    ensure_eq(value, Some(entry(0x2A)), "looked-up value")?;
+    ensure!(value == Some(entry(0x2A)), "looked-up value");
 
     // Two hops: the root and the single leaf on the path. Never the wide
     // sibling level, so fetches track depth, not width.
-    ensure_eq(store.gets(), 2, "fetches equal path depth")?;
-    ensure(
+    ensure!(store.gets() == 2, "fetches equal path depth");
+    ensure!(
         store.gets() < usize::from(width),
-        "fetches below level width",
-    )?;
+        "fetches below level width"
+    );
 
     // A second lookup on a different branch is again two hops: the frontier is
     // never widened, each key pays only its own path.
     store.gets.store(0, Ordering::Relaxed);
     let value = run(reader.get(&root, &Key::from(&[0x50u8, 0xFF][..])))?;
-    ensure_eq(value, Some(entry(0x50)), "second value")?;
-    ensure_eq(store.gets(), 2, "second lookup is also depth-bounded")
+    ensure!(value == Some(entry(0x50)), "second value");
+    ensure!(store.gets() == 2, "second lookup is also depth-bounded");
+    Ok(())
 }
 
 #[test]
-fn every_builder_key_reads_back_through_referenced_hops() -> TestResult {
+fn every_builder_key_reads_back_through_referenced_hops() -> Result<()> {
     // Build a real manifest through the builder so the reader is exercised
     // against the wire structure it exists to read, not a hand-laid table: the
     // shared-prefix grid forces compacted edges, embedded subtrees and, once a
@@ -127,20 +125,20 @@ fn every_builder_key_reads_back_through_referenced_hops() -> TestResult {
     builder.insert(Key::from(&b"prefix"[..]), entry(0x22), None);
     expected.push(("prefix".to_owned(), entry(0x22)));
     // An inline value must read back whole, not as a reference.
-    let inline = Entry::inline(Bytes::from_static(b"hello")).map_err(|e| e.to_string())?;
+    let inline = Entry::inline(Bytes::from_static(b"hello"))?;
     builder.insert(Key::from(&b"inline.txt"[..]), inline.clone(), None);
     expected.push(("inline.txt".to_owned(), inline));
     // The empty key sets the manifest's own value in the root extension.
     builder.insert(Key::empty(), entry(0x99), None);
 
-    let built = run(builder.build(&memory)).map_err(|e| e.to_string())?;
+    let built = run(builder.build(&memory))?;
     let root = *built.root();
     // More than one node spilled: the builder emitted referenced children, so
     // reading keys beneath them genuinely drives the fetch-and-descend path.
-    ensure(
+    ensure!(
         built.stats().nodes_written() > 1,
         "builder spilled referenced children",
-    )?;
+    );
 
     let store = CountingStore {
         inner: memory,
@@ -149,11 +147,10 @@ fn every_builder_key_reads_back_through_referenced_hops() -> TestResult {
     let reader: Reader<_> = Reader::new(&store);
 
     // The root extension answers the empty key.
-    ensure_eq(
-        run(reader.get(&root, &Key::empty())).map_err(|e| e.to_string())?,
-        Some(entry(0x99)),
+    ensure!(
+        run(reader.get(&root, &Key::empty()))? == Some(entry(0x99)),
         "empty key reads the root value",
-    )?;
+    );
 
     // Every key reads back its exact value, and no single lookup ever fetches a
     // whole level: the deepest path stays a small multiple of the tree depth,
@@ -161,16 +158,15 @@ fn every_builder_key_reads_back_through_referenced_hops() -> TestResult {
     let mut deepest = 0usize;
     for (key, value) in &expected {
         store.gets.store(0, Ordering::Relaxed);
-        let got = run(reader.get(&root, &Key::from(key.clone().into_bytes())))
-            .map_err(|e| e.to_string())?;
-        ensure_eq(got.as_ref(), Some(value), key)?;
+        let got = run(reader.get(&root, &Key::from(key.clone().into_bytes())))?;
+        ensure!(got.as_ref() == Some(value), "{key}");
         deepest = deepest.max(store.gets());
     }
-    ensure(deepest >= 2, "at least one key descends a referenced hop")?;
-    ensure(
+    ensure!(deepest >= 2, "at least one key descends a referenced hop");
+    ensure!(
         deepest < built.stats().nodes_written(),
         "no lookup fetches the whole tree",
-    )?;
+    );
 
     // Keys that diverge from, fall short of, or overrun a stored key are absent.
     for absent in [
@@ -180,17 +176,16 @@ fn every_builder_key_reads_back_through_referenced_hops() -> TestResult {
         "pr",
         "prefixed",
     ] {
-        ensure_eq(
-            run(reader.get(&root, &Key::from(absent.as_bytes()))).map_err(|e| e.to_string())?,
-            None,
-            absent,
-        )?;
+        ensure!(
+            run(reader.get(&root, &Key::from(absent.as_bytes())))?.is_none(),
+            "{absent}",
+        );
     }
     Ok(())
 }
 
 #[test]
-fn an_absent_key_stops_at_the_first_unmatched_fork() -> TestResult {
+fn an_absent_key_stops_at_the_first_unmatched_fork() -> Result<()> {
     let width = 64u16;
     let memory = MemoryStore::default();
     let root = wide_manifest(&memory, width)?;
@@ -204,6 +199,7 @@ fn an_absent_key_stops_at_the_first_unmatched_fork() -> TestResult {
     // A first byte no root fork carries: the walk stops at the root without
     // fetching any leaf.
     let value = run(reader.get(&root, &Key::from(&[0xFFu8, 0x00][..])))?;
-    ensure_eq(value, None, "absent value")?;
-    ensure_eq(store.gets(), 1, "only the root is fetched")
+    ensure!(value.is_none(), "absent value");
+    ensure!(store.gets() == 1, "only the root is fetched");
+    Ok(())
 }

--- a/crates/manifest/tests/scan.rs
+++ b/crates/manifest/tests/scan.rs
@@ -6,18 +6,15 @@ use core::future::Future;
 use core::pin::Pin;
 use core::task::{Context, Poll};
 use std::collections::BTreeMap;
-use std::error::Error;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use anyhow::{Result, ensure};
 use bytes::Bytes;
 use nectar_manifest::{Builder, Cursor, Entry, Format, Key, Reader, V1};
 use nectar_primitives::store::{ChunkGet, MemoryStore};
 use nectar_primitives::{Chunk, ChunkAddress, StandardChunkSet, Verified};
 use nectar_testing::run;
 use proptest::prelude::*;
-
-mod common;
-use common::{TestResult, ensure, ensure_eq};
 
 /// A trusted store that counts every `get`, so a test can read off how many
 /// nodes a walk fetched.
@@ -73,38 +70,38 @@ fn corpus() -> Vec<(Key, Vec<u8>)> {
 }
 
 /// Build the corpus into `store` and return the root and an ordered oracle.
-fn build(store: &MemoryStore) -> Result<(ChunkAddress, Oracle), Box<dyn Error>> {
+fn build(store: &MemoryStore) -> Result<(ChunkAddress, Oracle)> {
     let mut builder = Builder::new();
     let mut oracle = Oracle::new();
     for (key, bytes) in corpus() {
-        let value = Entry::inline(Bytes::from(bytes)).map_err(|e| e.to_string())?;
+        let value = Entry::inline(Bytes::from(bytes))?;
         builder.insert(key.clone(), value.clone(), None);
         oracle.insert(key.as_bytes().to_vec(), value);
     }
-    let built = run(builder.build(store)).map_err(|e| e.to_string())?;
+    let built = run(builder.build(store))?;
     Ok((*built.root(), oracle))
 }
 
 /// Collect a whole cursor into an ordered vector.
-fn collect(mut cursor: Cursor<'_, &CountingStore>) -> Result<Rows, Box<dyn Error>> {
+fn collect(mut cursor: Cursor<'_, &CountingStore>) -> Result<Rows> {
     let mut out = Vec::new();
-    while let Some((key, value)) = run(cursor.next()).map_err(|e| e.to_string())? {
+    while let Some((key, value)) = run(cursor.next())? {
         out.push((key.as_bytes().to_vec(), value));
     }
     Ok(out)
 }
 
 #[test]
-fn iteration_fetches_nodes_not_values() -> TestResult {
+fn iteration_fetches_nodes_not_values() -> Result<()> {
     let memory = MemoryStore::default();
     let (root, oracle) = build(&memory)?;
     // The builder spilled referenced children, so the walk genuinely crosses
     // fetched hops rather than reading one embedded root.
     let nodes = memory.len();
-    ensure(nodes > 1, "manifest spilled referenced children")?;
+    ensure!(nodes > 1, "manifest spilled referenced children");
     // Every value is inline, so the store holds trie nodes only. If iteration
     // fetched values it would fetch chunks that do not exist.
-    ensure(oracle.len() > nodes, "more keys than trie nodes")?;
+    ensure!(oracle.len() > nodes, "more keys than trie nodes");
 
     let store = CountingStore {
         inner: memory,
@@ -112,18 +109,19 @@ fn iteration_fetches_nodes_not_values() -> TestResult {
     };
     let reader: Reader<_> = Reader::new(&store);
 
-    let got = collect(run(reader.iter(&root)).map_err(|e| e.to_string())?)?;
+    let got = collect(run(reader.iter(&root))?)?;
     let expected: Rows = oracle.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-    ensure_eq(got, expected, "iteration matches the ordered oracle")?;
+    ensure!(got == expected, "iteration matches the ordered oracle");
 
     // The whole walk fetched exactly the trie nodes, once each, and far fewer
     // than the key count: values ride in the fork records, so no leaf is pulled.
-    ensure_eq(store.gets(), nodes, "one fetch per trie node")?;
-    ensure(store.gets() < oracle.len(), "fetches below the key count")
+    ensure!(store.gets() == nodes, "one fetch per trie node");
+    ensure!(store.gets() < oracle.len(), "fetches below the key count");
+    Ok(())
 }
 
 #[test]
-fn range_matches_the_oracle() -> TestResult {
+fn range_matches_the_oracle() -> Result<()> {
     let store = MemoryStore::default();
     let (root, oracle) = build(&store)?;
     let counting = CountingStore {
@@ -139,20 +137,18 @@ fn range_matches_the_oracle() -> TestResult {
         (&b"pre"[..], &b"zzz"[..]),
         (&b"dir11/file0039.txt"[..], &b"zzz"[..]),
     ] {
-        let got = collect(
-            run(reader.range(&root, &Key::from(lo), &Key::from(hi))).map_err(|e| e.to_string())?,
-        )?;
+        let got = collect(run(reader.range(&root, &Key::from(lo), &Key::from(hi)))?)?;
         let expected: Rows = oracle
             .range(lo.to_vec()..hi.to_vec())
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
-        ensure_eq(got, expected, "range matches the oracle")?;
+        ensure!(got == expected, "range matches the oracle");
     }
     Ok(())
 }
 
 #[test]
-fn prefix_matches_the_oracle() -> TestResult {
+fn prefix_matches_the_oracle() -> Result<()> {
     let store = MemoryStore::default();
     let (root, oracle) = build(&store)?;
     let reader: Reader<_> = Reader::new(&store);
@@ -165,9 +161,9 @@ fn prefix_matches_the_oracle() -> TestResult {
         &b""[..],
     ] {
         let got: Rows = {
-            let mut cursor = run(reader.prefix(&root, &Key::from(p))).map_err(|e| e.to_string())?;
+            let mut cursor = run(reader.prefix(&root, &Key::from(p)))?;
             let mut out = Vec::new();
-            while let Some((key, value)) = run(cursor.next()).map_err(|e| e.to_string())? {
+            while let Some((key, value)) = run(cursor.next())? {
                 out.push((key.as_bytes().to_vec(), value));
             }
             out
@@ -177,7 +173,7 @@ fn prefix_matches_the_oracle() -> TestResult {
             .filter(|(k, _)| k.starts_with(p))
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
-        ensure_eq(got, expected, "prefix matches the oracle")?;
+        ensure!(got == expected, "prefix matches the oracle");
     }
     Ok(())
 }
@@ -238,29 +234,29 @@ impl ChunkGet<StandardChunkSet> for GatedStore {
 /// Build a wide manifest whose first-byte subtrees each outgrow the inline bound
 /// and become referenced children, so the root fans out into many sibling nodes
 /// a scan must fetch. Returns the root and an ordered oracle.
-fn wide_build(store: &MemoryStore) -> Result<(ChunkAddress, Oracle), Box<dyn Error>> {
+fn wide_build(store: &MemoryStore) -> Result<(ChunkAddress, Oracle)> {
     let mut builder = Builder::new();
     let mut oracle = Oracle::new();
     for a in 0u8..48 {
         for b in 0u8..96 {
             let key = vec![a, b];
-            let value = Entry::inline(Bytes::from(vec![a ^ b; 32])).map_err(|e| e.to_string())?;
+            let value = Entry::inline(Bytes::from(vec![a ^ b; 32]))?;
             builder.insert(Key::from(key.clone()), value.clone(), None);
             oracle.insert(key, value);
         }
     }
-    let built = run(builder.build(store)).map_err(|e| e.to_string())?;
+    let built = run(builder.build(store))?;
     Ok((*built.root(), oracle))
 }
 
 #[test]
-fn read_ahead_bounds_in_flight_and_matches_the_oracle() -> TestResult {
+fn read_ahead_bounds_in_flight_and_matches_the_oracle() -> Result<()> {
     let memory = MemoryStore::default();
     let (root, oracle) = wide_build(&memory)?;
     // The root fans out into referenced children, so the walk crosses many
     // sibling hops rather than reading one embedded root.
     let nodes = memory.len();
-    ensure(nodes > 8, "manifest fans out into many referenced children")?;
+    ensure!(nodes > 8, "manifest fans out into many referenced children");
 
     let store = GatedStore {
         inner: memory,
@@ -269,33 +265,33 @@ fn read_ahead_bounds_in_flight_and_matches_the_oracle() -> TestResult {
     let reader: Reader<_> = Reader::new(&store);
 
     let got: Rows = {
-        let mut cursor = run(reader.iter(&root)).map_err(|e| e.to_string())?;
+        let mut cursor = run(reader.iter(&root))?;
         let mut out = Vec::new();
-        while let Some((key, value)) = run(cursor.next()).map_err(|e| e.to_string())? {
+        while let Some((key, value)) = run(cursor.next())? {
             out.push((key.as_bytes().to_vec(), value));
         }
         out
     };
     let expected: Rows = oracle.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-    ensure_eq(got, expected, "read-ahead iteration matches the oracle")?;
+    ensure!(got == expected, "read-ahead iteration matches the oracle");
 
     // The concurrent walk fetches exactly the trie nodes a serial walk would,
     // once each: read-ahead cuts round trips, not fetch count.
-    ensure_eq(
-        store.gets.load(Ordering::Relaxed),
-        nodes,
+    ensure!(
+        store.gets.load(Ordering::Relaxed) == nodes,
         "one fetch per trie node",
-    )?;
+    );
 
     let peak = store.peak.load(Ordering::Relaxed);
     let cap = V1::READ_AHEAD;
     // The window overlapped fetches: read-ahead is genuinely concurrent.
-    ensure(peak > 1, "read-ahead ran fetches concurrently")?;
+    ensure!(peak > 1, "read-ahead ran fetches concurrently");
     // Peak in-flight never exceeds the cap: the window is bounded, not O(width).
-    ensure(
+    ensure!(
         peak <= cap,
-        &format!("peak in-flight {peak} exceeded the read-ahead cap {cap}"),
-    )
+        "peak in-flight {peak} exceeded the read-ahead cap {cap}",
+    );
+    Ok(())
 }
 
 proptest! {
@@ -340,17 +336,17 @@ proptest! {
 }
 
 #[test]
-fn read_ahead_never_fetches_past_the_upper_bound() -> TestResult {
+fn read_ahead_never_fetches_past_the_upper_bound() -> Result<()> {
     let memory = MemoryStore::default();
     let (root, oracle) = wide_build(&memory)?;
     // The root fans out into one referenced child per leading byte, so there are
     // more sibling subtrees than the window: an unbounded prefetch would pull
     // whole subtrees the bounded walk never visits.
     let siblings = memory.len().saturating_sub(1);
-    ensure(
+    ensure!(
         siblings > V1::READ_AHEAD,
         "more sibling subtrees than the window",
-    )?;
+    );
 
     // A gated store is essential here: its fetches park on the first poll, so a
     // future the window launches past the bound genuinely starts (and is
@@ -369,9 +365,9 @@ fn read_ahead_never_fetches_past_the_upper_bound() -> TestResult {
     let lo = Key::from(&[0u8][..]);
     let hi = Key::from(&[1u8][..]);
     let got: Rows = {
-        let mut cursor = run(reader.range(&root, &lo, &hi)).map_err(|e| e.to_string())?;
+        let mut cursor = run(reader.range(&root, &lo, &hi))?;
         let mut out = Vec::new();
-        while let Some((key, value)) = run(cursor.next()).map_err(|e| e.to_string())? {
+        while let Some((key, value)) = run(cursor.next())? {
             out.push((key.as_bytes().to_vec(), value));
         }
         out
@@ -381,20 +377,23 @@ fn read_ahead_never_fetches_past_the_upper_bound() -> TestResult {
         .filter(|(k, _)| k.as_slice() >= lo.as_bytes() && k.as_slice() < hi.as_bytes())
         .map(|(k, v)| (k.clone(), v.clone()))
         .collect();
-    ensure(!expected.is_empty(), "the range covers the first subtree")?;
-    ensure_eq(got, expected, "bounded read-ahead matches the range oracle")?;
+    ensure!(!expected.is_empty(), "the range covers the first subtree");
+    ensure!(
+        got == expected,
+        "bounded read-ahead matches the range oracle"
+    );
 
     // Exactly the root and the one in-range subtree: no sibling past the bound is
     // prefetched, so the window respects the range at the serial fetch count.
-    ensure_eq(
-        store.gets.load(Ordering::Relaxed),
-        2,
+    ensure!(
+        store.gets.load(Ordering::Relaxed) == 2,
         "root and the one in-range subtree only",
-    )
+    );
+    Ok(())
 }
 
 #[test]
-fn floor_matches_the_oracle() -> TestResult {
+fn floor_matches_the_oracle() -> Result<()> {
     let store = MemoryStore::default();
     let (root, oracle) = build(&store)?;
     let reader: Reader<_> = Reader::new(&store);
@@ -410,14 +409,13 @@ fn floor_matches_the_oracle() -> TestResult {
         &b"prefiy"[..],
         &b"zzzzz"[..],
     ] {
-        let got = run(reader.floor(&root, &Key::from(target)))
-            .map_err(|e| e.to_string())?
-            .map(|(k, v)| (k.as_bytes().to_vec(), v));
+        let got =
+            run(reader.floor(&root, &Key::from(target)))?.map(|(k, v)| (k.as_bytes().to_vec(), v));
         let expected = oracle
             .range(..=target.to_vec())
             .next_back()
             .map(|(k, v)| (k.clone(), v.clone()));
-        ensure_eq(got, expected, "floor matches the oracle")?;
+        ensure!(got == expected, "floor matches the oracle");
     }
     Ok(())
 }


### PR DESCRIPTION
## What

Adds `anyhow = "1"` to `[workspace.dependencies]` (tests-and-examples section) and as a dev-dependency of `nectar-manifest` (dev-only, never reaches shipped crates; already present transitively in the lock, so the `Cargo.lock` delta is one line).

Deletes the hand-rolled `TestResult` alias and `ensure`/`ensure_eq` helpers from `crates/manifest/tests/common/mod.rs`, leaving only the `split_whole` fixture, byte-identical to main.

Converts all ten test files (bridge, builder, conformance, counted, determinism, membound, order, read_profile, reader, scan) to return `anyhow::Result`: `ensure`/`ensure_eq` call sites become `anyhow::ensure!` with the original messages, and `Option::ok_or("...")` sites become `anyhow::Context`.

This PR does not touch epic #443's drift-register rows; `apply.rs` and the drift-register are untouched, and no rows are removed or added.

## Why

Closes epic #443's issue #412: replace the crate-local `TestResult`/`ensure`/`ensure_eq` machinery in `nectar-manifest`'s integration tests with `anyhow`, matching the workspace's existing dev-dependency conventions and removing duplicate assertion tooling without weakening any assertion.

## Testing

Verified at 47d10026 (single commit on origin/main@1da787cf), toolchain 1.94 via `nix develop`.

- `cargo fmt --all -- --check`: the only diff is in `crates/file/src/split/handoff.rs:97`, byte-identical to origin/main, pre-existing drift in an untouched crate; CI has no fmt gate, so it is left alone to keep the diff scoped.
- `cargo clippy -p nectar-manifest --all-targets --locked`: clean (one pre-existing warning in the untouched `nectar-primitives` lib).
- `cargo nextest run -p nectar-manifest --locked --no-tests=warn --no-fail-fast`: 220 passed, 0 skipped.
- `cargo nextest run --workspace --locked --no-tests=warn --no-fail-fast`: 902 passed, 1 skipped (wasm smoke).
- `cargo test --doc -p nectar-manifest --locked`: 5 passed.

## AI Assistance

Implemented and reviewed with Claude (Anthropic).

Closes #412
