### PR TITLE
primitives: single-owner-only chunk registry with verified narrowing

### DIFF
--- a/crates/primitives/src/chunk/mod.rs
+++ b/crates/primitives/src/chunk/mod.rs
@@ -294,7 +294,8 @@ pub use reference::{ChunkRef, RefKind, Reference, WrongRefKind};
 pub use any_chunk::AnyChunk;
 pub use chunk_type::ChunkType;
 pub use registry::{
-    AnyChunkSet, ChunkRegistry, ChunkTypeInfo, ContentOnlyChunkSet, StandardChunkSet,
+    AnyChunkSet, ChunkRegistry, ChunkTypeInfo, ContentOnlyChunkSet, SingleOwnerOnlyChunkSet,
+    StandardChunkSet,
 };
 pub use type_id::ChunkTypeId;
 pub use type_tag::{ChunkTypeTag, ChunkVersion, TagWireError};

--- a/crates/primitives/src/chunk/registry.rs
+++ b/crates/primitives/src/chunk/registry.rs
@@ -1,8 +1,9 @@
 //! Compile-time chunk type registry
 //!
 //! This module provides the [`ChunkRegistry`] trait: the closed envelope type
-//! IS the type-level set of chunk types a network accepts. [`StandardChunkSet`]
-//! and [`ContentOnlyChunkSet`] are the built-in registries.
+//! IS the type-level set of chunk types a network accepts. [`StandardChunkSet`],
+//! [`ContentOnlyChunkSet`], and [`SingleOwnerOnlyChunkSet`] are the built-in
+//! registries.
 
 use bytes::Bytes;
 
@@ -13,7 +14,7 @@ use super::address::ChunkAddress;
 use super::any_chunk::AnyChunk;
 use super::content::{CacHeader, ContentChunk};
 use super::error::ChunkError;
-use super::single_owner::SocHeader;
+use super::single_owner::{SingleOwnerChunk, SocHeader};
 use super::traits::{ChunkHeader, ChunkOps};
 use super::type_id::ChunkTypeId;
 use super::type_tag::ChunkTypeTag;
