### PR TITLE
file: ungate the sequential engine core for no_std guests

### DIFF
--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -48,6 +48,14 @@ jobs:
                   # removed or the workspace version bumps.
                   cargo check --locked --manifest-path crates/mantaray/Cargo.toml \
                     --no-default-features --target ${{ matrix.target }}
+            # The sequential read, join and walk core of nectar-file, with the
+            # primitives dependency on; the bare pass above keeps the hollow
+            # shape honest.
+            - name: Check nectar-file with the primitives core
+              run: |
+                  cargo check --locked -p nectar-file \
+                    --no-default-features --features primitives \
+                    --target ${{ matrix.target }}
             # The bare-metal core of nectar-primitives. Only in the rv64 lane:
             # the wasm32 shape of the crate is the std build with the wasm
             # target table (wasm-bindgen), not the no_std core.

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -40,6 +40,14 @@ jobs:
             # dir rather than in a separate job that rebuilds the workspace.
             - name: Run doctests
               run: cargo test --doc --workspace --locked
+            # The no-std engine core: the vector-pinned roots and the split
+            # parity batteries run on the exact arms a guest executes, rather
+            # than being merely type-checked by the no_std workflow.
+            - name: Run file no-std core tests
+              run: |
+                  cargo nextest run \
+                    -p nectar-file --no-default-features --features primitives --locked \
+                    --no-tests=warn --no-fail-fast
             # The async io adapters are feature-gated off the default build;
             # cover their tests and the range-request doctest here.
             - name: Run tokio adapter tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,11 +62,11 @@ check.all_targets = true
 nectar-clock = { version = "0.4.0", path = "crates/clock", default-features = false }
 nectar-contracts = { version = "0.4.0", path = "crates/contracts" }
 nectar-feeds = { version = "0.4.0", path = "crates/feeds" }
-nectar-file = { version = "0.4.0", path = "crates/file" }
+nectar-file = { version = "0.4.0", path = "crates/file", default-features = false }
 nectar-manifest = { version = "0.4.0", path = "crates/manifest" }
 nectar-mantaray = { version = "0.4.0", path = "crates/mantaray" }
 nectar-marker = { version = "0.4.0", path = "crates/marker" }
-nectar-primitives = { version = "0.4.0", path = "crates/primitives" }
+nectar-primitives = { version = "0.4.0", path = "crates/primitives", default-features = false }
 nectar-swarms = { version = "0.4.0", path = "crates/swarms" }
 nectar-tasks = { version = "0.4.0", path = "crates/tasks" }
 nectar-postage = { version = "0.4.0", path = "crates/postage" }

--- a/crates/benches/Cargo.toml
+++ b/crates/benches/Cargo.toml
@@ -34,7 +34,7 @@ nectar-file = { workspace = true, features = ["rayon"] }
 nectar-mantaray = { workspace = true, features = ["hazmat"] }
 nectar-postage = { workspace = true, features = ["parallel"] }
 nectar-postage-issuer = { workspace = true, features = ["parallel"] }
-nectar-primitives = { workspace = true, features = ["encryption"] }
+nectar-primitives = { workspace = true, features = ["encryption", "std"] }
 nectar-testing.workspace = true
 rand.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "time"] }

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -32,6 +32,6 @@ nectar-contracts.workspace = true
 nectar-postage.workspace = true
 nectar-postage-issuer = { workspace = true, features = ["parallel"] }
 nectar-postage-usage = { workspace = true, features = ["client", "seal"] }
-nectar-primitives.workspace = true
+nectar-primitives = { workspace = true, features = ["std"] }
 thiserror = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/file/Cargo.toml
+++ b/crates/file/Cargo.toml
@@ -49,16 +49,17 @@ tokio = { workspace = true, features = ["io-util", "time"] }
 [features]
 default = [ "std" ]
 
+# The sequential engine core without std: the primitives dependency, the
+# byte buffers and the poll utilities, alloc-only.
+primitives = [ "dep:bytes", "dep:futures-util", "dep:nectar-primitives" ]
+
 # Standard library interop; the filesystem and io adapters land with the
-# write engine. The walk engine rides this feature until the primitives core
-# builds bare-metal.
+# write engine.
 std = [
 	"bytes?/std",
-	"dep:bytes",
-	"dep:futures-util",
-	"dep:nectar-primitives",
 	"futures-util?/std",
 	"nectar-primitives?/std",
+	"primitives",
 	"thiserror/std",
 ]
 

