### PR TITLE
refactor(manifest): share read-ahead scheduler

### DIFF
--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -107,6 +107,7 @@ mod order;
 mod packing;
 mod reader;
 mod scan;
+mod sched;
 mod store;
 mod traverse;
 mod value;

--- a/crates/manifest/src/scan.rs
+++ b/crates/manifest/src/scan.rs
@@ -16,11 +16,8 @@
 //! count a serial walk pays.
 
 use core::cmp::Ordering;
-use core::future::Future;
-use core::pin::Pin;
 
 use bytes::Bytes;
-use futures::stream::{FuturesUnordered, StreamExt};
 use nectar_primitives::ChunkAddress;
 #[cfg(feature = "encryption")]
 use nectar_primitives::EncryptedChunkRef;
@@ -30,6 +27,7 @@ use crate::fork::{Child, ForkTable};
 use crate::format::{Format, V1};
 use crate::node::Node;
 use crate::reader::{Reader, ReaderError};
+use crate::sched::{Frame, Plan, Scheduler};
 use crate::store::NodeGet;
 use crate::value::{Entry, Key};
 
@@ -77,44 +75,6 @@ impl<F: Format> Step<F> {
     }
 }
 
-/// One chunk's ordered contents plus the key prefix that reaches its root.
-#[derive(Clone, Debug)]
-struct Frame<F: Format> {
-    /// Key bytes consumed to reach this chunk's root.
-    base: Bytes,
-    /// The chunk's steps in ascending key order.
-    steps: Vec<Step<F>>,
-    /// The next step to visit.
-    index: usize,
-    /// Per-step prefetch tag, parallel to `steps`: the sequence id a referenced
-    /// child was launched under, once the read-ahead window scheduled it.
-    sched: Vec<Option<usize>>,
-}
-
-impl<F: Format> Frame<F> {
-    /// A frame over `steps`, resuming at `index`, with an empty prefetch tag.
-    fn new(base: Bytes, steps: Vec<Step<F>>, index: usize) -> Self {
-        let sched = vec![None; steps.len()];
-        Self {
-            base,
-            steps,
-            index,
-            sched,
-        }
-    }
-}
-
-/// A launched node fetch tagged with the sequence id it was scheduled under, so
-/// out-of-order completions route back to the descent that awaits them.
-type Fetched<F> = (usize, Result<Vec<Step<F>>, ReaderError>);
-
-/// An in-flight node fetch. Boxed to hold heterogeneous fetch futures in one
-/// queue; `Send` on native, unbounded on the single-threaded wasm executor.
-#[cfg(not(target_arch = "wasm32"))]
-type Fetch<'a, F> = Pin<Box<dyn Future<Output = Fetched<F>> + Send + 'a>>;
-#[cfg(target_arch = "wasm32")]
-type Fetch<'a, F> = Pin<Box<dyn Future<Output = Fetched<F>> + 'a>>;
-
 /// An ordered cursor over a manifest, yielding `(key, value)` in key order.
 ///
 /// The cursor fetches trie nodes on demand and retains one frame per referenced
@@ -136,13 +96,8 @@ pub struct Cursor<'a, S, F: Format = V1> {
     stack: Vec<Frame<F>>,
     end: Option<Bytes>,
     done: bool,
-    /// Node fetches launched by the read-ahead window, awaiting completion.
-    inflight: FuturesUnordered<Fetch<'a, F>>,
-    /// Completions that arrived before the descent awaiting them; drained by
-    /// sequence id. Bounded with `inflight` by the window, so O(depth) overall.
-    ready: Vec<Fetched<F>>,
-    /// The next fetch sequence id to hand out.
-    next_seq: usize,
+    /// The read-ahead window over prefetched node fetches.
+    sched: Scheduler<'a, Vec<Step<F>>>,
     /// Remaining yields a paginated cursor may return; `None` is unbounded.
     remaining: Option<usize>,
 }
@@ -232,9 +187,7 @@ where
             stack,
             end,
             done: false,
