### PR TITLE
test(manifest): add chain-regime proptest arms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2109,6 +2109,7 @@ dependencies = [
  "bytes",
  "futures",
  "nectar-file",
+ "nectar-manifest",
  "nectar-primitives 0.4.0",
  "nectar-testing",
  "proptest",

--- a/crates/manifest/Cargo.toml
+++ b/crates/manifest/Cargo.toml
@@ -29,6 +29,8 @@ thiserror.workspace = true
 [dev-dependencies]
 anyhow.workspace = true
 arbitrary.workspace = true
+# Self dev-dependency: exposes the `generators` module to integration tests.
+nectar-manifest = { workspace = true, features = ["arbitrary"] }
 nectar-primitives = { workspace = true, features = ["arbitrary"] }
 nectar-testing = { workspace = true, features = ["fixtures"] }
 proptest.workspace = true

--- a/crates/manifest/src/packing.rs
+++ b/crates/manifest/src/packing.rs
@@ -326,6 +326,61 @@ mod tests {
         }
     }
 
+    // The exact leaf-capacity threshold: a two-fork run weighing exactly
+    // CAP_FORK packs as one segment; one more byte forces the cut before the
+    // second fork.
+    #[test]
+    fn a_leaf_run_packs_to_cap_fork_and_splits_one_byte_past() {
+        // The head stays under SEG_MIN, so no content cut can close the run
+        // before the capacity check sees the tail fork.
+        let head = V1::SEG_MIN - 1;
+        let fit = V1::CAP_FORK - head;
+        assert_eq!(head + fit, 4091);
+        let run = |tail: usize| {
+            let forks = vec![
+                (
+                    Prefix::try_from(&b"a"[..]).unwrap(),
+                    SegmentWeight::new(head).unwrap(),
+                ),
+                (
+                    Prefix::try_from(&b"b"[..]).unwrap(),
+                    SegmentWeight::new(tail).unwrap(),
+                ),
+            ];
+            segment::<V1>(&forks, SegmentKind::Leaf)
+        };
+        assert_eq!(run(fit), vec![0..2]);
+        assert_eq!(run(fit + 1), vec![0..1, 1..2]);
+    }
+
+    // The exact spill threshold: a head fork whose hash clears the widest
+    // sub-target window keeps its run open at SEG_TARGET - 1, and one more
+    // byte of weight alone forces the cut.
+    #[test]
+    fn the_forced_cut_fires_exactly_at_seg_target() {
+        assert_eq!(V1::SEG_TARGET, 2048);
+        assert_eq!(h64(b"jh"), 0xfff2_7cd7_3ef7_f1fa);
+        assert!(h64(b"jh") >= u64::try_from(V1::SEG_TARGET - 1).unwrap() * V1::CUT_SCALE);
+        assert!(!cut::<V1>(b"jh", V1::SEG_TARGET - 1));
+        assert!(cut::<V1>(b"jh", V1::SEG_TARGET));
+
+        let run = |weight: usize| {
+            let forks = vec![
+                (
+                    Prefix::try_from(&b"jh"[..]).unwrap(),
+                    SegmentWeight::new(weight).unwrap(),
+                ),
+                (
+                    Prefix::try_from(&b"b"[..]).unwrap(),
+                    SegmentWeight::new(100).unwrap(),
+                ),
+            ];
+            segment::<V1>(&forks, SegmentKind::Leaf)
+        };
+        assert_eq!(run(V1::SEG_TARGET - 1), vec![0..2]);
+        assert_eq!(run(V1::SEG_TARGET), vec![0..1, 1..2]);
+    }
+
     #[test]
     fn segment_reproduces_the_worked_leaf_partition() {
         let forks = worked_forks();

--- a/crates/manifest/tests/determinism.rs
+++ b/crates/manifest/tests/determinism.rs
@@ -10,11 +10,14 @@ use core::ops::Range;
 use std::collections::BTreeMap;
 
 use anyhow::{Context, Result, ensure};
+use arbitrary::Unstructured;
 use nectar_manifest::{
-    Domain, Entry, ForkTable, Format, Node, Prefix, SegmentKind, SegmentWeight, V1, cut, h64,
-    segment, spill,
+    Builder, Domain, Entry, ForkTable, Format, Key, Node, Prefix, SegmentKind, SegmentWeight, V1,
+    cut, generators, h64, segment, spill,
 };
-use nectar_primitives::{ChunkAddress, ChunkRef};
+use nectar_primitives::store::MemoryStore;
+use nectar_primitives::{ChunkAddress, ChunkOps, ChunkRef};
+use nectar_testing::run;
 use proptest::prelude::*;
 
 const fn ref32(byte: u8) -> ChunkRef {
@@ -219,6 +222,70 @@ proptest! {
         let route = 5usize.saturating_add(ChunkRef::SIZE);
         let top = dir.dirs().len().saturating_mul(route);
         prop_assert!(top <= V1::CAP_DIR);
+    }
+}
+
+/// One chain-regime row: key, entry, optional metadata.
+type ChainRow = generators::Row<V1>;
+
+/// Chain-regime rows bridged from a proptest byte seed: the generator rows
+/// under a diverging pair whose shared run crosses `PLEN_MAX`, deduplicated
+/// by key so insert order cannot change the winning entry.
+fn chain_rows_case(seed: &[u8]) -> Result<Vec<ChainRow>, TestCaseError> {
+    fn draw(u: &mut Unstructured<'_>) -> arbitrary::Result<Vec<ChainRow>> {
+        let shared = u.int_in_range(V1::PLEN_MAX..=generators::chain_threshold::<V1>(3))?;
+        let (left, right) = generators::diverging_pair(u, shared)?;
+        let mut map = BTreeMap::new();
+        for (key, entry, meta) in generators::chain_rows::<V1>(u)? {
+            map.insert(key.as_bytes().to_vec(), (entry, meta));
+        }
+        // The pair lands last, so every case splits inside a chained edge.
+        for (fill, key) in [(0u8, left), (1u8, right)] {
+            map.insert(key.as_bytes().to_vec(), (Entry::from(ref32(fill)), None));
+        }
+        Ok(map
+            .into_iter()
+            .map(|(key, (entry, meta))| (Key::from(key), entry, meta))
+            .collect())
+    }
+    let mut u = Unstructured::new(seed);
+    draw(&mut u).map_err(|e| TestCaseError::fail(e.to_string()))
+}
+
+/// Build rows through the public builder in the given order, returning the
+/// root and every stored chunk payload by address.
+fn build_in_order<'a>(
+    rows: impl Iterator<Item = &'a ChainRow>,
+) -> Result<(ChunkAddress, BTreeMap<ChunkAddress, Vec<u8>>), TestCaseError> {
+    let store = MemoryStore::default();
+    let mut builder = Builder::<V1>::new();
+    for (key, entry, meta) in rows {
+        builder.insert(key.clone(), entry.clone(), meta.clone());
+    }
+    let built = run(builder.build(&store)).map_err(|e| TestCaseError::fail(e.to_string()))?;
+    let chunks = store
+        .into_chunks()
+        .into_iter()
+        .map(|(address, chunk)| (address, chunk.envelope().data().as_ref().to_vec()))
+        .collect();
+    Ok((*built.root(), chunks))
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    // Invariant I6 at the chain regime: shared runs crossing PLEN_MAX chain
+    // through multiple forks and the diverging pair splits inside the chained
+    // edge, yet the packed chunk set stays a pure function of the key set
+    // whatever the insert order.
+    #[test]
+    fn chained_edges_pack_history_independently(
+        seed in prop::collection::vec(any::<u8>(), 0..4096),
+    ) {
+        let rows = chain_rows_case(&seed)?;
+        let forward = build_in_order(rows.iter())?;
+        let reversed = build_in_order(rows.iter().rev())?;
+        prop_assert_eq!(forward, reversed);
     }
 }
 