--- a/crates/file/build.rs
+++ b/crates/file/build.rs
@@ -1,11 +1,13 @@
 //! Emits the `multi_thread` cfg alias.
 
 fn main() {
-    // Send/Sync bounds apply; wasm32 and the `unsync` feature relax them.
+    // Send/Sync bounds apply; wasm32, bare metal and the `unsync` feature
+    // relax them, mirroring the marker traits.
     println!("cargo::rustc-check-cfg=cfg(multi_thread)");
     let wasm32 = std::env::var("CARGO_CFG_TARGET_ARCH").as_deref() == Ok("wasm32");
+    let bare = std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("none");
     let unsync = std::env::var_os("CARGO_FEATURE_UNSYNC").is_some();
-    if !wasm32 && !unsync {
+    if !wasm32 && !bare && !unsync {
         println!("cargo::rustc-cfg=multi_thread");
     }
 }

--- a/crates/file/src/lib.rs
+++ b/crates/file/src/lib.rs
@@ -84,8 +84,8 @@ extern crate alloc;
 #[cfg(any(test, feature = "std"))]
 extern crate std;
 
-// The marker traits bound only the std-gated surfaces today.
-#[cfg(not(feature = "std"))]
+// The marker traits bound only the engine surfaces behind `primitives`.
+#[cfg(not(feature = "primitives"))]
 use nectar_marker as _;
 
 #[cfg(all(feature = "rayon", target_arch = "wasm32"))]
@@ -95,45 +95,41 @@ compile_error!("feature `rayon` needs a native thread pool; wasm32 builds must d
 compile_error!("feature `rayon` needs `Send` chunks and errors; it excludes the `unsync` escape");
 
 pub mod config;
-#[cfg(any(all(test, feature = "std"), feature = "arbitrary"))]
+#[cfg(any(test, feature = "arbitrary"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "arbitrary")))]
 pub mod generators;
 pub mod geometry;
-#[cfg(feature = "std")]
+#[cfg(feature = "primitives")]
 mod inflight;
-#[cfg(feature = "std")]
+#[cfg(feature = "primitives")]
 mod num;
 /// Shared fuzz and test oracle for the malformed-intermediate walk.
 /// Compiled for in-crate tests and for fuzz builds (`arbitrary`); exempt
 /// from semver guarantees.
-#[cfg(any(test, feature = "arbitrary"))]
+#[cfg(any(all(test, feature = "primitives"), feature = "arbitrary"))]
 #[doc(hidden)]
 pub mod oracles;
-#[cfg(all(
-    feature = "rayon",
-    not(target_arch = "wasm32"),
-    not(feature = "unsync")
-))]
+#[cfg(feature = "rayon")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
 pub mod parallel;
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+#[cfg(feature = "primitives")]
+#[cfg_attr(docsrs, doc(cfg(feature = "primitives")))]
 pub mod read;
 pub mod sink;
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+#[cfg(feature = "primitives")]
+#[cfg_attr(docsrs, doc(cfg(feature = "primitives")))]
 pub mod split;
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+#[cfg(feature = "primitives")]
+#[cfg_attr(docsrs, doc(cfg(feature = "primitives")))]
 pub mod store;
 pub mod sync;
-#[cfg(all(test, feature = "std"))]
+#[cfg(all(test, feature = "primitives"))]
 mod testutil;
 #[cfg(feature = "tokio")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub mod tokio;
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+#[cfg(feature = "primitives")]
+#[cfg_attr(docsrs, doc(cfg(feature = "primitives")))]
 pub mod walk;
 
 #[cfg(feature = "tokio")]
@@ -142,13 +138,9 @@ pub use self::tokio::{SeekOverflow, TokioReader};
 pub use self::tokio::{SpawnedReader, TokioWriter};
 pub use config::{BranchBudget, HashWindow, PutWindow, Window};
 pub use geometry::{DEFAULT_BODY_SIZE, Mode, branches, max_depth};
-#[cfg(all(
-    feature = "rayon",
-    not(target_arch = "wasm32"),
-    not(feature = "unsync")
-))]
+#[cfg(feature = "rayon")]
 pub use parallel::{ReadAt, ReadAtError, split_read_at};
-#[cfg(feature = "std")]
+#[cfg(feature = "primitives")]
 pub use read::{
     AnyFile, CollectError, DownloadBuilder, DownloadError, File, FileFrames, FileReader,
     FileStream, OpenError, Progress, ProgressFn, ReadBuilder, SeekPastEnd,
@@ -156,14 +148,16 @@ pub use read::{
 #[cfg(feature = "std")]
 pub use sink::FsSink;
 pub use sink::{DataSink, MemSink, MemSinkError};
-#[cfg(all(feature = "std", feature = "encryption"))]
+#[cfg(all(feature = "primitives", any(feature = "std", not(multi_thread))))]
+pub use split::collect_into;
+#[cfg(all(feature = "primitives", feature = "encryption"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
 pub use split::{KeyError, KeySource, RandomKeys};
-#[cfg(feature = "std")]
-pub use split::{SealError, Sealed, Split, SplitError, SplitMode, SplitStats, collect_into};
-#[cfg(feature = "std")]
+#[cfg(feature = "primitives")]
+pub use split::{SealError, Sealed, Split, SplitError, SplitMode, SplitStats};
+#[cfg(feature = "primitives")]
 pub use store::{BoxedStore, BoxedStoreError, DynAnyFile, DynFile, DynFileReader, DynFileStream};
-#[cfg(feature = "std")]
+#[cfg(feature = "primitives")]
 pub use walk::{
     DecodeError, Encrypted, Frame, Plain, ShapeError, Walk, WalkError, WalkMode, WalkStats,
 };

--- a/crates/file/src/split/engine.rs
+++ b/crates/file/src/split/engine.rs
@@ -18,18 +18,10 @@ use nectar_primitives::store::ChunkPut;
 
 use super::SplitStats;
 use super::error::{SealError, SplitError};
-#[cfg(all(
-    feature = "rayon",
-    not(target_arch = "wasm32"),
-    not(feature = "unsync")
-))]
+#[cfg(feature = "rayon")]
 use super::handoff::{self, Handoff};
 use super::mode::{Sealed, SplitMode};