-            inflight: FuturesUnordered::new(),
-            ready: Vec::new(),
-            next_seq: 0,
+            sched: Scheduler::new(),
             remaining: None,
         })
     }
@@ -247,9 +200,7 @@ where
             stack: Vec::new(),
             end: None,
             done: true,
-            inflight: FuturesUnordered::new(),
-            ready: Vec::new(),
-            next_seq: 0,
+            sched: Scheduler::new(),
             remaining: None,
         }
     }
@@ -291,7 +242,7 @@ where
                                 Advance::Yield(join(&frame.base, suffix), entry.clone())
                             }
                             Step::Ref { suffix, addr } => {
-                                let seq = frame.sched.get(index).copied().flatten();
+                                let seq = frame.tag(index);
                                 Advance::Descend(join(&frame.base, suffix), *addr, seq)
                             }
                             Step::Encrypted { suffix, .. } => {
@@ -341,82 +292,49 @@ where
         }
     }
 
-    /// Fill the read-ahead window: launch node fetches for the referenced
-    /// children the walk will reach next, in ascending-key order, until at most
-    /// [`Format::READ_AHEAD`] fetches are in flight.
-    ///
-    /// Scheduling mirrors the walk's own termination, so it launches exactly the
-    /// nodes the walk fetches: it stops at the first step at or past the upper
-    /// bound and at the first encrypted child, and never relaunches a child
-    /// already tagged with a sequence id.
+    /// Fill the read-ahead window with the referenced children the walk will
+    /// reach next: it stops at the first step at or past the upper bound and
+    /// at the first encrypted child, which the walk errors on.
     fn schedule(&mut self) {
-        let cap = F::READ_AHEAD;
         let store = self.store;
-        // Deepest frame first: that is ascending-key order from the cursor, so
-        // the child needed soonest is always launched first and never starved.
-        'outer: for frame in self.stack.iter_mut().rev() {
-            let mut index = frame.index;
-            while let Some(step) = frame.steps.get(index) {
-                if self.inflight.len().saturating_add(self.ready.len()) >= cap {
-                    break 'outer;
-                }
-                let key = join(&frame.base, step.suffix());
-                if self
-                    .end
-                    .as_ref()
-                    .is_some_and(|end| key.as_slice() >= end.as_ref())
-                {
+        let end = self.end.as_ref();
+        self.sched
+            .fill(F::READ_AHEAD, &mut self.stack, |base, step| {
+                let key = join(base, step.suffix());
+                if end.is_some_and(|end| key.as_slice() >= end.as_ref()) {
                     // The walk stops at this bound; nothing beyond it is fetched.
-                    break 'outer;
+                    return Plan::Stop;
                 }
                 match step {
                     // The walk errors here; no deeper node is fetched.
-                    Step::Encrypted { .. } => break 'outer,
-                    Step::Ref { addr, .. } if !matches!(frame.sched.get(index), Some(Some(_))) => {
-                        let seq = self.next_seq;
-                        self.next_seq = self.next_seq.saturating_add(1);
-                        if let Some(slot) = frame.sched.get_mut(index) {
-                            *slot = Some(seq);
-                        }
+                    Step::Encrypted { .. } => Plan::Stop,
+                    Step::Value { .. } => Plan::Skip,
+                    Step::Ref { addr, .. } => {
                         let addr = *addr;
-                        let fetch: Fetch<'a, F> = Box::pin(async move {
-                            let result = store
+                        Plan::Fetch(async move {
+                            store
                                 .get_node::<F>(&addr)
                                 .await
                                 .map(|node| flatten(&node, false))
-                                .map_err(ReaderError::from);
-                            (seq, result)
-                        });
-                        self.inflight.push(fetch);
+                                .map_err(ReaderError::from)
+                        })
                     }
-                    Step::Ref { .. } | Step::Value { .. } => {}
                 }
-                index = index.saturating_add(1);
-            }
-        }
+            });
     }
 
