### PR TITLE
refactor: consolidate spec citations into per-crate SPEC.md

### DIFF
--- a/crates/mantaray/SPEC.md
+++ b/crates/mantaray/SPEC.md
@@ -1,0 +1,9 @@
+# Spec references
+
+Source citations for the wire format this crate ports from the reference client. Citations pin the reference client at tag `v2.8.1`.
+
+## Wire format
+
+| Citation | Description |
+|---|---|
+| `pkg/manifest/mantaray/docs/format/node.md` | Node and fork byte layout for manifest versions 0.1 and 0.2; `ref_size` is a single uniform width in {32, 64} governing the entry slot and every fork ref slot. |

--- a/crates/mantaray/src/codec.rs
+++ b/crates/mantaray/src/codec.rs
@@ -2,7 +2,7 @@
 //!
 //! Wire behaviour: fork reference slots are carried at their full declared
 //! width, so the encrypted width writes and reads the child's address and
-//! decryption key (bee-spec node.md stores the full reference). Earlier
+//! decryption key (`SPEC.md#wire-format` stores the full reference). Earlier
 //! encoders zero-padded the key half; those images still decode, yielding an
 //! all-zero key. Plain manifests are unaffected.
 
@@ -97,23 +97,22 @@ fn encode_node<R: Reference>(node: &Node<R>) -> Result<Vec<u8>> {
     Ok(data)
 }
 
-// ┌─────────────────────────── HAZMAT ───────────────────────────┐
-// │ BEE-WORKAROUND(bee#5483): bee's mantaray writer occasionally  │
-// │ emits a node with `ref_size = 0` (the byte at header offset  │
-// │ 63) for entry-less terminal nodes. This is not spec-legal:  │
-// │ the spec doc (bee/pkg/manifest/mantaray/docs/format/node.md) │
-// │ and every reference impl (bee, mantaray-js, nectar) treat    │
-// │ `ref_size` as a single uniform width in {32, 64} governing   │
-// │ both the entry slot and every fork ref slot. mantaray-js     │
-// │ documents the bee artifact with an explicit FIXME: "in Bee,  │
-// │ if one uploads a file on the bzz endpoint, the node under    │
-// │ `/` gets 0 refsize."                                         │
-// │                                                              │
-// │ Remove the `RefSize::EmptyTerminal` variant, its zero-width   │
-// │ classification in `parse_header`, and `decode_empty_terminal` │
-// │ once the upstream bee fix lands and downstream consumers have │
-// │ upgraded past the buggy releases.                            │
-// └──────────────────────────────────────────────────────────────┘
+// ┌──────────────────────────── HAZMAT ────────────────────────────┐
+// │ BEE-WORKAROUND(bee#5483): the reference client's mantaray      │
+// │ writer occasionally emits a node with `ref_size = 0` (the      │
+// │ byte at header offset 63) for entry-less terminal nodes.       │
+// │ This is not spec-legal: the wire-format doc                    │
+// │ (`SPEC.md#wire-format`) and every other implementation treat   │
+// │ `ref_size` as a single uniform width in {32, 64} governing     │
+// │ both the entry slot and every fork ref slot. mantaray-js       │
+// │ documents the artifact with an explicit FIXME (a file          │
+// │ uploaded on the bzz endpoint gets a 0-refsize node under `/`). │
+// │                                                                │
+// │ Remove the `RefSize::EmptyTerminal` variant, its zero-width    │
+// │ classification in `parse_header`, and `decode_empty_terminal`  │
+// │ once the upstream fix lands and downstream consumers have      │
+// │ upgraded past the buggy releases.                              │
+// └────────────────────────────────────────────────────────────────┘
 
 /// The reference width declared by a node header.
 ///
@@ -316,8 +315,9 @@ fn parse_fork_body<R: Reference>(body: &[u8], has_metadata: bool) -> DecodeResul
 /// Construction is the sole fallible step: a fork whose child was never
 /// persisted has no reference, and oversized metadata cannot be sized into the
 /// `u16` length field. Once built, [`emit`](Self::emit) cannot produce a