-#[cfg(all(
-    feature = "rayon",
-    not(target_arch = "wasm32"),
-    not(feature = "unsync")
-))]
+#[cfg(feature = "rayon")]
 use crate::config::HashWindow;
 use crate::config::PutWindow;
 use crate::inflight::InFlight;
@@ -49,29 +41,17 @@ type BoxPut<E> = Pin<Box<dyn Future<Output = PutDone<E>> + Send>>;
 type BoxPut<E> = Pin<Box<dyn Future<Output = PutDone<E>>>>;
 
 /// Handoff carrying one pool leaf seal back to the engine.
-#[cfg(all(
-    feature = "rayon",
-    not(target_arch = "wasm32"),
-    not(feature = "unsync")
-))]
+#[cfg(feature = "rayon")]
 type SealHandoff<M, const B: usize> = Handoff<Result<Sealed<M, B>, SealError>>;
 
 /// Submitter queueing one leaf payload on the pool under its drawn state.
-#[cfg(all(
-    feature = "rayon",
-    not(target_arch = "wasm32"),
-    not(feature = "unsync")
-))]
+#[cfg(feature = "rayon")]
 type SealSubmit<M, const B: usize> =
     Box<dyn Fn(<M as SplitMode>::Draw, Bytes) -> SealHandoff<M, B> + Send + Sync>;
 
 /// One leaf seal in flight on the pool: its span and the handoff its sealed
 /// chunk arrives on.
-#[cfg(all(
-    feature = "rayon",
-    not(target_arch = "wasm32"),
-    not(feature = "unsync")
-))]
+#[cfg(feature = "rayon")]
 struct PendingSeal<M: SplitMode, const B: usize> {
     span: u64,
     handoff: SealHandoff<M, B>,
@@ -79,11 +59,7 @@ struct PendingSeal<M: SplitMode, const B: usize> {
 
 /// Pool fan-out for leaf seals: a bounded deque of in-flight jobs and the
 /// submitter that queues one payload.
-#[cfg(all(
-    feature = "rayon",
-    not(target_arch = "wasm32"),
-    not(feature = "unsync")
-))]
+#[cfg(feature = "rayon")]
 struct HashFan<M: SplitMode, const B: usize> {
     window: usize,
     submit: SealSubmit<M, B>,
@@ -150,11 +126,7 @@ where
     pending: VecDeque<Chunk<Verified, AnyChunkSet<B>>>,
     in_flight: InFlight<PutDone<S::Error>>,
     /// Pool fan-out for leaf seals; `None` keeps sealing inline.
-    #[cfg(all(
-        feature = "rayon",
-        not(target_arch = "wasm32"),
-        not(feature = "unsync")
-    ))]
+    #[cfg(feature = "rayon")]
     hash: Option<HashFan<M, B>>,
     phase: Phase,
     root: Option<M::Root>,
@@ -202,11 +174,7 @@ where
             spine: Vec::new(),
             pending: VecDeque::new(),
             in_flight: InFlight::new(),
-            #[cfg(all(
-                feature = "rayon",
-                not(target_arch = "wasm32"),
-                not(feature = "unsync")
-            ))]
+            #[cfg(feature = "rayon")]
             hash: None,
             phase: Phase::Writing,
             root: None,
@@ -240,11 +208,7 @@ where
     /// assert_eq!(root.as_bytes().len(), 32);
     /// # });
     /// ```
-    #[cfg(all(
-        feature = "rayon",
-        not(target_arch = "wasm32"),
-        not(feature = "unsync")
-    ))]
+    #[cfg(feature = "rayon")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
     #[must_use]
     pub fn with_hash_window(mut self, window: HashWindow) -> Self
@@ -297,11 +261,7 @@ where
         if let Err(error) = self.step_puts(cx) {
             return Poll::Ready(Err(self.poison(error)));
         }
-        #[cfg(all(
-            feature = "rayon",
-            not(target_arch = "wasm32"),
-            not(feature = "unsync")
-        ))]
+        #[cfg(feature = "rayon")]
         if let Err(error) = self.drain_seals(cx) {
             return Poll::Ready(Err(self.poison(error)));
         }
@@ -345,11 +305,7 @@ where
                     // Every pool leaf seal must land before the tail seals
                     // and the spine closes, so the ascent stays in leaf
                     // order.
