### PR TITLE
primitives: build bare-metal on riscv64imac

### DIFF
--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -48,9 +48,17 @@ jobs:
                   # removed or the workspace version bumps.
                   cargo check --locked --manifest-path crates/mantaray/Cargo.toml \
                     --no-default-features --target ${{ matrix.target }}
-            # nectar-primitives does not yet build bare-metal, so the
-            # single-thread send escape (the unsync feature) and its
-            # !Send-store compile proof are checked for the host inside the
+            # The bare-metal core of nectar-primitives. Only in the rv64 lane:
+            # the wasm32 shape of the crate is the std build with the wasm
+            # target table (wasm-bindgen), not the no_std core.
+            - name: Check nectar-primitives bare-metal
+              if: matrix.target == 'riscv64imac-unknown-none-elf'
+              run: |
+                  cargo check --locked -p nectar-primitives \
+                    --no-default-features \
+                    --target ${{ matrix.target }}
+            # The single-thread send escape (the unsync feature) and its
+            # !Send-store compile proof, checked for the host inside the
             # rv64 lane, the target shape the escape exists for.
             - name: Check the unsync send escape
               if: matrix.target == 'riscv64imac-unknown-none-elf'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2371,6 +2371,7 @@ dependencies = [
  "js-sys",
  "k256",
  "keccak-batch",
+ "nectar-clock",
  "nectar-marker",
  "nectar-testing",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,8 +82,8 @@ alloy-chains = { version = "0.2.30", default-features = false }
 alloy-signer = { version = "2.0", default-features = false }
 alloy-signer-local = { version = "2.0", default-features = false }
 
-# k256 with precomputed tables for faster ECDSA
-k256 = { version = "0.13", default-features = false, features = ["ecdsa", "precomputed-tables", "std"] }
+# k256 base; std consumers add std + precomputed-tables (which needs std)
+k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
 
 # hashing
 digest = "0.11"
@@ -152,7 +152,7 @@ getrandom_02 = { package = "getrandom", version = "0.2", default-features = fals
 # "wasm_js" feature selects the browser backend so B256::random links on wasm32.
 getrandom_04 = { package = "getrandom", version = "0.4", default-features = false, features = ["wasm_js"] }
 bitflags = { version = "2", default-features = false }
-subtle = "2"
+subtle = { version = "2", default-features = false, features = ["i128"] }
 zeroize = "1"
 
 [profile.release]

--- a/crates/marker/src/lib.rs
+++ b/crates/marker/src/lib.rs
@@ -1,38 +1,38 @@
 //! Thread-safety markers: `Send`/`Sync` on multi-threaded targets, unbounded
-//! on wasm32 and under the `unsync` feature (the single-thread escape for
-//! non-wasm targets such as zkVM guests).
+//! on single-threaded ones (wasm32, bare metal) and under the `unsync`
+//! feature (the single-thread escape for hosted targets such as zkVM guests).
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-/// `Send` on multi-threaded targets, no bound on wasm32 or with the `unsync`
-/// feature. A single-threaded executor may hold `!Send` state (a JS handle
-/// in the browser) across an await point.
-#[cfg(not(any(target_arch = "wasm32", feature = "unsync")))]
+/// `Send` on multi-threaded targets, no bound on wasm32, bare metal, or with
+/// the `unsync` feature. A single-threaded executor may hold `!Send` state
+/// (a JS handle in the browser) across an await point.
+#[cfg(not(any(target_arch = "wasm32", target_os = "none", feature = "unsync")))]
 pub trait MaybeSend: Send {}
-#[cfg(not(any(target_arch = "wasm32", feature = "unsync")))]
+#[cfg(not(any(target_arch = "wasm32", target_os = "none", feature = "unsync")))]
 impl<T: ?Sized + Send> MaybeSend for T {}
 
-/// `Send` on multi-threaded targets, no bound on wasm32 or with the `unsync`
-/// feature. A single-threaded executor may hold `!Send` state (a JS handle
-/// in the browser) across an await point.
-#[cfg(any(target_arch = "wasm32", feature = "unsync"))]
+/// `Send` on multi-threaded targets, no bound on wasm32, bare metal, or with
+/// the `unsync` feature. A single-threaded executor may hold `!Send` state
+/// (a JS handle in the browser) across an await point.
+#[cfg(any(target_arch = "wasm32", target_os = "none", feature = "unsync"))]
 pub trait MaybeSend {}
-#[cfg(any(target_arch = "wasm32", feature = "unsync"))]
+#[cfg(any(target_arch = "wasm32", target_os = "none", feature = "unsync"))]
 impl<T: ?Sized> MaybeSend for T {}
 
-/// `Sync` on multi-threaded targets, no bound on wasm32 or with the `unsync`
-/// feature. Single-thread state (a JS handle) is `!Sync`; on a
+/// `Sync` on multi-threaded targets, no bound on wasm32, bare metal, or with
+/// the `unsync` feature. Single-thread state (a JS handle) is `!Sync`; on a
 /// single-threaded executor that is sound.
-#[cfg(not(any(target_arch = "wasm32", feature = "unsync")))]
+#[cfg(not(any(target_arch = "wasm32", target_os = "none", feature = "unsync")))]
 pub trait MaybeSync: Sync {}
-#[cfg(not(any(target_arch = "wasm32", feature = "unsync")))]
+#[cfg(not(any(target_arch = "wasm32", target_os = "none", feature = "unsync")))]
 impl<T: ?Sized + Sync> MaybeSync for T {}
 
-/// `Sync` on multi-threaded targets, no bound on wasm32 or with the `unsync`
-/// feature. Single-thread state (a JS handle) is `!Sync`; on a
+/// `Sync` on multi-threaded targets, no bound on wasm32, bare metal, or with
+/// the `unsync` feature. Single-thread state (a JS handle) is `!Sync`; on a
 /// single-threaded executor that is sound.
-#[cfg(any(target_arch = "wasm32", feature = "unsync"))]
+#[cfg(any(target_arch = "wasm32", target_os = "none", feature = "unsync"))]
 pub trait MaybeSync {}
-#[cfg(any(target_arch = "wasm32", feature = "unsync"))]
+#[cfg(any(target_arch = "wasm32", target_os = "none", feature = "unsync"))]
 impl<T: ?Sized> MaybeSync for T {}

--- a/crates/postage/Cargo.toml
+++ b/crates/postage/Cargo.toml
@@ -52,6 +52,8 @@ default = [ "std" ]
 std = [
 	"alloy-primitives/std",
 	"dep:web-time",
+	"k256/precomputed-tables",
+	"k256/std",
 	"nectar-primitives/std",
 	"serde?/std",
 	"thiserror/std",

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -19,18 +19,21 @@ workspace = true
 
 [dependencies]
 # nectar
+nectar-clock.workspace = true
 nectar-marker.workspace = true
 
 ## alloy crypto
-# alloy-primitives noted below in architecture-dependent set of crates
-alloy-signer.workspace = true
-alloy-signer-local.workspace = true
+# Base set: signature recovery (k256) stays in the bare-metal core; the
+# asm-keccak and getrandom extras ride the target tables below.
+alloy-primitives = { workspace = true, features = ["k256"] }
+alloy-signer = { workspace = true, optional = true }
+alloy-signer-local = { workspace = true, optional = true }
 
 ## rust crypto
 digest.workspace = true
 hybrid-array.workspace = true
 k256 = { workspace = true, features = ["ecdh"] }
-keccak-batch.workspace = true
+keccak-batch = { workspace = true, optional = true }
 
 # derive macros
 derive_more.workspace = true
@@ -47,20 +50,20 @@ subtle.workspace = true
 zeroize = { workspace = true, features = ["derive"] }
 
 # synchronization
-parking_lot = "0.12"
+parking_lot = { version = "0.12", optional = true }
 
-# wall clock: std::time on native, browser clock on wasm32 (see Timestamp::now)
-web-time.workspace = true
+# wall clock for retry jitter: std::time on native, browser clock on wasm32
+web-time = { workspace = true, optional = true }
 
 # arbitrary
 arbitrary = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 
 # rayon for parallelism (works on both native and WASM via wasm-bindgen-rayon)
-rayon.workspace = true
+rayon = { workspace = true, optional = true }
 
-# Only for non-WASM targets
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# Only for hosted non-WASM targets (bare metal has no asm keccak or entropy)
+[target.'cfg(all(not(target_arch = "wasm32"), not(target_os = "none")))'.dependencies]
 alloy-primitives = { workspace = true, features = ["asm-keccak", "getrandom"] }
 
 # Only for WASM-specific targets
@@ -94,7 +97,18 @@ rand.workspace = true
 
 [features]
 default = [ "std" ]
-std = [ "futures-core/std" ]
+std = [
+	"dep:alloy-signer",
+	"dep:alloy-signer-local",
+	"dep:keccak-batch",
+	"dep:parking_lot",
+	"dep:rayon",
+	"dep:web-time",
+	"futures-core/std",
+	"k256/precomputed-tables",
+	"k256/std",
+	"nectar-clock/std",
+]
 # WASM thread pool via wasm-bindgen-rayon. OFF by default so the default wasm
 # build needs no SharedArrayBuffer / cross-origin isolation — letting it run on
 # hosts that can't set COOP/COEP (e.g. the eth.limo ENS gateway). Enable it
@@ -102,7 +116,7 @@ std = [ "futures-core/std" ]
 # requires shared memory). Must stay out of `default`: dependents pull this
 # crate with default features, so a default-on threads feature would be forced
 # on transitively and couldn't be opted out.
-wasm-threads = [ "dep:wasm-bindgen-rayon" ]
+wasm-threads = [ "dep:rayon", "dep:wasm-bindgen-rayon" ]
 # Plain-terminology umbrella for "run in parallel", matching the `parallel`
 # feature on nectar-postage and nectar-postage-issuer. Native builds already
 # parallelize through rayon, so this is a no-op there; on wasm32 it opts into the

--- a/crates/primitives/build.rs
+++ b/crates/primitives/build.rs
@@ -1,11 +1,13 @@
 //! Emits the `multi_thread` cfg alias.
 
 fn main() {
-    // Send/Sync bounds apply; wasm32 and the `unsync` feature relax them.
+    // Send/Sync bounds apply; wasm32, bare metal, and the `unsync` feature
+    // relax them.
     println!("cargo::rustc-check-cfg=cfg(multi_thread)");
     let wasm32 = std::env::var("CARGO_CFG_TARGET_ARCH").as_deref() == Ok("wasm32");
+    let bare_metal = std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("none");
     let unsync = std::env::var_os("CARGO_FEATURE_UNSYNC").is_some();
-    if !wasm32 && !unsync {
+    if !wasm32 && !bare_metal && !unsync {
         println!("cargo::rustc-cfg=multi_thread");
     }
 }

--- a/crates/primitives/src/address.rs
+++ b/crates/primitives/src/address.rs
@@ -97,7 +97,7 @@ impl XorMetric for OverlayAddress {
 impl TryFrom<&[u8]> for OverlayAddress {
     type Error = WrongLength;
 
-    fn try_from(slice: &[u8]) -> std::result::Result<Self, Self::Error> {
+    fn try_from(slice: &[u8]) -> core::result::Result<Self, Self::Error> {
         let bytes: [u8; 32] = slice.try_into().map_err(|_| WrongLength {
             expected: 32,
             got: slice.len(),

--- a/crates/primitives/src/bmt/hasher.rs
+++ b/crates/primitives/src/bmt/hasher.rs
@@ -62,6 +62,7 @@ pub(super) fn node_hasher(prefix: Option<&[u8]>) -> Keccak256 {
 ///
 /// Consumes exactly `out.len()` pairs from `pairs` (the caller guarantees the
 /// iterator yields that many); each output is `keccak(prefix || left || right)`.
+#[cfg(feature = "std")]
 pub(super) fn hash_pairs<'a>(
     prefix: Option<&[u8]>,
     pairs: impl Iterator<Item = &'a [u8]>,
@@ -81,6 +82,21 @@ pub(super) fn hash_pairs<'a>(
     }
     let inputs: Vec<&[u8]> = scratch.chunks_exact(entry).collect();
     keccak_batch::keccak256_many_into(&inputs, out);
+}
+
+/// Hash 64-byte sibling pairs sequentially: the `no_std` baseline, one
+/// `keccak(prefix || left || right)` per pair on the patchable keccak seam.
+#[cfg(not(feature = "std"))]
+pub(super) fn hash_pairs<'a>(
+    prefix: Option<&[u8]>,
+    pairs: impl Iterator<Item = &'a [u8]>,
+    out: &mut [[u8; 32]],
+) {
+    for (slot, pair) in out.iter_mut().zip(pairs) {
+        let mut hasher = node_hasher(prefix);
+        hasher.update(pair);
+        slot.copy_from_slice(hasher.finalize().as_slice());
+    }
 }
 
 /// BMT hasher with configurable body size.
@@ -401,12 +417,15 @@ impl<const BODY_SIZE: usize> Hasher<BODY_SIZE> {
         Bytes::copy_from_slice(live)
     }
 
-    /// Get segments for the current level of data
+    /// Get segments for the current level of data.
+    ///
+    /// Parallel via rayon on hosted non-wasm targets; the sequential walk is
+    /// the wasm32 and `no_std` baseline.
     #[inline]
     pub fn get_level_segments(&self, data: &[u8]) -> Vec<B256> {
         let branches = branches_for_body_size(BODY_SIZE);
 
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(all(feature = "std", not(target_arch = "wasm32")))]
         {
             use rayon::prelude::*;
             (0..branches)
@@ -415,7 +434,7 @@ impl<const BODY_SIZE: usize> Hasher<BODY_SIZE> {
                 .collect()
         }
 
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(not(all(feature = "std", not(target_arch = "wasm32"))))]
         {
             (0..branches)
                 .map(|i| self.compute_segment_hash(data, i))

--- a/crates/primitives/src/cache.rs
+++ b/crates/primitives/src/cache.rs
@@ -3,23 +3,38 @@
 //! This module provides components for caching expensive computations
 //! that only need to be calculated once.
 
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+#[cfg(not(feature = "std"))]
+use once_cell::race::OnceBox;
+#[cfg(feature = "std")]
 use std::sync::OnceLock;
 
 /// Generic cache for lazily computed values.
 ///
 /// This structure provides an efficient way to cache and retrieve any value
 /// that only needs to be computed once, computing it only when first needed.
+///
+/// Backed by `OnceLock` under `std` and by the lock-free boxed once-cell on
+/// the `no_std` side, so holders stay `Sync` on both.
 #[derive(Debug)]
 pub(crate) struct OnceCache<T> {
     /// The cached value
+    #[cfg(feature = "std")]
     value: OnceLock<T>,
+    /// The cached value
+    #[cfg(not(feature = "std"))]
+    value: OnceBox<T>,
 }
 
 impl<T> OnceCache<T> {
     /// Create a new empty cache
     pub(crate) const fn new() -> Self {
         Self {
+            #[cfg(feature = "std")]
             value: OnceLock::new(),
+            #[cfg(not(feature = "std"))]
+            value: OnceBox::new(),
         }
     }
 
@@ -27,8 +42,16 @@ impl<T> OnceCache<T> {
     pub(crate) fn with_value(value: T) -> Self {
         let cache = Self::new();
         // This will only fail if the value is already set, which is impossible for a new cache
+        #[cfg(feature = "std")]
         let _ = cache.value.set(value);
+        #[cfg(not(feature = "std"))]
+        let _ = cache.value.set(Box::new(value));
         cache
+    }
+
+    /// Get the cached value if it has been computed
+    pub(crate) fn get(&self) -> Option<&T> {
+        self.value.get()
     }
 
     /// Get the cached value, computing it if necessary
@@ -36,7 +59,14 @@ impl<T> OnceCache<T> {
     where
         F: FnOnce() -> T,
     {
-        self.value.get_or_init(compute_fn)
+        #[cfg(feature = "std")]
+        {
+            self.value.get_or_init(compute_fn)
+        }
+        #[cfg(not(feature = "std"))]
+        {
+            self.value.get_or_init(|| Box::new(compute_fn()))
+        }
     }
 }
 

--- a/crates/primitives/src/chunk/address.rs
+++ b/crates/primitives/src/chunk/address.rs
@@ -86,7 +86,7 @@ impl XorMetric for ChunkAddress {
 impl TryFrom<&[u8]> for ChunkAddress {
     type Error = WrongLength;
 
-    fn try_from(slice: &[u8]) -> std::result::Result<Self, Self::Error> {
+    fn try_from(slice: &[u8]) -> core::result::Result<Self, Self::Error> {
         let bytes: [u8; 32] = slice.try_into().map_err(|_| WrongLength {
             expected: 32,
             got: slice.len(),

--- a/crates/primitives/src/chunk/any_chunk.rs
+++ b/crates/primitives/src/chunk/any_chunk.rs
@@ -6,6 +6,8 @@
 use bytes::Bytes;
 
 use crate::bmt::DEFAULT_BODY_SIZE;
+use alloc::vec::Vec;
+
 use crate::error::Result;
 
 use super::address::ChunkAddress;

--- a/crates/primitives/src/chunk/bmt_body.rs
+++ b/crates/primitives/src/chunk/bmt_body.rs
@@ -4,10 +4,10 @@
 //! which form the basis for content-addressed chunks in the storage system.
 
 use bytes::{Bytes, BytesMut};
-use std::marker::PhantomData;
-use std::sync::OnceLock;
+use core::marker::PhantomData;
 
 use crate::bmt::{DEFAULT_BODY_SIZE, DerivedAddress, Hasher, SPAN_SIZE};
+use crate::cache::OnceCache;
 use crate::chunk::ChunkAddress;
 use crate::chunk::error::{self, ChunkError};
 use crate::error::{PrimitivesError, Result};
@@ -17,7 +17,7 @@ use crate::error::{PrimitivesError, Result};
 pub struct BmtBody<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> {
     span: u64,
     data: Bytes,
-    cached_hash: OnceLock<DerivedAddress>,
+    cached_hash: OnceCache<DerivedAddress>,
 }
 
 /// Structural equality over span and payload. Never derives the hash: when
@@ -39,7 +39,7 @@ impl<const BODY_SIZE: usize> BmtBody<BODY_SIZE> {
         Self {
             span,
             data,
-            cached_hash: OnceLock::new(),
+            cached_hash: OnceCache::new(),
         }
     }
 
@@ -85,7 +85,7 @@ impl<const BODY_SIZE: usize> BmtBody<BODY_SIZE> {
 
     /// The body's BMT root with hasher provenance; computed once, cached.
     pub(crate) fn derived_hash(&self) -> DerivedAddress {
-        *self.cached_hash.get_or_init(|| self.calculate_hash())
+        *self.cached_hash.get_or_compute(|| self.calculate_hash())
     }
 
     fn calculate_hash(&self) -> DerivedAddress {

--- a/crates/primitives/src/chunk/content.rs
+++ b/crates/primitives/src/chunk/content.rs
@@ -6,7 +6,7 @@
 
 use alloy_primitives::{B256, hex};
 use bytes::{Bytes, BytesMut};
-use std::fmt;
+use core::fmt;
 
 use crate::bmt::DEFAULT_BODY_SIZE;
 use crate::error::Result;
@@ -52,7 +52,7 @@ impl ChunkHeader for CacHeader {
         &self,
         body_hash: B256,
         expected: &ChunkAddress,
-    ) -> std::result::Result<(), ChunkError> {
+    ) -> core::result::Result<(), ChunkError> {
         let actual = self.commit(body_hash);
         if actual != *expected {
             return Err(ChunkError::verification_failed(*expected, actual));
@@ -67,7 +67,7 @@ impl ChunkHeader for CacHeader {
 
     fn encode(&self, _out: &mut BytesMut) {}
 
-    fn decode(_cursor: &mut wire::Cursor<'_>) -> std::result::Result<Self, ChunkError> {
+    fn decode(_cursor: &mut wire::Cursor<'_>) -> core::result::Result<Self, ChunkError> {
         Ok(Self)
     }
 }

--- a/crates/primitives/src/chunk/encryption/key.rs
+++ b/crates/primitives/src/chunk/encryption/key.rs
@@ -1,6 +1,6 @@
 //! Encryption key type.
 
-use std::mem::size_of;
+use core::mem::size_of;
 
 use alloy_primitives::B256;
 use subtle::ConstantTimeEq;
@@ -92,8 +92,8 @@ impl<'a> arbitrary::Arbitrary<'a> for EncryptionKey {
     }
 }
 
-impl std::fmt::Debug for EncryptionKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for EncryptionKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         // Show first 4 bytes as hex for identification
         write!(
             f,

--- a/crates/primitives/src/chunk/encryption/reference.rs
+++ b/crates/primitives/src/chunk/encryption/reference.rs
@@ -1,5 +1,7 @@
 //! Chunk reference types for encrypted chunks.
 
+use alloc::vec::Vec;
+
 use crate::chunk::reference::{RefKind, Reference, WrongRefKind, sealed};
 use crate::chunk::{ChunkAddress, ChunkRef};
 use crate::entry_ref::EntryRef;

--- a/crates/primitives/src/chunk/error.rs
+++ b/crates/primitives/src/chunk/error.rs
@@ -1,10 +1,12 @@
+use alloc::string::String;
+
 use super::address::ChunkAddress;
 use thiserror::Error;
 
 use super::type_tag::ChunkTypeTag;
 
 /// Result type for chunk operations
-pub(crate) type Result<T> = std::result::Result<T, ChunkError>;
+pub(crate) type Result<T> = core::result::Result<T, ChunkError>;
 
 /// Errors specific to chunk operations
 #[non_exhaustive]
@@ -39,6 +41,7 @@ pub enum ChunkError {
     Signature(#[from] alloy_primitives::SignatureError),
 
     /// Signer errors
+    #[cfg(feature = "std")]
     #[error("Signer error: {0}")]
     Signer(#[from] alloy_signer::Error),
 

--- a/crates/primitives/src/chunk/reference.rs
+++ b/crates/primitives/src/chunk/reference.rs
@@ -5,7 +5,8 @@
 //! and [`Reference`] carries them at the type level, so every wire-width
 //! constant in the crate derives from this single statement of the fact.
 
-use std::mem::size_of;
+use alloc::vec::Vec;
+use core::mem::size_of;
 
 use crate::chunk::ChunkAddress;
 use crate::entry_ref::EntryRef;

--- a/crates/primitives/src/chunk/registry.rs
+++ b/crates/primitives/src/chunk/registry.rs
@@ -5,6 +5,7 @@
 //! [`ContentOnlyChunkSet`], and [`SingleOwnerOnlyChunkSet`] are the built-in
 //! registries.
 
+use alloc::vec::Vec;
 use bytes::Bytes;
 
 use crate::bmt::DEFAULT_BODY_SIZE;

--- a/crates/primitives/src/chunk/single_owner.rs
+++ b/crates/primitives/src/chunk/single_owner.rs
@@ -4,12 +4,16 @@
 //! carrier under a [`SocHeader`], which binds the body to an owner via an
 //! id and a signature.
 
-use alloy_primitives::{Address, B256, Keccak256, Signature, address, b256, hex};
+#[cfg(feature = "std")]
+use alloy_primitives::b256;
+use alloy_primitives::{Address, B256, Keccak256, Signature, address, hex};
+#[cfg(feature = "std")]
 use alloy_signer::SignerSync;
+#[cfg(feature = "std")]
 use alloy_signer_local::PrivateKeySigner;
 use bytes::{Bytes, BytesMut};
-use std::fmt;
-use std::marker::PhantomData;
+use core::fmt;
+use core::marker::PhantomData;
 
 use crate::bmt::DEFAULT_BODY_SIZE;
 use crate::chunk::error::{self, ChunkError};
@@ -26,12 +30,13 @@ use super::type_id::ChunkTypeId;
 use super::type_tag::ChunkVersion;
 
 // Constants for field sizes
-const ID_SIZE: usize = std::mem::size_of::<B256>();
+const ID_SIZE: usize = size_of::<B256>();
 const SIGNATURE_SIZE: usize = 65;
 
 /// The address of the owner of the SOC for dispersed replicas.
 const DISPERSED_REPLICA_OWNER: Address = address!("0xdc5b20847f43d67928f49cd4f85d696b5a7617b5");
 /// Generated from the private key `0x0100000000000000000000000000000000000000000000000000000000000000`.
+#[cfg(feature = "std")]
 pub(crate) const DISPERSED_REPLICA_OWNER_PK: B256 =
     b256!("0x0100000000000000000000000000000000000000000000000000000000000000");
 
@@ -125,7 +130,7 @@ impl ChunkHeader for SocHeader {
         &self,
         body_hash: B256,
         expected: &ChunkAddress,
-    ) -> std::result::Result<(), ChunkError> {
+    ) -> core::result::Result<(), ChunkError> {
         let owner = self.owner(body_hash)?;
 
         // If the owner is the replica chunk owner, the ID must adhere to the
@@ -158,7 +163,7 @@ impl ChunkHeader for SocHeader {
         out.extend_from_slice(&self.signature.as_bytes());
     }
 
-    fn decode(cursor: &mut wire::Cursor<'_>) -> std::result::Result<Self, ChunkError> {
+    fn decode(cursor: &mut wire::Cursor<'_>) -> core::result::Result<Self, ChunkError> {
         let id = SocId::new(cursor.take::<[u8; ID_SIZE]>()?);
         let signature = Signature::from_raw(&cursor.take::<[u8; SIGNATURE_SIZE]>()?)?;
         Ok(Self::new(id, signature))
@@ -180,6 +185,7 @@ impl<const BODY_SIZE: usize> SingleOwnerChunk<BODY_SIZE> {
     /// # Returns
     ///
     /// A Result containing the new SingleOwnerChunk, or an error if creation fails.
+    #[cfg(feature = "std")]
     #[must_use = "this returns a new chunk without modifying the input"]
     pub fn new(id: SocId, data: impl Into<Bytes>, signer: &impl SignerSync) -> Result<Self> {
         SingleOwnerChunkBuilderImpl::<BODY_SIZE, Initial>::default()
@@ -217,6 +223,7 @@ impl<const BODY_SIZE: usize> SingleOwnerChunk<BODY_SIZE> {
     /// # Arguments
     /// * `mined_byte` - The first byte of the chunk's ID.
     /// * `body` - The underlying BMT body containing the data and metadata.
+    #[cfg(feature = "std")]
     #[must_use = "this returns a new chunk without modifying the input"]
     pub fn new_dispersed_replica(mined_byte: u8, body: BmtBody<BODY_SIZE>) -> Result<Self> {
         SingleOwnerChunkBuilderImpl::<BODY_SIZE, Initial>::default()
@@ -285,6 +292,7 @@ impl<const BODY_SIZE: usize> SingleOwnerChunk<BODY_SIZE> {
 impl<const BODY_SIZE: usize> fmt::Display for SingleOwnerChunk<BODY_SIZE> {
     #[allow(clippy::indexing_slicing)] // id is a fixed 32-byte value, so [..8] holds
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use alloc::string::ToString;
         let owner_str = self.owner().map_or_else(
             |_| "invalid".to_string(),
             |addr| hex::encode(addr.as_slice()),
@@ -361,6 +369,7 @@ impl<const BODY_SIZE: usize> SingleOwnerChunkBuilderImpl<BODY_SIZE, Initial> {
     }
 
     /// Initialize with a specific body
+    #[cfg(any(feature = "std", test, feature = "arbitrary"))]
     fn with_body(
         mut self,
         body: BmtBody<BODY_SIZE>,
@@ -390,6 +399,7 @@ impl<const BODY_SIZE: usize> SingleOwnerChunkBuilderImpl<BODY_SIZE, WithData> {
     }
 
     /// Creates a new dispersed replica chunk with the given first byte and transitions to ReadyToBuild
+    #[cfg(feature = "std")]
     #[allow(clippy::unwrap_used, clippy::indexing_slicing)] // the WithData typestate guarantees body is Some; id and body_hash are fixed 32-byte values; DISPERSED_REPLICA_OWNER_PK is a known-valid constant key
     fn dispersed_replica(
         self,
@@ -408,6 +418,7 @@ impl<const BODY_SIZE: usize> SingleOwnerChunkBuilderImpl<BODY_SIZE, WithData> {
 
 impl<const BODY_SIZE: usize> SingleOwnerChunkBuilderImpl<BODY_SIZE, WithId> {
     /// Sign the chunk with the given signer
+    #[cfg(feature = "std")]
     #[allow(clippy::unwrap_used)] // the WithId typestate guarantees body and id are Some
     fn with_signer(
         self,

--- a/crates/primitives/src/chunk/soc_id.rs
+++ b/crates/primitives/src/chunk/soc_id.rs
@@ -56,6 +56,9 @@ impl SocId {
     }
 
     /// Sample a cryptographically random id via `alloy_primitives::B256::random`.
+    ///
+    /// Absent on bare metal, which has no entropy source.
+    #[cfg(not(target_os = "none"))]
     pub fn random() -> Self {
         Self(B256::random())
     }

--- a/crates/primitives/src/chunk/trust.rs
+++ b/crates/primitives/src/chunk/trust.rs
@@ -6,7 +6,8 @@
 //! then verify; a store holding a [`TrustedSource`] capability is the single
 //! gated exception ([`Chunk::assume_verified`]).
 
-use std::marker::PhantomData;
+use alloc::vec::Vec;
+use core::marker::PhantomData;
 
 use alloy_primitives::Address;
 use bytes::Bytes;
@@ -262,8 +263,8 @@ impl<S: TrustState, R: ChunkRegistry> Clone for Chunk<S, R> {
     }
 }
 
-impl<S: TrustState, R: ChunkRegistry> std::fmt::Debug for Chunk<S, R> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<S: TrustState, R: ChunkRegistry> core::fmt::Debug for Chunk<S, R> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Chunk")
             .field("state", &S::NAME)
             .field("address", &self.address)

--- a/crates/primitives/src/chunk/type_tag.rs
+++ b/crates/primitives/src/chunk/type_tag.rs
@@ -107,7 +107,7 @@ impl From<ChunkTypeTag> for u16 {
 impl From<ChunkTypeTag> for u32 {
     #[inline]
     fn from(tag: ChunkTypeTag) -> Self {
-        u32::from(tag.to_u16())
+        Self::from(tag.to_u16())
     }
 }
 

--- a/crates/primitives/src/ecies.rs
+++ b/crates/primitives/src/ecies.rs
@@ -5,6 +5,7 @@
 //! the reference client's big-integer encoding. Wire-critical: ciphertexts
 //! must decrypt cross-client.
 
+use alloc::vec::Vec;
 use alloy_primitives::Keccak256;
 use thiserror::Error;
 

--- a/crates/primitives/src/entry_ref.rs
+++ b/crates/primitives/src/entry_ref.rs
@@ -1,5 +1,7 @@
 //! Unified file entry reference type.
 
+use alloc::vec::Vec;
+
 use crate::chunk::encryption::EncryptedChunkRef;
 use crate::chunk::{ChunkAddress, ChunkRef};
 

--- a/crates/primitives/src/error.rs
+++ b/crates/primitives/src/error.rs
@@ -39,7 +39,7 @@
 use thiserror::Error;
 
 /// Result type for operations in the primitives crate
-pub type Result<T> = std::result::Result<T, PrimitivesError>;
+pub type Result<T> = core::result::Result<T, PrimitivesError>;
 
 /// A byte slice did not carry the width its target type requires.
 ///
@@ -83,12 +83,13 @@ pub enum PrimitivesError {
     Ecies(#[from] crate::ecies::EciesError),
 
     /// Input/output errors
+    #[cfg(feature = "std")]
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
 
     /// Array conversion errors
     #[error("Array conversion error: {0}")]
-    ArrayConversion(#[from] std::array::TryFromSliceError),
+    ArrayConversion(#[from] core::array::TryFromSliceError),
 
     /// A byte slice had the wrong width for a fixed-width type
     #[error(transparent)]

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -32,6 +32,7 @@
 //! let owner_chunk = DefaultSingleOwnerChunk::new(id, b"Signed data".as_slice(), &wallet).unwrap();
 //! ```
 
+#![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(
     test,
     allow(
@@ -163,9 +164,11 @@ pub type DefaultMemoryStore = MemoryStore<StandardChunkSet>;
 
 // Chunk storage traits
 pub use store::{
-    ChunkGet, ChunkHas, ChunkPut, ChunkStoreError, MemoryStore, RetryConfig, RetryingChunkGet,
-    SingleOwnerGet, SingleOwnerGetError, Sleeper, TrustedGet,
+    ChunkGet, ChunkHas, ChunkPut, ChunkStoreError, MemoryStore, SingleOwnerGet,
+    SingleOwnerGetError, TrustedGet,
 };
+#[cfg(feature = "std")]
+pub use store::{RetryConfig, RetryingChunkGet, Sleeper};
 
 // The width-agnostic reference union: the manifest-to-file bridge type.
 pub use entry_ref::{EntryRef, InvalidEntryRef};

--- a/crates/primitives/src/nonce.rs
+++ b/crates/primitives/src/nonce.rs
@@ -45,6 +45,9 @@ impl Nonce {
     }
 
     /// Sample a cryptographically random nonce via `alloy_primitives::B256::random`.
+    ///
+    /// Absent on bare metal, which has no entropy source.
+    #[cfg(not(target_os = "none"))]
     pub fn random() -> Self {
         Self(B256::random())
     }

--- a/crates/primitives/src/signing.rs
+++ b/crates/primitives/src/signing.rs
@@ -34,6 +34,7 @@
 //! argument is whatever wire encoding the calling node uses for its multiaddr
 //! list.
 
+use alloc::vec::Vec;
 use alloy_primitives::Address;
 
 use crate::{NetworkId, Nonce, OverlayAddress, Timestamp};

--- a/crates/primitives/src/store/memory.rs
+++ b/crates/primitives/src/store/memory.rs
@@ -1,7 +1,8 @@
 //! In-memory chunk storage.
 
-use std::collections::HashMap;
+use alloc::collections::BTreeMap;
 
+#[cfg(feature = "std")]
 use parking_lot::RwLock;
 
 use crate::chunk::{Chunk, ChunkAddress, ChunkRegistry, StandardChunkSet, Verified};
@@ -9,16 +10,42 @@ use crate::chunk::{Chunk, ChunkAddress, ChunkRegistry, StandardChunkSet, Verifie
 use super::ChunkStoreError;
 use super::typed::{ChunkGet, ChunkHas, ChunkPut};
 
-/// In-memory chunk storage using a `RwLock<HashMap>`.
+/// Single-threaded stand-in for `RwLock` on the `no_std` side: guests execute
+/// single-threaded, so a `RefCell` provides the same interior mutability.
+#[cfg(not(feature = "std"))]
+#[derive(Debug)]
+struct RwLock<T>(core::cell::RefCell<T>);
+
+#[cfg(not(feature = "std"))]
+impl<T> RwLock<T> {
+    const fn new(value: T) -> Self {
+        Self(core::cell::RefCell::new(value))
+    }
+
+    fn read(&self) -> core::cell::Ref<'_, T> {
+        self.0.borrow()
+    }
+
+    fn write(&self) -> core::cell::RefMut<'_, T> {
+        self.0.borrow_mut()
+    }
+
+    fn into_inner(self) -> T {
+        self.0.into_inner()
+    }
+}
+
+/// In-memory chunk storage over an address-keyed map.
 ///
 /// Holds only sealed chunks and is process-private, so reads are `Verified`:
 /// nothing can alter a chunk between put and get.
 ///
 /// Uses interior mutability so `ChunkPut::put(&self)` works without
-/// external synchronization.
+/// external synchronization: `parking_lot::RwLock` under `std`, an unsync
+/// cell on the single-threaded `no_std` side.
 #[derive(Debug)]
 pub struct MemoryStore<R: ChunkRegistry = StandardChunkSet> {
-    chunks: RwLock<HashMap<ChunkAddress, Chunk<Verified, R>>>,
+    chunks: RwLock<BTreeMap<ChunkAddress, Chunk<Verified, R>>>,
 }
 
 impl<R: ChunkRegistry> Clone for MemoryStore<R> {
@@ -37,9 +64,9 @@ impl<R: ChunkRegistry> Default for MemoryStore<R> {
 
 impl<R: ChunkRegistry> MemoryStore<R> {
     /// Create an empty memory store.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
-            chunks: RwLock::new(HashMap::new()),
+            chunks: RwLock::new(BTreeMap::new()),
         }
     }
 
@@ -66,13 +93,13 @@ impl<R: ChunkRegistry> MemoryStore<R> {
     }
 
     /// Consume the store and return all chunks.
-    pub fn into_chunks(self) -> HashMap<ChunkAddress, Chunk<Verified, R>> {
+    pub fn into_chunks(self) -> BTreeMap<ChunkAddress, Chunk<Verified, R>> {
         self.chunks.into_inner()
     }
 }
 
 impl<R: ChunkRegistry> ChunkPut<R> for MemoryStore<R> {
-    type Error = std::convert::Infallible;
+    type Error = core::convert::Infallible;
 
     async fn put(&self, chunk: Chunk<Verified, R>) -> Result<(), Self::Error> {
         self.chunks.write().insert(*chunk.address(), chunk);
@@ -99,7 +126,7 @@ impl<R: ChunkRegistry> ChunkHas for MemoryStore<R> {
     }
 }
 
-impl<R: ChunkRegistry> ChunkGet<R> for HashMap<ChunkAddress, Chunk<Verified, R>> {
+impl<R: ChunkRegistry> ChunkGet<R> for BTreeMap<ChunkAddress, Chunk<Verified, R>> {
     type Trust = Verified;
     type Error = ChunkStoreError;
 
@@ -110,7 +137,26 @@ impl<R: ChunkRegistry> ChunkGet<R> for HashMap<ChunkAddress, Chunk<Verified, R>>
     }
 }
 
-impl<R: ChunkRegistry> ChunkHas for HashMap<ChunkAddress, Chunk<Verified, R>> {
+impl<R: ChunkRegistry> ChunkHas for BTreeMap<ChunkAddress, Chunk<Verified, R>> {
+    async fn has(&self, address: &ChunkAddress) -> bool {
+        self.contains_key(address)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: ChunkRegistry> ChunkGet<R> for std::collections::HashMap<ChunkAddress, Chunk<Verified, R>> {
+    type Trust = Verified;
+    type Error = ChunkStoreError;
+
+    async fn get(&self, address: &ChunkAddress) -> Result<Chunk<Verified, R>, Self::Error> {
+        self.get(address)
+            .cloned()
+            .ok_or_else(|| ChunkStoreError::not_found(address))
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: ChunkRegistry> ChunkHas for std::collections::HashMap<ChunkAddress, Chunk<Verified, R>> {
     async fn has(&self, address: &ChunkAddress) -> bool {
         self.contains_key(address)
     }

--- a/crates/primitives/src/store/mod.rs
+++ b/crates/primitives/src/store/mod.rs
@@ -2,18 +2,22 @@
 //!
 //! `ChunkGet`, `ChunkPut`, and `ChunkHas` are async and carry `MaybeSend`/
 //! `MaybeSync` bounds so a store may be `!Send` on single-threaded targets
-//! (wasm32, or any target under the `unsync` feature).
+//! (wasm32, bare metal, or any target under the `unsync` feature).
 
 mod memory;
+#[cfg(feature = "std")]
 mod retry;
 mod single_owner;
 mod typed;
 
 pub use crate::marker::{MaybeSend, MaybeSync};
 pub use memory::MemoryStore;
+#[cfg(feature = "std")]
 pub use retry::{RetryConfig, RetryingChunkGet, Sleeper};
 pub use single_owner::{SingleOwnerGet, SingleOwnerGetError};
 pub use typed::{ChunkGet, ChunkHas, ChunkPut, TrustedGet};
+
+use alloc::boxed::Box;
 
 use crate::chunk::{Chunk, ChunkAddress, ChunkRegistry, Verified};
 
@@ -32,12 +36,12 @@ pub type BoxedError = Box<dyn core::error::Error>;
 /// wasm32 and under the `unsync` feature where a backend error may hold
 /// single-thread state (a JS handle).
 #[cfg(multi_thread)]
-pub type SharedError = std::sync::Arc<dyn core::error::Error + Send + Sync>;
+pub type SharedError = alloc::sync::Arc<dyn core::error::Error + Send + Sync>;
 /// Shared store error: `Send + Sync` on multi-threaded targets, unbounded on
 /// wasm32 and under the `unsync` feature where a backend error may hold
 /// single-thread state (a JS handle).
 #[cfg(not(multi_thread))]
-pub type SharedError = std::sync::Arc<dyn core::error::Error>;
+pub type SharedError = alloc::sync::Arc<dyn core::error::Error>;
 
 /// Errors from chunk storage operations.
 #[non_exhaustive]

--- a/crates/primitives/src/store/typed.rs
+++ b/crates/primitives/src/store/typed.rs
@@ -6,7 +6,7 @@
 //! `Chunk<Verified, R>`); trust is a property of the read medium, declared
 //! once per backend through [`ChunkGet::Trust`].
 
-use std::future::Future;
+use core::future::Future;
 
 use crate::chunk::{Chunk, ChunkAddress, ChunkRegistry, StandardChunkSet, TrustState, Verified};
 use crate::marker::{MaybeSend, MaybeSync};

--- a/crates/primitives/src/timestamp.rs
+++ b/crates/primitives/src/timestamp.rs
@@ -4,8 +4,8 @@
 //! Verification rejects records whose timestamp drifts outside a
 //! caller-supplied window from local clock. See `SPEC.md#handshake-timestamp`.
 
+use core::time::Duration;
 use derive_more::{Display, From, Into};
-use std::time::Duration;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -55,25 +55,17 @@ impl Timestamp {
 
     /// Capture the current wall-clock time as a [`Timestamp`].
     ///
-    /// The clock comes from `web-time`, which is `std::time` on native targets
-    /// and the browser clock on `wasm32`, so this runs on every supported
-    /// target instead of panicking through the std unsupported-platform stub.
-    ///
-    /// # Panics
-    ///
-    /// Only if the system clock is set before the unix epoch (or past
-    /// `i64::MAX` unix-seconds), which would already break far more than this
-    /// primitive. Pre-1970 callers can construct via [`Self::from_seconds`]
-    /// manually.
-    #[allow(clippy::expect_used)] // documented invariants: panics only on a pre-1970 or absurdly far-future system clock
+    /// Reads [`nectar_clock::SystemClock`]: `std::time` on native targets,
+    /// the browser clock on `wasm32`. Guests without a wall clock construct
+    /// via [`Self::from_clock`] with an injected source instead.
+    #[cfg(feature = "std")]
     pub fn now() -> Self {
-        use web_time::{SystemTime, UNIX_EPOCH};
-        let secs = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("system clock set before unix epoch")
-            .as_secs();
-        // u64 -> i64: safe for the next ~290 billion years.
-        Self(i64::try_from(secs).expect("system clock exceeds i64 unix seconds"))
+        Self::from_clock(&nectar_clock::SystemClock)
+    }
+
+    /// Capture the current time from an injected [`nectar_clock::Clock`].
+    pub fn from_clock(clock: &impl nectar_clock::Clock) -> Self {
+        Self(clock.now_secs())
     }
 
     /// Verify this timestamp is within `window` of `local`.

--- a/crates/primitives/src/wire.rs
+++ b/crates/primitives/src/wire.rs
@@ -19,6 +19,7 @@
 //! # Ok::<(), nectar_primitives::wire::Underrun>(())
 //! ```
 
+use alloc::vec::Vec;
 use thiserror::Error;
 
 /// A short read: the buffer held fewer bytes than a field required.

--- a/crates/primitives/src/xor_metric.rs
+++ b/crates/primitives/src/xor_metric.rs
@@ -36,7 +36,7 @@
 //! }
 //! ```
 
-use std::cmp::Ordering;
+use core::cmp::Ordering;
 
 use alloy_primitives::U256;
 


### PR DESCRIPTION
## What
Flips nectar-primitives to build bare-metal on riscv64imac-unknown-none-elf, gated behind the existing `std` feature.
lib.rs gains `#![cfg_attr(not(feature = "std"), no_std)]` alongside the existing `extern crate alloc`.
Cargo.toml makes alloy-signer, alloy-signer-local, keccak-batch, parking_lot, web-time and rayon optional, pulled back in by `std`, and narrows the asm-keccak/getrandom alloy-primitives dependency to hosted non-wasm, non-`target_os = "none"` targets.
store/memory.rs replaces the `parking_lot::RwLock<HashMap>` with a `BTreeMap` on both sides, behind a cfg-gated lock: `parking_lot::RwLock` under std, a single-threaded `RefCell` wrapper under no_std; `into_chunks` now returns a `BTreeMap`, and the HashMap-based `ChunkGet`/`ChunkHas` convenience impls stay std-gated.
bmt/hasher.rs gates rayon, keccak-batch and the parallel `hash_pairs`/`get_level_segments` paths under std, adding a sequential per-pair keccak walk as the no_std baseline.
timestamp.rs routes `Timestamp::now` through `nectar_clock::SystemClock` (std-gated) and adds `Timestamp::from_clock` for injected clock sources, dropping the old expect-based panic path.
lib.rs re-exports `RetryConfig`, `RetryingChunkGet` and `Sleeper` only under `std`.

## Why
Closes #468.
nectar-primitives needs to build on bare-metal riscv64imac guests (zkVM-style targets) per the workspace's no_std policy; the blockers were the OS-backed lock, the HashMap dependency, rayon/keccak-batch parallelism, and the std-only wall clock, all now shed behind the `std` feature with no_std fallbacks on the same BTreeMap-backed store and a sequential keccak walk.

## Testing
All commands run under `nix develop` (Rust 1.94.0, matching CI) with the shared per-user sccache; `--locked` throughout.

CI-mirror battery, all green:
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked`, plus per-feature clippy passes for nectar-file (tokio, rayon, encryption), nectar-postage (serde), nectar-manifest (encryption)
- `unused_crate_dependencies` via `cargo rustc --lib` for nectar-primitives, nectar-marker, nectar-clock, nectar-postage
- `cargo machete`
- `cargo check --no-default-features --target riscv64imac-unknown-none-elf -p nectar-primitives` (the issue's done-criterion)
- unsync host escape build
- wasm32 build (only pre-existing wasm.rs warnings)
- full-workspace default-feature check
- 272 nectar-primitives unit tests, plus doctests, plus nectar-clock and nectar-marker tests

Independently reproduced by adversarial red-team review of the branch; no blocking, major, or minor defects found.

## AI Assistance
Implementation by fable, review by opus.