-    /// The steps of the child reached by a descent: take the prefetch launched
-    /// under `seq`, driving in-flight fetches until it completes and buffering
-    /// any earlier-arriving completions. Falls back to a direct fetch when the
-    /// descent was not prefetched.
+    /// The steps of the child reached by a descent: take the prefetch
+    /// launched under `seq`, or fetch directly when the descent was not
+    /// prefetched.
     async fn resolve(
         &mut self,
         seq: Option<usize>,
         addr: &ChunkAddress,
     ) -> Result<Vec<Step<F>>, ReaderError> {
-        if let Some(seq) = seq {
-            loop {
-                if let Some(pos) = self.ready.iter().position(|(other, _)| *other == seq) {
-                    return self.ready.swap_remove(pos).1;
-                }
-                match self.inflight.next().await {
-                    Some((other, result)) if other == seq => return result,
-                    Some(pair) => self.ready.push(pair),
-                    // The launched fetch is unaccounted for; fetch directly.
-                    None => break,
-                }
-            }
+        if let Some(seq) = seq
+            && let Some(result) = self.sched.take(seq).await
+        {
+            return result;
         }
         let node = self.store.get_node::<F>(addr).await?;
         Ok(flatten(&node, false))

--- a/crates/manifest/src/sched.rs
+++ b/crates/manifest/src/sched.rs
@@ -1,0 +1,182 @@
+//! Read-ahead scheduling shared by the ordered cursor and the dependency
+//! traversal: a bounded sliding window of tagged node fetches, generic over
+//! the completion payload.
+//!
+//! The walker owns the walk; the scheduler owns the window. Each walker
+//! plans one step at a time through [`Scheduler::fill`], so scheduling
+//! mirrors the walk's own termination and launches exactly the nodes the
+//! walk fetches, in the order the walk needs them.
+
+use core::future::Future;
+use core::pin::Pin;
+
+use bytes::Bytes;
+use futures::stream::{FuturesUnordered, StreamExt};
+
+use crate::format::Format;
+use crate::reader::ReaderError;
+use crate::scan::Step;
+
+/// A completed fetch tagged with the sequence id it was launched under, so
+/// out-of-order completions route back to the descent that awaits them.
+type Completion<T> = (usize, Result<T, ReaderError>);
+
+/// An in-flight fetch. Boxed to hold heterogeneous fetch futures in one
+/// queue; `Send` on native, unbounded on the single-threaded wasm executor.
+#[cfg(not(target_arch = "wasm32"))]
+type Fetch<'a, T> = Pin<Box<dyn Future<Output = Completion<T>> + Send + 'a>>;
+#[cfg(target_arch = "wasm32")]
+type Fetch<'a, T> = Pin<Box<dyn Future<Output = Completion<T>> + 'a>>;
+
+/// Bound on a schedulable fetch: `Send` on native, unbounded on the
+/// single-threaded wasm executor.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) trait FetchFuture<'a, T>:
+    Future<Output = Result<T, ReaderError>> + Send + 'a
+{
+}
+#[cfg(not(target_arch = "wasm32"))]
+impl<'a, T, Fut> FetchFuture<'a, T> for Fut where
+    Fut: Future<Output = Result<T, ReaderError>> + Send + 'a
+{
+}
+#[cfg(target_arch = "wasm32")]
+pub(crate) trait FetchFuture<'a, T>: Future<Output = Result<T, ReaderError>> + 'a {}
+#[cfg(target_arch = "wasm32")]
+impl<'a, T, Fut> FetchFuture<'a, T> for Fut where Fut: Future<Output = Result<T, ReaderError>> + 'a {}
+
+/// One chunk's ordered contents plus the walk position within them.
+#[derive(Clone, Debug)]
+pub(crate) struct Frame<F: Format> {
+    /// Key bytes consumed to reach this chunk's root; empty for a walker
+    /// that does not track keys.
+    pub(crate) base: Bytes,
+    /// The chunk's steps in ascending key order.
+    pub(crate) steps: Vec<Step<F>>,
+    /// The next step to visit.
+    pub(crate) index: usize,
+    /// Per-step prefetch tag, parallel to `steps`: the sequence id a
+    /// referenced child was launched under, once the window scheduled it.
+    sched: Vec<Option<usize>>,
+}
+
+impl<F: Format> Frame<F> {
+    /// A frame over `steps`, resuming at `index`, with an empty prefetch tag.
+    pub(crate) fn new(base: Bytes, steps: Vec<Step<F>>, index: usize) -> Self {
+        let sched = vec![None; steps.len()];
+        Self {
+            base,
+            steps,
+            index,
+            sched,
+        }
+    }
+
+    /// The sequence id the step at `index` was launched under, if scheduled.
+    pub(crate) fn tag(&self, index: usize) -> Option<usize> {
+        self.sched.get(index).copied().flatten()
+    }
+}
+
+/// What the walker plans for one step ahead of the walk.
+pub(crate) enum Plan<Fut> {
+    /// Nothing to fetch at this step.
+    Skip,
+    /// The walk stops at this step; nothing at or beyond it is fetched.
+    Stop,
+    /// Fetch the referenced child at this step.
+    Fetch(Fut),
+}
+
+/// A sliding read-ahead window of tagged node fetches, generic over the
+/// completion payload.
+///
+/// In-flight fetches plus buffered completions never exceed the cap passed
+/// to [`fill`](Self::fill). All state lives in `self`, so a cancelled await
+/// on [`take`](Self::take) loses no completions.
+#[derive(Debug)]
+pub(crate) struct Scheduler<'a, T> {
+    /// Fetches launched by the window, awaiting completion.
+    inflight: FuturesUnordered<Fetch<'a, T>>,
+    /// Completions that arrived before the descent awaiting them; drained by
+    /// sequence id. Bounded with `inflight` by the window.
+    ready: Vec<Completion<T>>,
+    /// The next fetch sequence id to hand out.
+    next_seq: usize,
+}
+
+impl<'a, T> Scheduler<'a, T> {
+    /// An empty window.
+    pub(crate) fn new() -> Self {
+        Self {
+            inflight: FuturesUnordered::new(),
+            ready: Vec::new(),
+            next_seq: 0,
+        }
+    }
+
+    /// Fill the window: walk the unvisited steps of `frames` and launch each
+    /// planned fetch, until at most `cap` fetches are in the window.
+    ///
+    /// Deepest frame first is ascending-key order from the walk, so the
+    /// child needed soonest is always launched first and never starved.
+    /// [`Plan::Stop`] ends scheduling where the walk itself stops, and a
+    /// step already tagged is never relaunched.
+    pub(crate) fn fill<F, Fut>(
+        &mut self,
+        cap: usize,
+        frames: &mut [Frame<F>],
+        mut plan: impl FnMut(&Bytes, &Step<F>) -> Plan<Fut>,
+    ) where
+        F: Format,
+        Fut: FetchFuture<'a, T>,
+    {
+        'outer: for frame in frames.iter_mut().rev() {
+            let mut index = frame.index;
+            while let Some(step) = frame.steps.get(index) {
+                if self.inflight.len().saturating_add(self.ready.len()) >= cap {
+                    break 'outer;
+                }
+                match plan(&frame.base, step) {
+                    Plan::Stop => break 'outer,
+                    Plan::Skip => {}
+                    Plan::Fetch(fetch) => {
+                        if !matches!(frame.sched.get(index), Some(Some(_))) {
+                            let seq = self.next_seq;
+                            self.next_seq = self.next_seq.saturating_add(1);
+                            if let Some(slot) = frame.sched.get_mut(index) {
+                                *slot = Some(seq);
+                            }
+                            self.inflight.push(box_fetch(seq, fetch));
+                        }
+                    }
+                }
+                index = index.saturating_add(1);
+            }
+        }
+    }
+
+    /// The completion launched under `seq`: drive in-flight fetches until it
+    /// arrives, buffering earlier-arriving completions. `None` when the
+    /// launch is unaccounted for and the caller must fetch directly.
+    pub(crate) async fn take(&mut self, seq: usize) -> Option<Result<T, ReaderError>> {
+        if let Some(pos) = self.ready.iter().position(|(other, _)| *other == seq) {
+            return Some(self.ready.swap_remove(pos).1);
+        }
+        loop {
+            match self.inflight.next().await {
+                Some((other, result)) if other == seq => return Some(result),
+                Some(pair) => self.ready.push(pair),
+                None => return None,
+            }
+        }
+    }
+}
+
+/// Tag `fetch` with `seq` and box it into the window's queue shape.
+fn box_fetch<'a, T, Fut>(seq: usize, fetch: Fut) -> Fetch<'a, T>
+where
+    Fut: FetchFuture<'a, T>,
+{
+    Box::pin(async move { (seq, fetch.await) })
+}

