### PR TITLE
ci(fuzz): persist minimized nightly corpus via automated PR

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -32,6 +32,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
+          allowlist: 'github-actions[bot]'
           path-to-signatures: 'nectar/cla.json'
           path-to-document: 'https://github.com/nxm-rs/nectar/blob/main/CLA.md'
           # branch should not be protected

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -6,8 +6,7 @@
 # The nightly corpus is persisted beyond actions/cache eviction: each cron
 # leg minimizes corpus plus committed seeds into a standalone set, and the
 # persist job commits it back into fuzz/seeds/<target>/ (hash-named files
-# next to the curated seeds) via an automated PR. ClusterFuzzLite was
-# considered and deferred until the estate wants coverage reporting.
+# next to the curated seeds) via an automated PR.
 name: fuzz
 
 on:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -2,6 +2,12 @@
 # properties. Targets build once under nightly plus the
 # sanitizer; each run job then executes the prebuilt binary, so nothing is
 # rebuilt and the run jobs need no toolchain.
+#
+# The nightly corpus is persisted beyond actions/cache eviction: each cron
+# leg minimizes corpus plus committed seeds into a standalone set, and the
+# persist job commits it back into fuzz/seeds/<target>/ (hash-named files
+# next to the curated seeds) via an automated PR. ClusterFuzzLite was
+# considered and deferred until the estate wants coverage reporting.
 name: fuzz
 
 on:
@@ -150,7 +156,7 @@ jobs:
                   key: fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}
                   restore-keys: |
                       fuzz-corpus-${{ matrix.target }}-
-            - name: Run ${{ matrix.target }} for 10 minutes and minimise
+            - name: Run ${{ matrix.target }} for 10 minutes and minimize
               run: |
                   bin="$PWD/fuzz-bin/${{ matrix.target }}"
                   chmod +x "$bin"
@@ -159,12 +165,81 @@ jobs:
                   seeds="fuzz/seeds/${{ matrix.target }}"
                   [ -d "$seeds" ] || seeds=""
                   "$bin" "$corpus" $seeds -max_total_time=600 -rss_limit_mb=2048 -artifact_prefix=fuzz/artifacts/
+                  # Merge the seeds too: the minimized set must stand alone so
+                  # the persist job can commit it as the durable coverage floor.
                   min=$(mktemp -d)
-                  "$bin" -merge=1 "$min" "$corpus"
+                  "$bin" -merge=1 "$min" "$corpus" $seeds
                   rm -rf "$corpus"; mkdir -p "$corpus"; cp -a "$min"/. "$corpus"/ 2>/dev/null || true
+            - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+              with:
+                  name: fuzz-corpus-min-${{ matrix.target }}
+                  path: fuzz/corpus/${{ matrix.target }}
+                  retention-days: 1
+                  if-no-files-found: ignore
             - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
               if: failure()
               with:
                   name: fuzz-artifacts-nightly-${{ matrix.target }}
                   path: fuzz/artifacts
                   if-no-files-found: ignore
+
+    persist:
+        name: fuzz corpus persist
+        if: github.event_name == 'schedule' && !cancelled()
+        needs: cron
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        permissions:
+            contents: write
+            pull-requests: write
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+            - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+              with:
+                  pattern: fuzz-corpus-min-*
+                  path: corpus-min
+            - name: Refresh the committed corpus under fuzz/seeds
+              run: |
+                  for dir in corpus-min/fuzz-corpus-min-*; do
+                      [ -d "$dir" ] || continue
+                      target="${dir##*/fuzz-corpus-min-}"
+                      seeds="fuzz/seeds/$target"
+                      mkdir -p "$seeds"
+                      # Replace only the hash-named machine entries; curated
+                      # valid-*/invalid-*/edge-*/crash-* seeds never match.
+                      find "$seeds" -maxdepth 1 -type f -regextype posix-extended \
+                          -regex '.*/[0-9a-f]{40}' -delete
+                      # Skip minimized entries byte-identical to a curated seed
+                      # (merge names files by content sha1).
+                      curated=$(find "$seeds" -maxdepth 1 -type f -print0 | xargs -0 -r sha1sum | cut -d' ' -f1 | tr '\n' ' ')
+                      for f in "$dir"/*; do
+                          [ -f "$f" ] || continue
+                          name="${f##*/}"
+                          case " $curated " in *" $name "*) continue ;; esac
+                          cp "$f" "$seeds/$name"
+                      done
+                  done
+            - name: Open or update the corpus refresh PR
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  git add -A fuzz/seeds
+                  if git diff --cached --quiet; then
+                      echo "committed corpus already current"
+                      exit 0
+                  fi
+                  summary=$(cd fuzz/seeds && for d in */; do
+                      printf -- '- %s: %s files, %s\n' "${d%/}" "$(find "$d" -type f | wc -l)" "$(du -sh "$d" | cut -f1)"
+                  done)
+                  git config user.name "github-actions[bot]"
+                  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+                  branch=ci/fuzz-corpus-refresh
+                  git checkout -B "$branch"
+                  git commit -m "chore(fuzz): refresh the committed minimized corpus"
+                  git push -f origin "$branch"
+                  existing=$(gh pr list --head "$branch" --state open --json number --jq '.[0].number')
+                  if [ -z "$existing" ]; then
+                      gh pr create --head "$branch" \
+                          --title "chore(fuzz): refresh the committed minimized corpus" \
+                          --body "$(printf 'Nightly-minimized fuzz corpus, committed so accumulated coverage survives actions/cache eviction. Hash-named files sit next to the curated seeds and replay through the existing stable seed-replay tests.\n\n%s' "$summary")"
+                  fi

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -100,6 +100,10 @@ which replays its seeds through the same fixed-point round trip.
   `mantaray_node_decode/crash-v01-header-only-64b.bin`, the input behind the
   bound-check fix in `crates/mantaray/src/codec.rs`). Name seeds
   `valid-*`/`invalid-*`/`edge-*`/`crash-*` with a size hint.
