### PR TITLE
mantaray: consolidate in-loop block_on into single-executor run

### DIFF
--- a/crates/mantaray/src/codec.rs
+++ b/crates/mantaray/src/codec.rs
@@ -1057,22 +1057,25 @@ mod tests {
     fn encode_decode_round_trip() {
         let mut n = Node::<ChunkRef>::new_unencrypted();
 
-        for entry in test_entries() {
-            let path = entry.path.as_bytes();
-            let e = {
-                let mut buf = [0u8; 32];
-                let len = path.len().min(32);
-                buf[32 - len..].copy_from_slice(&path[..len]);
-                ChunkRef::from(ChunkAddress::from(buf))
-            };
-            nectar_testing::run(n.add::<
-                nectar_primitives::store::NullLoader,
-                { nectar_primitives::bmt::DEFAULT_BODY_SIZE },
-            >(
-                path, Some(e), entry.metadata, &nectar_primitives::store::NullLoader,
-            ))
-            .unwrap();
-        }
+        nectar_testing::run(async {
+            for entry in test_entries() {
+                let path = entry.path.as_bytes();
+                let e = {
+                    let mut buf = [0u8; 32];
+                    let len = path.len().min(32);
+                    buf[32 - len..].copy_from_slice(&path[..len]);
+                    ChunkRef::from(ChunkAddress::from(buf))
+                };
+                n.add::<
+                    nectar_primitives::store::NullLoader,
+                    { nectar_primitives::bmt::DEFAULT_BODY_SIZE },
+                >(
+                    path, Some(e), entry.metadata, &nectar_primitives::store::NullLoader,
+                )
+                .await
+                .unwrap();
+            }
+        });
 
         // assign deterministic references to forks so encoding works
         for (counter, fork) in n.forks.values_mut().enumerate() {

--- a/crates/mantaray/src/node.rs
+++ b/crates/mantaray/src/node.rs
@@ -1430,21 +1430,23 @@ mod tests {
         run_add_and_lookup_node(&test_case_data()[5].items);
     }
 
-    fn run_add_and_lookup_with_load_save(items: &[&str]) {
+    async fn run_add_and_lookup_with_load_save(items: &[&str]) {
         let mut n = Node::default();
 
         for c in items {
             let e = make_entry(c);
-            node_add(&mut n, c.as_bytes(), e, BTreeMap::new());
+            n.add::<NullLoader, BS>(c.as_bytes(), Some(e), BTreeMap::new(), &NL)
+                .await
+                .unwrap();
         }
 
         let store = MemoryStore::<StandardChunkSet>::new();
-        run(n.save(&store)).unwrap();
+        n.save(&store).await.unwrap();
 
         let mut n2: Node = Node::from_reference(*n.reference().unwrap());
 
         for &d in items {
-            let node = run(n2.lookup_node(d.as_bytes(), &store)).unwrap();
+            let node = n2.lookup_node(d.as_bytes(), &store).await.unwrap();
             assert!(node.is_value());
             assert_eq!(node.entry(), Some(&make_entry(d)));
         }
@@ -1477,32 +1479,44 @@ mod tests {
 
     #[test]
     fn add_and_lookup_with_load_save_a() {
-        run_add_and_lookup_with_load_save(&test_case_data()[0].items);
+        run(async {
+            run_add_and_lookup_with_load_save(&test_case_data()[0].items).await;
+        });
     }
 
     #[test]
     fn add_and_lookup_with_load_save_simple() {
-        run_add_and_lookup_with_load_save(&test_case_data()[1].items);
+        run(async {
+            run_add_and_lookup_with_load_save(&test_case_data()[1].items).await;
+        });
     }
 
     #[test]
     fn add_and_lookup_with_load_save_nested_value() {
-        run_add_and_lookup_with_load_save(&test_case_data()[2].items);
+        run(async {
+            run_add_and_lookup_with_load_save(&test_case_data()[2].items).await;
+        });
     }
 
     #[test]
     fn add_and_lookup_with_load_save_nested_prefix() {
-        run_add_and_lookup_with_load_save(&test_case_data()[3].items);
+        run(async {
+            run_add_and_lookup_with_load_save(&test_case_data()[3].items).await;
+        });
     }
 
     #[test]
     fn add_and_lookup_with_load_save_conflicting_path() {
-        run_add_and_lookup_with_load_save(&test_case_data()[4].items);
+        run(async {
+            run_add_and_lookup_with_load_save(&test_case_data()[4].items).await;
+        });
     }
 
     #[test]
     fn add_and_lookup_with_load_save_spa_website() {
-        run_add_and_lookup_with_load_save(&test_case_data()[5].items);
+        run(async {
+            run_add_and_lookup_with_load_save(&test_case_data()[5].items).await;
+        });
     }
 
     fn run_remove(tc: RemoveTestCase) {
@@ -1562,30 +1576,32 @@ mod tests {
 
     // Tests save->reload->remove->save->reload->verify-removed cycle.
 
-    fn run_persist_remove(tc: RemoveTestCase) {
+    async fn run_persist_remove(tc: RemoveTestCase) {
         let store = MemoryStore::<StandardChunkSet>::new();
 
         // add entries and persist
         let mut n = Node::default();
         for c in &tc.items {
             let e = make_entry(&c.path);
-            run(n.add(c.path.as_bytes(), Some(e), c.metadata.clone(), &store)).unwrap();
+            n.add(c.path.as_bytes(), Some(e), c.metadata.clone(), &store)
+                .await
+                .unwrap();
         }
-        run(n.save(&store)).unwrap();
+        n.save(&store).await.unwrap();
         let ref_ = *n.reference().unwrap();
 
         // reload and remove
         let mut nn: Node = Node::from_reference(ref_);
         for path in &tc.remove {
-            run(nn.remove(path.as_bytes(), &store)).unwrap();
+            nn.remove(path.as_bytes(), &store).await.unwrap();
         }
-        run(nn.save(&store)).unwrap();
+        nn.save(&store).await.unwrap();
         let ref2 = *nn.reference().unwrap();
 
         // reload and verify removed paths are gone
         let mut nnn: Node = Node::from_reference(ref2);
         for path in &tc.remove {
-            let result = run(nnn.lookup_node(path.as_bytes(), &store));
+            let result = nnn.lookup_node(path.as_bytes(), &store).await;
             assert!(
                 result.is_err(),
                 "expected removed path '{path}' to be not found"
@@ -1595,12 +1611,16 @@ mod tests {
 
     #[test]
     fn persist_remove_simple() {
-        run_persist_remove(remove_test_case_data()[0].clone());
+        run(async {
+            run_persist_remove(remove_test_case_data()[0].clone()).await;
+        });
     }
 
     #[test]
     fn persist_remove_nested_prefix() {
-        run_persist_remove(remove_test_case_data()[1].clone());
+        run(async {
+            run_persist_remove(remove_test_case_data()[1].clone()).await;
+        });
     }
 
     fn make_entry_bytes(s: &[u8]) -> ChunkRef {

--- a/crates/mantaray/src/reader.rs
+++ b/crates/mantaray/src/reader.rs
@@ -246,23 +246,19 @@ mod tests {
     }
 
     /// Build a persisted manifest over the paths through the editor.
-    fn build(paths: &[&str]) -> (ChunkAddress, Store) {
+    async fn build(paths: &[&str]) -> (ChunkAddress, Store) {
         let mut editor: ManifestEditor<Store> = ManifestEditor::new(Store::new());
         for &p in paths {
             editor.put(p, make_addr(p));
         }
-        run(editor.commit()).unwrap()
+        editor.commit().await.unwrap()
     }
 
     /// Build a persisted manifest, then check the reader against the
     /// path-set model over the same store: a get hits exactly the stored
     /// paths, a prefix probe hits exactly the stored extensions.
     async fn assert_model(paths: &[&str]) {
-        let mut editor: ManifestEditor<Store> = ManifestEditor::new(Store::new());
-        for &p in paths {
-            editor.put(p, make_addr(p));
-        }
-        let (root, store) = editor.commit().await.unwrap();
+        let (root, store) = build(paths).await;
         let reader = Reader::new(store);
         for probe in probes(paths) {
             let got = reader.get(&root, probe.as_bytes()).await.unwrap();
@@ -382,7 +378,7 @@ mod tests {
 
     #[test]
     fn fetch_costs_are_depth_bounded() {
-        let (root, store) = build(&["abc"]);
+        let (root, store) = run(build(&["abc"]));
         let reader = Reader::new(CountingStore::new(store));
 
         // Value hit: root plus the terminal node.
@@ -404,7 +400,7 @@ mod tests {
     #[test]
     fn fetch_costs_stay_linear_in_path_length() {
         let paths = ["a", "ab", "abc", "abcd", "abcde"];
-        let (root, store) = build(&paths);
+        let (root, store) = run(build(&paths));
         let reader = Reader::new(CountingStore::new(store));
 
         run(async {
@@ -426,7 +422,7 @@ mod tests {
     #[test]
     fn max_depth_is_a_typed_error() {
         // One-byte edge chain: get("abcde") costs 6 fetches, has_prefix 5.
-        let (root, store) = build(&["a", "ab", "abc", "abcd", "abcde"]);
+        let (root, store) = run(build(&["a", "ab", "abc", "abcd", "abcde"]));
 
         let exact = Reader::with_max_depth(store, 6);
         assert!(run(exact.get(&root, b"abcde")).unwrap().is_some());
@@ -457,7 +453,7 @@ mod tests {
 
     #[test]
     fn empty_path_is_not_a_value() {
-        let (root, store) = build(&["a"]);
+        let (root, store) = run(build(&["a"]));
         let reader = Reader::new(store);
         assert_eq!(run(reader.get(&root, b"")).unwrap(), None);
     }

--- a/crates/mantaray/src/reader.rs
+++ b/crates/mantaray/src/reader.rs
@@ -257,11 +257,15 @@ mod tests {
     /// Build a persisted manifest, then check the reader against the
     /// path-set model over the same store: a get hits exactly the stored
     /// paths, a prefix probe hits exactly the stored extensions.
-    fn assert_model(paths: &[&str]) {
-        let (root, store) = build(paths);
+    async fn assert_model(paths: &[&str]) {
+        let mut editor: ManifestEditor<Store> = ManifestEditor::new(Store::new());
+        for &p in paths {
+            editor.put(p, make_addr(p));
+        }
+        let (root, store) = editor.commit().await.unwrap();
         let reader = Reader::new(store);
         for probe in probes(paths) {
-            let got = run(reader.get(&root, probe.as_bytes())).unwrap();
+            let got = reader.get(&root, probe.as_bytes()).await.unwrap();
             assert_eq!(
                 got.is_some(),
                 paths.contains(&probe.as_str()),
@@ -274,7 +278,7 @@ mod tests {
                     "reference for {probe:?}"
                 );
             }
-            let has = run(reader.has_prefix(&root, probe.as_bytes())).unwrap();
+            let has = reader.has_prefix(&root, probe.as_bytes()).await.unwrap();
             let want_has = probe.is_empty() || paths.iter().any(|p| p.starts_with(&probe));
             assert_eq!(has, want_has, "has_prefix({probe:?})");
         }
@@ -282,37 +286,41 @@ mod tests {
 
     #[test]
     fn get_and_has_prefix_match_the_path_set_model() {
-        for paths in corpora() {
-            assert_model(&paths);
-        }
+        run(async {
+            for paths in corpora() {
+                assert_model(&paths).await;
+            }
+        });
     }
 
     #[test]
     fn encrypted_trie_lookups_return_the_stored_references() {
-        let paths = ["secret/a.txt", "secret/b.txt", "top.txt"];
-        let key = EncryptionKey::from([0x5a; 32]);
-        let mut editor: ManifestEditor<Store, EncryptedChunkRef> =
-            ManifestEditor::new_encrypted(Store::new());
-        for p in paths {
-            editor.put(p, EncryptedChunkRef::new(make_addr(p), key.clone()));
-        }
-        let (manifest_ref, store) = run(editor.commit()).unwrap();
-        let (root, _key) = manifest_ref.into_parts();
-
-        let reader = Reader::new(store);
-        for p in paths {
-            let got = run(reader.get(&root, p.as_bytes())).unwrap().unwrap();
-            match got.reference() {
-                Some(EntryRef::Encrypted(reference)) => {
-                    assert_eq!(reference.address(), &make_addr(p), "address for {p:?}");
-                    assert_eq!(reference.key(), &key, "key for {p:?}");
-                }
-                other => panic!("encrypted get({p:?}) returned {other:?}"),
+        run(async {
+            let paths = ["secret/a.txt", "secret/b.txt", "top.txt"];
+            let key = EncryptionKey::from([0x5a; 32]);
+            let mut editor: ManifestEditor<Store, EncryptedChunkRef> =
+                ManifestEditor::new_encrypted(Store::new());
+            for p in paths {
+                editor.put(p, EncryptedChunkRef::new(make_addr(p), key.clone()));
             }
-        }
-        assert!(run(reader.has_prefix(&root, b"secret/")).unwrap());
-        assert!(!run(reader.has_prefix(&root, b"secrets")).unwrap());
-        assert_eq!(run(reader.get(&root, b"secret/")).unwrap(), None);
+            let (manifest_ref, store) = editor.commit().await.unwrap();
+            let (root, _key) = manifest_ref.into_parts();
+
+            let reader = Reader::new(store);
+            for p in paths {
+                let got = reader.get(&root, p.as_bytes()).await.unwrap().unwrap();
+                match got.reference() {
+                    Some(EntryRef::Encrypted(reference)) => {
+                        assert_eq!(reference.address(), &make_addr(p), "address for {p:?}");
+                        assert_eq!(reference.key(), &key, "key for {p:?}");
+                    }
+                    other => panic!("encrypted get({p:?}) returned {other:?}"),
+                }
+            }
+            assert!(reader.has_prefix(&root, b"secret/").await.unwrap());
+            assert!(!reader.has_prefix(&root, b"secrets").await.unwrap());
+            assert_eq!(reader.get(&root, b"secret/").await.unwrap(), None);
+        });
     }
 
     #[test]
@@ -399,18 +407,20 @@ mod tests {
         let (root, store) = build(&paths);
         let reader = Reader::new(CountingStore::new(store));
 
-        for p in paths {
-            assert!(run(reader.get(&root, p.as_bytes())).unwrap().is_some());
-            assert!(
-                reader.store().take() <= p.len() + 1,
-                "get({p:?}) exceeded the depth bound"
-            );
-            assert!(run(reader.has_prefix(&root, p.as_bytes())).unwrap());
-            assert!(
-                reader.store().take() <= p.len(),
-                "has_prefix({p:?}) exceeded the depth bound"
-            );
-        }
+        run(async {
+            for p in paths {
+                assert!(reader.get(&root, p.as_bytes()).await.unwrap().is_some());
+                assert!(
+                    reader.store().take() <= p.len() + 1,
+                    "get({p:?}) exceeded the depth bound"
+                );
+                assert!(reader.has_prefix(&root, p.as_bytes()).await.unwrap());
+                assert!(
+                    reader.store().take() <= p.len(),
+                    "has_prefix({p:?}) exceeded the depth bound"
+                );
+            }
+        });
     }
 
     #[test]


### PR DESCRIPTION
## What
Converts all in-loop, per-iteration `block_on` sites in `crates/mantaray/src/{codec.rs,node.rs,reader.rs}` to single-executor `run(async { .. })` shapes, so each affected test makes one executor entry instead of one per element.

- `codec.rs`: `encode_decode_round_trip`'s for-entry add loop now runs inside one `run(async{})` with `.await`.
- `node.rs`: `run_add_and_lookup_with_load_save` and `run_persist_remove` are now async fns (internal `run()` calls become `.await`); their `#[test]` callers wrap the call in `run(async{ helper(..).await })`.
- `reader.rs`: `assert_model` is now async; `get_and_has_prefix_match_the_path_set_model` wraps its corpora loop in one `run`; `encrypted_trie_lookups_return_the_stored_references` and `fetch_costs_stay_linear_in_path_length` have their bodies/loops wrapped in `run(async{})` (with `build()` kept outside the loop in the latter). `build` was also made async and awaited in `assert_model`, avoiding a hand-rolled duplicate of the live `build` fixture helper.

This preserves epic #443's drift-register row for the `assert_model`/`build` duplication hazard by removing the duplicate copy rather than tracking it as accepted drift.

No production code, `Cargo.toml`, feature flags, or lockfile are touched; this is a test-only refactor.

## Why
`nectar_testing::run` is `futures_executor::block_on`, which panics on re-entry (`EnterError`). Calling it once per loop iteration works but is unnecessarily heavy and risks accidental nesting as tests grow; consolidating to a single `run(async { .. })` per test/helper removes that hazard for #422.

## Testing
Independent verification on HEAD `7477eb3d` (based on `origin/main`), toolchain `cargo 1.94.0` via `nix develop` (flake pins rust 1.94, matching CI), all commands run `--locked`:

- `cargo fmt --all -- --check`: clean.
- `cargo clippy -p nectar-mantaray@0.4.0 --all-targets --locked`: exit 0, no warnings in the touched crate.
- All 129 `nectar-mantaray` tests pass.

Test and assertion counts are unchanged per file (codec.rs 30/30 tests, 55/55 asserts; node.rs 34/34 tests, 41/41 asserts; reader.rs 9/9 tests, 40/40 asserts). No excluded files touched, no feature/cfg/lock drift, no new allow headers.

## AI Assistance
Implemented and reviewed with Claude (Anthropic).
