### PR TITLE
feat(primitives): add the hpke envelope over the ecies compat baseline

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,7 +72,7 @@ jobs:
             # The modern envelope sits behind the primitives envelope
             # feature, likewise outside the default-features pass.
             - name: cargo clippy (envelope)
-              run: cargo clippy --locked --all-targets -p nectar-primitives --features envelope
+              run: cargo clippy --locked --all-targets -p nectar-primitives --features envelope,encryption
             # The pipeline's inline engine only compiles with the parallel
             # feature off; the workspace pass unifies parallel in via the
             # bench crate, so lint the inline shape explicitly.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,6 +69,10 @@ jobs:
             # likewise outside the default-features pass.
             - name: cargo clippy (manifest encryption)
               run: cargo clippy --locked --all-targets -p nectar-manifest --features encryption
+            # The modern envelope sits behind the primitives envelope
+            # feature, likewise outside the default-features pass.
+            - name: cargo clippy (envelope)
+              run: cargo clippy --locked --all-targets -p nectar-primitives --features envelope
             # The pipeline's inline engine only compiles with the parallel
             # feature off; the workspace pass unifies parallel in via the
             # bench crate, so lint the inline shape explicitly.

--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -57,6 +57,15 @@ jobs:
                   cargo check --locked -p nectar-primitives \
                     --no-default-features \
                     --target ${{ matrix.target }}
+            # Envelope open and decap need no RNG, so a bare-metal or proving
+            # guest opens envelopes without std. Sealing rides encryption (rand)
+            # and is excluded here.
+            - name: Check envelope open builds bare-metal
+              if: matrix.target == 'riscv64imac-unknown-none-elf'
+              run: |
+                  cargo check --locked -p nectar-primitives \
+                    --no-default-features --features envelope \
+                    --target ${{ matrix.target }}
             # The single-thread send escape (the unsync feature) and its
             # !Send-store compile proof, checked for the host inside the
             # rv64 lane, the target shape the escape exists for.

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -91,6 +91,16 @@ jobs:
                     --no-tests=warn --no-fail-fast
             - name: Run manifest encryption doctests
               run: cargo test --doc -p nectar-manifest --features encryption --locked
+            # The modern envelope (KAT, differential and forgery batteries)
+            # sits behind the primitives envelope feature; cover its tests
+            # and the no-downgrade compile-fail doctest here.
+            - name: Run envelope tests
+              run: |
+                  cargo nextest run \
+                    -p nectar-primitives --features envelope --locked \
+                    --no-tests=warn --no-fail-fast
+            - name: Run envelope doctests
+              run: cargo test --doc -p nectar-primitives --features envelope --locked
             # The encrypted allocation probes must see encryption without
             # rayon, matching the encrypted split shape above.
             - name: Run encrypted split integration tests

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -97,10 +97,10 @@ jobs:
             - name: Run envelope tests
               run: |
                   cargo nextest run \
-                    -p nectar-primitives --features envelope --locked \
+                    -p nectar-primitives --features envelope,encryption --locked \
                     --no-tests=warn --no-fail-fast
             - name: Run envelope doctests
-              run: cargo test --doc -p nectar-primitives --features envelope --locked
+              run: cargo test --doc -p nectar-primitives --features envelope,encryption --locked
             # The encrypted allocation probes must see encryption without
             # rayon, matching the encrypted split shape above.
             - name: Run encrypted split integration tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,41 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.6",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,7 +179,7 @@ dependencies = [
  "either",
  "serde",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -720,6 +755,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex 1.3.0",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,7 +955,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
- "shlex",
+ "shlex 2.0.1",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -917,6 +981,17 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
@@ -924,6 +999,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20 0.9.1",
+ "cipher",
+ "poly1305",
+ "zeroize",
 ]
 
 [[package]]
