### PR TITLE
test(file): share one executor per loop in reader/split tests

### DIFF
--- a/crates/file/src/read/tests.rs
+++ b/crates/file/src/read/tests.rs
@@ -80,15 +80,28 @@ fn plain_reader_matches_the_source_bytes() {
     for len in edge_sizes() {
         let data = fill(len);
         let (root, store) = split_fixture::<TINY>(&data);
-        for window in [1u16, 4] {
-            let file = run(File::<_, Plain, TINY>::open(store.clone(), root)).unwrap();
-            assert_eq!(file.len(), len as u64);
-            assert_eq!(file.is_empty(), len == 0);
-            let mut reader = file.read().window(Window::new(window).unwrap()).build();
-            assert_eq!(reader.effective_len(), len as u64);
-            assert_eq!(drain_reader(&mut reader), data, "diverged at {len}");
-            assert_eq!(reader.position(), len as u64);
-        }
+        run(async {
+            for window in [1u16, 4] {
+                let file = File::<_, Plain, TINY>::open(store.clone(), root)
+                    .await
+                    .unwrap();
+                assert_eq!(file.len(), len as u64);
+                assert_eq!(file.is_empty(), len == 0);
+                let mut reader = file.read().window(Window::new(window).unwrap()).build();
+                assert_eq!(reader.effective_len(), len as u64);
+                let mut out = Vec::new();
+                let mut buf = [0u8; 97];
+                loop {
+                    let n = reader.read(&mut buf).await.unwrap();
+                    if n == 0 {
+                        break;
+                    }
+                    out.extend_from_slice(&buf[..n]);
+                }
+                assert_eq!(out, data, "diverged at {len}");
+                assert_eq!(reader.position(), len as u64);
+            }
+        });
     }
 }
 
@@ -98,16 +111,26 @@ fn encrypted_reader_matches_the_source_bytes() {
     for len in edge_sizes() {
         let data = fill(len);
         let (root_ref, store) = split_encrypted_fixture::<TINY>(&data);
-        for window in [1u16, 4] {
-            let file = run(File::<_, Encrypted, TINY>::open_encrypted(
-                store.clone(),
-                root_ref.clone(),
-            ))
-            .unwrap();
-            assert_eq!(file.len(), len as u64);
-            let mut reader = file.read().window(Window::new(window).unwrap()).build();
-            assert_eq!(drain_reader(&mut reader), data, "diverged at {len}");
-        }
+        run(async {
+            for window in [1u16, 4] {
+                let file =
+                    File::<_, Encrypted, TINY>::open_encrypted(store.clone(), root_ref.clone())
+                        .await
+                        .unwrap();
+                assert_eq!(file.len(), len as u64);
+                let mut reader = file.read().window(Window::new(window).unwrap()).build();
+                let mut out = Vec::new();
+                let mut buf = [0u8; 97];
+                loop {
+                    let n = reader.read(&mut buf).await.unwrap();
+                    if n == 0 {
+                        break;
+                    }
+                    out.extend_from_slice(&buf[..n]);
+                }
+                assert_eq!(out, data, "diverged at {len}");
+            }
+        });
     }
 }
 
@@ -186,7 +209,7 @@ fn out_of_file_ranges_clip_to_effective_length() {
     assert!(drain_reader(&mut reader).is_empty());
 }
 
