### PR TITLE
docs: drop the stale publish-order list from RELEASING.md

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,24 +8,13 @@ The project is licensed `AGPL-3.0-or-later`. Every publishable crate ships the A
 
 All publishable crates share a single workspace version, defined once in `[workspace.package].version` in the root `Cargo.toml`. They bump together (`shared-version = true`) and are tagged once per release as `vX.Y.Z`. The workspace is at `0.x`, so a `minor` bump is the normal release level and may carry breaking changes until `1.0`.
 
-## Publishable crates and publish order
+## Publishable crates
 
-cargo-release computes the dependency order automatically and publishes leaves before dependents. For reference, the order is:
-
-1. `nectar-marker`
-2. `nectar-clock` (depends on `nectar-marker`)
-3. `nectar-primitives` (depends on `nectar-marker`)
-4. `nectar-contracts`
-5. `nectar-swarms`
-6. `nectar-postage` (depends on `nectar-primitives`)
-7. `nectar-mantaray` (depends on `nectar-primitives`)
-8. `nectar-postage-issuer` (depends on `nectar-postage`, `nectar-primitives`)
-
-The `bmt-wasm-demo` example crate is `publish = false` and is skipped.
+Every workspace crate without `publish = false` releases lockstep at the shared version. cargo-release computes the dependency order automatically and publishes leaves before dependents; the dry run (`cargo release minor`) prints the exact publish plan and is the authoritative view. Crates marked `publish = false` (examples and dev tooling) are skipped.
 
 ## Prerequisites
 
-- A crates.io account that is an owner of all eight crates, and a token available to cargo: run `cargo login`, or export `CARGO_REGISTRY_TOKEN`.
+- A crates.io account that is an owner of every already-published crate, and a token available to cargo (first-time publishes are created under the publishing account): run `cargo login`, or export `CARGO_REGISTRY_TOKEN`.
 - Your hardware signing key (YubiKey) unlocked in the gpg-agent, so cargo-release can create the signed release commit and signed `vX.Y.Z` tag without prompting.
 - A clean checkout of `main` with no uncommitted changes, up to date with the remote.
 - CI green on the commit you are about to release.
@@ -49,7 +38,7 @@ cargo release minor --execute
 2. Run the pre-release hook (`git-cliff`) to regenerate `CHANGELOG.md` for the new version.
 3. Create the signed release commit `chore(release): X.Y.Z`.
 4. Create the signed tag `vX.Y.Z`.
-5. Publish all eight crates to crates.io in dependency order.
+5. Publish every publishable crate to crates.io in dependency order.
 6. Push the release commit and tag to the remote.
 
 Use `patch` instead of `minor` for a patch release, or `cargo release X.Y.Z --execute` to set an exact version.


### PR DESCRIPTION
## What

Deletes the hand-maintained publish-order list from RELEASING.md and makes the document count-free: all publishable crates release lockstep, cargo-release computes dependency order, and the dry run is documented as the authoritative publish plan. The prerequisites line no longer counts crates and notes that first-time publishes are created under the publishing account.

## Why

The list drifted three times in one week of normal work (missing nectar-file, nectar-manifest and nectar-postage-usage, then the new marker, clock and tasks leaves). It documents nothing cargo-release does not already compute, and the next release will first-publish six crates, so counting was about to be wrong again. Maintainer decision: delete rather than guard.

## Testing

Docs-only change; rg confirms no crate count or enumerated order remains.

## AI Assistance

Prepared with Claude Code (rewrite and verification).
