### PR TITLE
fix(file): zeroize the serialized encrypted-reference buffers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2545,6 +2545,7 @@ dependencies = [
  "rayon",
  "thiserror",
  "tokio",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/file/Cargo.toml
+++ b/crates/file/Cargo.toml
@@ -28,6 +28,7 @@ nectar-tasks = { workspace = true, optional = true }
 rayon = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"], optional = true }
+zeroize = { workspace = true, optional = true }
 
 [build-dependencies]
 
@@ -75,7 +76,7 @@ rayon = [ "dep:futures-channel", "dep:rayon", "std" ]
 arbitrary = [ "dep:arbitrary", "nectar-primitives?/arbitrary", "std" ]
 
 # Split-side encrypted mode. Joining encrypted references stays unconditional.
-encryption = [ "nectar-primitives?/encryption" ]
+encryption = [ "dep:zeroize", "nectar-primitives?/encryption" ]
 
 # Single-thread send escape: relaxes the boxed fetch future off `Send` in
 # lockstep with the primitives store traits.

--- a/crates/file/src/read/tests.rs
+++ b/crates/file/src/read/tests.rs
@@ -419,8 +419,8 @@ fn truncated_ciphertext_is_a_typed_decode_error() {
     // A valid encrypted parent referencing the short chunk fails mid-walk.
     let span = 2 * TINY as u64;
     let mut refs = Vec::new();
-    refs.extend_from_slice(&EncryptedChunkRef::new(short_addr, child_key.clone()).to_bytes());
-    refs.extend_from_slice(&EncryptedChunkRef::new(short_addr, child_key).to_bytes());
+    refs.extend_from_slice(&*EncryptedChunkRef::new(short_addr, child_key.clone()).to_bytes());
+    refs.extend_from_slice(&*EncryptedChunkRef::new(short_addr, child_key).to_bytes());
     let parent_wire = encrypt_node(&parent_key, span, &refs);
     let (parent_addr, parent_chunk) =
         seal(ContentChunk::<TINY>::try_from(Bytes::from(parent_wire)).unwrap());

--- a/crates/file/src/split/encrypted.rs
+++ b/crates/file/src/split/encrypted.rs
@@ -8,6 +8,7 @@ use bytes::Bytes;
 use nectar_marker::{MaybeSend, MaybeSync};
 use nectar_primitives::chunk::encryption::{ChunkEncrypt, EncryptedChunkRef, EncryptionKey};
 use nectar_primitives::chunk::{AnyChunkSet, ContentChunk};
+use zeroize::Zeroize;
 
 use super::error::SealError;
 use super::mode::{Sealed, SplitMode};
@@ -76,18 +77,25 @@ impl<K: KeySource> SplitMode for Encrypted<K> {
         Ok(self.source().next_key()?)
     }
 
+    /// Seals the payload, then wipes it when this seal held the last
+    /// reference: an intermediate body carries every child key, and the
+    /// engine builds it uniquely owned. A payload shared with the caller is
+    /// left alone.
     fn seal_with<const B: usize>(
         key: EncryptionKey,
         payload: Bytes,
     ) -> Result<Sealed<Self, B>, SealError> {
-        let (chunk, reference) = ContentChunk::<B>::try_from(payload)?
-            .encrypt_with(&key)?
-            .into_parts();
+        let encrypted =
+            ContentChunk::<B>::try_from(payload.clone()).and_then(|plain| plain.encrypt_with(&key));
+        if let Ok(mut buf) = payload.try_into_mut() {
+            buf.as_mut().zeroize();
+        }
+        let (chunk, reference) = encrypted?.into_parts();
         Ok((chunk.seal::<AnyChunkSet<B>>(), reference))
     }
 
     fn write_ref(reference: &EncryptedChunkRef, out: &mut Vec<u8>) {
-        out.extend_from_slice(&reference.to_bytes());
+        out.extend_from_slice(&*reference.to_bytes());
     }
 
     fn into_root(reference: EncryptedChunkRef) -> EncryptedChunkRef {

--- a/crates/file/src/split/engine.rs
+++ b/crates/file/src/split/engine.rs
@@ -693,6 +693,9 @@ where
     }
 
     /// Seal one intermediate payload from its children's references.
+    ///
+    /// The payload is built uniquely owned: an encrypted mode's sealer
+    /// relies on that to wipe it, since the body carries every child key.
     fn seal_intermediate(
         &mut self,
         span: u64,

--- a/crates/primitives/src/chunk/encryption/reference.rs
+++ b/crates/primitives/src/chunk/encryption/reference.rs
@@ -7,6 +7,7 @@ use crate::chunk::{ChunkAddress, ChunkRef};
 use crate::entry_ref::EntryRef;
 use crate::error::WrongLength;
 use crate::wire::{Cursor, FromCursor, ToWriter, Underrun, Writer};
+use zeroize::Zeroizing;
 
 use super::key::EncryptionKey;
 
@@ -54,8 +55,10 @@ impl EncryptedChunkRef {
     }
 
     /// Serialize to the fixed wire form: address followed by decryption key.
-    pub const fn to_bytes(&self) -> [u8; Self::SIZE] {
-        let mut buf = [0u8; Self::SIZE];
+    ///
+    /// The buffer carries the key, so it wipes on drop.
+    pub fn to_bytes(&self) -> Zeroizing<[u8; Self::SIZE]> {
+        let mut buf = Zeroizing::new([0u8; Self::SIZE]);
         let (address, key) = buf.split_at_mut(ChunkRef::SIZE);
         address.copy_from_slice(self.address().as_bytes());
         key.copy_from_slice(self.key.as_bytes());
@@ -85,7 +88,7 @@ impl FromCursor for EncryptedChunkRef {
 /// Writes the 64 wire bytes, the mirror of the `FromCursor` impl above.
 impl ToWriter for EncryptedChunkRef {
     fn put_into(&self, w: &mut Writer<'_>) {
-        w.put(&self.to_bytes());
+        w.put(&*self.to_bytes());
     }
 }
 
@@ -148,30 +151,9 @@ impl<'a> arbitrary::Arbitrary<'a> for EncryptedChunkRef {
     }
 }
 
-impl From<&EncryptedChunkRef> for [u8; EncryptedChunkRef::SIZE] {
-    fn from(r: &EncryptedChunkRef) -> Self {
-        r.to_bytes()
-    }
-}
-
-impl From<EncryptedChunkRef> for [u8; EncryptedChunkRef::SIZE] {
-    fn from(r: EncryptedChunkRef) -> Self {
-        r.to_bytes()
-    }
-}
-
 impl From<[u8; Self::SIZE]> for EncryptedChunkRef {
     fn from(bytes: [u8; Self::SIZE]) -> Self {
         Self::from_bytes(&bytes)
-    }
-}
-
-impl From<&EncryptedChunkRef> for Vec<u8> {
-    fn from(r: &EncryptedChunkRef) -> Self {
-        let mut v = Self::with_capacity(EncryptedChunkRef::SIZE);
-        v.extend_from_slice(r.address().as_bytes());
-        v.extend_from_slice(r.key.as_bytes());
-        v
     }
 }
 
@@ -202,13 +184,13 @@ mod tests {
         assert_eq!(enc_ref.reference().address(), &addr);
         assert_eq!(enc_ref.key(), &key);
 
-        let bytes: [u8; 64] = (&enc_ref).into();
+        let bytes = enc_ref.to_bytes();
         assert_eq!(bytes.len(), 64);
 
         let recovered = EncryptedChunkRef::try_from(bytes.as_slice()).unwrap();
         assert_eq!(recovered, enc_ref);
 
-        assert_eq!(EncryptedChunkRef::from(bytes), enc_ref);
+        assert_eq!(EncryptedChunkRef::from(*bytes), enc_ref);
         assert_eq!(EncryptedChunkRef::from_bytes(&bytes), enc_ref);
     }
 

--- a/crates/primitives/src/entry_ref.rs
+++ b/crates/primitives/src/entry_ref.rs
@@ -3,7 +3,7 @@
 use alloc::vec::Vec;
 
 use crate::chunk::encryption::EncryptedChunkRef;
-use crate::chunk::{ChunkAddress, ChunkRef};
+use crate::chunk::{ChunkAddress, ChunkRef, Reference};
 
 /// A byte slice whose width is neither reference width.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
@@ -71,7 +71,7 @@ impl From<&EntryRef> for Vec<u8> {
     fn from(entry_ref: &EntryRef) -> Self {
         match entry_ref {
             EntryRef::Plain(reference) => reference.address().as_bytes().to_vec(),
-            EntryRef::Encrypted(enc) => Self::from(enc),
+            EntryRef::Encrypted(enc) => Reference::to_bytes(enc),
         }
     }
 }


### PR DESCRIPTION
## What
`EncryptedChunkRef::to_bytes` now returns `Zeroizing<[u8; SIZE]>` instead of a plain array, so the wire buffer carrying the decryption key wipes itself on drop. The bare-buffer escapes that could bypass the wipe (`From<&EncryptedChunkRef>`/`From<EncryptedChunkRef>` for `[u8; 64]`, and `From<&EncryptedChunkRef>` for `Vec<u8>`) are removed, and `entry_ref.rs` now routes its `Vec<u8>` conversion through the `Reference::to_bytes` trait method instead. On the file-splitting side, `Encrypted::seal_with` in `crates/file/src/split/encrypted.rs` clones the intermediate payload before encrypting, then reclaims the original `Bytes` via `try_into_mut` and zeroizes it once it is uniquely owned, covering the intermediate node body (which carries every child key) for both the rayon fan-out and default seal paths.

## Why
Closes #409.

Encrypted intermediate chunk bodies and encrypted references carry key material in plaintext buffers that previously had no wipe-on-drop guarantee, leaving copies of decryption keys resident in memory longer than necessary. The original issue also suggested wrapping the engine's `Vec` in `Zeroizing`, but tracing the allocation showed that `Vec` moves zero-copy into `Bytes` and then into the plaintext chunk body, so wrapping it there would wipe nothing; the effective seam is the `Bytes` handle retained in `Encrypted::seal_with`, reclaimed via `try_into_mut` after the plaintext clone is dropped.

## Testing
All commands run under `nix develop` (rust 1.94, sccache wrapper) with `--locked`, mirroring lint.yml/unit.yml/nostd.yml/zepter.yml.

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --locked`: pass (only pre-existing `doc_lazy_continuation` warnings in nectar-testing, untouched, non-deny).
- Per-feature clippy on the touched nectar-file: `--features tokio` / `rayon` / `encryption`, all pass.
- `cargo machete`: no unused deps.
- Adversarial review verified empirically that `bytes` 1.11.1 `try_into_mut` reclaims and wipes the uniquely-owned intermediate payload after the plaintext clone drops, while leaving caller-aliased leaf payloads untouched; both seal paths (rayon fan-out and default `mode.seal`) route intermediate bodies through `Encrypted::seal_with`, so the wipe covers every intermediate node, and encryption completes before the wipe. No wire-byte drift (pinned-tree + round-trip tests pass).

## AI Assistance
Implementation by fable, adversarial review by opus.
