### PR TITLE
test(file,testing): adopt allocation-counter for the allocation witness probes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocation-counter"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beb9e990c0a33699f1984d85a6abead615ccc72dd8130bf3e15dcabe2ca149c9"
+
+[[package]]
 name = "alloy-chains"
 version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2285,6 +2291,7 @@ dependencies = [
 name = "nectar-testing"
 version = "0.4.0"
 dependencies = [
+ "allocation-counter",
  "futures",
  "futures-executor",
  "nectar-file",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 
 # For tests and examples
+allocation-counter = "0.8"
 anyhow = "1"
 arbitrary = "1.4"
 criterion = { package = "codspeed-criterion-compat", version = "2.10.1" }

--- a/crates/file/Cargo.toml
+++ b/crates/file/Cargo.toml
@@ -37,7 +37,7 @@ nectar-mantaray.workspace = true
 # The oracle stores and chunk fixtures ride the primitives store surface,
 # including the encrypted reference width.
 nectar-primitives = { workspace = true, features = ["arbitrary", "encryption", "std"] }
-nectar-testing = { workspace = true, features = ["fixtures"] }
+nectar-testing = { workspace = true, features = ["alloc", "fixtures"] }
 tokio = { workspace = true, features = ["io-util", "time"] }
 
 [features]

--- a/crates/file/tests/alloc_probe.rs
+++ b/crates/file/tests/alloc_probe.rs
@@ -5,7 +5,7 @@
 //! allocation witness. Fetched bodies are shared offset sub-views, so the
 //! walk's staging buffer is the only place plaintext can land: `collect`
 //! reserves the output exactly, so allocated bytes beyond the output must
-//! grow by less than one body per added chunk, never by a per-chunk
+//! grow by less than a quarter body per added chunk, never by a per-chunk
 //! plaintext staging buffer.
 #![cfg(feature = "encryption")]
 // Integration-test code: unwraps, direct indexing, casts, and assertions
@@ -77,14 +77,15 @@ fn encrypted_read_body_allocations_stay_constant() {
     );
 
     // `collect` reserves the output exactly once at the payload size, so the
-    // bytes beyond the output are the walk's own traffic. A plaintext staging
-    // buffer per fetched chunk would grow that remainder by one body per
-    // added chunk; the bounded staging keeps it well under.
+    // bytes beyond the output are the walk's own traffic. Bounded staging
+    // holds that remainder's growth to a few hundred bytes per added chunk;
+    // a plaintext staging buffer even every fourth chunk would breach the
+    // quarter-body slope.
     let small_extra = small.bytes_total.saturating_sub((SMALL * BODY) as u64);
     let large_extra = large.bytes_total.saturating_sub((LARGE * BODY) as u64);
     let extra_delta = large_extra.saturating_sub(small_extra);
     assert!(
-        extra_delta < CHUNK_DELTA * BODY as u64,
-        "read traffic beyond the output grew {extra_delta} bytes over {CHUNK_DELTA} added chunks, at or above one body per chunk"
+        extra_delta < CHUNK_DELTA * (BODY as u64 / 4),
+        "read traffic beyond the output grew {extra_delta} bytes over {CHUNK_DELTA} added chunks, at or above a quarter body per chunk"
     );
 }

--- a/crates/file/tests/alloc_probe.rs
+++ b/crates/file/tests/alloc_probe.rs
@@ -1,11 +1,12 @@
 //! Allocation probe over the real encrypted read path.
 //!
 //! Splits a file through the encrypted splitter into a `MemoryStore`, then
-//! reads it back through `File::open_encrypted` and `collect` under a
-//! counting allocator. Fetched bodies are shared offset sub-views, so the
-//! walk's staging buffer is the only place plaintext can land: body-sized
-//! allocator calls during the read must stay a chunk-count-independent
-//! constant plus the output buffer, never one per chunk.
+//! reads it back through `File::open_encrypted` and `collect` under the
+//! allocation witness. Fetched bodies are shared offset sub-views, so the
+//! walk's staging buffer is the only place plaintext can land: `collect`
+//! reserves the output exactly, so allocated bytes beyond the output must
+//! grow by less than one body per added chunk, never by a per-chunk
+//! plaintext staging buffer.
 #![cfg(feature = "encryption")]
 // Integration-test code: unwraps, direct indexing, casts, and assertions
 // are setup and illustration, not shipped surface.
@@ -19,52 +20,15 @@
     clippy::missing_panics_doc
 )]
 
