### PR TITLE
refactor(primitives): route extended proximity and bit-suffix length through SwarmSpec

### DIFF
--- a/crates/benches/benches/address.rs
+++ b/crates/benches/benches/address.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::{B256, b256};
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
-use nectar_primitives::{OverlayAddress, XorMetric};
+use nectar_primitives::{Mainnet, OverlayAddress, XorMetric};
 use rand::prelude::*;
 
 pub fn address_benchmarks(c: &mut Criterion) {
@@ -42,15 +42,15 @@ pub fn address_benchmarks(c: &mut Criterion) {
 
     // Benchmark extended proximity calculation between addresses
     group.bench_function("extended_proximity_same", |b| {
-        b.iter(|| black_box(base_addr.extended_proximity(&base_addr)))
+        b.iter(|| black_box(base_addr.extended_proximity(&base_addr, &Mainnet)))
     });
 
     group.bench_function("extended_proximity_near", |b| {
-        b.iter(|| black_box(base_addr.extended_proximity(&near_addr)))
+        b.iter(|| black_box(base_addr.extended_proximity(&near_addr, &Mainnet)))
     });
 
     group.bench_function("extended_proximity_far", |b| {
-        b.iter(|| black_box(base_addr.extended_proximity(&far_addr)))
+        b.iter(|| black_box(base_addr.extended_proximity(&far_addr, &Mainnet)))
     });
 
     // Benchmark distance calculation between addresses

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -103,7 +103,7 @@ pub use overlay::compute_overlay;
 pub use proximity_order::{ProximityOrder, ProximityOrderError};
 pub use spec::{Mainnet, SwarmSpec, Testnet};
 pub use timestamp::{Timestamp, TimestampError};
-pub use xor_metric::{EXTENDED_PO, MAX_PO, XorMetric};
+pub use xor_metric::{MAX_PO, XorMetric};
 
 /// Former name of the node-identity address kind.
 #[deprecated(note = "use `OverlayAddress`; this alias is removed in the next release")]

--- a/crates/primitives/src/spec.rs
+++ b/crates/primitives/src/spec.rs
@@ -2,7 +2,8 @@
 //!
 //! Knobs are associated consts, so a network is a type ([`Mainnet`],
 //! [`Testnet`]) and a spec-parameterized value rejects an out-of-range one at
-//! compile time rather than at a validation call.
+//! compile time rather than at a validation call. Derived accessors are
+//! methods, callable on a spec value.
 
 use core::{num::NonZeroU8, time::Duration};
 
@@ -53,6 +54,23 @@ pub trait SwarmSpec {
     // A PO is range-validated to `MAX_PO` (31), so the saturating step never
     // saturates; it is the const-callable form of the increment.
     const BIN_COUNT: usize = Self::MAX_BIN.as_index().saturating_add(1);
+
+    /// Extra bits of proximity the bin-balancing path distinguishes past
+    /// [`MAX_PROXIMITY_ORDER`](Self::MAX_PROXIMITY_ORDER).
+    fn bit_suffix_length(&self) -> u8 {
+        4
+    }
+
+    /// Proximity cap for bin balancing, derived as
+    /// [`MAX_PROXIMITY_ORDER`](Self::MAX_PROXIMITY_ORDER) +
+    /// [`bit_suffix_length`](Self::bit_suffix_length) + 1; not an independent
+    /// knob.
+    fn extended_proximity_order(&self) -> u8 {
+        Self::MAX_PROXIMITY_ORDER
+            .get()
+            .saturating_add(self.bit_suffix_length())
+            .saturating_add(1)
+    }
 }
 
 /// Canonical mainnet spec ([`NetworkId::MAINNET`]).
@@ -87,6 +105,8 @@ mod tests {
         assert_eq!(Mainnet::MIN_BUCKET_DEPTH.get(), 16);
         assert_eq!(Mainnet::BIN_COUNT, 32);
         assert_eq!(Mainnet::MAX_BIN, Bin::MAX);
+        assert_eq!(Mainnet.bit_suffix_length(), 4);
+        assert_eq!(Mainnet.extended_proximity_order(), 36);
     }
 
     #[test]
@@ -114,5 +134,6 @@ mod tests {
         }
         assert_eq!(Shallow::MAX_BIN, Bin::new(7).unwrap());
         assert_eq!(Shallow::BIN_COUNT, 8);
+        assert_eq!(Shallow.extended_proximity_order(), 12);
     }
 }

--- a/crates/primitives/src/xor_metric.rs
+++ b/crates/primitives/src/xor_metric.rs
@@ -11,9 +11,9 @@
 //! ## Standard vs extended proximity
 //!
 //! - **Standard PO** ([`MAX_PO`] = 31): most routing operations; 32 bins.