--- a/crates/manifest/src/traverse.rs
+++ b/crates/manifest/src/traverse.rs
@@ -7,11 +7,9 @@
 //! closure: every node chunk, every segment chunk and each entry's referenced
 //! address.
 
-use core::future::Future;
-use core::pin::Pin;
 use std::collections::VecDeque;
 
-use futures::stream::{FuturesUnordered, StreamExt};
+use bytes::Bytes;
 #[cfg(feature = "encryption")]
 use nectar_primitives::EncryptedChunkRef;
 use nectar_primitives::store::MaybeSync;
@@ -20,45 +18,12 @@ use nectar_primitives::{ChunkAddress, EncryptionKey};
 use crate::format::{Format, V1};
 use crate::reader::{Reader, ReaderError};
 use crate::scan::{Step, flatten};
+use crate::sched::{Frame, Plan, Scheduler};
 use crate::store::{NodeGet, materialize_traced};
 
-/// One visited node's steps and the walk position within them.
-#[derive(Debug)]
-struct Frame<F: Format> {
-    /// The node's steps in ascending key order.
-    steps: Vec<Step<F>>,
-    /// The next step to visit.
-    index: usize,
-    /// Per-step prefetch tag, parallel to `steps`: the sequence id a
-    /// referenced child was launched under, once the window scheduled it.
-    sched: Vec<Option<usize>>,
-}
-
-impl<F: Format> Frame<F> {
-    /// A fresh frame over `steps` with an empty prefetch tag.
-    fn new(steps: Vec<Step<F>>) -> Self {
-        let sched = vec![None; steps.len()];
-        Self {
-            steps,
-            index: 0,
-            sched,
-        }
-    }
-}
-
-/// A completed node fetch: the sequence id it was launched under, its steps
-/// and the segment chunk addresses its reassembly visited.
-type Fetched<F> = (
-    usize,
-    Result<(Vec<Step<F>>, Vec<ChunkAddress>), ReaderError>,
-);
-
-/// An in-flight node fetch. Boxed to hold heterogeneous fetch futures in one
-/// queue; `Send` on native, unbounded on the single-threaded wasm executor.
-#[cfg(not(target_arch = "wasm32"))]
-type Fetch<'a, F> = Pin<Box<dyn Future<Output = Fetched<F>> + Send + 'a>>;
-#[cfg(target_arch = "wasm32")]
-type Fetch<'a, F> = Pin<Box<dyn Future<Output = Fetched<F>> + 'a>>;
+/// A visited node's completion payload: its steps and the segment chunk
+/// addresses its reassembly visited.
+type Visited<F> = (Vec<Step<F>>, Vec<ChunkAddress>);
 
 /// The stream's root reference, pending its first visit.
 #[derive(Debug)]
