### PR TITLE
test: convert in-loop executor sites to single-entry

### DIFF
--- a/crates/integration-tests/tests/file/membound.rs
+++ b/crates/integration-tests/tests/file/membound.rs
@@ -709,22 +709,25 @@ mod batch {
         let size = BRANCHES * BRANCHES * TINY + 999;
         let data = fill(size);
         let (streamed_root, streamed_store, _) = split_plain(&data, 4, 0);
-        for window in [1u16, 4] {
-            let store = GaugeStore::<TINY>::new(2);
-            let root = run(split_read_at::<_, _, Plain, TINY>(
-                data.clone(),
-                store.clone(),
-                PutWindow::new(window).unwrap(),
-            ))
-            .unwrap();
-            assert_eq!(root, streamed_root, "batch root diverged at {window}");
-            assert!(
-                store.puts.peak() <= usize::from(window),
-                "{} concurrent puts exceeded window {window}",
-                store.puts.peak()
-            );
-            assert_eq!(store.chunk_count(), streamed_store.chunk_count());
-        }
+        run(async {
+            for window in [1u16, 4] {
+                let store = GaugeStore::<TINY>::new(2);
+                let root = split_read_at::<_, _, Plain, TINY>(
+                    data.clone(),
+                    store.clone(),
+                    PutWindow::new(window).unwrap(),
+                )
+                .await
+                .unwrap();
+                assert_eq!(root, streamed_root, "batch root diverged at {window}");
+                assert!(
+                    store.puts.peak() <= usize::from(window),
+                    "{} concurrent puts exceeded window {window}",
+                    store.puts.peak()
+                );
+                assert_eq!(store.chunk_count(), streamed_store.chunk_count());
+            }
+        });
     }
 
     #[test]
@@ -732,40 +735,42 @@ mod batch {
         let size = BRANCHES * BRANCHES * TINY + 999;
         let data = fill(size);
         let (streamed_root, streamed_store, _) = split_plain(&data, 4, 0);
-        for (put_window, hash_window) in [(1u16, 1u16), (2, 4), (16, 8)] {
-            let store = GaugeStore::<TINY>::new(2);
-            let mut split: Split<GaugeStore<TINY>, Plain, TINY> =
-                Split::new(store.clone(), PutWindow::new(put_window).unwrap())
-                    .with_hash_window(HashWindow::new(hash_window).unwrap());
-            let root = run(async {
-                let mut buf = data.as_slice();
-                while !buf.is_empty() {
-                    let n = poll_fn(|cx| split.poll_write(cx, buf)).await.unwrap();
-                    buf = &buf[n..];
-                }
-                poll_fn(|cx| split.poll_finish(cx)).await.unwrap()
-            });
-            let stats = split.stats();
-            assert_eq!(root, streamed_root, "pooled root diverged at {put_window}");
-            assert!(
-                store.puts.peak() <= usize::from(put_window),
-                "{} concurrent puts exceeded window {put_window}",
-                store.puts.peak()
-            );
-            assert!(
-                stats.peak_put_in_flight <= usize::from(put_window),
-                "in flight {} exceeded window {put_window}",
-                stats.peak_put_in_flight
-            );
-            assert!(
-                stats.peak_hash_in_flight <= usize::from(hash_window),
-                "seals in flight {} exceeded the hash window {hash_window}",
-                stats.peak_hash_in_flight
-            );
-            assert!(stats.peak_pending <= stats.peak_spine);
-            assert_eq!(stats.bytes, size as u64);
-            assert_eq!(stats.puts, stats.leaves + stats.intermediates);
-            assert_eq!(store.chunk_count(), streamed_store.chunk_count());
-        }
+        run(async {
+            for (put_window, hash_window) in [(1u16, 1u16), (2, 4), (16, 8)] {
+                let store = GaugeStore::<TINY>::new(2);
+                let mut split: Split<GaugeStore<TINY>, Plain, TINY> =
+                    Split::new(store.clone(), PutWindow::new(put_window).unwrap())
+                        .with_hash_window(HashWindow::new(hash_window).unwrap());
+                let root = {
+                    let mut buf = data.as_slice();
+                    while !buf.is_empty() {
+                        let n = poll_fn(|cx| split.poll_write(cx, buf)).await.unwrap();
+                        buf = &buf[n..];
+                    }
+                    poll_fn(|cx| split.poll_finish(cx)).await.unwrap()
+                };
+                let stats = split.stats();
+                assert_eq!(root, streamed_root, "pooled root diverged at {put_window}");
+                assert!(
+                    store.puts.peak() <= usize::from(put_window),
+                    "{} concurrent puts exceeded window {put_window}",
+                    store.puts.peak()
+                );
+                assert!(
+                    stats.peak_put_in_flight <= usize::from(put_window),
+                    "in flight {} exceeded window {put_window}",
+                    stats.peak_put_in_flight
+                );
+                assert!(
+                    stats.peak_hash_in_flight <= usize::from(hash_window),
+                    "seals in flight {} exceeded the hash window {hash_window}",
+                    stats.peak_hash_in_flight
+                );
+                assert!(stats.peak_pending <= stats.peak_spine);
+                assert_eq!(stats.bytes, size as u64);
+                assert_eq!(stats.puts, stats.leaves + stats.intermediates);
+                assert_eq!(store.chunk_count(), streamed_store.chunk_count());
+            }
+        });
     }
 }