-//! - **Extended PO** ([`EXTENDED_PO`] = 36): Kademlia bin balancing, which
-//!   checks `po + BitSuffixLength + 1` (`BitSuffixLength = 4`), so bin 31
-//!   needs 31 + 4 + 1 = 36.
+//! - **Extended PO** ([`SwarmSpec::extended_proximity_order`]): Kademlia bin
+//!   balancing, which checks `po + bit_suffix_length + 1`, so bin 31 needs
+//!   31 + 4 + 1 = 36 on the canonical specs.
 //!
 //! Matches the Swarm reference implementation: leading matching bits (not
 //! bytes), capped at the respective maximum.
@@ -40,19 +40,14 @@ use core::cmp::Ordering;
 
 use alloy_primitives::U256;
 
-use crate::{Bin, ProximityOrder};
+use crate::{Bin, ProximityOrder, SwarmSpec};
 
 /// Maximum proximity order for standard routing operations.
 ///
-/// Value 31 gives 32 Kademlia bins (0-31).
+/// Value 31 gives 32 Kademlia bins (0-31). The protocol ceiling that
+/// [`ProximityOrder`] and [`Bin`] validate against; spec methods narrow
+/// below it per network.
 pub const MAX_PO: u8 = 31;
-
-/// Extended proximity order for Kademlia bin balancing.
-///
-/// Value 36 = MaxPO (31) + BitSuffixLength (4) + 1. Used when the Kademlia
-/// bin balancing algorithm needs to check proximity at finer granularity
-/// than standard routing.
-pub const EXTENDED_PO: u8 = MAX_PO + 5;
 
 /// XOR-metric operations over a 32-byte point.
 ///
