### PR TITLE
chunk: split ChunkError::InvalidSize into typed variants

### DIFF
--- a/crates/primitives/src/chunk/bmt_body.rs
+++ b/crates/primitives/src/chunk/bmt_body.rs
@@ -118,11 +118,10 @@ impl<const BODY_SIZE: usize> BmtBody<BODY_SIZE> {
 fn validate_data<const BODY_SIZE: usize>(data: impl Into<Bytes>) -> error::Result<Bytes> {
     let data = data.into();
     if data.len() > BODY_SIZE {
-        return Err(ChunkError::invalid_size(
-            "data exceeds maximum chunk size",
-            BODY_SIZE,
-            data.len(),
-        ));
+        return Err(ChunkError::BodyTooLarge {
+            max: BODY_SIZE,
+            actual: data.len(),
+        });
     }
     Ok(data)
 }
@@ -141,11 +140,10 @@ impl<const BODY_SIZE: usize> TryFrom<Bytes> for BmtBody<BODY_SIZE> {
     #[allow(clippy::unwrap_used)] // infallible: split_to(SPAN_SIZE) yields exactly 8 bytes (length checked above)
     fn try_from(mut buf: Bytes) -> Result<Self> {
         if buf.len() < SPAN_SIZE {
-            return Err(ChunkError::invalid_size(
-                "insufficient data for span",
-                SPAN_SIZE,
-                buf.len(),
-            )
+            return Err(ChunkError::TruncatedSpan {
+                expected: SPAN_SIZE,
+                actual: buf.len(),
+            }
             .into());
         }
 
@@ -240,11 +238,10 @@ impl<const BODY_SIZE: usize> BmtBodyBuilder<BODY_SIZE, WithSpan> {
             // span <= BODY_SIZE here, so it fits usize on all supported targets.
             let span_len = crate::cast::usize_from_u64(span);
             if data_len != span_len {
-                return Err(ChunkError::invalid_size(
-                    "span does not match data size",
-                    span_len,
-                    data_len,
-                )
+                return Err(ChunkError::SpanMismatch {
+                    span,
+                    actual: data_len,
+                }
                 .into());
             }
         }
@@ -330,7 +327,7 @@ mod tests {
         fn test_bmt_body_size_validation(span in 0..=u64::MAX, data_len in DEFAULT_BODY_SIZE + 1..=DEFAULT_BODY_SIZE * 2) {
             let data = vec![0; data_len];
             let result = create_bmt_body(span, data);
-            assert!(matches!(result, Err(PrimitivesError::Chunk(ChunkError::InvalidSize { .. }))));
+            assert!(matches!(result, Err(PrimitivesError::Chunk(ChunkError::BodyTooLarge { .. }))));
         }
 
         #[test]
@@ -360,7 +357,7 @@ mod tests {
                 .with_data(data.clone());
 
             if span <= DEFAULT_BODY_SIZE as u64 && data.len() != span as usize {
-                assert!(matches!(result, Err(PrimitivesError::Chunk(ChunkError::InvalidSize { .. }))));
+                assert!(matches!(result, Err(PrimitivesError::Chunk(ChunkError::SpanMismatch { .. }))));
             } else {
                 assert!(result.is_ok());
             }
@@ -406,13 +403,13 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(PrimitivesError::Chunk(ChunkError::InvalidSize { .. }))
+            Err(PrimitivesError::Chunk(ChunkError::BodyTooLarge { .. }))
         ));
 
         let result = DefaultBmtBody::try_from(vec![0; DEFAULT_BODY_SIZE + 9].as_slice());
         assert!(matches!(
             result,
-            Err(PrimitivesError::Chunk(ChunkError::InvalidSize { .. }))
+            Err(PrimitivesError::Chunk(ChunkError::BodyTooLarge { .. }))
         ));
     }
 }

--- a/crates/primitives/src/chunk/content.rs
+++ b/crates/primitives/src/chunk/content.rs
@@ -292,7 +292,7 @@ mod tests {
         #[test]
         fn test_chunk_size_validation(data in proptest::collection::vec(any::<u8>(), DEFAULT_BODY_SIZE + 1..DEFAULT_BODY_SIZE * 2)) {
             let result = DefaultContentChunk::new(data);
-            prop_assert_eq!(matches!(result, Err(PrimitivesError::Chunk(ChunkError::InvalidSize { .. }))), true);
+            prop_assert_eq!(matches!(result, Err(PrimitivesError::Chunk(ChunkError::BodyTooLarge { .. }))), true);
         }
 
         #[test]
@@ -309,7 +309,7 @@ mod tests {
         #[test]
         fn test_deserialize_invalid_chunks(data in proptest::collection::vec(any::<u8>(), 0..8)) {
             let result = DefaultContentChunk::try_from(data.as_slice());
-            prop_assert_eq!(matches!(result, Err(PrimitivesError::Chunk(ChunkError::InvalidSize { .. }))), true);
+            prop_assert_eq!(matches!(result, Err(PrimitivesError::Chunk(ChunkError::TruncatedSpan { .. }))), true);
         }
 
         /// Differential accept set: seal certifies exactly the (chunk, address)

--- a/crates/primitives/src/chunk/error.rs
+++ b/crates/primitives/src/chunk/error.rs
@@ -12,14 +12,30 @@ pub(crate) type Result<T> = core::result::Result<T, ChunkError>;
 #[non_exhaustive]
 #[derive(Error, Debug)]
 pub enum ChunkError {
-    /// Chunk size is invalid
-    #[error("Invalid chunk size: {message} (expected: {expected}, got: {actual})")]
-    InvalidSize {
-        /// What was being sized when the mismatch was found
-        message: &'static str,
-        /// Byte width the format requires
+    /// Chunk body exceeds the maximum body size
+    #[error("Chunk body too large: maximum {max} bytes, got {actual}")]
+    BodyTooLarge {
+        /// Maximum body size in bytes
+        max: usize,
+        /// Byte length actually observed
+        actual: usize,
+    },
+
+    /// Buffer too short to carry a span
+    #[error("Truncated span: expected {expected} bytes, got {actual}")]
+    TruncatedSpan {
+        /// Byte width a span requires
         expected: usize,
-        /// Byte width actually observed
+        /// Byte length actually observed
+        actual: usize,
+    },
+
+    /// Span disagrees with the data length it describes
+    #[error("Span mismatch: span says {span} bytes, data is {actual}")]
+    SpanMismatch {
+        /// Length the span claims
+        span: u64,
+        /// Data length actually observed
         actual: usize,
     },
 
@@ -60,15 +76,6 @@ pub enum ChunkError {
 }
 
 impl ChunkError {
-    /// Construct an [`InvalidSize`](Self::InvalidSize) error
-    pub const fn invalid_size(message: &'static str, expected: usize, actual: usize) -> Self {
-        Self::InvalidSize {
-            message,
-            expected,
-            actual,
-        }
-    }
-
     /// Construct an [`InvalidFormat`](Self::InvalidFormat) error
     pub fn invalid_format<S: Into<String>>(msg: S) -> Self {
         Self::InvalidFormat(msg.into())


### PR DESCRIPTION
## What

Splits `ChunkError::InvalidSize` into three typed variants: `BodyTooLarge { max, actual }`, `TruncatedSpan { expected, actual }`, and `SpanMismatch { span, actual }`, and removes the `invalid_size` constructor.

Updates the three `bmt_body.rs` call sites to the new variants (`SpanMismatch` now carries the raw `u64` span rather than a cast `usize`), and tightens the six previously loose `InvalidSize { .. }` test assertions in `bmt_body.rs` and `content.rs` to the exact per-condition variant.

`InvalidFormat`, `InvalidSignature`, and `validate()` are left untouched, per the #513/#319 scope boundary.

## Why

Closes #318.

A single catch-all `InvalidSize` variant let call sites and tests conflate three distinct failure conditions (body-too-large, truncated span buffer, span/data mismatch), so a regression in one path could pass a test written against another. Per-condition variants make the failure mode explicit in both the type and the `Display` message, and let the test assertions catch a mismatch instead of any size error.

## Testing

Reviewer-verified: diff is scoped to `crates/primitives/src/chunk/{error.rs,bmt_body.rs,content.rs}`; `rg` over `crates/` confirms no remaining references to `InvalidSize` or `invalid_size`; 276 unit tests plus doctests pass; primitives lib clippy clean.

## AI Assistance

Implemented with Claude (fable) and reviewed with Claude (opus).
