### PR TITLE
swarms/contracts: close coverage-audit tail with proptest module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2096,7 +2096,6 @@ version = "0.4.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
- "proptest",
  "serde",
 ]
 
@@ -2334,7 +2333,6 @@ dependencies = [
  "alloy-chains",
  "num_enum",
  "proptest",
- "proptest-arbitrary-interop",
  "serde",
  "strum 0.28.0",
 ]

--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -25,9 +25,6 @@ alloy-sol-types = { workspace = true }
 # optional
 serde = { workspace = true, optional = true }
 
-[dev-dependencies]
-proptest = { workspace = true }
-
 [features]
 default = [ "std" ]
 std = [ "alloy-primitives/std", "alloy-sol-types/std", "serde?/std" ]

--- a/crates/swarms/Cargo.toml
+++ b/crates/swarms/Cargo.toml
@@ -27,7 +27,6 @@ serde = { workspace = true, optional = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
-proptest-arbitrary-interop = { workspace = true }
 
 [features]
 default = [ "std" ]

--- a/crates/swarms/src/swarm.rs
+++ b/crates/swarms/src/swarm.rs
@@ -276,3 +276,27 @@ mod tests {
         assert_ne!(swarm, 5678u64);
     }
 }
+
+#[cfg(test)]
+mod proptests {
+    use super::*;
+    use proptest::prelude::*;
+    use strum::IntoEnumIterator;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        /// `id()` recovers the input regardless of the named/unchecked branch.
+        #[test]
+        fn from_id_recovers_id(id in any::<u64>()) {
+            prop_assert_eq!(Swarm::from_id(id).id(), id);
+        }
+
+        /// A named id classifies back to its own named swarm, not an unchecked id.
+        #[test]
+        fn from_id_recognizes_named(index in 0usize..NamedSwarm::iter().count()) {
+            let named = NamedSwarm::iter().nth(index).unwrap();
+            prop_assert_eq!(Swarm::from_id(named.id()).named(), Some(named));
+        }
+    }
+}


### PR DESCRIPTION
## What

Closes out the swarms/contracts coverage-audit tail from epic #443: adds a src-side `#[cfg(test)] mod proptests` to `crates/swarms/src/swarm.rs` with `ProptestConfig::with_cases(256)`, covering two invariants: `from_id_recovers_id` pins `Swarm::from_id(id).id() == id` for `any::<u64>()`, and `from_id_recognizes_named` pins `Swarm::from_id(named.id()).named() == Some(named)` for every `NamedSwarm` via `NamedSwarm::iter()`. Drops the now-unused `proptest-arbitrary-interop` dev-dep from `crates/swarms/Cargo.toml` (proptest itself is retained and used) and the wholly-unused `proptest` dev-dep from `crates/contracts/Cargo.toml`, removing its now-empty `[dev-dependencies]` section. `Cargo.lock` regenerated offline and committed.

This removes the swarms and contracts rows from the #443 coverage-audit drift register; no other rows are touched.

## Why

`Swarm::from_id` has a named/unchecked branch split that was previously untested at the property level; these two proptests pin the round-trip and classification invariants across the whole `u64` space and every `NamedSwarm` variant. The dropped dev-deps were unused and were flagged by the same audit.

## Testing

Independently verified in a fresh detached worktree inside the pinned `nix develop` shell (cargo 1.94.0, nextest 0.9.124, clippy 0.1.94), no mechanical fixes needed:

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --all-targets --locked` for `nectar-swarms` and `nectar-contracts` (default and `--all-features`): clean, zero warnings.
- `nextest` per touched crate across the same feature shapes: green.

## AI Assistance

Implemented and reviewed with Claude (Anthropic).

Closes #460