--- a/crates/manifest/tests/membound.rs
+++ b/crates/manifest/tests/membound.rs
@@ -10,10 +10,11 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::{Result, ensure};
+use arbitrary::Unstructured;
 use bytes::Bytes;
 use nectar_manifest::{
     ApplyError, BuildStats, Builder, Changeset, Entry, Key, KeyId, Metadata, Reader, V1, apply,
-    recanonicalize,
+    generators, recanonicalize,
 };
 use nectar_primitives::store::{ChunkGet, MemoryStore};
 use nectar_primitives::{
@@ -390,6 +391,32 @@ proptest! {
             // A wide/heavy merge that cannot fit a node reports a typed error.
             Err(ApplyError::Build(_) | ApplyError::Store(_)) => {}
             Err(other) => prop_assert!(false, "unexpected apply error: {:?}", other),
+        }
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    // The single-chunk invariant at the chain regime: low-entropy keys whose
+    // shared runs cross PLEN_MAX chain forks over multiple levels, and no
+    // emitted node exceeds one chunk body.
+    #[test]
+    fn no_built_chain_node_exceeds_budget(
+        seed in prop::collection::vec(any::<u8>(), 0..4096),
+    ) {
+        let mut u = Unstructured::new(&seed);
+        let rows = generators::chain_rows::<V1>(&mut u)
+            .map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let store = MemoryStore::default();
+        let mut builder = Builder::<V1>::new();
+        for (key, entry, meta) in rows {
+            builder.insert(key, entry, meta);
+        }
+        let built = run(builder.build(&store));
+        prop_assert!(built.is_ok(), "a chain set must pack, not error: {built:?}");
+        for len in chunk_lengths(&store) {
+            prop_assert!(len <= DEFAULT_BODY_SIZE, "built chain node over one chunk body");
         }
     }
 }