-                    #[cfg(all(
-                        feature = "rayon",
-                        not(target_arch = "wasm32"),
-                        not(feature = "unsync")
-                    ))]
+                    #[cfg(feature = "rayon")]
                     {
                         if let Err(error) = self.drain_seals(cx) {
                             return Poll::Ready(Err(self.poison(error)));
@@ -543,11 +499,7 @@ where
         if let Some((head, _)) = payload.split_first_chunk_mut::<SPAN_SIZE>() {
             *head = span.to_le_bytes();
         }
-        #[cfg(all(
-            feature = "rayon",
-            not(target_arch = "wasm32"),
-            not(feature = "unsync")
-        ))]
+        #[cfg(feature = "rayon")]
         if let Some(fan) = &mut self.hash {
             // The leaf's draw, then one per ascent seal its admission
             // triggers, so the draw order equals the serial engine's.
@@ -575,11 +527,7 @@ where
     /// Whether the write gate refuses bytes this poll: a full hash window
     /// when the fan-out is on, otherwise the serial put gate.
     fn write_gate_blocked(&self) -> bool {
-        #[cfg(all(
-            feature = "rayon",
-            not(target_arch = "wasm32"),
-            not(feature = "unsync")
-        ))]
+        #[cfg(feature = "rayon")]
         if let Some(fan) = &self.hash {
             return fan.seals.len() >= fan.window;
         }
@@ -595,11 +543,7 @@ where
     /// registered either way: every admission loops back through
     /// `step_puts`, so a put dispatched here is re-polled with the caller's
     /// waker before any return.
-    #[cfg(all(
-        feature = "rayon",
-        not(target_arch = "wasm32"),
-        not(feature = "unsync")
-    ))]
+    #[cfg(feature = "rayon")]
     fn drain_seals(&mut self, cx: &mut Context<'_>) -> Result<(), SplitError<S::Error>> {
         loop {
             self.step_puts(cx)?;
@@ -629,11 +573,7 @@ where
     }
 
     /// Leaf seals still on the pool; zero when the fan-out is off.
-    #[cfg(all(
-        feature = "rayon",
-        not(target_arch = "wasm32"),
-        not(feature = "unsync")
-    ))]
+    #[cfg(feature = "rayon")]
     fn seals_queued(&self) -> usize {
         self.hash.as_ref().map_or(0, |fan| fan.seals.len())
     }
@@ -717,11 +657,7 @@ where
     /// Seal one payload on the engine thread; under the pool fan-out a
     /// streaming ascent seal spends its submission-time draw.
     fn seal_inline(&mut self, payload: Bytes) -> Result<Sealed<M, B>, SealError> {
-        #[cfg(all(
-            feature = "rayon",
-            not(target_arch = "wasm32"),
-            not(feature = "unsync")
-        ))]
+        #[cfg(feature = "rayon")]
         if let Some(draw) = self.hash.as_mut().and_then(|fan| fan.draws.pop_front()) {
             return M::seal_with::<B>(draw, payload);
         }

--- a/crates/file/src/split/mod.rs
+++ b/crates/file/src/split/mod.rs
@@ -32,26 +32,16 @@
 mod encrypted;
 mod engine;
 mod error;
-#[cfg(all(
-    feature = "rayon",
-    not(target_arch = "wasm32"),
-    not(feature = "unsync")
-))]
+#[cfg(feature = "rayon")]
 mod handoff;
 mod mode;
+// The relay needs a shared queue: a mutex under std, a cell wherever the
+// Send/Sync bounds relax. Hosted no-std builds without `unsync` have
+// neither, so the surface is absent there.
+#[cfg(any(feature = "std", not(multi_thread)))]
+mod relay;
 #[cfg(test)]
 mod tests;
-
-use core::convert::Infallible;
-use core::future::poll_fn;
-use std::collections::VecDeque;
-use std::sync::{Arc, Mutex, PoisonError};
-
-use nectar_marker::MaybeSync;
-use nectar_primitives::chunk::{AnyChunkSet, Chunk, Verified};
-use nectar_primitives::store::ChunkPut;
-
-use crate::config::PutWindow;
 
 #[cfg(feature = "encryption")]
 #[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
@@ -59,119 +49,8 @@ pub use encrypted::{KeyError, KeySource, RandomKeys};
 pub use engine::Split;
 pub use error::{SealError, SplitError};
 pub use mode::{Sealed, SplitMode};