-fn run_seek_script<M: WalkMode>(
+async fn run_seek_script<M: WalkMode>(
     mut reader: FileReader<TinyStore, M, TINY>,
     data: &[u8],
     label: &str,
@@ -205,15 +228,13 @@ fn run_seek_script<M: WalkMode>(
         assert_eq!(reader.position(), pos, "{label}: position after seek");
         let mut buf = vec![0u8; want];
         let mut got = 0;
-        run(async {
-            loop {
-                let n = reader.read(&mut buf[got..]).await.unwrap();
-                if n == 0 {
-                    break;
-                }
-                got += n;
+        loop {
+            let n = reader.read(&mut buf[got..]).await.unwrap();
+            if n == 0 {
+                break;
             }
-        });
+            got += n;
+        }
         let expect_end = (pos as usize + want).min(len);
         let expect = &data[(pos as usize).min(len)..expect_end];
         assert_eq!(&buf[..got], expect, "{label}: seek {pos} read {want}");
@@ -229,9 +250,7 @@ fn run_seek_script<M: WalkMode>(
     );
     reader.seek(3).unwrap();
     let mut buf = [0u8; 4];
-    run(async {
-        reader.read(&mut buf).await.unwrap();
-    });
+    reader.read(&mut buf).await.unwrap();
     assert_eq!(&buf[..], &data[3..7], "{label}: read after failed seek");
 }
 
@@ -239,8 +258,10 @@ fn run_seek_script<M: WalkMode>(
 fn seek_reads_match_oracle_slices() {
     let data = fill(21 * TINY + 100);
     let (root, store) = split_fixture::<TINY>(&data);
-    let file = run(File::<_, Plain, TINY>::open(store, root)).unwrap();
-    run_seek_script(file.read().build(), &data, "plain");
+    run(async {
+        let file = File::<_, Plain, TINY>::open(store, root).await.unwrap();
+        run_seek_script(file.read().build(), &data, "plain").await;
+    });
 }
 
 #[cfg(feature = "encryption")]
@@ -248,8 +269,12 @@ fn seek_reads_match_oracle_slices() {
 fn encrypted_seek_reads_match_oracle_slices() {
     let data = fill(21 * TINY + 100);
     let (root_ref, store) = split_encrypted_fixture::<TINY>(&data);
-    let file = run(File::<_, Encrypted, TINY>::open_encrypted(store, root_ref)).unwrap();
-    run_seek_script(file.read().build(), &data, "encrypted");
+    run(async {
+        let file = File::<_, Encrypted, TINY>::open_encrypted(store, root_ref)
+            .await
+            .unwrap();
+        run_seek_script(file.read().build(), &data, "encrypted").await;
+    });
 }
 
 #[test]

--- a/crates/file/src/read/tests.rs
+++ b/crates/file/src/read/tests.rs
@@ -56,23 +56,31 @@ fn edge_sizes() -> Vec<usize> {
     ]
 }
 
+/// Reads the reader to end, one home for the drain loop shared by the sync
+/// wrapper and the async loop tests.
+async fn drain<S, M>(reader: &mut FileReader<S, M, TINY>) -> Vec<u8>
+where
+    S: TrustedGet<AnyChunkSet<TINY>, Error = ChunkStoreError> + Clone + 'static,
+    M: WalkMode,
+{
+    let mut out = Vec::new();
+    let mut buf = [0u8; 97];
+    loop {
+        let n = reader.read(&mut buf).await.unwrap();
+        if n == 0 {
+            break;
+        }
+        out.extend_from_slice(&buf[..n]);
+    }
+    out
+}
+
 fn drain_reader<S, M>(reader: &mut FileReader<S, M, TINY>) -> Vec<u8>
 where
     S: TrustedGet<AnyChunkSet<TINY>, Error = ChunkStoreError> + Clone + 'static,
     M: WalkMode,
 {
-    run(async {
-        let mut out = Vec::new();
-        let mut buf = [0u8; 97];
-        loop {
-            let n = reader.read(&mut buf).await.unwrap();
-            if n == 0 {
-                break;
-            }
-            out.extend_from_slice(&buf[..n]);
-        }
-        out
-    })
+    run(drain(reader))
 }
 
 #[test]
@@ -89,16 +97,7 @@ fn plain_reader_matches_the_source_bytes() {
                 assert_eq!(file.is_empty(), len == 0);
                 let mut reader = file.read().window(Window::new(window).unwrap()).build();
                 assert_eq!(reader.effective_len(), len as u64);
-                let mut out = Vec::new();
-                let mut buf = [0u8; 97];
-                loop {
-                    let n = reader.read(&mut buf).await.unwrap();
-                    if n == 0 {
-                        break;
-                    }
-                    out.extend_from_slice(&buf[..n]);
-                }
-                assert_eq!(out, data, "diverged at {len}");
+                assert_eq!(drain(&mut reader).await, data, "diverged at {len}");
                 assert_eq!(reader.position(), len as u64);
             }
         });
@@ -119,16 +118,7 @@ fn encrypted_reader_matches_the_source_bytes() {
                         .unwrap();
                 assert_eq!(file.len(), len as u64);
                 let mut reader = file.read().window(Window::new(window).unwrap()).build();
-                let mut out = Vec::new();
-                let mut buf = [0u8; 97];
-                loop {
-                    let n = reader.read(&mut buf).await.unwrap();
-                    if n == 0 {
-                        break;
-                    }
-                    out.extend_from_slice(&buf[..n]);
-                }
-                assert_eq!(out, data, "diverged at {len}");
+                assert_eq!(drain(&mut reader).await, data, "diverged at {len}");
             }
         });
     }

