### PR TITLE
feeds: retype getter/updater to single-owner-only registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2519,6 +2519,7 @@ dependencies = [
  "arbitrary",
  "bytes",
  "derive_more",
+ "futures-util",
  "nectar-feeds",
  "nectar-primitives 0.4.0",
  "nectar-testing",

--- a/crates/feeds/Cargo.toml
+++ b/crates/feeds/Cargo.toml
@@ -24,6 +24,7 @@ alloy-signer-local = { workspace = true, optional = true }
 arbitrary = { workspace = true, optional = true }
 bytes.workspace = true
 derive_more.workspace = true
+futures-util.workspace = true
 nectar-primitives = { workspace = true }
 thiserror.workspace = true
 

--- a/crates/feeds/src/error.rs
+++ b/crates/feeds/src/error.rs
@@ -20,9 +20,6 @@ pub enum FeedError {
         /// The address of the returned chunk.
         actual: ChunkAddress,
     },
-    /// The chunk at a feed slot is not a single-owner chunk.
-    #[error("chunk at {0} is not a single-owner chunk")]
-    NotSingleOwner(ChunkAddress),
     /// The signer is not the feed owner.
     #[error("owner mismatch: feed owner {expected}, signer {actual}")]
     OwnerMismatch {

--- a/crates/feeds/src/getter.rs
+++ b/crates/feeds/src/getter.rs
@@ -1,7 +1,9 @@
 //! Read side: fetch, certify and interpret updates over a chunk store.
 
 use core::fmt;
+use core::num::NonZeroUsize;
 
+use futures_util::future::join_all;
 use nectar_primitives::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{Chunk, IntoVerified, SingleOwnerOnlyChunkSet};
 use nectar_primitives::store::{ChunkGet, ChunkHas};
@@ -9,6 +11,7 @@ use nectar_primitives::store::{ChunkGet, ChunkHas};
 use crate::error::{FeedError, Result};
 use crate::feed::Feed;
 use crate::index::Index;
+use crate::probe::{self, Answers, Step};
 use crate::sequence::Sequence;
 use crate::update::FeedUpdate;
 
@@ -16,6 +19,7 @@ use crate::update::FeedUpdate;
 pub struct Getter<S, const BODY_SIZE: usize = DEFAULT_BODY_SIZE> {
     feed: Feed<BODY_SIZE>,
     store: S,
+    window: NonZeroUsize,
 }
 
 /// Latest sequence update plus the next free index.
@@ -33,6 +37,7 @@ impl<S, const BODY_SIZE: usize> fmt::Debug for Getter<S, BODY_SIZE> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Getter")
             .field("feed", &self.feed)
+            .field("window", &self.window)
             .finish_non_exhaustive()
     }
 }
@@ -40,7 +45,23 @@ impl<S, const BODY_SIZE: usize> fmt::Debug for Getter<S, BODY_SIZE> {
 impl<S, const BODY_SIZE: usize> Getter<S, BODY_SIZE> {
     /// Create a getter over `feed` reading from `store`.
     pub const fn new(feed: Feed<BODY_SIZE>, store: S) -> Self {
-        Self { feed, store }
+        Self {
+            feed,
+            store,
+            window: NonZeroUsize::MIN,
+        }
+    }
+
+    /// Set the concurrent presence-probe window of the latest-update
+    /// finders.
+    ///
+    /// A store-capacity knob, not a pure speedup: a wide round can induce
+    /// timeouts a presence probe must report as absence. Width one is the
+    /// sequential scan.
+    #[must_use]
+    pub const fn with_window(mut self, window: NonZeroUsize) -> Self {
+        self.window = window;
+        self
     }
 
     /// The feed this getter reads.
@@ -79,12 +100,6 @@ where
     Chunk<S::Trust, SingleOwnerOnlyChunkSet<BODY_SIZE>>:
         IntoVerified<Registry = SingleOwnerOnlyChunkSet<BODY_SIZE>>,
 {
-    async fn present(&self, index: u64) -> bool {
-        self.store
-            .has(&self.feed.update_address(&Sequence::new(index)))
-            .await
-    }
-
     /// Certify the update at `index` and pair it with its successor slot.
     async fn found(&self, index: u64) -> Result<Latest<BODY_SIZE>> {
         let seq = Sequence::new(index);
@@ -96,9 +111,53 @@ where
         })
     }
 
+    /// Run a replay resolver to a verdict, answering its faults in rounds of
+    /// at most [`window`](Self::with_window) concurrent presence probes.
+    ///
+    /// Only a completed probe answers an index; a speculative answer the
+    /// replay never consults is inert, so any width commits the boundary the
+    /// sequential scan would.
+    async fn drive(
+        &self,
+        floor: Sequence,
+        resolve: fn(u64, &Answers) -> Step,
+    ) -> Result<Latest<BODY_SIZE>> {
+        let base = floor.get();
+        let mut answers = Answers::new();
+        let mut plan = Vec::new();
+        loop {
+            match resolve(base, &answers) {
+                Step::Empty => {
+                    return Ok(Latest {
+                        update: None,
+                        next: Some(floor),
+                    });
+                }
+                Step::Commit { lo } => return self.found(lo).await,
+                Step::Fault(fault) => {
+                    fault.plan(self.window, &mut plan);
+                    plan.retain(|index| !answers.contains_key(index));
+                    let addressed: Vec<_> = plan
+                        .iter()
+                        .map(|&index| (index, self.feed.update_address(&Sequence::new(index))))
+                        .collect();
+                    let results =
+                        join_all(addressed.iter().map(|(_, address)| self.store.has(address)))
+                            .await;
+                    for (&(index, _), present) in addressed.iter().zip(results) {
+                        answers.insert(index, present);
+                    }
+                }
+            }
+        }
+    }
+
     /// Latest update by exponential-then-binary probing, from index zero.
     ///
     /// Assumes gapless publication: a hole reads as the end of the feed.
+    /// The returned update is certified; absence rests on unverified
+    /// presence answers, so a lying or unavailable store truncates the scan
+    /// to an earlier genuine update, never a forged one.
     pub async fn latest(&self) -> Result<Latest<BODY_SIZE>> {
         self.latest_from(Sequence::ZERO).await
     }
@@ -107,72 +166,13 @@ where
     /// known-present hint. An absent floor yields an empty result with
     /// `next = floor`.
     pub async fn latest_from(&self, floor: Sequence) -> Result<Latest<BODY_SIZE>> {
-        let base = floor.get();
-        if !self.present(base).await {
-            return Ok(Latest {
-                update: None,
-                next: Some(floor),
-            });
-        }
-
-        // Exponential phase: double the probe offset until a miss brackets
-        // the boundary between present and absent.
-        let mut lo = base;
-        let mut off: u64 = 1;
-        let mut hi = loop {
-            let Some(idx) = base.checked_add(off) else {
-                // The offset left the index space; the top slot decides.
-                if self.present(u64::MAX).await {
-                    return self.found(u64::MAX).await;
-                }
-                break u64::MAX;
-            };
-            if self.present(idx).await {
-                if idx == u64::MAX {
-                    return self.found(u64::MAX).await;
-                }
-                lo = idx;
-                off = off.saturating_mul(2);
-            } else {
-                break idx;
-            }
-        };
-
-        // Binary phase: `lo` present, `hi` absent; converge to adjacency.
-        while let Some(gap) = hi.checked_sub(lo) {
-            if gap <= 1 {
-                break;
-            }
-            let Some(mid) = lo.checked_add(gap / 2) else {
-                break;
-            };
-            if self.present(mid).await {
-                lo = mid;
-            } else {
-                hi = mid;
-            }
-        }
-        self.found(lo).await
+        self.drive(floor, probe::resolve_probing).await
     }
 
-    /// Latest update by stepwise scan from a floor slot, one probe per
-    /// index. The baseline the probing search is measured against.
+    /// Latest update by stepwise scan from a floor slot. The baseline the
+    /// probing search is measured against; the absence caveat of
+    /// [`latest`](Self::latest) applies.
     pub async fn latest_linear_from(&self, floor: Sequence) -> Result<Latest<BODY_SIZE>> {
-        if !self.present(floor.get()).await {
-            return Ok(Latest {
-                update: None,
-                next: Some(floor),
-            });
-        }
-        let mut last = floor.get();
-        loop {
-            let Some(candidate) = last.checked_add(1) else {
-                return self.found(last).await;
-            };
-            if !self.present(candidate).await {
-                return self.found(last).await;
-            }
-            last = candidate;
-        }
+        self.drive(floor, probe::resolve_linear).await
     }
 }

