### PR TITLE
test(file): add property coverage for split and join invariants

### DIFF
--- a/crates/file/src/read/tests.rs
+++ b/crates/file/src/read/tests.rs
@@ -754,3 +754,96 @@ fn download_restart_after_transient_failure_is_idempotent() {
     assert_eq!(written, data.len() as u64);
     assert_eq!(sink.as_ref(), data);
 }
+
+/// Shrinking stable coverage: split-and-join roundtrip and the seek model,
+/// composed from the structural-regime generators.
+mod properties {
+    use arbitrary::Unstructured;
+    use nectar_testing::run;
+    use proptest::prelude::*;
+
+    use nectar_testing::split_fixture;
+
+    use super::{File, SeekPastEnd, TINY, drain_reader};
+    use crate::generators;
+    use crate::walk::Plain;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(64))]
+
+        #[test]
+        fn split_and_join_round_trip(seed in proptest::collection::vec(any::<u8>(), 0..512)) {
+            let mut u = Unstructured::new(&seed);
+            let data = generators::body(&mut u).unwrap();
+            let (root, store) = split_fixture::<TINY>(&data);
+            let file = run(File::<_, Plain, TINY>::open(store, root)).unwrap();
+            prop_assert_eq!(file.len(), data.len() as u64);
+            prop_assert_eq!(run(file.collect(u64::MAX)).unwrap(), data);
+        }
+
+        #[test]
+        fn seek_and_drain_match_the_model(seed in proptest::collection::vec(any::<u8>(), 0..512)) {
+            let mut u = Unstructured::new(&seed);
+            let data = generators::multi_chunk_body(&mut u).unwrap();
+            let span = data.len() as u64;
+
+            // Both bounds may overshoot the file; the clip is the model.
+            let overshoot = span + 2 * TINY as u64 + 1;
+            let start_req = u.int_in_range(0..=overshoot).unwrap();
+            let end_req = u.int_in_range(0..=overshoot).unwrap();
+            let clip_end = end_req.min(span);
+            let clip_start = start_req.min(clip_end);
+            let model = &data[clip_start as usize..clip_end as usize];
+            let eff = clip_end - clip_start;
+
+            let (root, store) = split_fixture::<TINY>(&data);
+            let file = run(File::<_, Plain, TINY>::open(store, root)).unwrap();
+            let mut reader = file.read().range(start_req..end_req).build();
+            prop_assert_eq!(reader.effective_len(), eff);
+
+            // A past-end seek is typed and moves nothing.
+            let target = u.int_in_range(0..=eff + 1).unwrap();
+            let pos = match reader.seek(target) {
+                Ok(()) => {
+                    prop_assert!(target <= eff);
+                    target
+                }
+                Err(error) => {
+                    prop_assert!(target > eff);
+                    prop_assert_eq!(error, SeekPastEnd { requested: target, effective_len: eff });
+                    0
+                }
+            };
+            prop_assert_eq!(reader.position(), pos);
+            prop_assert_eq!(drain_reader(&mut reader), &model[pos as usize..]);
+            prop_assert_eq!(reader.position(), eff);
+        }
+    }
+
+    /// The encrypted width joins through its own fan-out and reference size.
+    #[cfg(feature = "encryption")]
+    mod encrypted {
+        use arbitrary::Unstructured;
+        use nectar_testing::run;
+        use proptest::prelude::*;
+
+        use super::super::{File, TINY};
+        use crate::generators;
+        use crate::testutil::split_encrypted_fixture;
+        use crate::walk::Encrypted;
+
+        proptest! {
+            #![proptest_config(ProptestConfig::with_cases(64))]
+
+            #[test]
+            fn split_and_join_round_trip(seed in proptest::collection::vec(any::<u8>(), 0..512)) {
+                let mut u = Unstructured::new(&seed);
+                let data = generators::body(&mut u).unwrap();
+                let (root_ref, store) = split_encrypted_fixture::<TINY>(&data);
+                let file = run(File::<_, Encrypted, TINY>::open_encrypted(store, root_ref)).unwrap();
+                prop_assert_eq!(file.len(), data.len() as u64);
+                prop_assert_eq!(run(file.collect(u64::MAX)).unwrap(), data);
+            }
+        }
+    }
+}