-use core::sync::atomic::{AtomicU64, Ordering};
-use std::alloc::{GlobalAlloc, Layout, System};
 use std::sync::Arc;
 
 use nectar_file::{Encrypted, File, RandomKeys};
 use nectar_primitives::chunk::AnyChunkSet;
 use nectar_primitives::store::MemoryStore;
-use nectar_testing::{run, split_into};
+use nectar_testing::{AllocationInfo, measure_allocations, run, split_into};
 
 /// Body size of the default profile.
 const BODY: usize = nectar_primitives::DEFAULT_BODY_SIZE;
-
-/// Allocator calls observed so far.
-static CALLS: AtomicU64 = AtomicU64::new(0);
-/// Allocator calls of at least one body size.
-static BODY_CALLS: AtomicU64 = AtomicU64::new(0);
-
-fn note(size: usize) {
-    CALLS.fetch_add(1, Ordering::Relaxed);
-    if size >= BODY {
-        BODY_CALLS.fetch_add(1, Ordering::Relaxed);
-    }
-}
-
-/// System allocator wrapper counting calls by size class.
-struct Counting;
-
-// SAFETY: delegates to `System` unchanged; the counters are side effects.
-unsafe impl GlobalAlloc for Counting {
-    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        note(layout.size());
-        unsafe { System.alloc(layout) }
-    }
-
-    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        unsafe { System.dealloc(ptr, layout) }
-    }
-
-    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
-        note(new_size);
-        unsafe { System.realloc(ptr, layout, new_size) }
-    }
-}
-
-#[global_allocator]
-static ALLOCATOR: Counting = Counting;
 
 type Store = Arc<MemoryStore<AnyChunkSet<BODY>>>;
 
@@ -75,43 +39,52 @@ fn fill(len: usize) -> Vec<u8> {
         .collect()
 }
 