-
-/// Split `data` under put `window` into the tree, storing every chunk in the
-/// borrowed `store`, and return the root.
-///
-/// The borrowed-store companion to [`Split::collect`]: where `collect` owns
-/// its store, this drives the split through an internal relay and forwards
-/// each sealed chunk to `store` between poll rounds. At most one put window of
-/// chunks is retained, so the memory bound is the split's own: puts in flight
-/// stay within `window` and buffered chunks within the spine height.
-///
-/// ```
-/// # nectar_testing::run(async {
-/// use nectar_file::split::collect_into;
-/// use nectar_file::{Plain, PutWindow};
-/// use nectar_primitives::chunk::AnyChunkSet;
-/// use nectar_primitives::store::MemoryStore;
-///
-/// let store = MemoryStore::<AnyChunkSet<4096>>::new();
-/// let window = PutWindow::new(4).unwrap();
-/// let root = collect_into::<_, Plain, 4096>(&store, window, b"hello swarm")
-///     .await
-///     .unwrap();
-/// # let _ = root;
-/// # });
-/// ```
-pub async fn collect_into<T, M, const B: usize>(
-    store: &T,
-    window: PutWindow,
-    data: &[u8],
-) -> Result<M::Root, SplitError<T::Error>>
-where
-    T: ChunkPut<AnyChunkSet<B>> + MaybeSync,
-    M: SplitMode + Default,
-{
-    let relay = Relay::<B>::default();
-    let mut split: Split<Relay<B>, M, B> = Split::new(relay.clone(), window);
-    let mut rest = data;
-    while !rest.is_empty() {
-        let taken = poll_fn(|cx| split.poll_write(cx, rest))
-            .await
-            .map_err(widen::<T::Error>)?;
-        rest = rest.get(taken..).unwrap_or(&[]);
-        // Forward every chunk sealed this round before more bytes enter, so
-        // the relay never holds more than the window.
-        drain(&relay, store).await?;
-    }
-    let root = poll_fn(|cx| split.poll_finish(cx))
-        .await
-        .map_err(widen::<T::Error>)?;
-    drain(&relay, store).await?;
-    Ok(root)
-}
-
-/// Widen the relay-backed split's error to the borrowed store's error. The
-/// relay is infallible, so the `Put` arm is unreachable.
-fn widen<E>(error: SplitError<Infallible>) -> SplitError<E> {
-    match error {
-        SplitError::Put { source, .. } => match source {},
-        SplitError::Seal(seal) => SplitError::Seal(seal),
-        SplitError::SpanOverflow { span, add } => SplitError::SpanOverflow { span, add },
-        SplitError::Finished => SplitError::Finished,
-        SplitError::Poisoned => SplitError::Poisoned,
-        SplitError::PoolDropped => SplitError::PoolDropped,
-        SplitError::SpineDepleted => SplitError::SpineDepleted,
-    }
-}
-
-/// Forward every queued chunk to the borrowed store in seal order, capturing
-/// each address before the put consumes the chunk.
-async fn drain<T, const B: usize>(relay: &Relay<B>, store: &T) -> Result<(), SplitError<T::Error>>
-where
-    T: ChunkPut<AnyChunkSet<B>> + MaybeSync,
-{
-    while let Some(chunk) = relay.pop() {
-        let address = *chunk.address();
-        store
-            .put(chunk)
-            .await
-            .map_err(|source| SplitError::Put { address, source })?;
-    }
-    Ok(())
-}
-
-/// Shared put queue bridging a borrowed store to the owned-handle store the
-/// split clones per put: relay puts land here in seal order and [`drain`]
-/// forwards them, so the split never parks and its memory bound carries over.
-#[derive(Clone, Default)]
-struct Relay<const B: usize> {
-    queue: Arc<Mutex<VecDeque<Chunk<Verified, AnyChunkSet<B>>>>>,
-}
-
-impl<const B: usize> Relay<B> {
-    /// The oldest queued chunk; a poisoned lock hands back its inner queue,
-    /// which a single push or pop cannot leave inconsistent.
-    fn pop(&self) -> Option<Chunk<Verified, AnyChunkSet<B>>> {
-        self.queue
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .pop_front()
-    }
-}
-
-impl<const B: usize> ChunkPut<AnyChunkSet<B>> for Relay<B> {
-    type Error = Infallible;
-
-    async fn put(&self, chunk: Chunk<Verified, AnyChunkSet<B>>) -> Result<(), Infallible> {
-        self.queue
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .push_back(chunk);
-        Ok(())
-    }
-}
+#[cfg(any(feature = "std", not(multi_thread)))]
+pub use relay::collect_into;
 
 /// Occupancy witnesses of one split.
 ///