+- Nightly CI also commits its minimized corpus into `fuzz/seeds/<target>/` as
+  sha1-named files via an automated PR, so accumulated coverage survives
+  cache eviction. Machine-managed: never hand-edit or rename these; the next
+  refresh replaces them wholesale.
 - `fuzz/corpus/`, `fuzz/artifacts/`, `fuzz/coverage/` are **gitignored**; the
   corpus lives in the CI cache and on developer machines.
 - When a fuzzer finds a crash: `cargo fuzz tmin` it, commit the minimized
@@ -116,7 +120,8 @@ which replays its seeds through the same fixed-point round trip.
   (`-rss_limit_mb=2048`) on a per-target cached corpus with the committed
   seeds merged in. Crash artifacts are uploaded on failure.
 - **Nightly cron** — 10 minutes per target on the same corpus caches,
-  followed by `cargo fuzz cmin` so the caches don't grow without bound.
+  followed by a merge-minimize over corpus plus seeds; the minimized set is
+  then committed back into `fuzz/seeds/` by an automated PR.
 
 ## NixOS gotchas
 


### PR DESCRIPTION
## What

Workflow-only change to `.github/workflows/fuzz.yml`, a small `allowlist` addition in `.github/workflows/cla.yml`, and a 2-bullet `fuzz/README.md` seed-policy note.
Each nightly cron leg now merge-minimizes with the committed seeds folded in (`-merge=1 $min $corpus $seeds`), so the resulting minimized set is a standalone coverage floor, and uploads it as artifact `fuzz-corpus-min-<target>` (1-day retention, success-only, so unminimized crash-run corpora never persist).
A new schedule-only `persist` job (`needs: cron`, `!cancelled()` so partial crash nights still persist the green legs; `permissions: contents write, pull-requests write`) downloads all minimized artifacts and, per target, prunes only prior machine entries (regex `[0-9a-f]{40}`; curated `valid-*`/`invalid-*`/`edge-*`/`crash-*` names can never match), skips minimized files byte-identical to a curated seed (libFuzzer names merged files by content sha1, so a name-vs-curated-sha1 comparison suffices), copies the rest into `fuzz/seeds/<target>/`, and opens or updates an automated PR against `ci/fuzz-corpus-refresh`.
This removes epic #443's corpus-persistence drift-register row (durable minimized corpus, committed automatically) and leaves the ClusterFuzzLite row untouched, since ClusterFuzzLite is not being adopted here.

## Why

The nightly corpus otherwise only lives in the `actions/cache` for each target and is subject to eviction, so accumulated coverage can silently regress between runs.
Folding the committed seeds into the nightly merge-minimize step makes the minimized artifact a standalone coverage floor rather than a delta against local cache state, and committing it back via PR (instead of pushing directly) keeps the change reviewable while the hash-named machine entries are kept visually and mechanically distinct from the curated `valid-*`/`invalid-*`/`edge-*`/`crash-*` seed names, so the seed-naming policy in `fuzz/README.md` needed the extra bullets to state that distinction rather than contradict it.

## Testing

Branch tip a0322458 (2 commits over `origin/main`). Diff touches only `.github/workflows/fuzz.yml`, `.github/workflows/cla.yml`, and `fuzz/README.md`; no Rust source, no `Cargo.toml`, no feature wiring.

- `cargo nextest run --workspace --locked --no-tests=warn --no-fail-fast`: 902 passed, 1 skipped, 0 failed (rust 1.94 via `nix develop`).
- `cargo metadata --locked`: clean at the workspace root and in `fuzz/`.
- `actionlint` on both changed workflows: clean.
- Per-crate clippy/nextest/doctests and the rv64 no_std check: not applicable, no crate code or `Cargo.toml` changed.
- `cargo fmt --all -- --check`: one pre-existing violation in `crates/file/src/split/handoff.rs`, untouched by this branch and byte-identical to `origin/main`, which fails the same check under the current rust 1.94/rustfmt 1.8.0 toolchain; no fmt gate exists in CI. Not introduced here, left alone to keep the PR scoped.
- Red-teamed against the epic #443 hunt list: no duplication regressions (no Rust code added; the persist job's shell dedup-by-sha1 against curated seeds is not an oracle/generator re-encoding and has no shelf equivalent), no weakened assertions (zero test changes vs `origin/main`), scope matches issue #439 (durable minimized corpus committed into `fuzz/seeds` via automated PR; ClusterFuzzLite not adopted), README bullets justified to keep the seed-naming policy from contradicting hash-named machine entries.

## AI Assistance

Implemented and red-teamed with Claude Sonnet 5 (Anthropic).

Closes #439