--- a/crates/feeds/src/getter.rs
+++ b/crates/feeds/src/getter.rs
@@ -3,7 +3,7 @@
 use core::fmt;
 
 use nectar_primitives::DEFAULT_BODY_SIZE;
-use nectar_primitives::chunk::{AnyChunkSet, Chunk, IntoVerified};
+use nectar_primitives::chunk::{Chunk, IntoVerified, SingleOwnerOnlyChunkSet};
 use nectar_primitives::store::{ChunkGet, ChunkHas};
 
 use crate::error::{FeedError, Result};
@@ -51,8 +51,9 @@ impl<S, const BODY_SIZE: usize> Getter<S, BODY_SIZE> {
 
 impl<S, const BODY_SIZE: usize> Getter<S, BODY_SIZE>
 where
-    S: ChunkGet<AnyChunkSet<BODY_SIZE>>,
-    Chunk<S::Trust, AnyChunkSet<BODY_SIZE>>: IntoVerified<Registry = AnyChunkSet<BODY_SIZE>>,
+    S: ChunkGet<SingleOwnerOnlyChunkSet<BODY_SIZE>>,
+    Chunk<S::Trust, SingleOwnerOnlyChunkSet<BODY_SIZE>>:
+        IntoVerified<Registry = SingleOwnerOnlyChunkSet<BODY_SIZE>>,
 {
     /// Fetch and certify the update at `index`.
     ///
@@ -68,18 +69,15 @@ where
                 actual: *chunk.address(),
             });
         }
-        let soc = chunk
-            .into_envelope()
-            .into_single_owner()
-            .ok_or(FeedError::NotSingleOwner(address))?;
-        Ok(FeedUpdate::new(index, soc))
+        Ok(FeedUpdate::new(index, chunk.into_envelope()))
     }
 }
 
 impl<S, const BODY_SIZE: usize> Getter<S, BODY_SIZE>
 where