--- a/crates/file/src/split/relay.rs
+++ b/crates/file/src/split/relay.rs
@@ -1,0 +1,152 @@
+//! Borrowed-store split entry point over an internal relay queue.
+
+use core::convert::Infallible;
+use core::future::poll_fn;
+
+#[cfg(not(feature = "std"))]
+use alloc::collections::VecDeque;
+#[cfg(not(feature = "std"))]
+use alloc::rc::Rc;
+#[cfg(not(feature = "std"))]
+use core::cell::RefCell;
+#[cfg(feature = "std")]
+use std::collections::VecDeque;
+#[cfg(feature = "std")]
+use std::sync::{Arc, Mutex, PoisonError};
+
+use nectar_marker::MaybeSync;
+use nectar_primitives::chunk::{AnyChunkSet, Chunk, Verified};
+use nectar_primitives::store::ChunkPut;
+
+use super::engine::Split;
+use super::error::SplitError;
+use super::mode::SplitMode;
+use crate::config::PutWindow;
+
+/// Split `data` under put `window` into the tree, storing every chunk in the
+/// borrowed `store`, and return the root.
+///
+/// The borrowed-store companion to [`Split::collect`]: where `collect` owns
+/// its store, this drives the split through an internal relay and forwards
+/// each sealed chunk to `store` between poll rounds. At most one put window of
+/// chunks is retained, so the memory bound is the split's own: puts in flight
+/// stay within `window` and buffered chunks within the spine height.
+///
+/// ```
+/// # nectar_testing::run(async {
+/// use nectar_file::split::collect_into;
+/// use nectar_file::{Plain, PutWindow};
+/// use nectar_primitives::chunk::AnyChunkSet;
+/// use nectar_primitives::store::MemoryStore;
+///
+/// let store = MemoryStore::<AnyChunkSet<4096>>::new();
+/// let window = PutWindow::new(4).unwrap();
+/// let root = collect_into::<_, Plain, 4096>(&store, window, b"hello swarm")
+///     .await
+///     .unwrap();
+/// # let _ = root;
+/// # });
+/// ```
+pub async fn collect_into<T, M, const B: usize>(
+    store: &T,
+    window: PutWindow,
+    data: &[u8],
+) -> Result<M::Root, SplitError<T::Error>>
+where
+    T: ChunkPut<AnyChunkSet<B>> + MaybeSync,
+    M: SplitMode + Default,
+{
+    let relay = Relay::<B>::default();
+    let mut split: Split<Relay<B>, M, B> = Split::new(relay.clone(), window);
+    let mut rest = data;
+    while !rest.is_empty() {
+        let taken = poll_fn(|cx| split.poll_write(cx, rest))
+            .await
+            .map_err(widen::<T::Error>)?;
+        rest = rest.get(taken..).unwrap_or(&[]);
+        // Forward every chunk sealed this round before more bytes enter, so
+        // the relay never holds more than the window.
+        drain(&relay, store).await?;
+    }
+    let root = poll_fn(|cx| split.poll_finish(cx))
+        .await
+        .map_err(widen::<T::Error>)?;
+    drain(&relay, store).await?;
+    Ok(root)
+}
+
+/// Widen the relay-backed split's error to the borrowed store's error. The
+/// relay is infallible, so the `Put` arm is unreachable.
+fn widen<E>(error: SplitError<Infallible>) -> SplitError<E> {
+    match error {
+        SplitError::Put { source, .. } => match source {},
+        SplitError::Seal(seal) => SplitError::Seal(seal),
+        SplitError::SpanOverflow { span, add } => SplitError::SpanOverflow { span, add },
+        SplitError::Finished => SplitError::Finished,
+        SplitError::Poisoned => SplitError::Poisoned,
+        SplitError::PoolDropped => SplitError::PoolDropped,
+        SplitError::SpineDepleted => SplitError::SpineDepleted,
+    }
+}
+
+/// Forward every queued chunk to the borrowed store in seal order, capturing
+/// each address before the put consumes the chunk.
+async fn drain<T, const B: usize>(relay: &Relay<B>, store: &T) -> Result<(), SplitError<T::Error>>
+where
+    T: ChunkPut<AnyChunkSet<B>> + MaybeSync,
+{
+    while let Some(chunk) = relay.pop() {
+        let address = *chunk.address();
+        store
+            .put(chunk)
+            .await
+            .map_err(|source| SplitError::Put { address, source })?;
+    }
+    Ok(())
+}
+
+/// Shared put queue bridging a borrowed store to the owned-handle store the
+/// split clones per put: relay puts land here in seal order and [`drain`]
+/// forwards them, so the split never parks and its memory bound carries over.
+#[derive(Clone, Default)]
+struct Relay<const B: usize> {
+    #[cfg(feature = "std")]
+    queue: Arc<Mutex<VecDeque<Chunk<Verified, AnyChunkSet<B>>>>>,
+    /// Single-thread dual: pop and put each borrow within one call, and no
+    /// borrow spans an await, so the cell is never held across a suspension.
+    #[cfg(not(feature = "std"))]
+    queue: Rc<RefCell<VecDeque<Chunk<Verified, AnyChunkSet<B>>>>>,
+}
+
+impl<const B: usize> Relay<B> {
+    /// The oldest queued chunk; a poisoned lock hands back its inner queue,
+    /// which a single push or pop cannot leave inconsistent.
+    #[cfg(feature = "std")]
+    fn pop(&self) -> Option<Chunk<Verified, AnyChunkSet<B>>> {
+        self.queue
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .pop_front()
+    }
+
+    /// The oldest queued chunk.
+    #[cfg(not(feature = "std"))]
+    fn pop(&self) -> Option<Chunk<Verified, AnyChunkSet<B>>> {
+        self.queue.borrow_mut().pop_front()
+    }
+}
+
+impl<const B: usize> ChunkPut<AnyChunkSet<B>> for Relay<B> {
+    type Error = Infallible;
+
+    async fn put(&self, chunk: Chunk<Verified, AnyChunkSet<B>>) -> Result<(), Infallible> {
+        #[cfg(feature = "std")]
+        self.queue
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .push_back(chunk);
+        #[cfg(not(feature = "std"))]
+        self.queue.borrow_mut().push_back(chunk);
+        Ok(())
+    }
+}

--- a/crates/file/src/split/tests.rs
+++ b/crates/file/src/split/tests.rs
@@ -5,11 +5,7 @@ use core::future::poll_fn;
 use core::task::{Context, Poll};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
-#[cfg(all(
-    feature = "rayon",
-    not(target_arch = "wasm32"),
-    not(feature = "unsync")
-))]
+#[cfg(feature = "rayon")]
 use std::vec;
 use std::vec::Vec;
 
@@ -557,11 +553,7 @@ mod encrypted {
     }
 
     /// Stream `data` through a pooled encrypted split in `step`-byte writes.
