### PR TITLE
manifest: convert in-loop executor sites to single executor

### DIFF
--- a/crates/manifest/src/apply.rs
+++ b/crates/manifest/src/apply.rs
@@ -769,6 +769,9 @@ fn common_prefix(a: &[u8], b: &[u8]) -> usize {
 
 #[cfg(test)]
 mod tests {
+    use core::future::Future;
+    use core::pin::Pin;
+
     use nectar_primitives::store::MemoryStore;
     use nectar_primitives::{ChunkAddress, ChunkRef};
     use nectar_testing::run;
@@ -785,27 +788,34 @@ mod tests {
 
     // Walk the counted tree, asserting every stored referenced-child count
     // equals the walked subtree size, and return the subtree's key count.
-    fn walk_counts(store: &MemoryStore, table: &ForkTable<V1>) -> u64 {
-        let mut total = 0u64;
-        for (_, record) in table.iter() {
-            let child = match record.child() {
-                None => 0,
-                Some(Child::Embedded(inner)) => walk_counts(store, inner),
-                Some(Child::Ref32(reference)) => {
-                    let node = run(store.get_node::<V1>(reference.address())).unwrap();
-                    let actual = walk_counts(store, node.forks());
-                    assert_eq!(
-                        record.child_count(),
-                        Some(SubtreeCount::new(actual)),
-                        "stored count must equal the walked subtree size"
-                    );
-                    actual
-                }
-                Some(Child::Ref64(_)) => unreachable!("a plaintext build has no encrypted child"),
-            };
-            total += u64::from(record.entry().is_some()) + child;
-        }
-        total
+    fn walk_counts<'a>(
+        store: &'a MemoryStore,
+        table: &'a ForkTable<V1>,
+    ) -> Pin<Box<dyn Future<Output = u64> + 'a>> {
+        Box::pin(async move {
+            let mut total = 0u64;
+            for (_, record) in table.iter() {
+                let child = match record.child() {
+                    None => 0,
+                    Some(Child::Embedded(inner)) => walk_counts(store, inner).await,
+                    Some(Child::Ref32(reference)) => {
+                        let node = store.get_node::<V1>(reference.address()).await.unwrap();
+                        let actual = walk_counts(store, node.forks()).await;
+                        assert_eq!(
+                            record.child_count(),
+                            Some(SubtreeCount::new(actual)),
+                            "stored count must equal the walked subtree size"
+                        );
+                        actual
+                    }
+                    Some(Child::Ref64(_)) => {
+                        unreachable!("a plaintext build has no encrypted child")
+                    }
+                };
+                total += u64::from(record.entry().is_some()) + child;
+            }
+            total
+        })
     }
 
     #[test]
@@ -824,7 +834,7 @@ mod tests {
         }
         let root = *run(builder.build(&store)).unwrap().root();
         let node = run(store.get_node::<V1>(&root)).unwrap();
-        let total = u64::from(node.entry().is_some()) + walk_counts(&store, node.forks());
+        let total = u64::from(node.entry().is_some()) + run(walk_counts(&store, node.forks()));
         assert_eq!(total, expected);
     }
 
@@ -854,7 +864,7 @@ mod tests {
 
         // The applied tree's stored counts still equal the walked subtree sizes.
         let node = run(store.get_node::<V1>(&applied)).unwrap();
-        let total = u64::from(node.entry().is_some()) + walk_counts(&store, node.forks());
+        let total = u64::from(node.entry().is_some()) + run(walk_counts(&store, node.forks()));
         assert_eq!(total, 64);
     }
 

--- a/crates/manifest/src/reader.rs
+++ b/crates/manifest/src/reader.rs
@@ -648,17 +648,21 @@ mod tests {
         // as the prefix range walked from the manifest root.
         let mut delegated = Vec::new();
         let mut cursor = run(reader.iter(sub.address())).unwrap();
-        while let Some((key, value)) = run(cursor.next()).unwrap() {
-            let mut full = b"mg/".to_vec();
-            full.extend_from_slice(key.as_bytes());
-            delegated.push((full, value));
-        }
+        run(async {
+            while let Some((key, value)) = cursor.next().await.unwrap() {
+                let mut full = b"mg/".to_vec();
+                full.extend_from_slice(key.as_bytes());
+                delegated.push((full, value));
+            }
+        });
 
         let mut walked = Vec::new();
         let mut cursor = run(reader.prefix(&root, &Key::from(&b"mg/"[..]))).unwrap();
-        while let Some((key, value)) = run(cursor.next()).unwrap() {
-            walked.push((key.as_bytes().to_vec(), value));
-        }
+        run(async {
+            while let Some((key, value)) = cursor.next().await.unwrap() {
+                walked.push((key.as_bytes().to_vec(), value));
+            }
+        });
         assert_eq!(delegated, walked);
     }
 


### PR DESCRIPTION
## What

Focused #422 pass over `crates/manifest/src`, converting the three in-loop executor-entry sites so each loop drives a single executor instead of one per iteration.

In `apply.rs`, the `walk_counts` counted-walk test oracle becomes an async recursive helper (`Pin<Box<dyn Future<Output = u64>>>`, boxed via `Box::pin` to allow the recursion) awaited once via `run(...)` at each of its two call sites; the per-node `store.get_node` calls inside it are now `.await` within that single executor. `use core::future::Future; use core::pin::Pin;` was added to the `apply` test module.

In `reader.rs`, the two `subtree_covers_exactly_the_prefix_key_set` cursor loops (formerly `while let Some(..) = run(cursor.next()).unwrap()`, one `run()` per iteration) are each wrapped as `run(async { while let Some(..) = cursor.next().await.unwrap() { .. } })`.

No other sites in the crate were touched; Cargo.lock did not move. This removes drift-register row 1 in the epic #443 tracker (the two files' in-loop-executor findings) and leaves the other rows untouched.

## Why

Each loop iteration previously spun up its own executor via `run(...)`; that is wasted setup/teardown per iteration and the pattern #422 is burning down crate by crate. Converting to a single `async` block/recursive future driven by one `run(...)` call removes the per-iteration executor without changing any test assertion.

## Testing

Verified independently (tip `3a8a370b`, merge-base `origin/main@0261389`), toolchain via `nix develop` (cargo 1.94.0, cargo-nextest 0.9.124, rustfmt 1.8.0):

- `cargo fmt --all -- --check`: clean.
- `cargo clippy -p nectar-manifest --all-targets --locked`: exit 0 (two pre-existing doc-warnings come from the `nectar-testing` dependency, not from this branch).
- `cargo nextest run -p nectar-manifest`: default 168 passed, `encryption` feature 175 passed, `--all-features` 175 passed, 0 failed, no hang.
- Whole-workspace default `cargo nextest run`: 949 passed / 1 skipped / 0 failed.
- `cargo test --doc -p nectar-manifest`: 5 passed.
- `cargo metadata --locked` in sync (no Cargo.toml/feature/fuzz changes, so rv64 no_std and fuzz metadata gates are not applicable).

Guardrails held: test list byte-identical to main (168), assertion-line and `#[test]` counts unchanged (apply 25/20, reader 19/12, before and after), the async boxed-future `walk_counts` recursion ran green in 0.23s without hanging.

## AI Assistance

Implemented and reviewed with Claude (Anthropic).