-/// misaligned image. bee-spec node.md: fork layout is node_type, prefix_len, a
-/// 30-byte prefix region, the full-width reference, then optional metadata.
+/// misaligned image. Per `SPEC.md#wire-format`: fork layout is node_type,
+/// prefix_len, a 30-byte prefix region, the full-width reference, then
+/// optional metadata.
 struct WireFork<'a, R: Reference> {
     node_type: NodeType,
     prefix: &'a Prefix,

--- a/crates/mantaray/src/error.rs
+++ b/crates/mantaray/src/error.rs
@@ -14,8 +14,8 @@ pub type DecodeResult<T> = core::result::Result<T, DecodeError>;
 ///
 /// Reported to callers through [`MantarayError::Corrupt`], which pairs the
 /// failure with the address of the chunk the malformed bytes came from so a
-/// deep-load failure names the offending chunk. bee-spec node.md governs the
-/// layout these variants reject.
+/// deep-load failure names the offending chunk. `SPEC.md#wire-format` governs
+/// the layout these variants reject.
 #[non_exhaustive]
 #[derive(thiserror::Error, Debug)]
 pub enum DecodeError {

--- a/crates/mantaray/src/lib.rs
+++ b/crates/mantaray/src/lib.rs
@@ -74,6 +74,11 @@
 //! assert!(decoded.entry().is_none());
 //! ```
 //!
+//! # Spec references
+//!
+//! Reference-client source citations for the wire format live in `SPEC.md`
+//! at the crate root.
+//!
 //! # Upstream-bug workarounds
 //!
 //! Code that exists solely to tolerate a defect in an upstream reference

--- a/crates/primitives/SPEC.md
+++ b/crates/primitives/SPEC.md
@@ -1,0 +1,60 @@
+# Spec references
+
+Source citations for the algorithms and wire formats this crate ports from the reference client. Citations pin the reference client at tag `v2.8.1`; line numbers are valid at that tag and may drift on later revisions.
+
+Module docs link here instead of restating citations inline.
+
+## Overlay derivation
+
+| Citation | Description |
+|---|---|
+| `pkg/crypto/crypto.go:45-57` | Overlay address is `keccak256(eth_address(20) \|\| network_id_le(8) \|\| nonce(32))`; the network id is little-endian in this hash. |
+
+## Network identifiers
+
+| Citation | Description |
+|---|---|
+| `pkg/swarm/swarm.go` | Canonical network identifiers (mainnet `1`, testnet `10`). |
+
+## Handshake sign-data
+
+| Citation | Description |
+|---|---|
+| `pkg/bzz/address.go:138-160` | BzzAddress sign-data layout: magic prefix, underlay bytes, overlay (32), network id big-endian (8), nonce (32), timestamp big-endian (8), chequebook (20). The 14-byte magic prefix is declared at the top of this range. |
+
+## Handshake timestamp
+
+| Citation | Description |
+|---|---|
+| `pkg/bzz/timestamp.go` | Sign-data timestamp is a signed big-endian `int64` of unix seconds; verification rejects records outside a drift window from the local clock. |
+
+## Kademlia parameters
+
+| Citation | Description |
+|---|---|
+| `pkg/topology/kademlia/kademlia.go:54-56` | Default saturation (8), over-saturation (18), and bootnode over-saturation (20) peer counts. |
+
+## Neighborhood depth
+
+| Citation | Description |
+|---|---|
+| `pkg/topology/kademlia/kademlia.go:896-920` | `recalcDepth`: depth candidate is the shallowest unsaturated bin, then anchored by the low-watermark cumulative count over the deepest bins. |
+
+## Single-owner chunks
+
+| Citation | Description |
+|---|---|
+| `pkg/soc/soc.go` | Single-owner chunk semantics; the SOC address is `keccak256(id \|\| owner)`. |
+
+## Chunk encryption
+
+| Citation | Description |
+|---|---|
+| `pkg/encryption/chunk_encryption.go` | `ChunkEncrypter`: span and data are encrypted separately with different initial counters. |
+
+## Transformed addresses
+
+| Citation | Description |
+|---|---|
+| `pkg/storer/sample.go` | `transformedAddressCAC`: anchor-prefixed BMT over span and payload, the redistribution sampler's per-round re-hash. |
+| `pkg/storer/sample_test.go` | Deterministic parity vectors: `TestSampleVectorCAC` (CAC) and `TestMakeInclusionProofsRegression` (SOC). |

--- a/crates/primitives/SPEC.md
+++ b/crates/primitives/SPEC.md
@@ -14,7 +14,7 @@ Module docs link here instead of restating citations inline.
 
 | Citation | Description |
 |---|---|
-| `pkg/swarm/swarm.go` | Canonical network identifiers (mainnet `1`, testnet `10`). |
+| `pkg/config/chain.go` | Canonical network identifiers (mainnet `1`, testnet `10`). |
 
 ## Handshake sign-data
 
@@ -57,4 +57,5 @@ Module docs link here instead of restating citations inline.
 | Citation | Description |
 |---|---|
 | `pkg/storer/sample.go` | `transformedAddressCAC`: anchor-prefixed BMT over span and payload, the redistribution sampler's per-round re-hash. |
-| `pkg/storer/sample_test.go` | Deterministic parity vectors: `TestSampleVectorCAC` (CAC) and `TestMakeInclusionProofsRegression` (SOC). |
+| `pkg/storer/sample_test.go` | Deterministic CAC parity vector: `TestSampleVectorCAC`. |
+| `pkg/storageincentives/proof_test.go` | Deterministic SOC parity vector: `TestMakeInclusionProofsRegression`. |

--- a/crates/primitives/src/bmt/tests.rs
+++ b/crates/primitives/src/bmt/tests.rs
@@ -167,13 +167,14 @@ fn reference_prefix_root(prefix: Option<&[u8]>, span: u64, payload: &[u8]) -> B2
     B256::from_slice(h.finalize().as_slice())
 }
 