-/// Full read of `leaves` body-sized leaves; returns (calls, body-sized
-/// calls) the open-plus-collect made.
-fn probe(leaves: usize) -> (u64, u64) {
+/// Full read of `leaves` body-sized leaves; returns the witness stats of the
+/// open-plus-collect.
+fn probe(leaves: usize) -> AllocationInfo {
     let data = fill(leaves * BODY);
     let (root, store) = split_into::<Encrypted<RandomKeys>, BODY>(&data);
     let store: Store = Arc::new(store);
 
-    let calls = CALLS.load(Ordering::Relaxed);
-    let body_calls = BODY_CALLS.load(Ordering::Relaxed);
-    let out = run(async {
-        let file: File<Store, Encrypted, BODY> = File::open_encrypted(store, root).await.unwrap();
-        file.collect(u64::MAX).await.unwrap()
+    let (out, info) = measure_allocations(|| {
+        run(async {
+            let file: File<Store, Encrypted, BODY> =
+                File::open_encrypted(store, root).await.unwrap();
+            file.collect(u64::MAX).await.unwrap()
+        })
     });
-    let calls = CALLS.load(Ordering::Relaxed) - calls;
-    let body_calls = BODY_CALLS.load(Ordering::Relaxed) - body_calls;
 
     assert_eq!(out, data, "plaintext diverged at {leaves} leaves");
-    (calls, body_calls)
+    info
 }
 
 #[test]
 fn encrypted_read_body_allocations_stay_constant() {
-    // Encrypted fan-out 64: 32 leaves sit under one root; 128 leaves add
-    // two intermediates.
-    let (small_calls, small_body) = probe(32);
-    let (large_calls, large_body) = probe(128);
-    println!("32 leaves (33 chunks): {small_calls} calls, {small_body} body-sized");
-    println!("128 leaves (131 chunks): {large_calls} calls, {large_body} body-sized");
-
-    // Output buffer plus a bounded staging remainder, independent of the
-    // chunk count; one per chunk would be 33 and 131.
-    assert!(
-        small_body <= 16,
-        "32-leaf read made {small_body} body-sized allocations"
+    // Encrypted fan-out 64: 32 leaves sit under one root (33 chunks); 128
+    // leaves add two intermediates (131 chunks).
+    const SMALL: usize = 32;
+    const LARGE: usize = 128;
+    const CHUNK_DELTA: u64 = 131 - 33;
+    let small = probe(SMALL);
+    let large = probe(LARGE);
+    println!(
+        "32 leaves (33 chunks): {} allocations, {} bytes",
+        small.count_total, small.bytes_total
     );
+    println!(
+        "128 leaves (131 chunks): {} allocations, {} bytes",
+        large.count_total, large.bytes_total
+    );
+
+    // `collect` reserves the output exactly once at the payload size, so the
+    // bytes beyond the output are the walk's own traffic. A plaintext staging
+    // buffer per fetched chunk would grow that remainder by one body per
+    // added chunk; the bounded staging keeps it well under.
+    let small_extra = small.bytes_total.saturating_sub((SMALL * BODY) as u64);
+    let large_extra = large.bytes_total.saturating_sub((LARGE * BODY) as u64);
+    let extra_delta = large_extra.saturating_sub(small_extra);
     assert!(
-        large_body <= 16,
-        "128-leaf read made {large_body} body-sized allocations"
+        extra_delta < CHUNK_DELTA * BODY as u64,
+        "read traffic beyond the output grew {extra_delta} bytes over {CHUNK_DELTA} added chunks, at or above one body per chunk"
     );
 }

--- a/crates/file/tests/plain_alloc_probe.rs
+++ b/crates/file/tests/plain_alloc_probe.rs
@@ -3,8 +3,8 @@
 //! Splits a file through the plain splitter into a `MemoryStore`, then reads
 //! it back through `File::open` under the allocation witness. Plain bodies
 //! pass through undecoded, so the marginal bytes per added fetch stay below
-//! one body, and the walk holds outstanding fetches in a reusable in-flight
-//! set, so the per-fetch allocation count stays below the
+//! a quarter body, and the walk holds outstanding fetches in a reusable
+//! in-flight set, so the per-fetch allocation count stays below the
 //! boxed-future-plus-task-node pair that a `FuturesUnordered` charged: one
 //! boxed store future per fetch plus a chunk-independent remainder, never
 //! two.
@@ -93,14 +93,14 @@ fn plain_read_allocations_stay_below_two_per_fetch() {
     );
 
     // Plain bodies pass through undecoded and nothing collects the payload,
-    // so a body-sized allocation per fetched node would grow the read's
-    // traffic by at least one body per added fetch; the reader's own staging
-    // is chunk-count independent, keeping the marginal bytes well under.
+    // so the reader's chunk-count-independent staging holds the marginal
+    // bytes to a few hundred per added fetch; a body-sized allocation even
+    // every fourth fetched node would breach the quarter-body slope.
     let byte_delta = large.bytes_total.saturating_sub(small.bytes_total);
     let fetch_delta = large_fetches - small_fetches;
     assert!(
-        byte_delta < fetch_delta * BODY as u64,
-        "read traffic grew {byte_delta} bytes over {fetch_delta} added fetches, at or above one body per fetch"
+        byte_delta < fetch_delta * (BODY as u64 / 4),
+        "read traffic grew {byte_delta} bytes over {fetch_delta} added fetches, at or above a quarter body per fetch"
     );
 
     // The reusable in-flight set holds one boxed store future per fetch and

--- a/crates/file/tests/plain_alloc_probe.rs
+++ b/crates/file/tests/plain_alloc_probe.rs
@@ -1,12 +1,13 @@
 //! Allocation probe over the real plain read path.
 //!
 //! Splits a file through the plain splitter into a `MemoryStore`, then reads
-//! it back through `File::open` under a counting allocator. Plain bodies pass
-//! through undecoded, so no body-sized allocation lands per fetched node, and
-//! the walk holds outstanding fetches in a reusable in-flight set, so the
-//! per-fetch allocation count stays below the boxed-future-plus-task-node
-//! pair that a `FuturesUnordered` charged: one boxed store future per fetch
-//! plus a chunk-independent remainder, never two.
+//! it back through `File::open` under the allocation witness. Plain bodies
+//! pass through undecoded, so the marginal bytes per added fetch stay below
+//! one body, and the walk holds outstanding fetches in a reusable in-flight
+//! set, so the per-fetch allocation count stays below the
+//! boxed-future-plus-task-node pair that a `FuturesUnordered` charged: one
+//! boxed store future per fetch plus a chunk-independent remainder, never
+//! two.
 // Integration-test code: unwraps, direct indexing, casts, and assertions are
 // setup and illustration, not shipped surface.
 #![allow(
@@ -20,52 +21,15 @@
 )]
 
 use core::future::poll_fn;
-use core::sync::atomic::{AtomicU64, Ordering};
-use std::alloc::{GlobalAlloc, Layout, System};
 use std::sync::Arc;
 
 use nectar_file::{File, Plain, PutWindow, Split};
 use nectar_primitives::chunk::{AnyChunkSet, ChunkAddress};
 use nectar_primitives::store::MemoryStore;
-use nectar_testing::run;
+use nectar_testing::{AllocationInfo, measure_allocations, run};
 
 /// Body size of the default profile.
 const BODY: usize = nectar_primitives::DEFAULT_BODY_SIZE;
-
-/// Allocator calls observed so far.
-static CALLS: AtomicU64 = AtomicU64::new(0);
-/// Allocator calls of at least one body size.
-static BODY_CALLS: AtomicU64 = AtomicU64::new(0);
-
-fn note(size: usize) {
-    CALLS.fetch_add(1, Ordering::Relaxed);
-    if size >= BODY {
-        BODY_CALLS.fetch_add(1, Ordering::Relaxed);
-    }
-}
-
-/// System allocator wrapper counting calls by size class.
-struct Counting;
-
-// SAFETY: delegates to `System` unchanged; the counters are side effects.
-unsafe impl GlobalAlloc for Counting {
-    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        note(layout.size());
-        unsafe { System.alloc(layout) }
-    }
-
-    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        unsafe { System.dealloc(ptr, layout) }
-    }
-
-    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
-        note(new_size);
-        unsafe { System.realloc(ptr, layout, new_size) }
-    }
-}
-
-#[global_allocator]
-static ALLOCATOR: Counting = Counting;
 
 type Store = Arc<MemoryStore<AnyChunkSet<BODY>>>;
 