@@ -150,23 +145,22 @@ pub trait XorMetric {
     #[must_use]
     fn proximity(&self, other: &impl XorMetric) -> ProximityOrder {
         // `proximity_up_to` is bounded by MAX_PO, so the cast is sound.
-        ProximityOrder::new_unchecked(proximity_up_to(self.point(), other.point(), MAX_PO.into()))
+        ProximityOrder::new_unchecked(proximity_up_to(self.point(), other.point(), MAX_PO))
     }
 
     /// Calculate the extended proximity order between `self` and another point.
     ///
     /// Returns the number of leading bits that match between the two points,
-    /// capped at [`EXTENDED_PO`] (36). Use this for Kademlia bin balancing
-    /// where the algorithm checks `po + BitSuffixLength + 1` (up to 36 for
-    /// bin 31).
+    /// capped at `spec.extended_proximity_order()`. Use this for Kademlia bin
+    /// balancing, which needs finer granularity than standard routing.
     ///
     /// Returns a raw `u8` because the extended range exceeds `ProximityOrder`'s
     /// invariant (`0..=MAX_PO`). For standard routing, use
     /// [`proximity()`](Self::proximity) instead.
     #[inline(always)]
     #[must_use]
-    fn extended_proximity(&self, other: &impl XorMetric) -> u8 {
-        proximity_up_to(self.point(), other.point(), EXTENDED_PO.into())
+    fn extended_proximity(&self, other: &impl XorMetric, spec: &impl SwarmSpec) -> u8 {
+        proximity_up_to(self.point(), other.point(), spec.extended_proximity_order())
     }
 
     /// XOR distance - bitwise XOR of the two 32-byte points as a new value of
@@ -210,11 +204,10 @@ impl<T: XorMetric> XorMetric for &T {
     clippy::indexing_slicing,
     clippy::as_conversions
 )]
-// max is MAX_PO (31) or EXTENDED_PO (36), so i <= max_bytes = 4 < 32 and i * 8 + leading_zeros <= 40 fits u8; the casts to u8 (max, i, and the u8 xor's leading_zeros <= 8) are all within those bounds
+// max is u8, so i <= max_bytes = max / 8 <= 31 < 32; at a mismatch the u8 xor's leading_zeros <= 7, so i * 8 + leading_zeros <= 248 + 7 fits u8, as do the i and leading_zeros casts
 #[inline(always)]
-fn proximity_up_to(bytes1: &[u8; 32], bytes2: &[u8; 32], max: usize) -> u8 {
-    let max_bytes = max / 8;
-    let max_bits = max as u8;
+fn proximity_up_to(bytes1: &[u8; 32], bytes2: &[u8; 32], max: u8) -> u8 {
+    let max_bytes = usize::from(max / 8);
 
     for i in 0..=max_bytes {
         let xor = bytes1[i] ^ bytes2[i];
@@ -222,29 +215,23 @@ fn proximity_up_to(bytes1: &[u8; 32], bytes2: &[u8; 32], max: usize) -> u8 {
             // Found a difference - use leading_zeros to count matching bits
             let leading_zeros = xor.leading_zeros() as u8;
             let proximity = (i as u8 * 8) + leading_zeros;
-
-            // Return the smaller of proximity or max_bits
-            return if proximity < max_bits {
-                proximity
-            } else {
-                max_bits
-            };
+            return proximity.min(max);
         }
 
         // If we're at the last byte we might need to check
         if i == max_bytes {
-            return max_bits; // All bits match up to max
+            return max; // All bits match up to max
         }
     }
 
     // If we've examined all bytes and found no differences
-    max_bits
+    max
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ChunkAddress, OverlayAddress};
+    use crate::{ChunkAddress, Mainnet, OverlayAddress};
     use alloy_primitives::B256;
 
     #[test]
@@ -260,7 +247,11 @@ mod tests {
     #[test]
     fn extended_proximity_exceeds_standard_cap() {
         let base = OverlayAddress::zero();
-        assert_eq!(base.extended_proximity(&base), EXTENDED_PO);
+        assert_eq!(base.extended_proximity(&base, &Mainnet), 36);
+        assert_eq!(
+            base.extended_proximity(&base, &Mainnet),
+            Mainnet.extended_proximity_order()
+        );
         assert_eq!(base.proximity(&base).get(), MAX_PO);
     }
 

--- a/crates/primitives/src/xor_metric.rs
+++ b/crates/primitives/src/xor_metric.rs
@@ -144,7 +144,7 @@ pub trait XorMetric {
     #[inline(always)]
     #[must_use]
     fn proximity(&self, other: &impl XorMetric) -> ProximityOrder {
-        // `proximity_up_to` is bounded by MAX_PO, so the cast is sound.
+        // `proximity_up_to` caps at MAX_PO, so the result is a valid `ProximityOrder`.
         ProximityOrder::new_unchecked(proximity_up_to(self.point(), other.point(), MAX_PO))
     }
 
@@ -231,7 +231,7 @@ fn proximity_up_to(bytes1: &[u8; 32], bytes2: &[u8; 32], max: u8) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ChunkAddress, Mainnet, OverlayAddress};
+    use crate::{ChunkAddress, Mainnet, NetworkId, OverlayAddress};
     use alloy_primitives::B256;
 
     #[test]
@@ -253,6 +253,33 @@ mod tests {
             Mainnet.extended_proximity_order()
         );
         assert_eq!(base.proximity(&base).get(), MAX_PO);
+    }
+
+    #[test]
+    fn extended_proximity_resolves_and_caps_past_standard() {
+        // Match through byte 3, differ at bit 34 (byte 4): standard proximity
+        // saturates at MAX_PO, the extended value resolves the finer 34.
+        let base = OverlayAddress::zero();
+        let mut bytes = [0u8; 32];
+        bytes[4] = 0b0010_0000;
+        let deeper = OverlayAddress::from(B256::from(bytes));
+        assert_eq!(base.proximity(&deeper).get(), MAX_PO);
+        assert_eq!(base.extended_proximity(&deeper, &Mainnet), 34);
+
+        // Differ only at bit 39: the raw count (39) exceeds the cap, so it
+        // clamps to the canonical 36.
+        let mut past_cap = [0u8; 32];
+        past_cap[4] = 0b0000_0001;
+        let past_cap = OverlayAddress::from(B256::from(past_cap));
+        assert_eq!(base.extended_proximity(&past_cap, &Mainnet), 36);
+
+        // A narrowed spec caps the extended value below the canonical 36.
+        struct Shallow;
+        impl SwarmSpec for Shallow {
+            const NETWORK_ID: NetworkId = NetworkId::TESTNET;
+            const MAX_PROXIMITY_ORDER: ProximityOrder = ProximityOrder::new_unchecked(7);
+        }
+        assert_eq!(base.extended_proximity(&base, &Shallow), 12);
     }
 
     #[test]


### PR DESCRIPTION
## What

`SwarmSpec` gains two provided methods: `bit_suffix_length()` (defaults to 4) and `extended_proximity_order()`, derived as `MAX_PROXIMITY_ORDER + bit_suffix_length + 1` via `saturating_add`. They are methods rather than associated consts, per the issue's dyn-compatibility rationale, and are callable directly on spec values since `Mainnet`/`Testnet` are unit structs.

The free `EXTENDED_PO` const is removed from `crates/primitives/src/xor_metric.rs` and its re-export from `crates/primitives/src/lib.rs` (semver-major). `XorMetric::extended_proximity` now takes a `&impl SwarmSpec` parameter and caps at `spec.extended_proximity_order()` instead of the removed const. `MAX_PO` stays as the protocol ceiling, with rustdoc noting that spec methods narrow below it per network.

`proximity_up_to` is tightened from `max: usize` to `max: u8`, dropping the max-as-u8 cast; the branchy min against `max_bits` is replaced with `proximity.min(max)`, and the safety comment is updated for the full `u8` range.

Call sites updated: the bin-balancing bench in `crates/benches/benches/address.rs` now passes `&Mainnet` to `extended_proximity`.

## Why

Closes #317.

`EXTENDED_PO` was a free const that could drift out of sync with a `SwarmSpec` narrowing `MAX_PROXIMITY_ORDER`, since it is not an independent fundamental (`MAX_PO + bitSuffixLength (4) + 1`). Routing it through the spec keeps bin balancing consistent with whatever proximity ceiling a given network defines.

## Testing

`cargo test -p nectar-primitives` (spec and xor_metric unit tests, including the new `extended_proximity_resolves_and_caps_past_standard` case and a narrowed-spec case capping at 12).

## AI Assistance

Implementation by Fable, review by Opus.
