### PR TITLE
feat(postage-issuer): add generic parallel-sign helpers over any issuer

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,6 +57,10 @@ jobs:
             # above never see them.
             - name: cargo clippy (postage serde)
               run: cargo clippy --locked --all-targets -p nectar-postage --features serde
+            # The parallel signing helpers sit behind the parallel feature,
+            # likewise outside the default-features pass.
+            - name: cargo clippy (postage-issuer parallel)
+              run: cargo clippy --locked --all-targets -p nectar-postage-issuer --features parallel
             # `unused_crate_dependencies` is enforced per-library via `cargo
             # rustc` (not `[workspace.lints]`) so the flag applies only to each
             # crate's own lib target — never to benches/examples/tests (which

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -103,6 +103,13 @@ jobs:
                   cargo nextest run \
                     -p nectar-postage --features serde --locked \
                     --no-tests=warn --no-fail-fast
+            # The parallel signing helpers sit behind the parallel feature,
+            # outside the default-features pass above.
+            - name: Run postage-issuer parallel tests
+              run: |
+                  cargo nextest run \
+                    -p nectar-postage-issuer --features parallel --locked \
+                    --no-tests=warn --no-fail-fast
 
     wasm:
         # The postage-usage client facade is meant to run in a browser. The

--- a/crates/postage-issuer/src/lib.rs
+++ b/crates/postage-issuer/src/lib.rs
@@ -112,6 +112,8 @@ mod dilute_handler;
 mod error;
 mod factory;
 mod issuer;
+#[cfg(feature = "parallel")]
+mod prepared;
 mod ring;
 mod sharded;
 mod sharded_ring;
@@ -149,5 +151,10 @@ pub use factory::{
 };
 
 // Parallel signing (requires parallel feature)
+#[cfg(feature = "parallel")]
+pub use prepared::{
+    StampPreparation, prepare_stamps, prepare_stamps_with_clock, sign_prepared_parallel,
+    stamp_parallel, stamp_parallel_with_clock,
+};
 #[cfg(feature = "parallel")]
 pub use sharded::{StampResult, sign_stamps_parallel, sign_stamps_parallel_with_clock};