-    #[cfg(all(
-        feature = "rayon",
-        not(target_arch = "wasm32"),
-        not(feature = "unsync")
-    ))]
+    #[cfg(feature = "rayon")]
     fn pooled_split_encrypted<K: KeySource>(
         data: &[u8],
         mode: Encrypted<K>,
@@ -720,11 +712,7 @@ mod encrypted {
     /// keys in seal order and the pooled chunk stream is byte-identical to
     /// the serial engine's. Only padless trees are byte-reproducible, so
     /// the sizes keep every node full.
-    #[cfg(all(
-        feature = "rayon",
-        not(target_arch = "wasm32"),
-        not(feature = "unsync")
-    ))]
+    #[cfg(feature = "rayon")]
     #[test]
     fn pooled_encrypted_chunk_streams_are_byte_identical_to_serial() {
         for depth in 0u32..4 {
@@ -754,11 +742,7 @@ mod encrypted {
     }
 
     /// The default random source through the pool still round trips.
-    #[cfg(all(
-        feature = "rayon",
-        not(target_arch = "wasm32"),
-        not(feature = "unsync")
-    ))]
+    #[cfg(feature = "rayon")]
     #[test]
     fn pooled_encrypted_split_round_trips() {
         use crate::config::HashWindow;
@@ -837,11 +821,7 @@ mod encrypted {
 
 /// Pooled-seal oracles: chunk streams identical to the serial engine,
 /// hash-window bounds, backpressure, drop and worker-panic paths.
-#[cfg(all(
-    feature = "rayon",
-    not(target_arch = "wasm32"),
-    not(feature = "unsync")
-))]
+#[cfg(feature = "rayon")]
 mod pooled {
     use core::future::poll_fn;
     use core::task::{Context, Poll};
@@ -1189,11 +1169,7 @@ mod pooled {
 
 /// Nightly gate: a stream past the `u32` span boundary keeps root equality
 /// with the batch ingest while memory stays bounded.
-#[cfg(all(
-    feature = "rayon",
-    not(target_arch = "wasm32"),
-    not(feature = "unsync")
-))]
+#[cfg(feature = "rayon")]
 #[test]
 #[ignore = "nightly: streams more than 4 GiB"]
 fn huge_stream_root_matches_the_batch_ingest() {

--- a/crates/integration-tests/Cargo.toml
+++ b/crates/integration-tests/Cargo.toml
@@ -33,13 +33,13 @@ futures.workspace = true
 # Registry-pinned legacy oracle for the submission-order differential gate:
 # identical op sequences must produce byte-identical roots.
 mantaray-old = { package = "nectar-mantaray", version = "=0.3.0" }
-nectar-file.workspace = true
+nectar-file = { workspace = true, features = ["std"] }
 nectar-manifest = { workspace = true, features = ["arbitrary"] }
 nectar-mantaray.workspace = true
 nectar-postage.workspace = true
 nectar-postage-issuer.workspace = true
 nectar-postage-usage.workspace = true
-nectar-primitives.workspace = true
+nectar-primitives = { workspace = true, features = ["std"] }
 nectar-testing = { workspace = true, features = ["alloc", "fixtures"] }
 proptest.workspace = true
 

--- a/crates/manifest-sim/Cargo.toml
+++ b/crates/manifest-sim/Cargo.toml
@@ -26,7 +26,7 @@ disallowed_methods = "deny"
 [dependencies]
 bytes.workspace = true
 nectar-manifest = { workspace = true }
-nectar-primitives = { workspace = true }
+nectar-primitives = { workspace = true, features = ["std"] }
 nectar-testing.workspace = true
 serde = { workspace = true, features = ["std", "derive"] }
 serde_json = { workspace = true, features = ["std"] }

--- a/crates/manifest/Cargo.toml
+++ b/crates/manifest/Cargo.toml
@@ -22,7 +22,7 @@ alloy-primitives = { workspace = true }
 arbitrary = { workspace = true, optional = true }
 bytes.workspace = true
 futures.workspace = true
-nectar-file = { workspace = true }
+nectar-file = { workspace = true, features = ["primitives"] }
 nectar-primitives = { workspace = true }
 thiserror.workspace = true
 

--- a/crates/postage-issuer/Cargo.toml
+++ b/crates/postage-issuer/Cargo.toml
@@ -45,7 +45,7 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 default = [ "std" ]
 
 # Standard library support
-std = [ "nectar-clock/std", "nectar-postage/std" ]
+std = [ "nectar-clock/std", "nectar-postage/std", "nectar-primitives/std" ]
 
 # Local key signing for testing and development
 local-signer = [ "dep:alloy-signer-local", "std" ]

--- a/crates/postage-usage/Cargo.toml
+++ b/crates/postage-usage/Cargo.toml
@@ -50,6 +50,7 @@ std = [
 	"nectar-clock?/std",
 	"nectar-postage-issuer/std",
 	"nectar-postage/std",
+	"nectar-primitives/std",
 	"thiserror/std",
 ]
 

--- a/crates/primitives/examples/wasm-demo/Cargo.toml
+++ b/crates/primitives/examples/wasm-demo/Cargo.toml
@@ -19,7 +19,7 @@ default = [ "console_error_panic_hook" ]
 
 [dependencies]
 bytes.workspace = true
-nectar-primitives.workspace = true
+nectar-primitives = { workspace = true, features = ["std"] }
 wasm-bindgen.workspace = true
 js-sys.workspace = true
 console_error_panic_hook = { version = "0.1.7", optional = true }

--- a/crates/primitives/src/bmt/wasm.rs
+++ b/crates/primitives/src/bmt/wasm.rs
@@ -2,6 +2,8 @@
 //!
 //! This module provides JavaScript-friendly wrappers around Hasher types.
 
+use alloc::string::ToString;
+
 use super::{Hasher, Proof, Prover};
 use crate::chunk::ChunkAddress;
 use alloy_primitives::B256;

--- a/crates/primitives/src/chunk/wasm.rs
+++ b/crates/primitives/src/chunk/wasm.rs
@@ -1,5 +1,8 @@
 //! WASM bindings for Chunk functionality.
 
+use alloc::format;
+use alloc::string::ToString;
+
 use super::content::ContentChunk;
 use super::traits::ChunkOps;
 use crate::bmt::{BRANCHES, DEFAULT_BODY_SIZE, HASH_SIZE, SPAN_SIZE};

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -17,9 +17,11 @@ publish = false
 [dependencies]
 allocation-counter = { workspace = true, optional = true }
 futures-executor.workspace = true
-nectar-file = { workspace = true, optional = true }
+# The engine surface only, so a consumer's no-std test lane keeps the file
+# crate's std feature off.
+nectar-file = { workspace = true, optional = true, features = ["primitives"] }
 nectar-postage = { workspace = true, optional = true }
-nectar-primitives = { workspace = true, optional = true }
+nectar-primitives = { workspace = true, optional = true, features = ["std"] }
 
 [features]
 # Allocation witness. Linking it swaps the global allocator of every target
@@ -34,6 +36,6 @@ fixtures = [ "dep:nectar-file", "dep:nectar-postage", "dep:nectar-primitives" ]
 # chunk traits on wasm32; the same store cannot compile on native targets.
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 futures.workspace = true
-nectar-file.workspace = true
-nectar-primitives.workspace = true
+nectar-file = { workspace = true, features = ["std"] }
+nectar-primitives = { workspace = true, features = ["std"] }
 wasm-bindgen-test.workspace = true


### PR DESCRIPTION
## What

Ungates the sequential read/walk/split/store/inflight/num core of `nectar-file` so it builds and runs on the `no_std`+`alloc` rv64 guest target, mirroring the pattern already established in `nectar-primitives`.

- Adds a `primitives` feature to `nectar-file` (`dep:nectar-primitives`, `dep:bytes`, `dep:futures-util`, alloc-only); `std` now forwards to it rather than owning the deps directly.
- Splits the borrowed-store `collect_into` relay out of `split/mod.rs` into its own `split/relay.rs`, with a `std` dual (`Arc<Mutex<VecDeque<_>>>`) and a single-threaded dual (`Rc<RefCell<VecDeque<_>>>`), gated on `any(std, not(multi_thread))`.
- `build.rs` now also clears the `multi_thread` cfg on `target_os = "none"` (previously only wasm32 and the `unsync` feature relaxed it), mirroring `nectar-marker`'s Send/Sync relaxation that the rv64 walk/store boxed futures require.
- Flips the workspace `nectar-file` and `nectar-primitives` dependency entries to `default-features = false` (a member-level override is a hard cargo error), with every consumer crate (`benches`, `examples`, `integration-tests`, `manifest`, `manifest-sim`, `postage-issuer`, `postage-usage`) now stating `std` (or, for `nectar-manifest`, `primitives`) explicitly on its own edge.
- `nectar-testing`'s `fixtures` edge enables only `["primitives"]` on `nectar-file` and only `["std"]` on `nectar-primitives`, so the host `nextest` lane stays free of a hidden `std` pull on the file crate.
- `nostd.yml` gains a `cargo check -p nectar-file --no-default-features --features primitives --target <rv64>` step alongside the existing bare-metal primitives check.
- `unit.yml` gains a `cargo nextest run -p nectar-file --no-default-features --features primitives` step so the no-std core is exercised on the arms a guest actually executes, not merely type-checked.

## Why

Closes #491.

`nectar-primitives` already builds bare-metal; `nectar-file`'s sequential engine (read, walk, split, store, inflight bookkeeping) was still hard-wired to `std`, blocking it from the rv64imac zkVM guest target that the rest of the `no_std` programme is moving the library core towards.

## Testing

- `cargo check --locked -p nectar-file --no-default-features --features primitives --target riscv64gc-unknown-none-elf` (new `nostd.yml` step).
- `cargo nextest run -p nectar-file --no-default-features --features primitives --locked` (new `unit.yml` step).
- `cargo clippy --workspace --all-targets --locked`: clean except two pre-existing `doc_lazy_continuation` warnings in `crates/testing/src/lib.rs`, untouched by this branch.
- `cargo fmt --all -- --check`: clean.

## AI Assistance

Implemented by fable, reviewed by opus, per github.com/nxm-rs/.github CONTRIBUTING.md.