--- a/crates/integration-tests/tests/manifest/bridge.rs
+++ b/crates/integration-tests/tests/manifest/bridge.rs
@@ -39,37 +39,40 @@ fn pattern(size: usize) -> Bytes {
 
 #[test]
 fn streaming_bridge_pins_the_direct_split_bytes() -> Result<()> {
-    for &size in SIZES {
-        let data = pattern(size);
-        let key = Key::from(&b"file"[..]);
+    run(async {
+        for &size in SIZES {
+            let data = pattern(size);
+            let key = Key::from(&b"file"[..]);
 
-        let store = MemoryStore::default();
-        let built = run(build_files(&store, [(key.clone(), data.clone())]))?;
+            let store = MemoryStore::default();
+            let built = build_files(&store, [(key.clone(), data.clone())]).await?;
 
-        // The reference bridge: the same manifest over a direct split's
-        // reference, with the direct chunk set as the file bytes oracle.
-        let (direct_root, direct_store) = run(split_whole(&data)).map_err(|e| anyhow!("{e}"))?;
-        let node_store = MemoryStore::default();
-        let mut builder: Builder = Builder::new();
-        builder.insert(key, Entry::from(ChunkRef::new(direct_root)), None);
-        let direct_built = run(builder.build(&node_store))?;
-        ensure!(built.root() == direct_built.root(), "manifest root");
+            // The reference bridge: the same manifest over a direct split's
+            // reference, with the direct chunk set as the file bytes oracle.
+            let (direct_root, direct_store) =
+                split_whole(&data).await.map_err(|e| anyhow!("{e}"))?;
+            let node_store = MemoryStore::default();
+            let mut builder: Builder = Builder::new();
+            builder.insert(key, Entry::from(ChunkRef::new(direct_root)), None);
+            let direct_built = builder.build(&node_store).await?;
+            ensure!(built.root() == direct_built.root(), "manifest root");
 
-        let direct = direct_store.into_chunks();
-        let nodes = node_store.into_chunks();
-        for address in direct.keys() {
-            ensure!(store.get(address).is_some(), "direct-split chunk stored");
+            let direct = direct_store.into_chunks();
+            let nodes = node_store.into_chunks();
+            for address in direct.keys() {
+                ensure!(store.get(address).is_some(), "direct-split chunk stored");
+            }
+            // Exact set equality: with the file chunks and manifest nodes both
+            // pinned, no other chunk may appear.
+            for address in store.into_chunks().keys() {
+                ensure!(
+                    direct.contains_key(address) || nodes.contains_key(address),
+                    "no chunk beyond the direct split set and the manifest nodes",
+                );
+            }
         }
-        // Exact set equality: with the file chunks and manifest nodes both
-        // pinned, no other chunk may appear.
-        for address in store.into_chunks().keys() {
-            ensure!(
-                direct.contains_key(address) || nodes.contains_key(address),
-                "no chunk beyond the direct split set and the manifest nodes",
-            );
-        }
-    }
-    Ok(())
+        Ok(())
+    })
 }
 
 #[test]

--- a/crates/integration-tests/tests/manifest/builder.rs
+++ b/crates/integration-tests/tests/manifest/builder.rs
@@ -201,23 +201,25 @@ fn build_files_splits_through_bmt_and_references_the_stored_roots() -> Result<()
 
     // Each file's manifest entry is its independent BMT root, and every file
     // chunk is present in the same store.
-    for (first, tail, data) in [
-        (b'i', &b"ndex.html"[..], page),
-        (b'l', &b"ogo.png"[..], logo),
-    ] {
-        let record = node.forks().get(first).context("missing fork")?;
-        ensure!(record.tail().as_bytes() == tail, "fork tail");
-        let address = record
-            .entry()
-            .context("fork has no entry")?
-            .address()
-            .context("entry is not a reference")?;
+    run(async {
+        for (first, tail, data) in [
+            (b'i', &b"ndex.html"[..], page),
+            (b'l', &b"ogo.png"[..], logo),
+        ] {
+            let record = node.forks().get(first).context("missing fork")?;
+            ensure!(record.tail().as_bytes() == tail, "fork tail");
+            let address = record
+                .entry()
+                .context("fork has no entry")?
+                .address()
+                .context("entry is not a reference")?;
 
-        let (expected_root, _) = run(split_whole(&data)).map_err(|e| anyhow!("{e}"))?;
-        ensure!(address == &expected_root, "file root reference");
-        ensure!(store.get(address).is_some(), "file root stored");
-    }
-    Ok(())
+            let (expected_root, _) = split_whole(&data).await.map_err(|e| anyhow!("{e}"))?;
+            ensure!(address == &expected_root, "file root reference");
+            ensure!(store.get(address).is_some(), "file root stored");
+        }
+        Ok(())
+    })
 }
 
 #[test]

--- a/crates/integration-tests/tests/manifest/counted.rs
+++ b/crates/integration-tests/tests/manifest/counted.rs
@@ -56,10 +56,13 @@ fn build_then_read_round_trips_every_key() -> Result<()> {
     let root = *run(builder.build(&store))?.root();
 
     let reader = Reader::<MemoryStore, V1>::new(store);
-    for (key, fill) in &all {
-        let got = run(reader.get(&root, key))?;
-        ensure!(got == Some(ref_entry::<V1>(*fill)), "read value mismatch");
-    }
+    run(async {
+        for (key, fill) in &all {
+            let got = reader.get(&root, key).await?;
+            ensure!(got == Some(ref_entry::<V1>(*fill)), "read value mismatch");
+        }
+        anyhow::Ok(())
+    })?;
     ensure!(
         run(reader.get(&root, &Key::from(&b"absent"[..])))?.is_none(),
         "absent key must read as None",

--- a/crates/integration-tests/tests/manifest/membound.rs
+++ b/crates/integration-tests/tests/manifest/membound.rs
@@ -184,18 +184,20 @@ fn a_million_key_manifest_is_depth_bounded() -> Result<()> {
         gets: AtomicUsize::new(0),
     };
     let reader: Reader<_> = Reader::new(&store);
-    for probe in [[0u8, 0, 0], [255, 255, 15], [128, 64, 8], [7, 200, 3]] {
-        store.gets.store(0, Ordering::Relaxed);
-        let value = run(reader.get(&root, &Key::from(&probe[..])))?;
-        ensure!(value == Some(entry(0x22)), "missing key {probe:?}");
-        // Three levels, each at most a segmented node and its covering segments.
-        ensure!(
-            store.gets() <= 24,
-            "lookup fetched {} nodes, not O(depth)",
-            store.gets(),
-        );
-    }
-    Ok(())
+    run(async {
+        for probe in [[0u8, 0, 0], [255, 255, 15], [128, 64, 8], [7, 200, 3]] {
+            store.gets.store(0, Ordering::Relaxed);
+            let value = reader.get(&root, &Key::from(&probe[..])).await?;
+            ensure!(value == Some(entry(0x22)), "missing key {probe:?}");
+            // Three levels, each at most a segmented node and its covering segments.
+            ensure!(
+                store.gets() <= 24,
+                "lookup fetched {} nodes, not O(depth)",
+                store.gets(),
+            );
+        }
+        Ok(())
+    })
 }
 
 #[test]
@@ -221,14 +223,16 @@ fn a_full_radix_256_node_of_heavy_records_packs_and_reads() -> Result<()> {
     assert_single_chunk_nodes(&store)?;
 
     let reader: Reader<_> = Reader::new(&store);
-    for first in [0u8, 1, 127, 200, 255] {
-        let value = run(reader.get(built.root(), &Key::from(vec![first])))?;
-        ensure!(
-            value == Some(entry(first)),
-            "missing key {first} after spill",
-        );
-    }
-    Ok(())
+    run(async {
+        for first in [0u8, 1, 127, 200, 255] {
+            let value = reader.get(built.root(), &Key::from(vec![first])).await?;
+            ensure!(
+                value == Some(entry(first)),
+                "missing key {first} after spill",
+            );
+        }
+        Ok(())
+    })
 }
 
 #[test]

--- a/crates/integration-tests/tests/manifest/order.rs
+++ b/crates/integration-tests/tests/manifest/order.rs
@@ -119,14 +119,17 @@ fn rank_select_count_agree_with_a_full_walk_oracle() -> Result<()> {
     ensure!(all.len() == keys.len(), "oracle lost keys");
 
     // select(i) is the i-th key; one past the end is None.
-    for (i, (key, value)) in all.iter().enumerate() {
-        let index = u64::try_from(i)?;
-        let got = run(reader.select(&root, index))?;
-        ensure!(
-            got.as_ref() == Some(&(key.clone(), value.clone())),
-            "select({i}) mismatch",
-        );
-    }
+    run(async {
+        for (i, (key, value)) in all.iter().enumerate() {
+            let index = u64::try_from(i)?;
+            let got = reader.select(&root, index).await?;
+            ensure!(
+                got.as_ref() == Some(&(key.clone(), value.clone())),
+                "select({i}) mismatch",
+            );
+        }
+        anyhow::Ok(())
+    })?;
     let end = u64::try_from(all.len())?;
     ensure!(
         run(reader.select(&root, end))?.is_none(),
@@ -146,24 +149,29 @@ fn rank_select_count_agree_with_a_full_walk_oracle() -> Result<()> {
         Key::from(&[12u8][..]),
         Key::from(&[255u8][..]),
     ];
-    for probe in &probes {
-        let expected = u64::try_from(all.iter().filter(|(k, _)| k < probe).count())?;
-        let got = run(reader.rank(&root, probe))?;
-        ensure!(got == expected, "rank mismatch: {got} != {expected}");
-    }
+    run(async {
+        for probe in &probes {
+            let expected = u64::try_from(all.iter().filter(|(k, _)| k < probe).count())?;
+            let got = reader.rank(&root, probe).await?;
+            ensure!(got == expected, "rank mismatch: {got} != {expected}");
+        }
+        anyhow::Ok(())
+    })?;
 
     // count(lo, hi) is the size of the half-open window.
-    for (lo, hi) in [
-        (Key::from(&[0u8, 0, 0][..]), Key::from(&[3u8, 0, 0][..])),
-        (Key::from(&[3u8, 5, 5][..]), Key::from(&[7u8, 2, 2][..])),
-        (Key::empty(), Key::from(&[12u8][..])),
-        (Key::from(&[9u8][..]), Key::from(&[3u8][..])),
-    ] {
-        let expected = u64::try_from(all.iter().filter(|(k, _)| lo <= *k && *k < hi).count())?;
-        let got = run(reader.count(&root, &lo, &hi))?;
-        ensure!(got == expected, "count mismatch: {got} != {expected}");
-    }
-    Ok(())
+    run(async {
+        for (lo, hi) in [
+            (Key::from(&[0u8, 0, 0][..]), Key::from(&[3u8, 0, 0][..])),
+            (Key::from(&[3u8, 5, 5][..]), Key::from(&[7u8, 2, 2][..])),
+            (Key::empty(), Key::from(&[12u8][..])),
+            (Key::from(&[9u8][..]), Key::from(&[3u8][..])),
+        ] {
+            let expected = u64::try_from(all.iter().filter(|(k, _)| lo <= *k && *k < hi).count())?;
+            let got = reader.count(&root, &lo, &hi).await?;
+            ensure!(got == expected, "count mismatch: {got} != {expected}");
+        }
+        Ok(())
+    })
 }
 
 #[test]
@@ -180,38 +188,47 @@ fn spilled_node_order_statistics_agree_with_the_oracle() -> Result<()> {
     // Sampled select and its inverse rank agree with the oracle across the whole
     // spilled listing, including both ends.
     let last = all.len().saturating_sub(1);
-    for i in (0..all.len()).step_by(311).chain([last]) {
-        let (key, value) = all.get(i).context("oracle index out of range")?;
-        let index = u64::try_from(i)?;
-        let got = run(reader.select(&root, index))?;
-        ensure!(
-            got.as_ref() == Some(&(key.clone(), value.clone())),
-            "spilled select({i}) mismatch",
-        );
-        let rank = run(reader.rank(&root, key))?;
-        ensure!(rank == index, "spilled rank at {i} mismatch");
-    }
+    run(async {
+        for i in (0..all.len()).step_by(311).chain([last]) {
+            let (key, value) = all.get(i).context("oracle index out of range")?;
+            let index = u64::try_from(i)?;
+            let got = reader.select(&root, index).await?;
+            ensure!(
+                got.as_ref() == Some(&(key.clone(), value.clone())),
+                "spilled select({i}) mismatch",
+            );
+            let rank = reader.rank(&root, key).await?;
+            ensure!(rank == index, "spilled rank at {i} mismatch");
+        }
+        anyhow::Ok(())
+    })?;
 
     // Windows spanning several segments count exactly.
-    for (lo, hi) in [
-        (Key::from(&[0u8, 0][..]), Key::from(&[100u8, 0][..])),
-        (Key::from(&[40u8, 25][..]), Key::from(&[210u8, 10][..])),
-        (Key::empty(), Key::from(&[255u8, 255][..])),
-    ] {
-        let expected = u64::try_from(all.iter().filter(|(k, _)| lo <= *k && *k < hi).count())?;
-        let got = run(reader.count(&root, &lo, &hi))?;
-        ensure!(
-            got == expected,
-            "spilled count mismatch: {got} != {expected}"
-        );
-    }
+    run(async {
+        for (lo, hi) in [
+            (Key::from(&[0u8, 0][..]), Key::from(&[100u8, 0][..])),
+            (Key::from(&[40u8, 25][..]), Key::from(&[210u8, 10][..])),
+            (Key::empty(), Key::from(&[255u8, 255][..])),
+        ] {
+            let expected = u64::try_from(all.iter().filter(|(k, _)| lo <= *k && *k < hi).count())?;
+            let got = reader.count(&root, &lo, &hi).await?;
+            ensure!(
+                got == expected,
+                "spilled count mismatch: {got} != {expected}"
+            );
+        }
+        anyhow::Ok(())
+    })?;
 
     // A page deep in the spilled listing is the matching oracle slice.
     let mut got = Vec::new();
     let mut cursor = run(reader.paginate_prefix(&root, &Key::empty(), 9000, 25))?;
-    while let Some(pair) = run(cursor.next())? {
-        got.push(pair);
-    }
+    run(async {
+        while let Some(pair) = cursor.next().await? {
+            got.push(pair);
+        }
+        anyhow::Ok(())
+    })?;
     let want: Vec<_> = all.iter().skip(9000).take(25).cloned().collect();
     ensure!(got == want, "spilled paginate mismatch");
     Ok(())
@@ -231,13 +248,15 @@ fn order_statistics_are_stable_under_shuffled_build_order() -> Result<()> {
 
     let reader = Reader::<MemoryStore, V1>::new(a_store);
     // A shuffled build is the same tree, so every rank and select is unchanged.
-    for index in [0u64, 1, 250, 500, 999] {
-        let got = run(reader.select(&a, index))?;
-        let (key, _) = got.context("select fell off the shuffled build")?;
-        let rank = run(reader.rank(&a, &key))?;
-        ensure!(rank == index, "rank/select disagree at {index}");
-    }
-    Ok(())
+    run(async {
+        for index in [0u64, 1, 250, 500, 999] {
+            let got = reader.select(&a, index).await?;
+            let (key, _) = got.context("select fell off the shuffled build")?;
+            let rank = reader.rank(&a, &key).await?;
+            ensure!(rank == index, "rank/select disagree at {index}");
+        }
+        Ok(())
+    })
 }
 
 #[test]
@@ -249,16 +268,21 @@ fn paginate_matches_iter_skip_take() -> Result<()> {
     let all = oracle(&reader, &root)?;
 
     // Whole-manifest pagination is exactly iter().skip(offset).take(limit).
-    for (offset, limit) in [(0u64, 7usize), (13, 20), (500, 33), (995, 50), (2000, 4)] {
-        let mut got = Vec::new();
-        let mut cursor = run(reader.paginate_prefix(&root, &Key::empty(), offset, limit))?;
-        while let Some(pair) = run(cursor.next())? {
-            got.push(pair);
+    run(async {
+        for (offset, limit) in [(0u64, 7usize), (13, 20), (500, 33), (995, 50), (2000, 4)] {
+            let mut got = Vec::new();
+            let mut cursor = reader
+                .paginate_prefix(&root, &Key::empty(), offset, limit)
+                .await?;
+            while let Some(pair) = cursor.next().await? {
+                got.push(pair);
+            }
+            let start = usize::try_from(offset)?;
+            let want: Vec<_> = all.iter().skip(start).take(limit).cloned().collect();
+            ensure!(got == want, "paginate_prefix({offset}, {limit}) mismatch");
         }
-        let start = usize::try_from(offset)?;
-        let want: Vec<_> = all.iter().skip(start).take(limit).cloned().collect();
-        ensure!(got == want, "paginate_prefix({offset}, {limit}) mismatch");
-    }
+        anyhow::Ok(())
+    })?;
 
     // Range pagination is the same over the range's own slice.
     let lo = Key::from(&[3u8, 0, 0][..]);
@@ -268,17 +292,19 @@ fn paginate_matches_iter_skip_take() -> Result<()> {
         .filter(|(k, _)| lo <= *k && *k < hi)
         .cloned()
         .collect();
-    for (offset, limit) in [(0u64, 10usize), (25, 40), (300, 12)] {
-        let mut got = Vec::new();
-        let mut cursor = run(reader.paginate(&root, &lo, &hi, offset, limit))?;
-        while let Some(pair) = run(cursor.next())? {
-            got.push(pair);
+    run(async {
+        for (offset, limit) in [(0u64, 10usize), (25, 40), (300, 12)] {
+            let mut got = Vec::new();
+            let mut cursor = reader.paginate(&root, &lo, &hi, offset, limit).await?;
+            while let Some(pair) = cursor.next().await? {
+                got.push(pair);
+            }
+            let start = usize::try_from(offset)?;
+            let want: Vec<_> = window.iter().skip(start).take(limit).cloned().collect();
+            ensure!(got == want, "paginate({offset}, {limit}) mismatch");
         }
-        let start = usize::try_from(offset)?;
-        let want: Vec<_> = window.iter().skip(start).take(limit).cloned().collect();
-        ensure!(got == want, "paginate({offset}, {limit}) mismatch");
-    }
-    Ok(())
+        Ok(())
+    })
 }
 
 #[test]
@@ -312,13 +338,19 @@ fn the_offset_seek_costs_depth_not_offset() -> Result<()> {
     // page and its read-ahead: the offset itself is free.
     reader.store().reset();
     let mut head = run(reader.paginate_prefix(&root, &Key::empty(), 0, 5))?;
-    while run(head.next())?.is_some() {}
+    run(async {
+        while head.next().await?.is_some() {}
+        anyhow::Ok(())
+    })?;
     let head_cost = reader.store().gets();
 
     reader.store().reset();
     let deep_offset = total.saturating_sub(5);
     let mut deep = run(reader.paginate_prefix(&root, &Key::empty(), deep_offset, 5))?;
-    while run(deep.next())?.is_some() {}
+    run(async {
+        while deep.next().await?.is_some() {}
+        anyhow::Ok(())
+    })?;
     let deep_cost = reader.store().gets();
 
     // The deep page pays for its own depth and window, not the offset it skipped.

--- a/crates/integration-tests/tests/manifest/read_profile.rs
+++ b/crates/integration-tests/tests/manifest/read_profile.rs
@@ -68,13 +68,16 @@ fn build_then_read_round_trips_every_key_under_the_read_profile() -> Result<()> 
     let root = *run(builder.build(&store))?.root();
 
     let reader = Reader::<MemoryStore, V1Read>::new(store);
-    for (key, fill) in windowed_keys() {
-        let got = run(reader.get(&root, &key))?;
-        ensure!(
-            got == Some(ref_entry::<V1Read>(fill)),
-            "read value mismatch"
-        );
-    }
+    run(async {
+        for (key, fill) in windowed_keys() {
+            let got = reader.get(&root, &key).await?;
+            ensure!(
+                got == Some(ref_entry::<V1Read>(fill)),
+                "read value mismatch"
+            );
+        }
+        anyhow::Ok(())
+    })?;
     // An absent key still reads as absent under the profile.
     ensure!(
         run(reader.get(&root, &Key::from(&b"absent"[..])))?.is_none(),
@@ -112,14 +115,16 @@ fn apply_matches_a_from_scratch_build_under_the_read_profile() -> Result<()> {
 
     // The applied manifest reads back the full key set.
     let reader = Reader::<MemoryStore, V1Read>::new(store);
-    for (key, fill) in &all {
-        let got = run(reader.get(&applied, key))?;
-        ensure!(
-            got == Some(ref_entry::<V1Read>(*fill)),
-            "applied value mismatch",
-        );
-    }
-    Ok(())
+    run(async {
+        for (key, fill) in &all {
+            let got = reader.get(&applied, key).await?;
+            ensure!(
+                got == Some(ref_entry::<V1Read>(*fill)),
+                "applied value mismatch",
+            );
+        }
+        Ok(())
+    })
 }
 
 #[test]

--- a/crates/integration-tests/tests/manifest/reader.rs
+++ b/crates/integration-tests/tests/manifest/reader.rs
@@ -45,20 +45,20 @@ fn entry(byte: u8) -> Entry {
 /// Build a deliberately wide two-level manifest: a root whose fork table holds
 /// one referenced leaf per first byte, each leaf terminating a single key. The
 /// second level is `width` chunks wide, but any one key sits two nodes deep.
-fn wide_manifest(store: &MemoryStore, width: u16) -> Result<ChunkAddress> {
+async fn wide_manifest(store: &MemoryStore, width: u16) -> Result<ChunkAddress> {
     let mut forks = ForkTable::<V1>::new();
     for first in 0..width {
         let first = u8::try_from(first)?;
         let mut leaf = ForkTable::new();
         leaf.insert(Prefix::try_from(&[0xFFu8][..])?, entry(first).into(), None)?;
-        let leaf_ref = run(store.put_node(&Node::new(None, leaf)))?;
+        let leaf_ref = store.put_node(&Node::new(None, leaf)).await?;
         forks.insert(
             Prefix::try_from(&[first][..])?,
             Child::Ref32(ChunkRef::new(leaf_ref)).into(),
             None,
         )?;
     }
-    Ok(run(store.put_node(&Node::new(None, forks)))?)
+    Ok(store.put_node(&Node::new(None, forks)).await?)
 }
 
 #[test]
@@ -67,7 +67,7 @@ fn a_lookup_fetches_depth_nodes_not_the_wide_level() -> Result<()> {
     // radix-full root spills to a directory, which is a later car's concern).
     let width = 100u16;
     let memory = MemoryStore::default();
-    let root = wide_manifest(&memory, width)?;
+    let root = run(wide_manifest(&memory, width))?;
 
     // The whole manifest is one root plus `width` leaves.
     ensure!(memory.len() == usize::from(width) + 1, "stored node count");
@@ -156,12 +156,17 @@ fn every_builder_key_reads_back_through_referenced_hops() -> Result<()> {
     // whole level: the deepest path stays a small multiple of the tree depth,
     // far below the spilled node count.
     let mut deepest = 0usize;
-    for (key, value) in &expected {
-        store.gets.store(0, Ordering::Relaxed);
-        let got = run(reader.get(&root, &Key::from(key.clone().into_bytes())))?;
-        ensure!(got.as_ref() == Some(value), "{key}");
-        deepest = deepest.max(store.gets());
-    }
+    run(async {
+        for (key, value) in &expected {
+            store.gets.store(0, Ordering::Relaxed);
+            let got = reader
+                .get(&root, &Key::from(key.clone().into_bytes()))
+                .await?;
+            ensure!(got.as_ref() == Some(value), "{key}");
+            deepest = deepest.max(store.gets());
+        }
+        anyhow::Ok(())
+    })?;
     ensure!(deepest >= 2, "at least one key descends a referenced hop");
     ensure!(
         deepest < built.stats().nodes_written(),
@@ -169,26 +174,31 @@ fn every_builder_key_reads_back_through_referenced_hops() -> Result<()> {
     );
 
     // Keys that diverge from, fall short of, or overrun a stored key are absent.
-    for absent in [
-        "nope",
-        "dir99/file0000.txt",
-        "dir00/file9999.txt",
-        "pr",
-        "prefixed",
-    ] {
-        ensure!(
-            run(reader.get(&root, &Key::from(absent.as_bytes())))?.is_none(),
-            "{absent}",
-        );
-    }
-    Ok(())
+    run(async {
+        for absent in [
+            "nope",
+            "dir99/file0000.txt",
+            "dir00/file9999.txt",
+            "pr",
+            "prefixed",
+        ] {
+            ensure!(
+                reader
+                    .get(&root, &Key::from(absent.as_bytes()))
+                    .await?
+                    .is_none(),
+                "{absent}",
+            );
+        }
+        Ok(())
+    })
 }
 
 #[test]
 fn an_absent_key_stops_at_the_first_unmatched_fork() -> Result<()> {
     let width = 64u16;
     let memory = MemoryStore::default();
-    let root = wide_manifest(&memory, width)?;
+    let root = run(wide_manifest(&memory, width))?;
 
     let store = CountingStore {
         inner: memory,

--- a/crates/integration-tests/tests/manifest/scan.rs
+++ b/crates/integration-tests/tests/manifest/scan.rs
@@ -154,29 +154,31 @@ fn prefix_matches_the_oracle() -> Result<()> {
     let (root, oracle) = build(&store)?;
     let reader: Reader<_> = Reader::new(&store);
 
-    for p in [
-        &b"dir05/"[..],
-        &b"dir1"[..],
-        &b"pre"[..],
-        &b"dir05/file000"[..],
-        &b""[..],
-    ] {
-        let got: Rows = {
-            let mut cursor = run(reader.prefix(&root, &Key::from(p)))?;
-            let mut out = Vec::new();
-            while let Some((key, value)) = run(cursor.next())? {
-                out.push((key.as_bytes().to_vec(), value));
-            }
-            out
-        };
-        let expected: Rows = oracle
-            .iter()
-            .filter(|(k, _)| k.starts_with(p))
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
-        ensure!(got == expected, "prefix matches the oracle");
-    }
-    Ok(())
+    run(async {
+        for p in [
+            &b"dir05/"[..],
+            &b"dir1"[..],
+            &b"pre"[..],
+            &b"dir05/file000"[..],
+            &b""[..],
+        ] {
+            let got: Rows = {
+                let mut cursor = reader.prefix(&root, &Key::from(p)).await?;
+                let mut out = Vec::new();
+                while let Some((key, value)) = cursor.next().await? {
+                    out.push((key.as_bytes().to_vec(), value));
+                }
+                out
+            };
+            let expected: Rows = oracle
+                .iter()
+                .filter(|(k, _)| k.starts_with(p))
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect();
+            ensure!(got == expected, "prefix matches the oracle");
+        }
+        Ok(())
+    })
 }
 
 /// A future that yields once: `Pending` on the first poll, `Ready` after. It
@@ -267,11 +269,13 @@ fn read_ahead_bounds_in_flight_and_matches_the_oracle() -> Result<()> {
 
     let got: Rows = {
         let mut cursor = run(reader.iter(&root))?;
-        let mut out = Vec::new();
-        while let Some((key, value)) = run(cursor.next())? {
-            out.push((key.as_bytes().to_vec(), value));
-        }
-        out
+        run(async {
+            let mut out = Vec::new();
+            while let Some((key, value)) = cursor.next().await? {
+                out.push((key.as_bytes().to_vec(), value));
+            }
+            anyhow::Ok(out)
+        })?
     };
     let expected: Rows = oracle.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
     ensure!(got == expected, "read-ahead iteration matches the oracle");
@@ -323,13 +327,17 @@ proptest! {
         let got: Rows = {
             let mut cursor = run(reader.iter(built.root()))
                 .map_err(|e| TestCaseError::fail(e.to_string()))?;
-            let mut out = Vec::new();
-            while let Some((key, value)) = run(cursor.next())
-                .map_err(|e| TestCaseError::fail(e.to_string()))?
-            {
-                out.push((key.as_bytes().to_vec(), value));
-            }
-            out
+            run(async {
+                let mut out = Vec::new();
+                while let Some((key, value)) = cursor
+                    .next()
+                    .await
+                    .map_err(|e| TestCaseError::fail(e.to_string()))?
+                {
+                    out.push((key.as_bytes().to_vec(), value));
+                }
+                Ok::<Rows, TestCaseError>(out)
+            })?
         };
         let expected: Rows = oracle.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
         prop_assert_eq!(got, expected);
@@ -372,13 +380,17 @@ proptest! {
         let got: Rows = {
             let mut cursor = run(reader.iter(built.root()))
                 .map_err(|e| TestCaseError::fail(e.to_string()))?;
-            let mut out = Vec::new();
-            while let Some((key, value)) = run(cursor.next())
-                .map_err(|e| TestCaseError::fail(e.to_string()))?
-            {
-                out.push((key.as_bytes().to_vec(), value));
-            }
-            out
+            run(async {
+                let mut out = Vec::new();
+                while let Some((key, value)) = cursor
+                    .next()
+                    .await
+                    .map_err(|e| TestCaseError::fail(e.to_string()))?
+                {
+                    out.push((key.as_bytes().to_vec(), value));
+                }
+                Ok::<Rows, TestCaseError>(out)
+            })?
         };
         let expected: Rows = oracle.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
         prop_assert_eq!(got, expected);
@@ -416,11 +428,13 @@ fn read_ahead_never_fetches_past_the_upper_bound() -> Result<()> {
     let hi = Key::from(&[1u8][..]);
     let got: Rows = {
         let mut cursor = run(reader.range(&root, &lo, &hi))?;
-        let mut out = Vec::new();
-        while let Some((key, value)) = run(cursor.next())? {
-            out.push((key.as_bytes().to_vec(), value));
-        }
-        out
+        run(async {
+            let mut out = Vec::new();
+            while let Some((key, value)) = cursor.next().await? {
+                out.push((key.as_bytes().to_vec(), value));
+            }
+            anyhow::Ok(out)
+        })?
     };
     let expected: Rows = oracle
         .iter()
@@ -448,24 +462,28 @@ fn floor_matches_the_oracle() -> Result<()> {
     let (root, oracle) = build(&store)?;
     let reader: Reader<_> = Reader::new(&store);
 
-    for target in [
-        &b""[..],
-        &b"a"[..],
-        &b"dir05/file0015.txt"[..],
-        &b"dir05/file0015.tyt"[..],
-        &b"dir05/file00155"[..],
-        &b"pre"[..],
-        &b"prefix"[..],
-        &b"prefiy"[..],
-        &b"zzzzz"[..],
-    ] {
-        let got =
-            run(reader.floor(&root, &Key::from(target)))?.map(|(k, v)| (k.as_bytes().to_vec(), v));
-        let expected = oracle
-            .range(..=target.to_vec())
-            .next_back()
-            .map(|(k, v)| (k.clone(), v.clone()));
-        ensure!(got == expected, "floor matches the oracle");
-    }
-    Ok(())
+    run(async {
+        for target in [
+            &b""[..],
+            &b"a"[..],
+            &b"dir05/file0015.txt"[..],
+            &b"dir05/file0015.tyt"[..],
+            &b"dir05/file00155"[..],
+            &b"pre"[..],
+            &b"prefix"[..],
+            &b"prefiy"[..],
+            &b"zzzzz"[..],
+        ] {
+            let got = reader
+                .floor(&root, &Key::from(target))
+                .await?
+                .map(|(k, v)| (k.as_bytes().to_vec(), v));
+            let expected = oracle
+                .range(..=target.to_vec())
+                .next_back()
+                .map(|(k, v)| (k.clone(), v.clone()));
+            ensure!(got == expected, "floor matches the oracle");
+        }
+        Ok(())
+    })
 }

--- a/crates/integration-tests/tests/mantaray/legacy_differential.rs
+++ b/crates/integration-tests/tests/mantaray/legacy_differential.rs
@@ -49,24 +49,24 @@ enum Outcome {
 
 /// Replay on the pinned legacy crate: fresh build, one save. A failing op
 /// stops the replay and is part of the differential contract.
-fn legacy_outcome(script: &[ScriptOp]) -> Outcome {
+async fn legacy_outcome(script: &[ScriptOp]) -> Outcome {
     let mut m = OldManifest::new(OldStore::new());
     for (index, op) in script.iter().enumerate() {
         let result = match op {
-            ScriptOp::Add(p, a) => run(m.add(p, *a)),
+            ScriptOp::Add(p, a) => m.add(p, *a).await,
             ScriptOp::AddMeta(p, a, k, v) => {
                 let meta: BTreeMap<String, String> = [(k.clone(), v.clone())].into();
-                run(m.add_with_metadata(p, *a, meta))
+                m.add_with_metadata(p, *a, meta).await
             }
-            ScriptOp::Rm(p) => run(m.remove(p)),
-            ScriptOp::SetIndex(v) => run(m.set_index_document(v)),
-            ScriptOp::SetError(v) => run(m.set_error_document(v)),
+            ScriptOp::Rm(p) => m.remove(p).await,
+            ScriptOp::SetIndex(v) => m.set_index_document(v).await,
+            ScriptOp::SetError(v) => m.set_error_document(v).await,
         };
         if result.is_err() {
             return Outcome::FailedAt(index);
         }
     }
-    let root = run(m.save()).unwrap();
+    let root = m.save().await.unwrap();
     let mut out = [0u8; 32];
     out.copy_from_slice(root.as_bytes());
     Outcome::Root(out)
@@ -74,7 +74,7 @@ fn legacy_outcome(script: &[ScriptOp]) -> Outcome {
 
 /// The legacy root for a script known to be valid.
 fn legacy_root(script: &[ScriptOp]) -> [u8; 32] {
-    match legacy_outcome(script) {
+    match run(legacy_outcome(script)) {
         Outcome::Root(root) => root,
         Outcome::FailedAt(index) => panic!("legacy replay failed at op {index}"),
     }
@@ -275,7 +275,7 @@ fn corpora_split_commits_match_legacy() {
 #[test]
 fn failing_op_index_matches_legacy() {
     let script = vec![add("ab"), add("a"), rm("a"), rm("ab")];
-    assert_eq!(legacy_outcome(&script), Outcome::FailedAt(3));
+    assert_eq!(run(legacy_outcome(&script)), Outcome::FailedAt(3));
     assert_eq!(editor_outcome(&script), Outcome::FailedAt(3));
     for split in 0..=script.len() {
         assert_eq!(editor_outcome_split(&script, split), Outcome::FailedAt(3));
@@ -416,7 +416,7 @@ proptest! {
     #[test]
     fn random_scripts_match_legacy(raw in proptest::collection::vec(any::<(u8, u8, u8)>(), 1..24)) {
         let script = build_script(&raw);
-        let want = legacy_outcome(&script);
+        let want = run(legacy_outcome(&script));
         prop_assert_eq!(editor_outcome(&script), want);
         prop_assert_eq!(editor_outcome_split(&script, script.len() / 2), want);
     }


### PR DESCRIPTION
## What
Converts in-loop and while-condition `run` (block_on) sites in `crates/integration-tests` to the async-native shape: each enclosing loop/while is wrapped in a single `run(async { ... .await ... })` so loop iterations drive one executor entry instead of one per iteration.
Makes two helpers with in-loop runs async (`reader.rs::wide_manifest`, `legacy_differential.rs::legacy_outcome`) and updates their call sites (`run(wide_manifest(..))` x2; `run(legacy_outcome(..))` x3).
Files touched: `manifest/{bridge,builder,counted,membound,order,read_profile,reader,scan}.rs`, `mantaray/legacy_differential.rs`, `file/membound.rs`.
This removes the epic #443 drift-register rows for the per-iteration-executor pattern in these ten files; two in-loop `run` sites were deliberately left unconverted (out of scope for this pass) and remain on the register.

## Why
Issue #422 prioritizes replacing per-iteration executor entry (`run`/`block_on` called once per loop iteration) with a single executor entry per loop, which is the behaviour-changing part with test-quality value.

## Testing
Verified on the tip of `t422/integration-inloop-executor` under the CI-pinned nix devshell. Every assertion and every `#[test]` is preserved verbatim; per-file assert and test counts are unchanged, confirmed by diff. No `src/`, `Cargo.toml` or `Cargo.lock` changes, so no lock-regen or no_std gate applies.

## AI Assistance
Implemented and red-teamed with Claude (Anthropic).