--- a/crates/postage-issuer/src/prepared.rs
+++ b/crates/postage-issuer/src/prepared.rs
@@ -1,0 +1,283 @@
+//! Serial-prepare / parallel-sign helpers for any [`StampIssuer`].
+//!
+//! Index allocation needs `&mut` and stays serial; only the signing fans out
+//! across threads. [`ShardedIssuerFor`](crate::ShardedIssuerFor) additionally
+//! has a fully concurrent allocation path in
+//! [`sign_stamps_parallel`](crate::sign_stamps_parallel).
+
+use alloy_primitives::B256;
+use alloy_signer::Signature;
+use rayon::prelude::*;
+
+use crate::error::SigningError;
+use crate::issuer::StampIssuer;
+use crate::sharded::StampResult;
+use crate::stamper::stamp_timestamp;
+use nectar_clock::{Clock, SystemClock};
+use nectar_postage::{Stamp, StampDigest, StampError};
+use nectar_primitives::ChunkAddress;
+
+/// A prepared stamp: the allocated digest for an address, or the allocation
+/// failure.
+#[derive(Debug, Clone)]
+pub struct StampPreparation {
+    /// The chunk address the preparation is for.
+    pub address: ChunkAddress,
+    /// The allocated digest, or why allocation failed.
+    pub result: Result<StampDigest, StampError>,
+}
+
+/// Allocates a digest per address from any issuer, in input order.
+///
+/// Sign the output with [`sign_prepared_parallel`], or with a custom strategy
+/// via [`StampDigest::to_prehash`] and
+/// [`BatchStamper::stamp_from_signature`](crate::BatchStamper::stamp_from_signature).
+pub fn prepare_stamps<I>(issuer: &mut I, addresses: &[ChunkAddress]) -> Vec<StampPreparation>
+where
+    I: StampIssuer + ?Sized,
+{
+    prepare_stamps_with_clock(issuer, addresses, &SystemClock)
+}
+
+/// [`prepare_stamps`] with an injected timestamp source, for deterministic
+/// stamp timestamps.
+pub fn prepare_stamps_with_clock<I, C>(
+    issuer: &mut I,
+    addresses: &[ChunkAddress],
+    clock: &C,
+) -> Vec<StampPreparation>
+where
+    I: StampIssuer + ?Sized,
+    C: Clock,
+{
+    addresses
+        .iter()
+        .map(|address| StampPreparation {
+            address: *address,
+            result: issuer.prepare_stamp(address, stamp_timestamp(clock)),
+        })
+        .collect()
+}
+
+/// Signs prepared digests in parallel, yielding results in input order.
+///
+/// The signer receives the 32-byte prehash and must sign it as an EIP-191
+/// personal message. A preparation that failed allocation passes its error
+/// through unsigned.
+pub fn sign_prepared_parallel<Sg, E>(
+    preparations: &[StampPreparation],
+    signer: &Sg,
+) -> Vec<StampResult>
+where
+    Sg: Fn(&B256) -> Result<Signature, E> + Sync,
+    E: Into<SigningError>,
+{
+    preparations
+        .par_iter()
+        .map(|preparation| StampResult {
+            address: preparation.address,
+            result: sign_preparation(preparation, signer),
+        })
+        .collect()
+}
+
+/// Prepares and signs stamps for the given addresses through any issuer.
+///
+/// Serial allocation followed by parallel signing; results are in input
+/// order.
+pub fn stamp_parallel<I, Sg, E>(
+    issuer: &mut I,
+    signer: &Sg,
+    addresses: &[ChunkAddress],
+) -> Vec<StampResult>
+where
+    I: StampIssuer + ?Sized,
+    Sg: Fn(&B256) -> Result<Signature, E> + Sync,
+    E: Into<SigningError>,
+{
+    stamp_parallel_with_clock(issuer, signer, addresses, &SystemClock)
+}
+
+/// [`stamp_parallel`] with an injected timestamp source, for deterministic
+/// stamp timestamps.
+pub fn stamp_parallel_with_clock<I, Sg, E, C>(
+    issuer: &mut I,
+    signer: &Sg,
+    addresses: &[ChunkAddress],
+    clock: &C,
+) -> Vec<StampResult>
+where
+    I: StampIssuer + ?Sized,
+    Sg: Fn(&B256) -> Result<Signature, E> + Sync,
+    E: Into<SigningError>,
+    C: Clock,
+{
+    let preparations = prepare_stamps_with_clock(issuer, addresses, clock);
+    sign_prepared_parallel(&preparations, signer)
+}
+
+fn sign_preparation<Sg, E>(
+    preparation: &StampPreparation,
+    signer: &Sg,
+) -> Result<Stamp, SigningError>
+where
+    Sg: Fn(&B256) -> Result<Signature, E>,
+    E: Into<SigningError>,
+{
+    let digest = preparation.result.clone()?;
+    let prehash = digest.to_prehash();
+    let sig = signer(&prehash).map_err(Into::into)?;
+    Ok(Stamp::with_index(
+        digest.batch_id,
+        digest.index,
+        digest.timestamp,
+        sig,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{MemoryIssuer, RingIssuer};
+    use alloy_signer::SignerSync;
+    use alloy_signer_local::PrivateKeySigner;
+    use nectar_postage::{Batch, BatchId, BucketDepth, StampIndex};
+
+    fn sign_fn(
+        signer: &PrivateKeySigner,
+    ) -> impl Fn(&B256) -> Result<Signature, SigningError> + Sync + '_ {
+        move |prehash| {
+            Ok(signer
+                .sign_message_sync(prehash.as_slice())
+                .map_err(alloy_signer::Error::other)?)
+        }
+    }
+
+    #[test]
+    fn test_stamp_parallel_memory_issuer() {
+        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 24, BucketDepth::new(16).unwrap());
+        let signer = PrivateKeySigner::random();
+
+        let addresses: Vec<_> = (0..100)
+            .map(|_| ChunkAddress::from(B256::random()))
+            .collect();
+
+        let results = stamp_parallel(&mut issuer, &sign_fn(&signer), &addresses);
+
+        assert_eq!(results.len(), 100);
+        for (result, address) in results.iter().zip(&addresses) {
+            assert_eq!(result.address, *address);
+            let stamp = result.result.as_ref().unwrap();
+            assert_eq!(stamp.batch(), BatchId::ZERO);
+        }
+        assert_eq!(issuer.stamps_issued(), Some(100));
+    }
+
+    #[test]
+    fn test_stamp_parallel_signature_recovers() {
+        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
+        let signer = PrivateKeySigner::random();
+
+        let address = ChunkAddress::from(B256::random());
+        let results = stamp_parallel(&mut issuer, &sign_fn(&signer), &[address]);
+
+        let stamp = results[0].result.as_ref().unwrap();
+        let digest = StampDigest::new(
+            address,
+            stamp.batch(),
+            StampIndex::new(stamp.bucket(), stamp.index()),
+            stamp.timestamp(),
+        );
+        let recovered = stamp
+            .signature()
+            .recover_address_from_msg(digest.to_prehash().as_slice())
+            .unwrap();
+        assert_eq!(recovered, signer.address());
+    }
+
+    #[test]
+    fn test_stamp_parallel_bucket_full_passes_through_in_order() {
+        // depth=17, bucket_depth=16 gives 2 slots per bucket.
+        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 17, BucketDepth::new(16).unwrap());
+        let signer = PrivateKeySigner::random();
+
+        let address = ChunkAddress::new([0xAB; 32]);
+        let results = stamp_parallel(&mut issuer, &sign_fn(&signer), &[address, address, address]);
+
+        assert!(results[0].result.is_ok());
+        assert!(results[1].result.is_ok());
+        assert!(matches!(
+            results[2].result,
+            Err(SigningError::Stamp(StampError::BucketFull { .. }))
+        ));
+    }
+
+    #[test]
+    fn test_two_phase_matches_combined() {
+        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 24, BucketDepth::new(16).unwrap());
+        let signer = PrivateKeySigner::random();
+
+        let addresses: Vec<_> = (0..10)
+            .map(|_| ChunkAddress::from(B256::random()))
+            .collect();
+
+        let preparations = prepare_stamps(&mut issuer, &addresses);
+        assert_eq!(preparations.len(), addresses.len());
+        for (preparation, address) in preparations.iter().zip(&addresses) {
+            assert_eq!(preparation.address, *address);
+            let digest = preparation.result.as_ref().unwrap();
+            assert_eq!(digest.chunk_address, *address);
+        }
+
+        let results = sign_prepared_parallel(&preparations, &sign_fn(&signer));
+        for (result, preparation) in results.iter().zip(&preparations) {
+            let stamp = result.result.as_ref().unwrap();
+            let digest = preparation.result.as_ref().unwrap();
+            assert_eq!(stamp.stamp_index(), digest.index);
+            assert_eq!(stamp.timestamp(), digest.timestamp);
+        }
+    }
+
+    #[test]
+    fn test_stamp_parallel_with_clock() {
+        use nectar_clock::ManualClock;
+
+        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 24, BucketDepth::new(16).unwrap());
+        let signer = PrivateKeySigner::random();
+        let clock = ManualClock::new(1_234_567_890);
+
+        let addresses: Vec<_> = (0..16)
+            .map(|_| ChunkAddress::from(B256::random()))
+            .collect();
+
+        let results = stamp_parallel_with_clock(&mut issuer, &sign_fn(&signer), &addresses, &clock);
+
+        assert_eq!(results.len(), 16);
+        for result in &results {
+            assert_eq!(result.result.as_ref().unwrap().timestamp(), 1_234_567_890);
+        }
+    }
+
+    #[test]
+    fn test_stamp_parallel_ring_issuer() {
+        // The helper is issuer-generic: a mutable batch's ring issuer works too.
+        let mutable = Batch::new(
+            BatchId::ZERO,
+            0,
+            0,
+            Default::default(),
+            20,
+            BucketDepth::new(16).unwrap(),
+            false,
+        );
+        let mut issuer = RingIssuer::external(&mutable).unwrap();
+        let signer = PrivateKeySigner::random();
+
+        let addresses: Vec<_> = (0..10)
+            .map(|_| ChunkAddress::from(B256::random()))
+            .collect();
+
+        let results = stamp_parallel(&mut issuer, &sign_fn(&signer), &addresses);
+        assert!(results.iter().all(|r| r.result.is_ok()));
+    }
+}