@@ -116,13 +81,8 @@ pub struct AddressStream<'a, S, F: Format = V1> {
     /// One frame per referenced hop on the current path.
     stack: Vec<Frame<F>>,
     done: bool,
-    /// Node fetches launched by the read-ahead window, awaiting completion.
-    inflight: FuturesUnordered<Fetch<'a, F>>,
-    /// Completions that arrived before the descent awaiting them; drained by
-    /// sequence id. Bounded with `inflight` by the window.
-    ready: Vec<Fetched<F>>,
-    /// The next fetch sequence id to hand out.
-    next_seq: usize,
+    /// The read-ahead window over prefetched node fetches.
+    sched: Scheduler<'a, Visited<F>>,
 }
 
 impl<'a, S, F: Format> AddressStream<'a, S, F> {
@@ -134,9 +94,7 @@ impl<'a, S, F: Format> AddressStream<'a, S, F> {
             pending: VecDeque::new(),
             stack: Vec::new(),
             done: false,
-            inflight: FuturesUnordered::new(),
-            ready: Vec::new(),
-            next_seq: 0,
+            sched: Scheduler::new(),
         }
     }
 }
@@ -184,13 +142,13 @@ where
                     Some(Step::Ref { addr, .. }) => Advance::Descend {
                         address: *addr,
                         key: None,
-                        seq: frame.sched.get(frame.index).copied().flatten(),
+                        seq: frame.tag(frame.index),
                     },
                     #[cfg(feature = "encryption")]
                     Some(Step::Encrypted { reference, .. }) => Advance::Descend {
                         address: *reference.address(),
                         key: Some(reference.key().clone()),
-                        seq: frame.sched.get(frame.index).copied().flatten(),
+                        seq: frame.tag(frame.index),
                     },
                     #[cfg(not(feature = "encryption"))]
                     Some(Step::Encrypted { .. }) => return Err(ReaderError::EncryptedChild),
