### PR TITLE
postage: inject nectar-clock into stamping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2246,6 +2246,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
+ "nectar-clock",
  "nectar-file",
  "nectar-postage",
  "nectar-primitives 0.4.0",
@@ -2266,6 +2267,7 @@ dependencies = [
  "arbitrary",
  "auto_impl",
  "bytes",
+ "nectar-clock",
  "nectar-postage",
  "nectar-postage-issuer",
  "nectar-primitives 0.4.0",
@@ -2274,7 +2276,6 @@ dependencies = [
  "proptest-arbitrary-interop",
  "thiserror",
  "tokio",
- "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ check.all_targets = true
 
 [workspace.dependencies]
 # nectar crates
-nectar-clock = { version = "0.4.0", path = "crates/clock" }
+nectar-clock = { version = "0.4.0", path = "crates/clock", default-features = false }
 nectar-contracts = { version = "0.4.0", path = "crates/contracts" }
 nectar-file = { version = "0.4.0", path = "crates/file" }
 nectar-manifest = { version = "0.4.0", path = "crates/manifest" }

--- a/crates/postage-issuer/Cargo.toml
+++ b/crates/postage-issuer/Cargo.toml
@@ -18,6 +18,7 @@ categories = ["cryptography", "data-structures"]
 workspace = true
 
 [dependencies]
+nectar-clock = { workspace = true }
 nectar-postage = { workspace = true }
 nectar-primitives = { workspace = true }
 alloy-primitives = { workspace = true }
@@ -43,7 +44,7 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 default = [ "std" ]
 
 # Standard library support
-std = [ "nectar-postage/std" ]
+std = [ "nectar-clock/std", "nectar-postage/std" ]
 
 # Local key signing for testing and development
 local-signer = [ "dep:alloy-signer-local", "std" ]

--- a/crates/postage-issuer/src/lib.rs
+++ b/crates/postage-issuer/src/lib.rs
@@ -150,4 +150,4 @@ pub use factory::{
 
 // Parallel signing (requires parallel feature)
 #[cfg(feature = "parallel")]
-pub use sharded::{StampResult, sign_stamps_parallel};
+pub use sharded::{StampResult, sign_stamps_parallel, sign_stamps_parallel_with_clock};

--- a/crates/postage-issuer/src/sharded.rs
+++ b/crates/postage-issuer/src/sharded.rs
@@ -24,9 +24,11 @@ use nectar_primitives::{ChunkAddress, Mainnet, SwarmSpec};
 #[cfg(feature = "parallel")]
 use {
     crate::error::SigningError,
+    crate::stamper::stamp_timestamp,
     alloy_primitives::B256,
     alloy_signer::Signature,
-    nectar_postage::{Stamp, current_timestamp},
+    nectar_clock::{Clock, SystemClock},
+    nectar_postage::Stamp,
 };
 
 /// Number of shards for bucket partitioning.
@@ -407,12 +409,30 @@ where
     Sg: Fn(&B256) -> Result<Signature, E> + Sync,
     E: Into<SigningError>,
 {
+    sign_stamps_parallel_with_clock(issuer, signer, addresses, &SystemClock)
+}
+
+/// [`sign_stamps_parallel`] with an injected timestamp source, for
+/// deterministic stamp timestamps.
+#[cfg(feature = "parallel")]
+pub fn sign_stamps_parallel_with_clock<Sp, Sg, E, C>(
+    issuer: &ShardedIssuerFor<Sp>,
+    signer: &Sg,
+    addresses: &[ChunkAddress],
+    clock: &C,
+) -> Vec<StampResult>
+where
+    Sp: SwarmSpec + Sync,
+    Sg: Fn(&B256) -> Result<Signature, E> + Sync,
+    E: Into<SigningError>,
+    C: Clock + Sync,
+{
     use rayon::prelude::*;
 
     addresses
         .par_iter()
         .map(|address| {
-            let result = sign_stamp_internal(issuer, signer, address);
+            let result = sign_stamp_internal(issuer, signer, address, clock);
             StampResult {
                 address: *address,
                 result,
@@ -422,17 +442,19 @@ where
 }
 
 #[cfg(feature = "parallel")]
-fn sign_stamp_internal<Sp, Sg, E>(
+fn sign_stamp_internal<Sp, Sg, E, C>(
     issuer: &ShardedIssuerFor<Sp>,
     signer: &Sg,
     address: &ChunkAddress,
+    clock: &C,
 ) -> Result<Stamp, SigningError>
 where
     Sp: SwarmSpec,
     Sg: Fn(&B256) -> Result<Signature, E>,
     E: Into<SigningError>,
+    C: Clock,
 {
-    let timestamp = current_timestamp();
+    let timestamp = stamp_timestamp(clock);
     let digest = issuer.prepare_stamp(address, timestamp)?;
     let prehash = digest.to_prehash();
     let sig = signer(&prehash).map_err(|e| e.into())?;
@@ -603,5 +625,35 @@ mod tests {
             assert!(result.result.is_ok());
         }
         assert_eq!(issuer.stamps_issued(), 100);
+    }
+
+    #[cfg(feature = "parallel")]
+    #[test]
+    fn test_parallel_signing_with_clock() {
+        use crate::error::SigningError;
+        use alloy_signer::SignerSync;
+        use alloy_signer_local::PrivateKeySigner;
+        use nectar_clock::ManualClock;
+
+        let issuer = ShardedIssuer::new(BatchId::ZERO, 24, BucketDepth::new(16).unwrap());
+        let signer = PrivateKeySigner::random();
+        let clock = ManualClock::new(1_234_567_890);
+
+        let addresses: Vec<_> = (0..16)
+            .map(|_| ChunkAddress::from(B256::random()))
+            .collect();
+
+        let sign_fn = |prehash: &B256| -> Result<Signature, SigningError> {
+            Ok(signer
+                .sign_message_sync(prehash.as_slice())
+                .map_err(alloy_signer::Error::other)?)
+        };
+
+        let results = sign_stamps_parallel_with_clock(&issuer, &sign_fn, &addresses, &clock);
+
+        assert_eq!(results.len(), 16);
+        for result in &results {
+            assert_eq!(result.result.as_ref().unwrap().timestamp(), 1_234_567_890);
+        }
     }
 }

--- a/crates/postage-issuer/src/stamper.rs
+++ b/crates/postage-issuer/src/stamper.rs
@@ -14,8 +14,17 @@ use alloy_signer::SignerSync;
 
 use crate::StampIssuer;
 use crate::error::SigningError;
-use nectar_postage::{BatchId, Stamp, StampDigest, StampError, current_timestamp};
+use nectar_clock::Clock;
+#[cfg(feature = "std")]
+use nectar_clock::SystemClock;
+use nectar_postage::{BatchId, Stamp, StampDigest, StampError};
 use nectar_primitives::ChunkAddress;
+
+/// Reads `clock` as a stamp timestamp: nanoseconds since the unix epoch,
+/// clamped to zero for pre-epoch readings.
+pub(crate) fn stamp_timestamp<C: Clock + ?Sized>(clock: &C) -> u64 {
+    u64::try_from(clock.now_ns()).unwrap_or(0)
+}
 
 /// A trait for entities that can stamp chunks.
 ///
@@ -91,6 +100,10 @@ pub trait Stamper {
 /// and handles the signing of stamps. This composition allows using different
 /// issuer implementations (e.g., `MemoryIssuer`, `ShardedIssuer`) with any signer.
 ///
+/// Stamp timestamps come from the clock type parameter, defaulting to the
+/// system clock; [`with_clock`](Self::with_clock) injects a deterministic
+/// source.
+///
 /// # Example
 ///
 /// ```ignore
@@ -100,18 +113,56 @@ pub trait Stamper {
 /// let mut stamper = BatchStamper::new(issuer, my_signer);
 /// let stamp = stamper.stamp(&chunk_address)?;
 /// ```
+#[cfg(feature = "std")]
 #[derive(Debug, Clone)]
-pub struct BatchStamper<I, S> {
+pub struct BatchStamper<I, S, C = SystemClock> {
     /// The issuer for tracking bucket utilization.
     issuer: I,
     /// The signer used to sign stamps.
     signer: S,
+    /// The timestamp source for issued stamps.
+    clock: C,
 }
 
+/// Without `std` there is no default clock; construct via
+/// [`with_clock`](Self::with_clock).
+#[cfg(not(feature = "std"))]
+#[derive(Debug, Clone)]
+pub struct BatchStamper<I, S, C> {
+    /// The issuer for tracking bucket utilization.
+    issuer: I,
+    /// The signer used to sign stamps.
+    signer: S,
+    /// The timestamp source for issued stamps.
+    clock: C,
+}
+
+#[cfg(feature = "std")]
 impl<I, S> BatchStamper<I, S> {
-    /// Creates a new batch stamper with the given issuer and signer.
+    /// Creates a new batch stamper with the given issuer and signer, reading
+    /// stamp timestamps from the system clock.
     pub const fn new(issuer: I, signer: S) -> Self {
-        Self { issuer, signer }
+        Self {
+            issuer,
+            signer,
+            clock: SystemClock,
+        }
+    }
+}
+
+impl<I, S, C> BatchStamper<I, S, C> {
+    /// Creates a batch stamper that reads stamp timestamps from `clock`.
+    pub const fn with_clock(issuer: I, signer: S, clock: C) -> Self {
+        Self {
+            issuer,
+            signer,
+            clock,
+        }
+    }
+
+    /// Returns a reference to the clock.
+    pub const fn clock(&self) -> &C {
+        &self.clock
     }
 
     /// Returns a reference to the issuer.
@@ -145,7 +196,7 @@ impl<I, S> BatchStamper<I, S> {
     }
 }
 
-impl<I, S> BatchStamper<I, S>
+impl<I, S, C> BatchStamper<I, S, C>
 where
     I: StampIssuer,
 {
@@ -162,15 +213,16 @@ where
     }
 }
 
-impl<I, S> Stamper for BatchStamper<I, S>
+impl<I, S, C> Stamper for BatchStamper<I, S, C>
 where
     I: StampIssuer,
     S: SignerSync,
+    C: Clock,
 {
     type Error = SigningError;
 
     fn stamp(&mut self, address: &ChunkAddress) -> Result<Stamp, Self::Error> {
-        let timestamp = current_timestamp();
+        let timestamp = stamp_timestamp(&self.clock);
         let digest = self.issuer.prepare_stamp(address, timestamp)?;
         let prehash = digest.to_prehash();
 
@@ -249,6 +301,28 @@ mod tests {
         // All should be in the same bucket
         assert_eq!(stamp1.bucket(), stamp2.bucket());
         assert_eq!(stamp2.bucket(), stamp3.bucket());
+    }
+
+    #[test]
+    fn test_batch_stamper_injected_clock() {
+        use nectar_clock::ManualClock;
+
+        let issuer = MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
+        let clock = ManualClock::new(1_234_567_890);
+        let mut stamper = BatchStamper::with_clock(issuer, MockSigner, &clock);
+
+        let address = ChunkAddress::new([0xAB; 32]);
+        let stamp = stamper.stamp(&address).unwrap();
+        assert_eq!(stamp.timestamp(), 1_234_567_890);
+
+        clock.set_ns(2_000_000_000);
+        let stamp = stamper.stamp(&address).unwrap();
+        assert_eq!(stamp.timestamp(), 2_000_000_000);
+
+        // A pre-epoch reading clamps to zero, matching the default clock path.
+        clock.set_ns(-1);
+        let stamp = stamper.stamp(&address).unwrap();
+        assert_eq!(stamp.timestamp(), 0);
     }
 
     #[test]

--- a/crates/postage-usage/Cargo.toml
+++ b/crates/postage-usage/Cargo.toml
@@ -29,7 +29,7 @@ thiserror = { workspace = true }
 alloy-signer = { workspace = true, optional = true }
 arbitrary = { workspace = true, optional = true }
 auto_impl = { workspace = true, optional = true }
-web-time = { workspace = true, optional = true }
+nectar-clock = { workspace = true, optional = true }
 
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = ["getrandom"] }
@@ -47,6 +47,7 @@ default = [ "std" ]
 # Standard library support.
 std = [
 	"alloy-primitives/std",
+	"nectar-clock?/std",
 	"nectar-postage-issuer/std",
 	"nectar-postage/std",
 	"thiserror/std",
@@ -74,8 +75,8 @@ seal = [ "dep:alloy-signer", "std" ]
 # High-level async facade (`BatchStamper`) that collapses the open / stamp /
 # flush cross-machine roam into three calls. The consumer supplies the network
 # through the `SnapshotSource` and `SnapshotSink` traits. Implies `seal` (it seals
-# every persist) and `std` (it reads the wall clock for the seal timestamp).
-client = [ "dep:auto_impl", "dep:web-time", "seal", "std" ]
+# every persist) and `std` (the seal timestamp defaults to the system clock).
+client = [ "dep:auto_impl", "dep:nectar-clock", "seal", "std" ]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/postage-usage/src/client.rs
+++ b/crates/postage-usage/src/client.rs
@@ -28,7 +28,7 @@
 
 use alloc::vec::Vec;
 
-use web_time::{SystemTime, UNIX_EPOCH};
+use nectar_clock::{Clock, SystemClock};
 
 use alloy_primitives::Address;
 use alloy_signer::SignerSync;
@@ -142,14 +142,20 @@ where
 /// The owner is fixed at `open` from the signer's address, and every snapshot
 /// chunk address is derived from it and the batch id, so a second machine
 /// holding only the same key and batch id recovers the same state.
+///
+/// Seal timestamps come from the clock type parameter, defaulting to the
+/// system clock; [`open_with_clock`](Self::open_with_clock) injects a
+/// deterministic source.
 #[derive(Debug)]
-pub struct BatchStamperFor<Sg, Src, Snk, S: SwarmSpec = Mainnet> {
+pub struct BatchStamperFor<Sg, Src, Snk, S: SwarmSpec = Mainnet, C = SystemClock> {
     signer: Sg,
     owner: Address,
     batch_id: BatchId,
     source: Src,
     sink: Snk,
     snapshot: SnapshotFor<S>,
+    /// The timestamp source for seals.
+    clock: C,
     /// Whether a persist has been emitted in this session. A clean snapshot that
     /// has already persisted once this session makes [`flush`](Self::flush) a
     /// no-op; a clean but never-persisted snapshot still flushes once so a fresh
@@ -158,7 +164,7 @@ pub struct BatchStamperFor<Sg, Src, Snk, S: SwarmSpec = Mainnet> {
 }
 
 /// The [`BatchStamperFor`] of the mainnet spec.
-pub type BatchStamper<Sg, Src, Snk> = BatchStamperFor<Sg, Src, Snk, Mainnet>;
+pub type BatchStamper<Sg, Src, Snk, C = SystemClock> = BatchStamperFor<Sg, Src, Snk, Mainnet, C>;
 
 impl<Sg, Src, Snk, S> BatchStamperFor<Sg, Src, Snk, S>
 where
@@ -168,6 +174,30 @@ where
     S: SwarmSpec,
 {
     /// Opens a stamper for `batch`, recovering published state or starting fresh.
+    ///
+    /// Seal timestamps come from the system clock; see
+    /// [`open_with_clock`](Self::open_with_clock) for the recovery contract and
+    /// for injecting a deterministic source.
+    pub async fn open(
+        signer: Sg,
+        batch: &Batch<S>,
+        source: Src,
+        sink: Snk,
+    ) -> Result<Self, ClientError<Src::Error, Snk::Error>> {
+        Self::open_with_clock(signer, batch, source, sink, SystemClock).await
+    }
+}
+
+impl<Sg, Src, Snk, S, C> BatchStamperFor<Sg, Src, Snk, S, C>
+where
+    Sg: SignerSync + alloy_signer::Signer,
+    Src: SnapshotSource,
+    Snk: SnapshotSink,
+    S: SwarmSpec,
+    C: Clock,
+{
+    /// Opens a stamper for `batch` whose seal timestamps read from `clock`,
+    /// recovering published state or starting fresh.
     ///
     /// The owner is taken from `signer.address()`. The root chunk address is
     /// derived from the batch id, owner, and index 0, then read through `source`:
@@ -183,11 +213,12 @@ where
     /// - `Err`: the read could not be completed. This aborts; it never starts
     ///   fresh, so a transport failure cannot downgrade a batch that already has
     ///   a published root.
-    pub async fn open(
+    pub async fn open_with_clock(
         signer: Sg,
         batch: &Batch<S>,
         source: Src,
         sink: Snk,
+        clock: C,
     ) -> Result<Self, ClientError<Src::Error, Snk::Error>> {
         let owner = signer.address();
         let batch_id = batch.id();
@@ -232,6 +263,7 @@ where
             source,
             sink,
             snapshot,
+            clock,
             persisted_this_session: false,
         })
     }
@@ -262,7 +294,7 @@ where
     /// - `Err`: the read could not be completed. This aborts; it never persists
     ///   against a floor it could not read.
     ///
-    /// The seal timestamp is the wall clock, nudged past the previous seal so the
+    /// The seal timestamp is the clock reading, nudged past the previous seal so the
     /// in-process monotonicity guard in [`seal_plan`] never trips and the reserve
     /// overwrites each metadata chunk in place. A persist whose next sequence does
     /// not strictly exceed the live floor surfaces as
@@ -287,13 +319,10 @@ where
         let plan = self.snapshot.revalidate(floor)?.plan_persist(&self.owner)?;
 
         // The seal timestamp must strictly increase across flushes so the reserve
-        // overwrites each metadata chunk in place. Take the wall clock, but lift
-        // it past the previous seal so a coarse or non-advancing clock never trips
-        // the in-process guard in `seal_plan`.
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
+        // overwrites each metadata chunk in place. Read the clock (pre-epoch
+        // clamps to zero), but lift it past the previous seal so a coarse or
+        // non-advancing clock never trips the in-process guard in `seal_plan`.
+        let now = u64::try_from(self.clock.now_secs()).unwrap_or(0);
         // `previous` is a wall-clock seal timestamp in seconds, recorded by
         // an earlier flush, so it sits far below u64::MAX and the increment
         // cannot overflow.
@@ -479,6 +508,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn flush_seals_with_the_injected_clock() {
+        use nectar_clock::ManualClock;
+
+        let signer = PrivateKeySigner::random();
+        let batch = test_batch(&signer, true);
+        let net = MemNet::default();
+
+        let clock = ManualClock::new(1_000 * 1_000_000_000);
+        let mut stamper =
+            BatchStamper::open_with_clock(signer, &batch, net.clone(), net.clone(), &clock)
+                .await
+                .unwrap();
+
+        stamper
+            .stamp(&ChunkAddress::from(B256::repeat_byte(0x99)))
+            .unwrap();
+        stamper.flush().await.unwrap();
+        assert_eq!(stamper.snapshot().last_seal_timestamp(), Some(1_000));
+
+        // A non-advancing clock still seals strictly after the previous seal.
+        stamper
+            .stamp(&ChunkAddress::from(B256::repeat_byte(0x77)))
+            .unwrap();
+        stamper.flush().await.unwrap();
+        assert_eq!(stamper.snapshot().last_seal_timestamp(), Some(1_001));
+
+        clock.advance(core::time::Duration::from_secs(60));
+        stamper
+            .stamp(&ChunkAddress::from(B256::repeat_byte(0x55)))
+            .unwrap();
+        stamper.flush().await.unwrap();
+        assert_eq!(stamper.snapshot().last_seal_timestamp(), Some(1_060));
+    }
+
+    #[tokio::test]
     async fn open_recovers_published_batch() {
         let signer = PrivateKeySigner::random();
         let owner = signer.address();
@@ -536,6 +600,7 @@ mod tests {
             source: FailingSource,
             sink: net.clone(),
             snapshot: Snapshot::from_batch(&batch).unwrap(),
+            clock: SystemClock,
             persisted_this_session: false,
         };
         stamper
@@ -625,6 +690,7 @@ mod tests {
             source: net.clone(),
             sink: net.clone(),
             snapshot: stale,
+            clock: SystemClock,
             persisted_this_session: false,
         };
         b.stamp(&ChunkAddress::from(B256::repeat_byte(0x03)))

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1913,6 +1913,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "nectar-clock"
+version = "0.4.0"
+dependencies = [
+ "nectar-marker",
+ "web-time",
+]
+
+[[package]]
 name = "nectar-file"
 version = "0.4.0"
 dependencies = [
@@ -1993,6 +2001,7 @@ version = "0.4.0"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
+ "nectar-clock",
  "nectar-postage",
  "nectar-primitives",
  "thiserror",
@@ -2005,6 +2014,7 @@ dependencies = [
  "alloy-primitives",
  "arbitrary",
  "bytes",
+ "nectar-clock",
  "nectar-postage",
  "nectar-postage-issuer",
  "nectar-primitives",


### PR DESCRIPTION
## What

Threads the `nectar-clock` `Clock` trait through the postage stamping paths that read wall-clock time.

`BatchStamper` (postage-issuer) gains a defaulted clock type parameter (`C = SystemClock`), plus `with_clock`/`clock()` accessors; `BatchStamper::new` keeps its existing signature and default output is unchanged (`stamp_timestamp` reads `now_ns()` as `u64`, clamping pre-epoch reads to zero, matching the previous `current_timestamp` behaviour).

Parallel signing keeps `sign_stamps_parallel` and adds `sign_stamps_parallel_with_clock`, which threads a `Clock` through the sharded `sign_stamp_internal` helper.

`postage-usage`'s `BatchStamperFor` client facade gains a clock type parameter too; `open` keeps its signature and delegates to a new `open_with_clock`, which stores the clock and uses it for the seal timestamp in `flush` (`now_secs()`, clamped to zero pre-epoch) instead of reading `web-time::SystemTime` directly.

`postage-issuer`'s `std` feature now also enables `nectar-clock/std`; `postage-usage`'s `client` feature depends on `nectar-clock` instead of `web-time` and enables `nectar-clock?/std` under `std`. The workspace `Cargo.toml` `nectar-clock` entry now carries `default-features = false` (required for the member crates' `no_std` overrides to take effect). `Cargo.lock` and `fuzz/Cargo.lock` are regenerated and committed: the workspace lock drops `web-time` from the dependency graph and adds `nectar-clock` to both crates, and the fuzz lock picks up the new `nectar-clock` edges.

## Why

Closes #134.

Stamp and seal timestamps were reading the wall clock directly (`current_timestamp` in postage-issuer, `web-time::SystemTime` in postage-usage), which is untestable and inconsistent with the rest of the codebase's `nectar-clock` seam. Injecting `Clock` with a `SystemClock` default keeps existing call sites and output byte-for-byte identical while making the timestamp source deterministic and swappable for tests.

## Testing

New deterministic tests using `nectar-clock::ManualClock`:

- `test_batch_stamper_injected_clock` (postage-issuer): verifies `BatchStamper::with_clock` stamps use the injected clock, including the pre-epoch clamp-to-zero case.
- `test_parallel_signing_with_clock` (postage-issuer): verifies `sign_stamps_parallel_with_clock` produces the injected timestamp across sharded signing.
- `flush_seals_with_the_injected_clock` (postage-usage): verifies `open_with_clock` seals use the injected clock, including the monotonic-nudge-past-previous-seal behaviour and a non-advancing clock.

## AI Assistance

Implemented by Claude (Fable), reviewed by Claude (Opus), per nxm-rs/.github CONTRIBUTING.md.
