### PR TITLE
file: draw pooled split keys at submission

### DIFF
--- a/crates/file/src/split/encrypted.rs
+++ b/crates/file/src/split/encrypted.rs
@@ -17,7 +17,8 @@ use crate::walk::Encrypted;
 /// Key supply for the encrypted split; one fresh key seals one chunk.
 ///
 /// Sources are shared handles: a clone draws from the same stream, so keys
-/// stay unique across the streaming ascent and pool workers.
+/// stay unique across clones. The split draws every key on the engine
+/// thread in seal order, so a deterministic source reproduces the tree.
 pub trait KeySource: MaybeSend + MaybeSync + 'static {
     /// The key sealing the next chunk.
     fn next_key(&self) -> Result<EncryptionKey, KeyError>;
@@ -65,13 +66,20 @@ impl<K: KeySource> SplitMode for Encrypted<K> {
 
     type Ref = EncryptedChunkRef;
     type Root = EncryptedChunkRef;
+    type Draw = EncryptionKey;
 
     fn data_slots(branches: u64) -> u64 {
         branches
     }
 
-    fn seal<const B: usize>(&self, payload: Bytes) -> Result<Sealed<Self, B>, SealError> {
-        let key = self.source().next_key()?;
+    fn draw(&self) -> Result<EncryptionKey, SealError> {
+        Ok(self.source().next_key()?)
+    }
+
+    fn seal_with<const B: usize>(
+        key: EncryptionKey,
+        payload: Bytes,
+    ) -> Result<Sealed<Self, B>, SealError> {
         let (chunk, reference) = ContentChunk::<B>::try_from(payload)?
             .encrypt_with(&key)?
             .into_parts();

--- a/crates/file/src/split/engine.rs
+++ b/crates/file/src/split/engine.rs
@@ -17,26 +17,14 @@ use nectar_primitives::chunk::{AnyChunkSet, Chunk, ChunkAddress, Verified};
 use nectar_primitives::store::ChunkPut;
 
 use super::SplitStats;
-#[cfg(all(
-    feature = "rayon",
-    not(target_arch = "wasm32"),
-    not(feature = "unsync")
-))]
-use super::error::SealError;
-use super::error::SplitError;
+use super::error::{SealError, SplitError};
 #[cfg(all(
     feature = "rayon",
     not(target_arch = "wasm32"),
     not(feature = "unsync")
 ))]
 use super::handoff::{self, Handoff};
-#[cfg(all(
-    feature = "rayon",
-    not(target_arch = "wasm32"),
-    not(feature = "unsync")
-))]
-use super::mode::Sealed;
-use super::mode::SplitMode;
+use super::mode::{Sealed, SplitMode};
 #[cfg(all(
     feature = "rayon",
     not(target_arch = "wasm32"),
@@ -68,13 +56,14 @@ type BoxPut<E> = Pin<Box<dyn Future<Output = PutDone<E>>>>;
 ))]
 type SealHandoff<M, const B: usize> = Handoff<Result<Sealed<M, B>, SealError>>;
 
-/// Submitter queueing one leaf payload on the pool.
+/// Submitter queueing one leaf payload on the pool under its drawn state.
 #[cfg(all(
     feature = "rayon",
     not(target_arch = "wasm32"),
     not(feature = "unsync")
 ))]
-type SealSubmit<M, const B: usize> = Box<dyn Fn(Bytes) -> SealHandoff<M, B> + Send + Sync>;
+type SealSubmit<M, const B: usize> =
+    Box<dyn Fn(<M as SplitMode>::Draw, Bytes) -> SealHandoff<M, B> + Send + Sync>;
 
 /// One leaf seal in flight on the pool: its span and the handoff its sealed
 /// chunk arrives on.
@@ -99,6 +88,11 @@ struct HashFan<M: SplitMode, const B: usize> {
     window: usize,
     submit: SealSubmit<M, B>,
     seals: VecDeque<PendingSeal<M, B>>,
+    /// Draws stashed at submission for the ascent seals the queued leaves
+    /// trigger on admission; spent front-first.
+    draws: VecDeque<M::Draw>,
+    /// Leaves submitted so far; positions the ascent draws.
+    submitted: u64,
 }
 
 /// One spine level: references awaiting a close and the bytes they span.