@@ -219,6 +220,49 @@ impl ChunkRegistry for ContentOnlyChunkSet {
 
 const _: () = ContentOnlyChunkSet::DISTINCT_TAGS;
 
+/// Registry that accepts only single-owner chunks at body size `BODY_SIZE`,
+/// carried directly as [`SingleOwnerChunk`]: a single-member set needs no
+/// envelope enum. The registry carries the body size so no store trait
+/// restates it.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SingleOwnerOnlyChunkSet<const BODY_SIZE: usize = DEFAULT_BODY_SIZE>;
+
+impl<const BODY_SIZE: usize> ChunkRegistry for SingleOwnerOnlyChunkSet<BODY_SIZE> {
+    type Envelope = SingleOwnerChunk<BODY_SIZE>;
+
+    const MEMBERS: &'static [ChunkTypeInfo] = &[ChunkTypeInfo::of::<SocHeader>()];
+
+    fn parse_typed(bytes: &[u8]) -> Result<Self::Envelope> {
+        let (tag, payload) = bytes.split_first_chunk::<2>().ok_or_else(|| {
+            ChunkError::invalid_format("typed-chunk encoding shorter than the two-byte type tag")
+        })?;
+        let tag = ChunkTypeTag::from(*tag);
+        if !Self::supports(tag) {
+            return Err(ChunkError::unsupported_tag(tag).into());
+        }
+        SingleOwnerChunk::try_from(Bytes::copy_from_slice(payload))
+    }
+
+    fn decode_wire(address: &ChunkAddress, data: Bytes) -> Result<Self::Envelope> {
+        let chunk = SingleOwnerChunk::try_from(data)?;
+        // Full acceptance rule (owner recovery, replica pin, address
+        // compare), never a bare address compare.
+        chunk.verify(address)?;
+        Ok(chunk)
+    }
+
+    fn encode_typed(chunk: &Self::Envelope) -> Vec<u8> {
+        let tag = ChunkTypeInfo::of::<SocHeader>().tag.to_bytes();
+        let wire = chunk.clone().into_bytes();
+        let mut out = Vec::with_capacity(wire.len().saturating_add(tag.len()));
+        out.extend_from_slice(&tag);
+        out.extend_from_slice(&wire);
+        out
+    }
+}
+
+const _: () = SingleOwnerOnlyChunkSet::<DEFAULT_BODY_SIZE>::DISTINCT_TAGS;
+
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
@@ -230,6 +274,7 @@ mod tests {
     use crate::error::PrimitivesError;
 
     type DefaultContentChunk = ContentChunk<DEFAULT_BODY_SIZE>;
+    type SocOnly = SingleOwnerOnlyChunkSet<DEFAULT_BODY_SIZE>;
 
     const CAC_TAG: ChunkTypeTag = ChunkTypeTag::new(CacHeader::TYPE_ID, CacHeader::VERSION);
     const SOC_TAG: ChunkTypeTag = ChunkTypeTag::new(SocHeader::TYPE_ID, SocHeader::VERSION);
@@ -290,6 +335,15 @@ mod tests {
     }
 
     #[test]
+    fn soc_only_supports() {
+        assert!(SocOnly::supports(SOC_TAG));
+        assert!(!SocOnly::supports(CAC_TAG));
+        assert!(SocOnly::supports_id(ChunkTypeId::SINGLE_OWNER));
+        assert!(!SocOnly::supports_id(ChunkTypeId::CONTENT));
+        assert_eq!(SocOnly::MEMBERS.len(), 1);
+    }
+
+    #[test]
     fn duplicate_tag_scan() {
         assert_eq!(ChunkTypeInfo::duplicate_tag(&[]), None);
         assert_eq!(
@@ -300,6 +354,7 @@ mod tests {
             ChunkTypeInfo::duplicate_tag(ContentOnlyChunkSet::MEMBERS),
             None
         );
+        assert_eq!(ChunkTypeInfo::duplicate_tag(SocOnly::MEMBERS), None);
 
         let dup = [
             ChunkTypeInfo::of::<CacHeader>(),
@@ -365,6 +420,10 @@ mod tests {
         let content_only = ContentOnlyChunkSet::encode_typed(&content);
         assert!(ContentOnlyChunkSet::parse_typed(&content_only).is_ok());
         assert!(ContentOnlyChunkSet::decode_typed(&wrong, &content_only).is_err());
+
+        let soc_only = SocOnly::encode_typed(&sample_single_owner());
+        assert!(SocOnly::parse_typed(&soc_only).is_ok());
+        assert!(SocOnly::decode_typed(&wrong, &soc_only).is_err());
     }
 
     #[test]
@@ -467,6 +526,84 @@ mod tests {
         let wire = soc.into_bytes();
 
         assert!(ContentOnlyChunkSet::decode_wire(&address, wire).is_err());
+    }
+
+    #[test]
+    fn soc_only_typed_round_trip() {
+        let soc = sample_single_owner();
+        let address = *soc.address();
+
+        let encoded = SocOnly::encode_typed(&soc);
+        // The typed form must agree with the standard registry's encoding.
+        assert_eq!(encoded, StandardChunkSet::encode_typed(&soc.into()));
+
+        let decoded = SocOnly::decode_typed(&address, &encoded).unwrap();
+        assert_eq!(*decoded.address(), address);
+    }
+
+    #[test]
+    fn soc_only_typed_rejects_cac_tag_as_unsupported() {
+        let content = DefaultContentChunk::new(&b"wrong network"[..]).unwrap();
+        let address = *content.address();
+        let encoded = StandardChunkSet::encode_typed(&content.into());
+
+        let err = SocOnly::decode_typed(&address, &encoded).unwrap_err();
+        match err {
+            PrimitivesError::Chunk(ChunkError::UnsupportedTag(t)) => assert_eq!(t, CAC_TAG),
+            other => panic!("expected UnsupportedTag, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn soc_only_typed_short_input_errors() {
+        let address: ChunkAddress = [0u8; 32].into();
+        assert!(SocOnly::decode_typed(&address, &[]).is_err());
+        assert!(SocOnly::decode_typed(&address, &[1]).is_err());
+    }
+
+    #[test]
+    fn soc_only_wire_round_trip() {
+        let soc = sample_single_owner();
+        let address = *soc.address();
+        let wire: Bytes = soc.into_bytes();
+
+        // The same bare wire bytes the standard registry's single-owner arm
+        // consumes.
+        let via_standard = StandardChunkSet::decode_wire(&address, wire.clone()).unwrap();
+        assert!(via_standard.is_single_owner());
+
+        let decoded = SocOnly::decode_wire(&address, wire.clone()).unwrap();
+        assert_eq!(*decoded.address(), address);
+        assert_eq!(decoded.into_bytes(), wire);
+    }
+
+    #[test]
+    fn soc_only_wire_rejects_content_bytes() {
+        // A content chunk's wire bytes carry no 97-byte id-plus-signature
+        // header, so no single-owner interpretation certifies at its address.
+        let content = DefaultContentChunk::new(&b"bare cac wire"[..]).unwrap();
+        let address = *content.address();
+        let wire = content.into_bytes();
+
+        assert!(SocOnly::decode_wire(&address, wire).is_err());
+    }
+
+    /// The single-member wire path still runs the full acceptance rule: a
+    /// garbage signature commits under the zero owner, and asking for
+    /// exactly that committed address must fail, where a bare address
+    /// compare would pass.
+    #[test]
+    fn soc_only_wire_rejects_garbage_signature_at_committed_address() {
+        let soc = sample_single_owner();
+        let mut wire = soc.into_bytes().to_vec();
+        // Clobber the 65 signature bytes after the 32-byte id.
+        for byte in wire.iter_mut().skip(32).take(65) {
+            *byte = 0xff;
+        }
+        let forged = SingleOwnerChunk::<DEFAULT_BODY_SIZE>::try_from(wire.as_slice()).unwrap();
+        let committed = *forged.address();
+
+        assert!(SocOnly::decode_wire(&committed, Bytes::from(wire)).is_err());
     }
 
     /// Replay crafted edge inputs through the shared `chunk_decode` oracle

--- a/crates/primitives/src/chunk/trust.rs
+++ b/crates/primitives/src/chunk/trust.rs
@@ -15,7 +15,7 @@ use crate::cache::OnceCache;
 use crate::error::Result;
 
 use super::address::ChunkAddress;
-use super::registry::{ChunkRegistry, StandardChunkSet};
+use super::registry::{AnyChunkSet, ChunkRegistry, SingleOwnerOnlyChunkSet, StandardChunkSet};
 use super::traits::ChunkOps;
 
 mod sealed {
@@ -223,6 +223,31 @@ impl<R: ChunkRegistry> Chunk<Verified, R> {
     /// Consume into the decoded envelope.
     pub fn into_envelope(self) -> R::Envelope {
         self.inner
+    }
+}
+
+impl<const BODY_SIZE: usize> Chunk<Verified, AnyChunkSet<BODY_SIZE>> {
+    /// Narrow to the single-owner-only registry; `None` for a content chunk.
+    ///
+    /// The address fact and the memoized owner transfer as-is: the
+    /// single-owner arm was certified by its full acceptance rule already,
+    /// so no crypto re-runs.
+    #[must_use]
+    pub fn narrow_single_owner(
+        self,
+    ) -> Option<Chunk<Verified, SingleOwnerOnlyChunkSet<BODY_SIZE>>> {
+        let Self {
+            address,
+            inner,
+            owner,
+            _state,
+        } = self;
+        Some(Chunk {
+            address,
+            inner: inner.into_single_owner()?,
+            owner,
+            _state: PhantomData,
+        })
     }
 }
 
@@ -483,6 +508,33 @@ mod tests {
         }
         let lying = DefaultSingleOwnerChunk::try_from(wire.as_slice()).unwrap();
         assert!(Chunk::<Verified>::from_envelope(lying.into()).is_err());
+    }
+
+    /// Narrowing transfers the Verified fact without re-running any
+    /// acceptance rule: the address and the memoized owner carry over.
+    #[test]
+    fn narrow_single_owner_preserves_the_verified_fact() {
+        let signer = test_signer();
+        let soc = DefaultSingleOwnerChunk::new(SocId::ZERO, b"narrowed".to_vec(), &signer).unwrap();
+        let address = *soc.address();
+        let wide = Chunk::<Verified>::from_envelope(soc.into()).unwrap();
+        // Warm the owner cache so the narrowed chunk serves the memoized
+        // value instead of recovering again.
+        assert_eq!(wide.owner(), Some(signer.address()));
+        let typed = wide.typed_bytes();
+
+        let narrow = wide.narrow_single_owner().unwrap();
+        assert_eq!(narrow.address(), &address);
+        assert_eq!(narrow.owner(), Some(signer.address()));
+        // The typed (store) encoding is byte-identical across the narrowing.
+        assert_eq!(narrow.typed_bytes(), typed);
+    }
+
+    #[test]
+    fn narrow_single_owner_rejects_a_content_chunk() {
+        let content = DefaultContentChunk::new(&b"stays wide"[..]).unwrap();
+        let wide = Chunk::<Verified>::from_envelope(content.into()).unwrap();
+        assert!(wide.narrow_single_owner().is_none());
     }
 
     #[test]

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -138,6 +138,7 @@ pub use chunk::{
     RefKind,
     Reference,
     SingleOwnerChunk,
+    SingleOwnerOnlyChunkSet,
     SocHeader,
     SocId,
     StandardChunkSet,
@@ -163,7 +164,7 @@ pub type DefaultMemoryStore = MemoryStore<StandardChunkSet>;
 // Chunk storage traits
 pub use store::{
     ChunkGet, ChunkHas, ChunkPut, ChunkStoreError, MemoryStore, RetryConfig, RetryingChunkGet,
-    Sleeper, TrustedGet,
+    SingleOwnerGet, SingleOwnerGetError, Sleeper, TrustedGet,
 };
 
 // The width-agnostic reference union: the manifest-to-file bridge type.

--- a/crates/primitives/src/store/mod.rs
+++ b/crates/primitives/src/store/mod.rs
@@ -6,11 +6,13 @@
 
 mod memory;
 mod retry;
+mod single_owner;
 mod typed;
 
 pub use crate::marker::{MaybeSend, MaybeSync};
 pub use memory::MemoryStore;
 pub use retry::{RetryConfig, RetryingChunkGet, Sleeper};
+pub use single_owner::{SingleOwnerGet, SingleOwnerGetError};
 pub use typed::{ChunkGet, ChunkHas, ChunkPut, TrustedGet};
 
 use crate::chunk::{Chunk, ChunkAddress, ChunkRegistry, Verified};

--- a/crates/primitives/src/store/single_owner.rs
+++ b/crates/primitives/src/store/single_owner.rs
@@ -1,0 +1,106 @@
+//! Single-owner narrowing store adapter.
+
+use crate::chunk::{AnyChunkSet, Chunk, ChunkAddress, SingleOwnerOnlyChunkSet, Verified};
+
+use super::typed::ChunkGet;
+
+/// Single-owner view over a store typed at [`AnyChunkSet`].
+///
+/// Gets narrow through the Verified-preserving narrowing, so no acceptance
+/// rule re-runs; a chunk of any other type is a typed error, not a panic.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SingleOwnerGet<T>(T);
+
+impl<T> SingleOwnerGet<T> {
+    /// Wrap a store typed at [`AnyChunkSet`].
+    pub const fn new(inner: T) -> Self {
+        Self(inner)
+    }
+
+    /// Borrow the inner store.
+    pub const fn inner(&self) -> &T {
+        &self.0
+    }
+
+    /// Consume into the inner store.
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+/// Error of the narrowing get.
+#[derive(Debug, thiserror::Error)]
+pub enum SingleOwnerGetError<E> {
+    /// The inner store failed.
+    #[error(transparent)]
+    Inner(E),
+    /// The chunk at the address is not a single-owner chunk.
+    #[error("chunk at {0} is not a single-owner chunk")]
+    NotSingleOwner(ChunkAddress),
+}
+
+impl<const BODY_SIZE: usize, T> ChunkGet<SingleOwnerOnlyChunkSet<BODY_SIZE>> for SingleOwnerGet<T>
+where
+    T: ChunkGet<AnyChunkSet<BODY_SIZE>, Trust = Verified>,
+{
+    type Trust = Verified;
+    type Error = SingleOwnerGetError<T::Error>;
+
+    async fn get(
+        &self,
+        address: &ChunkAddress,
+    ) -> Result<Chunk<Verified, SingleOwnerOnlyChunkSet<BODY_SIZE>>, Self::Error> {
+        let chunk = self
+            .0
+            .get(address)
+            .await
+            .map_err(SingleOwnerGetError::Inner)?;
+        chunk
+            .narrow_single_owner()
+            .ok_or(SingleOwnerGetError::NotSingleOwner(*address))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::typed::ChunkPut;
+    use super::super::{ChunkStoreError, MemoryStore};
+    use super::*;
+    use crate::chunk::{ChunkOps, ContentChunk, SingleOwnerChunk, SocId, StandardChunkSet};
+    use nectar_testing::run;
+
+    #[test]
+    fn get_narrows_single_owner_and_rejects_others() {
+        let signer = alloy_signer_local::PrivateKeySigner::from_slice(&[0x42u8; 32]).unwrap();
+        let soc = SingleOwnerChunk::new(SocId::ZERO, b"stored soc".to_vec(), &signer).unwrap();
+        let soc_addr = *soc.address();
+        let content = ContentChunk::new(&b"stored cac"[..]).unwrap();
+        let cac_addr = *content.address();
+
+        let store = MemoryStore::<StandardChunkSet>::new();
+        run(ChunkPut::put(
+            &store,
+            Chunk::from_envelope(soc.into()).unwrap(),
+        ))
+        .unwrap();
+        run(ChunkPut::put(
+            &store,
+            Chunk::from_envelope(content.into()).unwrap(),
+        ))
+        .unwrap();
+
+        let narrow = SingleOwnerGet::new(store);
+        let got = run(ChunkGet::get(&narrow, &soc_addr)).unwrap();
+        assert_eq!(got.address(), &soc_addr);
+        assert_eq!(got.owner(), Some(signer.address()));
+
+        assert!(matches!(
+            run(ChunkGet::get(&narrow, &cac_addr)),
+            Err(SingleOwnerGetError::NotSingleOwner(a)) if a == cac_addr
+        ));
+        assert!(matches!(
+            run(ChunkGet::get(&narrow, &ChunkAddress::default())),
+            Err(SingleOwnerGetError::Inner(ChunkStoreError::NotFound(_)))
+        ));
+    }
+}


### PR DESCRIPTION
## What

Adds `SingleOwnerOnlyChunkSet<const BODY_SIZE = DEFAULT_BODY_SIZE>` to `crates/primitives/src/chunk/registry.rs` as the symmetric single-owner twin of `ContentOnlyChunkSet`: a single-member `MEMBERS` carrying the `SocHeader` tag, with `parse_typed`/`encode_typed` mirroring the content-only implementations and `decode_wire` going through `SingleOwnerChunk::try_from` followed by full `chunk.verify`, so the complete acceptance rule (owner recovery, replica pin, address compare) always runs rather than a bare address compare. The `DISTINCT_TAGS` guard is asserted at the default body size.

Adds the Verified-preserving narrowing `Chunk::<Verified, AnyChunkSet<B>>::narrow_single_owner()` in `chunk/trust.rs`: a direct field move, so the address fact and the memoized owner transfer across the narrowing with no re-verification.

Adds a thin `SingleOwnerGet<T>` store adapter in the new `crates/primitives/src/store/single_owner.rs`, implementing `ChunkGet<SingleOwnerOnlyChunkSet<BODY_SIZE>>` over an inner Verified-trust `ChunkGet<AnyChunkSet<BODY_SIZE>>`, with a typed `SingleOwnerGetError<E>` (`Inner` vs `NotSingleOwner`) rather than a panic when the stored chunk isn't single-owner.

Re-exports `SingleOwnerOnlyChunkSet` through `chunk/mod.rs` and `lib.rs`, and `SingleOwnerGet`/`SingleOwnerGetError` through `store/mod.rs` and `lib.rs`.

All changes are additive: new type, new narrowing method, new store adapter, and export lines. No existing API, wire format, or `Cargo.toml` changes.

## Why

Closes #511.

Consumers that only ever deal in single-owner chunks currently have to hold an `AnyChunkSet`/`StandardChunkSet` typed store and either accept the wider envelope or hand-roll narrowing and its own acceptance check. `SingleOwnerOnlyChunkSet` gives them a typed registry that carries only single-owner chunks, and `narrow_single_owner` plus `SingleOwnerGet` let them get there from an already-verified `AnyChunkSet` store without re-running any crypto.

## Testing

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --locked`: no new warnings, no new lint suppressions (only pre-existing warn-level lints outside the changed lines).
- `cargo nextest run --workspace --locked`: all 272 primitives lib tests pass, including new coverage for `SingleOwnerOnlyChunkSet` typed/wire round trips, the unsupported-tag and short-input rejection paths, the garbage-signature-at-committed-address rejection (proving the full acceptance rule runs, not a bare address compare), `narrow_single_owner`'s owner/address preservation and its rejection of content chunks, and `SingleOwnerGet`'s narrowing, not-single-owner, and not-found paths.
- Wire compatibility verified byte-exact: `SingleOwnerOnlyChunkSet::encode_typed` output is asserted equal to `StandardChunkSet`'s single-owner-arm encoding, and `decode_wire` is exercised against the same bare wire bytes `StandardChunkSet::decode_wire` accepts.

## AI Assistance

Implementation by Fable, review by Opus.