@@ -223,23 +181,17 @@ where
     fn enter(&mut self, address: ChunkAddress, segments: Vec<ChunkAddress>, steps: Vec<Step<F>>) {
         self.pending.push_back(address);
         self.pending.extend(segments);
-        self.stack.push(Frame::new(steps));
+        self.stack.push(Frame::new(Bytes::new(), steps, 0));
     }
 
-    /// Fill the read-ahead window: launch node fetches for the referenced
-    /// children the walk reaches next, in ascending-key order, until at most
-    /// [`Format::READ_AHEAD`] fetches are in flight.
+    /// Fill the read-ahead window with the referenced children the walk
+    /// reaches next, opening an encrypted child with the key its record
+    /// carries; without the `encryption` feature it stops there, where the
+    /// walk errors.
     fn schedule(&mut self) {
-        let cap = F::READ_AHEAD;
         let store = self.store;
-        // Deepest frame first: that is ascending-key order from the walk, so
-        // the child needed soonest is always launched first.
-        'outer: for frame in self.stack.iter_mut().rev() {
-            let mut index = frame.index;
-            while let Some(step) = frame.steps.get(index) {
-                if self.inflight.len().saturating_add(self.ready.len()) >= cap {
-                    break 'outer;
-                }
+        self.sched
+            .fill(F::READ_AHEAD, &mut self.stack, |_base, step| {
                 let target = match step {
                     Step::Value { .. } => None,
                     Step::Ref { addr, .. } => Some((*addr, None)),
@@ -249,51 +201,33 @@ where
                     }
                     // The walk errors here; nothing beyond it is fetched.
                     #[cfg(not(feature = "encryption"))]
-                    Step::Encrypted { .. } => break 'outer,
+                    Step::Encrypted { .. } => return Plan::Stop,
                 };
-                if let Some((address, key)) = target
-                    && !matches!(frame.sched.get(index), Some(Some(_)))
-                {
-                    let seq = self.next_seq;
-                    self.next_seq = self.next_seq.saturating_add(1);
-                    if let Some(slot) = frame.sched.get_mut(index) {
-                        *slot = Some(seq);
-                    }
-                    let fetch: Fetch<'a, F> = Box::pin(async move {
-                        let result = materialize_traced::<S, F>(store, &address, key.as_ref())
-                            .await
-                            .map(|(node, segments)| (flatten(&node, false), segments))
-                            .map_err(ReaderError::from);
-                        (seq, result)
-                    });
-                    self.inflight.push(fetch);
-                }
-                index = index.saturating_add(1);
-            }
-        }
+                let Some((address, key)) = target else {
+                    return Plan::Skip;
+                };
+                Plan::Fetch(async move {
+                    materialize_traced::<S, F>(store, &address, key.as_ref())
+                        .await
+                        .map(|(node, segments)| (flatten(&node, false), segments))
+                        .map_err(ReaderError::from)
+                })
+            });
     }
 
     /// The steps and segment trace of the child at `address`: take the
