### PR TITLE
primitives: narrow content-only read chunk set

### DIFF
--- a/crates/benches/benches/latency_bench.rs
+++ b/crates/benches/benches/latency_bench.rs
@@ -23,7 +23,7 @@ use criterion::{
 use nectar_file::{File, Plain, PutWindow, Split, Window};
 use nectar_primitives::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{AnyChunkSet, Chunk, ChunkAddress, Verified};
-use nectar_primitives::store::{ChunkGet, ChunkPut, ChunkStoreError};
+use nectar_primitives::store::{ChunkGet, ChunkPut, ChunkStoreError, ContentGet};
 use tokio::runtime::Runtime;
 
 /// Narrow body for the deep group: fan-out 8, so a hundred leaves already
@@ -152,8 +152,10 @@ fn read_group<const B: usize>(c: &mut Criterion, name: &str, latency: Duration, 
         group.bench_with_input(BenchmarkId::from_parameter(window), &window, |b, &w| {
             b.iter(|| {
                 rt.block_on(async {
-                    let file: File<LatencyStore<B>, Plain, B> =
-                        File::open(store.clone(), root).await.unwrap();
+                    let file: File<ContentGet<LatencyStore<B>>, Plain, B> =
+                        File::open(ContentGet::new(store.clone()), root)
+                            .await
+                            .unwrap();
                     let mut reader = file.read().window(Window::new(w).unwrap()).build();
                     let mut total = 0usize;
                     while let Some(segment) = reader.next_segment().await {

--- a/crates/benches/benches/mantaray_bench.rs
+++ b/crates/benches/benches/mantaray_bench.rs
@@ -2,7 +2,7 @@ use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use nectar_mantaray::{Cursor, ManifestEditor, MemoryStore, Reader, hazmat};
 use nectar_primitives::StandardChunkSet;
 use nectar_primitives::chunk::{ChunkAddress, ChunkOps};
-use nectar_primitives::store::ChunkGet;
+use nectar_primitives::store::{ChunkGet, ContentGet};
 use nectar_testing::run;
 
 type Store = MemoryStore<StandardChunkSet>;
@@ -87,7 +87,7 @@ fn bench_get(c: &mut Criterion) {
     let mut group = c.benchmark_group("get");
 
     let (root, store) = build_spa();
-    let reader = Reader::new(store);
+    let reader = Reader::new(ContentGet::new(store));
 
     group.bench_function("existing_path", |b| {
         b.iter(|| {
@@ -97,7 +97,7 @@ fn bench_get(c: &mut Criterion) {
     });
 
     let (large_root, large_store) = build_large(500);
-    let large_reader = Reader::new(large_store);
+    let large_reader = Reader::new(ContentGet::new(large_store));
 
     group.bench_function("500_paths_deep", |b| {
         b.iter(|| {
@@ -131,7 +131,7 @@ fn bench_has_prefix(c: &mut Criterion) {
     let mut group = c.benchmark_group("has_prefix");
 
     let (root, store) = build_spa();
-    let reader = Reader::new(store);
+    let reader = Reader::new(ContentGet::new(store));
 
     group.bench_function("existing_prefix", |b| {
         b.iter(|| run(reader.has_prefix(&root, b"js/")).unwrap());
@@ -179,7 +179,8 @@ fn bench_decode(c: &mut Criterion) {
 /// Drain the ordered listing cursor, returning the entry count.
 fn drain_cursor(root: ChunkAddress, store: &Store) -> u32 {
     run(async {
-        let mut cursor: Cursor<Store> = Cursor::new(store.clone(), root);
+        let mut cursor: Cursor<ContentGet<Store>> =
+            Cursor::new(ContentGet::new(store.clone()), root);
         let mut count = 0u32;
         while let Some(entry) = cursor.next().await {
             entry.unwrap();
@@ -213,7 +214,7 @@ fn bench_full_workflow(c: &mut Criterion) {
     group.bench_function("commit_then_lookup", |b| {
         b.iter(|| {
             let (root, store) = build_spa();
-            let reader = Reader::new(store);
+            let reader = Reader::new(ContentGet::new(store));
             let paths: &[&[u8]] = &[
                 b"css/app.css",
                 b"favicon.ico",

--- a/crates/file/src/lib.rs
+++ b/crates/file/src/lib.rs
@@ -22,6 +22,7 @@
 //! ```
 //! use nectar_file::AnyFile;
 //! use nectar_mantaray::{ManifestEditor, Reader};
+//! use nectar_primitives::store::ContentGet;
 //!
 //! # nectar_testing::run(async {
 //! let data = b"hello swarm".to_vec();
@@ -38,7 +39,7 @@
 //! editor.remove("stale.txt");
 //! let (manifest_root, store) = editor.commit().await.unwrap();
 //!
-//! let reader = Reader::new(store.clone());
+//! let reader = Reader::new(ContentGet::new(store.clone()));
 //! assert!(
 //!     reader
 //!         .get(&manifest_root, b"stale.txt")
@@ -51,7 +52,7 @@
 //!     .await
 //!     .unwrap()
 //!     .unwrap();
-//! let file = AnyFile::open(store, entry.reference().unwrap().clone())
+//! let file = AnyFile::open(ContentGet::new(store), entry.reference().unwrap().clone())
 //!     .await
 //!     .unwrap();
 //! assert_eq!(file.collect(u64::MAX).await.unwrap(), data);

--- a/crates/file/src/oracles.rs
+++ b/crates/file/src/oracles.rs
@@ -8,7 +8,7 @@
 
 use alloc::vec::Vec;
 
-use nectar_primitives::chunk::{AnyChunkSet, Chunk, ChunkAddress, ContentChunk, Verified};
+use nectar_primitives::chunk::{Chunk, ChunkAddress, ContentChunk, ContentOnlyChunkSet, Verified};
 use nectar_primitives::oracles::Violation;
 use nectar_primitives::store::MemoryStore;
 
@@ -37,7 +37,10 @@ fn synth(span: u64, payload: &[u8]) -> Option<ContentChunk<BODY>> {
 /// Open and drain the tree at `root`; malformed trees may only fail typed.
 /// Returns whether the open and the bounded collect both succeeded, in
 /// which case the delivered length must equal the declared span.
-fn probe(store: &MemoryStore<AnyChunkSet<BODY>>, root: ChunkAddress) -> Result<bool, Violation> {
+fn probe(
+    store: &MemoryStore<ContentOnlyChunkSet<BODY>>,
+    root: ChunkAddress,
+) -> Result<bool, Violation> {
     let store = store.clone();
     let outcome = drive(async move {
         let Ok(file) = File::<_, Plain, BODY>::open(store, root).await else {
@@ -77,7 +80,7 @@ pub fn malformed_walk(
     root_span: u64,
     arity: u8,
 ) -> Result<Option<bool>, Violation> {
-    let mut chunks: Vec<Chunk<Verified, AnyChunkSet<BODY>>> = Vec::new();
+    let mut chunks: Vec<Chunk<Verified, ContentOnlyChunkSet<BODY>>> = Vec::new();
     for (span, payload) in specs.iter().take(MAX_CHUNKS) {
         if let Some(chunk) = synth(*span, payload) {
             chunks.push(chunk.seal());
@@ -96,7 +99,7 @@ pub fn malformed_walk(
             body.extend_from_slice(address.as_bytes());
         }
         if let Some(root) = synth(root_span, &body) {
-            let sealed: Chunk<Verified, AnyChunkSet<BODY>> = root.seal();
+            let sealed: Chunk<Verified, ContentOnlyChunkSet<BODY>> = root.seal();
             let root_address = *sealed.address();
             let store =
                 MemoryStore::from_chunks(store.clone().into_chunks().into_values().chain([sealed]));

--- a/crates/file/src/parallel/tests.rs
+++ b/crates/file/src/parallel/tests.rs
@@ -210,6 +210,8 @@ impl<const B: usize> nectar_primitives::store::ChunkGet<AnyChunkSet<B>> for Test
 fn encrypted_ingest_reads_back_through_the_walk() {
     use core::future::poll_fn;
 
+    use nectar_primitives::store::ContentGet;
+
     use crate::config::Window;
     use crate::split::RandomKeys;
     use crate::walk::{Encrypted, Walk};
@@ -222,8 +224,8 @@ fn encrypted_ingest_reads_back_through_the_walk() {
         PutWindow::DEFAULT,
     ))
     .unwrap();
-    let mut walk: Walk<TestStore<TINY>, Encrypted, TINY> = Walk::new(
-        store,
+    let mut walk: Walk<ContentGet<TestStore<TINY>>, Encrypted, TINY> = Walk::new(
+        ContentGet::new(store),
         *root.address(),
         root.key().clone(),
         data.len() as u64,

--- a/crates/file/src/read/cancel.rs
+++ b/crates/file/src/read/cancel.rs
@@ -13,7 +13,7 @@ use std::vec::Vec;
 
 use futures::Stream;
 use futures::task::noop_waker;
-use nectar_primitives::chunk::{AnyChunkSet, Chunk, ChunkAddress, Verified};
+use nectar_primitives::chunk::{Chunk, ChunkAddress, ContentOnlyChunkSet, Verified};
 use nectar_primitives::store::{ChunkGet, ChunkStoreError, MemoryStore, TrustedGet};
 use nectar_testing::{run, split_fixture, yield_now};
 
@@ -33,7 +33,7 @@ const TINY: usize = 256;
 /// Polls after which a test declares the pipeline stalled.
 const POLL_CAP: usize = 100_000;
 
-type TinyRegistry = AnyChunkSet<TINY>;
+type TinyRegistry = ContentOnlyChunkSet<TINY>;
 type TinyChunk = Chunk<Verified, TinyRegistry>;
 type TinyStore = MemoryStore<TinyRegistry>;
 

--- a/crates/file/src/read/download.rs
+++ b/crates/file/src/read/download.rs
@@ -7,7 +7,7 @@ use core::time::Duration;
 
 use futures_util::stream::StreamExt;
 use nectar_primitives::DEFAULT_BODY_SIZE;
-use nectar_primitives::chunk::{AnyChunkSet, ChunkAddress};
+use nectar_primitives::chunk::{ChunkAddress, ContentOnlyChunkSet};
 use nectar_primitives::store::TrustedGet;
 
 use super::body_size;
@@ -57,7 +57,9 @@ pub type ProgressFn = Box<dyn FnMut(Progress)>;
 /// # )
 /// # .await
 /// # .unwrap();
-/// let file = File::open(store, root).await.unwrap();
+/// let file = File::open(nectar_primitives::store::ContentGet::new(store), root)
+///     .await
+///     .unwrap();
 /// let mut sink = MemSink::new();
 /// let written = file
 ///     .download()
@@ -137,7 +139,7 @@ impl<S, M: WalkMode, const B: usize> DownloadBuilder<S, M, B> {
 
 impl<S, M, const B: usize> DownloadBuilder<S, M, B>
 where
-    S: TrustedGet<AnyChunkSet<B>> + Clone + 'static,
+    S: TrustedGet<ContentOnlyChunkSet<B>> + Clone + 'static,
     M: WalkMode,
 {
     /// Run the download to completion, returning the bytes written.

--- a/crates/file/src/read/file.rs
+++ b/crates/file/src/read/file.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 use core::fmt;
 
 use nectar_primitives::chunk::encryption::{EncryptedChunkRef, EncryptionKey, transcrypt_in_place};
-use nectar_primitives::chunk::{AnyChunkSet, ChunkAddress, ChunkOps};
+use nectar_primitives::chunk::{ChunkAddress, ChunkOps, ContentOnlyChunkSet};
 use nectar_primitives::store::TrustedGet;
 use nectar_primitives::{DEFAULT_BODY_SIZE, EntryRef};
 
@@ -70,7 +70,7 @@ impl<S: Clone, M: WalkMode, const B: usize> File<S, M, B> {
 
 impl<S, M, const B: usize> File<S, M, B>
 where
-    S: TrustedGet<AnyChunkSet<B>> + Clone + 'static,
+    S: TrustedGet<ContentOnlyChunkSet<B>> + Clone + 'static,
     M: WalkMode,
 {
     /// Assemble the whole file in memory, at most `max` bytes.
@@ -81,7 +81,7 @@ where
 
 impl<S, const B: usize> File<S, Plain, B>
 where
-    S: TrustedGet<AnyChunkSet<B>> + Clone + 'static,
+    S: TrustedGet<ContentOnlyChunkSet<B>> + Clone + 'static,
 {
     /// Open a plain file at its root address, reading the span off the root
     /// chunk.
@@ -99,7 +99,7 @@ where
 
 impl<S, const B: usize> File<S, Encrypted, B>
 where
-    S: TrustedGet<AnyChunkSet<B>> + Clone + 'static,
+    S: TrustedGet<ContentOnlyChunkSet<B>> + Clone + 'static,
 {
     /// Open an encrypted file at its root reference, decrypting the span off
     /// the root chunk with the reference's key.
@@ -148,7 +148,7 @@ pub enum AnyFile<S, const B: usize = DEFAULT_BODY_SIZE> {
 
 impl<S, const B: usize> AnyFile<S, B>
 where
-    S: TrustedGet<AnyChunkSet<B>> + Clone + 'static,
+    S: TrustedGet<ContentOnlyChunkSet<B>> + Clone + 'static,
 {
     /// Open a file from a wire reference, dispatching the mode on the
     /// reference width.
@@ -221,11 +221,11 @@ async fn fetch_root<S, const B: usize>(
     store: &S,
     address: ChunkAddress,
 ) -> Result<
-    <AnyChunkSet<B> as nectar_primitives::chunk::ChunkRegistry>::Envelope,
+    <ContentOnlyChunkSet<B> as nectar_primitives::chunk::ChunkRegistry>::Envelope,
     OpenError<S::Error>,
 >
 where
-    S: TrustedGet<AnyChunkSet<B>>,
+    S: TrustedGet<ContentOnlyChunkSet<B>>,
 {
     let chunk = store
         .get(&address)

--- a/crates/file/src/read/frames.rs
+++ b/crates/file/src/read/frames.rs
@@ -7,7 +7,7 @@ use core::task::{Context, Poll};
 
 use futures_util::stream::Stream;
 use nectar_primitives::DEFAULT_BODY_SIZE;
-use nectar_primitives::chunk::AnyChunkSet;
+use nectar_primitives::chunk::ContentOnlyChunkSet;
 use nectar_primitives::store::TrustedGet;
 
 use crate::walk::{Frame, Walk, WalkError, WalkMode, WalkStats};
@@ -16,7 +16,7 @@ use crate::walk::{Frame, Walk, WalkError, WalkMode, WalkStats};
 /// frames tile the range exactly once, in no particular order.
 pub struct FileFrames<S, M, const B: usize = DEFAULT_BODY_SIZE>
 where
-    S: TrustedGet<AnyChunkSet<B>>,
+    S: TrustedGet<ContentOnlyChunkSet<B>>,
     M: WalkMode,
 {
     walk: Walk<S, M, B>,
@@ -24,7 +24,7 @@ where
 
 impl<S, M, const B: usize> FileFrames<S, M, B>
 where
-    S: TrustedGet<AnyChunkSet<B>> + Clone + 'static,
+    S: TrustedGet<ContentOnlyChunkSet<B>> + Clone + 'static,
     M: WalkMode,
 {
     pub(super) const fn new(walk: Walk<S, M, B>) -> Self {
@@ -46,14 +46,14 @@ where
 /// state and boxed futures, never a self-reference.
 impl<S, M, const B: usize> Unpin for FileFrames<S, M, B>
 where
-    S: TrustedGet<AnyChunkSet<B>>,
+    S: TrustedGet<ContentOnlyChunkSet<B>>,
     M: WalkMode,
 {
 }
 
 impl<S, M, const B: usize> Stream for FileFrames<S, M, B>
 where
-    S: TrustedGet<AnyChunkSet<B>> + Clone + 'static,
+    S: TrustedGet<ContentOnlyChunkSet<B>> + Clone + 'static,
     M: WalkMode,
 {
     type Item = Result<Frame, WalkError<S::Error>>;
@@ -65,7 +65,7 @@ where
 
 impl<S, M, const B: usize> fmt::Debug for FileFrames<S, M, B>
 where
-    S: TrustedGet<AnyChunkSet<B>>,
+    S: TrustedGet<ContentOnlyChunkSet<B>>,
     M: WalkMode,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/file/src/read/reader.rs
+++ b/crates/file/src/read/reader.rs
@@ -12,7 +12,7 @@ use core::time::Duration;
 use bytes::Bytes;
 use futures_util::stream::{Stream, StreamExt};
 use nectar_primitives::DEFAULT_BODY_SIZE;
-use nectar_primitives::chunk::{AnyChunkSet, ChunkAddress};
+use nectar_primitives::chunk::{ChunkAddress, ContentOnlyChunkSet};
 use nectar_primitives::store::TrustedGet;
 
 use super::body_size;
@@ -83,7 +83,7 @@ impl<S, M: WalkMode, const B: usize> ReadBuilder<S, M, B> {
 
 impl<S, M, const B: usize> ReadBuilder<S, M, B>
 where
-    S: TrustedGet<AnyChunkSet<B>> + Clone + 'static,
+    S: TrustedGet<ContentOnlyChunkSet<B>> + Clone + 'static,
     M: WalkMode,
 {
     /// Build the ordered, seekable reader.
@@ -177,7 +177,7 @@ impl<S, M: WalkMode, const B: usize> fmt::Debug for ReadBuilder<S, M, B> {
 /// only when a call returns.
 pub struct FileReader<S, M, const B: usize = DEFAULT_BODY_SIZE>
 where
-    S: TrustedGet<AnyChunkSet<B>>,
+    S: TrustedGet<ContentOnlyChunkSet<B>>,
     M: WalkMode,
 {
     store: S,
@@ -198,7 +198,7 @@ where
 
 impl<S, M, const B: usize> FileReader<S, M, B>
 where
-    S: TrustedGet<AnyChunkSet<B>> + Clone + 'static,
+    S: TrustedGet<ContentOnlyChunkSet<B>> + Clone + 'static,
     M: WalkMode,
 {
     /// Current position within the clipped range.
@@ -331,7 +331,7 @@ where
 #[cfg(all(feature = "tokio", multi_thread))]
 pub(crate) struct ReaderParts<S, M, const B: usize>
 where
-    S: TrustedGet<AnyChunkSet<B>>,
+    S: TrustedGet<ContentOnlyChunkSet<B>>,
     M: WalkMode,
 {
     pub(crate) store: S,
@@ -348,7 +348,7 @@ where
 
 impl<S, M, const B: usize> fmt::Debug for FileReader<S, M, B>
 where
-    S: TrustedGet<AnyChunkSet<B>>,
+    S: TrustedGet<ContentOnlyChunkSet<B>>,
     M: WalkMode,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -382,7 +382,9 @@ where
 /// # )
 /// # .await
 /// # .unwrap();
-/// let file = File::open(store, root).await.unwrap();
+/// let file = File::open(nectar_primitives::store::ContentGet::new(store), root)
+///     .await
+///     .unwrap();
 /// let mut stream = file.read().range(4_096..12_288).stream();
 /// let mut out = Vec::new();
 /// while let Some(run) = stream.next().await {
@@ -393,7 +395,7 @@ where
 /// ```
 pub struct FileStream<S, M, const B: usize = DEFAULT_BODY_SIZE>
 where
-    S: TrustedGet<AnyChunkSet<B>>,
+    S: TrustedGet<ContentOnlyChunkSet<B>>,
     M: WalkMode,
 {
     /// Partially consumed frame handed over by a reader, delivered first.
@@ -405,14 +407,14 @@ where
 /// state and boxed futures, never a self-reference.
 impl<S, M, const B: usize> Unpin for FileStream<S, M, B>
 where
-    S: TrustedGet<AnyChunkSet<B>>,
+    S: TrustedGet<ContentOnlyChunkSet<B>>,
     M: WalkMode,
 {
 }
 
 impl<S, M, const B: usize> Stream for FileStream<S, M, B>
 where
-    S: TrustedGet<AnyChunkSet<B>> + Clone + 'static,
+    S: TrustedGet<ContentOnlyChunkSet<B>> + Clone + 'static,
     M: WalkMode,
 {
     type Item = Result<Bytes, WalkError<S::Error>>;
@@ -430,7 +432,7 @@ where
 
 impl<S, M, const B: usize> fmt::Debug for FileStream<S, M, B>
 where
-    S: TrustedGet<AnyChunkSet<B>>,
+    S: TrustedGet<ContentOnlyChunkSet<B>>,
     M: WalkMode,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/file/src/read/tests.rs
+++ b/crates/file/src/read/tests.rs
@@ -12,7 +12,7 @@ use std::vec::Vec;
 use bytes::Bytes;
 use nectar_primitives::chunk::encryption::{EncryptedChunkRef, EncryptionKey};
 use nectar_primitives::chunk::{
-    AnyChunk, AnyChunkSet, Chunk, ChunkAddress, ChunkOps, ChunkRef, ContentChunk,
+    Chunk, ChunkAddress, ChunkOps, ChunkRef, ContentChunk, ContentOnlyChunkSet,
 };
 use nectar_primitives::store::{ChunkStoreError, MemoryStore, TrustedGet};
 use nectar_primitives::{EntryRef, transcrypt};
@@ -30,7 +30,7 @@ use crate::walk::{DecodeError, Encrypted, Plain, WalkError, WalkMode};
 /// build deep trees.
 const TINY: usize = 256;
 
-type TinyStore = MemoryStore<AnyChunkSet<TINY>>;
+type TinyStore = MemoryStore<ContentOnlyChunkSet<TINY>>;
 
 /// Distinct byte per file position so slices are position-sensitive.
 fn fill(len: usize) -> Vec<u8> {
@@ -60,7 +60,7 @@ fn edge_sizes() -> Vec<usize> {
 /// wrapper and the async loop tests.
 async fn drain<S, M>(reader: &mut FileReader<S, M, TINY>) -> Vec<u8>
 where
-    S: TrustedGet<AnyChunkSet<TINY>, Error = ChunkStoreError> + Clone + 'static,
+    S: TrustedGet<ContentOnlyChunkSet<TINY>, Error = ChunkStoreError> + Clone + 'static,
     M: WalkMode,
 {
     let mut out = Vec::new();
@@ -77,7 +77,7 @@ where
 
 fn drain_reader<S, M>(reader: &mut FileReader<S, M, TINY>) -> Vec<u8>
 where
-    S: TrustedGet<AnyChunkSet<TINY>, Error = ChunkStoreError> + Clone + 'static,
+    S: TrustedGet<ContentOnlyChunkSet<TINY>, Error = ChunkStoreError> + Clone + 'static,
     M: WalkMode,
 {
     run(drain(reader))
@@ -376,10 +376,10 @@ fn seal(
     content: ContentChunk<TINY>,
 ) -> (
     ChunkAddress,
-    Chunk<nectar_primitives::chunk::Verified, AnyChunkSet<TINY>>,
+    Chunk<nectar_primitives::chunk::Verified, ContentOnlyChunkSet<TINY>>,
 ) {
     let address = *content.address();
-    let chunk = Chunk::from_envelope(AnyChunk::from(content)).unwrap();
+    let chunk = Chunk::from_envelope(content).unwrap();
     (address, chunk)
 }
 
@@ -468,7 +468,7 @@ fn debug_never_leaks_the_decryption_key() {
 
 fn collect_frames<S, M>(mut frames: super::FileFrames<S, M, TINY>) -> Vec<crate::walk::Frame>
 where
-    S: TrustedGet<AnyChunkSet<TINY>, Error = ChunkStoreError> + Clone + 'static,
+    S: TrustedGet<ContentOnlyChunkSet<TINY>, Error = ChunkStoreError> + Clone + 'static,
     M: WalkMode,
 {
     run(async {
@@ -629,14 +629,15 @@ struct CountingStore {
     gets: std::sync::Arc<std::sync::atomic::AtomicUsize>,
 }
 
-impl nectar_primitives::store::ChunkGet<AnyChunkSet<TINY>> for CountingStore {
+impl nectar_primitives::store::ChunkGet<ContentOnlyChunkSet<TINY>> for CountingStore {
     type Trust = nectar_primitives::chunk::Verified;
     type Error = ChunkStoreError;
 
     async fn get(
         &self,
         address: &ChunkAddress,
-    ) -> Result<Chunk<nectar_primitives::chunk::Verified, AnyChunkSet<TINY>>, ChunkStoreError> {
+    ) -> Result<Chunk<nectar_primitives::chunk::Verified, ContentOnlyChunkSet<TINY>>, ChunkStoreError>
+    {
         self.gets.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         nectar_primitives::store::ChunkGet::get(self.inner.as_ref(), address).await
     }
@@ -720,14 +721,15 @@ struct FailOnce {
     countdown: std::sync::Arc<std::sync::Mutex<Option<usize>>>,
 }
 
-impl nectar_primitives::store::ChunkGet<AnyChunkSet<TINY>> for FailOnce {
+impl nectar_primitives::store::ChunkGet<ContentOnlyChunkSet<TINY>> for FailOnce {
     type Trust = nectar_primitives::chunk::Verified;
     type Error = ChunkStoreError;
 
     async fn get(
         &self,
         address: &ChunkAddress,
-    ) -> Result<Chunk<nectar_primitives::chunk::Verified, AnyChunkSet<TINY>>, ChunkStoreError> {
+    ) -> Result<Chunk<nectar_primitives::chunk::Verified, ContentOnlyChunkSet<TINY>>, ChunkStoreError>
+    {
         let fail = {
             let mut slot = self.countdown.lock().unwrap();
             match slot.as_mut() {

--- a/crates/file/src/split/tests.rs
+++ b/crates/file/src/split/tests.rs
@@ -15,7 +15,7 @@ use std::vec::Vec;
 
 use futures::task::noop_waker;
 use nectar_primitives::chunk::{AnyChunkSet, Chunk, ChunkAddress, Verified};
-use nectar_primitives::store::{ChunkGet, ChunkPut, ChunkStoreError};
+use nectar_primitives::store::{ChunkGet, ChunkPut, ChunkStoreError, ContentGet};
 use nectar_testing::{run, yield_now};
 
 use super::{Split, SplitError, SplitStats};
@@ -296,8 +296,8 @@ fn default_profile_roots_are_pinned() {
 fn split_then_walk_round_trips() {
     let data = fill(37 * TINY + 41);
     let (root, store, _) = stream_split::<TINY>(&data, 4, usize::MAX, 1);
-    let mut walk: Walk<TestStore<TINY>, Plain, TINY> = Walk::new(
-        store,
+    let mut walk: Walk<ContentGet<TestStore<TINY>>, Plain, TINY> = Walk::new(
+        ContentGet::new(store),
         root,
         (),
         data.len() as u64,
@@ -487,6 +487,7 @@ mod encrypted {
     use std::vec::Vec;
 
     use nectar_primitives::chunk::encryption::{EncryptedChunkRef, EncryptionKey};
+    use nectar_primitives::store::ContentGet;
     use nectar_testing::run;
 
     use super::{BRANCHES, TINY, TestStore, fill, sorted, tree_chunks};
@@ -626,8 +627,8 @@ mod encrypted {
                     }
                     poll_fn(|cx| split.poll_finish(cx)).await.unwrap()
                 };
-                let mut walk: Walk<TestStore<TINY>, Encrypted, TINY> = Walk::new(
-                    store,
+                let mut walk: Walk<ContentGet<TestStore<TINY>>, Encrypted, TINY> = Walk::new(
+                    ContentGet::new(store),
                     *root.address(),
                     root.key().clone(),
                     size as u64,
@@ -661,8 +662,8 @@ mod encrypted {
         let data = fill(size);
         let (root, store, _) =
             stream_split_encrypted(&data, Encrypted::new(SeqKeys::default()), 719, 1);
-        let mut walk: Walk<TestStore<TINY>, Encrypted, TINY> = Walk::new(
-            store,
+        let mut walk: Walk<ContentGet<TestStore<TINY>>, Encrypted, TINY> = Walk::new(
+            ContentGet::new(store),
             *root.address(),
             root.key().clone(),
             size as u64,
@@ -776,8 +777,8 @@ mod encrypted {
             }
             poll_fn(|cx| split.poll_finish(cx)).await.unwrap()
         });
-        let mut walk: Walk<TestStore<TINY>, Encrypted, TINY> = Walk::new(
-            store,
+        let mut walk: Walk<ContentGet<TestStore<TINY>>, Encrypted, TINY> = Walk::new(
+            ContentGet::new(store),
             *root.address(),
             root.key().clone(),
             size as u64,

--- a/crates/file/src/store.rs
+++ b/crates/file/src/store.rs
@@ -12,7 +12,7 @@ use core::pin::Pin;
 
 use nectar_marker::{MaybeSend, MaybeSync};
 use nectar_primitives::DEFAULT_BODY_SIZE;
-use nectar_primitives::chunk::{AnyChunkSet, Chunk, ChunkAddress, Verified};
+use nectar_primitives::chunk::{Chunk, ChunkAddress, ContentOnlyChunkSet, Verified};
 use nectar_primitives::store::{BoxedError, ChunkGet, TrustedGet};
 
 use crate::read::{AnyFile, File, FileReader, FileStream};
@@ -27,13 +27,17 @@ pub struct BoxedStoreError(#[source] BoxedError);
 /// Boxed erased fetch future: `Send` on multi-threaded targets, unbounded on
 /// wasm32 and under the `unsync` feature.
 #[cfg(multi_thread)]
-type BoxGet<const B: usize> =
-    Pin<Box<dyn Future<Output = Result<Chunk<Verified, AnyChunkSet<B>>, BoxedStoreError>> + Send>>;
+type BoxGet<const B: usize> = Pin<
+    Box<
+        dyn Future<Output = Result<Chunk<Verified, ContentOnlyChunkSet<B>>, BoxedStoreError>>
+            + Send,
+    >,
+>;
 /// Boxed erased fetch future: `Send` on multi-threaded targets, unbounded on
 /// wasm32 and under the `unsync` feature.
 #[cfg(not(multi_thread))]
 type BoxGet<const B: usize> =
-    Pin<Box<dyn Future<Output = Result<Chunk<Verified, AnyChunkSet<B>>, BoxedStoreError>>>>;
+    Pin<Box<dyn Future<Output = Result<Chunk<Verified, ContentOnlyChunkSet<B>>, BoxedStoreError>>>>;
 
 /// Object-safe fetch surface the adapter erases stores through.
 trait ErasedGet<const B: usize>: MaybeSend + MaybeSync {
@@ -42,7 +46,7 @@ trait ErasedGet<const B: usize>: MaybeSend + MaybeSync {
 
 impl<S, const B: usize> ErasedGet<B> for S
 where
-    S: TrustedGet<AnyChunkSet<B>> + Clone + 'static,
+    S: TrustedGet<ContentOnlyChunkSet<B>> + Clone + 'static,
 {
     fn get(&self, address: ChunkAddress) -> BoxGet<B> {
         let store = self.clone();
@@ -62,7 +66,7 @@ impl<const B: usize> BoxedStore<B> {
     /// Erase a trusted store behind one nameable handle.
     pub fn new<S>(store: S) -> Self
     where
-        S: TrustedGet<AnyChunkSet<B>> + Clone + 'static,
+        S: TrustedGet<ContentOnlyChunkSet<B>> + Clone + 'static,
     {
         Self(Arc::new(store))
     }
@@ -80,14 +84,14 @@ impl<const B: usize> fmt::Debug for BoxedStore<B> {
     }
 }
 
-impl<const B: usize> ChunkGet<AnyChunkSet<B>> for BoxedStore<B> {
+impl<const B: usize> ChunkGet<ContentOnlyChunkSet<B>> for BoxedStore<B> {
     type Trust = Verified;
     type Error = BoxedStoreError;
 
     fn get(
         &self,
         address: &ChunkAddress,
-    ) -> impl Future<Output = Result<Chunk<Verified, AnyChunkSet<B>>, Self::Error>> + MaybeSend
+    ) -> impl Future<Output = Result<Chunk<Verified, ContentOnlyChunkSet<B>>, Self::Error>> + MaybeSend
     {
         self.0.get(*address)
     }

--- a/crates/file/src/sync.rs
+++ b/crates/file/src/sync.rs
@@ -37,7 +37,9 @@ pub struct Pending;
 /// # .unwrap()
 /// # .unwrap();
 /// let bytes = drive(async {
-///     let file = File::open(store, root).await.unwrap();
+///     let file = File::open(nectar_primitives::store::ContentGet::new(store), root)
+///         .await
+///         .unwrap();
 ///     file.collect(u64::MAX).await.unwrap()
 /// })
 /// .unwrap();

--- a/crates/file/src/testutil.rs
+++ b/crates/file/src/testutil.rs
@@ -102,7 +102,10 @@ where
 #[cfg(feature = "encryption")]
 pub(crate) fn split_encrypted_fixture<const B: usize>(
     data: &[u8],
-) -> (EncryptedChunkRef, MemoryStore<AnyChunkSet<B>>) {
+) -> (
+    EncryptedChunkRef,
+    MemoryStore<nectar_primitives::chunk::ContentOnlyChunkSet<B>>,
+) {
     use crate::split::{RandomKeys, Split};
     use crate::walk::Encrypted;
 
@@ -113,5 +116,10 @@ pub(crate) fn split_encrypted_fixture<const B: usize>(
         B,
     >::collect(Arc::clone(&store), data))
     .unwrap();
-    (root, Arc::into_inner(store).unwrap())
+    let chunks = Arc::into_inner(store)
+        .unwrap()
+        .into_chunks()
+        .into_values()
+        .map(|chunk| chunk.narrow_content().unwrap());
+    (root, MemoryStore::from_chunks(chunks))
 }

--- a/crates/file/src/tokio/mod.rs
+++ b/crates/file/src/tokio/mod.rs
@@ -19,7 +19,7 @@
 //!
 //! use nectar_file::{File, Plain, Split, TokioReader};
 //! use nectar_primitives::chunk::AnyChunkSet;
-//! use nectar_primitives::store::MemoryStore;
+//! use nectar_primitives::store::{ContentGet, MemoryStore};
 //! use tokio::io::{AsyncReadExt, AsyncSeekExt, SeekFrom};
 //!
 //! type Store = Arc<MemoryStore<AnyChunkSet<4096>>>;
@@ -31,7 +31,7 @@
 //!     .collect();
 //! # let store: Store = Arc::new(MemoryStore::new());
 //! # let root = Split::<_, Plain, 4096>::collect(Arc::clone(&store), &data).await.unwrap();
-//! let file: File<Store> = File::open(store, root).await.unwrap();
+//! let file: File<ContentGet<Store>> = File::open(ContentGet::new(store), root).await.unwrap();
 //!
 //! // A plain AsyncRead + AsyncSeek: seek to a range, then read it back.
 //! let mut reader = TokioReader::from(file.read().build());

--- a/crates/file/src/tokio/reader.rs
+++ b/crates/file/src/tokio/reader.rs
@@ -7,7 +7,7 @@ use std::io;
 use std::io::SeekFrom;
 
 use nectar_primitives::DEFAULT_BODY_SIZE;
-use nectar_primitives::chunk::AnyChunkSet;
+use nectar_primitives::chunk::ContentOnlyChunkSet;
 use nectar_primitives::store::TrustedGet;
 use tokio::io::{AsyncRead, AsyncSeek, ReadBuf};
 
@@ -23,7 +23,7 @@ use crate::walk::WalkMode;
 /// `InvalidInput`, never a clamp.
 pub struct TokioReader<S, M, const B: usize = DEFAULT_BODY_SIZE>
 where
-    S: TrustedGet<AnyChunkSet<B>>,
+    S: TrustedGet<ContentOnlyChunkSet<B>>,
     M: WalkMode,
 {
     inner: FileReader<S, M, B>,
@@ -31,7 +31,7 @@ where
 
 impl<S, M, const B: usize> TokioReader<S, M, B>
 where
-    S: TrustedGet<AnyChunkSet<B>> + Clone + 'static,
+    S: TrustedGet<ContentOnlyChunkSet<B>> + Clone + 'static,
     M: WalkMode,
 {
     /// Current position within the clipped range.
@@ -47,7 +47,7 @@ where
 
 impl<S, M, const B: usize> From<FileReader<S, M, B>> for TokioReader<S, M, B>
 where
-    S: TrustedGet<AnyChunkSet<B>>,
+    S: TrustedGet<ContentOnlyChunkSet<B>>,
     M: WalkMode,
 {
     fn from(inner: FileReader<S, M, B>) -> Self {
@@ -57,7 +57,7 @@ where
 
 impl<S, M, const B: usize> From<TokioReader<S, M, B>> for FileReader<S, M, B>
 where
-    S: TrustedGet<AnyChunkSet<B>>,
+    S: TrustedGet<ContentOnlyChunkSet<B>>,
     M: WalkMode,
 {
     fn from(reader: TokioReader<S, M, B>) -> Self {
@@ -69,14 +69,14 @@ where
 /// state and boxed futures, never a self-reference.
 impl<S, M, const B: usize> Unpin for TokioReader<S, M, B>
 where
-    S: TrustedGet<AnyChunkSet<B>>,
+    S: TrustedGet<ContentOnlyChunkSet<B>>,
     M: WalkMode,
 {
 }
 
 impl<S, M, const B: usize> AsyncRead for TokioReader<S, M, B>
 where
-    S: TrustedGet<AnyChunkSet<B>> + Clone + 'static,
+    S: TrustedGet<ContentOnlyChunkSet<B>> + Clone + 'static,
     S::Error: std::error::Error + Send + Sync + 'static,
     M: WalkMode,
 {
@@ -99,7 +99,7 @@ where
 
 impl<S, M, const B: usize> AsyncSeek for TokioReader<S, M, B>
 where
-    S: TrustedGet<AnyChunkSet<B>> + Clone + 'static,
+    S: TrustedGet<ContentOnlyChunkSet<B>> + Clone + 'static,
     S::Error: std::error::Error + Send + Sync + 'static,
     M: WalkMode,
 {
@@ -121,7 +121,7 @@ where
 
 impl<S, M, const B: usize> fmt::Debug for TokioReader<S, M, B>
 where
-    S: TrustedGet<AnyChunkSet<B>>,
+    S: TrustedGet<ContentOnlyChunkSet<B>>,
     M: WalkMode,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/file/src/tokio/spawned.rs
+++ b/crates/file/src/tokio/spawned.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use nectar_primitives::DEFAULT_BODY_SIZE;
-use nectar_primitives::chunk::{AnyChunkSet, ChunkAddress};
+use nectar_primitives::chunk::{ChunkAddress, ContentOnlyChunkSet};
 use nectar_primitives::store::TrustedGet;
 use nectar_tasks::{Spawn, TaskHandle, TokioSpawner};
 use tokio::io::{AsyncRead, AsyncSeek, ReadBuf};
@@ -36,7 +36,7 @@ type Frames<E> = mpsc::Receiver<Result<Frame, WalkError<E>>>;
 /// clamp.
 pub struct SpawnedReader<S, M, const B: usize = DEFAULT_BODY_SIZE>
 where
-    S: TrustedGet<AnyChunkSet<B>>,
+    S: TrustedGet<ContentOnlyChunkSet<B>>,
     M: WalkMode,
 {
     store: S,
@@ -59,7 +59,7 @@ where
 
 impl<S, M, const B: usize> SpawnedReader<S, M, B>
 where
-    S: TrustedGet<AnyChunkSet<B>> + Clone + Send + 'static,
+    S: TrustedGet<ContentOnlyChunkSet<B>> + Clone + Send + 'static,
     S::Error: Send,
     M: WalkMode,
 {
@@ -141,7 +141,7 @@ fn drive<S, M, const B: usize>(
     window: Window,
 ) -> (Frames<S::Error>, TaskHandle)
 where
-    S: TrustedGet<AnyChunkSet<B>> + Clone + Send + 'static,
+    S: TrustedGet<ContentOnlyChunkSet<B>> + Clone + Send + 'static,
     S::Error: Send,
     M: WalkMode,
 {
@@ -164,14 +164,14 @@ where
 /// state and channel handles, never a self-reference.
 impl<S, M, const B: usize> Unpin for SpawnedReader<S, M, B>
 where
-    S: TrustedGet<AnyChunkSet<B>>,
+    S: TrustedGet<ContentOnlyChunkSet<B>>,
     M: WalkMode,
 {
 }
 
 impl<S, M, const B: usize> AsyncRead for SpawnedReader<S, M, B>
 where
-    S: TrustedGet<AnyChunkSet<B>> + Clone + Send + 'static,
+    S: TrustedGet<ContentOnlyChunkSet<B>> + Clone + Send + 'static,
     S::Error: std::error::Error + Send + Sync + 'static,
     M: WalkMode,
 {
@@ -203,7 +203,7 @@ where
 
 impl<S, M, const B: usize> AsyncSeek for SpawnedReader<S, M, B>
 where
-    S: TrustedGet<AnyChunkSet<B>> + Clone + Send + 'static,
+    S: TrustedGet<ContentOnlyChunkSet<B>> + Clone + Send + 'static,
     S::Error: std::error::Error + Send + Sync + 'static,
     M: WalkMode,
 {
@@ -224,7 +224,7 @@ where
 
 impl<S, M, const B: usize> fmt::Debug for SpawnedReader<S, M, B>
 where
-    S: TrustedGet<AnyChunkSet<B>>,
+    S: TrustedGet<ContentOnlyChunkSet<B>>,
     M: WalkMode,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/file/src/tokio/tests.rs
+++ b/crates/file/src/tokio/tests.rs
@@ -7,8 +7,8 @@ use std::string::ToString;
 use std::sync::{Arc, Mutex};
 use std::vec::Vec;
 
-use nectar_primitives::chunk::{AnyChunkSet, Chunk, ChunkAddress, Verified};
-use nectar_primitives::store::{ChunkGet, ChunkPut, ChunkStoreError, MemoryStore};
+use nectar_primitives::chunk::{AnyChunkSet, Chunk, ChunkAddress, ContentOnlyChunkSet, Verified};
+use nectar_primitives::store::{ChunkGet, ChunkPut, ChunkStoreError, ContentGet, MemoryStore};
 use nectar_testing::split_fixture;
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 
@@ -23,7 +23,7 @@ use crate::walk::Plain;
 /// already build deep trees.
 const TINY: usize = 256;
 
-type TinyStore = MemoryStore<AnyChunkSet<TINY>>;
+type TinyStore = MemoryStore<ContentOnlyChunkSet<TINY>>;
 
 /// Distinct byte per file position so slices are position-sensitive.
 fn fill(len: usize) -> Vec<u8> {
@@ -218,14 +218,14 @@ struct FailAfter {
     countdown: Arc<Mutex<usize>>,
 }
 
-impl ChunkGet<AnyChunkSet<TINY>> for FailAfter {
+impl ChunkGet<ContentOnlyChunkSet<TINY>> for FailAfter {
     type Trust = Verified;
     type Error = ChunkStoreError;
 
     async fn get(
         &self,
         address: &ChunkAddress,
-    ) -> Result<Chunk<Verified, AnyChunkSet<TINY>>, ChunkStoreError> {
+    ) -> Result<Chunk<Verified, ContentOnlyChunkSet<TINY>>, ChunkStoreError> {
         {
             let mut left = self.countdown.lock().unwrap();
             if *left == 0 {
@@ -263,9 +263,9 @@ async fn walk_failures_surface_as_io_errors_on_both_drivers() {
 }
 
 /// Shared store handle: clones share one map, unlike the snapshot-cloning
-/// memory store.
+/// memory store. Writes stay wide; reads narrow through [`ContentGet`].
 #[derive(Clone, Default)]
-struct SharedStore(Arc<TinyStore>);
+struct SharedStore(Arc<MemoryStore<AnyChunkSet<TINY>>>);
 
 impl ChunkPut<AnyChunkSet<TINY>> for SharedStore {
     type Error = std::convert::Infallible;
@@ -317,7 +317,9 @@ async fn writer_roots_match_the_whole_buffer_split() {
         let (expected, _) = split_fixture::<TINY>(&data);
         assert_eq!(root, expected, "diverged at {len}");
 
-        let file = File::<_, Plain, TINY>::open(store, root).await.unwrap();
+        let file = File::<_, Plain, TINY>::open(ContentGet::new(store), root)
+            .await
+            .unwrap();
         let mut out = Vec::new();
         TokioReader::from(file.read().build())
             .read_to_end(&mut out)
@@ -346,7 +348,7 @@ async fn writer_shutdown_is_fused_and_later_writes_fail() {
 
 #[tokio::test]
 async fn writer_put_failures_surface_as_io_errors() {
-    let store = reject_all::<_, TINY>(TinyStore::default());
+    let store = reject_all::<_, TINY>(MemoryStore::<AnyChunkSet<TINY>>::default());
     let mut writer = TokioWriter::from(Split::<_, Plain, TINY>::new(store, PutWindow::DEFAULT));
     let data = fill(2 * TINY);
     let error = async {

--- a/crates/file/src/walk/engine.rs
+++ b/crates/file/src/walk/engine.rs
@@ -10,7 +10,7 @@ use core::task::{Context, Poll};
 
 use bytes::{Bytes, BytesMut};
 use nectar_primitives::DEFAULT_BODY_SIZE;
-use nectar_primitives::chunk::{AnyChunkSet, Chunk, ChunkAddress, ChunkOps, Verified};
+use nectar_primitives::chunk::{Chunk, ChunkAddress, ChunkOps, ContentOnlyChunkSet, Verified};
 use nectar_primitives::store::TrustedGet;
 
 use super::error::{ShapeError, WalkError};
@@ -41,7 +41,7 @@ impl<M: WalkMode> Node<M> {
 
 /// Completion payload; the future carries its node back, which is the whole
 /// of sequence routing.
-type Fetched<M, E, const B: usize> = (Node<M>, Result<Chunk<Verified, AnyChunkSet<B>>, E>);
+type Fetched<M, E, const B: usize> = (Node<M>, Result<Chunk<Verified, ContentOnlyChunkSet<B>>, E>);
 
 /// Boxed fetch future: `Send` on multi-threaded targets, unbounded on wasm32
 /// and under the `unsync` feature.
@@ -69,7 +69,7 @@ enum Drain {
 /// admission invariants.
 pub struct Walk<S, M, const B: usize = DEFAULT_BODY_SIZE>
 where
-    S: TrustedGet<AnyChunkSet<B>>,
+    S: TrustedGet<ContentOnlyChunkSet<B>>,
     M: WalkMode,
 {
     store: S,
@@ -101,7 +101,7 @@ where
 
 impl<S, M, const B: usize> Walk<S, M, B>
 where
-    S: TrustedGet<AnyChunkSet<B>> + Clone + 'static,
+    S: TrustedGet<ContentOnlyChunkSet<B>> + Clone + 'static,
     M: WalkMode,
 {
     /// Compile-time profile guard for the walk's span arithmetic.
@@ -388,7 +388,7 @@ where
     fn absorb(
         &mut self,
         node: Node<M>,
-        fetched: Result<Chunk<Verified, AnyChunkSet<B>>, S::Error>,
+        fetched: Result<Chunk<Verified, ContentOnlyChunkSet<B>>, S::Error>,
     ) -> Result<(), WalkError<S::Error>> {
         let leaf = node.span <= self.body;
         let key = node.key(self.range_start);
@@ -522,7 +522,7 @@ where
 
 impl<S, M, const B: usize> fmt::Debug for Walk<S, M, B>
 where
-    S: TrustedGet<AnyChunkSet<B>>,
+    S: TrustedGet<ContentOnlyChunkSet<B>>,
     M: WalkMode,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/file/src/walk/tests.rs
+++ b/crates/file/src/walk/tests.rs
@@ -10,7 +10,7 @@ use std::vec::Vec;
 
 use bytes::Bytes;
 use nectar_primitives::chunk::{
-    AnyChunk, AnyChunkSet, Chunk, ChunkAddress, ChunkOps, ContentChunk, Verified,
+    Chunk, ChunkAddress, ChunkOps, ContentChunk, ContentOnlyChunkSet, Verified,
 };
 use nectar_primitives::store::{ChunkGet, ChunkStoreError, TrustedGet};
 use nectar_testing::{run, yield_now};
@@ -24,7 +24,7 @@ const TINY: usize = 256;
 const TINY_U64: u64 = 256;
 const BRANCHES: usize = 8;
 
-type TinyRegistry = AnyChunkSet<TINY>;
+type TinyRegistry = ContentOnlyChunkSet<TINY>;
 type TinyChunk = Chunk<Verified, TinyRegistry>;
 type TinyWalk<S> = Walk<S, Plain, TINY>;
 
@@ -38,7 +38,7 @@ fn fill(len: usize) -> Vec<u8> {
 
 fn seal(content: ContentChunk<TINY>) -> (ChunkAddress, TinyChunk) {
     let address = *content.address();
-    let chunk = Chunk::from_envelope(AnyChunk::from(content)).unwrap();
+    let chunk = Chunk::from_envelope(content).unwrap();
     (address, chunk)
 }
 

--- a/crates/integration-tests/tests/file/alloc_probe.rs
+++ b/crates/integration-tests/tests/file/alloc_probe.rs
@@ -12,14 +12,14 @@
 use std::sync::Arc;
 
 use nectar_file::{Encrypted, File, RandomKeys};
-use nectar_primitives::chunk::AnyChunkSet;
+use nectar_primitives::chunk::ContentOnlyChunkSet;
 use nectar_primitives::store::MemoryStore;
 use nectar_testing::{AllocationInfo, measure_allocations, run, split_into};
 
 /// Body size of the default profile.
 const BODY: usize = nectar_primitives::DEFAULT_BODY_SIZE;
 
-type Store = Arc<MemoryStore<AnyChunkSet<BODY>>>;
+type Store = Arc<MemoryStore<ContentOnlyChunkSet<BODY>>>;
 
 /// Distinct byte per position so every chunk address is unique.
 fn fill(len: usize) -> Vec<u8> {

--- a/crates/integration-tests/tests/file/membound.rs
+++ b/crates/integration-tests/tests/file/membound.rs
@@ -23,7 +23,7 @@ use nectar_file::{
     SplitStats, WalkMode, WalkStats, Window,
 };
 use nectar_primitives::chunk::{AnyChunkSet, Chunk, ChunkAddress, Verified};
-use nectar_primitives::store::{ChunkGet, ChunkPut, ChunkStoreError};
+use nectar_primitives::store::{ChunkGet, ChunkPut, ChunkStoreError, ContentGet};
 use nectar_testing::{run, yield_now};
 
 /// Tiny body size: fan-out 8, so a few hundred leaves already build a deep
@@ -31,7 +31,7 @@ use nectar_testing::{run, yield_now};
 const TINY: usize = 256;
 const BRANCHES: usize = 8;
 
-type PlainFile = File<GaugeStore<TINY>, Plain, TINY>;
+type PlainFile = File<ContentGet<GaugeStore<TINY>>, Plain, TINY>;
 
 /// Distinct byte per file position so every node address is unique.
 fn fill(len: usize) -> Vec<u8> {
@@ -215,13 +215,13 @@ fn split_plain(
 }
 
 fn open_plain(store: GaugeStore<TINY>, root: ChunkAddress) -> PlainFile {
-    run(File::open(store, root)).unwrap()
+    run(File::open(ContentGet::new(store), root)).unwrap()
 }
 
 /// Drain a reader in order, pausing `pause` yields per segment to model a
 /// slow consumer.
 fn drain_reader<M: WalkMode>(
-    reader: &mut FileReader<GaugeStore<TINY>, M, TINY>,
+    reader: &mut FileReader<ContentGet<GaugeStore<TINY>>, M, TINY>,
     pause: usize,
 ) -> Vec<u8> {
     run(async {
@@ -611,6 +611,7 @@ mod encrypted {
 
     use nectar_file::{Encrypted, File, KeyError, KeySource, PutWindow, Split, SplitStats, Window};
     use nectar_primitives::chunk::encryption::{EncryptedChunkRef, EncryptionKey};
+    use nectar_primitives::store::ContentGet;
     use nectar_testing::run;
 
     use super::{
@@ -679,8 +680,8 @@ mod encrypted {
             );
 
             let store = built.fresh(2);
-            let file: File<GaugeStore<TINY>, Encrypted, TINY> =
-                run(File::open_encrypted(store.clone(), root)).unwrap();
+            let file: File<ContentGet<GaugeStore<TINY>>, Encrypted, TINY> =
+                run(File::open_encrypted(ContentGet::new(store.clone()), root)).unwrap();
             assert_eq!(store.gets.total(), 1, "open fetched more than the root");
             assert_eq!(file.len(), size as u64);
             let window = 3u16;

--- a/crates/integration-tests/tests/file/plain_alloc_probe.rs
+++ b/crates/integration-tests/tests/file/plain_alloc_probe.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 use nectar_file::{File, Plain, PutWindow, Split};
 use nectar_primitives::chunk::{AnyChunkSet, ChunkAddress};
-use nectar_primitives::store::MemoryStore;
+use nectar_primitives::store::{ContentGet, MemoryStore};
 use nectar_testing::{AllocationInfo, measure_allocations, run};
 
 /// Body size of the default profile.
@@ -53,7 +53,8 @@ fn probe(leaves: usize) -> (AllocationInfo, u64) {
 
     let ((read, fetches), info) = measure_allocations(|| {
         run(async {
-            let file: File<Store, Plain, BODY> = File::open(store, root).await.unwrap();
+            let file: File<ContentGet<Store>, Plain, BODY> =
+                File::open(ContentGet::new(store), root).await.unwrap();
             let mut reader = file.read().build();
             let mut read = 0usize;
             while let Some(segment) = reader.next_segment().await {

--- a/crates/integration-tests/tests/manifest/apply.rs
+++ b/crates/integration-tests/tests/manifest/apply.rs
@@ -9,7 +9,7 @@ use std::collections::BTreeMap;
 
 use bytes::Bytes;
 use nectar_manifest::{Builder, Changeset, Entry, Key, KeyId, Metadata, V1, apply};
-use nectar_primitives::{ChunkAddress, ChunkRef, MemoryStore};
+use nectar_primitives::{ChunkAddress, ChunkRef, ContentGet, MemoryStore};
 use nectar_testing::run;
 use proptest::prelude::*;
 
@@ -151,8 +151,8 @@ fn assert_apply_equals_rebuild(
         }
     }
 
-    let applied =
-        run(apply(&store, &root, &changeset)).map_err(|e| TestCaseError::fail(e.to_string()))?;
+    let applied = run(apply(&ContentGet::new(&store), &root, &changeset))
+        .map_err(|e| TestCaseError::fail(e.to_string()))?;
     let expected = rebuild(&map)?;
     prop_assert_eq!(applied, expected);
     Ok(())

--- a/crates/integration-tests/tests/manifest/bridge.rs
+++ b/crates/integration-tests/tests/manifest/bridge.rs
@@ -8,7 +8,7 @@
 use anyhow::{Result, anyhow, ensure};
 use bytes::Bytes;
 use nectar_manifest::{Builder, Entry, Key, Reader, build_files};
-use nectar_primitives::{ChunkRef, DEFAULT_BODY_SIZE, MemoryStore};
+use nectar_primitives::{ChunkRef, ContentGet, DEFAULT_BODY_SIZE, MemoryStore};
 use nectar_testing::{run, split_whole};
 
 const B: usize = DEFAULT_BODY_SIZE;
@@ -85,7 +85,7 @@ fn bridged_files_round_trip_byte_exact() -> Result<()> {
     ];
     let root = *run(build_files(&store, files))?.root();
 
-    let reader: Reader<_> = Reader::new(store);
+    let reader: Reader<_> = Reader::new(ContentGet::new(store));
     ensure!(
         run(reader.fetch(&root, &Key::from(&b"a/big"[..])))? == Some(big),
         "deep file round trip",

--- a/crates/integration-tests/tests/manifest/builder.rs
+++ b/crates/integration-tests/tests/manifest/builder.rs
@@ -10,7 +10,7 @@ use nectar_manifest::{
     BuildStats, Builder, Child, Entry, ForkPayload, ForkTable, Key, KeyId, Metadata, Node, NodeGet,
     Prefix, RootExtension, V1, build_files,
 };
-use nectar_primitives::{ChunkAddress, ChunkOps, ChunkRef, MemoryStore};
+use nectar_primitives::{ChunkAddress, ChunkOps, ChunkRef, ContentGet, MemoryStore};
 use nectar_testing::{run, split_whole};
 
 const fn ref32(byte: u8) -> ChunkRef {
@@ -90,7 +90,7 @@ fn builds_the_worked_example_byte_for_byte() -> Result<()> {
         "root payload",
     );
 
-    let decoded: Node = run(store.get_node(built.root()))?;
+    let decoded: Node = run(ContentGet::new(&store).get_node(built.root()))?;
     ensure!(decoded == worked_example_node()?, "decoded root");
     Ok(())
 }
@@ -181,7 +181,7 @@ fn the_empty_builder_publishes_the_empty_root() -> Result<()> {
     ensure!(built.stats().peak_open_nodes() == 1, "one open node");
     ensure!(built.stats().nodes_written() == 1, "one node written");
 
-    let node: Node = run(store.get_node(built.root()))?;
+    let node: Node = run(ContentGet::new(&store).get_node(built.root()))?;
     ensure!(node.is_empty(), "root is the empty map");
     Ok(())
 }
@@ -197,7 +197,7 @@ fn build_files_splits_through_bmt_and_references_the_stored_roots() -> Result<()
     ];
 
     let built = run(build_files(&store, files))?;
-    let node: Node = run(store.get_node(built.root()))?;
+    let node: Node = run(ContentGet::new(&store).get_node(built.root()))?;
 
     // Each file's manifest entry is its independent BMT root, and every file
     // chunk is present in the same store.
@@ -231,7 +231,7 @@ fn a_key_that_prefixes_another_shares_a_fork() -> Result<()> {
         .insert(Key::from(&b"ab"[..]), Entry::from(ref32(2)), None);
     let built = run(builder.build(&store))?;
 
-    let node: Node = run(store.get_node(built.root()))?;
+    let node: Node = run(ContentGet::new(&store).get_node(built.root()))?;
     let record = node.forks().get(b'a').context("missing fork a")?;
     ensure!(record.tail().is_empty(), "single-byte edge");
     // "a" terminates here and the trie continues to "ab".

--- a/crates/integration-tests/tests/manifest/counted.rs
+++ b/crates/integration-tests/tests/manifest/counted.rs
@@ -6,7 +6,7 @@
 use anyhow::{Result, ensure};
 use bytes::Bytes;
 use nectar_manifest::{Builder, Changeset, Entry, Key, Reader, V1, apply};
-use nectar_primitives::{ChunkAddress, ChunkRef, MemoryStore};
+use nectar_primitives::{ChunkAddress, ChunkRef, ContentGet, MemoryStore};
 use nectar_testing::run;
 
 fn ref_entry<F: nectar_manifest::Format>(fill: u8) -> Entry<F> {
@@ -55,7 +55,7 @@ fn build_then_read_round_trips_every_key() -> Result<()> {
     }
     let root = *run(builder.build(&store))?.root();
 
-    let reader = Reader::<MemoryStore, V1>::new(store);
+    let reader = Reader::<_, V1>::new(ContentGet::new(store));
     run(async {
         for (key, fill) in &all {
             let got = reader.get(&root, key).await?;
@@ -86,7 +86,7 @@ fn apply_matches_a_from_scratch_build() -> Result<()> {
     for (key, fill) in all.iter().skip(split) {
         changeset.put(key.clone(), ref_entry::<V1>(*fill), None);
     }
-    let applied = run(apply(&store, &base_root, &changeset))?;
+    let applied = run(apply(&ContentGet::new(&store), &base_root, &changeset))?;
 
     let scratch = build::<V1>(&all)?;
     ensure!(applied == scratch, "apply must match a from-scratch build");
@@ -101,7 +101,7 @@ fn an_inline_value_round_trips() -> Result<()> {
     builder.insert(Key::from(&b"index.html"[..]), value.clone(), None);
     let root = *run(builder.build(&store))?.root();
 
-    let reader = Reader::<MemoryStore, V1>::new(store);
+    let reader = Reader::<_, V1>::new(ContentGet::new(store));
     let got = run(reader.get(&root, &Key::from(&b"index.html"[..])))?;
     ensure!(got == Some(value), "inline value must round-trip");
     Ok(())

--- a/crates/integration-tests/tests/manifest/membound.rs
+++ b/crates/integration-tests/tests/manifest/membound.rs
@@ -16,9 +16,9 @@ use nectar_manifest::{
     ApplyError, BuildStats, Builder, Changeset, Entry, Key, KeyId, Metadata, Reader, V1, apply,
     generators, recanonicalize,
 };
-use nectar_primitives::store::{ChunkGet, MemoryStore};
+use nectar_primitives::store::{ChunkGet, ContentGet, MemoryStore};
 use nectar_primitives::{
-    Chunk, ChunkAddress, ChunkOps, ChunkRef, DEFAULT_BODY_SIZE, StandardChunkSet, Verified,
+    Chunk, ChunkAddress, ChunkOps, ChunkRef, ContentOnlyChunkSet, DEFAULT_BODY_SIZE, Verified,
 };
 use nectar_testing::run;
 use proptest::prelude::*;
@@ -32,7 +32,7 @@ fn entry(byte: u8) -> Entry<V1> {
 /// lookup fetched.
 #[derive(Debug, Default)]
 struct CountingStore {
-    inner: MemoryStore,
+    inner: ContentGet<MemoryStore>,
     gets: AtomicUsize,
 }
 
@@ -42,14 +42,14 @@ impl CountingStore {
     }
 }
 
-impl ChunkGet<StandardChunkSet> for CountingStore {
+impl ChunkGet<ContentOnlyChunkSet> for CountingStore {
     type Trust = Verified;
-    type Error = <MemoryStore as ChunkGet>::Error;
+    type Error = <ContentGet<MemoryStore> as ChunkGet<ContentOnlyChunkSet>>::Error;
 
     async fn get(
         &self,
         address: &ChunkAddress,
-    ) -> Result<Chunk<Verified, StandardChunkSet>, Self::Error> {
+    ) -> Result<Chunk<Verified, ContentOnlyChunkSet>, Self::Error> {
         self.gets.fetch_add(1, Ordering::Relaxed);
         ChunkGet::get(&self.inner, address).await
     }
@@ -180,7 +180,7 @@ fn a_million_key_manifest_is_depth_bounded() -> Result<()> {
     // small constant per level, so the fetch count is bounded independent of the
     // key count.
     let store = CountingStore {
-        inner,
+        inner: ContentGet::new(inner),
         gets: AtomicUsize::new(0),
     };
     let reader: Reader<_> = Reader::new(&store);
@@ -222,7 +222,7 @@ fn a_full_radix_256_node_of_heavy_records_packs_and_reads() -> Result<()> {
     );
     assert_single_chunk_nodes(&store)?;
 
-    let reader: Reader<_> = Reader::new(&store);
+    let reader: Reader<_> = Reader::new(ContentGet::new(&store));
     run(async {
         for first in [0u8, 1, 127, 200, 255] {
             let value = reader.get(built.root(), &Key::from(vec![first])).await?;
@@ -300,7 +300,11 @@ fn apply_over_a_spilled_node_matches_a_from_scratch_build() -> Result<()> {
         let byte = u8::try_from(first)?;
         changeset.put(Key::from(vec![byte]), entry(byte), Some(heavy()?));
     }
-    let applied = run(apply(&base_store, base.root(), &changeset))?;
+    let applied = run(apply(
+        &ContentGet::new(&base_store),
+        base.root(),
+        &changeset,
+    ))?;
 
     // A from-scratch build of the merged key set.
     let scratch_store = MemoryStore::default();
@@ -386,7 +390,7 @@ proptest! {
         for (key, fill, _) in &delta {
             changeset.put(Key::from(key.clone()), entry(*fill), None);
         }
-        match run(apply(&store, built.root(), &changeset)) {
+        match run(apply(&ContentGet::new(&store), built.root(), &changeset)) {
             Ok(_) => {
                 for len in chunk_lengths(&store) {
                     prop_assert!(len <= DEFAULT_BODY_SIZE, "applied node over one chunk body");

--- a/crates/integration-tests/tests/manifest/order.rs
+++ b/crates/integration-tests/tests/manifest/order.rs
@@ -7,8 +7,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::{Context, Result, ensure};
 use nectar_manifest::{Builder, Entry, Key, Reader, V1};
-use nectar_primitives::store::{ChunkGet, MemoryStore};
-use nectar_primitives::{Chunk, ChunkAddress, ChunkRef, StandardChunkSet, Verified};
+use nectar_primitives::store::{ChunkGet, ContentGet, MemoryStore};
+use nectar_primitives::{Chunk, ChunkAddress, ChunkRef, ContentOnlyChunkSet, Verified};
 use nectar_testing::run;
 
 /// A key set paired with the value each key carries.
@@ -25,7 +25,7 @@ fn entry(fill: u8) -> Entry<V1> {
 /// fetched.
 #[derive(Debug, Default)]
 struct CountingStore {
-    inner: MemoryStore,
+    inner: ContentGet<MemoryStore>,
     gets: AtomicUsize,
 }
 
@@ -39,14 +39,14 @@ impl CountingStore {
     }
 }
 
-impl ChunkGet<StandardChunkSet> for CountingStore {
+impl ChunkGet<ContentOnlyChunkSet> for CountingStore {
     type Trust = Verified;
-    type Error = <MemoryStore as ChunkGet>::Error;
+    type Error = <ContentGet<MemoryStore> as ChunkGet<ContentOnlyChunkSet>>::Error;
 
     async fn get(
         &self,
         address: &ChunkAddress,
-    ) -> Result<Chunk<Verified, StandardChunkSet>, Self::Error> {
+    ) -> Result<Chunk<Verified, ContentOnlyChunkSet>, Self::Error> {
         self.gets.fetch_add(1, Ordering::Relaxed);
         ChunkGet::get(&self.inner, address).await
     }
@@ -100,7 +100,7 @@ fn build(store: &MemoryStore, keys: &[(Key, u8)]) -> Result<ChunkAddress> {
 }
 
 /// The ground-truth ordering: every `(key, value)` a full walk yields.
-fn oracle(reader: &Reader<MemoryStore, V1>, root: &ChunkAddress) -> Result<Pairs> {
+fn oracle(reader: &Reader<ContentGet<MemoryStore>, V1>, root: &ChunkAddress) -> Result<Pairs> {
     let mut out = Vec::new();
     let mut cursor = run(reader.iter(root))?;
     while let Some(pair) = run(cursor.next())? {
@@ -114,7 +114,7 @@ fn rank_select_count_agree_with_a_full_walk_oracle() -> Result<()> {
     let store = MemoryStore::default();
     let keys = radix_keys(12, 3);
     let root = build(&store, &keys)?;
-    let reader = Reader::<MemoryStore, V1>::new(store);
+    let reader = Reader::<_, V1>::new(ContentGet::new(store));
     let all = oracle(&reader, &root)?;
     ensure!(all.len() == keys.len(), "oracle lost keys");
 
@@ -181,7 +181,7 @@ fn spilled_node_order_statistics_agree_with_the_oracle() -> Result<()> {
     let store = MemoryStore::default();
     let keys = wide_keys();
     let root = build(&store, &keys)?;
-    let reader = Reader::<MemoryStore, V1>::new(store);
+    let reader = Reader::<_, V1>::new(ContentGet::new(store));
     let all = oracle(&reader, &root)?;
     ensure!(all.len() == keys.len(), "oracle lost keys");
 
@@ -246,7 +246,7 @@ fn order_statistics_are_stable_under_shuffled_build_order() -> Result<()> {
     let b = build(&b_store, &reversed)?;
     ensure!(a == b, "shuffled build must root identically");
 
-    let reader = Reader::<MemoryStore, V1>::new(a_store);
+    let reader = Reader::<_, V1>::new(ContentGet::new(a_store));
     // A shuffled build is the same tree, so every rank and select is unchanged.
     run(async {
         for index in [0u64, 1, 250, 500, 999] {
@@ -264,7 +264,7 @@ fn paginate_matches_iter_skip_take() -> Result<()> {
     let store = MemoryStore::default();
     let keys = radix_keys(10, 3);
     let root = build(&store, &keys)?;
-    let reader = Reader::<MemoryStore, V1>::new(store);
+    let reader = Reader::<_, V1>::new(ContentGet::new(store));
     let all = oracle(&reader, &root)?;
 
     // Whole-manifest pagination is exactly iter().skip(offset).take(limit).
@@ -315,7 +315,7 @@ fn the_offset_seek_costs_depth_not_offset() -> Result<()> {
     let keys = wide_keys();
     let root = build(&inner, &keys)?;
     let store = CountingStore {
-        inner,
+        inner: ContentGet::new(inner),
         gets: AtomicUsize::new(0),
     };
     let reader = Reader::<CountingStore, V1>::new(store);

--- a/crates/integration-tests/tests/manifest/read_profile.rs
+++ b/crates/integration-tests/tests/manifest/read_profile.rs
@@ -6,7 +6,7 @@
 use anyhow::{Result, ensure};
 use bytes::Bytes;
 use nectar_manifest::{Builder, Changeset, Entry, Key, Reader, V1, V1Read, apply};
-use nectar_primitives::{ChunkAddress, ChunkRef, MemoryStore};
+use nectar_primitives::{ChunkAddress, ChunkRef, ContentGet, MemoryStore};
 use nectar_testing::run;
 
 fn ref_entry<F: nectar_manifest::Format>(fill: u8) -> Entry<F> {
@@ -67,7 +67,7 @@ fn build_then_read_round_trips_every_key_under_the_read_profile() -> Result<()> 
     }
     let root = *run(builder.build(&store))?.root();
 
-    let reader = Reader::<MemoryStore, V1Read>::new(store);
+    let reader = Reader::<_, V1Read>::new(ContentGet::new(store));
     run(async {
         for (key, fill) in windowed_keys() {
             let got = reader.get(&root, &key).await?;
@@ -103,7 +103,7 @@ fn apply_matches_a_from_scratch_build_under_the_read_profile() -> Result<()> {
     for (key, fill) in all.iter().skip(split) {
         changeset.put(key.clone(), ref_entry::<V1Read>(*fill), None);
     }
-    let applied = run(apply(&store, &base_root, &changeset))?;
+    let applied = run(apply(&ContentGet::new(&store), &base_root, &changeset))?;
 
     // A from-scratch build of the merged key set lands on the same root, byte
     // for byte: history independence holds under the read profile too.
@@ -114,7 +114,7 @@ fn apply_matches_a_from_scratch_build_under_the_read_profile() -> Result<()> {
     );
 
     // The applied manifest reads back the full key set.
-    let reader = Reader::<MemoryStore, V1Read>::new(store);
+    let reader = Reader::<_, V1Read>::new(ContentGet::new(store));
     run(async {
         for (key, fill) in &all {
             let got = reader.get(&applied, key).await?;
@@ -135,7 +135,7 @@ fn an_inline_value_round_trips_under_the_read_profile() -> Result<()> {
     builder.insert(Key::from(&b"index.html"[..]), value.clone(), None);
     let root = *run(builder.build(&store))?.root();
 
-    let reader = Reader::<MemoryStore, V1Read>::new(store);
+    let reader = Reader::<_, V1Read>::new(ContentGet::new(store));
     let got = run(reader.get(&root, &Key::from(&b"index.html"[..])))?;
     ensure!(got == Some(value), "inline value must round-trip");
     Ok(())

--- a/crates/integration-tests/tests/manifest/reader.rs
+++ b/crates/integration-tests/tests/manifest/reader.rs
@@ -7,15 +7,15 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use anyhow::{Result, ensure};
 use bytes::Bytes;
 use nectar_manifest::{Builder, Child, Entry, ForkTable, Key, Node, NodePut, Prefix, Reader, V1};
-use nectar_primitives::store::{ChunkGet, MemoryStore};
-use nectar_primitives::{Chunk, ChunkAddress, ChunkRef, StandardChunkSet, Verified};
+use nectar_primitives::store::{ChunkGet, ContentGet, MemoryStore};
+use nectar_primitives::{Chunk, ChunkAddress, ChunkRef, ContentOnlyChunkSet, Verified};
 use nectar_testing::run;
 
 /// A trusted store that counts every `get`, so a test can read off how many
 /// nodes a lookup fetched.
 #[derive(Debug, Default)]
 struct CountingStore {
-    inner: MemoryStore,
+    inner: ContentGet<MemoryStore>,
     gets: AtomicUsize,
 }
 
@@ -25,14 +25,14 @@ impl CountingStore {
     }
 }
 
-impl ChunkGet<StandardChunkSet> for CountingStore {
+impl ChunkGet<ContentOnlyChunkSet> for CountingStore {
     type Trust = Verified;
-    type Error = <MemoryStore as ChunkGet>::Error;
+    type Error = <ContentGet<MemoryStore> as ChunkGet<ContentOnlyChunkSet>>::Error;
 
     async fn get(
         &self,
         address: &ChunkAddress,
-    ) -> Result<Chunk<Verified, StandardChunkSet>, Self::Error> {
+    ) -> Result<Chunk<Verified, ContentOnlyChunkSet>, Self::Error> {
         self.gets.fetch_add(1, Ordering::Relaxed);
         ChunkGet::get(&self.inner, address).await
     }
@@ -73,7 +73,7 @@ fn a_lookup_fetches_depth_nodes_not_the_wide_level() -> Result<()> {
     ensure!(memory.len() == usize::from(width) + 1, "stored node count");
 
     let store = CountingStore {
-        inner: memory,
+        inner: ContentGet::new(memory),
         gets: AtomicUsize::new(0),
     };
     let reader: Reader<_> = Reader::new(&store);
@@ -141,7 +141,7 @@ fn every_builder_key_reads_back_through_referenced_hops() -> Result<()> {
     );
 
     let store = CountingStore {
-        inner: memory,
+        inner: ContentGet::new(memory),
         gets: AtomicUsize::new(0),
     };
     let reader: Reader<_> = Reader::new(&store);
@@ -201,7 +201,7 @@ fn an_absent_key_stops_at_the_first_unmatched_fork() -> Result<()> {
     let root = run(wide_manifest(&memory, width))?;
 
     let store = CountingStore {
-        inner: memory,
+        inner: ContentGet::new(memory),
         gets: AtomicUsize::new(0),
     };
     let reader: Reader<_> = Reader::new(&store);

--- a/crates/integration-tests/tests/manifest/scan.rs
+++ b/crates/integration-tests/tests/manifest/scan.rs
@@ -12,8 +12,8 @@ use anyhow::{Result, ensure};
 use arbitrary::Unstructured;
 use bytes::Bytes;
 use nectar_manifest::{Builder, Cursor, Entry, Format, Key, Reader, V1, generators};
-use nectar_primitives::store::{ChunkGet, MemoryStore};
-use nectar_primitives::{Chunk, ChunkAddress, StandardChunkSet, Verified};
+use nectar_primitives::store::{ChunkGet, ContentGet, MemoryStore};
+use nectar_primitives::{Chunk, ChunkAddress, ContentOnlyChunkSet, Verified};
 use nectar_testing::run;
 use proptest::prelude::*;
 
@@ -21,7 +21,7 @@ use proptest::prelude::*;
 /// nodes a walk fetched.
 #[derive(Debug, Default)]
 struct CountingStore {
-    inner: MemoryStore,
+    inner: ContentGet<MemoryStore>,
     gets: AtomicUsize,
 }
 
@@ -31,14 +31,14 @@ impl CountingStore {
     }
 }
 
-impl ChunkGet<StandardChunkSet> for CountingStore {
+impl ChunkGet<ContentOnlyChunkSet> for CountingStore {
     type Trust = Verified;
-    type Error = <MemoryStore as ChunkGet>::Error;
+    type Error = <ContentGet<MemoryStore> as ChunkGet<ContentOnlyChunkSet>>::Error;
 
     async fn get(
         &self,
         address: &ChunkAddress,
-    ) -> Result<Chunk<Verified, StandardChunkSet>, Self::Error> {
+    ) -> Result<Chunk<Verified, ContentOnlyChunkSet>, Self::Error> {
         self.gets.fetch_add(1, Ordering::Relaxed);
         ChunkGet::get(&self.inner, address).await
     }
@@ -105,7 +105,7 @@ fn iteration_fetches_nodes_not_values() -> Result<()> {
     ensure!(oracle.len() > nodes, "more keys than trie nodes");
 
     let store = CountingStore {
-        inner: memory,
+        inner: ContentGet::new(memory),
         gets: AtomicUsize::new(0),
     };
     let reader: Reader<_> = Reader::new(&store);
@@ -126,7 +126,7 @@ fn range_matches_the_oracle() -> Result<()> {
     let store = MemoryStore::default();
     let (root, oracle) = build(&store)?;
     let counting = CountingStore {
-        inner: store,
+        inner: ContentGet::new(store),
         gets: AtomicUsize::new(0),
     };
     let reader: Reader<_> = Reader::new(&counting);
@@ -152,7 +152,7 @@ fn range_matches_the_oracle() -> Result<()> {
 fn prefix_matches_the_oracle() -> Result<()> {
     let store = MemoryStore::default();
     let (root, oracle) = build(&store)?;
-    let reader: Reader<_> = Reader::new(&store);
+    let reader: Reader<_> = Reader::new(ContentGet::new(&store));
 
     run(async {
         for p in [
@@ -207,20 +207,20 @@ impl Future for YieldOnce {
 /// under the single-threaded test executor.
 #[derive(Debug, Default)]
 struct GatedStore {
-    inner: MemoryStore,
+    inner: ContentGet<MemoryStore>,
     inflight: AtomicUsize,
     peak: AtomicUsize,
     gets: AtomicUsize,
 }
 
-impl ChunkGet<StandardChunkSet> for GatedStore {
+impl ChunkGet<ContentOnlyChunkSet> for GatedStore {
     type Trust = Verified;
-    type Error = <MemoryStore as ChunkGet>::Error;
+    type Error = <ContentGet<MemoryStore> as ChunkGet<ContentOnlyChunkSet>>::Error;
 
     async fn get(
         &self,
         address: &ChunkAddress,
-    ) -> Result<Chunk<Verified, StandardChunkSet>, Self::Error> {
+    ) -> Result<Chunk<Verified, ContentOnlyChunkSet>, Self::Error> {
         self.gets.fetch_add(1, Ordering::Relaxed);
         let now = self
             .inflight
@@ -262,7 +262,7 @@ fn read_ahead_bounds_in_flight_and_matches_the_oracle() -> Result<()> {
     ensure!(nodes > 8, "manifest fans out into many referenced children");
 
     let store = GatedStore {
-        inner: memory,
+        inner: ContentGet::new(memory),
         ..Default::default()
     };
     let reader: Reader<_> = Reader::new(&store);
@@ -323,7 +323,7 @@ proptest! {
         }
         let built = run(builder.build(&store))
             .map_err(|e| TestCaseError::fail(e.to_string()))?;
-        let reader: Reader<_> = Reader::new(&store);
+        let reader: Reader<_> = Reader::new(ContentGet::new(&store));
         let got: Rows = {
             let mut cursor = run(reader.iter(built.root()))
                 .map_err(|e| TestCaseError::fail(e.to_string()))?;
@@ -376,7 +376,7 @@ proptest! {
         }
         let built = run(builder.build(&store))
             .map_err(|e| TestCaseError::fail(e.to_string()))?;
-        let reader: Reader<_> = Reader::new(&store);
+        let reader: Reader<_> = Reader::new(ContentGet::new(&store));
         let got: Rows = {
             let mut cursor = run(reader.iter(built.root()))
                 .map_err(|e| TestCaseError::fail(e.to_string()))?;
@@ -416,7 +416,7 @@ fn read_ahead_never_fetches_past_the_upper_bound() -> Result<()> {
     // hides the over-fetch, because the awaited fetch completes before the
     // executor ever polls the surplus futures.
     let store = GatedStore {
-        inner: memory,
+        inner: ContentGet::new(memory),
         ..Default::default()
     };
     let reader: Reader<_> = Reader::new(&store);
@@ -460,7 +460,7 @@ fn read_ahead_never_fetches_past_the_upper_bound() -> Result<()> {
 fn floor_matches_the_oracle() -> Result<()> {
     let store = MemoryStore::default();
     let (root, oracle) = build(&store)?;
-    let reader: Reader<_> = Reader::new(&store);
+    let reader: Reader<_> = Reader::new(ContentGet::new(&store));
 
     run(async {
         for target in [

--- a/crates/manifest-sim/src/perf.rs
+++ b/crates/manifest-sim/src/perf.rs
@@ -18,7 +18,7 @@ use nectar_testing::run;
 use nectar_manifest::{
     Builder, Changeset, Entry, Format, Key, KeyId, Metadata, Reader, V1, V1Read, apply,
 };
-use nectar_primitives::store::MemoryStore;
+use nectar_primitives::store::{ContentGet, MemoryStore};
 use nectar_primitives::{ChunkAddress, ChunkRef, StandardChunkSet};
 
 use crate::corpus::{Corpus, GenKey, tagged_addr, value_addr};
@@ -182,7 +182,7 @@ fn range_rounds<F: Format>(
 ) -> Result<(u64, u64, u64), Err> {
     let out = block_on_paused(async {
         let latency = LatencyStore::<StandardChunkSet>::new(store, RTT_UNIT);
-        let reader = Reader::<&LatencyStore<'_, StandardChunkSet>, F>::new(&latency);
+        let reader = Reader::<_, F>::new(ContentGet::new(&latency));
         let t0 = tokio::time::Instant::now();
         let mut cursor = reader.range(root, lo, hi).await?;
         let mut keys = 0u64;
@@ -203,7 +203,7 @@ fn prefix_rounds<F: Format>(
 ) -> Result<(u64, u64, u64), Err> {
     let out = block_on_paused(async {
         let latency = LatencyStore::<StandardChunkSet>::new(store, RTT_UNIT);
-        let reader = Reader::<&LatencyStore<'_, StandardChunkSet>, F>::new(&latency);
+        let reader = Reader::<_, F>::new(ContentGet::new(&latency));
         let t0 = tokio::time::Instant::now();
         let mut cursor = reader.prefix(root, prefix).await?;
         let mut keys = 0u64;
@@ -288,7 +288,7 @@ pub fn parallel_cursor_cells(
 /// Mean and max get-depth over a key sample, counted as store fetches per get.
 fn get_depth<F: Format>(
     store: &CountingStore<StandardChunkSet>,
-    reader: &Reader<&CountingStore<StandardChunkSet>, F>,
+    reader: &Reader<ContentGet<&CountingStore<StandardChunkSet>>, F>,
     root: &ChunkAddress,
     keys: &[GenKey],
     idxs: &[usize],
@@ -315,7 +315,7 @@ fn get_depth<F: Format>(
 /// format over one corpus.
 fn read_side<F: Format>(keys: &[GenKey]) -> Result<ReadProfileSide, Err> {
     let (store, root) = build_counting::<F>(keys)?;
-    let reader = Reader::<&CountingStore<StandardChunkSet>, F>::new(&store);
+    let reader = Reader::<_, F>::new(ContentGet::new(&store));
     let n = keys.len();
     let idxs = sample_indices(n, 256);
     let (depth_mean, depth_max) = get_depth::<F>(&store, &reader, &root, keys, &idxs)?;
@@ -341,7 +341,7 @@ fn read_side<F: Format>(keys: &[GenKey]) -> Result<ReadProfileSide, Err> {
                 meta_for::<F>(k),
             );
             let before = store.puts();
-            let _ = run(apply(&store, &root, &cs))?;
+            let _ = run(apply(&ContentGet::new(&store), &root, &cs))?;
             rewrites.push(store.puts().saturating_sub(before));
         }
     }
@@ -411,7 +411,7 @@ pub fn paginate_cells(
     keys: &[GenKey],
 ) -> Result<Vec<PaginateCell>, Err> {
     let (store, root) = build_counting::<V1>(keys)?;
-    let reader = Reader::<&CountingStore<StandardChunkSet>, V1>::new(&store);
+    let reader = Reader::<_, V1>::new(ContentGet::new(&store));
     let n = keys.len() as u64;
     let empty = Key::empty();
     let mut cells = Vec::new();
@@ -486,7 +486,7 @@ pub fn subtree_serve_cell(
         return Ok(None);
     };
     let (store, root) = build_counting::<V1>(keys)?;
-    let reader = Reader::<&CountingStore<StandardChunkSet>, V1>::new(&store);
+    let reader = Reader::<_, V1>::new(ContentGet::new(&store));
     let pk = Key::from(prefix.as_slice());
 
     let before = store.gets();

--- a/crates/manifest/src/apply.rs
+++ b/crates/manifest/src/apply.rs
@@ -772,7 +772,7 @@ mod tests {
     use core::future::Future;
     use core::pin::Pin;
 
-    use nectar_primitives::store::MemoryStore;
+    use nectar_primitives::store::{ContentGet, MemoryStore};
     use nectar_primitives::{ChunkAddress, ChunkRef};
     use nectar_testing::run;
 
@@ -789,7 +789,7 @@ mod tests {
     // Walk the counted tree, asserting every stored referenced-child count
     // equals the walked subtree size, and return the subtree's key count.
     fn walk_counts<'a>(
-        store: &'a MemoryStore,
+        store: &'a ContentGet<MemoryStore>,
         table: &'a ForkTable<V1>,
     ) -> Pin<Box<dyn Future<Output = u64> + 'a>> {
         Box::pin(async move {
@@ -820,7 +820,7 @@ mod tests {
 
     #[test]
     fn counted_child_counts_match_a_full_walk_oracle() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let mut builder = Builder::<V1>::new();
         let mut expected = 0u64;
         // Many wide sub-trees, each referenced (over the embedding budget), under
@@ -840,7 +840,7 @@ mod tests {
 
     #[test]
     fn counted_apply_matches_a_rebuild_and_preserves_counts() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         // A base that references a wide sub-tree under "a", then a changeset that
         // deepens it: apply must reproduce the from-scratch counted root.
         let mut base = Builder::<V1>::new();
@@ -859,7 +859,9 @@ mod tests {
         for x in 0u8..64 {
             scratch.insert(Key::from(&[b'a', x][..]), entry(x), None);
         }
-        let scratch_root = *run(scratch.build(&MemoryStore::default())).unwrap().root();
+        let scratch_root = *run(scratch.build(&ContentGet::new(MemoryStore::default())))
+            .unwrap()
+            .root();
         assert_eq!(applied, scratch_root, "apply must match a counted rebuild");
 
         // The applied tree's stored counts still equal the walked subtree sizes.
@@ -869,7 +871,7 @@ mod tests {
     }
 
     // Build a manifest from `keys` and return its root.
-    fn build(store: &MemoryStore, keys: &[(&[u8], u8)]) -> ChunkAddress {
+    fn build(store: &ContentGet<MemoryStore>, keys: &[(&[u8], u8)]) -> ChunkAddress {
         let mut builder = Builder::<V1>::new();
         for (key, fill) in keys {
             builder.insert(Key::from(*key), entry(*fill), None);
@@ -880,12 +882,12 @@ mod tests {
     // The root a from-scratch build of `keys` produces, for the byte-identity
     // check: a fresh store makes the address depend on the bytes alone.
     fn rebuilt(keys: &[(&[u8], u8)]) -> ChunkAddress {
-        build(&MemoryStore::default(), keys)
+        build(&ContentGet::new(MemoryStore::default()), keys)
     }
 
     #[test]
     fn an_empty_changeset_returns_the_root_unchanged() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let root = build(&store, &[(b"a", 1), (b"b", 2)]);
         let out = run(apply(&store, &root, &Changeset::<V1>::new())).unwrap();
         assert_eq!(out, root);
@@ -893,7 +895,7 @@ mod tests {
 
     #[test]
     fn a_single_insert_equals_a_rebuild() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let root = build(&store, &[(b"a", 1), (b"c", 3)]);
         let mut cs = Changeset::<V1>::new();
         cs.put(Key::from(&b"b"[..]), entry(2), None);
@@ -903,7 +905,7 @@ mod tests {
 
     #[test]
     fn a_batch_touching_one_ancestor_equals_a_rebuild() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let root = build(&store, &[(b"road", 1), (b"roam", 2)]);
         // Two inserts under the shared "ro" ancestor, rewritten in one pass.
         let mut cs = Changeset::<V1>::new();
@@ -918,7 +920,7 @@ mod tests {
 
     #[test]
     fn an_update_overwrites_in_place() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let root = build(&store, &[(b"a", 1), (b"b", 2)]);
         let mut cs = Changeset::<V1>::new();
         cs.put(Key::from(&b"a"[..]), entry(9), None);
@@ -928,7 +930,7 @@ mod tests {
 
     #[test]
     fn a_deletion_that_re_inlines_a_sibling_equals_a_rebuild() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         // "roam"/"road" share a "roa" branch; deleting one collapses the branch
         // back into a single compacted edge.
         let root = build(&store, &[(b"roam", 1), (b"road", 2), (b"x", 3)]);
@@ -940,7 +942,7 @@ mod tests {
 
     #[test]
     fn deleting_the_last_child_removes_the_fork() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let root = build(&store, &[(b"a", 1), (b"b", 2)]);
         let mut cs = Changeset::<V1>::new();
         cs.remove(Key::from(&b"a"[..]));
@@ -950,7 +952,7 @@ mod tests {
 
     #[test]
     fn deleting_an_absent_key_is_a_no_op() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let root = build(&store, &[(b"a", 1), (b"ab", 2)]);
         let mut cs = Changeset::<V1>::new();
         cs.remove(Key::from(&b"absent"[..]));
@@ -962,7 +964,7 @@ mod tests {
 
     #[test]
     fn a_split_within_an_edge_equals_a_rebuild() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         // "abcdef" sits behind a long compacted edge; inserting "abz" branches
         // inside that edge.
         let root = build(&store, &[(b"abcdef", 1)]);
@@ -974,7 +976,7 @@ mod tests {
 
     #[test]
     fn a_split_above_a_chain_boundary_recompacts_like_a_rebuild() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         // A 256-byte key sits behind a PLEN_MAX(255) chain: one 255-byte edge
         // over a child holding its last byte. Inserting a key that shares only
         // the first byte branches above that chain, shortening the existing edge
@@ -991,7 +993,7 @@ mod tests {
 
     #[test]
     fn a_split_above_a_multi_fork_chain_recompacts_like_a_rebuild() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         // A 511-byte key sits behind a PLEN_MAX(255) chain of three forks
         // (255 + 255 + 1). Inserting its one-byte prefix branches at the head,
         // leaving a 510-byte continuation run whose canonical shape is a
@@ -1008,7 +1010,7 @@ mod tests {
 
     #[test]
     fn a_split_above_a_deep_chain_recompacts_like_a_rebuild() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         // A 766-byte key is a four-fork chain (255 + 255 + 255 + 1); branching
         // at its head must re-segment the whole 765-byte run, not just the top
         // link.
@@ -1023,7 +1025,7 @@ mod tests {
 
     #[test]
     fn a_remove_beside_a_recapped_chain_insert_equals_a_rebuild() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         // Removing the only key while inserting a 257-byte sibling splits the
         // shared first byte, and the re-capped PLEN_MAX(255) chain boundary
         // lands one byte earlier than the inserted subtree's own cap: the tail
@@ -1041,7 +1043,7 @@ mod tests {
 
     #[test]
     fn the_empty_key_sets_and_clears_the_root_value() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let root = build(&store, &[(b"a", 1)]);
         let mut set = Changeset::<V1>::new();
         set.put(Key::empty(), entry(7), None);
@@ -1050,7 +1052,9 @@ mod tests {
         let mut expect = Builder::<V1>::new();
         expect.insert(Key::empty(), entry(7), None);
         expect.insert(Key::from(&b"a"[..]), entry(1), None);
-        let rebuilt_root = *run(expect.build(&MemoryStore::default())).unwrap().root();
+        let rebuilt_root = *run(expect.build(&ContentGet::new(MemoryStore::default())))
+            .unwrap()
+            .root();
         assert_eq!(with_root, rebuilt_root);
 
         let mut clear = Changeset::<V1>::new();
@@ -1061,7 +1065,7 @@ mod tests {
 
     #[test]
     fn a_collapse_past_the_prefix_bound_chains_like_a_rebuild() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         // Two keys sharing a 200-byte prefix, total length 260: the fork over
         // the shared run terminates one key and continues to the other. Deleting
         // the terminal leaves a single 260-byte key whose from-scratch shape is
@@ -1078,7 +1082,7 @@ mod tests {
 
     #[test]
     fn a_split_above_a_spilled_chain_link_equals_a_rebuild() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         // A 1708-byte key spills its top chain link (subtree body over
         // INLINE_MAX), so the shifted run continues behind a reference.
         let long = vec![0x07u8; 1708];
@@ -1091,7 +1095,7 @@ mod tests {
 
     #[test]
     fn a_delete_merging_into_a_spilled_chain_equals_a_rebuild() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         // Stripping the short key's terminal merges its edge into a continuation
         // that has spilled to a reference.
         let short = vec![0x07u8; 100];
@@ -1106,7 +1110,7 @@ mod tests {
 
     #[test]
     fn an_edge_at_its_forced_cut_absorbs_nothing() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         // The root edge fills PLEN_MAX exactly, so its boundary is the forced
         // cut a build places and its spilled continuation must stay put: a
         // stripped terminal here merges nothing.
@@ -1131,7 +1135,7 @@ mod tests {
 
     #[test]
     fn carried_metadata_survives_a_rebuild() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let meta = Metadata::new(KeyId::ContentType, Bytes::from_static(b"text/html")).unwrap();
         let root = build(&store, &[(b"a", 1)]);
         let mut cs = Changeset::<V1>::new();
@@ -1141,7 +1145,9 @@ mod tests {
         let mut expect = Builder::<V1>::new();
         expect.insert(Key::from(&b"a"[..]), entry(1), None);
         expect.insert(Key::from(&b"index.html"[..]), entry(2), Some(meta));
-        let rebuilt_root = *run(expect.build(&MemoryStore::default())).unwrap().root();
+        let rebuilt_root = *run(expect.build(&ContentGet::new(MemoryStore::default())))
+            .unwrap()
+            .root();
         assert_eq!(out, rebuilt_root);
     }
 }

--- a/crates/manifest/src/dx.rs
+++ b/crates/manifest/src/dx.rs
@@ -9,16 +9,16 @@
 
 use bytes::Bytes;
 use nectar_file::{CollectError, File, OpenError};
-use nectar_primitives::ChunkAddress;
 use nectar_primitives::store::{ChunkGet, MaybeSync};
+use nectar_primitives::{ChunkAddress, ContentOnlyChunkSet};
 
 use crate::format::Format;
 use crate::reader::{Reader, ReaderError};
 use crate::store::NodeGet;
 use crate::value::{Entry, Key};
 
-/// The store error of `S` over the standard registry.
-type StoreError<S> = <S as ChunkGet>::Error;
+/// The store error of `S` over the content-only registry.
+type StoreError<S> = <S as ChunkGet<ContentOnlyChunkSet>>::Error;
 
 /// A failure resolving a key or entry to its file bytes.
 #[non_exhaustive]
@@ -74,7 +74,7 @@ where
     /// ```
     /// use nectar_testing::run;
     /// use nectar_manifest::{build_files, Key, Reader};
-    /// use nectar_primitives::MemoryStore;
+    /// use nectar_primitives::{ContentGet, MemoryStore};
     ///
     /// let store = MemoryStore::default();
     /// let files = [(
@@ -83,7 +83,7 @@ where
     /// )];
     /// let root = *run(build_files(&store, files)).unwrap().root();
     ///
-    /// let reader: Reader<_> = Reader::new(store.clone());
+    /// let reader: Reader<_> = Reader::new(ContentGet::new(store.clone()));
     /// let page = run(reader.fetch(&root, &Key::from(&b"index.html"[..]))).unwrap();
     /// assert_eq!(page.as_deref(), Some(&b"<h1>hi</h1>"[..]));
     /// ```
@@ -102,7 +102,7 @@ where
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
-    use nectar_primitives::store::MemoryStore;
+    use nectar_primitives::store::{ContentGet, MemoryStore};
     use nectar_testing::run;
 
     use crate::builder::{Builder, build_files};
@@ -112,7 +112,7 @@ mod tests {
 
     #[test]
     fn publish_then_fetch_round_trips_file_bytes() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let files = [
             (
                 Key::from(&b"index.html"[..]),
@@ -139,7 +139,7 @@ mod tests {
 
     #[test]
     fn fetch_of_an_absent_key_is_none() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let files = [(Key::from(&b"a"[..]), Bytes::from_static(b"x"))];
         let root = *run(build_files(&store, files)).unwrap().root();
 
@@ -152,7 +152,7 @@ mod tests {
 
     #[test]
     fn read_returns_inline_bytes_directly() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let mut builder = Builder::new();
         let value: Entry = Entry::inline(Bytes::from_static(b"inline")).unwrap();
         builder.insert(Key::from(&b"k"[..]), value, None);

--- a/crates/manifest/src/encryption.rs
+++ b/crates/manifest/src/encryption.rs
@@ -33,7 +33,8 @@ use core::future::Future;
 use alloy_primitives::Keccak256;
 use nectar_primitives::store::{ChunkPut, MaybeSend, MaybeSync, TrustedGet};
 use nectar_primitives::{
-    Chunk, ChunkOps, ContentChunk, EncryptedChunkRef, EncryptionKey, transcrypt_in_place,
+    Chunk, ChunkOps, ContentChunk, ContentOnlyChunkSet, EncryptedChunkRef, EncryptionKey,
+    transcrypt_in_place,
 };
 
 use crate::codec::DecodeError;
@@ -149,7 +150,7 @@ impl<T: ChunkPut> EncryptedNodePut for T {}
 ///
 /// Blanket-implemented for every [`TrustedGet`]; the ref64 carries both the
 /// address to fetch and the key to decrypt with.
-pub trait EncryptedNodeGet: TrustedGet {
+pub trait EncryptedNodeGet: TrustedGet<ContentOnlyChunkSet> {
     /// Load the chunk at `reference`'s address and decrypt it with its key,
     /// materializing a spilled node's forks from its keyed segments so the
     /// caller always sees one logical node.
@@ -172,12 +173,12 @@ pub trait EncryptedNodeGet: TrustedGet {
     }
 }
 
-impl<T: TrustedGet> EncryptedNodeGet for T {}
+impl<T: TrustedGet<ContentOnlyChunkSet>> EncryptedNodeGet for T {}
 
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
-    use nectar_primitives::store::MemoryStore;
+    use nectar_primitives::store::{ContentGet, MemoryStore};
     use nectar_primitives::{ChunkAddress, ChunkRef};
     use nectar_testing::run;
 
@@ -269,7 +270,7 @@ mod tests {
 
     #[test]
     fn round_trips_through_a_memory_store() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let node = sample();
         let reference = run(store.put_node_encrypted(&node, SECRET)).unwrap();
         let opened: Node = run(store.get_node_encrypted(&reference)).unwrap();
@@ -281,7 +282,7 @@ mod tests {
         // The privacy rule made concrete: sealing a child yields a ref64 whose
         // key is exactly the child's derived key, so a parent that records the
         // ref64 carries that key in its own bytes.
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let child = sample();
         let reference = run(store.put_node_encrypted(&child, SECRET)).unwrap();
         assert_eq!(

--- a/crates/manifest/src/folder.rs
+++ b/crates/manifest/src/folder.rs
@@ -337,7 +337,7 @@ fn directory_index<F: Format>(path: &[u8], index: &[u8]) -> Key {
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
-    use nectar_primitives::store::MemoryStore;
+    use nectar_primitives::store::{ContentGet, MemoryStore};
     use nectar_primitives::{ChunkAddress, ChunkRef};
     use nectar_testing::run;
 
@@ -351,7 +351,7 @@ mod tests {
     }
 
     /// Build a manifest from `(key, value)` pairs and return its root address.
-    fn manifest(store: &MemoryStore, pairs: &[(&[u8], u8)]) -> ChunkAddress {
+    fn manifest(store: &ContentGet<MemoryStore>, pairs: &[(&[u8], u8)]) -> ChunkAddress {
         let mut builder = Builder::new();
         for (key, byte) in pairs {
             builder.insert(Key::from(&key[..]), entry(*byte), None);
@@ -360,7 +360,7 @@ mod tests {
     }
 
     /// Drain a listing into its entries.
-    fn entries(mut listing: Listing<'_, &MemoryStore>) -> Vec<DirEntry> {
+    fn entries(mut listing: Listing<'_, &ContentGet<MemoryStore>>) -> Vec<DirEntry> {
         let mut out = Vec::new();
         while let Some(item) = run(listing.next()).unwrap() {
             out.push(item);
@@ -383,7 +383,7 @@ mod tests {
 
     #[test]
     fn list_collapses_subdirectories_at_the_separator() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let root = manifest(
             &store,
             &[
@@ -409,7 +409,7 @@ mod tests {
 
     #[test]
     fn list_of_a_nested_directory_reads_one_level() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let root = manifest(
             &store,
             &[
@@ -427,7 +427,7 @@ mod tests {
 
     #[test]
     fn list_collapses_consecutive_subdirectories() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         // Two subdirectories in a row exercise the reseek-then-collapse-again
         // path: each named subtree must be skipped without swallowing the next.
         let root = manifest(
@@ -447,7 +447,7 @@ mod tests {
 
     #[test]
     fn list_skips_the_directory_key_itself() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         // A key exactly equal to the listed directory path is the directory
         // itself, not a child.
         let root = manifest(&store, &[(b"dir/", 0x01), (b"dir/a", 0x02)]);
@@ -485,7 +485,7 @@ mod tests {
         use crate::node::Node;
         use crate::store::NodePut;
 
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         // A referenced "mg/" subtree holding a nested subdirectory and a file,
         // so listing it delegates to the subtree root and still collapses and
         // reseeks in the subtree's own key space.
@@ -536,7 +536,7 @@ mod tests {
 
     #[test]
     fn serve_prefers_an_exact_key() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let root = manifest(&store, &[(b"a.html", 0x01)]);
         let reader: Reader<_> = Reader::new(&store);
         assert_eq!(
@@ -550,7 +550,7 @@ mod tests {
 
     #[test]
     fn serve_falls_back_to_the_index_document() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let mut builder = Builder::new();
         builder.insert(Key::from(&b"index.html"[..]), entry(0x01), None);
         builder.insert(Key::from(&b"docs/index.html"[..]), entry(0x02), None);
@@ -592,7 +592,7 @@ mod tests {
 
     #[test]
     fn serve_falls_back_to_the_error_document() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let mut builder = Builder::new();
         builder.insert(Key::from(&b"404.html"[..]), entry(0x09), None);
         builder.manifest_metadata(
@@ -612,7 +612,7 @@ mod tests {
 
     #[test]
     fn serve_missing_without_conventions_is_missing() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let root = manifest(&store, &[(b"a.html", 0x01)]);
         let reader: Reader<_> = Reader::new(&store);
         assert_eq!(
@@ -623,7 +623,7 @@ mod tests {
 
     #[test]
     fn website_reads_the_root_conventions() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let mut builder = Builder::new();
         builder.insert(Key::from(&b"index.html"[..]), entry(0x01), None);
         let mut meta = Metadata::new(
@@ -647,11 +647,11 @@ mod tests {
     use core::sync::atomic::{AtomicUsize, Ordering};
 
     use nectar_primitives::store::ChunkGet;
-    use nectar_primitives::{Chunk, StandardChunkSet, Verified};
+    use nectar_primitives::{Chunk, ContentOnlyChunkSet, Verified};
 
     #[derive(Debug, Default)]
     struct CountingStore {
-        inner: MemoryStore,
+        inner: ContentGet<MemoryStore>,
         gets: AtomicUsize,
     }
 
@@ -665,14 +665,14 @@ mod tests {
         }
     }
 
-    impl ChunkGet<StandardChunkSet> for CountingStore {
+    impl ChunkGet<ContentOnlyChunkSet> for CountingStore {
         type Trust = Verified;
-        type Error = <MemoryStore as ChunkGet>::Error;
+        type Error = <ContentGet<MemoryStore> as ChunkGet<ContentOnlyChunkSet>>::Error;
 
         async fn get(
             &self,
             address: &ChunkAddress,
-        ) -> Result<Chunk<Verified, StandardChunkSet>, Self::Error> {
+        ) -> Result<Chunk<Verified, ContentOnlyChunkSet>, Self::Error> {
             self.gets.fetch_add(1, Ordering::Relaxed);
             ChunkGet::get(&self.inner, address).await
         }

--- a/crates/manifest/src/order.rs
+++ b/crates/manifest/src/order.rs
@@ -531,7 +531,7 @@ fn select_fragment<F: Format>(steps: Vec<Ranked<F>>, index: &mut u64) -> Option<
 
 #[cfg(test)]
 mod tests {
-    use nectar_primitives::store::MemoryStore;
+    use nectar_primitives::store::{ContentGet, MemoryStore};
     use nectar_primitives::{ChunkAddress, ChunkRef, EncryptedChunkRef, EncryptionKey};
     use nectar_testing::run;
 
@@ -555,12 +555,12 @@ mod tests {
 
     #[test]
     fn the_root_entry_is_index_zero_and_lifts_every_rank() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let root_ext = RootExtension::new(Some(entry(9)), None);
         let mut forks = ForkTable::new();
         forks.insert(prefix(b"k"), entry(1).into(), None).unwrap();
         let root = run(store.put_node(&Node::<V1>::new(root_ext, forks))).unwrap();
-        let reader = Reader::<&MemoryStore, V1>::new(&store);
+        let reader = Reader::<&ContentGet<MemoryStore>, V1>::new(&store);
 
         // The empty key leads iteration at index 0; "k" follows at index 1.
         assert_eq!(
@@ -586,7 +586,7 @@ mod tests {
 
     // A root holding "a" and "z" as plain values with an encrypted five-key
     // subtree wedged between them under "m"; the count rides the fork record.
-    fn with_encrypted(store: &MemoryStore) -> ChunkAddress {
+    fn with_encrypted(store: &ContentGet<MemoryStore>) -> ChunkAddress {
         let mut forks = ForkTable::new();
         forks
             .insert(prefix(b"a"), entry(0xA1).into(), None)
@@ -614,9 +614,9 @@ mod tests {
 
     #[test]
     fn an_encrypted_subtree_is_counted_without_being_opened() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let root = with_encrypted(&store);
-        let reader = Reader::<&MemoryStore, V1>::new(&store);
+        let reader = Reader::<&ContentGet<MemoryStore>, V1>::new(&store);
 
         // Ranking past the encrypted subtree adds its stored count: "a", then its
         // five keys, all strictly before "z".
@@ -632,9 +632,9 @@ mod tests {
 
     #[test]
     fn descending_into_an_encrypted_subtree_is_an_error() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let root = with_encrypted(&store);
-        let reader = Reader::<&MemoryStore, V1>::new(&store);
+        let reader = Reader::<&ContentGet<MemoryStore>, V1>::new(&store);
 
         // A rank whose key funnels into the encrypted subtree cannot be answered.
         assert!(matches!(
@@ -650,9 +650,9 @@ mod tests {
 
     #[test]
     fn an_empty_manifest_has_no_keys() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let root = run(store.put_node(&Node::<V1>::empty())).unwrap();
-        let reader = Reader::<&MemoryStore, V1>::new(&store);
+        let reader = Reader::<&ContentGet<MemoryStore>, V1>::new(&store);
         assert_eq!(run(reader.rank(&root, &Key::from(&b"x"[..]))).unwrap(), 0);
         assert_eq!(run(reader.select(&root, 0)).unwrap(), None);
         let mut cursor = run(reader.paginate_prefix(&root, &Key::empty(), 0, 10)).unwrap();

--- a/crates/manifest/src/reader.rs
+++ b/crates/manifest/src/reader.rs
@@ -389,7 +389,7 @@ fn descend<F: Format>(table: &ForkTable<F>, key: &[u8], pos: usize) -> Descent<F
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
-    use nectar_primitives::store::MemoryStore;
+    use nectar_primitives::store::{ContentGet, MemoryStore};
     use nectar_primitives::{ChunkAddress, ChunkRef, EncryptedChunkRef, EncryptionKey};
     use nectar_testing::run;
 
@@ -411,7 +411,7 @@ mod tests {
 
     #[test]
     fn descends_embedded_and_referenced_children_alike() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
 
         // A leaf reached by reference, holding the key "img/logo.png".
         let mut leaf = ForkTable::new();
@@ -461,7 +461,7 @@ mod tests {
 
     #[test]
     fn a_fork_with_only_a_child_holds_no_value_at_its_own_prefix() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let mut child = ForkTable::new();
         child.insert(prefix(b"b"), entry(1).into(), None).unwrap();
         let mut forks = ForkTable::new();
@@ -481,7 +481,7 @@ mod tests {
 
     #[test]
     fn the_empty_key_reads_the_root_extension_value() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let root_ext = crate::node::RootExtension::new(Some(entry(9)), None);
         let root = run(store.put_node(&Node::new(root_ext, ForkTable::new()))).unwrap();
 
@@ -494,7 +494,7 @@ mod tests {
 
     #[test]
     fn inline_values_read_back_whole() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let value = Entry::inline(Bytes::from_static(b"hi")).unwrap();
         let mut forks = ForkTable::new();
         forks
@@ -511,7 +511,7 @@ mod tests {
 
     // A manifest whose "mg/" directory is a referenced subtree holding one key
     // "mg/logo.png", with "index.html" embedded in the root under "i".
-    fn subtree_sample(store: &MemoryStore) -> (ChunkAddress, ChunkAddress) {
+    fn subtree_sample(store: &ContentGet<MemoryStore>) -> (ChunkAddress, ChunkAddress) {
         let mut leaf = ForkTable::new();
         leaf.insert(prefix(b"logo.png"), entry(0xBB).into(), None)
             .unwrap();
@@ -538,7 +538,7 @@ mod tests {
 
     #[test]
     fn subtree_of_the_empty_prefix_is_the_root() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let (root, _) = subtree_sample(&store);
         let reader: Reader<_> = Reader::new(&store);
         assert_eq!(
@@ -549,7 +549,7 @@ mod tests {
 
     #[test]
     fn subtree_returns_the_referenced_child_covering_the_prefix() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let (root, leaf_ref) = subtree_sample(&store);
         let reader: Reader<_> = Reader::new(&store);
         // The prefix ends exactly at the referenced edge: the child is the
@@ -568,7 +568,7 @@ mod tests {
 
     #[test]
     fn subtree_of_a_mid_edge_prefix_with_no_boundary_is_none() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let (root, _) = subtree_sample(&store);
         let reader: Reader<_> = Reader::new(&store);
         // "mg/logo" lands within the leaf's "logo.png" edge, which terminates a
@@ -581,7 +581,7 @@ mod tests {
 
     #[test]
     fn subtree_of_an_embedded_prefix_is_none() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let (root, _) = subtree_sample(&store);
         let reader: Reader<_> = Reader::new(&store);
         // "index.html" lives embedded in the root chunk, with no chunk of its
@@ -594,7 +594,7 @@ mod tests {
 
     #[test]
     fn subtree_of_an_absent_prefix_is_none() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let (root, _) = subtree_sample(&store);
         let reader: Reader<_> = Reader::new(&store);
         assert_eq!(
@@ -605,7 +605,7 @@ mod tests {
 
     #[test]
     fn subtree_through_an_encrypted_child_is_an_error() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         // A "sec/" directory referenced through an encrypted (ref64) child: the
         // plain reader cannot open it, and a 32-byte reference cannot carry it.
         let mut forks = ForkTable::new();
@@ -636,7 +636,7 @@ mod tests {
 
     #[test]
     fn subtree_covers_exactly_the_prefix_key_set() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let (root, leaf_ref) = subtree_sample(&store);
         let reader: Reader<_> = Reader::new(&store);
         let sub = run(reader.subtree(&root, &Key::from(&b"mg/"[..])))
@@ -668,7 +668,7 @@ mod tests {
 
     #[test]
     fn a_missing_root_is_a_store_error() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let reader: Reader<_> = Reader::new(&store);
         let err = run(reader.get(&ChunkAddress::new([0; 32]), &Key::from(&b"x"[..]))).unwrap_err();
         assert!(matches!(err, ReaderError::Store(StoreError::Store(_))));

--- a/crates/manifest/src/scan.rs
+++ b/crates/manifest/src/scan.rs
@@ -680,14 +680,19 @@ pub(crate) fn successor(prefix: &[u8]) -> Option<Bytes> {
 mod tests {
     use core::task::Poll;
 
-    use nectar_primitives::store::{ChunkGet, ChunkStoreError, MemoryStore};
-    use nectar_primitives::{ChunkAddress, ChunkRef, EncryptedChunkRef, EncryptionKey, Verified};
+    use nectar_primitives::store::{
+        ChunkGet, ChunkStoreError, ContentGet, ContentGetError, MemoryStore,
+    };
+    use nectar_primitives::{
+        Chunk, ChunkAddress, ChunkRef, ContentOnlyChunkSet, EncryptedChunkRef, EncryptionKey,
+        Verified,
+    };
     use nectar_testing::run;
 
     use crate::bounded::Prefix;
     use crate::fork::{Child, ForkTable};
     use crate::node::Node;
-    use crate::store::{NodeChunk, NodePut};
+    use crate::store::NodePut;
     use crate::value::{Entry, Key};
 
     use super::*;
@@ -700,7 +705,7 @@ mod tests {
         Prefix::try_from(bytes).unwrap()
     }
 
-    fn drain(mut cursor: Cursor<'_, &MemoryStore>) -> Vec<(Vec<u8>, Entry)> {
+    fn drain(mut cursor: Cursor<'_, &ContentGet<MemoryStore>>) -> Vec<(Vec<u8>, Entry)> {
         let mut out = Vec::new();
         while let Some((key, value)) = run(cursor.next()).unwrap() {
             out.push((key.as_bytes().to_vec(), value));
@@ -710,7 +715,7 @@ mod tests {
 
     // A two-level manifest: a root fork "a" behind an embedded child holding
     // "aa"/"ab", and "b" behind a referenced leaf holding "ba".
-    fn sample(store: &MemoryStore) -> ChunkAddress {
+    fn sample(store: &ContentGet<MemoryStore>) -> ChunkAddress {
         let mut leaf = ForkTable::new();
         leaf.insert(prefix(b"a"), entry(0xBA).into(), None).unwrap();
         let leaf_ref = run(store.put_node(&Node::new(None, leaf))).unwrap();
@@ -738,7 +743,7 @@ mod tests {
 
     #[test]
     fn iteration_is_ascending_across_embedded_and_referenced_children() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let root = sample(&store);
         let reader: Reader<_> = Reader::new(&store);
         let got = drain(run(reader.iter(&root)).unwrap());
@@ -754,7 +759,7 @@ mod tests {
 
     #[test]
     fn the_root_value_is_the_empty_key_and_leads_iteration() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let root_ext = crate::node::RootExtension::new(Some(entry(9)), None);
         let mut forks = ForkTable::new();
         forks.insert(prefix(b"k"), entry(1).into(), None).unwrap();
@@ -766,7 +771,7 @@ mod tests {
 
     #[test]
     fn range_is_half_open() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let root = sample(&store);
         let reader: Reader<_> = Reader::new(&store);
         let got = drain(
@@ -781,7 +786,7 @@ mod tests {
 
     #[test]
     fn range_starting_between_keys_seeks_to_the_ceiling() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let root = sample(&store);
         let reader: Reader<_> = Reader::new(&store);
         let got =
@@ -791,7 +796,7 @@ mod tests {
 
     #[test]
     fn prefix_selects_one_subtree() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let root = sample(&store);
         let reader: Reader<_> = Reader::new(&store);
         let got = drain(run(reader.prefix(&root, &Key::from(&b"a"[..]))).unwrap());
@@ -803,7 +808,7 @@ mod tests {
 
     #[test]
     fn floor_resolves_present_absent_and_below_all_keys() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let root = sample(&store);
         let reader: Reader<_> = Reader::new(&store);
         // Exact hit.
@@ -838,7 +843,7 @@ mod tests {
 
     // A root holding "a" and "z" as plain values with an encrypted subtree
     // wedged between them under "m".
-    fn with_encrypted(store: &MemoryStore) -> ChunkAddress {
+    fn with_encrypted(store: &ContentGet<MemoryStore>) -> ChunkAddress {
         let mut forks = ForkTable::new();
         forks
             .insert(prefix(b"a"), entry(0xA1).into(), None)
@@ -854,7 +859,7 @@ mod tests {
 
     #[test]
     fn iteration_surfaces_an_encrypted_subtree_as_an_error() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let root = with_encrypted(&store);
         let reader: Reader<_> = Reader::new(&store);
         let mut cursor = run(reader.iter(&root)).unwrap();
@@ -872,7 +877,7 @@ mod tests {
 
     #[test]
     fn a_bound_short_of_the_encrypted_edge_prunes_it() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let root = with_encrypted(&store);
         let reader: Reader<_> = Reader::new(&store);
         // "m" is the exclusive upper bound, so the encrypted child at "m" is
@@ -884,7 +889,7 @@ mod tests {
 
     #[test]
     fn floor_past_an_encrypted_edge_reads_the_plain_key() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let root = with_encrypted(&store);
         let reader: Reader<_> = Reader::new(&store);
         // The floor of "z" is "z" itself; the encrypted subtree is left of the
@@ -897,7 +902,7 @@ mod tests {
 
     #[test]
     fn floor_landing_in_an_encrypted_subtree_cannot_be_read() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let root = with_encrypted(&store);
         let reader: Reader<_> = Reader::new(&store);
         // Every key at or below "n" that could be the floor lives in the
@@ -909,7 +914,7 @@ mod tests {
     }
 
     // A root value "a" plus a referenced leaf under "b" holding "ba".
-    fn with_ref(store: &MemoryStore) -> (ChunkAddress, ChunkAddress) {
+    fn with_ref(store: &ContentGet<MemoryStore>) -> (ChunkAddress, ChunkAddress) {
         let mut leaf = ForkTable::new();
         leaf.insert(prefix(b"a"), entry(0xBA).into(), None).unwrap();
         let leaf_addr = run(store.put_node(&Node::new(None, leaf))).unwrap();
@@ -946,14 +951,17 @@ mod tests {
     /// Store wrapper that yields once per get, so a `next` future can be
     /// observed mid-fetch.
     struct SlowStore {
-        inner: MemoryStore,
+        inner: ContentGet<MemoryStore>,
     }
 
-    impl ChunkGet for SlowStore {
+    impl ChunkGet<ContentOnlyChunkSet> for SlowStore {
         type Trust = Verified;
-        type Error = <MemoryStore as ChunkGet>::Error;
+        type Error = ContentGetError<ChunkStoreError>;
 
-        async fn get(&self, address: &ChunkAddress) -> Result<NodeChunk, Self::Error> {
+        async fn get(
+            &self,
+            address: &ChunkAddress,
+        ) -> Result<Chunk<Verified, ContentOnlyChunkSet>, Self::Error> {
             yield_once().await;
             ChunkGet::get(&self.inner, address).await
         }
@@ -961,7 +969,7 @@ mod tests {
 
     #[test]
     fn a_dropped_next_future_loses_no_keys() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let (root, _) = with_ref(&store);
         let slow = SlowStore { inner: store };
         let reader: Reader<_> = Reader::new(&slow);
@@ -989,21 +997,24 @@ mod tests {
 
     /// Store wrapper that fails the first `failures` gets of one address.
     struct FlakyStore {
-        inner: MemoryStore,
+        inner: ContentGet<MemoryStore>,
         deny: ChunkAddress,
         failures: std::sync::Mutex<usize>,
     }
 
-    impl ChunkGet for FlakyStore {
+    impl ChunkGet<ContentOnlyChunkSet> for FlakyStore {
         type Trust = Verified;
-        type Error = <MemoryStore as ChunkGet>::Error;
+        type Error = ContentGetError<ChunkStoreError>;
 
-        async fn get(&self, address: &ChunkAddress) -> Result<NodeChunk, Self::Error> {
+        async fn get(
+            &self,
+            address: &ChunkAddress,
+        ) -> Result<Chunk<Verified, ContentOnlyChunkSet>, Self::Error> {
             if *address == self.deny {
                 let mut left = self.failures.lock().unwrap();
                 if *left > 0 {
                     *left = left.saturating_sub(1);
-                    return Err(ChunkStoreError::not_found(address));
+                    return Err(ContentGetError::Inner(ChunkStoreError::not_found(address)));
                 }
             }
             ChunkGet::get(&self.inner, address).await
@@ -1012,7 +1023,7 @@ mod tests {
 
     #[test]
     fn a_failed_resolve_replays_the_same_descent() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let (root, leaf) = with_ref(&store);
         let flaky = FlakyStore {
             inner: store,

--- a/crates/manifest/src/store.rs
+++ b/crates/manifest/src/store.rs
@@ -6,14 +6,16 @@
 //! path never re-hashes. The write path seals a freshly built payload into a
 //! [`Verified`] content chunk, deriving the address rather than trusting one.
 //!
-//! [`NodeGet`] and [`NodePut`] reuse the primitives store traits unchanged;
-//! they are the seam the streaming builder and reader both sit on.
+//! [`NodeGet`] and [`NodePut`] reuse the primitives store traits; the read
+//! seam binds the content-only registry, so a non-content chunk is rejected
+//! at decode rather than decoded as a node.
 
 use core::future::Future;
 
 use nectar_primitives::store::{BoxedError, ChunkPut, MaybeSend, MaybeSync, TrustedGet};
 use nectar_primitives::{
-    Chunk, ChunkAddress, ChunkOps, ContentChunk, EncryptionKey, Verified, transcrypt_in_place,
+    Chunk, ChunkAddress, ChunkOps, ContentChunk, ContentOnlyChunkSet, EncryptionKey, Verified,
+    transcrypt_in_place,
 };
 
 use crate::codec::{DecodeError, DecodedChunk, EncodeError};
@@ -24,6 +26,10 @@ use crate::node::Node;
 /// A manifest node sealed as a verified content chunk over the standard
 /// registry, whose content-chunk member carries the node payload.
 pub type NodeChunk = Chunk<Verified>;
+
+/// A node chunk read back through the content-only registry: the fetch
+/// itself certifies `address == BMT(body)`.
+type FetchedChunk = Chunk<Verified, ContentOnlyChunkSet>;
 
 /// A node write or read failure across the store seam.
 #[non_exhaustive]
@@ -72,7 +78,7 @@ impl<F: Format> Node<F> {
 ///
 /// Blanket-implemented for every [`TrustedGet`]; the `Trust = Verified`
 /// bound is what lets [`get_node`](Self::get_node) skip re-hashing.
-pub trait NodeGet: TrustedGet {
+pub trait NodeGet: TrustedGet<ContentOnlyChunkSet> {
     /// Load and decode the node at `address`, materializing a spilled node's
     /// forks from its segments so the caller always sees one logical node.
     ///
@@ -90,7 +96,7 @@ pub trait NodeGet: TrustedGet {
     }
 }
 
-impl<T: TrustedGet> NodeGet for T {}
+impl<T: TrustedGet<ContentOnlyChunkSet>> NodeGet for T {}
 
 /// The greatest legal segment-directory depth (spec 5.4); a deeper nesting is a
 /// malformed image, not a tree this format ever produces.
@@ -99,7 +105,7 @@ const MAX_DIR_DEPTH: usize = 2;
 /// Load the node at `address`, reassembling a segmented node's forks in place.
 async fn materialize_node<S, F>(store: &S, address: &ChunkAddress) -> Result<Node<F>, StoreError>
 where
-    S: TrustedGet + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
     F: Format,
 {
     let (node, _) = materialize_traced::<S, F>(store, address, None).await?;
@@ -117,7 +123,7 @@ pub(crate) async fn materialize_traced<S, F>(
     key: Option<&EncryptionKey>,
 ) -> Result<(Node<F>, Vec<ChunkAddress>), StoreError>
 where
-    S: TrustedGet + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
     F: Format,
 {
     let chunk = store.get(address).await.map_err(StoreError::store)?;
@@ -144,7 +150,7 @@ where
 
 /// Decode a certified chunk, decrypting first when a key travels with it.
 fn decode_fetched<F: Format>(
-    chunk: &NodeChunk,
+    chunk: &FetchedChunk,
     key: Option<&EncryptionKey>,
 ) -> Result<DecodedChunk<F>, DecodeError> {
     key.map_or_else(
@@ -168,7 +174,7 @@ async fn collect_segment_forks<S, F>(
     trace: &mut Vec<ChunkAddress>,
 ) -> Result<ForkTable<F>, StoreError>
 where
-    S: TrustedGet + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
     F: Format,
 {
     if depth >= MAX_DIR_DEPTH {
@@ -238,7 +244,7 @@ impl<T: ChunkPut> NodePut for T {}
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
-    use nectar_primitives::store::MemoryStore;
+    use nectar_primitives::store::{ContentGet, MemoryStore};
     use nectar_primitives::{ChunkAddress, ChunkRef, DefaultContentChunk};
     use nectar_testing::run;
 
@@ -273,7 +279,7 @@ mod tests {
 
     #[test]
     fn round_trips_through_a_memory_store() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let node = sample();
 
         let address = run(store.put_node(&node)).unwrap();
@@ -301,7 +307,7 @@ mod tests {
 
     #[test]
     fn missing_address_is_a_store_error() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let err = run(store.get_node::<crate::V1>(&ChunkAddress::new([0; 32]))).unwrap_err();
         assert!(matches!(err, StoreError::Store(_)));
     }

--- a/crates/manifest/src/traverse.rs
+++ b/crates/manifest/src/traverse.rs
@@ -331,8 +331,10 @@ mod tests {
     use bytes::Bytes;
     #[cfg(not(feature = "encryption"))]
     use nectar_primitives::EncryptedChunkRef;
-    use nectar_primitives::store::{ChunkGet, ChunkPut, MemoryStore};
-    use nectar_primitives::{Chunk, ChunkAddress, ChunkOps, ChunkRef, ContentChunk};
+    use nectar_primitives::store::{ChunkGet, ChunkPut, ContentGet, MemoryStore};
+    use nectar_primitives::{
+        Chunk, ChunkAddress, ChunkOps, ChunkRef, ContentChunk, ContentOnlyChunkSet, Verified,
+    };
 
     use nectar_testing::run;
 
@@ -361,7 +363,7 @@ mod tests {
     }
 
     /// Seal a raw payload as a content chunk and store it.
-    fn put_raw(store: &MemoryStore, payload: Vec<u8>) -> ChunkAddress {
+    fn put_raw(store: &ContentGet<MemoryStore>, payload: Vec<u8>) -> ChunkAddress {
         let content = ContentChunk::new(payload).unwrap();
         let chunk: NodeChunk = Chunk::from_envelope(content.into()).unwrap();
         let address = *chunk.address();
@@ -384,7 +386,7 @@ mod tests {
 
     // A two-level manifest: a root fork "a" behind an embedded child holding
     // "aa"/"ab", and "b" behind a referenced leaf holding "ba".
-    fn sample(store: &MemoryStore) -> (ChunkAddress, ChunkAddress) {
+    fn sample(store: &ContentGet<MemoryStore>) -> (ChunkAddress, ChunkAddress) {
         let mut leaf = ForkTable::new();
         leaf.insert(prefix(b"a"), entry(0xBA).into(), None).unwrap();
         let leaf_addr = run(store.put_node(&Node::new(None, leaf))).unwrap();
@@ -413,7 +415,7 @@ mod tests {
 
     #[test]
     fn streams_nodes_and_entry_addresses_depth_first() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let (root, leaf) = sample(&store);
         let reader: Reader<_> = Reader::new(&store);
         let got = drain(reader.addresses(&root));
@@ -422,7 +424,7 @@ mod tests {
 
     #[test]
     fn the_root_extension_entry_leads_the_closure() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let root_ext = RootExtension::new(Some(entry(9)), None);
         let mut forks = ForkTable::new();
         forks.insert(prefix(b"k"), entry(1).into(), None).unwrap();
@@ -433,7 +435,7 @@ mod tests {
 
     #[test]
     fn inline_entries_contribute_no_address() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let mut forks = ForkTable::new();
         forks
             .insert(
@@ -449,7 +451,7 @@ mod tests {
 
     #[test]
     fn a_ref64_entry_yields_its_address() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let mut forks = ForkTable::new();
         forks
             .insert(
@@ -469,7 +471,7 @@ mod tests {
 
     #[test]
     fn a_shared_subtree_repeats_at_each_reference() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let mut leaf = ForkTable::new();
         leaf.insert(prefix(b"x"), entry(0x33).into(), None).unwrap();
         let leaf_addr = run(store.put_node(&Node::new(None, leaf))).unwrap();
@@ -493,7 +495,7 @@ mod tests {
 
     #[test]
     fn a_spilled_node_streams_its_segment_chunks() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let mut builder = Builder::<V1>::new();
         for byte in 0u8..=255 {
             builder.insert(Key::from(&[byte][..]), entry(byte), None);
@@ -501,7 +503,7 @@ mod tests {
         let root = *run(builder.build(&store)).unwrap().root();
 
         // The expected segment addresses, straight off the root chunk's wire.
-        let chunk = store.get(&root).unwrap();
+        let chunk = store.inner().get(&root).unwrap();
         let decoded = Node::<V1>::decode_chunk(chunk.envelope().data()).unwrap();
         let crate::codec::DecodedChunk::Segmented(_, dir) = decoded else {
             panic!("a 256-fork root must spill");
@@ -518,7 +520,7 @@ mod tests {
 
         // Completeness: the streamed chunk set is exactly what the build
         // stored, plus the entry addresses that live outside the store.
-        let stored: HashSet<ChunkAddress> = store.into_chunks().into_keys().collect();
+        let stored: HashSet<ChunkAddress> = store.into_inner().into_chunks().into_keys().collect();
         let streamed: HashSet<ChunkAddress> = got.iter().copied().collect();
         let entries: HashSet<ChunkAddress> = (0u8..=255).map(addr).collect();
         assert_eq!(
@@ -532,7 +534,7 @@ mod tests {
 
     #[test]
     fn keyed_descriptors_under_a_plain_arrival_are_rejected() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let dir = SegmentDir {
             wide: true,
             descriptors: vec![SegDesc {
@@ -557,7 +559,7 @@ mod tests {
     #[cfg(not(feature = "encryption"))]
     #[test]
     fn an_encrypted_child_ends_the_walk_and_stays_an_error() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let mut forks = ForkTable::new();
         forks
             .insert(prefix(b"a"), entry(0xA1).into(), None)
@@ -599,12 +601,12 @@ mod tests {
     }
 
     struct SlowInner {
-        store: MemoryStore,
+        store: ContentGet<MemoryStore>,
         fetched: std::sync::Mutex<Vec<ChunkAddress>>,
     }
 
     impl SlowStore {
-        fn new(store: MemoryStore) -> Self {
+        fn new(store: ContentGet<MemoryStore>) -> Self {
             Self {
                 inner: std::sync::Arc::new(SlowInner {
                     store,
@@ -633,11 +635,14 @@ mod tests {
         .await;
     }
 
-    impl ChunkGet for SlowStore {
-        type Trust = nectar_primitives::Verified;
-        type Error = <MemoryStore as ChunkGet>::Error;
+    impl ChunkGet<ContentOnlyChunkSet> for SlowStore {
+        type Trust = Verified;
+        type Error = <ContentGet<MemoryStore> as ChunkGet<ContentOnlyChunkSet>>::Error;
 
-        async fn get(&self, address: &ChunkAddress) -> Result<NodeChunk, Self::Error> {
+        async fn get(
+            &self,
+            address: &ChunkAddress,
+        ) -> Result<Chunk<Verified, ContentOnlyChunkSet>, Self::Error> {
             self.inner.fetched.lock().unwrap().push(*address);
             yield_once().await;
             ChunkGet::get(&self.inner.store, address).await
@@ -646,7 +651,7 @@ mod tests {
 
     #[test]
     fn a_dropped_next_future_loses_no_addresses() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let (root, leaf) = sample(&store);
         let slow = SlowStore::new(store);
         let reader: Reader<_> = Reader::new(&slow);
@@ -668,7 +673,7 @@ mod tests {
 
     #[test]
     fn the_walk_fetches_exactly_the_chunks_it_names() {
-        let store = MemoryStore::default();
+        let store = ContentGet::new(MemoryStore::default());
         let (root, leaf) = sample(&store);
         let slow = SlowStore::new(store);
         let reader: Reader<_> = Reader::new(&slow);
@@ -695,7 +700,7 @@ mod tests {
 
         #[test]
         fn a_plain_parent_opens_its_encrypted_child() {
-            let store = MemoryStore::default();
+            let store = ContentGet::new(MemoryStore::default());
             let mut child = Node::empty();
             child
                 .forks_mut()
@@ -720,7 +725,7 @@ mod tests {
 
         #[test]
         fn an_encrypted_root_streams_the_same_closure_shape() {
-            let store = MemoryStore::default();
+            let store = ContentGet::new(MemoryStore::default());
             run(async {
                 let mut child = Node::empty();
                 child
@@ -772,7 +777,7 @@ mod tests {
 
         #[test]
         fn an_encrypted_spilled_node_streams_its_keyed_segments() {
-            let store = MemoryStore::default();
+            let store = ContentGet::new(MemoryStore::default());
             let mut table = ForkTable::new();
             table.insert(prefix(b"a"), entry(1).into(), None).unwrap();
             table.insert(prefix(b"b"), entry(2).into(), None).unwrap();
@@ -803,7 +808,7 @@ mod tests {
 
         #[test]
         fn bare_descriptors_under_an_encrypted_arrival_are_rejected() {
-            let store = MemoryStore::default();
+            let store = ContentGet::new(MemoryStore::default());
             let dir = SegmentDir {
                 wide: false,
                 descriptors: vec![SegDesc {

--- a/crates/mantaray/src/cursor.rs
+++ b/crates/mantaray/src/cursor.rs
@@ -23,7 +23,7 @@ use futures::stream::FuturesUnordered;
 use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{ChunkAddress, ChunkOps};
 use nectar_primitives::store::TrustedGet;
-use nectar_primitives::{AnyChunkSet, Chunk, Verified};
+use nectar_primitives::{Chunk, ContentOnlyChunkSet, Verified};
 
 use crate::entry::Entry;
 use crate::error::CursorError;
@@ -108,7 +108,7 @@ enum Slot {
 type Fetched<const B: usize> = (
     u64,
     Pending,
-    Result<Chunk<Verified, AnyChunkSet<B>>, CursorError>,
+    Result<Chunk<Verified, ContentOnlyChunkSet<B>>, CursorError>,
 );
 
 /// Boxed fetch future: `Send` on native, unbounded on wasm32 so `!Send`
@@ -144,7 +144,7 @@ struct TrieWalk<S, const BS: usize> {
 
 impl<S, const BS: usize> TrieWalk<S, BS>
 where
-    S: TrustedGet<AnyChunkSet<BS>> + Clone + 'static,
+    S: TrustedGet<ContentOnlyChunkSet<BS>> + Clone + 'static,
 {
     fn new(
         store: S,
@@ -273,7 +273,7 @@ where
         &mut self,
         id: u64,
         pending: Pending,
-        fetched: Result<Chunk<Verified, AnyChunkSet<BS>>, CursorError>,
+        fetched: Result<Chunk<Verified, ContentOnlyChunkSet<BS>>, CursorError>,
     ) {
         self.in_flight_count = self.in_flight_count.saturating_sub(1);
         let outcome = match fetched {
@@ -365,7 +365,7 @@ fn narrow_after(after: Option<&[u8]>, edge: &[u8]) -> Option<Option<Vec<u8>>> {
 /// editor.put("a.txt", ChunkAddress::from([1u8; 32]));
 /// editor.put("b/c.txt", ChunkAddress::from([2u8; 32]));
 /// let (root, store) = editor.commit().await.unwrap();
-/// let mut cursor = Cursor::new(store, root).with_prefix("b/");
+/// let mut cursor = Cursor::new(ContentGet::new(store), root).with_prefix("b/");
 /// let entry = cursor.next().await.unwrap().unwrap();
 /// assert_eq!(entry.path(), b"b/c.txt");
 /// assert!(cursor.next().await.is_none());
@@ -432,7 +432,7 @@ impl<S, const BS: usize> Cursor<S, BS> {
 
 impl<S, const BS: usize> Cursor<S, BS>
 where
-    S: TrustedGet<AnyChunkSet<BS>> + Clone + 'static,
+    S: TrustedGet<ContentOnlyChunkSet<BS>> + Clone + 'static,
 {
     /// Deliver the next entry in path order.
     ///
@@ -484,7 +484,7 @@ where
 
 impl<S, const BS: usize> Stream for Cursor<S, BS>
 where
-    S: TrustedGet<AnyChunkSet<BS>> + Clone + Unpin + 'static,
+    S: TrustedGet<ContentOnlyChunkSet<BS>> + Clone + Unpin + 'static,
 {
     type Item = Result<Entry, CursorError>;
 
@@ -546,7 +546,7 @@ impl<S, const BS: usize> AddressStream<S, BS> {
 
 impl<S, const BS: usize> AddressStream<S, BS>
 where
-    S: TrustedGet<AnyChunkSet<BS>> + Clone + 'static,
+    S: TrustedGet<ContentOnlyChunkSet<BS>> + Clone + 'static,
 {
     /// Deliver the next address in depth-first order.
     ///
@@ -585,7 +585,7 @@ where
 
 impl<S, const BS: usize> Stream for AddressStream<S, BS>
 where
-    S: TrustedGet<AnyChunkSet<BS>> + Clone + Unpin + 'static,
+    S: TrustedGet<ContentOnlyChunkSet<BS>> + Clone + Unpin + 'static,
 {
     type Item = Result<ChunkAddress, CursorError>;
 
@@ -611,7 +611,7 @@ mod tests {
 
     use bytes::Bytes;
     use nectar_primitives::chunk::{ChunkRef, ContentChunk};
-    use nectar_primitives::store::{ChunkGet, ChunkPut, MemoryStore};
+    use nectar_primitives::store::{ChunkGet, ChunkPut, ContentGet, MemoryStore};
     use nectar_primitives::{EncryptedChunkRef, EncryptionKey, EntryRef, StandardChunkSet};
     use nectar_testing::run;
 
@@ -663,7 +663,7 @@ mod tests {
 
     fn collect_entries<S>(mut cursor: Cursor<S>) -> Vec<Entry>
     where
-        S: TrustedGet<AnyChunkSet<DEFAULT_BODY_SIZE>> + Clone + 'static,
+        S: TrustedGet<ContentOnlyChunkSet<DEFAULT_BODY_SIZE>> + Clone + 'static,
     {
         run(async {
             let mut out = Vec::new();
@@ -676,7 +676,7 @@ mod tests {
 
     fn collect_until_err<S>(mut cursor: Cursor<S>) -> (Vec<Entry>, Option<CursorError>)
     where
-        S: TrustedGet<AnyChunkSet<DEFAULT_BODY_SIZE>> + Clone + 'static,
+        S: TrustedGet<ContentOnlyChunkSet<DEFAULT_BODY_SIZE>> + Clone + 'static,
     {
         run(async {
             let mut out = Vec::new();
@@ -692,7 +692,7 @@ mod tests {
 
     fn collect_addresses<S>(mut stream: AddressStream<S>) -> Vec<ChunkAddress>
     where
-        S: TrustedGet<AnyChunkSet<DEFAULT_BODY_SIZE>> + Clone + 'static,
+        S: TrustedGet<ContentOnlyChunkSet<DEFAULT_BODY_SIZE>> + Clone + 'static,
     {
         run(async {
             let mut out = Vec::new();
@@ -711,7 +711,7 @@ mod tests {
     }
 
     struct Recording {
-        store: Store,
+        store: ContentGet<Store>,
         fetched: Mutex<Vec<ChunkAddress>>,
         inflight: AtomicUsize,
         peak: AtomicUsize,
@@ -724,7 +724,7 @@ mod tests {
         fn with(store: Store, delay: bool, fail: Option<ChunkAddress>) -> Self {
             Self {
                 inner: std::sync::Arc::new(Recording {
-                    store,
+                    store: ContentGet::new(store),
                     fetched: Mutex::new(Vec::new()),
                     inflight: AtomicUsize::new(0),
                     peak: AtomicUsize::new(0),
@@ -782,11 +782,14 @@ mod tests {
         .await;
     }
 
-    impl ChunkGet<StandardChunkSet> for RecordingStore {
+    impl ChunkGet<ContentOnlyChunkSet> for RecordingStore {
         type Trust = Verified;
-        type Error = <Store as ChunkGet<StandardChunkSet>>::Error;
+        type Error = <ContentGet<Store> as ChunkGet<ContentOnlyChunkSet>>::Error;
 
-        async fn get(&self, address: &ChunkAddress) -> Result<Chunk, Self::Error> {
+        async fn get(
+            &self,
+            address: &ChunkAddress,
+        ) -> Result<Chunk<Verified, ContentOnlyChunkSet>, Self::Error> {
             self.inner.fetched.lock().unwrap().push(*address);
             let level = self.inner.inflight.fetch_add(1, Ordering::SeqCst) + 1;
             self.inner.peak.fetch_max(level, Ordering::SeqCst);
@@ -827,7 +830,7 @@ mod tests {
     fn listing_yields_every_path_in_path_order() {
         for paths in corpora() {
             let (root, store) = build(&paths);
-            let got = collect_entries(Cursor::new(store, root));
+            let got = collect_entries(Cursor::new(ContentGet::new(store), root));
             let mut want = paths.clone();
             want.sort_unstable();
             assert_eq!(got.len(), want.len(), "corpus {paths:?}");
@@ -853,7 +856,7 @@ mod tests {
         editor.set_index_document("index.html");
         let (root, store) = run(editor.commit()).unwrap();
 
-        let got = collect_entries(Cursor::new(store, root));
+        let got = collect_entries(Cursor::new(ContentGet::new(store), root));
         assert_eq!(got.len(), 3);
         let plain = got.iter().find(|e| e.path() == b"plain.txt").unwrap();
         assert_eq!(
@@ -882,7 +885,7 @@ mod tests {
         let (manifest_ref, store) = run(editor.commit()).unwrap();
         let (root, _key) = manifest_ref.into_parts();
 
-        let got = collect_entries(Cursor::new(store, root));
+        let got = collect_entries(Cursor::new(ContentGet::new(store), root));
         let mut want = paths.to_vec();
         want.sort_unstable();
         assert_eq!(got.len(), want.len());
@@ -902,7 +905,7 @@ mod tests {
     fn prefix_narrows_the_listing() {
         for paths in corpora() {
             let (root, store) = build(&paths);
-            let full = collect_entries(Cursor::new(store.clone(), root));
+            let full = collect_entries(Cursor::new(ContentGet::new(store.clone()), root));
             let mut probes = vec![String::new(), "zzz-absent".to_string()];
             for p in &paths {
                 probes.push((*p).to_string());
@@ -918,7 +921,9 @@ mod tests {
                     .filter(|e| e.path().starts_with(probe.as_bytes()))
                     .cloned()
                     .collect();
-                let got = collect_entries(Cursor::new(store.clone(), root).with_prefix(&probe));
+                let got = collect_entries(
+                    Cursor::new(ContentGet::new(store.clone()), root).with_prefix(&probe),
+                );
                 assert_eq!(got, want, "prefix {probe:?} over {paths:?}");
             }
         }
@@ -928,11 +933,13 @@ mod tests {
     fn resume_after_continues_where_the_page_ended() {
         for paths in corpora() {
             let (root, store) = build(&paths);
-            let full = collect_entries(Cursor::new(store.clone(), root));
+            let full = collect_entries(Cursor::new(ContentGet::new(store.clone()), root));
             for k in 0..full.len() {
-                let page = collect_entries(Cursor::new(store.clone(), root).with_limit(k));
+                let page = collect_entries(
+                    Cursor::new(ContentGet::new(store.clone()), root).with_limit(k),
+                );
                 assert_eq!(page.as_slice(), &full[..k]);
-                let mut resumed = Cursor::new(store.clone(), root);
+                let mut resumed = Cursor::new(ContentGet::new(store.clone()), root);
                 if let Some(last) = page.last() {
                     resumed = resumed.after(last.path());
                 }
@@ -948,7 +955,7 @@ mod tests {
     fn resume_tokens_need_not_be_stored_paths() {
         for paths in corpora() {
             let (root, store) = build(&paths);
-            let full = collect_entries(Cursor::new(store.clone(), root));
+            let full = collect_entries(Cursor::new(ContentGet::new(store.clone()), root));
             let mut tokens = vec![String::new(), "zzz-absent".to_string()];
             for p in &paths {
                 tokens.push(format!("{p}0"));
@@ -962,7 +969,9 @@ mod tests {
                     .filter(|e| e.path() > token.as_bytes())
                     .cloned()
                     .collect();
-                let got = collect_entries(Cursor::new(store.clone(), root).after(&token));
+                let got = collect_entries(
+                    Cursor::new(ContentGet::new(store.clone()), root).after(&token),
+                );
                 assert_eq!(got, want, "token {token:?} over {paths:?}");
             }
         }
@@ -978,14 +987,14 @@ mod tests {
             "robots.txt",
         ];
         let (root, store) = build(&paths);
-        let full = collect_entries(Cursor::new(store.clone(), root));
+        let full = collect_entries(Cursor::new(ContentGet::new(store.clone()), root));
         let want: Vec<Entry> = full
             .iter()
             .filter(|e| e.path().starts_with(b"img/") && e.path() > b"img/1.png".as_slice())
             .cloned()
             .collect();
         let got = collect_entries(
-            Cursor::new(store, root)
+            Cursor::new(ContentGet::new(store), root)
                 .with_prefix("img/")
                 .after("img/1.png"),
         );
@@ -1128,7 +1137,7 @@ mod tests {
         let sealed: Chunk = Chunk::from_envelope(root_chunk.into()).unwrap();
         run(store.put(sealed)).unwrap();
 
-        let (entries, err) = collect_until_err(Cursor::new(store, root));
+        let (entries, err) = collect_until_err(Cursor::new(ContentGet::new(store), root));
         assert!(entries.is_empty());
         assert!(matches!(err, Some(CursorError::Corrupt { address, .. }) if address == gaddr));
     }
@@ -1153,9 +1162,11 @@ mod tests {
     fn address_stream_covers_nodes_and_entries() {
         for paths in corpora() {
             let (root, store) = build(&paths);
-            let ordered = collect_addresses(AddressStream::new(store.clone(), root));
-            let windowed =
-                collect_addresses(AddressStream::new(store.clone(), root).with_window(window(8)));
+            let ordered =
+                collect_addresses(AddressStream::new(ContentGet::new(store.clone()), root));
+            let windowed = collect_addresses(
+                AddressStream::new(ContentGet::new(store.clone()), root).with_window(window(8)),
+            );
             assert_eq!(
                 ordered, windowed,
                 "delivery order must not depend on the window"
@@ -1187,7 +1198,7 @@ mod tests {
 
         // Value entries ride the full encrypted width on the wire; the
         // stream carries their 32-byte addresses next to every node address.
-        let mut got = collect_addresses(AddressStream::new(store.clone(), root));
+        let mut got = collect_addresses(AddressStream::new(ContentGet::new(store.clone()), root));
         got.sort();
         let mut want: Vec<ChunkAddress> = store.into_chunks().keys().copied().collect();
         want.extend(paths.iter().map(|p| make_addr(p)));
@@ -1199,9 +1210,9 @@ mod tests {
     fn empty_trie_lists_nothing_and_streams_only_the_root() {
         let editor: ManifestEditor<Store> = ManifestEditor::new(Store::new());
         let (root, store) = run(editor.commit()).unwrap();
-        assert!(collect_entries(Cursor::new(store.clone(), root)).is_empty());
+        assert!(collect_entries(Cursor::new(ContentGet::new(store.clone()), root)).is_empty());
         assert_eq!(
-            collect_addresses(AddressStream::new(store, root)),
+            collect_addresses(AddressStream::new(ContentGet::new(store), root)),
             vec![root]
         );
     }
@@ -1209,7 +1220,7 @@ mod tests {
     #[test]
     fn missing_root_is_a_store_error() {
         let root = make_addr("nowhere");
-        let (entries, err) = collect_until_err(Cursor::new(Store::new(), root));
+        let (entries, err) = collect_until_err(Cursor::new(ContentGet::new(Store::new()), root));
         assert!(entries.is_empty());
         assert!(matches!(err, Some(CursorError::Store { address, .. }) if address == root));
     }
@@ -1218,10 +1229,12 @@ mod tests {
     fn cursor_and_address_stream_drive_as_streams() {
         use futures::StreamExt;
         let (root, store) = build(&["a", "b", "c"]);
-        let entries: Vec<_> = run(Cursor::new(store.clone(), root).collect::<Vec<_>>());
+        let entries: Vec<_> =
+            run(Cursor::new(ContentGet::new(store.clone()), root).collect::<Vec<_>>());
         assert_eq!(entries.len(), 3);
         assert!(entries.iter().all(Result::is_ok));
-        let addresses: Vec<_> = run(AddressStream::new(store, root).collect::<Vec<_>>());
+        let addresses: Vec<_> =
+            run(AddressStream::new(ContentGet::new(store), root).collect::<Vec<_>>());
         assert!(addresses.len() > 3);
         assert!(addresses.iter().all(Result::is_ok));
     }

--- a/crates/mantaray/src/cursor.rs
+++ b/crates/mantaray/src/cursor.rs
@@ -360,6 +360,7 @@ fn narrow_after(after: Option<&[u8]>, edge: &[u8]) -> Option<Option<Vec<u8>>> {
 /// ```
 /// # use nectar_mantaray::{Cursor, ManifestEditor, DefaultMemoryStore};
 /// # use nectar_primitives::chunk::ChunkAddress;
+/// # use nectar_primitives::store::ContentGet;
 /// # nectar_testing::run(async {
 /// let mut editor = ManifestEditor::new(DefaultMemoryStore::new());
 /// editor.put("a.txt", ChunkAddress::from([1u8; 32]));

--- a/crates/mantaray/src/editor.rs
+++ b/crates/mantaray/src/editor.rs
@@ -484,7 +484,7 @@ mod tests {
     use super::*;
     use core::sync::atomic::{AtomicUsize, Ordering};
 
-    use nectar_primitives::store::{ChunkGet, MemoryStore};
+    use nectar_primitives::store::{ChunkGet, ContentGet, MemoryStore};
     use nectar_primitives::{EncryptedChunkRef, EncryptionKey, StandardChunkSet, Verified};
     use nectar_testing::run;
 
@@ -640,7 +640,7 @@ mod tests {
     fn committed_root_is_readable() {
         let script = corpora().swap_remove(4);
         let (root, store) = editor_replay(&script);
-        let reader = crate::Reader::new(store);
+        let reader = crate::Reader::new(ContentGet::new(store));
         let entry = run(reader.get(&root, b"img/1.png")).unwrap().unwrap();
         assert_eq!(
             entry.reference().map(|r| *r.address()),
@@ -657,7 +657,7 @@ mod tests {
         editor.put("//", make_addr("s"));
         editor.set_index_document("doc");
         let (root, store) = run(editor.commit()).unwrap();
-        let entry = run(crate::Reader::new(store).get(&root, b"/"))
+        let entry = run(crate::Reader::new(ContentGet::new(store)).get(&root, b"/"))
             .unwrap()
             .expect("metadata-carrying edge reads back");
         assert!(entry.reference().is_none());
@@ -717,7 +717,7 @@ mod tests {
         let (got, store) = run(editor.commit()).unwrap();
         assert_eq!(got, want);
 
-        let reader = crate::Reader::new(store);
+        let reader = crate::Reader::new(ContentGet::new(store));
         let entry = run(reader.get(&got, b"/")).unwrap().unwrap();
         assert_eq!(
             entry.metadata().get("website-index-document").cloned(),

--- a/crates/mantaray/src/oracles.rs
+++ b/crates/mantaray/src/oracles.rs
@@ -12,6 +12,7 @@ use std::collections::BTreeMap;
 use nectar_primitives::EncryptedChunkRef;
 use nectar_primitives::chunk::{ChunkAddress, ChunkRef, RefKind, Reference};
 use nectar_primitives::oracles::Violation;
+use nectar_primitives::store::ContentGet;
 
 use crate::node::Node;
 use crate::view::NodeView;
@@ -386,7 +387,7 @@ pub async fn editor_differential(ops: &[EditorOp]) -> Result<(), Violation> {
     };
 
     let want = model(ops);
-    let reader = Reader::new(store);
+    let reader = Reader::new(ContentGet::new(store));
     for (p, addr) in &want.entries {
         // The empty path is never addressable through the reader.
         if p.is_empty() {

--- a/crates/mantaray/src/reader.rs
+++ b/crates/mantaray/src/reader.rs
@@ -8,7 +8,7 @@
 
 use alloc::sync::Arc;
 
-use nectar_primitives::AnyChunkSet;
+use nectar_primitives::ContentOnlyChunkSet;
 use nectar_primitives::bmt::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{ChunkAddress, ChunkOps};
 use nectar_primitives::store::TrustedGet;
@@ -66,7 +66,7 @@ impl<S, const BS: usize> Reader<S, BS> {
     }
 }
 
-impl<S: TrustedGet<AnyChunkSet<BS>>, const BS: usize> Reader<S, BS> {
+impl<S: TrustedGet<ContentOnlyChunkSet<BS>>, const BS: usize> Reader<S, BS> {
     /// The entry at `path` under the trie rooted at `root`, or `None` when
     /// the path is absent or names a bare edge. A metadata-carrying edge
     /// (the root documents node) reads back as an entry with no reference.
@@ -191,7 +191,7 @@ mod tests {
 
     use bytes::Bytes;
     use nectar_primitives::chunk::{ChunkOps, ContentChunk};
-    use nectar_primitives::store::{ChunkGet, ChunkPut, MemoryStore};
+    use nectar_primitives::store::{ChunkGet, ChunkPut, ContentGet, MemoryStore};
     use nectar_primitives::{
         Chunk, EncryptedChunkRef, EncryptionKey, EntryRef, StandardChunkSet, Verified,
     };
@@ -259,7 +259,7 @@ mod tests {
     /// paths, a prefix probe hits exactly the stored extensions.
     async fn assert_model(paths: &[&str]) {
         let (root, store) = build(paths).await;
-        let reader = Reader::new(store);
+        let reader = Reader::new(ContentGet::new(store));
         for probe in probes(paths) {
             let got = reader.get(&root, probe.as_bytes()).await.unwrap();
             assert_eq!(
@@ -302,7 +302,7 @@ mod tests {
             let (manifest_ref, store) = editor.commit().await.unwrap();
             let (root, _key) = manifest_ref.into_parts();
 
-            let reader = Reader::new(store);
+            let reader = Reader::new(ContentGet::new(store));
             for p in paths {
                 let got = reader.get(&root, p.as_bytes()).await.unwrap().unwrap();
                 match got.reference() {
@@ -329,7 +329,7 @@ mod tests {
         editor.set_index_document("index.html");
         let (root, store) = run(editor.commit()).unwrap();
 
-        let reader = Reader::new(store);
+        let reader = Reader::new(ContentGet::new(store));
         let plain = run(reader.get(&root, b"plain.txt")).unwrap().unwrap();
         assert_eq!(
             plain.reference().map(|r| *r.address()),
@@ -349,14 +349,14 @@ mod tests {
 
     /// Store wrapper counting `get` calls, pinning the reader's fetch costs.
     struct CountingStore {
-        inner: Store,
+        inner: ContentGet<Store>,
         gets: AtomicUsize,
     }
 
     impl CountingStore {
         fn new(inner: Store) -> Self {
             Self {
-                inner,
+                inner: ContentGet::new(inner),
                 gets: AtomicUsize::new(0),
             }
         }
@@ -366,11 +366,14 @@ mod tests {
         }
     }
 
-    impl ChunkGet<StandardChunkSet> for CountingStore {
+    impl ChunkGet<ContentOnlyChunkSet> for CountingStore {
         type Trust = Verified;
-        type Error = <Store as ChunkGet<StandardChunkSet>>::Error;
+        type Error = <ContentGet<Store> as ChunkGet<ContentOnlyChunkSet>>::Error;
 
-        async fn get(&self, address: &ChunkAddress) -> Result<Chunk, Self::Error> {
+        async fn get(
+            &self,
+            address: &ChunkAddress,
+        ) -> Result<Chunk<Verified, ContentOnlyChunkSet>, Self::Error> {
             self.gets.fetch_add(1, Ordering::SeqCst);
             ChunkGet::get(&self.inner, address).await
         }
@@ -424,7 +427,7 @@ mod tests {
         // One-byte edge chain: get("abcde") costs 6 fetches, has_prefix 5.
         let (root, store) = run(build(&["a", "ab", "abc", "abcd", "abcde"]));
 
-        let exact = Reader::with_max_depth(store, 6);
+        let exact = Reader::with_max_depth(ContentGet::new(store), 6);
         assert!(run(exact.get(&root, b"abcde")).unwrap().is_some());
         assert!(run(exact.has_prefix(&root, b"abcde")).unwrap());
 
@@ -454,13 +457,13 @@ mod tests {
     #[test]
     fn empty_path_is_not_a_value() {
         let (root, store) = run(build(&["a"]));
-        let reader = Reader::new(store);
+        let reader = Reader::new(ContentGet::new(store));
         assert_eq!(run(reader.get(&root, b"")).unwrap(), None);
     }
 
     #[test]
     fn missing_root_is_a_store_error() {
-        let reader: Reader<Store> = Reader::new(Store::new());
+        let reader: Reader<ContentGet<Store>> = Reader::new(ContentGet::new(Store::new()));
         let root = make_addr("nowhere");
         assert!(matches!(
             run(reader.get(&root, b"x")),
@@ -483,7 +486,7 @@ mod tests {
         let sealed: Chunk = Chunk::from_envelope(chunk.into()).unwrap();
         run(store.put(sealed)).unwrap();
 
-        let reader = Reader::new(store);
+        let reader = Reader::new(ContentGet::new(store));
         assert!(matches!(
             run(reader.get(&root, b"x")),
             Err(ReaderError::Corrupt { address, .. }) if address == root

--- a/crates/primitives/src/chunk/registry.rs
+++ b/crates/primitives/src/chunk/registry.rs
@@ -182,13 +182,15 @@ impl<const BODY_SIZE: usize> ChunkRegistry for AnyChunkSet<BODY_SIZE> {
 
 const _: () = StandardChunkSet::DISTINCT_TAGS;
 
-/// Registry that accepts only content-addressed chunks, carried directly as
-/// [`ContentChunk`]: a single-member set needs no envelope enum.
+/// Registry that accepts only content-addressed chunks at body size
+/// `BODY_SIZE`, carried directly as [`ContentChunk`]: a single-member set
+/// needs no envelope enum. The registry carries the body size so no store
+/// trait restates it.
 #[derive(Debug, Clone, Copy, Default)]
-pub struct ContentOnlyChunkSet;
+pub struct ContentOnlyChunkSet<const BODY_SIZE: usize = DEFAULT_BODY_SIZE>;
 
-impl ChunkRegistry for ContentOnlyChunkSet {
-    type Envelope = ContentChunk;
+impl<const BODY_SIZE: usize> ChunkRegistry for ContentOnlyChunkSet<BODY_SIZE> {
+    type Envelope = ContentChunk<BODY_SIZE>;
 
     const MEMBERS: &'static [ChunkTypeInfo] = &[ChunkTypeInfo::of::<CacHeader>()];
 
@@ -200,11 +202,11 @@ impl ChunkRegistry for ContentOnlyChunkSet {
         if !Self::supports(tag) {
             return Err(ChunkError::unsupported_tag(tag).into());
         }
-        ContentChunk::try_from(Bytes::copy_from_slice(payload))
+        ContentChunk::<BODY_SIZE>::try_from(Bytes::copy_from_slice(payload))
     }
 
     fn decode_wire(address: &ChunkAddress, data: Bytes) -> Result<Self::Envelope> {
-        let chunk = ContentChunk::try_from(data)?;
+        let chunk = ContentChunk::<BODY_SIZE>::try_from(data)?;
         chunk.verify(address)?;
         Ok(chunk)
     }
@@ -219,7 +221,7 @@ impl ChunkRegistry for ContentOnlyChunkSet {
     }
 }
 
-const _: () = ContentOnlyChunkSet::DISTINCT_TAGS;
+const _: () = ContentOnlyChunkSet::<DEFAULT_BODY_SIZE>::DISTINCT_TAGS;
 
 /// Registry that accepts only single-owner chunks at body size `BODY_SIZE`,
 /// carried directly as [`SingleOwnerChunk`]: a single-member set needs no
@@ -275,6 +277,7 @@ mod tests {
     use crate::error::PrimitivesError;
 
     type DefaultContentChunk = ContentChunk<DEFAULT_BODY_SIZE>;
+    type ContentOnly = ContentOnlyChunkSet<DEFAULT_BODY_SIZE>;
     type SocOnly = SingleOwnerOnlyChunkSet<DEFAULT_BODY_SIZE>;
 
     const CAC_TAG: ChunkTypeTag = ChunkTypeTag::new(CacHeader::TYPE_ID, CacHeader::VERSION);
@@ -328,11 +331,11 @@ mod tests {
 
     #[test]
     fn content_only_supports() {
-        assert!(ContentOnlyChunkSet::supports(CAC_TAG));
-        assert!(!ContentOnlyChunkSet::supports(SOC_TAG));
-        assert!(ContentOnlyChunkSet::supports_id(ChunkTypeId::CONTENT));
-        assert!(!ContentOnlyChunkSet::supports_id(ChunkTypeId::SINGLE_OWNER));
-        assert_eq!(ContentOnlyChunkSet::MEMBERS.len(), 1);
+        assert!(ContentOnly::supports(CAC_TAG));
+        assert!(!ContentOnly::supports(SOC_TAG));
+        assert!(ContentOnly::supports_id(ChunkTypeId::CONTENT));
+        assert!(!ContentOnly::supports_id(ChunkTypeId::SINGLE_OWNER));
+        assert_eq!(ContentOnly::MEMBERS.len(), 1);
     }
 
     #[test]
@@ -351,10 +354,7 @@ mod tests {
             ChunkTypeInfo::duplicate_tag(StandardChunkSet::MEMBERS),
             None
         );
-        assert_eq!(
-            ChunkTypeInfo::duplicate_tag(ContentOnlyChunkSet::MEMBERS),
-            None
-        );
+        assert_eq!(ChunkTypeInfo::duplicate_tag(ContentOnly::MEMBERS), None);
         assert_eq!(ChunkTypeInfo::duplicate_tag(SocOnly::MEMBERS), None);
 
         let dup = [
@@ -418,9 +418,9 @@ mod tests {
         assert!(StandardChunkSet::parse_typed(&standard).is_ok());
         assert!(StandardChunkSet::decode_typed(&wrong, &standard).is_err());
 
-        let content_only = ContentOnlyChunkSet::encode_typed(&content);
-        assert!(ContentOnlyChunkSet::parse_typed(&content_only).is_ok());
-        assert!(ContentOnlyChunkSet::decode_typed(&wrong, &content_only).is_err());
+        let content_only = ContentOnly::encode_typed(&content);
+        assert!(ContentOnly::parse_typed(&content_only).is_ok());
+        assert!(ContentOnly::decode_typed(&wrong, &content_only).is_err());
 
         let soc_only = SocOnly::encode_typed(&sample_single_owner());
         assert!(SocOnly::parse_typed(&soc_only).is_ok());
@@ -470,11 +470,11 @@ mod tests {
         let content = DefaultContentChunk::new(&b"content only"[..]).unwrap();
         let address = *content.address();
 
-        let encoded = ContentOnlyChunkSet::encode_typed(&content);
+        let encoded = ContentOnly::encode_typed(&content);
         // The typed form must agree with the standard registry's encoding.
         assert_eq!(encoded, StandardChunkSet::encode_typed(&content.into()));
 
-        let decoded = ContentOnlyChunkSet::decode_typed(&address, &encoded).unwrap();
+        let decoded = ContentOnly::decode_typed(&address, &encoded).unwrap();
         assert_eq!(*decoded.address(), address);
     }
 
@@ -484,7 +484,7 @@ mod tests {
         let address = *soc.address();
         let encoded = StandardChunkSet::encode_typed(&soc.into());
 
-        let err = ContentOnlyChunkSet::decode_typed(&address, &encoded).unwrap_err();
+        let err = ContentOnly::decode_typed(&address, &encoded).unwrap_err();
         match err {
             PrimitivesError::Chunk(ChunkError::UnsupportedTag(t)) => assert_eq!(t, SOC_TAG),
             other => panic!("expected UnsupportedTag, got {other:?}"),
@@ -494,17 +494,17 @@ mod tests {
     #[test]
     fn content_only_typed_short_input_errors() {
         let address: ChunkAddress = [0u8; 32].into();
-        assert!(ContentOnlyChunkSet::decode_typed(&address, &[]).is_err());
-        assert!(ContentOnlyChunkSet::decode_typed(&address, &[0]).is_err());
+        assert!(ContentOnly::decode_typed(&address, &[]).is_err());
+        assert!(ContentOnly::decode_typed(&address, &[0]).is_err());
     }
 
     #[test]
     fn content_only_typed_address_mismatch_errors() {
         let content = DefaultContentChunk::new(&b"chunk A"[..]).unwrap();
-        let encoded = ContentOnlyChunkSet::encode_typed(&content);
+        let encoded = ContentOnly::encode_typed(&content);
 
         let wrong: ChunkAddress = [0xFFu8; 32].into();
-        assert!(ContentOnlyChunkSet::decode_typed(&wrong, &encoded).is_err());
+        assert!(ContentOnly::decode_typed(&wrong, &encoded).is_err());
     }
 
     #[test]
@@ -513,7 +513,7 @@ mod tests {
         let address = *content.address();
         let wire: Bytes = content.clone().into_bytes();
 
-        let decoded = ContentOnlyChunkSet::decode_wire(&address, wire).unwrap();
+        let decoded = ContentOnly::decode_wire(&address, wire).unwrap();
         assert_eq!(*decoded.address(), address);
         assert_eq!(decoded.data(), content.data());
     }
@@ -526,7 +526,7 @@ mod tests {
         let address = *soc.address();
         let wire = soc.into_bytes();
 
-        assert!(ContentOnlyChunkSet::decode_wire(&address, wire).is_err());
+        assert!(ContentOnly::decode_wire(&address, wire).is_err());
     }
 
     #[test]

--- a/crates/primitives/src/chunk/trust.rs
+++ b/crates/primitives/src/chunk/trust.rs
@@ -16,7 +16,9 @@ use crate::cache::OnceCache;
 use crate::error::Result;
 
 use super::address::ChunkAddress;
-use super::registry::{AnyChunkSet, ChunkRegistry, SingleOwnerOnlyChunkSet, StandardChunkSet};
+use super::registry::{
+    AnyChunkSet, ChunkRegistry, ContentOnlyChunkSet, SingleOwnerOnlyChunkSet, StandardChunkSet,
+};
 use super::traits::ChunkOps;
 
 mod sealed {
@@ -246,6 +248,26 @@ impl<const BODY_SIZE: usize> Chunk<Verified, AnyChunkSet<BODY_SIZE>> {
         Some(Chunk {
             address,
             inner: inner.into_single_owner()?,
+            owner,
+            _state: PhantomData,
+        })
+    }
+
+    /// Narrow to the content-only registry; `None` for a single-owner chunk.
+    ///
+    /// The address fact transfers as-is: the content arm was certified by
+    /// its full acceptance rule already, so no hash re-runs.
+    #[must_use]
+    pub fn narrow_content(self) -> Option<Chunk<Verified, ContentOnlyChunkSet<BODY_SIZE>>> {
+        let Self {
+            address,
+            inner,
+            owner,
+            _state,
+        } = self;
+        Some(Chunk {
+            address,
+            inner: inner.into_content()?,
             owner,
             _state: PhantomData,
         })
@@ -536,6 +558,29 @@ mod tests {
         let content = DefaultContentChunk::new(&b"stays wide"[..]).unwrap();
         let wide = Chunk::<Verified>::from_envelope(content.into()).unwrap();
         assert!(wide.narrow_single_owner().is_none());
+    }
+
+    /// Narrowing transfers the Verified fact without re-running any
+    /// acceptance rule: the address carries over and the typed encoding is
+    /// byte-identical.
+    #[test]
+    fn narrow_content_preserves_the_verified_fact() {
+        let content = DefaultContentChunk::new(&b"narrowed"[..]).unwrap();
+        let address = *content.address();
+        let wide = Chunk::<Verified>::from_envelope(content.into()).unwrap();
+        let typed = wide.typed_bytes();
+
+        let narrow = wide.narrow_content().unwrap();
+        assert_eq!(narrow.address(), &address);
+        assert_eq!(narrow.typed_bytes(), typed);
+    }
+
+    #[test]
+    fn narrow_content_rejects_a_single_owner_chunk() {
+        let soc = DefaultSingleOwnerChunk::new(SocId::ZERO, b"stays wide".to_vec(), &test_signer())
+            .unwrap();
+        let wide = Chunk::<Verified>::from_envelope(soc.into()).unwrap();
+        assert!(wide.narrow_content().is_none());
     }
 
     #[test]

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -164,8 +164,8 @@ pub type DefaultMemoryStore = MemoryStore<StandardChunkSet>;
 
 // Chunk storage traits
 pub use store::{
-    ChunkGet, ChunkHas, ChunkPut, ChunkStoreError, MemoryStore, SingleOwnerGet,
-    SingleOwnerGetError, TrustedGet,
+    ChunkGet, ChunkHas, ChunkPut, ChunkStoreError, ContentGet, ContentGetError, MemoryStore,
+    SingleOwnerGet, SingleOwnerGetError, TrustedGet,
 };
 #[cfg(feature = "std")]
 pub use store::{RetryConfig, RetryingChunkGet, Sleeper};

--- a/crates/primitives/src/store/content.rs
+++ b/crates/primitives/src/store/content.rs
@@ -1,0 +1,119 @@
+//! Content-only narrowing store adapter.
+
+use crate::chunk::{
+    AnyChunkSet, Chunk, ChunkAddress, ChunkRegistry, ContentOnlyChunkSet, Verified,
+};
+
+use super::typed::{ChunkGet, ChunkHas, ChunkPut};
+
+/// Content-only view over a store typed at [`AnyChunkSet`].
+///
+/// Gets narrow through the Verified-preserving narrowing, so no acceptance
+/// rule re-runs; a chunk of any other type is a typed error, not a panic.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ContentGet<T>(T);
+
+impl<T> ContentGet<T> {
+    /// Wrap a store typed at [`AnyChunkSet`].
+    pub const fn new(inner: T) -> Self {
+        Self(inner)
+    }
+
+    /// Borrow the inner store.
+    pub const fn inner(&self) -> &T {
+        &self.0
+    }
+
+    /// Consume into the inner store.
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+/// Error of the narrowing get.
+#[derive(Debug, thiserror::Error)]
+pub enum ContentGetError<E> {
+    /// The inner store failed.
+    #[error(transparent)]
+    Inner(E),
+    /// The chunk at the address is not a content chunk.
+    #[error("chunk at {0} is not a content chunk")]
+    NotContent(ChunkAddress),
+}
+
+impl<const BODY_SIZE: usize, T> ChunkGet<ContentOnlyChunkSet<BODY_SIZE>> for ContentGet<T>
+where
+    T: ChunkGet<AnyChunkSet<BODY_SIZE>, Trust = Verified>,
+{
+    type Trust = Verified;
+    type Error = ContentGetError<T::Error>;
+
+    async fn get(
+        &self,
+        address: &ChunkAddress,
+    ) -> Result<Chunk<Verified, ContentOnlyChunkSet<BODY_SIZE>>, Self::Error> {
+        let chunk = self.0.get(address).await.map_err(ContentGetError::Inner)?;
+        chunk
+            .narrow_content()
+            .ok_or(ContentGetError::NotContent(*address))
+    }
+}
+
+// Writes pass through untouched: only the read face narrows, so one wrapped
+// store serves a read-narrowed, write-wide surface.
+impl<R: ChunkRegistry, T: ChunkPut<R>> ChunkPut<R> for ContentGet<T> {
+    type Error = T::Error;
+
+    async fn put(&self, chunk: Chunk<Verified, R>) -> Result<(), Self::Error> {
+        self.0.put(chunk).await
+    }
+}
+
+impl<T: ChunkHas> ChunkHas for ContentGet<T> {
+    async fn has(&self, address: &ChunkAddress) -> bool {
+        self.0.has(address).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::typed::ChunkPut;
+    use super::super::{ChunkStoreError, MemoryStore};
+    use super::*;
+    use crate::chunk::{ChunkOps, ContentChunk, SingleOwnerChunk, SocId, StandardChunkSet};
+    use nectar_testing::run;
+
+    #[test]
+    fn get_narrows_content_and_rejects_others() {
+        let signer = alloy_signer_local::PrivateKeySigner::from_slice(&[0x42u8; 32]).unwrap();
+        let soc = SingleOwnerChunk::new(SocId::ZERO, b"stored soc".to_vec(), &signer).unwrap();
+        let soc_addr = *soc.address();
+        let content = ContentChunk::new(&b"stored cac"[..]).unwrap();
+        let cac_addr = *content.address();
+
+        let store = MemoryStore::<StandardChunkSet>::new();
+        run(ChunkPut::put(
+            &store,
+            Chunk::from_envelope(soc.into()).unwrap(),
+        ))
+        .unwrap();
+        run(ChunkPut::put(
+            &store,
+            Chunk::from_envelope(content.into()).unwrap(),
+        ))
+        .unwrap();
+
+        let narrow = ContentGet::new(store);
+        let got = run(ChunkGet::get(&narrow, &cac_addr)).unwrap();
+        assert_eq!(got.address(), &cac_addr);
+
+        assert!(matches!(
+            run(ChunkGet::get(&narrow, &soc_addr)),
+            Err(ContentGetError::NotContent(a)) if a == soc_addr
+        ));
+        assert!(matches!(
+            run(ChunkGet::get(&narrow, &ChunkAddress::default())),
+            Err(ContentGetError::Inner(ChunkStoreError::NotFound(_)))
+        ));
+    }
+}

--- a/crates/primitives/src/store/mod.rs
+++ b/crates/primitives/src/store/mod.rs
@@ -4,6 +4,7 @@
 //! `MaybeSync` bounds so a store may be `!Send` on single-threaded targets
 //! (wasm32, bare metal, or any target under the `unsync` feature).
 
+mod content;
 mod memory;
 #[cfg(feature = "std")]
 mod retry;
@@ -11,6 +12,7 @@ mod single_owner;
 mod typed;
 
 pub use crate::marker::{MaybeSend, MaybeSync};
+pub use content::{ContentGet, ContentGetError};
 pub use memory::MemoryStore;
 #[cfg(feature = "std")]
 pub use retry::{RetryConfig, RetryingChunkGet, Sleeper};

--- a/crates/testing/src/fixtures.rs
+++ b/crates/testing/src/fixtures.rs
@@ -7,19 +7,23 @@ use std::sync::Arc;
 
 use nectar_file::{Plain, Split, SplitMode};
 use nectar_postage::BucketDepth;
-use nectar_primitives::chunk::{AnyChunkSet, ChunkAddress};
+use nectar_primitives::chunk::{AnyChunkSet, ChunkAddress, ContentOnlyChunkSet};
 use nectar_primitives::store::MemoryStore;
 use nectar_primitives::{DEFAULT_BODY_SIZE, NetworkId, SwarmSpec};
 
 use crate::run;
 
+/// A split's output store, narrowed for the content-only read paths.
+pub type SplitStore<const B: usize = DEFAULT_BODY_SIZE> = MemoryStore<ContentOnlyChunkSet<B>>;
+
 /// Splits `data` whole through the streaming engine into a fresh store,
-/// returning the root and the filled store. `MemoryStore` clones deeply, so
-/// the split writes through a shared `Arc` handle that unwraps once the puts
-/// have drained.
+/// returning the root and the filled store narrowed to the content-only
+/// registry the read paths bind. `MemoryStore` clones deeply, so the split
+/// writes through a shared `Arc` handle that unwraps once the puts have
+/// drained.
 pub async fn try_split_into<M, const B: usize>(
     data: &[u8],
-) -> Result<(M::Root, MemoryStore<AnyChunkSet<B>>), Box<dyn Error>>
+) -> Result<(M::Root, SplitStore<B>), Box<dyn Error>>
 where
     M: SplitMode + Default,
 {
@@ -27,12 +31,21 @@ where
     let root =
         Split::<Arc<MemoryStore<AnyChunkSet<B>>>, M, B>::collect(Arc::clone(&store), data).await?;
     let store = Arc::into_inner(store).ok_or("split still holds the store")?;
-    Ok((root, store))
+    let chunks = store
+        .into_chunks()
+        .into_values()
+        .map(|chunk| {
+            chunk
+                .narrow_content()
+                .ok_or("split wrote a non-content chunk")
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok((root, MemoryStore::from_chunks(chunks)))
 }
 
 /// [`try_split_into`] driven to completion on the calling thread; panics on
 /// a split failure.
-pub fn split_into<M, const B: usize>(data: &[u8]) -> (M::Root, MemoryStore<AnyChunkSet<B>>)
+pub fn split_into<M, const B: usize>(data: &[u8]) -> (M::Root, SplitStore<B>)
 where
     M: SplitMode + Default,
 {
@@ -40,12 +53,12 @@ where
 }
 
 /// Plain split of `data` at the default profile, returning root and store.
-pub async fn split_whole(data: &[u8]) -> Result<(ChunkAddress, MemoryStore), Box<dyn Error>> {
+pub async fn split_whole(data: &[u8]) -> Result<(ChunkAddress, SplitStore), Box<dyn Error>> {
     try_split_into::<Plain, DEFAULT_BODY_SIZE>(data).await
 }
 
 /// Plain split of `data` into a fresh memory store, returning root and store.
-pub fn split_fixture<const B: usize>(data: &[u8]) -> (ChunkAddress, MemoryStore<AnyChunkSet<B>>) {
+pub fn split_fixture<const B: usize>(data: &[u8]) -> (ChunkAddress, SplitStore<B>) {
     split_into::<Plain, B>(data)
 }
 

--- a/crates/testing/tests/wasm_smoke.rs
+++ b/crates/testing/tests/wasm_smoke.rs
@@ -10,8 +10,8 @@ use std::rc::Rc;
 use futures::StreamExt;
 use nectar_file::{File, Plain, Split, Window};
 use nectar_primitives::{
-    AnyChunkSet, Chunk, ChunkAddress, ChunkGet, ChunkPut, ChunkStoreError, DEFAULT_BODY_SIZE,
-    Verified,
+    AnyChunkSet, Chunk, ChunkAddress, ChunkGet, ChunkPut, ChunkStoreError, ContentGet,
+    DEFAULT_BODY_SIZE, Verified,
 };
 use wasm_bindgen_test::wasm_bindgen_test;
 
@@ -72,7 +72,7 @@ async fn non_send_store_round_trips_a_file() {
     let store = RcStore::default();
     let data = sample_data();
     let root = write_file(&store, &data).await;
-    let file = File::<_, Plain, DEFAULT_BODY_SIZE>::open(store.clone(), root)
+    let file = File::<_, Plain, DEFAULT_BODY_SIZE>::open(ContentGet::new(store.clone()), root)
         .await
         .unwrap();
     let out = file.collect(u64::MAX).await.unwrap();
@@ -85,7 +85,7 @@ async fn windowed_read_ahead_stays_within_bound() {
     let store = RcStore::default();
     let data = sample_data();
     let root = write_file(&store, &data).await;
-    let file = File::<_, Plain, DEFAULT_BODY_SIZE>::open(store.clone(), root)
+    let file = File::<_, Plain, DEFAULT_BODY_SIZE>::open(ContentGet::new(store.clone()), root)
         .await
         .unwrap();
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -2012,6 +2012,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "nectar-clock",
+ "nectar-marker",
  "nectar-postage",
  "nectar-primitives",
  "thiserror",

--- a/fuzz/fuzz_targets/file_split_root.rs
+++ b/fuzz/fuzz_targets/file_split_root.rs
@@ -16,7 +16,7 @@ use nectar_file::sync::drive;
 use nectar_file::{File, Plain, PutWindow, Split};
 use nectar_fuzz::tile;
 use nectar_primitives::chunk::{AnyChunkSet, Chunk, ChunkAddress, Verified};
-use nectar_primitives::store::{ChunkGet, ChunkPut, ChunkStoreError};
+use nectar_primitives::store::{ChunkGet, ChunkPut, ChunkStoreError, ContentGet};
 
 /// Tiny body size: fan-out 8, so a few KiB already builds a deep tree.
 const BODY: usize = 256;
@@ -115,7 +115,7 @@ fuzz_target!(|input: (Vec<u8>, u16, Vec<u16>, Vec<u16>, u16, u16)| {
     assert_eq!(root_a, root_b, "root diverged across write segmentations");
 
     let read_back = drive(async move {
-        let file = File::<_, Plain, BODY>::open(store, root_a)
+        let file = File::<_, Plain, BODY>::open(ContentGet::new(store), root_a)
             .await
             .expect("open must succeed over the written store");
         file.collect(u64::MAX)

--- a/fuzz/fuzz_targets/manifest_apply_rebuild.rs
+++ b/fuzz/fuzz_targets/manifest_apply_rebuild.rs
@@ -14,7 +14,7 @@ use libfuzzer_sys::fuzz_target;
 use nectar_fuzz::{Val, entry};
 use nectar_manifest::{Builder, Changeset, Entry, Key, V1, apply};
 use nectar_primitives::ChunkAddress;
-use nectar_primitives::store::MemoryStore;
+use nectar_primitives::store::{ContentGet, MemoryStore};
 use nectar_testing::run;
 
 use std::collections::BTreeMap;
@@ -58,7 +58,7 @@ fuzz_target!(
             }
         }
 
-        let applied = run(apply(&store, &root, &changeset));
+        let applied = run(apply(&ContentGet::new(&store), &root, &changeset));
         let rebuilt = build(&merged).map(|(_, root)| root);
 
         if let (Ok(applied), Some(rebuilt)) = (applied, rebuilt) {


### PR DESCRIPTION
## What

Makes `ContentOnlyChunkSet` body-size generic (`ContentOnlyChunkSet<const BODY_SIZE = DEFAULT_BODY_SIZE>`, `Envelope = ContentChunk<BODY_SIZE>`) in `crates/primitives/src/chunk/registry.rs`, adds `Chunk<Verified, AnyChunkSet<B>>::narrow_content` in `crates/primitives/src/chunk/trust.rs` (mirrors `narrow_single_owner`, transfers the Verified fact without re-hashing), and adds a `ContentGet` adapter in `crates/primitives/src/store/content.rs` (mirrors the `SingleOwnerGet` pattern) that narrows the read face of a store typed at `AnyChunkSet` while forwarding `ChunkPut`/`ChunkHas` untouched.

The file read surface is narrowed onto this: `read/{file,reader,download,frames}`, `walk/engine`, `tokio/{reader,spawned}`, and `store.rs` (including `Boxed`), plus the touched call sites across `manifest`, `mantaray`, `manifest-sim`, `benches`, `testing`, `integration-tests`, and `fuzz`.

## Why

Closes #410.

Type-level narrowing to `ContentOnlyChunkSet` lets a single store handle typed at `AnyChunkSet` serve a read-narrowed, write-wide surface, so combined surfaces like manifest apply (`NodeGet` + `ChunkPut`) keep one store handle instead of maintaining separate narrow and wide typings.

## Testing

- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --locked` clean.
- Per-feature clippy for the touched gated crates (nectar-file: tokio, rayon, encryption; nectar-manifest: encryption; nectar-integration-tests: rayon, encryption, seal, issuer) clean.
- `cargo nextest run --workspace --locked`: 1054 passed, 1 skipped.
- `cargo test --doc --workspace` green (a doctest import gap in `mantaray::cursor`'s Cursor doctest, missing the `ContentGet` import, was found and fixed in cf20b20f).
- manifest-sim and benches compile; fuzz workspace clean under `--locked`.

## AI Assistance

Implementation by Fable, review by Opus.