--- a/crates/file/src/split/tests.rs
+++ b/crates/file/src/split/tests.rs
@@ -577,46 +577,48 @@ mod encrypted {
 
     #[test]
     fn encrypted_roots_read_back_with_the_pinned_tree_shape() {
-        for size in sizes() {
-            let data = fill(size);
-            // The rand-gated default source through the `Default` mode.
-            let store = TestStore::<TINY>::new(1);
-            let mut split: Split<TestStore<TINY>, Encrypted<RandomKeys>, TINY> =
-                Split::new(store.clone(), PutWindow::new(4).unwrap());
-            let root = run(async {
-                let mut buf = data.as_slice();
-                while !buf.is_empty() {
-                    let n = poll_fn(|cx| split.poll_write(cx, buf)).await.unwrap();
-                    buf = &buf[n..];
-                }
-                poll_fn(|cx| split.poll_finish(cx)).await.unwrap()
-            });
-            let mut walk: Walk<TestStore<TINY>, Encrypted, TINY> = Walk::new(
-                store,
-                *root.address(),
-                root.key().clone(),
-                size as u64,
-                0..u64::MAX,
-                Window::new(4).unwrap(),
-            );
-            let plaintext = run(async {
-                let mut bytes = Vec::new();
-                while let Some(frame) = poll_fn(|cx| walk.poll_next_ordered(cx)).await {
-                    bytes.extend_from_slice(&frame.unwrap().data);
-                }
-                bytes
-            });
-            assert_eq!(plaintext, data, "plaintext diverged at {size}");
+        run(async {
+            for size in sizes() {
+                let data = fill(size);
+                // The rand-gated default source through the `Default` mode.
+                let store = TestStore::<TINY>::new(1);
+                let mut split: Split<TestStore<TINY>, Encrypted<RandomKeys>, TINY> =
+                    Split::new(store.clone(), PutWindow::new(4).unwrap());
+                let root = {
+                    let mut buf = data.as_slice();
+                    while !buf.is_empty() {
+                        let n = poll_fn(|cx| split.poll_write(cx, buf)).await.unwrap();
+                        buf = &buf[n..];
+                    }
+                    poll_fn(|cx| split.poll_finish(cx)).await.unwrap()
+                };
+                let mut walk: Walk<TestStore<TINY>, Encrypted, TINY> = Walk::new(
+                    store,
+                    *root.address(),
+                    root.key().clone(),
+                    size as u64,
+                    0..u64::MAX,
+                    Window::new(4).unwrap(),
+                );
+                let plaintext = {
+                    let mut bytes = Vec::new();
+                    while let Some(frame) = poll_fn(|cx| walk.poll_next_ordered(cx)).await {
+                        bytes.extend_from_slice(&frame.unwrap().data);
+                    }
+                    bytes
+                };
+                assert_eq!(plaintext, data, "plaintext diverged at {size}");
 
-            let stats = split.stats();
-            assert_eq!(
-                stats.puts,
-                tree_chunks(size, TINY, ENC_BRANCHES),
-                "chunk count diverged at {size}"
-            );
-            assert_eq!(stats.bytes, size as u64);
-            assert_eq!(stats.leaves + stats.intermediates, stats.puts);
-        }
+                let stats = split.stats();
+                assert_eq!(
+                    stats.puts,
+                    tree_chunks(size, TINY, ENC_BRANCHES),
+                    "chunk count diverged at {size}"
+                );
+                assert_eq!(stats.bytes, size as u64);
+                assert_eq!(stats.leaves + stats.intermediates, stats.puts);
+            }
+        });
     }
 
     #[test]


### PR DESCRIPTION
## What
Converts the five priority-one in-loop `run()`/`block_on` sites in `crates/file` reader and split tests to share one executor entry per loop, test-only, no production code touched.
In `crates/file/src/read/tests.rs`: `plain_reader_matches_the_source_bytes` and `encrypted_reader_matches_the_source_bytes` now wrap the `for window` loop in a single `run(async { .. })`, with `File::open`/`open_encrypted` awaited inline; `run_seek_script` is now an async fn with its two internal `run()` blocks flattened to bare `.await`, and both callers (`seek_reads_match_oracle_slices`, `encrypted_seek_reads_match_oracle_slices`) wrap `open` + `run_seek_script` in one `run(async { .. }).await`.
The reader drain loop is extracted into a new async `drain` helper; `drain_reader` becomes a thin `run(drain(reader))` sync wrapper, and the two reader tests call `drain(&mut reader).await` directly from inside their shared executor entry rather than re-nesting `block_on`.
In `crates/file/src/split/tests.rs`: `encrypted_roots_read_back_with_the_pinned_tree_shape` merges its two per-iteration `run()` blocks (write+finish, then walk) into a single `run(async { for size { .. } })`.
Every assertion is preserved by value and message; this removes the epic #443 drift-register rows for these five in-loop `block_on`/`run()` sites in `crates/file`.

## Why
Priority-1 async-native pass for #422: each loop iteration was previously opening and tearing down its own executor per `run()` call, which is exactly the in-loop `block_on` shape #443 flags. Sharing one executor per loop removes that per-iteration executor churn while keeping the test bodies and their assertions identical.

## Testing
Independent verification from a fresh detached worktree at tip 699f4442 under `nix develop` (cargo 1.94.0, nextest 0.9.124, rustfmt 1.8.0):
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --locked --all-targets -p nectar-file` across all three CI feature shapes (tokio, rayon, encryption): pass, only pre-existing doc warnings emitted.
Scope confirmed test-body-only: `crates/file/src/read/tests.rs` and `crates/file/src/split/tests.rs`, no production/source files touched.

## AI Assistance
Implemented, red-teamed, and PR-drafted with Claude (Sonnet).

Part of #422

