### PR TITLE
feat(file): size the fetch window from a throughput hint

### DIFF
--- a/crates/file/src/config.rs
+++ b/crates/file/src/config.rs
@@ -1,7 +1,8 @@
 //! Engine admission budgets: the bounded windows the drains admit work
 //! against.
 
-use core::num::{NonZeroU16, NonZeroU32};
+use core::num::{NonZeroU16, NonZeroU32, NonZeroUsize};
+use core::time::Duration;
 
 /// Sixteen slots: the default depth of both bounded windows.
 const DEFAULT_SLOTS: NonZeroU16 = match NonZeroU16::new(16) {
@@ -10,7 +11,11 @@ const DEFAULT_SLOTS: NonZeroU16 = match NonZeroU16::new(16) {
 };
 const _: () = assert!(DEFAULT_SLOTS.get() == 16);
 
-/// Fetch window: leaf fetches a read drain may hold in flight.
+/// Denominator scale of the throughput hint's byte-nanosecond arithmetic.
+const NANOS_PER_SEC: u128 = 1_000_000_000;
+
+/// Fetch window: leaf bodies a read drain may hold resident, in flight or
+/// buffered awaiting delivery.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Window(NonZeroU16);
 
@@ -30,6 +35,40 @@ impl Window {
     /// Window depth in slots.
     pub const fn get(self) -> u16 {
         self.0.get()
+    }
+
+    /// Little's law sizing: the slots that sustain `bytes_per_second` when
+    /// a leaf fetch takes `mean_latency`, `ceil(rate * latency /
+    /// body_size)` saturated into `1..=u16::MAX`.
+    ///
+    /// ```
+    /// use core::num::NonZeroUsize;
+    /// use core::time::Duration;
+    /// use nectar_file::Window;
+    ///
+    /// let body = NonZeroUsize::new(4096).unwrap();
+    /// // A 1 MB/s stream at 120 ms per fetch needs thirty slots.
+    /// let window = Window::for_throughput(1_000_000, Duration::from_millis(120), body);
+    /// assert_eq!(window.get(), 30);
+    /// ```
+    pub const fn for_throughput(
+        bytes_per_second: u64,
+        mean_latency: Duration,
+        body_size: NonZeroUsize,
+    ) -> Self {
+        // Bytes resident under Little's law, in byte-nanoseconds to keep
+        // the arithmetic integral.
+        let resident = u128_from_u64(bytes_per_second).checked_mul(mean_latency.as_nanos());
+        // Never zero: the body size is nonzero and the factor saturates.
+        let slot = u128_from_usize(body_size.get()).saturating_mul(NANOS_PER_SEC);
+        let slots = match resident {
+            Some(bytes) => bytes.div_ceil(slot),
+            None => u128::MAX,
+        };
+        match NonZeroU16::new(saturating_u16(slots)) {
+            Some(slots) => Self(slots),
+            None => Self(NonZeroU16::MIN),
+        }
     }
 }
 
@@ -171,6 +210,36 @@ const fn u32_from_u16(value: u16) -> u32 {
     u32::from_le_bytes([low, high, 0, 0])
 }
 
+/// Lossless const widening; `From` is not const-callable.
+const fn u128_from_u64(value: u64) -> u128 {
+    let [a, b, c, d, e, f, g, h] = value.to_le_bytes();
+    u128::from_le_bytes([a, b, c, d, e, f, g, h, 0, 0, 0, 0, 0, 0, 0, 0])
+}
+
+/// Lossless const widening; `From` is not const-callable.
+#[cfg(target_pointer_width = "64")]
+const fn u128_from_usize(value: usize) -> u128 {
+    let [a, b, c, d, e, f, g, h] = value.to_le_bytes();
+    u128::from_le_bytes([a, b, c, d, e, f, g, h, 0, 0, 0, 0, 0, 0, 0, 0])
+}
+
+/// Lossless const widening; `From` is not const-callable.
+#[cfg(target_pointer_width = "32")]
+const fn u128_from_usize(value: usize) -> u128 {
+    let [a, b, c, d] = value.to_le_bytes();
+    u128::from_le_bytes([a, b, c, d, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+}
+
+/// Saturating const narrowing: values past `u16::MAX` clamp to it.
+const fn saturating_u16(value: u128) -> u16 {
+    if value > 0xFFFF {
+        u16::MAX
+    } else {
+        let [low, high, ..] = value.to_le_bytes();
+        u16::from_le_bytes([low, high])
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -198,6 +267,47 @@ mod tests {
         assert_eq!(NonZeroU16::from(Window::from(slots)), slots);
         assert_eq!(NonZeroU16::from(PutWindow::from(slots)), slots);
         assert_eq!(NonZeroU16::from(HashWindow::from(slots)), slots);
+    }
+
+    #[test]
+    fn throughput_window_applies_littles_law() {
+        let body = NonZeroUsize::new(4096).unwrap();
+        // Sixteen bodies per second at one second per fetch.
+        let window = Window::for_throughput(16 * 4096, Duration::from_secs(1), body);
+        assert_eq!(window.get(), 16);
+        // A partial slot rounds up.
+        let window = Window::for_throughput(16 * 4096 + 1, Duration::from_secs(1), body);
+        assert_eq!(window.get(), 17);
+        // A quarter of the latency needs a quarter of the slots.
+        let window = Window::for_throughput(16 * 4096, Duration::from_millis(250), body);
+        assert_eq!(window.get(), 4);
+    }
+
+    #[test]
+    fn throughput_window_floors_at_one() {
+        let body = NonZeroUsize::new(4096).unwrap();
+        assert_eq!(
+            Window::for_throughput(0, Duration::from_secs(1), body).get(),
+            1
+        );
+        assert_eq!(
+            Window::for_throughput(u64::MAX, Duration::ZERO, body).get(),
+            1
+        );
+        assert_eq!(
+            Window::for_throughput(1, Duration::from_nanos(1), body).get(),
+            1
+        );
+    }
+
+    #[test]
+    fn throughput_window_saturates_at_slot_width() {
+        let body = NonZeroUsize::new(1).unwrap();
+        let window = Window::for_throughput(u64::MAX, Duration::from_secs(1), body);
+        assert_eq!(window.get(), u16::MAX);
+        // An overflowing byte-nanosecond product saturates, never wraps.
+        let window = Window::for_throughput(u64::MAX, Duration::MAX, body);
+        assert_eq!(window.get(), u16::MAX);
     }
 
     #[test]

--- a/crates/file/src/read/download.rs
+++ b/crates/file/src/read/download.rs
@@ -3,12 +3,14 @@
 use alloc::boxed::Box;
 use core::fmt;
 use core::ops::Range;
+use core::time::Duration;
 
 use futures_util::stream::StreamExt;
 use nectar_primitives::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{AnyChunkSet, ChunkAddress};
 use nectar_primitives::store::TrustedGet;
 
+use super::body_size;
 use super::error::DownloadError;
 use super::frames::FileFrames;
 use crate::config::Window;
@@ -105,6 +107,17 @@ impl<S, M: WalkMode, const B: usize> DownloadBuilder<S, M, B> {
     pub const fn window(mut self, window: Window) -> Self {
         self.window = window;
         self
+    }
+
+    /// Fetch window sized to sustain `bytes_per_second` at `mean_latency`
+    /// per leaf fetch; see [`Window::for_throughput`].
+    #[must_use]
+    pub const fn throughput(self, bytes_per_second: u64, mean_latency: Duration) -> Self {
+        self.window(Window::for_throughput(
+            bytes_per_second,
+            mean_latency,
+            body_size::<B>(),
+        ))
     }
 
     /// Absolute byte range to download, clipped to the file.

--- a/crates/file/src/read/mod.rs
+++ b/crates/file/src/read/mod.rs
@@ -10,6 +10,8 @@
 //! [`ReadBuilder::collect`] assembles a bounded in-memory copy, typed
 //! [`CollectError::TooLarge`] past its bound.
 
+use core::num::NonZeroUsize;
+
 #[cfg(test)]
 mod cancel;
 mod download;
@@ -19,6 +21,15 @@ mod frames;
 mod reader;
 #[cfg(test)]
 mod tests;
+
+/// The profile's body size as a typed nonzero. A zero profile never walks;
+/// the floor only keeps the conversion total.
+const fn body_size<const B: usize>() -> NonZeroUsize {
+    match NonZeroUsize::new(B) {
+        Some(body) => body,
+        None => NonZeroUsize::MIN,
+    }
+}
 
 pub use download::{DownloadBuilder, Progress, ProgressFn};
 pub use error::{CollectError, DownloadError, OpenError, SeekPastEnd};

--- a/crates/file/src/read/reader.rs
+++ b/crates/file/src/read/reader.rs
@@ -7,6 +7,7 @@ use core::mem;
 use core::ops::Range;
 use core::pin::Pin;
 use core::task::{Context, Poll};
+use core::time::Duration;
 
 use bytes::Bytes;
 use futures_util::stream::{Stream, StreamExt};
@@ -14,6 +15,7 @@ use nectar_primitives::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{AnyChunkSet, ChunkAddress};
 use nectar_primitives::store::TrustedGet;
 
+use super::body_size;
 use super::error::{CollectError, SeekPastEnd};
 use super::frames::FileFrames;
 use crate::config::Window;
@@ -58,6 +60,17 @@ impl<S, M: WalkMode, const B: usize> ReadBuilder<S, M, B> {
     pub const fn window(mut self, window: Window) -> Self {
         self.window = window;
         self
+    }
+
+    /// Fetch window sized to sustain `bytes_per_second` at `mean_latency`
+    /// per leaf fetch; see [`Window::for_throughput`].
+    #[must_use]
+    pub const fn throughput(self, bytes_per_second: u64, mean_latency: Duration) -> Self {
+        self.window(Window::for_throughput(
+            bytes_per_second,
+            mean_latency,
+            body_size::<B>(),
+        ))
     }
 
     /// Absolute byte range to read, clipped to the file.

--- a/crates/file/src/read/tests.rs
+++ b/crates/file/src/read/tests.rs
@@ -104,6 +104,22 @@ fn plain_reader_matches_the_source_bytes() {
     }
 }
 
+#[test]
+fn throughput_hint_sizes_the_window() {
+    let data = fill(TINY * 8);
+    let (root, store) = split_fixture::<TINY>(&data);
+    run(async {
+        let file = File::<_, Plain, TINY>::open(store, root).await.unwrap();
+        // One body per second at one second per fetch: a single slot.
+        let mut reader = file
+            .read()
+            .throughput(TINY as u64, core::time::Duration::from_secs(1))
+            .build();
+        assert_eq!(drain(&mut reader).await, data);
+        assert!(reader.stats().peak_occupancy <= 1);
+    });
+}
+
 #[cfg(feature = "encryption")]
 #[test]
 fn encrypted_reader_matches_the_source_bytes() {


### PR DESCRIPTION
## What

Adds `Window::for_throughput(bytes_per_second, mean_latency, body_size)` in `crates/file/src/config.rs`, a const Little's law sizing helper: `ceil(rate * latency / body_size)`, saturated into `1..=u16::MAX`, using overflow-safe integral (byte-nanosecond) arithmetic with no panicking ops.

Exposes it as a const `throughput(bytes_per_second, mean_latency)` knob on both `ReadBuilder` (`crates/file/src/read/reader.rs`) and `DownloadBuilder` (`crates/file/src/read/download.rs`), closing over the profile's `B` body size via a shared `body_size::<B>()` helper added to `crates/file/src/read/mod.rs`.

Folds in the `Window` docstring fix: it now states the occupancy bound covers resident leaf bodies, in flight or buffered.

The adaptive controller is untouched.

## Why

Closes #402
Closes #404

## Testing

- `config.rs` unit battery: exact sizing, round-up on a partial slot, latency scaling, floor at one, saturation at `u16::MAX` (including an overflowing byte-nanosecond product).
- A doctest on `Window::for_throughput`.
- A behavioural read test (`crates/file/src/read/tests.rs`) pinning `peak_occupancy <= 1` under a one-slot hint.

## AI Assistance

Implementation by Claude (Fable 5), reviewed by Claude (Opus).