-/// Cross-implementation parity gate against bee's published deterministic
-/// vector (pkg/storer/sample_test.go TestSampleVectorCAC).
+/// Cross-implementation parity gate against the reference client's published
+/// deterministic vector (`TestSampleVectorCAC`, see `SPEC.md#transformed-addresses`).
 ///
 /// Chunk content is 4096 bytes with byte[i] = i % 256; the CAC span is 4096
 /// (little-endian). The plain BMT root is the chunk address and the
-/// anchor-prefixed BMT root is bee's transformed address. Reproducing both
-/// byte-for-byte proves nectar's per-node prefixing is bee-identical.
+/// anchor-prefixed BMT root is the transformed address. Reproducing both
+/// byte-for-byte proves nectar's per-node prefixing matches the reference
+/// client.
 #[test]
 fn test_bee_sample_vector_cac_parity() {
     const ANCHOR: &[u8] = b"swarm-test-anchor-deterministic!";

--- a/crates/primitives/src/chunk/any_chunk.rs
+++ b/crates/primitives/src/chunk/any_chunk.rs
@@ -617,13 +617,14 @@ mod tests {
         assert!(DefaultAnyChunk::from_wire_bytes(&addr, opaque).is_err());
     }
 
-    // --- transformed address (redistribution sampler) bee parity -------------
+    // --- transformed address (redistribution sampler) parity -----------------
     //
     // nectar owns the parity oracle for the anchor-keyed transformed address.
-    // The vectors below are taken from bee so that any drift in the prefixed
+    // The vectors below are taken from the reference client
+    // (SPEC.md#transformed-addresses) so that any drift in the prefixed
     // BMT or the single-owner outer wrap is caught here, at the primitive.
 
-    /// bee `TestSampleVectorCAC` (`pkg/storer/sample_test.go`): a 4096-byte CAC
+    /// The reference client's `TestSampleVectorCAC` vector: a 4096-byte CAC
     /// whose payload is the repeating pattern `i % 256`, transformed under the
     /// anchor `swarm-test-anchor-deterministic!`.
     #[test]
@@ -661,7 +662,7 @@ mod tests {
         );
     }
 