@@ -221,9 +215,10 @@ where
     }
 
     /// Fan leaf sealing onto the rayon pool, holding at most `window` seals
-    /// in flight; sealed leaves are admitted in leaf order, so a
-    /// deterministic mode's chunk stream matches the serial engine.
-    /// Configure before the first write.
+    /// in flight; sealed leaves are admitted in leaf order and every draw
+    /// lands at submission, so a deterministic mode's chunk stream is
+    /// byte-identical to the serial engine's. Configure before the first
+    /// write.
     ///
     /// ```
     /// use core::future::poll_fn;
@@ -254,17 +249,16 @@ where
     #[must_use]
     pub fn with_hash_window(mut self, window: HashWindow) -> Self
     where
-        M: Clone,
         M::Ref: Send,
     {
-        let mode = self.mode.clone();
         self.hash = Some(HashFan {
             window: usize::from(window.get()),
-            submit: Box::new(move |payload| {
-                let mode = mode.clone();
-                handoff::submit(move || mode.seal::<B>(payload))
+            submit: Box::new(|draw, payload| {
+                handoff::submit(move || M::seal_with::<B>(draw, payload))
             }),
             seals: VecDeque::new(),
+            draws: VecDeque::new(),
+            submitted: 0,
         });
         self
     }
@@ -555,7 +549,19 @@ where
             not(feature = "unsync")
         ))]
         if let Some(fan) = &mut self.hash {
-            let handoff = (fan.submit)(Bytes::from(payload));
+            // The leaf's draw, then one per ascent seal its admission
+            // triggers, so the draw order equals the serial engine's.
+            let draw = self.mode.draw()?;
+            fan.submitted = fan.submitted.saturating_add(1);
+            let mut filled = fan.submitted;
+            while filled.checked_rem(self.slots) == Some(0) {
+                fan.draws.push_back(self.mode.draw()?);
+                let Some(next) = filled.checked_div(self.slots) else {
+                    break;
+                };
+                filled = next;
+            }
+            let handoff = (fan.submit)(draw, Bytes::from(payload));
             fan.seals.push_back(PendingSeal { span, handoff });
             self.stats.peak_hash_in_flight = self.stats.peak_hash_in_flight.max(fan.seals.len());
             return Ok(());
@@ -699,10 +705,24 @@ where
         for reference in refs {
             M::write_ref(reference, &mut payload);
         }
-        let (chunk, reference) = self.mode.seal::<B>(Bytes::from(payload))?;
+        let (chunk, reference) = self.seal_inline(Bytes::from(payload))?;
         self.stats.intermediates = self.stats.intermediates.saturating_add(1);
         self.enqueue(chunk)?;
         Ok(reference)
+    }
+
+    /// Seal one payload on the engine thread; under the pool fan-out a
+    /// streaming ascent seal spends its submission-time draw.
+    fn seal_inline(&mut self, payload: Bytes) -> Result<Sealed<M, B>, SealError> {
+        #[cfg(all(
+            feature = "rayon",
+            not(target_arch = "wasm32"),
+            not(feature = "unsync")
+        ))]
+        if let Some(draw) = self.hash.as_mut().and_then(|fan| fan.draws.pop_front()) {
+            return M::seal_with::<B>(draw, payload);
+        }
+        self.mode.seal::<B>(payload)
     }
 
     /// Queue a sealed chunk for the put window, admitting what fits.

--- a/crates/file/src/split/mod.rs
+++ b/crates/file/src/split/mod.rs
@@ -24,9 +24,9 @@
 //! 5. Fused finish: `poll_finish` is cancel-safe and re-callable; after the
 //!    root is delivered every later call returns the same root.
 //! 6. Bounded hash window: pool leaf seals in flight never exceed the
-//!    [`HashWindow`](crate::HashWindow), and sealed leaves are admitted in
-//!    leaf order, so a deterministic mode's chunk stream matches the serial
-//!    engine.
+//!    [`HashWindow`](crate::HashWindow); sealed leaves are admitted in leaf
+//!    order and every draw lands at submission, so a deterministic mode's
+//!    chunk stream is byte-identical to the serial engine's.
 
 #[cfg(feature = "encryption")]
 mod encrypted;