-    /// prefetch launched under `seq`, buffering earlier-arriving completions,
-    /// or fetch directly when the descent was not prefetched.
+    /// prefetch launched under `seq`, or fetch directly when the descent was
+    /// not prefetched.
     async fn resolve(
         &mut self,
         seq: Option<usize>,
         address: ChunkAddress,
         key: Option<EncryptionKey>,
-    ) -> Result<(Vec<Step<F>>, Vec<ChunkAddress>), ReaderError> {
-        if let Some(seq) = seq {
-            loop {
-                if let Some(pos) = self.ready.iter().position(|(other, _)| *other == seq) {
-                    return self.ready.swap_remove(pos).1;
-                }
-                match self.inflight.next().await {
-                    Some((other, result)) if other == seq => return result,
-                    Some(pair) => self.ready.push(pair),
-                    // The launched fetch is unaccounted for; fetch directly.
-                    None => break,
-                }
-            }
+    ) -> Result<Visited<F>, ReaderError> {
+        if let Some(seq) = seq
+            && let Some(result) = self.sched.take(seq).await
+        {
+            return result;
         }
         let (node, segments) =
             materialize_traced::<S, F>(self.store, &address, key.as_ref()).await?;


### PR DESCRIPTION
## What
Extracts the duplicated schedule/resolve read-ahead machinery from `scan.rs` and `traverse.rs` into a new private crate-internal module `crates/manifest/src/sched.rs`, generic over the completion payload (`Vec<Step<F>>` for the cursor, `(Vec<Step<F>>, Vec<ChunkAddress>)` for the traversal).
The module owns `Frame` (steps + walk index + per-step prefetch tags, base key prefix optional), `Scheduler` (tagged fetch window: fill/take, sequence ids, ready buffer, wasm32/native `Send` cfg via a `FetchFuture` bound trait) and `Plan` (Skip/Stop/Fetch).
Each walker keeps its own per-step plan closure, so error semantics are preserved exactly: scan keeps its key-order upper-bound pruning and stop-at-encrypted-child, traverse keeps its replayable encrypted-child error and key-carrying encrypted descent.
Zero public surface change.

Closes #500.

## Why
`scan.rs` and `traverse.rs` had grown independent, near-identical read-ahead scheduling logic; consolidating it into one generic module removes the duplication while preserving each walker's distinct error semantics.

## Testing
Verified at 90c99c8c (single commit, based on origin/main).
All commands run under `nix develop` (rust 1.94.0, the CI pin) with a shared `CARGO_TARGET_DIR` and `RUSTC_WRAPPER=sccache`.

- `cargo fmt --all -- --check` — clean.
- `cargo clippy --workspace --all-targets --locked` — no errors; only warnings are pre-existing `doc_lazy_continuation` in `nectar-testing/src/lib.rs`, an untouched crate.
- `cargo clippy --locked --all-targets -p nectar-manifest --features encryption` — clean.
- Full test battery passes on both `--all-features` (190+5) and `--no-default-features` (180+5).
- Behaviour is bit-identical, including the flagged plan-before-tag reordering: tagged steps are always in-bounds `Ref`s, so the launched fetch set is unchanged, and this is guarded by the exact-fetch-count/bound/replay/cancel tests.

## AI Assistance
Implemented with Claude (Fable), reviewed with Claude (Opus).