--- a/crates/file/src/split/tests.rs
+++ b/crates/file/src/split/tests.rs
@@ -1173,3 +1173,36 @@ fn huge_stream_root_matches_the_batch_ingest() {
     assert_eq!(root, batch_root);
     assert_eq!(split.stats().bytes, size);
 }
+
+/// Shrinking stable coverage: root idempotence over write segmentation,
+/// composed from the structural-regime generators.
+mod properties {
+    use arbitrary::Unstructured;
+    use proptest::prelude::*;
+
+    use super::{TINY, sorted, stream_split};
+    use crate::generators;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(64))]
+
+        #[test]
+        fn root_and_chunk_set_are_invariant_over_segmentation(
+            seed in proptest::collection::vec(any::<u8>(), 0..512)
+        ) {
+            let mut u = Unstructured::new(&seed);
+            let data = generators::body(&mut u).unwrap();
+            let arm = |u: &mut Unstructured<'_>| {
+                let window = u.int_in_range(1..=8u16).unwrap();
+                let step = u.int_in_range(1..=1024usize).unwrap();
+                let delay = u.int_in_range(0..=2usize).unwrap();
+                stream_split::<TINY>(&data, window, step, delay)
+            };
+            let (root_a, store_a, stats) = arm(&mut u);
+            let (root_b, store_b, _) = arm(&mut u);
+            prop_assert_eq!(root_a, root_b);
+            prop_assert_eq!(sorted(store_a.log()), sorted(store_b.log()));
+            prop_assert_eq!(stats.bytes, data.len() as u64);
+        }
+    }
+}


### PR DESCRIPTION
## What
Adds property-based test coverage for the file split/join path, composing the regime generators introduced in the parent branch (`generators::body` / `generators::multi_chunk_body`) via a proptest-drawn seed fed through `Unstructured`, so failures shrink.

- `crates/file/src/split/tests.rs`: `properties::root_and_chunk_set_are_invariant_over_segmentation` runs two independent streamed splits (drawn put window, write step and put delay) over the same body and asserts they agree on root and sorted chunk set, reusing the existing `stream_split`/`sorted` helpers.
- `crates/file/src/read/tests.rs`: `properties::split_and_join_round_trip` (plain path, via `testutil::split_fixture` and `File::open`) and `properties::seek_and_drain_match_the_model` (drawn overshooting range, clip rule checked against `effective_len`, drawn seek target asserting the typed `SeekPastEnd` past-end case), plus the `encrypted` sub-module's own `split_and_join_round_trip` over `testutil::split_encrypted_fixture`/`File::open_encrypted`. All properties run at `ProptestConfig::with_cases(64)`.

Test-only change: 125 insertions across the two files, no manifest or lock changes (`proptest`/`arbitrary` dev-deps already present from the `t443/437-regime-generators` parent).

Closes the epic #443 drift-register row for issue #442 (file split/join property coverage); the sibling regime-generator infrastructure row stays open against #437.

## Why
The split/read paths previously had example-based tests only; these properties pin the segmentation-invariance and seek/drain-vs-model invariants across the input space the parent's generators can produce, catching regressions that fixed examples would miss.

This PR is stacked on `t443/437-regime-generators` and merges after its parent; GitHub will retarget the base once the parent merges.

## Testing
Verified at 6903e6f9 in a detached worktree under the repo's pinned 1.94.0 toolchain (`nix develop`).

- `cargo metadata --locked`: clean.
- `cargo clippy -p nectar-file --all-targets --locked` across all CI feature shapes (default, tokio, rayon, encryption, rayon+encryption): clean for `nectar-file`.
- `cargo nextest run --workspace --locked --no-tests=warn --no-fail-fast`: 916 passed, 1 skipped.
- `cargo nextest run -p nectar-file` per CI feature shape: tokio 93 passed; rayon+encryption 122 passed, 1 skipped; encryption 99 passed.

Red-team review found no blockers and no fixes needed: no duplicate oracle, generator, or fixture was added, the three properties compose the parent's shared generators and existing helpers/fixtures only.

## AI Assistance
Implemented and reviewed with Claude (Anthropic).

Closes #442