@@ -966,6 +1054,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.6",
+ "inout",
+ "zeroize",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -989,6 +1099,12 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "codspeed"
@@ -1116,6 +1232,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core-models"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee3344d349528f449816cfa85e558c439bdca5a6d8a738cfb21e69f0b2b1952f"
+dependencies = [
+ "hax-lib",
+ "pastey",
+ "rand 0.10.1",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1131,6 +1258,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crabgrind"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7459e07732f6de74001fcf73a3fdfbb0f368e4fd8e2392f4a2206a065e6e95"
+dependencies = [
+ "bindgen",
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1233,6 +1371,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version 0.4.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1364,6 +1546,7 @@ checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1426,7 +1609,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "hkdf",
+ "hkdf 0.12.4",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -1508,6 +1691,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1700,6 +1889,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1754,6 +1953,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "hax-lib"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01a33cb227f97ee5c419064c31d7c55a7d895f28d8019ccdadc311cc036500c4"
+dependencies = [
+ "hax-lib-macros",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "hax-lib-macros"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28da835a5f153e9f3d0cc1f42ee605a1cfa9093c93348193793d60a1b0908b51"
+dependencies = [
+ "hax-lib-macros-types",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "hax-lib-macros-types"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed327e9a28d6ee018a4a9ba842d4ee27e378c8a591d2beb6f42f32b24a02fcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1786,7 +2022,16 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -1796,6 +2041,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "hpke-rs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812de62ab573b876c6c40d7553bae9402ae3bad95b64af06f964388eecb9b7b1"
+dependencies = [
+ "hpke-rs-crypto",
+ "libcrux-sha3",
+ "log",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "hpke-rs-crypto"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c461da2e0c9c93d875b597f0c78214fb0d2d5c57834b2ef2a2fa057fa20e24"
+dependencies = [
+ "rand 0.10.1",
+ "zeroize",
+]
+
+[[package]]
+name = "hpke-rs-rust-crypto"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a606ac19851da841862ef5f39d26d6227bfcfb4047417801a66c1f6e6652d71"
+dependencies = [
+ "aes-gcm",
+ "chacha20poly1305",
+ "hkdf 0.13.0",
+ "hpke-rs-crypto",
+ "k256",
+ "p256",
+ "p384",
+ "rand 0.10.1",
+ "rand_chacha 0.10.0",
+ "rand_core 0.10.1",
+ "sha2 0.11.0",
+ "subtle",
+ "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]
@@ -1898,6 +2197,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1964,7 +2272,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "serdect",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2027,6 +2335,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libcrux-intrinsics"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98a0c574d4eb81d0814bc2b91e4a433d7e0b35851b1d62eb5dd95c064f1f76d0"
+dependencies = [
+ "core-models",
+ "hax-lib",
+]
+
+[[package]]
+name = "libcrux-platform"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9e21d7ed31a92ac539bd69a8c970b183ee883872d2d19ce27036e24cb8ecc4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "libcrux-secrets"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79054fc9037cb70d6a546cf094cea7d7df06af5e49d230ba24103d27ccc886f1"
+dependencies = [
+ "crabgrind",
+ "hax-lib",
+]
+
+[[package]]
+name = "libcrux-sha3"
+version = "0.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c09f5c39afae0528e1f70a3c1e3c6ee649ec1f19dda26fc9b6ea91108fb879ef"
+dependencies = [
+ "hax-lib",
+ "libcrux-intrinsics",
+ "libcrux-platform",
+ "libcrux-traits",
+]
+
+[[package]]
+name = "libcrux-traits"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fa7a21e8c2e8baa8b40f0b176740f2ca4baadd79d1b00e48d6b1e363c42085a"
+dependencies = [
+ "libcrux-secrets",
+ "rand 0.10.1",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2079,6 +2448,12 @@ dependencies = [
  "cc",
  "walkdir",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "nectar-benches"
@@ -2220,7 +2595,7 @@ dependencies = [
  "nectar-testing",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tokio",
 ]
 
@@ -2360,6 +2735,7 @@ dependencies = [
  "alloy-signer-local",
  "arbitrary",
  "bytes",
+ "chacha20poly1305",
  "derive_more",
  "digest 0.11.3",
  "futures",
@@ -2367,6 +2743,10 @@ dependencies = [
  "getrandom 0.2.17",
  "getrandom 0.3.4",
  "getrandom 0.4.2",
+ "hkdf 0.12.4",
+ "hpke-rs",
+ "hpke-rs-crypto",
+ "hpke-rs-rust-crypto",
  "hybrid-array",
  "js-sys",
  "k256",
@@ -2381,6 +2761,7 @@ dependencies = [
  "rand 0.10.1",
  "rayon",
  "serde",
+ "sha2 0.10.9",
  "subtle",
  "thiserror",
  "wasm-bindgen",
@@ -2421,6 +2802,16 @@ dependencies = [
  "nectar-postage",
  "nectar-primitives 0.4.0",
  "wasm-bindgen-test",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2529,6 +2920,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "elliptic-curve",
+ "primeorder",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "elliptic-curve",
+ "primeorder",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2586,6 +3003,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pest"
 version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2610,6 +3033,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plotters"
@@ -2637,6 +3066,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -2668,6 +3120,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -2823,7 +3284,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.0",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
 ]
@@ -2846,6 +3307,16 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2977,7 +3448,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -3303,6 +3774,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha3"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3321,6 +3803,12 @@ dependencies = [
  "cc",
  "cfg-if",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shlex"
@@ -3691,6 +4179,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.6",
+ "subtle",
+]
 
 [[package]]
 name = "uuid"
@@ -4189,6 +4687,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,15 @@ alloy-signer-local = { version = "2.0", default-features = false }
 # k256 base; std consumers add std + precomputed-tables (which needs std)
 k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
 
+# hpke envelope suite
+chacha20poly1305 = { version = "0.10", default-features = false, features = ["alloc"] }
+hkdf = { version = "0.12", default-features = false }
+sha2 = { version = "0.10", default-features = false }
+# reference hpke implementation, differential test oracle only
+hpke-rs = "0.7"
+hpke-rs-crypto = "0.7"
+hpke-rs-rust-crypto = "0.7"
+
 # hashing
 digest = "0.11"
 hybrid-array = { version = "0.4", features = ["extra-sizes"] }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -135,7 +135,7 @@ serde = [ "dep:serde" ]
 arbitrary = [ "alloy-primitives/arbitrary", "dep:arbitrary", "dep:rand", "std" ]
 encryption = [ "dep:rand" ]
 # Modern envelope: RFC 9180 HPKE over the frozen ecies compat baseline.
-envelope = [ "dep:chacha20poly1305", "dep:hkdf", "dep:sha2", "encryption" ]
+envelope = [ "dep:chacha20poly1305", "dep:hkdf", "dep:sha2" ]
 # Single-thread send escape for non-wasm targets (e.g. zkVM guests): applies
 # the wasm32 relaxation of MaybeSend/MaybeSync and the boxed error aliases on
 # any target. An explicit feature rather than a target cfg so CI can exercise

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -30,10 +30,13 @@ alloy-signer = { workspace = true, optional = true }
 alloy-signer-local = { workspace = true, optional = true }
 
 ## rust crypto
+chacha20poly1305 = { workspace = true, optional = true }
 digest.workspace = true
+hkdf = { workspace = true, optional = true }
 hybrid-array.workspace = true
 k256 = { workspace = true, features = ["ecdh"] }
 keccak-batch = { workspace = true, optional = true }
+sha2 = { workspace = true, optional = true }
 
 # derive macros
 derive_more.workspace = true
@@ -90,6 +93,9 @@ alloy-primitives = { workspace = true, features = ["arbitrary", "getrandom", "as
 
 arbitrary = { workspace = true }
 futures.workspace = true
+hpke-rs.workspace = true
+hpke-rs-crypto.workspace = true
+hpke-rs-rust-crypto.workspace = true
 nectar-testing.workspace = true
 proptest.workspace = true
 proptest-arbitrary-interop.workspace = true
@@ -128,6 +134,8 @@ parallel = [ "wasm-threads" ]
 serde = [ "dep:serde" ]
 arbitrary = [ "alloy-primitives/arbitrary", "dep:arbitrary", "dep:rand", "std" ]
 encryption = [ "dep:rand" ]
+# Modern envelope: RFC 9180 HPKE over the frozen ecies compat baseline.
+envelope = [ "dep:chacha20poly1305", "dep:hkdf", "dep:sha2", "encryption" ]
 # Single-thread send escape for non-wasm targets (e.g. zkVM guests): applies
 # the wasm32 relaxation of MaybeSend/MaybeSync and the boxed error aliases on
 # any target. An explicit feature rather than a target cfg so CI can exercise

--- a/crates/primitives/src/envelope/attestation.rs
+++ b/crates/primitives/src/envelope/attestation.rs
@@ -1,0 +1,200 @@
+//! Envelope-capability attestation.
+//!
+//! A peer pins its envelope capability by signing its encryption key with
+//! its long-term secp256k1 identity key (EIP-191 personal sign, matching
+//! the handshake). Verification is the only mint of [`Recipient<Hpke>`];
+//! provenance, the pinned-peer registry and fail-closed enforcement live
+//! with the node, which must treat a missing token for a pinned peer as an
+//! attack, never as licence to fall back to compat.
+
+use alloy_primitives::{Address, Signature};
+use k256::PublicKey;
+use k256::elliptic_curve::sec1::ToEncodedPoint;
+use thiserror::Error;
+
+use crate::error::WrongLength;
+
+use super::{Hpke, Recipient};
+
+/// Domain prefix of the attestation sign-data.
+pub const ATTESTATION_PREFIX: &[u8] = b"nectar/env/v1 attest";
+
+/// Byte length of a serialized attestation: compressed key plus signature.
+const SIZE: usize = 33 + 65;
+
+/// Build the attestation sign-data: `prefix || compressed SEC1 key`.
+///
+/// Signing is not wrapped: the identity key personal-signs (EIP-191) this
+/// buffer, matching the handshake convention.
+#[must_use]
+pub fn sign_data(key: &PublicKey) -> Vec<u8> {
+    let point = key.to_encoded_point(true);
+    let mut out = Vec::new();
+    out.extend_from_slice(ATTESTATION_PREFIX);
+    out.extend_from_slice(point.as_bytes());
+    out
+}
+
+/// Errors from decoding or verifying an attestation.
+#[non_exhaustive]
+#[derive(Debug, Error)]
+pub enum AttestationError {
+    /// The serialized token has the wrong length.
+    #[error(transparent)]
+    Length(#[from] WrongLength),
+    /// The attested key is not a valid curve point.
+    #[error("attested key is not a valid curve point")]
+    Key,
+    /// The signature is malformed or unrecoverable.
+    #[error("signature is malformed or unrecoverable")]
+    Signature,
+    /// The recovered signer is not the pinned identity.
+    #[error("recovered signer {recovered} does not match identity {expected}")]
+    Signer {
+        /// The pinned identity.
+        expected: Address,
+        /// The address the signature recovered to.
+        recovered: Address,
+    },
+}
+
+/// Signed statement that an identity receives under the envelope key.
+#[derive(Debug, Clone)]
+pub struct EnvelopeAttestation {
+    key: PublicKey,
+    signature: Signature,
+}
+
+impl EnvelopeAttestation {
+    /// Assemble a token from its parts; [`Self::verify`] does the checking.
+    #[must_use]
+    pub const fn new(key: PublicKey, signature: Signature) -> Self {
+        Self { key, signature }
+    }
+
+    /// The attested envelope key.
+    #[must_use]
+    pub const fn key(&self) -> &PublicKey {
+        &self.key
+    }
+
+    /// The identity signature over [`sign_data`].
+    #[must_use]
+    pub const fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    /// Verify against the pinned identity and mint the sealing handle.
+    pub fn verify(&self, identity: Address) -> Result<Recipient<Hpke>, AttestationError> {
+        let recovered = self
+            .signature
+            .recover_address_from_msg(sign_data(&self.key))
+            .map_err(|_| AttestationError::Signature)?;
+        if recovered != identity {
+            return Err(AttestationError::Signer {
+                expected: identity,
+                recovered,
+            });
+        }
+        Ok(Recipient::attested(self.key))
+    }
+
+    /// Serialize: `compressed key || 65-byte signature`.
+    #[must_use]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(self.key.to_encoded_point(true).as_bytes());
+        out.extend_from_slice(&self.signature.as_bytes());
+        out
+    }
+}
+
+impl TryFrom<&[u8]> for EnvelopeAttestation {
+    type Error = AttestationError;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        let wrong_length = WrongLength {
+            expected: SIZE,
+            got: bytes.len(),
+        };
+        let Some((key_bytes, rest)) = bytes.split_first_chunk::<33>() else {
+            return Err(wrong_length.into());
+        };
+        let signature_bytes: &[u8; 65] = rest.try_into().map_err(|_| wrong_length)?;
+        let key = PublicKey::from_sec1_bytes(key_bytes).map_err(|_| AttestationError::Key)?;
+        let signature =
+            Signature::from_raw_array(signature_bytes).map_err(|_| AttestationError::Signature)?;
+        Ok(Self::new(key, signature))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_signer::SignerSync;
+    use alloy_signer_local::LocalSigner;
+
+    use crate::ecies::generate_secret;
+
+    fn attested() -> (LocalSigner<k256::ecdsa::SigningKey>, EnvelopeAttestation) {
+        let identity = LocalSigner::random();
+        let envelope_key = generate_secret().public_key();
+        let signature = identity
+            .sign_message_sync(&sign_data(&envelope_key))
+            .unwrap();
+        let attestation = EnvelopeAttestation::new(envelope_key, signature);
+        (identity, attestation)
+    }
+
+    #[test]
+    fn verify_mints_the_recipient() {
+        let (identity, attestation) = attested();
+        let recipient = attestation.verify(identity.address()).unwrap();
+        assert_eq!(recipient.key(), attestation.key());
+    }
+
+    #[test]
+    fn wrong_identity_is_rejected() {
+        let (identity, attestation) = attested();
+        let other = LocalSigner::random().address();
+        let err = attestation.verify(other).unwrap_err();
+        assert!(matches!(
+            err,
+            AttestationError::Signer { expected, recovered }
+                if expected == other && recovered == identity.address()
+        ));
+    }
+
+    #[test]
+    fn swapped_key_breaks_the_signature() {
+        let (identity, attestation) = attested();
+        let forged =
+            EnvelopeAttestation::new(generate_secret().public_key(), *attestation.signature());
+        assert!(forged.verify(identity.address()).is_err());
+    }
+
+    #[test]
+    fn bytes_roundtrip() {
+        let (identity, attestation) = attested();
+        let bytes = attestation.to_bytes();
+        assert_eq!(bytes.len(), SIZE);
+        let decoded = EnvelopeAttestation::try_from(bytes.as_slice()).unwrap();
+        assert_eq!(decoded.key(), attestation.key());
+        let recipient = decoded.verify(identity.address()).unwrap();
+        assert_eq!(recipient.key(), attestation.key());
+    }
+
+    #[test]
+    fn short_token_is_rejected() {
+        let err = EnvelopeAttestation::try_from([0u8; 10].as_slice()).unwrap_err();
+        assert!(matches!(err, AttestationError::Length(_)));
+    }
+
+    #[test]
+    fn sign_data_layout() {
+        let key = generate_secret().public_key();
+        let data = sign_data(&key);
+        assert_eq!(&data[..ATTESTATION_PREFIX.len()], ATTESTATION_PREFIX);
+        assert_eq!(data.len(), ATTESTATION_PREFIX.len() + 33);
+    }
+}

--- a/crates/primitives/src/envelope/attestation.rs
+++ b/crates/primitives/src/envelope/attestation.rs
@@ -7,6 +7,7 @@
 //! with the node, which must treat a missing token for a pinned peer as an
 //! attack, never as licence to fall back to compat.
 
+use alloc::vec::Vec;
 use alloy_primitives::{Address, Signature};
 use k256::PublicKey;
 use k256::elliptic_curve::sec1::ToEncodedPoint;

--- a/crates/primitives/src/envelope/compat.rs
+++ b/crates/primitives/src/envelope/compat.rs
@@ -1,0 +1,50 @@
+//! Thin adapter over the frozen [`crate::ecies`] construction.
+//!
+//! Wire-frozen: hint, key derivation and ciphertext are byte-for-byte the
+//! compat baseline; only the frame around them is shared with the envelope.
+
+use k256::SecretKey;
+
+use crate::ecies::{self, Hint, Salt};
+
+use super::{Compat, OpenError, Opened, Recipient, Record, SealedRecord, hint_matches};
+
+#[cfg(feature = "encryption")]
+pub(super) fn seal(
+    recipient: &Recipient<Compat>,
+    salt: Salt<'_>,
+    plaintext: &[u8],
+    ct_len: usize,
+) -> Result<SealedRecord<Compat>, ecies::EciesError> {
+    let encrypted = ecies::encrypt(recipient.key(), salt, plaintext, Some(ct_len))?;
+    let hint = *Hint::derive(&encrypted.key, salt).as_bytes();
+    let (enc_x, parity) = super::x_and_parity(&encrypted.ephemeral);
+    Ok(SealedRecord::from_parts(
+        hint,
+        parity,
+        enc_x,
+        encrypted.ciphertext,
+        encrypted.key,
+    ))
+}
+
+pub(super) fn open(
+    secret: &SecretKey,
+    salt: Salt<'_>,
+    record: &Record<'_>,
+) -> Result<Option<Opened<Compat>>, OpenError> {
+    // Compat ECDH only uses the shared x, so either parity reconstructs the
+    // same key; use the carried bit for symmetry with the envelope.
+    let Some(ephemeral) = super::reconstruct(record.enc_x(), record.parity()) else {
+        return Ok(None);
+    };
+    let key = ecies::shared_key(secret, &ephemeral, salt);
+    if !hint_matches(Hint::derive(&key, salt).as_bytes(), record.hint()) {
+        return Ok(None);
+    }
+    let plaintext = ecies::decrypt(&key, record.ciphertext());
+    Ok(Some(Opened {
+        plaintext,
+        extra: key,
+    }))
+}

--- a/crates/primitives/src/envelope/hpke.rs
+++ b/crates/primitives/src/envelope/hpke.rs
@@ -6,6 +6,7 @@
 //! SEC1, and every secret intermediate is zeroized on drop. Auth and psk
 //! modes arrive with their consumers.
 
+use alloc::vec::Vec;
 use chacha20poly1305::aead::AeadInPlace;
 use chacha20poly1305::{ChaCha20Poly1305, KeyInit, Nonce, Tag};
 use hkdf::Hkdf;
@@ -135,7 +136,7 @@ fn labeled_expand(
     let hk = Hkdf::<Sha256>::from_prk(prk).map_err(|_| ExportError)?;
     let length = u16::try_from(okm.len()).map_err(|_| ExportError)?;
     let length_bytes = length.to_be_bytes();
-    let mut info: Vec<&[u8]> = vec![&length_bytes, b"HPKE-v1", suite_id, label];
+    let mut info: Vec<&[u8]> = alloc::vec![&length_bytes, b"HPKE-v1", suite_id, label];
     info.extend_from_slice(info_parts);
     hk.expand_multi_info(&info, okm).map_err(|_| ExportError)
 }

--- a/crates/primitives/src/envelope/hpke.rs
+++ b/crates/primitives/src/envelope/hpke.rs
@@ -1,0 +1,655 @@
+//! The envelope suite: RFC 9180 base mode over the draft secp256k1 KEM.
+//!
+//! The KEM is composed directly from k256 and HKDF-SHA256 per
+//! draft-wahby-cfrg-hpke-kem-secp256k1 (codepoint 0x0016): x-only ECDH is
+//! rejected for zero output, `enc` enters `kem_context` as uncompressed
+//! SEC1, and every secret intermediate is zeroized on drop. Auth and psk
+//! modes arrive with their consumers.
+
+use chacha20poly1305::aead::AeadInPlace;
+use chacha20poly1305::{ChaCha20Poly1305, KeyInit, Nonce, Tag};
+use hkdf::Hkdf;
+use k256::elliptic_curve::sec1::ToEncodedPoint;
+use k256::{PublicKey, SecretKey};
+use sha2::Sha256;
+use subtle::ConstantTimeEq;
+use thiserror::Error;
+use zeroize::Zeroizing;
+
+use super::{Hpke, LABEL, OpenError, Opened, Recipient, Record, SealedRecord, Topic, hint_matches};
+
+/// `"KEM"` plus the draft codepoint 0x0016.
+const KEM_SUITE_ID: &[u8] = b"KEM\x00\x16";
+/// `"HPKE"` plus kem 0x0016, kdf 0x0001, aead 0x0003.
+const HPKE_SUITE_ID: &[u8] = b"HPKE\x00\x16\x00\x01\x00\x03";
+/// mode_base.
+const MODE_BASE: u8 = 0x00;
+/// Exporter context of the envelope hint.
+const HINT_CONTEXT: &[u8] = b"nectar/env/v1 hint";
+
+/// Poly1305 tag length.
+const TAG_SIZE: usize = 16;
+/// Big-endian length prefix inside the sealed plaintext.
+const LEN_PREFIX: usize = 2;
+/// Smallest admissible ciphertext region.
+const MIN_CT_LEN: usize = TAG_SIZE + LEN_PREFIX;
+
+/// Key-derivation context: the domain label followed by the topic.
+#[derive(Debug, Clone, Copy)]
+pub struct Info<'a> {
+    topic: &'a Topic,
+}
+
+impl<'a> Info<'a> {
+    /// The bound topic.
+    #[must_use]
+    pub const fn topic(&self) -> &'a Topic {
+        self.topic
+    }
+}
+
+impl<'a> From<&'a Topic> for Info<'a> {
+    fn from(topic: &'a Topic) -> Self {
+        Self { topic }
+    }
+}
+
+/// An export length exceeded the HKDF expand bound.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+#[error("requested length exceeds the hkdf expand bound")]
+pub struct ExportError;
+
+/// Keypair derivation exhausted the candidate loop; probability 2^-256 per
+/// step, unreachable in practice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+#[error("keypair derivation exhausted its candidate space")]
+pub struct DeriveKeyPairError;
+
+/// Errors from an envelope seal.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum HpkeSealError {
+    /// The message does not fit the ciphertext region.
+    #[error("plaintext too long: {len} bytes, capacity {max}")]
+    MessageTooLong {
+        /// Plaintext length.
+        len: usize,
+        /// Region capacity after tag and length prefix.
+        max: usize,
+    },
+    /// The region cannot hold the tag and length prefix.
+    #[error("ciphertext region too small: {ct_len} bytes, minimum {MIN_CT_LEN}")]
+    RegionTooSmall {
+        /// Requested region length.
+        ct_len: usize,
+    },
+    /// A fixed-size derivation failed; unreachable for the pinned suite.
+    #[error("suite derivation invariant violated")]
+    Internal,
+}
+
+/// Exporter interface over the context's `exporter_secret`.
+pub struct Exporter {
+    secret: Zeroizing<[u8; 32]>,
+}
+
+impl Exporter {
+    /// Fill `okm` with `LabeledExpand(exporter_secret, "sec", context, L)`.
+    pub fn export(&self, context: &[u8], okm: &mut [u8]) -> Result<(), ExportError> {
+        labeled_expand(HPKE_SUITE_ID, &self.secret, b"sec", &[context], okm)
+    }
+}
+
+impl core::fmt::Debug for Exporter {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("Exporter(..)")
+    }
+}
+
+/// `LabeledExtract(salt, label, ikm)` with `ikm` given in parts.
+fn labeled_extract(
+    suite_id: &[u8],
+    salt: &[u8],
+    label: &[u8],
+    ikm_parts: &[&[u8]],
+) -> Zeroizing<[u8; 32]> {
+    let mut ikm = Zeroizing::new(Vec::new());
+    ikm.extend_from_slice(b"HPKE-v1");
+    ikm.extend_from_slice(suite_id);
+    ikm.extend_from_slice(label);
+    for part in ikm_parts {
+        ikm.extend_from_slice(part);
+    }
+    let (prk, _) = Hkdf::<Sha256>::extract(Some(salt), &ikm);
+    Zeroizing::new(prk.into())
+}
+
+/// `LabeledExpand(prk, label, info, okm.len())` with `info` given in parts.
+fn labeled_expand(
+    suite_id: &[u8],
+    prk: &[u8; 32],
+    label: &[u8],
+    info_parts: &[&[u8]],
+    okm: &mut [u8],
+) -> Result<(), ExportError> {
+    let hk = Hkdf::<Sha256>::from_prk(prk).map_err(|_| ExportError)?;
+    let length = u16::try_from(okm.len()).map_err(|_| ExportError)?;
+    let length_bytes = length.to_be_bytes();
+    let mut info: Vec<&[u8]> = vec![&length_bytes, b"HPKE-v1", suite_id, label];
+    info.extend_from_slice(info_parts);
+    hk.expand_multi_info(&info, okm).map_err(|_| ExportError)
+}
+
+/// DHKEM ExtractAndExpand; `Ok(None)` rejects a zero ECDH output.
+fn extract_and_expand(
+    dh: &[u8],
+    enc: &[u8],
+    pkr: &[u8],
+) -> Result<Option<Zeroizing<[u8; 32]>>, ExportError> {
+    if bool::from(dh.ct_eq(&[0u8; 32])) {
+        return Ok(None);
+    }
+    let eae_prk = labeled_extract(KEM_SUITE_ID, b"", b"eae_prk", &[dh]);
+    let mut shared = Zeroizing::new([0u8; 32]);
+    labeled_expand(
+        KEM_SUITE_ID,
+        &eae_prk,
+        b"shared_secret",
+        &[enc, pkr],
+        shared.as_mut_slice(),
+    )?;
+    Ok(Some(shared))
+}
+
+/// DeriveKeyPair per the draft; the secp256k1 bitmask is 0xff.
+pub fn derive_key_pair(ikm: &[u8]) -> Result<(SecretKey, PublicKey), DeriveKeyPairError> {
+    let dkp_prk = labeled_extract(KEM_SUITE_ID, b"", b"dkp_prk", &[ikm]);
+    for counter in 0u8..=255 {
+        let mut candidate = Zeroizing::new([0u8; 32]);
+        labeled_expand(
+            KEM_SUITE_ID,
+            &dkp_prk,
+            b"candidate",
+            &[&[counter]],
+            candidate.as_mut_slice(),
+        )
+        .map_err(|_| DeriveKeyPairError)?;
+        if let Ok(secret) = SecretKey::from_slice(candidate.as_slice()) {
+            let public = secret.public_key();
+            return Ok((secret, public));
+        }
+    }
+    Err(DeriveKeyPairError)
+}
+
+/// Derived per-message key material.
+struct Schedule {
+    key: Zeroizing<[u8; 32]>,
+    base_nonce: [u8; 12],
+    exporter: Exporter,
+}
+
+impl Schedule {
+    /// The envelope hint: `export("nectar/env/v1 hint", 8)`.
+    fn hint(&self) -> Result<[u8; 8], ExportError> {
+        let mut hint = [0u8; 8];
+        self.exporter.export(HINT_CONTEXT, &mut hint)?;
+        Ok(hint)
+    }
+}
+
+/// KeySchedule for mode_base with `info = LABEL || topic`.
+fn key_schedule(shared: &[u8; 32], topic: &Topic) -> Result<Schedule, ExportError> {
+    let psk_id_hash = labeled_extract(HPKE_SUITE_ID, b"", b"psk_id_hash", &[]);
+    let info_hash = labeled_extract(HPKE_SUITE_ID, b"", b"info_hash", &[LABEL, topic.as_bytes()]);
+    let mut context = Vec::new();
+    context.push(MODE_BASE);
+    context.extend_from_slice(psk_id_hash.as_slice());
+    context.extend_from_slice(info_hash.as_slice());
+
+    let secret = labeled_extract(HPKE_SUITE_ID, shared, b"secret", &[]);
+    let mut key = Zeroizing::new([0u8; 32]);
+    labeled_expand(
+        HPKE_SUITE_ID,
+        &secret,
+        b"key",
+        &[&context],
+        key.as_mut_slice(),
+    )?;
+    let mut base_nonce = [0u8; 12];
+    labeled_expand(
+        HPKE_SUITE_ID,
+        &secret,
+        b"base_nonce",
+        &[&context],
+        &mut base_nonce,
+    )?;
+    let mut exporter_secret = Zeroizing::new([0u8; 32]);
+    labeled_expand(
+        HPKE_SUITE_ID,
+        &secret,
+        b"exp",
+        &[&context],
+        exporter_secret.as_mut_slice(),
+    )?;
+    Ok(Schedule {
+        key,
+        base_nonce,
+        exporter: Exporter {
+            secret: exporter_secret,
+        },
+    })
+}
+
+/// Decap once per record; `Ok(None)` when `enc_x` is off-curve or the ECDH
+/// output is rejected.
+pub(super) fn decap(
+    secret: &SecretKey,
+    record: &Record<'_>,
+) -> Result<Option<Zeroizing<[u8; 32]>>, OpenError> {
+    let Some(enc) = super::reconstruct(record.enc_x(), record.parity()) else {
+        return Ok(None);
+    };
+    let dh = k256::ecdh::diffie_hellman(secret.to_nonzero_scalar(), enc.as_affine());
+    let dh_bytes: &[u8] = dh.raw_secret_bytes().as_ref();
+    let enc_point = enc.to_encoded_point(false);
+    let pkr_point = secret.public_key().to_encoded_point(false);
+    extract_and_expand(dh_bytes, enc_point.as_bytes(), pkr_point.as_bytes())
+        .map_err(|_| OpenError::Internal)
+}
+
+/// Hint probe plus AEAD open for one topic over an established shared
+/// secret; a hint collision fails the tag and falls through as `Ok(None)`.
+pub(super) fn open_with_shared(
+    shared: &Zeroizing<[u8; 32]>,
+    topic: &Topic,
+    record: &Record<'_>,
+) -> Result<Option<Opened<Hpke>>, OpenError> {
+    let schedule = key_schedule(shared, topic).map_err(|_| OpenError::Internal)?;
+    let hint = schedule.hint().map_err(|_| OpenError::Internal)?;
+    if !hint_matches(&hint, record.hint()) {
+        return Ok(None);
+    }
+    let Some((body, tag)) = record.ciphertext().split_last_chunk::<TAG_SIZE>() else {
+        return Ok(None);
+    };
+    let cipher = ChaCha20Poly1305::new_from_slice(schedule.key.as_slice())
+        .map_err(|_| OpenError::Internal)?;
+    let nonce = Nonce::from(schedule.base_nonce);
+    let mut buf = Zeroizing::new(body.to_vec());
+    if cipher
+        .decrypt_in_place_detached(&nonce, b"", &mut buf, &Tag::from(*tag))
+        .is_err()
+    {
+        return Ok(None);
+    }
+    let Some((length_bytes, rest)) = buf.split_first_chunk::<LEN_PREFIX>() else {
+        return Err(OpenError::MalformedMessage);
+    };
+    let length = usize::from(u16::from_be_bytes(*length_bytes));
+    let message = rest.get(..length).ok_or(OpenError::MalformedMessage)?;
+    Ok(Some(Opened {
+        plaintext: message.to_vec(),
+        extra: schedule.exporter,
+    }))
+}
+
+pub(super) fn open(
+    secret: &SecretKey,
+    ctx: Info<'_>,
+    record: &Record<'_>,
+) -> Result<Option<Opened<Hpke>>, OpenError> {
+    let Some(shared) = decap(secret, record)? else {
+        return Ok(None);
+    };
+    open_with_shared(&shared, ctx.topic(), record)
+}
+
+#[cfg(feature = "encryption")]
+pub(super) fn seal(
+    recipient: &Recipient<Hpke>,
+    ctx: Info<'_>,
+    plaintext: &[u8],
+    ct_len: usize,
+) -> Result<SealedRecord<Hpke>, HpkeSealError> {
+    seal_with_ephemeral(
+        &crate::ecies::generate_secret(),
+        recipient.key(),
+        ctx.topic(),
+        plaintext,
+        ct_len,
+    )
+}
+
+/// Deterministic apart from the ephemeral; reached from [`seal`] and, for
+/// the pinned vectors, from the KAT tests only.
+fn seal_with_ephemeral(
+    ephemeral: &SecretKey,
+    recipient: &PublicKey,
+    topic: &Topic,
+    plaintext: &[u8],
+    ct_len: usize,
+) -> Result<SealedRecord<Hpke>, HpkeSealError> {
+    let capacity = ct_len
+        .checked_sub(MIN_CT_LEN)
+        .ok_or(HpkeSealError::RegionTooSmall { ct_len })?;
+    let max = capacity.min(usize::from(u16::MAX));
+    if plaintext.len() > max {
+        return Err(HpkeSealError::MessageTooLong {
+            len: plaintext.len(),
+            max,
+        });
+    }
+    let length = u16::try_from(plaintext.len()).map_err(|_| HpkeSealError::Internal)?;
+
+    // Encap toward the recipient.
+    let dh = k256::ecdh::diffie_hellman(ephemeral.to_nonzero_scalar(), recipient.as_affine());
+    let dh_bytes: &[u8] = dh.raw_secret_bytes().as_ref();
+    let enc = ephemeral.public_key();
+    let enc_point = enc.to_encoded_point(false);
+    let pkr_point = recipient.to_encoded_point(false);
+    let shared = extract_and_expand(dh_bytes, enc_point.as_bytes(), pkr_point.as_bytes())
+        .map_err(|_| HpkeSealError::Internal)?
+        .ok_or(HpkeSealError::Internal)?;
+
+    let schedule = key_schedule(&shared, topic).map_err(|_| HpkeSealError::Internal)?;
+    let hint = schedule.hint().map_err(|_| HpkeSealError::Internal)?;
+
+    // `len || msg || pad`, sealed to fill the region exactly.
+    let inner_len = ct_len
+        .checked_sub(TAG_SIZE)
+        .ok_or(HpkeSealError::Internal)?;
+    let mut buf = Vec::with_capacity(ct_len);
+    buf.extend_from_slice(&length.to_be_bytes());
+    buf.extend_from_slice(plaintext);
+    buf.resize(inner_len, 0);
+
+    let cipher = ChaCha20Poly1305::new_from_slice(schedule.key.as_slice())
+        .map_err(|_| HpkeSealError::Internal)?;
+    let nonce = Nonce::from(schedule.base_nonce);
+    let tag = cipher
+        .encrypt_in_place_detached(&nonce, b"", &mut buf)
+        .map_err(|_| HpkeSealError::Internal)?;
+    buf.extend_from_slice(&tag);
+
+    let (enc_x, parity) = super::x_and_parity(&enc);
+    Ok(SealedRecord::from_parts(
+        hint,
+        parity,
+        enc_x,
+        buf,
+        schedule.exporter,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{hex, keccak256};
+    use hpke_rs::{Hpke as RefHpke, HpkePrivateKey, HpkePublicKey, Mode};
+    use hpke_rs_crypto::types::{AeadAlgorithm, KdfAlgorithm, KemAlgorithm};
+    use hpke_rs_rust_crypto::HpkeRustCrypto;
+
+    fn reference() -> RefHpke<HpkeRustCrypto> {
+        RefHpke::new(
+            Mode::Base,
+            KemAlgorithm::DhKemK256,
+            KdfAlgorithm::HkdfSha256,
+            AeadAlgorithm::ChaCha20Poly1305,
+        )
+    }
+
+    fn info_bytes(topic: &Topic) -> Vec<u8> {
+        let mut info = LABEL.to_vec();
+        info.extend_from_slice(topic.as_bytes());
+        info
+    }
+
+    fn topic() -> Topic {
+        Topic::new(keccak256(b"nectar envelope kat topic").0)
+    }
+
+    /// Deterministic keys: the scalars are keccak256 of the ASCII labels.
+    fn recipient_keys() -> (SecretKey, PublicKey) {
+        let secret =
+            SecretKey::from_slice(keccak256(b"nectar envelope kat recipient").as_slice()).unwrap();
+        let public = secret.public_key();
+        (secret, public)
+    }
+
+    fn ephemeral_key() -> SecretKey {
+        SecretKey::from_slice(keccak256(b"nectar envelope kat ephemeral").as_slice()).unwrap()
+    }
+
+    fn record_from(bytes: &[u8]) -> Record<'_> {
+        Record::parse(bytes).unwrap()
+    }
+
+    #[test]
+    fn differential_our_seal_reference_open() {
+        let (recipient_sk, recipient_pk) = recipient_keys();
+        let topic = topic();
+        let msg = b"differential message";
+        let sealed = seal_with_ephemeral(&ephemeral_key(), &recipient_pk, &topic, msg, 64).unwrap();
+
+        let enc = ephemeral_key().public_key().to_encoded_point(false);
+        let bytes = sealed.to_bytes();
+        let record = record_from(&bytes);
+        let inner = reference()
+            .open(
+                enc.as_bytes(),
+                &recipient_sk.to_bytes().to_vec().into(),
+                &info_bytes(&topic),
+                b"",
+                record.ciphertext(),
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        // The reference sees our inner framing: len || msg || pad.
+        let (length, rest) = inner.split_first_chunk::<2>().unwrap();
+        let length = usize::from(u16::from_be_bytes(*length));
+        assert_eq!(length, msg.len());
+        assert_eq!(&rest[..length], msg);
+        assert_eq!(inner.len(), 64 - TAG_SIZE);
+    }
+
+    #[test]
+    fn differential_reference_seal_our_open() {
+        let (recipient_sk, recipient_pk) = recipient_keys();
+        let topic = topic();
+        let msg = b"reference sealed this";
+        let pk_r = HpkePublicKey::new(recipient_pk.to_encoded_point(false).as_bytes().to_vec());
+        let (enc, ct) = reference()
+            .seal(&pk_r, &info_bytes(&topic), b"", msg, None, None, None)
+            .unwrap();
+
+        // Rebuild the shared secret from their enc and open their ct raw.
+        let enc_pub = PublicKey::from_sec1_bytes(&enc).unwrap();
+        let dh = k256::ecdh::diffie_hellman(recipient_sk.to_nonzero_scalar(), enc_pub.as_affine());
+        let dh_bytes: &[u8] = dh.raw_secret_bytes().as_ref();
+        let enc_point = enc_pub.to_encoded_point(false);
+        assert_eq!(enc_point.as_bytes(), &enc[..]);
+        let pkr_point = recipient_pk.to_encoded_point(false);
+        let shared = extract_and_expand(dh_bytes, enc_point.as_bytes(), pkr_point.as_bytes())
+            .unwrap()
+            .unwrap();
+        let schedule = key_schedule(&shared, &topic).unwrap();
+        let (body, tag) = ct.split_last_chunk::<TAG_SIZE>().unwrap();
+        let cipher = ChaCha20Poly1305::new_from_slice(schedule.key.as_slice()).unwrap();
+        let mut buf = body.to_vec();
+        cipher
+            .decrypt_in_place_detached(
+                &Nonce::from(schedule.base_nonce),
+                b"",
+                &mut buf,
+                &Tag::from(*tag),
+            )
+            .unwrap();
+        assert_eq!(buf, msg);
+    }
+
+    #[test]
+    fn differential_export_and_hint() {
+        let (recipient_sk, recipient_pk) = recipient_keys();
+        let topic = topic();
+        let sealed =
+            seal_with_ephemeral(&ephemeral_key(), &recipient_pk, &topic, b"x", 64).unwrap();
+        let enc = ephemeral_key().public_key().to_encoded_point(false);
+
+        let theirs = reference()
+            .receiver_export(
+                enc.as_bytes(),
+                &recipient_sk.to_bytes().to_vec().into(),
+                &info_bytes(&topic),
+                None,
+                None,
+                None,
+                HINT_CONTEXT,
+                8,
+            )
+            .unwrap();
+        let bytes = sealed.to_bytes();
+        let record = record_from(&bytes);
+        assert_eq!(&theirs[..], record.hint());
+
+        let mut ours = [0u8; 8];
+        sealed.extra().export(HINT_CONTEXT, &mut ours).unwrap();
+        assert_eq!(&theirs[..], &ours);
+    }
+
+    #[test]
+    fn differential_derive_key_pair() {
+        let ikm = keccak256(b"nectar envelope kat ikm").0;
+        let (secret, public) = derive_key_pair(&ikm).unwrap();
+        let theirs = reference().derive_key_pair(&ikm).unwrap();
+        let (their_sk, their_pk) = theirs.into_keys();
+        assert_eq!(their_sk, HpkePrivateKey::from(secret.to_bytes().to_vec()));
+        assert_eq!(
+            their_pk.as_slice(),
+            public.to_encoded_point(false).as_bytes()
+        );
+    }
+
+    #[test]
+    fn region_too_small() {
+        let (_, recipient_pk) = recipient_keys();
+        let err =
+            seal_with_ephemeral(&ephemeral_key(), &recipient_pk, &topic(), b"", 17).unwrap_err();
+        assert_eq!(err, HpkeSealError::RegionTooSmall { ct_len: 17 });
+    }
+
+    #[test]
+    fn message_too_long() {
+        let (_, recipient_pk) = recipient_keys();
+        let err = seal_with_ephemeral(&ephemeral_key(), &recipient_pk, &topic(), &[0u8; 47], 64)
+            .unwrap_err();
+        assert_eq!(err, HpkeSealError::MessageTooLong { len: 47, max: 46 });
+    }
+
+    #[test]
+    fn off_curve_enc_rejects_cheaply() {
+        let (recipient_sk, recipient_pk) = recipient_keys();
+        let sealed =
+            seal_with_ephemeral(&ephemeral_key(), &recipient_pk, &topic(), b"msg", 64).unwrap();
+        let mut bytes = sealed.to_bytes();
+        // Find an x that is off-curve for both parities, deterministically.
+        let mut x = [0u8; 32];
+        while super::super::reconstruct(&x, false).is_some()
+            || super::super::reconstruct(&x, true).is_some()
+        {
+            x[31] = x[31].wrapping_add(1);
+        }
+        bytes[40..72].copy_from_slice(&x);
+        let record = record_from(&bytes);
+        assert!(decap(&recipient_sk, &record).unwrap().is_none());
+        assert!(
+            open(&recipient_sk, Info::from(&topic()), &record)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn exporter_length_bound() {
+        let (_, recipient_pk) = recipient_keys();
+        let sealed =
+            seal_with_ephemeral(&ephemeral_key(), &recipient_pk, &topic(), b"x", 64).unwrap();
+        let mut too_long = vec![0u8; 32 * 256];
+        assert_eq!(
+            sealed.extra().export(b"ctx", &mut too_long).unwrap_err(),
+            ExportError
+        );
+    }
+
+    /// Nectar-owned conformance vector in the RFC 9180 appendix shape:
+    /// mode_base, kem 0x0016, kdf 0x0001, aead 0x0003, `ct_len` 64. The
+    /// draft KEM has no registry vectors; these pin the whole chain from
+    /// scalars to the serialized frame.
+    #[test]
+    fn kat_pinned() {
+        const SK_RM: [u8; 32] =
+            hex!("92f8eb1624814af780f0057c70922fbcfc11c7c4d660621f8ace98e8d1b74c0f");
+        const PK_RM: [u8; 65] = hex!(
+            "044bcc9cf73bde3b2b8cd50ccbe1121045d68c154673bc770f3120f1054b3667a528eb4c4d8cf27b88bc708a79cf46699500c293f51652ac06d6ec81df3e5be420"
+        );
+        const SK_EM: [u8; 32] =
+            hex!("ccfdec3c5c5e08d13dc3e92ab3b60fca31a794ef089bd549d77ec0cc2a7fcb4f");
+        const ENC: [u8; 65] = hex!(
+            "04059ad0913b3994ee1124c74c717ef77105853d98d035f104eb59abb843c284a1f64be32b1705005723b677b6443d2b3e328f9a5d74f1526c4df9dece28197d14"
+        );
+        const TOPIC: [u8; 32] =
+            hex!("495d20024ea5c3b8b0c1a496340482662f282f72a3d54914c0836b5eb9aff574");
+        const SHARED_SECRET: [u8; 32] =
+            hex!("a0828bc0a22e17da6114de7be55825fc3984f13b701abb0b777d3eb9876555c8");
+        const KEY: [u8; 32] =
+            hex!("38baadc102a68013e1149955e36c3feb0ba28aeacb923e6de32fda54c087d5db");
+        const BASE_NONCE: [u8; 12] = hex!("6b806eaf22c4319f6cc50878");
+        const HINT: [u8; 8] = hex!("e53a0642aa151e15");
+        const FRAME: [u8; 136] = hex!(
+            "e53a0642aa151e150000000000000000000000000000000000000000000000000000000000000000059ad0913b3994ee1124c74c717ef77105853d98d035f104eb59abb843c284a1dcc31c32e025943268d6d7b68f80c9c3dd6ad02e1769ad7824722ec2be1963e0a9f7b48940a16dd464f6e13b6cf52e5a4a21b2407c7b661e494efc9f76eb8ad2"
+        );
+        const MSG: &[u8] = b"nectar envelope kat message";
+
+        let recipient_sk = SecretKey::from_slice(&SK_RM).unwrap();
+        let recipient_pk = recipient_sk.public_key();
+        assert_eq!(recipient_pk.to_encoded_point(false).as_bytes(), PK_RM);
+        let eph = SecretKey::from_slice(&SK_EM).unwrap();
+        assert_eq!(eph.public_key().to_encoded_point(false).as_bytes(), ENC);
+        let topic = Topic::new(TOPIC);
+
+        let dh = k256::ecdh::diffie_hellman(eph.to_nonzero_scalar(), recipient_pk.as_affine());
+        let dh_bytes: &[u8] = dh.raw_secret_bytes().as_ref();
+        let shared = extract_and_expand(dh_bytes, &ENC, &PK_RM).unwrap().unwrap();
+        assert_eq!(*shared, SHARED_SECRET);
+        let schedule = key_schedule(&shared, &topic).unwrap();
+        assert_eq!(*schedule.key, KEY);
+        assert_eq!(schedule.base_nonce, BASE_NONCE);
+        assert_eq!(schedule.hint().unwrap(), HINT);
+
+        let sealed = seal_with_ephemeral(&eph, &recipient_pk, &topic, MSG, 64).unwrap();
+        assert_eq!(sealed.to_bytes(), FRAME);
+
+        let record = record_from(&FRAME);
+        let opened = open(&recipient_sk, Info::from(&topic), &record)
+            .unwrap()
+            .unwrap();
+        assert_eq!(opened.plaintext, MSG);
+    }
+
+    /// Pinned DeriveKeyPair vector for the draft KEM.
+    #[test]
+    fn kat_derive_key_pair_pinned() {
+        const IKM: [u8; 32] =
+            hex!("a19f0627fc71bc68959c8dba381a3415a149ffa17711b63084e53a4eae030add");
+        const SK: [u8; 32] =
+            hex!("356863ac16c2d7d1c30e8f7c5b63bf4759e315a0d88bed24408ecfc13959c99e");
+        const PK: [u8; 65] = hex!(
+            "043148e5388b2676c8d8e05da2a918125e33e07dd2c57f7c401623b20785c419c84ce65c28c9585f7150b08040b3f06d849fc2bf414700875757aa6bc23e412af3"
+        );
+        let (secret, public) = derive_key_pair(&IKM).unwrap();
+        assert_eq!(secret.to_bytes().to_vec(), SK.to_vec());
+        assert_eq!(public.to_encoded_point(false).as_bytes(), PK);
+    }
+}

--- a/crates/primitives/src/envelope/hpke.rs
+++ b/crates/primitives/src/envelope/hpke.rs
@@ -323,6 +323,7 @@ pub(super) fn seal(
 
 /// Deterministic apart from the ephemeral; reached from [`seal`] and, for
 /// the pinned vectors, from the KAT tests only.
+#[cfg(feature = "encryption")]
 fn seal_with_ephemeral(
     ephemeral: &SecretKey,
     recipient: &PublicKey,

--- a/crates/primitives/src/envelope/mod.rs
+++ b/crates/primitives/src/envelope/mod.rs
@@ -1,0 +1,940 @@
+//! Versioned modern envelope over the frozen ecies compat baseline.
+//!
+//! Two sealed schemes share one frozen frame inside the chunk payload:
+//! `hint[0..8] || nonce[8..40] || enc_x[40..72] || ct[72..]`. Compat is the
+//! byte-frozen [`crate::ecies`] construction; the envelope is RFC 9180 HPKE
+//! with the single suite DHKEM(secp256k1, HKDF-SHA256) + HKDF-SHA256 +
+//! ChaCha20-Poly1305 under the domain label `nectar/env/v1`.
+//!
+//! The KEM is draft-wahby-cfrg-hpke-kem-secp256k1 (requested codepoint
+//! 0x0016): an expired individual CFRG draft, absent from the IANA HPKE
+//! registry. The codepoint is ecosystem convention only, so the conformance
+//! vectors carried by the test suite are nectar-owned and normative here.
+//!
+//! The version discriminant is cryptographic, not syntactic: compat keeps
+//! `keccak256(key || salt)[..8]` in the hint slot, the envelope hint is
+//! `export("nectar/env/v1 hint", 8)`; the labelled transcripts are
+//! domain-disjoint, so only the recipient can tell the schemes apart. The
+//! hint is mandatory for envelope records: ChaCha20-Poly1305 is not
+//! key-committing, and trial-opening one ciphertext against many per-topic
+//! key schedules without the hint gate is a partitioning oracle.
+//!
+//! `enc` travels x-only; the low bit of `nonce[0]` carries the ephemeral y
+//! parity in both schemes (miners hold it fixed). The envelope reconstructs
+//! canonical uncompressed SEC1 before `kem_context`; compat ECDH ignores
+//! parity, so a flipped bit is an authenticated decap failure (DoS only) for
+//! the envelope and a no-op for compat. Records of both schemes are
+//! curve-membership-detectable against uniform bytes: the anonymity set is
+//! trojan chunks, at exact parity with the deployed compat path.
+//!
+//! Trial order: decap once per record (after chunk validity and
+//! proof-of-work checks; that per-valid-chunk cost is inherent), one hint
+//! probe per candidate topic, AEAD open only on a hint match. HKDF-SHA256
+//! deliberately adds SHA-256 beside the otherwise keccak-only proving
+//! surface.
+
+use core::fmt;
+use core::marker::PhantomData;
+
+use k256::{PublicKey, SecretKey};
+use subtle::ConstantTimeEq;
+use thiserror::Error;
+
+use crate::ecies::Salt;
+
+mod attestation;
+mod compat;
+mod hpke;
+
+pub use attestation::{ATTESTATION_PREFIX, AttestationError, EnvelopeAttestation, sign_data};
+pub use hpke::{DeriveKeyPairError, ExportError, Exporter, HpkeSealError, Info, derive_key_pair};
+
+use crate::chunk::encryption::EncryptionKey;
+use crate::ecies::EciesError;
+
+/// Domain label of the envelope suite.
+pub const LABEL: &[u8] = b"nectar/env/v1";
+
+/// Byte length of the hint slot.
+pub const HINT_SIZE: usize = 8;
+/// Byte length of the mining nonce slot.
+pub const NONCE_SIZE: usize = 32;
+/// Byte length of the x-only ephemeral slot.
+pub const ENC_X_SIZE: usize = 32;
+/// Byte length of the frame header preceding the ciphertext region.
+pub const HEADER_SIZE: usize = HINT_SIZE + NONCE_SIZE + ENC_X_SIZE;
+
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for super::Compat {}
+    impl Sealed for super::Hpke {}
+    impl Sealed for super::EnvelopeOnly {}
+    impl Sealed for super::EnvelopeThenCompat {}
+}
+
+/// 32-byte topic a record is addressed under.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Topic([u8; 32]);
+
+impl Topic {
+    /// Wrap raw topic bytes.
+    #[must_use]
+    pub const fn new(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// Access the raw topic bytes.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl From<[u8; 32]> for Topic {
+    fn from(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+}
+
+impl<'a> From<&'a Topic> for Salt<'a> {
+    fn from(topic: &'a Topic) -> Self {
+        Self::raw(&topic.0)
+    }
+}
+
+/// Scheme label reported in open results; never a dispatcher.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SchemeId {
+    /// The frozen reference-client construction.
+    Compat,
+    /// The HPKE envelope.
+    Envelope,
+}
+
+/// One of the two envelope schemes; sealed, dispatch rides the type.
+pub trait Scheme: sealed::Sealed + Sized {
+    /// Per-scheme key-derivation context built from a topic.
+    type Context<'a>: From<&'a Topic>;
+    /// Scheme-specific by-product of a seal or open.
+    type Extra: fmt::Debug;
+    /// Proof carried by a [`Recipient`] of how it was minted.
+    type Provenance: Clone + fmt::Debug;
+    /// Errors from sealing.
+    type SealError: core::error::Error;
+
+    /// AEAD tag bytes spent inside the ciphertext region.
+    const TAG: usize;
+    /// Report label for open results.
+    const ID: SchemeId;
+
+    /// Seal `plaintext` toward `recipient` into a `ct_len`-byte ciphertext
+    /// region.
+    #[cfg(feature = "encryption")]
+    fn seal(
+        recipient: &Recipient<Self>,
+        ctx: Self::Context<'_>,
+        plaintext: &[u8],
+        ct_len: usize,
+    ) -> Result<SealedRecord<Self>, Self::SealError>;
+
+    /// Try to open `record` under `secret` for one context. `Ok(None)` means
+    /// the record is not recognized under this scheme and context.
+    fn open(
+        secret: &SecretKey,
+        ctx: Self::Context<'_>,
+        record: &Record<'_>,
+    ) -> Result<Option<Opened<Self>>, OpenError>;
+}
+
+/// The frozen reference-client construction, adapted over [`crate::ecies`].
+#[derive(Debug, Clone, Copy)]
+pub enum Compat {}
+
+/// The HPKE envelope suite; one sealed type, no agility.
+#[derive(Debug, Clone, Copy)]
+pub enum Hpke {}
+
+/// Loud, greppable justification for sealing toward a compat recipient.
+#[derive(Debug, Clone, Copy)]
+pub struct InteropReason(&'static str);
+
+impl InteropReason {
+    /// Record why compat interop is unavoidable here.
+    #[must_use]
+    pub const fn new(reason: &'static str) -> Self {
+        Self(reason)
+    }
+
+    /// The recorded justification.
+    #[must_use]
+    pub const fn as_str(&self) -> &'static str {
+        self.0
+    }
+}
+
+/// Proof that a [`Recipient<Hpke>`] came from a verified
+/// [`EnvelopeAttestation`]; not constructible outside this crate.
+#[derive(Clone)]
+pub struct Attested(());
+
+impl fmt::Debug for Attested {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Attested")
+    }
+}
+
+/// Sealing handle for one recipient key under one scheme.
+///
+/// Upgrade is one-way: no conversion between schemes exists in either
+/// direction.
+///
+/// ```compile_fail
+/// use nectar_primitives::envelope::{Compat, Hpke, Recipient, Scheme, Topic};
+///
+/// fn downgrade(recipient: &Recipient<Hpke>, topic: &Topic) {
+///     // compat seal toward an envelope recipient must not typecheck
+///     let _ = Compat::seal(recipient, topic.into(), b"msg", 64);
+/// }
+/// ```
+#[derive(Clone)]
+pub struct Recipient<S: Scheme> {
+    key: PublicKey,
+    provenance: S::Provenance,
+}
+
+impl<S: Scheme> Recipient<S> {
+    /// The recipient public key.
+    #[must_use]
+    pub const fn key(&self) -> &PublicKey {
+        &self.key
+    }
+}
+
+impl<S: Scheme> fmt::Debug for Recipient<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Recipient")
+            .field("scheme", &S::ID)
+            .field("key", &self.key)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Recipient<Compat> {
+    /// The one sanctioned downgrade path: address a reader that only speaks
+    /// the reference construction.
+    #[must_use]
+    pub const fn assume_reference(key: PublicKey, reason: InteropReason) -> Self {
+        Self {
+            key,
+            provenance: reason,
+        }
+    }
+
+    /// Why this recipient is compat.
+    #[must_use]
+    pub const fn reason(&self) -> InteropReason {
+        self.provenance
+    }
+}
+
+impl Recipient<Hpke> {
+    /// Mint from a verified attestation; the only construction path.
+    pub(crate) const fn attested(key: PublicKey) -> Self {
+        Self {
+            key,
+            provenance: Attested(()),
+        }
+    }
+}
+
+/// A record payload was shorter than the frame header.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+#[error("record too short: {got} bytes, header is {HEADER_SIZE}")]
+pub struct RecordTooShort {
+    /// Observed payload length.
+    pub got: usize,
+}
+
+/// Parsed view of the frozen frame.
+#[derive(Debug, Clone, Copy)]
+pub struct Record<'a> {
+    hint: &'a [u8; HINT_SIZE],
+    nonce: &'a [u8; NONCE_SIZE],
+    enc_x: &'a [u8; ENC_X_SIZE],
+    ct: &'a [u8],
+}
+
+impl<'a> Record<'a> {
+    /// Split a chunk payload into the frame fields.
+    pub const fn parse(payload: &'a [u8]) -> Result<Self, RecordTooShort> {
+        let got = payload.len();
+        let Some((hint, rest)) = payload.split_first_chunk::<HINT_SIZE>() else {
+            return Err(RecordTooShort { got });
+        };
+        let Some((nonce, rest)) = rest.split_first_chunk::<NONCE_SIZE>() else {
+            return Err(RecordTooShort { got });
+        };
+        let Some((enc_x, ct)) = rest.split_first_chunk::<ENC_X_SIZE>() else {
+            return Err(RecordTooShort { got });
+        };
+        Ok(Self {
+            hint,
+            nonce,
+            enc_x,
+            ct,
+        })
+    }
+
+    /// The hint slot.
+    #[must_use]
+    pub const fn hint(&self) -> &[u8; HINT_SIZE] {
+        self.hint
+    }
+
+    /// The mining nonce slot.
+    #[must_use]
+    pub const fn nonce(&self) -> &[u8; NONCE_SIZE] {
+        self.nonce
+    }
+
+    /// The x-only ephemeral slot.
+    #[must_use]
+    pub const fn enc_x(&self) -> &[u8; ENC_X_SIZE] {
+        self.enc_x
+    }
+
+    /// The ciphertext region.
+    #[must_use]
+    pub const fn ciphertext(&self) -> &'a [u8] {
+        self.ct
+    }
+
+    /// Ephemeral y parity carried in the low bit of `nonce[0]`.
+    #[must_use]
+    pub const fn parity(&self) -> bool {
+        let [first, ..] = self.nonce;
+        *first & 1 == 1
+    }
+}
+
+/// Output of a successful open.
+pub struct Opened<S: Scheme> {
+    /// Recovered plaintext. Envelope: the exact message; compat: the whole
+    /// decrypted ciphertext region, framing left to the caller.
+    pub plaintext: Vec<u8>,
+    /// Scheme-specific by-product.
+    pub extra: S::Extra,
+}
+
+impl<S: Scheme> fmt::Debug for Opened<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Opened")
+            .field("scheme", &S::ID)
+            .field("plaintext_len", &self.plaintext.len())
+            .field("extra", &self.extra)
+            .finish()
+    }
+}
+
+/// Errors from opening a record that was recognized as ours.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum OpenError {
+    /// The authenticated inner framing is inconsistent.
+    #[error("authenticated inner framing is malformed")]
+    MalformedMessage,
+    /// A fixed-size derivation failed; unreachable for the pinned suite.
+    #[error("suite derivation invariant violated")]
+    Internal,
+}
+
+/// A sealed record ready for framing into a chunk payload.
+pub struct SealedRecord<S: Scheme> {
+    hint: [u8; HINT_SIZE],
+    nonce: [u8; NONCE_SIZE],
+    enc_x: [u8; ENC_X_SIZE],
+    ct: Vec<u8>,
+    extra: S::Extra,
+}
+
+impl<S: Scheme> SealedRecord<S> {
+    pub(crate) fn from_parts(
+        hint: [u8; HINT_SIZE],
+        parity: bool,
+        enc_x: [u8; ENC_X_SIZE],
+        ct: Vec<u8>,
+        extra: S::Extra,
+    ) -> Self {
+        let mut nonce = [0u8; NONCE_SIZE];
+        let [first, ..] = &mut nonce;
+        *first = u8::from(parity);
+        Self {
+            hint,
+            nonce,
+            enc_x,
+            ct,
+            extra,
+        }
+    }
+
+    /// Replace the mining nonce; the parity bit is reasserted.
+    pub const fn set_nonce(&mut self, mut nonce: [u8; NONCE_SIZE]) {
+        let [current, ..] = &self.nonce;
+        let parity = *current & 1;
+        let [first, ..] = &mut nonce;
+        *first = (*first & 0xfe) | parity;
+        self.nonce = nonce;
+    }
+
+    /// Serialize the frozen frame.
+    #[must_use]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(HEADER_SIZE.saturating_add(self.ct.len()));
+        out.extend_from_slice(&self.hint);
+        out.extend_from_slice(&self.nonce);
+        out.extend_from_slice(&self.enc_x);
+        out.extend_from_slice(&self.ct);
+        out
+    }
+
+    /// Scheme-specific by-product of the seal.
+    #[must_use]
+    pub const fn extra(&self) -> &S::Extra {
+        &self.extra
+    }
+
+    /// Consume into the scheme-specific by-product.
+    #[must_use]
+    pub fn into_extra(self) -> S::Extra {
+        self.extra
+    }
+}
+
+impl<S: Scheme> fmt::Debug for SealedRecord<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SealedRecord")
+            .field("scheme", &S::ID)
+            .field("ct_len", &self.ct.len())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Constant-time hint comparison.
+pub(crate) fn hint_matches(derived: &[u8; HINT_SIZE], carried: &[u8; HINT_SIZE]) -> bool {
+    derived.ct_eq(carried).into()
+}
+
+/// Delivery policy of an [`Inbox`]; sealed.
+pub trait Policy: sealed::Sealed {
+    /// Whether compat probes are admitted after the envelope pass.
+    const COMPAT: bool;
+}
+
+/// Envelope-only delivery: compat hints are never computed, so compat
+/// records are undeliverable outright.
+#[derive(Debug, Clone, Copy)]
+pub enum EnvelopeOnly {}
+
+impl Policy for EnvelopeOnly {
+    const COMPAT: bool = false;
+}
+
+/// Strictly transitional delivery: envelope first, compat probes after.
+/// Forbidden for peers pinned envelope-capable; compat has no integrity or
+/// sender authentication.
+#[derive(Debug, Clone, Copy)]
+pub enum EnvelopeThenCompat {}
+
+impl Policy for EnvelopeThenCompat {
+    const COMPAT: bool = true;
+}
+
+/// Trial-decrypt driver for one recipient secret under a delivery policy.
+pub struct Inbox<P: Policy> {
+    secret: SecretKey,
+    _policy: PhantomData<P>,
+}
+
+impl<P: Policy> fmt::Debug for Inbox<P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Inbox")
+            .field("compat", &P::COMPAT)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Inbox<EnvelopeOnly> {
+    /// Envelope-only inbox for `secret`.
+    #[must_use]
+    pub const fn new(secret: SecretKey) -> Self {
+        Self {
+            secret,
+            _policy: PhantomData,
+        }
+    }
+}
+
+impl Inbox<EnvelopeThenCompat> {
+    /// Transitional inbox for `secret`; flip to [`EnvelopeOnly`] the moment
+    /// the peer set is confirmed envelope-capable.
+    #[must_use]
+    pub const fn transitional(secret: SecretKey) -> Self {
+        Self {
+            secret,
+            _policy: PhantomData,
+        }
+    }
+}
+
+impl<P: Policy> Inbox<P> {
+    /// Trial-open `record` against `topics`: one decap, an envelope hint
+    /// probe per topic, then compat probes where the policy admits them.
+    pub fn open(
+        &self,
+        topics: &[Topic],
+        record: &Record<'_>,
+    ) -> Result<Option<(Topic, InboxOpened)>, OpenError> {
+        if let Some(shared) = hpke::decap(&self.secret, record)? {
+            for topic in topics {
+                if let Some(opened) = hpke::open_with_shared(&shared, topic, record)? {
+                    return Ok(Some((*topic, InboxOpened::Envelope(opened))));
+                }
+            }
+        }
+        if P::COMPAT {
+            for topic in topics {
+                if let Some(opened) = Compat::open(&self.secret, topic.into(), record)? {
+                    return Ok(Some((*topic, InboxOpened::Compat(opened))));
+                }
+            }
+        }
+        Ok(None)
+    }
+}
+
+/// Erased inbox delivery; match once at the edge.
+#[derive(Debug)]
+pub enum InboxOpened {
+    /// Opened under the envelope.
+    Envelope(Opened<Hpke>),
+    /// Opened under compat.
+    Compat(Opened<Compat>),
+}
+
+impl InboxOpened {
+    /// Which scheme delivered.
+    #[must_use]
+    pub const fn scheme(&self) -> SchemeId {
+        match self {
+            Self::Envelope(_) => SchemeId::Envelope,
+            Self::Compat(_) => SchemeId::Compat,
+        }
+    }
+}
+
+/// Edge-only recipient union for heterogeneous collections; matches once
+/// and calls the monomorphized path, never enters the seam.
+#[derive(Debug, Clone)]
+pub enum AnyRecipient {
+    /// An attested envelope recipient.
+    Envelope(Recipient<Hpke>),
+    /// A justified compat recipient.
+    Compat(Recipient<Compat>),
+}
+
+/// Erased sealed record from [`AnyRecipient::seal`].
+#[derive(Debug)]
+pub enum AnySealed {
+    /// Sealed under the envelope.
+    Envelope(SealedRecord<Hpke>),
+    /// Sealed under compat.
+    Compat(SealedRecord<Compat>),
+}
+
+impl AnySealed {
+    /// Which scheme sealed.
+    #[must_use]
+    pub const fn scheme(&self) -> SchemeId {
+        match self {
+            Self::Envelope(_) => SchemeId::Envelope,
+            Self::Compat(_) => SchemeId::Compat,
+        }
+    }
+
+    /// Serialize the frozen frame.
+    #[must_use]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        match self {
+            Self::Envelope(record) => record.to_bytes(),
+            Self::Compat(record) => record.to_bytes(),
+        }
+    }
+}
+
+/// Errors from [`AnyRecipient::seal`].
+#[derive(Debug, Error)]
+pub enum AnySealError {
+    /// The envelope seal failed.
+    #[error(transparent)]
+    Envelope(#[from] HpkeSealError),
+    /// The compat seal failed.
+    #[error(transparent)]
+    Compat(#[from] EciesError),
+}
+
+#[cfg(feature = "encryption")]
+impl AnyRecipient {
+    /// Seal toward this recipient, scheme inferred from the handle.
+    pub fn seal(
+        &self,
+        topic: &Topic,
+        plaintext: &[u8],
+        ct_len: usize,
+    ) -> Result<AnySealed, AnySealError> {
+        match self {
+            Self::Envelope(recipient) => Ok(AnySealed::Envelope(Hpke::seal(
+                recipient,
+                topic.into(),
+                plaintext,
+                ct_len,
+            )?)),
+            Self::Compat(recipient) => Ok(AnySealed::Compat(Compat::seal(
+                recipient,
+                topic.into(),
+                plaintext,
+                ct_len,
+            )?)),
+        }
+    }
+}
+
+/// Split a public key into its x coordinate and y parity.
+pub(crate) fn x_and_parity(key: &PublicKey) -> ([u8; 32], bool) {
+    use k256::elliptic_curve::point::AffineCoordinates;
+    let affine = key.as_affine();
+    (affine.x().into(), affine.y_is_odd().into())
+}
+
+/// Reconstruct a public key from an x-only slot and a parity bit.
+pub(crate) fn reconstruct(enc_x: &[u8; ENC_X_SIZE], parity: bool) -> Option<PublicKey> {
+    let mut sec1 = [0u8; 33];
+    let [tag, x @ ..] = &mut sec1;
+    *tag = if parity { 0x03 } else { 0x02 };
+    *x = *enc_x;
+    PublicKey::from_sec1_bytes(&sec1).ok()
+}
+
+// Compat has no extra beyond the derived key; keep the association explicit.
+impl Scheme for Compat {
+    type Context<'a> = Salt<'a>;
+    type Extra = EncryptionKey;
+    type Provenance = InteropReason;
+    type SealError = EciesError;
+
+    const TAG: usize = 0;
+    const ID: SchemeId = SchemeId::Compat;
+
+    #[cfg(feature = "encryption")]
+    fn seal(
+        recipient: &Recipient<Self>,
+        ctx: Self::Context<'_>,
+        plaintext: &[u8],
+        ct_len: usize,
+    ) -> Result<SealedRecord<Self>, Self::SealError> {
+        compat::seal(recipient, ctx, plaintext, ct_len)
+    }
+
+    fn open(
+        secret: &SecretKey,
+        ctx: Self::Context<'_>,
+        record: &Record<'_>,
+    ) -> Result<Option<Opened<Self>>, OpenError> {
+        compat::open(secret, ctx, record)
+    }
+}
+
+impl Scheme for Hpke {
+    type Context<'a> = Info<'a>;
+    type Extra = Exporter;
+    type Provenance = Attested;
+    type SealError = HpkeSealError;
+
+    const TAG: usize = 16;
+    const ID: SchemeId = SchemeId::Envelope;
+
+    #[cfg(feature = "encryption")]
+    fn seal(
+        recipient: &Recipient<Self>,
+        ctx: Self::Context<'_>,
+        plaintext: &[u8],
+        ct_len: usize,
+    ) -> Result<SealedRecord<Self>, Self::SealError> {
+        hpke::seal(recipient, ctx, plaintext, ct_len)
+    }
+
+    fn open(
+        secret: &SecretKey,
+        ctx: Self::Context<'_>,
+        record: &Record<'_>,
+    ) -> Result<Option<Opened<Self>>, OpenError> {
+        hpke::open(secret, ctx, record)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::keccak256;
+
+    use crate::ecies;
+
+    fn keys(label: &[u8]) -> (SecretKey, PublicKey) {
+        let secret = SecretKey::from_slice(keccak256(label).as_slice()).unwrap();
+        let public = secret.public_key();
+        (secret, public)
+    }
+
+    fn topic() -> Topic {
+        Topic::new(keccak256(b"nectar envelope seam topic").0)
+    }
+
+    fn envelope_recipient(key: PublicKey) -> Recipient<Hpke> {
+        Recipient::attested(key)
+    }
+
+    fn compat_recipient(key: PublicKey) -> Recipient<Compat> {
+        Recipient::assume_reference(key, InteropReason::new("seam test"))
+    }
+
+    #[test]
+    fn envelope_roundtrip_via_seam() {
+        let (secret, public) = keys(b"nectar envelope seam recipient");
+        let topic = topic();
+        let msg = b"seam roundtrip";
+        let sealed = Hpke::seal(&envelope_recipient(public), (&topic).into(), msg, 4024).unwrap();
+        let bytes = sealed.to_bytes();
+        assert_eq!(bytes.len(), HEADER_SIZE + 4024);
+
+        let record = Record::parse(&bytes).unwrap();
+        let opened = Hpke::open(&secret, (&topic).into(), &record)
+            .unwrap()
+            .unwrap();
+        assert_eq!(opened.plaintext, msg);
+
+        // Both sides export identical bytes for the same context.
+        let mut sender = [0u8; 16];
+        sealed.extra().export(b"reply", &mut sender).unwrap();
+        let mut receiver = [0u8; 16];
+        opened.extra.export(b"reply", &mut receiver).unwrap();
+        assert_eq!(sender, receiver);
+    }
+
+    #[test]
+    fn envelope_wrong_topic_is_undeliverable() {
+        let (secret, public) = keys(b"nectar envelope seam recipient");
+        let sealed = Hpke::seal(&envelope_recipient(public), (&topic()).into(), b"m", 64).unwrap();
+        let bytes = sealed.to_bytes();
+        let record = Record::parse(&bytes).unwrap();
+        let other = Topic::new(keccak256(b"other topic").0);
+        assert!(
+            Hpke::open(&secret, (&other).into(), &record)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn compat_roundtrip_matches_ecies() {
+        let (secret, public) = keys(b"nectar envelope seam recipient");
+        let topic = topic();
+        let msg = b"compat roundtrip";
+        let sealed = Compat::seal(&compat_recipient(public), (&topic).into(), msg, 100).unwrap();
+        let bytes = sealed.to_bytes();
+        assert_eq!(bytes.len(), HEADER_SIZE + 100);
+
+        let record = Record::parse(&bytes).unwrap();
+        let opened = Compat::open(&secret, (&topic).into(), &record)
+            .unwrap()
+            .unwrap();
+        assert_eq!(&opened.plaintext[..msg.len()], msg);
+        assert_eq!(opened.plaintext.len(), 100);
+
+        // The adapter is byte-for-byte the frozen construction.
+        let ephemeral = reconstruct(record.enc_x(), record.parity()).unwrap();
+        let key = ecies::shared_key(&secret, &ephemeral, (&topic).into());
+        assert_eq!(key, opened.extra);
+        assert_eq!(
+            ecies::Hint::derive(&key, (&topic).into()).as_bytes(),
+            record.hint()
+        );
+        assert_eq!(ecies::decrypt(&key, record.ciphertext()), opened.plaintext);
+    }
+
+    #[test]
+    fn schemes_never_cross_open() {
+        let (secret, public) = keys(b"nectar envelope seam recipient");
+        let topic = topic();
+
+        let envelope = Hpke::seal(&envelope_recipient(public), (&topic).into(), b"e", 64).unwrap();
+        let bytes = envelope.to_bytes();
+        let record = Record::parse(&bytes).unwrap();
+        assert!(
+            Compat::open(&secret, (&topic).into(), &record)
+                .unwrap()
+                .is_none()
+        );
+
+        let compat = Compat::seal(&compat_recipient(public), (&topic).into(), b"c", 64).unwrap();
+        let bytes = compat.to_bytes();
+        let record = Record::parse(&bytes).unwrap();
+        assert!(
+            Hpke::open(&secret, (&topic).into(), &record)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn envelope_only_inbox_rejects_compat_forgeries() {
+        let (secret, public) = keys(b"nectar envelope seam recipient");
+        let topic = topic();
+        let compat = Compat::seal(&compat_recipient(public), (&topic).into(), b"f", 64).unwrap();
+        let bytes = compat.to_bytes();
+        let record = Record::parse(&bytes).unwrap();
+
+        let inbox = Inbox::<EnvelopeOnly>::new(secret.clone());
+        assert!(inbox.open(&[topic], &record).unwrap().is_none());
+
+        // The transitional inbox still delivers it, reported as compat.
+        let inbox = Inbox::<EnvelopeThenCompat>::transitional(secret);
+        let (delivered_topic, opened) = inbox.open(&[topic], &record).unwrap().unwrap();
+        assert_eq!(delivered_topic, topic);
+        assert_eq!(opened.scheme(), SchemeId::Compat);
+    }
+
+    #[test]
+    fn inbox_delivers_envelope_on_the_right_topic() {
+        let (secret, public) = keys(b"nectar envelope seam recipient");
+        let topic = topic();
+        let decoy = Topic::new(keccak256(b"decoy topic").0);
+        let sealed = Hpke::seal(&envelope_recipient(public), (&topic).into(), b"m", 64).unwrap();
+        let bytes = sealed.to_bytes();
+        let record = Record::parse(&bytes).unwrap();
+
+        let inbox = Inbox::<EnvelopeOnly>::new(secret);
+        let (delivered_topic, opened) = inbox.open(&[decoy, topic], &record).unwrap().unwrap();
+        assert_eq!(delivered_topic, topic);
+        assert_eq!(opened.scheme(), SchemeId::Envelope);
+        let InboxOpened::Envelope(opened) = opened else {
+            panic!("wrong scheme");
+        };
+        assert_eq!(opened.plaintext, b"m");
+    }
+
+    #[test]
+    fn remining_the_nonce_keeps_the_record_open() {
+        let (secret, public) = keys(b"nectar envelope seam recipient");
+        let topic = topic();
+        let mut sealed =
+            Hpke::seal(&envelope_recipient(public), (&topic).into(), b"m", 64).unwrap();
+        let parity_before = {
+            let bytes = sealed.to_bytes();
+            bytes[8] & 1
+        };
+        sealed.set_nonce([0xff; 32]);
+        let bytes = sealed.to_bytes();
+        assert_eq!(bytes[8] & 1, parity_before);
+        assert_eq!(&bytes[9..40], &[0xff; 31]);
+
+        let record = Record::parse(&bytes).unwrap();
+        assert!(
+            Hpke::open(&secret, (&topic).into(), &record)
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn flipped_parity_is_dos_only_for_the_envelope() {
+        let (secret, public) = keys(b"nectar envelope seam recipient");
+        let topic = topic();
+
+        let sealed = Hpke::seal(&envelope_recipient(public), (&topic).into(), b"m", 64).unwrap();
+        let mut bytes = sealed.to_bytes();
+        bytes[8] ^= 1;
+        let record = Record::parse(&bytes).unwrap();
+        assert!(
+            Hpke::open(&secret, (&topic).into(), &record)
+                .unwrap()
+                .is_none()
+        );
+
+        // Compat ECDH ignores parity: the flipped record still opens.
+        let sealed = Compat::seal(&compat_recipient(public), (&topic).into(), b"m", 64).unwrap();
+        let mut bytes = sealed.to_bytes();
+        bytes[8] ^= 1;
+        let record = Record::parse(&bytes).unwrap();
+        assert!(
+            Compat::open(&secret, (&topic).into(), &record)
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn record_parse_rejects_short_payloads() {
+        assert_eq!(
+            Record::parse(&[0u8; HEADER_SIZE - 1]).unwrap_err(),
+            RecordTooShort {
+                got: HEADER_SIZE - 1
+            }
+        );
+        let record = Record::parse(&[0u8; HEADER_SIZE]).unwrap();
+        assert!(record.ciphertext().is_empty());
+    }
+
+    #[test]
+    fn any_recipient_seals_via_the_monomorphized_paths() {
+        let (secret, public) = keys(b"nectar envelope seam recipient");
+        let topic = topic();
+
+        let any = AnyRecipient::Envelope(envelope_recipient(public));
+        let sealed = any.seal(&topic, b"m", 64).unwrap();
+        assert_eq!(sealed.scheme(), SchemeId::Envelope);
+        let bytes = sealed.to_bytes();
+        let record = Record::parse(&bytes).unwrap();
+        assert!(
+            Hpke::open(&secret, (&topic).into(), &record)
+                .unwrap()
+                .is_some()
+        );
+
+        let any = AnyRecipient::Compat(compat_recipient(public));
+        let sealed = any.seal(&topic, b"m", 64).unwrap();
+        assert_eq!(sealed.scheme(), SchemeId::Compat);
+        let bytes = sealed.to_bytes();
+        let record = Record::parse(&bytes).unwrap();
+        assert!(
+            Compat::open(&secret, (&topic).into(), &record)
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn compat_reason_is_carried() {
+        let (_, public) = keys(b"nectar envelope seam recipient");
+        let recipient =
+            Recipient::assume_reference(public, InteropReason::new("legacy gateway peer"));
+        assert_eq!(recipient.reason().as_str(), "legacy gateway peer");
+        assert_eq!(recipient.key(), &public);
+    }
+
+    #[test]
+    fn scheme_constants() {
+        assert_eq!(Compat::TAG, 0);
+        assert_eq!(Hpke::TAG, 16);
+        assert_eq!(Compat::ID, SchemeId::Compat);
+        assert_eq!(Hpke::ID, SchemeId::Envelope);
+    }
+}

--- a/crates/primitives/src/envelope/mod.rs
+++ b/crates/primitives/src/envelope/mod.rs
@@ -33,6 +33,7 @@
 //! deliberately adds SHA-256 beside the otherwise keccak-only proving
 //! surface.
 
+use alloc::vec::Vec;
 use core::fmt;
 use core::marker::PhantomData;
 

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -61,6 +61,8 @@ mod cast;
 pub mod chunk;
 pub mod ecies;
 pub mod entry_ref;
+#[cfg(feature = "envelope")]
+pub mod envelope;
 pub mod error;
 #[cfg(any(test, feature = "arbitrary"))]
 pub mod generators;


### PR DESCRIPTION
## What

Adds a feature-gated `envelope` module to `crates/primitives/src/envelope/` implementing a versioned modern envelope over the frozen `ecies` compat baseline.

Both schemes share one frozen frame inside the chunk payload: `hint || nonce || enc_x || ct`, with the ephemeral y-parity bit carried in bit 0 of `nonce[0]` (`SealedRecord::set_nonce` preserves it).
The envelope scheme is RFC 9180 HPKE `mode_base`, composed directly from `k256` + `hkdf` + `sha2` + `chacha20poly1305` (not `hpke-rs`), with the single suite DHKEM(secp256k1, HKDF-SHA256) + HKDF-SHA256 + ChaCha20-Poly1305 under codepoint 0x0016 from draft-wahby-cfrg-hpke-kem-secp256k1.
`enc` travels x-only and is reconstructed to canonical uncompressed SEC1 before `kem_context`, with off-curve and zero-ECDH rejection and `Zeroizing` intermediates throughout.
The topic is bound in `info`; `aad` is left empty.
A mandatory exporter-derived hint (`export("nectar/env/v1 hint", 8)`) gates AEAD trial-opening, and the plaintext uses `len || msg || pad` inner framing.

The module exposes a sealed two-scheme seam: a `Scheme` trait with a `Context` GAT plus `Extra`, `Provenance`, `TAG`, `ID` associated items, uninhabited `Compat`/`Hpke` marker types, a report-only `SchemeId`, and an edge-only `AnyRecipient`.
It also adds `EnvelopeAttestation` (with `sign_data`), a public `derive_key_pair`, an `Exporter` extra, and an `Inbox<EnvelopeOnly | EnvelopeThenCompat>` trial-decrypt driver.

New optional dependencies (`chacha20poly1305`, `hkdf`, `sha2`) sit behind the new `envelope` feature on `nectar-primitives`, which also pulls in `encryption`; `hpke-rs`/`hpke-rs-crypto`/`hpke-rs-rust-crypto` are dev-dependencies used only as the differential test oracle.
CI gains a dedicated `cargo clippy --features envelope` lint job and `cargo nextest run` / `cargo test --doc` jobs scoped to `-p nectar-primitives --features envelope`.

## Why

Closes #471.

## Testing

Reviewed independently at HEAD `36a9030c`: built and ran the crate under `--features envelope --locked`, all 306 tests pass, including pinned KATs, differentials against the independent `hpke-rs` `DhKemK256` oracle, and the compile-fail no-downgrade doctest.

## AI Assistance

Implemented with Fable, reviewed with Opus.