-    S: ChunkGet<AnyChunkSet<BODY_SIZE>> + ChunkHas,
-    Chunk<S::Trust, AnyChunkSet<BODY_SIZE>>: IntoVerified<Registry = AnyChunkSet<BODY_SIZE>>,
+    S: ChunkGet<SingleOwnerOnlyChunkSet<BODY_SIZE>> + ChunkHas,
+    Chunk<S::Trust, SingleOwnerOnlyChunkSet<BODY_SIZE>>:
+        IntoVerified<Registry = SingleOwnerOnlyChunkSet<BODY_SIZE>>,
 {
     async fn present(&self, index: u64) -> bool {
         self.store

--- a/crates/feeds/src/lib.rs
+++ b/crates/feeds/src/lib.rs
@@ -49,6 +49,7 @@ mod error;
 mod feed;
 mod getter;
 mod index;
+mod probe;
 mod sequence;
 mod topic;
 mod update;

--- a/crates/feeds/src/probe.rs
+++ b/crates/feeds/src/probe.rs
@@ -1,0 +1,471 @@
+//! Pure replay resolvers and round planning for the windowed finders.
+//!
+//! A resolver replays a sequential scan's decision procedure over a map of
+//! completed presence answers and faults on the first index it consults
+//! without one. The driver answers faults in rounds of bounded concurrent
+//! probes; speculative answers the replay never consults are inert, so any
+//! window width commits the boundary the sequential scan would.
+
+use std::collections::{BTreeMap, VecDeque};
+
+use core::num::NonZeroUsize;
+
+/// Completed presence answers by index. Only a completed answer may enter;
+/// an absent key is "not yet asked", never "absent".
+pub(crate) type Answers = BTreeMap<u64, bool>;
+
+/// One replay outcome over a fixed answer map.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Step {
+    /// The replay consulted an index with no completed answer.
+    Fault(Fault),
+    /// Boundary committed: the update at `lo` is the result.
+    Commit {
+        /// Highest index observed present with an observed-absent successor,
+        /// or the top slot.
+        lo: u64,
+    },
+    /// The floor slot is absent.
+    Empty,
+}
+
+/// A consulted-but-unanswered index plus the replay phase that consulted it,
+/// the seed of one round's probe plan.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Fault {
+    index: u64,
+    phase: Phase,
+}
+
+/// Replay phase at the fault, selecting the speculation shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Phase {
+    /// The floor probe; speculation climbs the ladder from the floor.
+    Floor,
+    /// The exponential ladder at offset `off` from `base`.
+    Ladder { base: u64, off: u64 },
+    /// The top-slot arm after the offset left the index space.
+    Top,
+    /// The binary phase over the open bracket `(lo, hi)`.
+    Binary { lo: u64, hi: u64 },
+    /// The stepwise scan; speculation is consecutive successors.
+    Linear,
+}
+
+impl Fault {
+    /// The index this round must answer.
+    #[cfg(test)]
+    const fn index(&self) -> u64 {
+        self.index
+    }
+
+    /// Plan one round into `out`: the faulting index first, then speculative
+    /// indices along the replay's own future consult path, at most `width`
+    /// in total.
+    pub(crate) fn plan(&self, width: NonZeroUsize, out: &mut Vec<u64>) {
+        out.clear();
+        out.push(self.index);
+        let cap = width.get();
+        match self.phase {
+            Phase::Floor => ladder(self.index, 1, cap, out),
+            Phase::Ladder { base, off } => ladder(base, off.saturating_mul(2), cap, out),
+            Phase::Top => {}
+            Phase::Binary { lo, hi } => bisections(lo, hi, cap, out),
+            Phase::Linear => successors(self.index, cap, out),
+        }
+    }
+}
+
+/// Replay of the exponential-then-binary scan from `base`.
+pub(crate) fn resolve_probing(base: u64, answers: &Answers) -> Step {
+    match answers.get(&base) {
+        None => {
+            return Step::Fault(Fault {
+                index: base,
+                phase: Phase::Floor,
+            });
+        }
+        Some(false) => return Step::Empty,
+        Some(true) => {}
+    }
+
+    // Exponential phase: double the probe offset until a miss brackets the
+    // boundary; past the end of the index space the top slot decides.
+    let mut lo = base;
+    let mut off: u64 = 1;
+    let mut hi = loop {
+        let (index, phase) = base
+            .checked_add(off)
+            .map_or((u64::MAX, Phase::Top), |index| {
+                (index, Phase::Ladder { base, off })
+            });
+        match answers.get(&index) {
+            None => return Step::Fault(Fault { index, phase }),
+            Some(true) if index == u64::MAX => return Step::Commit { lo: u64::MAX },
+            Some(true) => {
+                lo = index;
+                off = off.saturating_mul(2);
+            }
+            Some(false) => break index,
+        }
+    };
+
+    // Binary phase: `lo` present, `hi` absent; converge to adjacency.
+    while let Some(gap) = hi.checked_sub(lo) {
+        if gap <= 1 {
+            break;
+        }
+        let Some(mid) = lo.checked_add(gap / 2) else {
+            break;
+        };
+        match answers.get(&mid) {
+            None => {
+                return Step::Fault(Fault {
+                    index: mid,
+                    phase: Phase::Binary { lo, hi },
+                });
+            }
+            Some(true) => lo = mid,
+            Some(false) => hi = mid,
+        }
+    }
+    Step::Commit { lo }
+}
+
+/// Replay of the stepwise scan from `base`.
+pub(crate) fn resolve_linear(base: u64, answers: &Answers) -> Step {
+    match answers.get(&base) {
+        None => {
+            return Step::Fault(Fault {
+                index: base,
+                phase: Phase::Linear,
+            });
+        }
+        Some(false) => return Step::Empty,
+        Some(true) => {}
+    }
+    let mut last = base;
+    loop {
+        let Some(candidate) = last.checked_add(1) else {
+            return Step::Commit { lo: last };
+        };
+        match answers.get(&candidate) {
+            None => {
+                return Step::Fault(Fault {
+                    index: candidate,
+                    phase: Phase::Linear,
+                });
+            }
+            Some(true) => last = candidate,
+            Some(false) => return Step::Commit { lo: last },
+        }
+    }
+}
+
+/// Ladder rungs `base + first_off`, `base + 2 * first_off`, ...; past the
+/// end of the index space the top slot is planned once.
+fn ladder(base: u64, first_off: u64, cap: usize, out: &mut Vec<u64>) {
+    let mut off = first_off;
+    while out.len() < cap {
+        let index = base.saturating_add(off);
+        push_unique(out, index);
+        if index == u64::MAX {
+            break;
+        }
+        off = off.saturating_mul(2);
+    }
+}
+
+/// Breadth-first midpoints of the decision tree under `(lo, hi)`; the root
+/// midpoint is the faulting index already planned.
+fn bisections(lo: u64, hi: u64, cap: usize, out: &mut Vec<u64>) {
+    let mut intervals = VecDeque::from([(lo, hi)]);
+    while let Some((low, high)) = intervals.pop_front() {
+        if out.len() >= cap {
+            break;
+        }
+        let Some(gap) = high.checked_sub(low) else {
+            continue;
+        };
+        if gap <= 1 {
+            continue;
+        }
+        let Some(mid) = low.checked_add(gap / 2) else {
+            continue;
+        };
+        push_unique(out, mid);
+        intervals.push_back((low, mid));
+        intervals.push_back((mid, high));
+    }
+}
+
+/// Consecutive successors of `from`, stopping at the top of the index space.
+fn successors(from: u64, cap: usize, out: &mut Vec<u64>) {
+    let mut index = from;
+    while out.len() < cap {
+        let Some(next) = index.checked_add(1) else {
+            break;
+        };
+        push_unique(out, next);
+        index = next;
+    }
+}
+
+fn push_unique(out: &mut Vec<u64>, index: u64) {
+    if !out.contains(&index) {
+        out.push(index);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use super::*;
+
+    /// Total presence oracle: a finite pattern at the floor, a constant
+    /// beyond it. Arbitrary, so gappy and adversarial maps are covered.
+    struct Oracle {
+        base: u64,
+        pattern: Vec<bool>,
+        beyond: bool,
+    }
+
+    impl Oracle {
+        fn has(&self, index: u64) -> bool {
+            index
+                .checked_sub(self.base)
+                .and_then(|off| usize::try_from(off).ok())
+                .and_then(|off| self.pattern.get(off).copied())
+                .unwrap_or(self.beyond)
+        }
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum Outcome {
+        Empty,
+        Commit(u64),
+    }
+
+    /// Direct port of the sequential exponential-then-binary scan, recording
+    /// its consult order.
+    fn sequential_probing(base: u64, oracle: &Oracle, trace: &mut Vec<u64>) -> Outcome {
+        let mut consult = |index: u64| {
+            trace.push(index);
+            oracle.has(index)
+        };
+        if !consult(base) {
+            return Outcome::Empty;
+        }
+        let mut lo = base;
+        let mut off: u64 = 1;
+        let mut hi = loop {
+            let Some(index) = base.checked_add(off) else {
+                if consult(u64::MAX) {
+                    return Outcome::Commit(u64::MAX);
+                }
+                break u64::MAX;
+            };
+            if consult(index) {
+                if index == u64::MAX {
+                    return Outcome::Commit(u64::MAX);
+                }
+                lo = index;
+                off = off.saturating_mul(2);
+            } else {
+                break index;
+            }
+        };
+        while let Some(gap) = hi.checked_sub(lo) {
+            if gap <= 1 {
+                break;
+            }
+            let Some(mid) = lo.checked_add(gap / 2) else {
+                break;
+            };
+            if consult(mid) {
+                lo = mid;
+            } else {
+                hi = mid;
+            }
+        }
+        Outcome::Commit(lo)
+    }
+
+    /// Direct port of the sequential stepwise scan, recording its consult
+    /// order.
+    fn sequential_linear(base: u64, oracle: &Oracle, trace: &mut Vec<u64>) -> Outcome {
+        let mut consult = |index: u64| {
+            trace.push(index);
+            oracle.has(index)
+        };
+        if !consult(base) {
+            return Outcome::Empty;
+        }
+        let mut last = base;
+        loop {
+            let Some(candidate) = last.checked_add(1) else {
+                return Outcome::Commit(last);
+            };
+            if !consult(candidate) {
+                return Outcome::Commit(last);
+            }
+            last = candidate;
+        }
+    }
+
+    /// Pure round driver: faults are always answered, speculative probes may
+    /// be adversarially dropped (left unanswered) per the mask.
+    fn simulate(
+        resolve: fn(u64, &Answers) -> Step,
+        base: u64,
+        oracle: &Oracle,
+        width: NonZeroUsize,
+        drops: &[bool],
+        trace: &mut Vec<u64>,
+    ) -> Outcome {
+        let mut answers = Answers::new();
+        let mut plan = Vec::new();
+        let mut cursor = 0usize;
+        loop {
+            match resolve(base, &answers) {
+                Step::Empty => return Outcome::Empty,
+                Step::Commit { lo } => return Outcome::Commit(lo),
+                Step::Fault(fault) => {
+                    fault.plan(width, &mut plan);
+                    plan.retain(|index| !answers.contains_key(index));
+                    for &index in &plan {
+                        let dropped =
+                            index != fault.index() && drops.get(cursor).copied().unwrap_or(false);
+                        cursor = cursor.wrapping_add(1);
+                        if !dropped {
+                            trace.push(index);
+                            answers.insert(index, oracle.has(index));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    const ONE: NonZeroUsize = NonZeroUsize::MIN;
+
+    fn width(n: usize) -> NonZeroUsize {
+        NonZeroUsize::new(n).unwrap()
+    }
+
+    #[test]
+    fn empty_answers_fault_on_the_floor() {
+        let answers = Answers::new();
+        for resolve in [resolve_probing, resolve_linear] {
+            let Step::Fault(fault) = resolve(7, &answers) else {
+                panic!("expected a floor fault");
+            };
+            assert_eq!(fault.index(), 7);
+        }
+    }
+
+    #[test]
+    fn floor_fault_plans_the_ladder() {
+        let answers = Answers::new();
+        let Step::Fault(fault) = resolve_probing(0, &answers) else {
+            panic!("expected a floor fault");
+        };
+        let mut plan = Vec::new();
+        fault.plan(width(4), &mut plan);
+        assert_eq!(plan, vec![0, 1, 2, 4]);
+    }
+
+    #[test]
+    fn binary_fault_plans_the_decision_tree() {
+        // Present through 8, absent at 16: the bracket is (8, 16), the
+        // faulting midpoint 12, and speculation covers both child midpoints.
+        let mut answers = Answers::new();
+        for index in [0, 1, 2, 4, 8] {
+            answers.insert(index, true);
+        }
+        answers.insert(16, false);
+        let Step::Fault(fault) = resolve_probing(0, &answers) else {
+            panic!("expected a binary fault");
+        };
+        assert_eq!(fault.index(), 12);
+        let mut plan = Vec::new();
+        fault.plan(width(3), &mut plan);
+        assert_eq!(plan, vec![12, 10, 14]);
+    }
+
+    #[test]
+    fn ladder_near_the_top_plans_the_top_slot_once() {
+        let answers = Answers::new();
+        let Step::Fault(fault) = resolve_probing(u64::MAX - 2, &answers) else {
+            panic!("expected a floor fault");
+        };
+        let mut plan = Vec::new();
+        fault.plan(width(8), &mut plan);
+        assert_eq!(plan, vec![u64::MAX - 2, u64::MAX - 1, u64::MAX]);
+    }
+
+    proptest! {
+        /// Any window width, any drop pattern: the windowed probing finder
+        /// reaches the sequential scan's verdict.
+        #[test]
+        fn windowed_probing_matches_sequential(
+            base in prop_oneof![0u64..=192, u64::MAX - 192..=u64::MAX],
+            pattern in proptest::collection::vec(any::<bool>(), 0..96),
+            beyond in any::<bool>(),
+            w in 1usize..=16,
+            drops in proptest::collection::vec(any::<bool>(), 0..256),
+        ) {
+            let oracle = Oracle { base, pattern, beyond };
+            let expected = sequential_probing(base, &oracle, &mut Vec::new());
+            let got = simulate(
+                resolve_probing, base, &oracle, width(w), &drops, &mut Vec::new(),
+            );
+            prop_assert_eq!(got, expected);
+        }
+
+        /// Any window width, any drop pattern: the windowed stepwise finder
+        /// reaches the sequential scan's verdict.
+        #[test]
+        fn windowed_linear_matches_sequential(
+            base in prop_oneof![0u64..=192, u64::MAX - 192..=u64::MAX],
+            pattern in proptest::collection::vec(any::<bool>(), 0..96),
+            w in 1usize..=16,
+            drops in proptest::collection::vec(any::<bool>(), 0..256),
+        ) {
+            // A constant-present tail would make the stepwise reference walk
+            // the whole index space; the finite pattern keeps it bounded.
+            let oracle = Oracle { base, pattern, beyond: false };
+            let expected = sequential_linear(base, &oracle, &mut Vec::new());
+            let got = simulate(
+                resolve_linear, base, &oracle, width(w), &drops, &mut Vec::new(),
+            );
+            prop_assert_eq!(got, expected);
+        }
+
+        /// Width one issues exactly the sequential consult sequence.
+        #[test]
+        fn width_one_is_the_sequential_trace(
+            base in prop_oneof![0u64..=192, u64::MAX - 192..=u64::MAX],
+            pattern in proptest::collection::vec(any::<bool>(), 0..96),
+            beyond in any::<bool>(),
+        ) {
+            let oracle = Oracle { base, pattern, beyond };
+
+            let mut expected_trace = Vec::new();
+            let expected = sequential_probing(base, &oracle, &mut expected_trace);
+            let mut trace = Vec::new();
+            let got = simulate(resolve_probing, base, &oracle, ONE, &[], &mut trace);
+            prop_assert_eq!(got, expected);
+            prop_assert_eq!(&trace, &expected_trace);
+
+            let oracle = Oracle { beyond: false, ..oracle };
+            let mut expected_trace = Vec::new();
+            let expected = sequential_linear(base, &oracle, &mut expected_trace);
+            let mut trace = Vec::new();
+            let got = simulate(resolve_linear, base, &oracle, ONE, &[], &mut trace);
+            prop_assert_eq!(got, expected);
+            prop_assert_eq!(trace, expected_trace);
+        }
+    }
+}

--- a/crates/feeds/src/probe.rs
+++ b/crates/feeds/src/probe.rs
@@ -354,6 +354,19 @@ mod tests {
         NonZeroUsize::new(n).unwrap()
     }
 
+    /// The sequential scan may consult one index twice (the top slot, probed
+    /// as the floor and again on the exhausted-ladder arm); the resolver
+    /// caches every answer and never re-consults, so the width-one trace is
+    /// the sequential trace with repeat consultations dropped.
+    fn first_consultations(trace: &[u64]) -> Vec<u64> {
+        let mut seen = BTreeMap::new();
+        trace
+            .iter()
+            .copied()
+            .filter(|index| seen.insert(*index, ()).is_none())
+            .collect()
+    }
+
     #[test]
     fn empty_answers_fault_on_the_floor() {
         let answers = Answers::new();
@@ -457,7 +470,7 @@ mod tests {
             let mut trace = Vec::new();
             let got = simulate(resolve_probing, base, &oracle, ONE, &[], &mut trace);
             prop_assert_eq!(got, expected);
-            prop_assert_eq!(&trace, &expected_trace);
+            prop_assert_eq!(trace, first_consultations(&expected_trace));
 
             let oracle = Oracle { beyond: false, ..oracle };
             let mut expected_trace = Vec::new();
@@ -465,7 +478,7 @@ mod tests {
             let mut trace = Vec::new();
             let got = simulate(resolve_linear, base, &oracle, ONE, &[], &mut trace);
             prop_assert_eq!(got, expected);
-            prop_assert_eq!(trace, expected_trace);
+            prop_assert_eq!(trace, first_consultations(&expected_trace));
         }
     }
 }

--- a/crates/feeds/src/updater.rs
+++ b/crates/feeds/src/updater.rs
@@ -4,7 +4,7 @@ use core::fmt;
 
 use alloy_signer::SignerSync;
 use bytes::Bytes;
-use nectar_primitives::chunk::{AnyChunkSet, Chunk, SingleOwnerChunk, Verified};
+use nectar_primitives::chunk::{Chunk, SingleOwnerChunk, SingleOwnerOnlyChunkSet, Verified};
 use nectar_primitives::store::ChunkPut;
 use nectar_primitives::{DEFAULT_BODY_SIZE, PrimitivesError};
 
@@ -62,7 +62,7 @@ impl<S, Sig, const BODY_SIZE: usize> Updater<S, Sig, BODY_SIZE> {
 
 impl<S, Sig, const BODY_SIZE: usize> Updater<S, Sig, BODY_SIZE>
 where
-    S: ChunkPut<AnyChunkSet<BODY_SIZE>>,
+    S: ChunkPut<SingleOwnerOnlyChunkSet<BODY_SIZE>>,
     Sig: SignerSync,
 {
     /// Sign and publish `payload` at the next sequence position, advancing
@@ -97,7 +97,8 @@ where
                 actual: owner,
             });
         }
-        let sealed = Chunk::<Verified, AnyChunkSet<BODY_SIZE>>::from_envelope(soc.clone().into())?;
+        let sealed =
+            Chunk::<Verified, SingleOwnerOnlyChunkSet<BODY_SIZE>>::from_envelope(soc.clone())?;
         self.store.put(sealed).await.map_err(FeedError::store)?;
         Ok(FeedUpdate::new(index, soc))
     }

--- a/crates/feeds/tests/feed_roundtrip.rs
+++ b/crates/feeds/tests/feed_roundtrip.rs
@@ -14,14 +14,21 @@
 use alloy_primitives::hex;
 use alloy_signer_local::PrivateKeySigner;
 use nectar_feeds::{Feed, FeedError, Getter, Index, Sequence, Topic, Updater};
-use nectar_primitives::chunk::{ChunkAddress, ChunkOps, TrustedSource, Unverified};
-use nectar_primitives::store::{ChunkGet, ChunkHas, ChunkStoreError};
+use nectar_primitives::chunk::{
+    ChunkAddress, ChunkOps, SingleOwnerChunk, SingleOwnerOnlyChunkSet, TrustedSource, Unverified,
+};
+use nectar_primitives::store::{
+    ChunkGet, ChunkHas, ChunkPut, ChunkStoreError, MemoryStore, SingleOwnerGet,
+};
 use nectar_primitives::{
     Chunk, ChunkRegistry, DEFAULT_BODY_SIZE, DefaultContentChunk, DefaultMemoryStore,
     StandardChunkSet,
 };
 use nectar_testing::run;
 use proptest::prelude::*;
+
+/// Single-owner-only store the feed handles are typed against.
+type SocStore = MemoryStore<SingleOwnerOnlyChunkSet>;
 
 fn signer() -> PrivateKeySigner {
     let pk = hex!("2c7536e3605d9c16a7a3d7b1898e529396a65c23a3bcbd4012a11cf2731b0fbc");
@@ -37,7 +44,7 @@ fn append_then_read_round_trips() {
     run(async {
         let signer = signer();
         let feed = feed_for(&signer);
-        let store = DefaultMemoryStore::new();
+        let store = SocStore::new();
         let mut updater = Updater::new(feed, &store, &signer);
 
         let payloads: [&[u8]; 3] = [b"first", b"second", b"third"];
@@ -61,7 +68,7 @@ fn append_then_read_round_trips() {
 fn empty_feed_has_no_latest() {
     run(async {
         let signer = signer();
-        let getter = Getter::new(feed_for(&signer), DefaultMemoryStore::new());
+        let getter = Getter::new(feed_for(&signer), SocStore::new());
 
         for latest in [
             getter.latest().await.unwrap(),
@@ -78,7 +85,7 @@ fn finders_agree_while_the_feed_grows() {
     run(async {
         let signer = signer();
         let feed = feed_for(&signer);
-        let store = DefaultMemoryStore::new();
+        let store = SocStore::new();
         let mut updater = Updater::new(feed, &store, &signer);
         let getter = Getter::new(feed, &store);
 
@@ -103,7 +110,7 @@ fn latest_from_respects_the_floor() {
     run(async {
         let signer = signer();
         let feed = feed_for(&signer);
-        let store = DefaultMemoryStore::new();
+        let store = SocStore::new();
         let mut updater = Updater::new(feed, &store, &signer);
         for n in 0u64..5 {
             updater.append(n.to_be_bytes().to_vec()).await.unwrap();
@@ -127,7 +134,7 @@ fn wrong_signer_is_rejected_before_the_write() {
         let signer = signer();
         let other = PrivateKeySigner::from_slice(&[0x42u8; 32]).unwrap();
         let feed = Feed::<DEFAULT_BODY_SIZE>::new(Topic::from_label("roundtrip"), other.address());
-        let store = DefaultMemoryStore::new();
+        let store = SocStore::new();
         let mut updater = Updater::new(feed, &store, &signer);
 
         let err = updater.append(b"payload".to_vec()).await.unwrap_err();
@@ -143,7 +150,7 @@ fn sequence_space_exhausts_at_the_top_slot() {
     run(async {
         let signer = signer();
         let feed = feed_for(&signer);
-        let store = DefaultMemoryStore::new();
+        let store = SocStore::new();
         let mut updater = Updater::resume(feed, &store, &signer, Sequence::MAX);
 
         let update = updater.append(b"last".to_vec()).await.unwrap();
@@ -169,7 +176,7 @@ fn sequence_space_exhausts_at_the_top_slot() {
 fn missing_update_surfaces_the_store_error() {
     run(async {
         let signer = signer();
-        let getter = Getter::new(feed_for(&signer), DefaultMemoryStore::new());
+        let getter = Getter::new(feed_for(&signer), SocStore::new());
         assert!(matches!(
             getter.at(Sequence::ZERO).await.unwrap_err(),
             FeedError::Store(_)
@@ -179,16 +186,16 @@ fn missing_update_surfaces_the_store_error() {
 
 /// Store double reading back unverified parses of what the inner store holds,
 /// exercising the getter's certification path.
-struct Unverifying<'a>(&'a DefaultMemoryStore);
+struct Unverifying<'a>(&'a SocStore);
 
-impl ChunkGet<StandardChunkSet> for Unverifying<'_> {
+impl ChunkGet<SingleOwnerOnlyChunkSet> for Unverifying<'_> {
     type Trust = Unverified;
     type Error = ChunkStoreError;
 
     async fn get(
         &self,
         address: &ChunkAddress,
-    ) -> Result<Chunk<Unverified, StandardChunkSet>, Self::Error> {
+    ) -> Result<Chunk<Unverified, SingleOwnerOnlyChunkSet>, Self::Error> {
         let chunk = ChunkGet::get(self.0, address).await?;
         Chunk::parse(*address, &chunk.typed_bytes())
             .map_err(|_| ChunkStoreError::not_found(address))
@@ -206,7 +213,7 @@ fn unverified_reads_are_certified() {
     run(async {
         let signer = signer();
         let feed = feed_for(&signer);
-        let store = DefaultMemoryStore::new();
+        let store = SocStore::new();
         let mut updater = Updater::new(feed, &store, &signer);
         updater.append(b"payload".to_vec()).await.unwrap();
 
@@ -222,18 +229,18 @@ fn unverified_reads_are_certified() {
 /// Store that serves one fixed slot's bytes under whatever address is asked
 /// for: certification must reject the relabelled chunk.
 struct Rebinding<'a> {
-    inner: &'a DefaultMemoryStore,
+    inner: &'a SocStore,
     from: ChunkAddress,
 }
 
-impl ChunkGet<StandardChunkSet> for Rebinding<'_> {
+impl ChunkGet<SingleOwnerOnlyChunkSet> for Rebinding<'_> {
     type Trust = Unverified;
     type Error = ChunkStoreError;
 
     async fn get(
         &self,
         address: &ChunkAddress,
-    ) -> Result<Chunk<Unverified, StandardChunkSet>, Self::Error> {
+    ) -> Result<Chunk<Unverified, SingleOwnerOnlyChunkSet>, Self::Error> {
         let chunk = ChunkGet::get(self.inner, &self.from).await?;
         Chunk::parse(*address, &chunk.typed_bytes())
             .map_err(|_| ChunkStoreError::not_found(address))
@@ -245,7 +252,7 @@ fn relabelled_chunk_fails_certification() {
     run(async {
         let signer = signer();
         let feed = feed_for(&signer);
-        let store = DefaultMemoryStore::new();
+        let store = SocStore::new();
         let mut updater = Updater::new(feed, &store, &signer);
         updater.append(b"payload".to_vec()).await.unwrap();
 
@@ -263,8 +270,8 @@ fn relabelled_chunk_fails_certification() {
     });
 }
 
-/// Trusted store lying about type: a content chunk vouched for at the feed
-/// slot must still be rejected as not single-owner.
+/// Trusted general store lying about type: a content chunk vouched for at
+/// the feed slot must still be rejected on the narrowing seam.
 struct LyingTrusted {
     bytes: Vec<u8>,
     source: TrustedSource,
@@ -285,7 +292,7 @@ impl ChunkGet<StandardChunkSet> for LyingTrusted {
 }
 
 #[test]
-fn content_chunk_at_a_feed_slot_is_rejected() {
+fn content_chunk_at_a_feed_slot_is_a_typed_store_error() {
     run(async {
         let signer = signer();
         let feed = feed_for(&signer);
@@ -296,11 +303,37 @@ fn content_chunk_at_a_feed_slot_is_rejected() {
             source: unsafe { TrustedSource::grant() },
         };
 
-        let getter = Getter::new(feed, store);
+        let getter = Getter::new(feed, SingleOwnerGet::new(store));
         assert!(matches!(
             getter.at(Sequence::ZERO).await.unwrap_err(),
-            FeedError::NotSingleOwner(_)
+            FeedError::Store(_)
         ));
+    });
+}
+
+#[test]
+fn shared_general_store_adapts_through_the_narrowing_get() {
+    run(async {
+        let signer = signer();
+        let feed = feed_for(&signer);
+        let shared = DefaultMemoryStore::new();
+        let soc = SingleOwnerChunk::new(
+            feed.update_id(&Sequence::ZERO),
+            b"payload".to_vec(),
+            &signer,
+        )
+        .unwrap();
+        ChunkPut::put(&shared, Chunk::from_envelope(soc.into()).unwrap())
+            .await
+            .unwrap();
+
+        let getter = Getter::new(feed, SingleOwnerGet::new(&shared));
+        let update = getter.at(Sequence::ZERO).await.unwrap();
+        assert_eq!(update.payload().as_ref(), b"payload");
+
+        let latest = getter.latest().await.unwrap();
+        assert_eq!(latest.update.unwrap().index(), &Sequence::ZERO);
+        assert_eq!(latest.next, Sequence::ZERO.next());
     });
 }
 
@@ -320,7 +353,7 @@ proptest! {
         };
 
         run(async {
-            let store = DefaultMemoryStore::new();
+            let store = SocStore::new();
             let mut updater = Updater::new(feed, &store, &signer);
             let written = updater.append(payload.clone()).await.unwrap();
 

--- a/crates/feeds/tests/feed_roundtrip.rs
+++ b/crates/feeds/tests/feed_roundtrip.rs
@@ -312,6 +312,36 @@ fn content_chunk_at_a_feed_slot_is_a_typed_store_error() {
 }
 
 #[test]
+fn windowed_finders_agree_with_sequential() {
+    run(async {
+        let signer = signer();
+        let feed = feed_for(&signer);
+        let store = SocStore::new();
+        let mut updater = Updater::new(feed, &store, &signer);
+        for n in 0u64..21 {
+            updater.append(n.to_be_bytes().to_vec()).await.unwrap();
+        }
+
+        for width in [1usize, 2, 7, 15] {
+            let getter =
+                Getter::new(feed, &store).with_window(core::num::NonZeroUsize::new(width).unwrap());
+            for latest in [
+                getter.latest().await.unwrap(),
+                getter.latest_from(Sequence::new(3)).await.unwrap(),
+                getter.latest_linear_from(Sequence::ZERO).await.unwrap(),
+            ] {
+                assert_eq!(latest.update.unwrap().index(), &Sequence::new(20));
+                assert_eq!(latest.next, Some(Sequence::new(21)));
+            }
+
+            let empty = getter.latest_from(Sequence::new(21)).await.unwrap();
+            assert!(empty.update.is_none());
+            assert_eq!(empty.next, Some(Sequence::new(21)));
+        }
+    });
+}
+
+#[test]
 fn shared_general_store_adapts_through_the_narrowing_get() {
     run(async {
         let signer = signer();

--- a/crates/feeds/tests/sequence_vectors.rs
+++ b/crates/feeds/tests/sequence_vectors.rs
@@ -20,10 +20,9 @@ use alloy_primitives::{B256, Signature, address, b256, hex};
 use alloy_signer_local::PrivateKeySigner;
 use bytes::Bytes;
 use nectar_feeds::{Feed, Getter, Sequence, Topic};
-use nectar_primitives::chunk::{ChunkAddress, ChunkOps, SocId};
-use nectar_primitives::{
-    Chunk, DEFAULT_BODY_SIZE, DefaultContentChunk, DefaultMemoryStore, DefaultSingleOwnerChunk,
-};
+use nectar_primitives::chunk::{ChunkAddress, ChunkOps, SingleOwnerOnlyChunkSet, SocId};
+use nectar_primitives::store::MemoryStore;
+use nectar_primitives::{Chunk, DEFAULT_BODY_SIZE, DefaultContentChunk, DefaultSingleOwnerChunk};
 
 /// The single-owner chunk anchor: id of all zeroes, payload `"foo"`, and the
 /// known-good signature from the reference client's vectors. Pins the SOC
@@ -158,7 +157,8 @@ fn getter_reads_reference_vector() {
     let soc =
         DefaultSingleOwnerChunk::new(feed.update_id(&Sequence::ZERO), b"data".to_vec(), &signer)
             .unwrap();
-    let store = DefaultMemoryStore::from_chunks([Chunk::from_envelope(soc.into()).unwrap()]);
+    let store =
+        MemoryStore::<SingleOwnerOnlyChunkSet>::from_chunks([Chunk::from_envelope(soc).unwrap()]);
 
     let update = nectar_testing::run(Getter::new(feed, &store).at(Sequence::ZERO)).unwrap();
     assert_eq!(update.payload().as_ref(), b"data");

--- a/crates/primitives/src/store/single_owner.rs
+++ b/crates/primitives/src/store/single_owner.rs
@@ -2,7 +2,7 @@
 
 use crate::chunk::{AnyChunkSet, Chunk, ChunkAddress, SingleOwnerOnlyChunkSet, Verified};
 
-use super::typed::ChunkGet;
+use super::typed::{ChunkGet, ChunkHas};
 
 /// Single-owner view over a store typed at [`AnyChunkSet`].
 ///
@@ -58,6 +58,13 @@ where
         chunk
             .narrow_single_owner()
             .ok_or(SingleOwnerGetError::NotSingleOwner(*address))
+    }
+}
+
+/// Existence is registry-agnostic, so the check passes through unchanged.
+impl<T: ChunkHas> ChunkHas for SingleOwnerGet<T> {
+    async fn has(&self, address: &ChunkAddress) -> bool {
+        self.0.has(address).await
     }
 }
 


### PR DESCRIPTION
## What

Retypes the feeds getter and updater from `AnyChunkSet<BODY_SIZE>` to `SingleOwnerOnlyChunkSet<BODY_SIZE>` (both the getter impl bounds and the `ChunkPut` bound on the updater), collapsing the previous downcast into a direct `into_envelope()`/`from_envelope(soc.clone())` path and deleting `FeedError::NotSingleOwner`, which is now unreachable.

Adds a `ChunkHas` passthrough impl on `SingleOwnerGet` in `nectar-primitives` so shared `AnyChunkSet` stores still adapt for the feed finders under the new typing.

Adds `crates/feeds/src/probe.rs`: pure replay resolvers (`resolve_probing` for the floor/ladder/`u64::MAX`-top-arm/binary search, `resolve_linear`) that fault on the first unanswered consulted index.

Tests are retyped onto `MemoryStore<SingleOwnerOnlyChunkSet>`; the lying-trusted content-chunk test now exercises the narrowing seam as `FeedError::Store`; a new shared-store adapter round trip is added; and the width-one trace-equivalence proptest is corrected to compare against first-consultations, since the resolver probes each index at most once (a red-team pass caught this as CI-red before the fix).

Closes #512.

## Why

The feed getter/updater previously stored and fetched through the generic `AnyChunkSet` registry with a runtime downcast to single-owner chunks. Feeds are single-owner by construction, so typing the store bound directly at `SingleOwnerOnlyChunkSet` removes the downcast and its associated `NotSingleOwner` error path, moving the invariant to the type system. This is a 0.5.0-breaking change to the getter/updater store bounds.

## Testing

Independent CI-mirror gate, run under `nix develop` with the CI-pinned toolchain (cargo/rustc 1.94.0, sccache wrapper):

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --locked`: pass (only pre-existing, unrelated `clippy::doc_lazy_continuation` warnings in `crates/testing/src/lib.rs`, not a changed file).
- `cargo clippy --locked --all-targets -p nectar-primitives --features envelope,encryption`: pass.
- `cargo nextest run --workspace --locked --no-tests=warn --no-fail-fast`: 1064 passed, 1 skipped.
- `cargo test --doc --workspace --locked`: pass.

## AI Assistance

Implemented with Claude (Fable), reviewed with Claude (Opus).