-    /// A single-owner chunk vector from bee's `TestMakeInclusionProofsRegression`
+    /// A single-owner chunk vector from the reference client's `TestMakeInclusionProofsRegression`
     /// oracle (anchor1 = `0x64`). Exercises the SOC path: the wrapped content
     /// chunk is re-hashed under the anchor, then the SOC transformed address is
     /// the plain `keccak256(soc_address || inner)`.

--- a/crates/primitives/src/chunk/bmt_body.rs
+++ b/crates/primitives/src/chunk/bmt_body.rs
@@ -99,7 +99,8 @@ impl<const BODY_SIZE: usize> BmtBody<BODY_SIZE> {
     ///
     /// This is the prefixed BMT of the body (`span` + `payload`), where the
     /// `anchor` is mixed into *every* node hash via [`Hasher::with_prefix`].
-    /// It mirrors bee's `transformedAddressCAC` (`pkg/storer/sample.go`) and is
+    /// It mirrors the reference client's `transformedAddressCAC`
+    /// (`SPEC.md#transformed-addresses`) and is
     /// the redistribution sampler's per-round, per-node re-hash of a chunk
     /// body. The span is serialised little-endian by the hasher.
     ///

--- a/crates/primitives/src/chunk/encryption/chunk.rs
+++ b/crates/primitives/src/chunk/encryption/chunk.rs
@@ -1,7 +1,7 @@
 //! Chunk-level encryption and decryption.
 //!
 //! Encrypts a chunk's span and data separately with different initial counters,
-//! matching Go's `ChunkEncrypter` in `pkg/encryption/chunk_encryption.go`.
+//! matching the reference client's `ChunkEncrypter` (`SPEC.md#chunk-encryption`).
 
 #[cfg(any(test, feature = "encryption"))]
 use crate::bmt::SPAN_SIZE;

--- a/crates/primitives/src/chunk/soc_id.rs
+++ b/crates/primitives/src/chunk/soc_id.rs
@@ -2,8 +2,8 @@
 //!
 //! A [`SocId`] is the 32-byte identifier a single-owner chunk is signed
 //! under; the SOC address is `keccak256(id || owner)`. See
-//! [`SingleOwnerChunk`](super::single_owner::SingleOwnerChunk) and bee
-//! `pkg/soc/soc.go` for the reference semantics.
+//! [`SingleOwnerChunk`](super::single_owner::SingleOwnerChunk) and
+//! `SPEC.md#single-owner-chunks` for the reference semantics.
 
 use alloy_primitives::B256;
 use derive_more::{AsRef, Display, From, Into};

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -9,6 +9,9 @@
 //! - **Binary Merkle Tree**: Efficient content addressing and proof generation ([`bmt::Hasher`])
 //! - **OverlayAddress**: 256-bit identifiers for network addressing
 //!
+//! Reference-client source citations for the ported algorithms live in
+//! `SPEC.md` at the crate root.
+//!
 //! ## Usage Examples
 //!
 //! ```

--- a/crates/primitives/src/neighborhood_depth.rs
+++ b/crates/primitives/src/neighborhood_depth.rs
@@ -1,8 +1,9 @@
 //! Canonical neighborhood-depth recomputation.
 //!
-//! Neighborhood depth from per-bin peer counts.
-//! (`recalcDepth`). The wrapper type (`NeighborhoodDepth`) stays in the
-//! routing layer of each downstream impl; nectar only owns the math.
+//! Neighborhood depth from per-bin peer counts, matching the reference
+//! client's `recalcDepth` (`SPEC.md#neighborhood-depth`). The wrapper type
+//! (`NeighborhoodDepth`) stays in the routing layer of each downstream impl;
+//! nectar only owns the math.
 
 use crate::Bin;
 

--- a/crates/primitives/src/network_id.rs
+++ b/crates/primitives/src/network_id.rs
@@ -2,9 +2,9 @@
 //!
 //! [`NetworkId`] is mixed into the overlay address (see [`compute_overlay`])
 //! so that a single keypair derives a different overlay on each network.
-//! This is the Swarm-wide partitioning mechanism inherited from bee
-//! (see `pkg/crypto/crypto.go:45-57` for the derivation, and
-//! `pkg/swarm/swarm.go` for canonical IDs).
+//! This is the Swarm-wide partitioning mechanism inherited from the reference
+//! client (derivation: `SPEC.md#overlay-derivation`; canonical IDs:
+//! `SPEC.md#network-identifiers`).
 //!
 //! [`compute_overlay`]: crate::compute_overlay
 
@@ -13,7 +13,7 @@ use derive_more::{Display, From, Into};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-/// Swarm network identifier (u64 wire-compatible with bee).
+/// Swarm network identifier (u64 wire-compatible with the reference client).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Display, From, Into)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
@@ -40,14 +40,14 @@ impl NetworkId {
     }
 
     /// Eight-byte little-endian representation (used in
-    /// [`compute_overlay`](crate::compute_overlay) per bee).
+    /// [`compute_overlay`](crate::compute_overlay), see `SPEC.md#overlay-derivation`).
     #[inline]
     pub const fn to_le_bytes(self) -> [u8; 8] {
         self.0.to_le_bytes()
     }
 
-    /// Eight-byte big-endian representation (used in the BzzAddress sign-data
-    /// per bee `pkg/bzz/address.go:138-160`).
+    /// Eight-byte big-endian representation (used in the BzzAddress sign-data,
+    /// see `SPEC.md#handshake-sign-data`).
     #[inline]
     pub const fn to_be_bytes(self) -> [u8; 8] {
         self.0.to_be_bytes()

--- a/crates/primitives/src/nonce.rs
+++ b/crates/primitives/src/nonce.rs
@@ -3,7 +3,7 @@
 //! A [`Nonce`] is the 32-byte value mixed with an Ethereum address and a
 //! [`NetworkId`](crate::NetworkId) when deriving the Swarm overlay address.
 //! See [`compute_overlay`](crate::compute_overlay) for the canonical
-//! derivation matching bee `pkg/crypto/crypto.go:45-57`.
+//! derivation (`SPEC.md#overlay-derivation`).
 
 use alloy_primitives::B256;
 use derive_more::{AsRef, Display, From, Into};

--- a/crates/primitives/src/overlay.rs
+++ b/crates/primitives/src/overlay.rs
@@ -1,7 +1,7 @@
 //! Canonical overlay address derivation.
 //!
 //! The Swarm overlay address is `keccak256(ethereum_address || network_id || nonce)`
-//! per bee `pkg/crypto/crypto.go:45-57`. Network ID is encoded in
+//! per the reference client (`SPEC.md#overlay-derivation`). Network ID is encoded in
 //! **little-endian** in this hash (distinct from the big-endian encoding used
 //! in the BzzAddress sign-data, see [`crate::signing::sign_data`]).
 

--- a/crates/primitives/src/signing.rs
+++ b/crates/primitives/src/signing.rs
@@ -2,8 +2,8 @@
 //!
 //! The Swarm peer record (overlay + underlay + nonce + timestamp + chequebook)
 //! is authenticated by an EIP-191 personal-sign signature over the byte
-//! sequence built by [`sign_data`] below. The layout matches bee
-//! `pkg/bzz/address.go:138-160` exactly so any Swarm impl can interop.
+//! sequence built by [`sign_data`] below. The layout matches the reference
+//! client exactly (`SPEC.md#handshake-sign-data`) so any Swarm impl can interop.
 //!
 //! ```text
 //! sign_data = "bee-handshake-"        (14 bytes)
@@ -38,14 +38,14 @@ use alloy_primitives::Address;
 
 use crate::{NetworkId, Nonce, OverlayAddress, Timestamp};
 
-/// Magic prefix matching bee `pkg/bzz/address.go:138` (`signDataPrefix`).
+/// Magic prefix of the sign-data layout (`SPEC.md#handshake-sign-data`).
 pub const SIGN_DATA_PREFIX: &[u8] = b"bee-handshake-";
 
 /// Build the canonical sign-data buffer for a BzzAddress.
 ///
 /// `underlay_bytes` is the wire-encoded multiaddr list (caller-defined format).
 /// `chequebook` is `None` for nodes without a chequebook; the byte layout
-/// pads with 20 zero bytes either way, matching bee's `common.Address{}.Bytes()`
+/// pads with 20 zero bytes either way, matching the reference client's
 /// behaviour (so `None` and `Some(Address::ZERO)` produce byte-identical
 /// sign-data - verified by the test suite).
 #[must_use]

--- a/crates/primitives/src/spec.rs
+++ b/crates/primitives/src/spec.rs
@@ -11,8 +11,9 @@ use crate::{Bin, NetworkId, ProximityOrder};
 /// Canonical Swarm network spec.
 ///
 /// Only [`NETWORK_ID`](Self::NETWORK_ID) is required; the rest default to the
-/// reference client's values and may be overridden per deployment. Defaulted
-/// consts can be added without breaking implementors.
+/// reference client's values (`SPEC.md#kademlia-parameters`) and may be
+/// overridden per deployment. Defaulted consts can be added without breaking
+/// implementors.
 pub trait SwarmSpec {
     /// Network identifier used in [`compute_overlay`](crate::compute_overlay)
     /// and the BzzAddress sign-data.

--- a/crates/primitives/src/timestamp.rs
+++ b/crates/primitives/src/timestamp.rs
@@ -1,8 +1,8 @@
 //! Typed unix-seconds timestamp used in BzzAddress sign-data.
 //!
-//! The bee handshake sign-data carries an `int64` timestamp (big-endian,
-//! signed). Verification rejects records whose timestamp drifts outside a
-//! caller-supplied window from local clock. See bee `pkg/bzz/timestamp.go`.
+//! The handshake sign-data carries an `int64` timestamp (big-endian, signed).
+//! Verification rejects records whose timestamp drifts outside a
+//! caller-supplied window from local clock. See `SPEC.md#handshake-timestamp`.
 
 use derive_more::{Display, From, Into};
 use std::time::Duration;
@@ -10,7 +10,7 @@ use std::time::Duration;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-/// Unix-seconds timestamp (signed, matching bee's `int64`).
+/// Unix-seconds timestamp (signed, matching the reference client's `int64`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Display, From, Into)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]


### PR DESCRIPTION
## What

Groups the crates' reference-client citations into two per-crate `SPEC.md` files, `crates/primitives/SPEC.md` (nine concept-area tables: overlay derivation, network identifiers, handshake sign-data, handshake timestamp, kademlia parameters, neighborhood depth, single-owner chunks, chunk encryption, transformed addresses) and `crates/mantaray/SPEC.md` (wire format), both pinning the reference client at tag `v2.8.1`. 16 source files across the two crates now point at terse `SPEC.md#anchor` references instead of restating inline path citations, and every touched line refers to "the reference client" rather than naming it directly. A follow-up commit corrects two citations found wrong during verification: the network-id table now points at `pkg/config/chain.go` (was `pkg/swarm/swarm.go`), and the transformed-addresses table splits the CAC and SOC deterministic parity vectors into their own rows, since the SOC vector actually lives in `pkg/storageincentives/proof_test.go`, not `pkg/storer/sample_test.go`.

Closes #42.

## Why

Inline per-line citations scattered the same reference-client pointers across many files and made them expensive to keep in sync. Consolidating them into per-crate SPEC.md tables, pinned to a tag, gives one place to update on a reference-client bump and lets module docs link an anchor instead of repeating a citation.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked`
- Deterministic CAC/SOC parity vector tests rerun and pass
- Every citation, including those accreted from the issue thread, re-verified live against the v2.8.1 tag before pinning
- Diff is doc-comment only; no Cargo.toml or code-logic changes

## AI Assistance

Implemented with Claude (Fable), reviewed with Claude (Opus).