--- a/crates/file/src/split/mode.rs
+++ b/crates/file/src/split/mode.rs
@@ -18,7 +18,9 @@ pub type Sealed<M, const B: usize> = (Chunk<Verified, AnyChunkSet<B>>, <M as Spl
 ///
 /// The engine stays mode-blind: a mode contributes its [`Mode`] geometry,
 /// the per-intermediate data-slot count (the parity retrofit seam), and the
-/// sealer for one payload; the ascent itself is shared.
+/// sealer for one payload; the ascent itself is shared. Sealing splits in
+/// two so the pool fan-out can draw ordered state (an encrypted mode's key)
+/// at submission and spend it on a worker.
 pub trait SplitMode: MaybeSend + MaybeSync + 'static {
     /// Reference layout this mode writes.
     const MODE: Mode;
@@ -29,15 +31,30 @@ pub trait SplitMode: MaybeSend + MaybeSync + 'static {
     /// Reference naming the finished tree.
     type Root: Clone + Debug + MaybeSend + MaybeSync + 'static;
 
+    /// Per-seal state drawn ahead of the seal; `()` for stateless modes.
+    type Draw: MaybeSend + 'static;
+
     /// Data-carrying reference slots per intermediate body. Plain modes use
     /// every slot; a parity variant reserves trailing slots instead.
     fn data_slots(branches: u64) -> u64;
 
-    /// Seal one payload into a chunk and the reference that names it.
+    /// Draw the state sealing the next payload; one draw per seal, in seal
+    /// order.
+    fn draw(&self) -> Result<Self::Draw, SealError>;
+
+    /// Seal one payload under a previously drawn state.
     ///
     /// The payload is the chunk's wire body: a little-endian `u64` span
     /// followed by the spanned content (leaf bytes or packed references).
-    fn seal<const B: usize>(&self, payload: Bytes) -> Result<Sealed<Self, B>, SealError>;
+    fn seal_with<const B: usize>(
+        draw: Self::Draw,
+        payload: Bytes,
+    ) -> Result<Sealed<Self, B>, SealError>;
+
+    /// Seal one payload in place: one draw, spent immediately.
+    fn seal<const B: usize>(&self, payload: Bytes) -> Result<Sealed<Self, B>, SealError> {
+        Self::seal_with(self.draw()?, payload)
+    }
 
     /// Append one reference's wire bytes to a parent payload under build.
     fn write_ref(reference: &Self::Ref, out: &mut Vec<u8>);
@@ -53,12 +70,17 @@ impl SplitMode for Plain {
 
     type Ref = ChunkAddress;
     type Root = ChunkAddress;
+    type Draw = ();
 
     fn data_slots(branches: u64) -> u64 {
         branches
     }
 
-    fn seal<const B: usize>(&self, payload: Bytes) -> Result<Sealed<Self, B>, SealError> {
+    fn draw(&self) -> Result<(), SealError> {
+        Ok(())
+    }
+
+    fn seal_with<const B: usize>((): (), payload: Bytes) -> Result<Sealed<Self, B>, SealError> {
         let chunk = ContentChunk::<B>::try_from(payload)?.seal::<AnyChunkSet<B>>();
         let address = *chunk.address();
         Ok((chunk, address))

--- a/crates/file/src/split/tests.rs
+++ b/crates/file/src/split/tests.rs
@@ -536,10 +536,44 @@ mod encrypted {
         data: &[u8],
         mode: Encrypted<K>,
         step: usize,
+        delay: usize,
     ) -> (EncryptedChunkRef, TestStore<TINY>, SplitStats) {
-        let store = TestStore::<TINY>::new(1);
+        let store = TestStore::<TINY>::new(delay);
         let mut split: Split<TestStore<TINY>, Encrypted<K>, TINY> =
             Split::with_mode(store.clone(), mode, PutWindow::new(4).unwrap());
+        let root = run(async {
+            for piece in data.chunks(step.max(1)) {
+                let mut buf = piece;
+                while !buf.is_empty() {
+                    let n = poll_fn(|cx| split.poll_write(cx, buf)).await.unwrap();
+                    buf = &buf[n..];
+                }
+            }
+            poll_fn(|cx| split.poll_finish(cx)).await.unwrap()
+        });
+        let stats = split.stats();
+        (root, store, stats)
+    }
+
+    /// Stream `data` through a pooled encrypted split in `step`-byte writes.
+    #[cfg(all(
+        feature = "rayon",
+        not(target_arch = "wasm32"),
+        not(feature = "unsync")
+    ))]
+    fn pooled_split_encrypted<K: KeySource>(
+        data: &[u8],
+        mode: Encrypted<K>,
+        hash_window: u16,
+        step: usize,
+        delay: usize,
+    ) -> (EncryptedChunkRef, TestStore<TINY>, SplitStats) {
+        use crate::config::HashWindow;
+
+        let store = TestStore::<TINY>::new(delay);
+        let mut split: Split<TestStore<TINY>, Encrypted<K>, TINY> =
+            Split::with_mode(store.clone(), mode, PutWindow::new(4).unwrap())
+                .with_hash_window(HashWindow::new(hash_window).unwrap());
         let root = run(async {
             for piece in data.chunks(step.max(1)) {
                 let mut buf = piece;
@@ -626,7 +660,7 @@ mod encrypted {
         let size = 13 * TINY + 29;
         let data = fill(size);
         let (root, store, _) =
-            stream_split_encrypted(&data, Encrypted::new(SeqKeys::default()), 719);
+            stream_split_encrypted(&data, Encrypted::new(SeqKeys::default()), 719, 1);
         let mut walk: Walk<TestStore<TINY>, Encrypted, TINY> = Walk::new(
             store,
             *root.address(),
@@ -662,7 +696,7 @@ mod encrypted {
         assert_eq!(plain_stats.peak_spine, 3);
 
         let (_, _, enc_stats) =
-            stream_split_encrypted(&data, Encrypted::new(SeqKeys::default()), 719);
+            stream_split_encrypted(&data, Encrypted::new(SeqKeys::default()), 719, 1);
         assert_eq!(enc_stats.leaves, 64);
         assert_eq!(enc_stats.intermediates, 21);
         assert_eq!(enc_stats.peak_spine, 4);
@@ -674,15 +708,51 @@ mod encrypted {
         // ciphertexts and the whole tree is a function of the key stream.
         let data = fill(16 * TINY);
         let (first_root, first_store, _) =
-            stream_split_encrypted(&data, Encrypted::new(SeqKeys::default()), 719);
+            stream_split_encrypted(&data, Encrypted::new(SeqKeys::default()), 719, 1);
         let (second_root, second_store, _) =
-            stream_split_encrypted(&data, Encrypted::new(SeqKeys::default()), 97);
+            stream_split_encrypted(&data, Encrypted::new(SeqKeys::default()), 97, 1);
         assert_eq!(first_root, second_root);
         assert_eq!(sorted(first_store.log()), sorted(second_store.log()));
     }
 
-    /// Keys are drawn on the workers, so only the round trip is pinned:
-    /// pooled encrypted output is not byte-reproducible.
+    /// Every draw lands at submission, so a deterministic source assigns
+    /// keys in seal order and the pooled chunk stream is byte-identical to
+    /// the serial engine's. Only padless trees are byte-reproducible, so
+    /// the sizes keep every node full.
+    #[cfg(all(
+        feature = "rayon",
+        not(target_arch = "wasm32"),
+        not(feature = "unsync")
+    ))]
+    #[test]
+    fn pooled_encrypted_chunk_streams_are_byte_identical_to_serial() {
+        for depth in 0u32..4 {
+            let size = ENC_BRANCHES.pow(depth) * TINY;
+            let data = fill(size);
+            // Zero put delay settles every put at dispatch, so the ordered
+            // log is the dispatch order: the wire chunk stream itself.
+            let (serial_root, serial_store, serial_stats) =
+                stream_split_encrypted(&data, Encrypted::new(SeqKeys::default()), 719, 0);
+            for hash_window in [1u16, 4] {
+                let (root, store, stats) = pooled_split_encrypted(
+                    &data,
+                    Encrypted::new(SeqKeys::default()),
+                    hash_window,
+                    719,
+                    0,
+                );
+                assert_eq!(root, serial_root, "root diverged at {size}");
+                assert_eq!(
+                    store.log(),
+                    serial_store.log(),
+                    "chunk stream diverged at {size}"
+                );
+                assert_eq!(stats.puts, serial_stats.puts);
+            }
+        }
+    }
+
+    /// The default random source through the pool still round trips.
     #[cfg(all(
         feature = "rayon",
         not(target_arch = "wasm32"),
@@ -844,17 +914,25 @@ mod pooled {
 
         type Ref = ChunkAddress;
         type Root = ChunkAddress;
+        type Draw = Self;
 
         fn data_slots(branches: u64) -> u64 {
             branches
         }
 
-        fn seal<const B: usize>(&self, payload: Bytes) -> Result<Sealed<Self, B>, SealError> {
-            std::thread::sleep(self.stall);
+        fn draw(&self) -> Result<Self, SealError> {
+            Ok(self.clone())
+        }
+
+        fn seal_with<const B: usize>(
+            mode: Self,
+            payload: Bytes,
+        ) -> Result<Sealed<Self, B>, SealError> {
+            std::thread::sleep(mode.stall);
             let chunk = ContentChunk::<B>::try_from(payload)?
                 .seal::<nectar_primitives::chunk::AnyChunkSet<B>>();
             let address = *chunk.address();
-            self.sealed.fetch_add(1, Ordering::Relaxed);
+            mode.sealed.fetch_add(1, Ordering::Relaxed);
             Ok((chunk, address))
         }
 
@@ -1024,12 +1102,20 @@ mod pooled {
 
         type Ref = ChunkAddress;
         type Root = ChunkAddress;
+        type Draw = ();
 
         fn data_slots(branches: u64) -> u64 {
             branches
         }
 
-        fn seal<const B: usize>(&self, _payload: Bytes) -> Result<Sealed<Self, B>, SealError> {
+        fn draw(&self) -> Result<(), SealError> {
+            Ok(())
+        }
+
+        fn seal_with<const B: usize>(
+            (): (),
+            _payload: Bytes,
+        ) -> Result<Sealed<Self, B>, SealError> {
             panic!("seal panicked on the worker")
         }
 


### PR DESCRIPTION
## What

Moves every pooled-split key draw to submission time. `SplitMode` now splits sealing into `draw` (ordered state) and `seal_with` (worker work), with `seal` provided as `draw` + `seal_with` so the serial arm stays byte-unchanged. The engine draws the leaf's key before the pool handoff and pre-draws (stashes) one key per intermediate seal that leaf's admission will trigger, spent front-first by the admission-side ascent; closing seals draw inline with the stash provably empty.

## Why

Closes #492.

Intermediates draw from the same `KeySource` at admission time and their interleaving with submissions is scheduling-dependent, so the issue's leaf-only fix is insufficient (verified: the naive fix fails the new parity test 30/30). Stashing every ascent-intermediate draw at submission and spending it front-first on admission makes the pooled encrypted arm byte-identical to the serial arm by construction.

## Testing

A new parity test pins pooled encrypted == serial encrypted (root, ordered chunk log, put count) with a deterministic `SeqKeys` double at padless sizes for hash windows 1 and 4; 0/30 flaky over repeated runs.

All checks were run from the branch tip (2c33054) with the CI toolchain (`nix develop`, rustc/cargo 1.94), `RUSTC_WRAPPER=sccache`, a shared `CARGO_TARGET_DIR`, `CARGO_INCREMENTAL=0`, replicating the CI workflow commands:

- lint.yml: `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets --locked` passes; per-feature `cargo clippy --locked --all-targets -p nectar-file --features {tokio|rayon|encryption}` all pass. Only warnings are pre-existing `doc_lazy_continuation` notes in the untouched `crates/testing`, non-fatal and unchanged by this branch.
- unit.yml: `cargo nextest run --workspace --locked` = 958 passed / 1 skipped; `cargo test --doc --workspace --locked` passes; feature lanes for nectar-file (tokio; rayon,encryption; encryption) pass for both nextest and doctests, including the pooled encrypted ingest tests.

## AI Assistance

Implemented with Claude (Fable); reviewed with Claude (Opus).
