### PR TITLE
refactor(primitives): make narrow_single_owner internal to the single-owner seam

### DIFF
--- a/crates/primitives/src/chunk/trust.rs
+++ b/crates/primitives/src/chunk/trust.rs
@@ -234,9 +234,11 @@ impl<const BODY_SIZE: usize> Chunk<Verified, AnyChunkSet<BODY_SIZE>> {
     ///
     /// The address fact and the memoized owner transfer as-is: the
     /// single-owner arm was certified by its full acceptance rule already,
-    /// so no crypto re-runs.
+    /// so no crypto re-runs. The public seam for a single-owner view over a
+    /// general store is [`SingleOwnerGet`](crate::store::SingleOwnerGet), which
+    /// drives this narrowing per fetch; this method is its mechanism.
     #[must_use]
-    pub fn narrow_single_owner(
+    pub(crate) fn narrow_single_owner(
         self,
     ) -> Option<Chunk<Verified, SingleOwnerOnlyChunkSet<BODY_SIZE>>> {
         let Self {


### PR DESCRIPTION
## What

Demote `Chunk::narrow_single_owner` from `pub` to `pub(crate)`, leaving `SingleOwnerGet` as the single public way to narrow an `AnyChunkSet` view to the single-owner-only registry.

## Why

Two public narrowing surfaces were redundant. `SingleOwnerGet<T>` is the store adapter consumers bind (`ChunkGet<SingleOwnerOnlyChunkSet>`), and its `get` drives `narrow_single_owner` per fetch, turning a non-single-owner chunk into a typed `NotSingleOwner` error. The chunk-level `narrow_single_owner` exposed a second, lower-level way to do the same thing whose only non-test caller was `SingleOwnerGet` itself, and which only re-enabled the bind-AnyChunkSet-then-narrow-inline pattern the single-owner registry work moves away from. Keeping one public seam (the store adapter) leaves the primitive as its internal mechanism.

## Testing

nectar-primitives clippy --all-targets and nextest green (272 tests); the narrowing is still exercised through SingleOwnerGet and the retained in-crate unit tests.

## AI Assistance

Implementation and verification with Claude Code.
