### PR TITLE
test(primitives): run encrypted-ref arbitrary impls in the unit lane

### DIFF
--- a/crates/primitives/src/chunk/encryption/key.rs
+++ b/crates/primitives/src/chunk/encryption/key.rs
@@ -83,7 +83,7 @@ impl TryFrom<&[u8]> for EncryptionKey {
     }
 }
 
-#[cfg(feature = "arbitrary")]
+#[cfg(any(test, feature = "arbitrary"))]
 impl<'a> arbitrary::Arbitrary<'a> for EncryptionKey {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self(<[u8; Self::SIZE] as arbitrary::Arbitrary>::arbitrary(

--- a/crates/primitives/src/chunk/encryption/reference.rs
+++ b/crates/primitives/src/chunk/encryption/reference.rs
@@ -136,7 +136,7 @@ impl Reference for EncryptedChunkRef {
     }
 }
 
-#[cfg(feature = "arbitrary")]
+#[cfg(any(test, feature = "arbitrary"))]
 impl<'a> arbitrary::Arbitrary<'a> for EncryptedChunkRef {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self::new(


### PR DESCRIPTION
## What

Widen the `Arbitrary` impl gates on `EncryptionKey` (`crates/primitives/src/chunk/encryption/key.rs`) and `EncryptedChunkRef` (`crates/primitives/src/chunk/encryption/reference.rs`) from `#[cfg(feature = "arbitrary")]` to `#[cfg(any(test, feature = "arbitrary"))]`, one line each, aligning them with the convention already used by every sibling generator (`ChunkRef`, `ContentChunk`, `ChunkAddress`, and others).

These were the only bare `feature = "arbitrary"` gates left in shipped src (verified by sweeping every `crates/*/src` file); the canonical `stamp_encode_decode_round_trip` row and its `seed_replay_stamp_decode` sibling were already resolved on `main` by PRs #453 and #456 and are preserved as-is here, no changes to `crates/postage`.

## Why

The rest of the codebase's `Arbitrary` impls run in the default `std` unit test lane via the `any(test, feature = "arbitrary")` gate, but these two encrypted-ref impls were left on the bare `arbitrary` feature, so their generators (and any test exercising them) silently did not compile or run without that feature enabled. This was the only remaining substance of #457 after auditing every `crates/*/src` file for `arbitrary` cfg gating.

## Testing

Full battery re-run in the worktree under `nix develop` (cargo 1.94.0, rustc 1.94.0, nextest 0.9.124, the CI-pinned toolchain).

## AI Assistance

Implemented with Claude Opus 4.8 and Claude Sonnet 5 (Claude Code).

Closes #457