--- a/crates/manifest/tests/scan.rs
+++ b/crates/manifest/tests/scan.rs
@@ -9,8 +9,9 @@ use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::{Result, ensure};
+use arbitrary::Unstructured;
 use bytes::Bytes;
-use nectar_manifest::{Builder, Cursor, Entry, Format, Key, Reader, V1};
+use nectar_manifest::{Builder, Cursor, Entry, Format, Key, Reader, V1, generators};
 use nectar_primitives::store::{ChunkGet, MemoryStore};
 use nectar_primitives::{Chunk, ChunkAddress, StandardChunkSet, Verified};
 use nectar_testing::run;
@@ -310,6 +311,55 @@ proptest! {
             let value = Entry::inline(Bytes::from(vec![fill; 32]))
                 .map_err(|e| TestCaseError::fail(e.to_string()))?;
             oracle.insert(key, value);
+        }
+        let store = MemoryStore::default();
+        let mut builder = Builder::new();
+        for (key, value) in &oracle {
+            builder.insert(Key::from(key.clone()), value.clone(), None);
+        }
+        let built = run(builder.build(&store))
+            .map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let reader: Reader<_> = Reader::new(&store);
+        let got: Rows = {
+            let mut cursor = run(reader.iter(built.root()))
+                .map_err(|e| TestCaseError::fail(e.to_string()))?;
+            let mut out = Vec::new();
+            while let Some((key, value)) = run(cursor.next())
+                .map_err(|e| TestCaseError::fail(e.to_string()))?
+            {
+                out.push((key.as_bytes().to_vec(), value));
+            }
+            out
+        };
+        let expected: Rows = oracle.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+        prop_assert_eq!(got, expected);
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    // Ordered iteration at the chain regime: low-entropy keys whose shared
+    // runs cross PLEN_MAX chain forks over multiple levels, and the cursor
+    // still returns exactly the ordered oracle across the chained edges.
+    #[test]
+    fn iteration_matches_the_oracle_across_chained_edges(
+        seed in prop::collection::vec(any::<u8>(), 0..8192),
+    ) {
+        let mut u = Unstructured::new(&seed);
+        let count = u
+            .int_in_range(0..=12usize)
+            .map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let mut oracle = Oracle::new();
+        for _ in 0..count {
+            let key = generators::chain_key::<V1>(&mut u)
+                .map_err(|e| TestCaseError::fail(e.to_string()))?;
+            let fill = u
+                .int_in_range(0..=u8::MAX)
+                .map_err(|e| TestCaseError::fail(e.to_string()))?;
+            let value = Entry::inline(Bytes::from(vec![fill; 16]))
+                .map_err(|e| TestCaseError::fail(e.to_string()))?;
+            oracle.insert(key.as_bytes().to_vec(), value);
         }
         let store = MemoryStore::default();
         let mut builder = Builder::new();

--- a/crates/mantaray/tests/legacy_differential.rs
+++ b/crates/mantaray/tests/legacy_differential.rs
@@ -337,19 +337,35 @@ fn clean_ancestor_hazard_regression() {
     assert_eq!(got, want, "the editor reproduced the clean-ancestor hazard");
 }
 
-/// Path pool for randomized scripts: split-prone stems, nested folders, the
-/// root path, and edges past the 30-byte prefix limit.
+/// Path pool for randomized scripts: split-prone stems, mid-edge splits,
+/// nested and deep folders, boundary-remove-prone parents, the root path,
+/// and long edges at and past the 30-byte prefix limit, including a pair
+/// diverging inside the long edge. Every shape is exercised by the
+/// deterministic corpora above, so the pool stays within pinned-crate
+/// support.
 const PATHS: &[&str] = &[
     "a",
     "ab",
     "abc",
+    "abcdef",
+    "abcxyz",
     "app.js",
     "app.js.map",
+    "app.js.map.gz",
     "index.html",
     "img/1.png",
     "img/2.png",
+    "img/3.png",
     "img/sub/deep.png",
+    "d/x",
+    "d/y",
+    "da",
     "dir/sub/file00.dat",
+    "dir/sub/file01.dat",
+    "a/b/c/d/e/f/g/h/file00.dat",
+    "a/b/c/x.txt",
+    "oneverylongpathsegmentthatexceedsthethirtybyteprefixlimitforsure",
+    "oneverylongpathsegmentthatexceedsthethirtybyteprefixlimitforsurely",
     "oneverylongpathsegmentthatexceedsthethirtybyteprefixlimitforsure/x",
     "/",
 ];


### PR DESCRIPTION
## What
Adds chain-regime proptest strategy arms for the manifest test suite, each in its own in-file `ProptestConfig::with_cases(64)` block, bridged through the parent branch's `nectar_manifest::generators` module (`chain_rows`, `chain_key`, `diverging_pair`, `chain_threshold`) via `arbitrary::Unstructured`.
`crates/manifest/tests/determinism.rs` gains `chained_edges_pack_history_independently`: deduped chain rows plus a diverging pair whose shared run is drawn `PLEN_MAX..=chain_threshold(3)`, built through the public `Builder` forward and reversed, asserting identical root and byte-identical chunk sets.
`crates/manifest/tests/membound.rs` gains `no_built_chain_node_exceeds_budget`: the single-chunk invariant over chain rows.
`crates/manifest/tests/scan.rs` gains `iteration_matches_the_oracle_across_chained_edges`: ordered-oracle iteration over chain keys through the cursor.
`crates/mantaray/tests/legacy_differential.rs` extends the `PATHS` pool with mid-edge-split, deep-folder, boundary-remove-prone, and long-edge-diverging-pair entries, reusing the deterministic corpora's existing path vocabulary.
Also touches `crates/manifest/src/packing.rs` (unit tests), `crates/manifest/Cargo.toml` (self dev-dependency), and `Cargo.lock`.
This removes epic #443 drift-register row for chain-regime coverage while preserving the other rows untouched.

## Why
Closes the chain-regime gap left after #437 landed the generator primitives: shared key runs crossing `PLEN_MAX` were previously untested for pack-order independence, node-size budget, and ordered iteration.
This PR is stacked on the `t443/437-regime-generators` branch and merges after its parent; GitHub will retarget onto `main` automatically once the parent merges.

## Testing
All commands run in a fresh detached worktree at `origin/t443/441-manifest-regimes` (89940163), toolchain Rust 1.94.0 via the repo devshell (matches the CI pin).
`cargo fmt --all -- --check`: the branch's five touched `.rs` files are fmt-clean (verified individually with rustfmt 1.8.0-stable `--check`). The full-workspace run flags one pre-existing diff in `crates/file/src/split/handoff.rs`, code already on `main` via PR #431 and byte-identical on the base branch; this repo has no CI fmt job, so it is latent on `main` and out of scope for this branch.
`cargo clippy --locked --all-targets` and the new proptest suites were run against the branch; adversarial review found nothing to fix: no duplication (new arms bridge through the parent's generators module, the two new file-local helpers in `determinism.rs` have no pre-existing equivalent, `apply.rs`'s separate `Parts` strategies are drift-register row 1, and the legacy pool extension reuses the deterministic corpora's path vocabulary), and no weakened assertions (purely additive).

## AI Assistance
Implemented and reviewed with Claude (Anthropic).

Closes #441