--- a/crates/postage-issuer/src/prepared.rs
+++ b/crates/postage-issuer/src/prepared.rs
@@ -239,6 +239,28 @@ mod tests {
     }
 
     #[test]
+    fn test_stamp_parallel_signer_error_passes_through_in_order() {
+        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 24, BucketDepth::new(16).unwrap());
+
+        let addresses: Vec<_> = (0..20)
+            .map(|_| ChunkAddress::from(B256::random()))
+            .collect();
+
+        // A signer that always fails: allocation succeeds, so every result must
+        // carry the signer error through in input order.
+        let failing = |_: &B256| -> Result<Signature, SigningError> {
+            Err(alloy_signer::Error::message("signer offline").into())
+        };
+        let results = stamp_parallel(&mut issuer, &failing, &addresses);
+
+        assert_eq!(results.len(), addresses.len());
+        for (result, address) in results.iter().zip(&addresses) {
+            assert_eq!(result.address, *address);
+            assert!(matches!(result.result, Err(SigningError::Signer(_))));
+        }
+    }
+
+    #[test]
     fn test_stamp_parallel_with_clock() {
         use nectar_clock::ManualClock;
 


### PR DESCRIPTION
## What

Adds a generic serial-prepare / parallel-sign path over any `StampIssuer`, in a new `crates/postage-issuer/src/prepared.rs` module gated behind the existing `parallel` feature.

`prepare_stamps` allocates a digest per address serially (any issuer needs `&mut`, one at a time), preserving input order. Stamp timestamps come from the injected `nectar-clock` source: `prepare_stamps_with_clock` takes any `Clock`, and the plain `prepare_stamps` defaults to the system clock, matching the pattern main established for `sign_stamps_parallel` / `sign_stamps_parallel_with_clock` and `BatchStamper::with_clock`.

`sign_prepared_parallel` fans the signing step out across a rayon `par_iter`, taking the same `Fn(&B256) -> Result<Signature, E>` signer shape as the existing sharded `sign_stamps_parallel`; an allocation failure passes through unsigned rather than being signed.

`stamp_parallel` combines both steps for the common case of one issuer plus one signer, with `stamp_parallel_with_clock` as the deterministic-timestamp variant.

All helpers are exported at the crate top level from `lib.rs`, alongside the existing `StampResult` type which is reused for the output.

CI now covers the `parallel` feature for `postage-issuer` in both `lint.yml` (clippy) and `unit.yml` (nextest), matching the existing pattern used for `postage`'s `serde` feature.

## Why

Closes #38.

The existing `sign_stamps_parallel` only works over `ShardedIssuerFor`, which has a fully concurrent allocation path. Other issuers (e.g. `MemoryIssuer`, `RingIssuer`) need `&mut` for allocation and so cannot use that path; this gives them an equivalent serial-allocate / parallel-sign helper without touching any existing signatures. Purely additive: no dependency or `Cargo.lock` changes beyond the `nectar-clock` dependency already introduced on main.

The clock threading follows the injected-time rework that landed on main: the default clock preserves the previous behaviour byte for byte, and the `_with_clock` variants make wire-visible stamp timestamps deterministic under test.

## Testing

Scoped battery re-run locally on the rebased branch (based on `origin/main` at the clock-injection head), Rust 1.94 via `nix develop`, `RUSTC_WRAPPER=sccache`, `CARGO_INCREMENTAL=0`. All green.

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --locked --all-targets -p nectar-postage-issuer` (default and `--features parallel`, after `cargo clean -p`): pass, no warnings in the crate.
- `cargo rustc --locked -p nectar-postage-issuer --lib -- -D unused_crate_dependencies`: pass.
- `cargo nextest run -p nectar-postage-issuer --locked` (default and `--features parallel`): 59 and 68 passed respectively.
- `cargo test --doc -p nectar-postage-issuer --locked`: pass.

Seven tests cover: `MemoryIssuer` bulk signing, signature recovery, in-order `BucketFull` and signer-error pass-through, the two-phase `prepare_stamps` / `sign_prepared_parallel` split, `RingIssuer` genericity, and deterministic timestamps through `stamp_parallel_with_clock` with a `ManualClock`.

## AI Assistance

Implementation by Claude (Fable), review by Claude (Opus).