@@ -91,60 +55,65 @@ fn split_plain(data: &[u8]) -> (ChunkAddress, Store) {
     (root, store)
 }
 
-/// Full read of `leaves` body-sized leaves; returns the calls, body-sized
-/// calls, and fetches the open-plus-drain made.
-fn probe(leaves: usize) -> (u64, u64, u64) {
+/// Full read of `leaves` body-sized leaves; returns the witness stats and
+/// the fetches the open-plus-drain made.
+fn probe(leaves: usize) -> (AllocationInfo, u64) {
     let data = fill(leaves * BODY);
     let (root, store) = split_plain(&data);
 
-    let calls = CALLS.load(Ordering::Relaxed);
-    let body_calls = BODY_CALLS.load(Ordering::Relaxed);
-    let (read, fetches) = run(async {
-        let file: File<Store, Plain, BODY> = File::open(store, root).await.unwrap();
-        let mut reader = file.read().build();
-        let mut read = 0usize;
-        while let Some(segment) = reader.next_segment().await {
-            read += segment.unwrap().len();
-        }
-        (read, reader.stats().fetches)
+    let ((read, fetches), info) = measure_allocations(|| {
+        run(async {
+            let file: File<Store, Plain, BODY> = File::open(store, root).await.unwrap();
+            let mut reader = file.read().build();
+            let mut read = 0usize;
+            while let Some(segment) = reader.next_segment().await {
+                read += segment.unwrap().len();
+            }
+            (read, reader.stats().fetches)
+        })
     });
-    let calls = CALLS.load(Ordering::Relaxed) - calls;
-    let body_calls = BODY_CALLS.load(Ordering::Relaxed) - body_calls;
 
     assert_eq!(read, data.len(), "plaintext short at {leaves} leaves");
-    (calls, body_calls, fetches)
+    (info, fetches)
 }
 
 #[test]
 fn plain_read_allocations_stay_below_two_per_fetch() {
     // Plain fan-out 128: 128 leaves sit under one root; 512 leaves add four
-    // intermediates, so the fetch count scales while the peaks do not.
-    let (small_calls, small_body, small_fetches) = probe(128);
-    let (large_calls, large_body, large_fetches) = probe(512);
-    println!("128 leaves: {small_calls} calls, {small_body} body-sized, {small_fetches} fetches");
-    println!("512 leaves: {large_calls} calls, {large_body} body-sized, {large_fetches} fetches");
-
-    // Plain bodies pass through undecoded, so the only body-sized allocations
-    // are the reader's own staging, independent of the chunk count; one body
-    // per fetch would be 129 and 517.
-    assert!(
-        small_body <= 16,
-        "128-leaf read made {small_body} body-sized allocations"
+    // intermediates, so the fetch count scales while the staging does not.
+    let (small, small_fetches) = probe(128);
+    let (large, large_fetches) = probe(512);
+    println!(
+        "128 leaves: {} allocations, {} bytes, {small_fetches} fetches",
+        small.count_total, small.bytes_total
     );
+    println!(
+        "512 leaves: {} allocations, {} bytes, {large_fetches} fetches",
+        large.count_total, large.bytes_total
+    );
+
+    // Plain bodies pass through undecoded and nothing collects the payload,
+    // so a body-sized allocation per fetched node would grow the read's
+    // traffic by at least one body per added fetch; the reader's own staging
+    // is chunk-count independent, keeping the marginal bytes well under.
+    let byte_delta = large.bytes_total.saturating_sub(small.bytes_total);
+    let fetch_delta = large_fetches - small_fetches;
     assert!(
-        large_body <= 16,
-        "512-leaf read made {large_body} body-sized allocations"
+        byte_delta < fetch_delta * BODY as u64,
+        "read traffic grew {byte_delta} bytes over {fetch_delta} added fetches, at or above one body per fetch"
     );
 
     // The reusable in-flight set holds one boxed store future per fetch and
     // no per-push task node, so total allocations stay below two per fetch; a
     // `FuturesUnordered` charged two (box plus `Arc<Task>`).
     assert!(
-        large_calls * 2 < large_fetches * 3,
-        "512-leaf read made {large_calls} allocations over {large_fetches} fetches, at or above 1.5 per fetch"
+        large.count_total * 2 < large_fetches * 3,
+        "512-leaf read made {} allocations over {large_fetches} fetches, at or above 1.5 per fetch",
+        large.count_total
     );
     assert!(
-        small_calls * 2 < small_fetches * 3,
-        "128-leaf read made {small_calls} allocations over {small_fetches} fetches, at or above 1.5 per fetch"
+        small.count_total * 2 < small_fetches * 3,
+        "128-leaf read made {} allocations over {small_fetches} fetches, at or above 1.5 per fetch",
+        small.count_total
     );
 }

--- a/crates/file/tests/split_membound.rs
+++ b/crates/file/tests/split_membound.rs
@@ -6,10 +6,10 @@
 //! constant, `O(put window + spine depth)` bodies plus the spine of
 //! references, never `O(payload)`.
 //!
-//! A counting global allocator records peak live bytes while a drop-store
-//! discards each body on put, so the peak is the pure engine working set. The
-//! payload scales 16x across three sizes that mirror 8/32/128 MiB at the
-//! default body; the peak stays flat.
+//! The allocation witness records peak live bytes while a drop-store
+//! discards each body on put, so the peak is the pure engine working set.
+//! The payload scales 16x across three sizes that mirror 8/32/128 MiB at
+//! the default body; the peak stays flat.
 // Integration-test code: unwraps, direct indexing, casts, and assertions are
 // setup and illustration, not shipped surface.
 #![allow(
@@ -24,53 +24,19 @@
 
 use core::future::{Future, poll_fn};
 use core::pin::Pin;
-use core::sync::atomic::{AtomicUsize, Ordering};
 use core::task::{Context, Poll};
-use std::alloc::{GlobalAlloc, Layout, System};
 use std::sync::{Arc, Mutex};
 
 use nectar_file::{Plain, PutWindow, Split};
 use nectar_primitives::chunk::{AnyChunkSet, Chunk, Verified};
 use nectar_primitives::store::{ChunkPut, ChunkStoreError};
-use nectar_testing::run;
+use nectar_testing::{measure_allocations, run};
 
 /// Tiny body: fan-out 8, so a few thousand leaves build a deep tree at a
 /// modest byte count.
 const B: usize = 256;
 /// Put window held for the witness.
 const WINDOW: u16 = 8;
-
-static LIVE: AtomicUsize = AtomicUsize::new(0);
-static PEAK: AtomicUsize = AtomicUsize::new(0);
-
-/// System allocator wrapper tracking live and peak bytes.
-struct Counting;
-
-// SAFETY: delegates to `System` unchanged; the counters are side effects.
-unsafe impl GlobalAlloc for Counting {
-    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        let ptr = unsafe { System.alloc(layout) };
-        if !ptr.is_null() {
-            let live = LIVE.fetch_add(layout.size(), Ordering::Relaxed) + layout.size();
-            PEAK.fetch_max(live, Ordering::Relaxed);
-        }
-        ptr
-    }
-
-    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        LIVE.fetch_sub(layout.size(), Ordering::Relaxed);
-        unsafe { System.dealloc(ptr, layout) }
-    }
-}
-
-#[global_allocator]
-static ALLOCATOR: Counting = Counting;
-
-/// Reset the peak to the current live bytes, so a following measurement nets
-/// out the baseline (the reused input block and harness state).
-fn reset_peak() {
-    PEAK.store(LIVE.load(Ordering::Relaxed), Ordering::Relaxed);
-}
 
 /// A put future that parks once before completing, so up to `window` bodies
 /// occupy the in-flight set at a time.
@@ -120,38 +86,39 @@ impl ChunkPut<AnyChunkSet<B>> for DropStore {
 
 /// Stream `total` deterministic bytes through a plain split from a small
 /// reused block, so the input never lives as one payload-sized allocation,
-/// and return the peak live-byte delta the split added over the baseline.
-fn split_peak_delta(total: usize) -> usize {
+/// and return the peak live bytes (`bytes_max`) the split added over the
+/// witness baseline.
+fn split_peak(total: usize) -> u64 {
     const BLOCK: usize = 4096;
     let store = DropStore::new();
     let mut split: Split<DropStore, Plain, B> = Split::new(store, PutWindow::new(WINDOW).unwrap());
     let mut block = vec![0u8; BLOCK];
-    let baseline = LIVE.load(Ordering::Relaxed);
-    reset_peak();
-    run(async {
-        let mut produced = 0usize;
-        while produced < total {
-            let take = BLOCK.min(total - produced);
-            for (j, slot) in block[..take].iter_mut().enumerate() {
-                // splitmix64 of the absolute byte index: aperiodic, so every
-                // body is unique and nothing dedups.
-                let i = (produced + j) as u64;
-                let mut z = i.wrapping_add(0x9E37_79B9_7F4A_7C15);
-                z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
-                z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
-                z ^= z >> 31;
-                *slot = z as u8;
+    let ((), info) = measure_allocations(|| {
+        run(async {
+            let mut produced = 0usize;
+            while produced < total {
+                let take = BLOCK.min(total - produced);
+                for (j, slot) in block[..take].iter_mut().enumerate() {
+                    // splitmix64 of the absolute byte index: aperiodic, so
+                    // every body is unique and nothing dedups.
+                    let i = (produced + j) as u64;
+                    let mut z = i.wrapping_add(0x9E37_79B9_7F4A_7C15);
+                    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+                    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+                    z ^= z >> 31;
+                    *slot = z as u8;
+                }
+                let mut buf = &block[..take];
+                while !buf.is_empty() {
+                    let n = poll_fn(|cx| split.poll_write(cx, buf)).await.unwrap();
+                    buf = &buf[n..];
+                }
+                produced += take;
             }
-            let mut buf = &block[..take];
-            while !buf.is_empty() {
-                let n = poll_fn(|cx| split.poll_write(cx, buf)).await.unwrap();
-                buf = &buf[n..];
-            }
-            produced += take;
-        }
-        poll_fn(|cx| split.poll_finish(cx)).await.unwrap();
+            poll_fn(|cx| split.poll_finish(cx)).await.unwrap();
+        })
     });
-    PEAK.load(Ordering::Relaxed).saturating_sub(baseline)
+    info.bytes_max
 }
 
 #[test]
@@ -159,7 +126,7 @@ fn split_working_set_is_flat_in_payload() {
     // Leaf counts 2048 / 8192 / 32768 mirror the tree of 8 / 32 / 128 MiB at
     // the default body; the payload scales 16x.
     let sizes = [2048 * B, 8192 * B, 32768 * B];
-    let peaks: Vec<usize> = sizes.iter().map(|&size| split_peak_delta(size)).collect();
+    let peaks: Vec<u64> = sizes.iter().map(|&size| split_peak(size)).collect();
     for (size, peak) in sizes.iter().zip(&peaks) {
         println!("{:>4} KiB payload | engine peak {peak} bytes", size / 1024);
     }
@@ -176,7 +143,7 @@ fn split_working_set_is_flat_in_payload() {
 
     // A payload-independent working set: the peak stays a small fraction of
     // the smallest payload, so no body-proportional buffer is retained.
-    let smallest = sizes[0];
+    let smallest = sizes[0] as u64;
     assert!(
         max < smallest / 16,
         "engine peak {max} bytes is not small against the {smallest}-byte payload"

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -15,12 +15,17 @@ description = "Deterministic async test harness and shared fixtures for the nect
 publish = false
 
 [dependencies]
+allocation-counter = { workspace = true, optional = true }
 futures-executor.workspace = true
 nectar-file = { workspace = true, optional = true }
 nectar-postage = { workspace = true, optional = true }
 nectar-primitives = { workspace = true, optional = true }
 
 [features]
+# Allocation witness. Linking it swaps the global allocator of every target
+# in the enabling crate, so enable it per probe crate, never by default.
+alloc = [ "dep:allocation-counter" ]
+
 # Shared split fixtures and SwarmSpec doubles. Encrypted-mode splits ride the
 # mode-generic `split_into`; callers bring their own encryption features.
 fixtures = [ "dep:nectar-file", "dep:nectar-postage", "dep:nectar-primitives" ]

--- a/crates/testing/src/alloc.rs
+++ b/crates/testing/src/alloc.rs
@@ -1,0 +1,15 @@
+//! Allocation witness over the counting global allocator.
+
+pub use allocation_counter::AllocationInfo;
+
+/// Runs `f` and returns its output with the allocator traffic it caused.
+///
+/// Counting is thread-local: it composes with [`run`](crate::run)'s
+/// single-thread `block_on`, and anything allocated on a pool thread is
+/// invisible to the witness. `bytes_max` is the peak net bytes over the
+/// call's own baseline, so no reset is needed between measurements.
+pub fn measure_allocations<T>(f: impl FnOnce() -> T) -> (T, AllocationInfo) {
+    let mut out = None;
+    let info = allocation_counter::measure(|| out = Some(f()));
+    (out.expect("measured closure ran"), info)
+}

--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -37,11 +37,16 @@
 //! 7. Derive hygiene: crate-side impls are hand-written (the two-tier
 //!    pattern is semantic, not derivable); only the fuzz workspace pulls the
 //!    `arbitrary` derive, for its target-local input grammars.
-//! Behind `fixtures`: the shared split fixtures and spec doubles.
+//! Behind `fixtures`: the shared split fixtures and spec doubles. Behind
+//! `alloc`: the allocation witness.
 
 mod seeds;
 
 pub use seeds::SeedReplay;
+#[cfg(feature = "alloc")]
+mod alloc;
+#[cfg(feature = "alloc")]
+pub use alloc::*;
 #[cfg(feature = "fixtures")]
 mod fixtures;
 #[cfg(feature = "fixtures")]


### PR DESCRIPTION
## What

Adopts `allocation-counter` 0.8.1 as a workspace dev-dependency and hosts one witness helper, `measure_allocations(f) -> (T, AllocationInfo)`, in `crates/testing/src/alloc.rs`, behind a new `nectar-testing` `alloc` feature (linking it swaps the enabling crate's global allocator, so it stays opt-in per probe crate, never on by default).
The rustdoc on the helper documents the thread-local caveat (composes with `run`'s single-thread `block_on`; pool-thread allocations are invisible to it) and that `bytes_max` is peak net bytes over the call's own baseline.
All three hand-rolled `GlobalAlloc` wrappers are deleted: `crates/file/tests/alloc_probe.rs` and `plain_alloc_probe.rs` each lose their duplicate size-classed `Counting` pair, and `split_membound.rs` loses its live/peak variant, in favour of the shared witness.
This removes the duplicated-allocator-wrapper drift noted for epic #443; the other drift-register rows are untouched by this branch.
This PR is stacked on `t443/436-testing-fixtures` and merges after its parent; GitHub will retarget it onto `develop` once the parent lands.

## Why

Three near-identical `GlobalAlloc` wrappers had accreted across the file-crate probes purely to count allocations; `allocation-counter` is a maintained crate that does the same job with one shared, documented helper, so the duplication and its maintenance burden go away.
The size-classed absolute assertions in the probes were reformulated as deltas: the encrypted probe now asserts that bytes beyond the exactly-reserved `collect` output grow by under a quarter body per added chunk across the 32-vs-128-leaf runs (measured 17,168 B against a 401,408 B bound), and the plain probe asserts an analogous marginal-bytes-per-fetch bound, both tighter and less brittle than the previous absolute figures.

## Testing

All gates re-run independently in a fresh detached worktree of `t443/413-allocation-counter` (toolchain: `nix develop`, rust 1.94.0).
`cargo fmt --all -- --check` initially failed on one pre-existing hunk in `crates/file/src/split/handoff.rs`, a file untouched by this branch (an assertion rustfmt now splits, already fixed independently on sibling train branches); fixed mechanically and committed as `mfw78 <mfw78@nxm.rs>` unsigned (3dad96c9, "style(file): reflow a handoff assertion rustfmt now splits") and pushed, after which fmt check is clean.
Clippy is clean across all CI shapes touching the changed crates: workspace default `--all-targets`, and `-p nectar-file` with `tokio`, `rayon`, and `encryption`.
Tests are all green: whole-workspace `cargo nextest run --workspace --locked --no-tests=warn --no-fail-fast` (902 passed, 1 skipped), including the three rewritten probes `alloc_probe`, `plain_alloc_probe`, and `split_membound`.

## AI Assistance

Implemented and red-teamed with Claude (Anthropic).

Closes #413

