### PR TITLE
feat(postage)!: stamp verification on the rv64 lane, gate the issuer's concurrent machinery

### DIFF
--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -36,9 +36,13 @@ jobs:
                   targets: ${{ matrix.target }}
             - name: Check no_std crates without std
               run: |
+                  # nectar-postage is the proving-grade surface (stamp wire
+                  # types and verification); nectar-postage-issuer rides as its
+                  # gated sequential core.
                   cargo check --locked \
                     -p nectar-swarms -p nectar-contracts -p nectar-file \
                     -p nectar-marker -p nectar-clock \
+                    -p nectar-postage -p nectar-postage-issuer \
                     --no-default-features \
                     --target ${{ matrix.target }}
                   # nectar-mantaray by path: the editor's differential gate pins a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2670,7 +2670,6 @@ dependencies = [
  "rayon",
  "serde",
  "thiserror",
- "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ nectar-marker = { version = "0.4.0", path = "crates/marker" }
 nectar-primitives = { version = "0.4.0", path = "crates/primitives", default-features = false }
 nectar-swarms = { version = "0.4.0", path = "crates/swarms" }
 nectar-tasks = { version = "0.4.0", path = "crates/tasks" }
-nectar-postage = { version = "0.4.0", path = "crates/postage" }
+nectar-postage = { version = "0.4.0", path = "crates/postage", default-features = false }
 nectar-postage-issuer = { version = "0.4.0", path = "crates/postage-issuer" }
 nectar-postage-usage = { version = "0.4.0", path = "crates/postage-usage" }
 nectar-testing = { path = "crates/testing" }

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -29,7 +29,7 @@ alloy-signer.workspace = true
 alloy-signer-local.workspace = true
 bytes.workspace = true
 nectar-contracts.workspace = true
-nectar-postage.workspace = true
+nectar-postage = { workspace = true, features = ["std"] }
 nectar-postage-issuer = { workspace = true, features = ["parallel"] }
 nectar-postage-usage = { workspace = true, features = ["client", "seal"] }
 nectar-primitives = { workspace = true, features = ["std"] }

--- a/crates/integration-tests/Cargo.toml
+++ b/crates/integration-tests/Cargo.toml
@@ -36,7 +36,7 @@ mantaray-old = { package = "nectar-mantaray", version = "=0.3.0" }
 nectar-file = { workspace = true, features = ["std"] }
 nectar-manifest = { workspace = true, features = ["arbitrary"] }
 nectar-mantaray.workspace = true
-nectar-postage.workspace = true
+nectar-postage = { workspace = true, features = ["std"] }
 nectar-postage-issuer.workspace = true
 nectar-postage-usage.workspace = true
 nectar-primitives = { workspace = true, features = ["std"] }

--- a/crates/postage-issuer/Cargo.toml
+++ b/crates/postage-issuer/Cargo.toml
@@ -23,10 +23,11 @@ nectar-marker = { workspace = true }
 nectar-postage = { workspace = true }
 nectar-primitives = { workspace = true }
 alloy-primitives = { workspace = true }
-alloy-signer = { workspace = true }
 thiserror = { workspace = true }
 
 # optional
+# The signer stack requires std; the no_std core only allocates digests.
+alloy-signer = { workspace = true, optional = true }
 alloy-signer-local = { workspace = true, optional = true }
 rayon = { workspace = true, optional = true }
 
@@ -44,8 +45,13 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 [features]
 default = [ "std" ]
 
-# Standard library support
-std = [ "nectar-clock/std", "nectar-postage/std", "nectar-primitives/std" ]
+# Standard library support: the signer stack, the concurrent issuers
+# (sharded, sharded ring), the factory and the dilution registry live behind
+# this gate.
+std = [
+	"dep:alloy-signer",
+	"nectar-clock/std",
+	"nectar-postage/std", "nectar-primitives/std" ]
 
 # Local key signing for testing and development
 local-signer = [ "dep:alloy-signer-local", "std" ]

--- a/crates/postage-issuer/Cargo.toml
+++ b/crates/postage-issuer/Cargo.toml
@@ -51,7 +51,9 @@ default = [ "std" ]
 std = [
 	"dep:alloy-signer",
 	"nectar-clock/std",
-	"nectar-postage/std", "nectar-primitives/std" ]
+	"nectar-postage/std",
+	"nectar-primitives/std",
+]
 
 # Local key signing for testing and development
 local-signer = [ "dep:alloy-signer-local", "std" ]

--- a/crates/postage-issuer/src/counter.rs
+++ b/crates/postage-issuer/src/counter.rs
@@ -26,8 +26,6 @@
 //! small, so the sum does not count overwrites. The snapshot codec writes and
 //! re-checks this sum in both modes.
 
-extern crate alloc;
-
 use alloc::vec;
 use alloc::vec::Vec;
 

--- a/crates/postage-issuer/src/error.rs
+++ b/crates/postage-issuer/src/error.rs
@@ -56,6 +56,7 @@ pub enum SigningError {
     /// Signing operation failed.
     ///
     /// The allocated index is burnt; a retry allocates a fresh one.
+    #[cfg(feature = "std")]
     #[error(transparent)]
     Signer(#[from] alloy_signer::Error),
 
@@ -70,4 +71,18 @@ pub enum SigningError {
     /// No allocation happened; a retry is free.
     #[error("address not admitted before the pipeline stopped")]
     NotAdmitted,
+}
+
+impl SigningError {
+    /// Whether the signer itself failed, as opposed to a per-item refusal.
+    pub const fn is_systemic(&self) -> bool {
+        #[cfg(feature = "std")]
+        {
+            matches!(self, Self::Signer(_) | Self::Dropped)
+        }
+        #[cfg(not(feature = "std"))]
+        {
+            matches!(self, Self::Dropped)
+        }
+    }
 }

--- a/crates/postage-issuer/src/lib.rs
+++ b/crates/postage-issuer/src/lib.rs
@@ -75,7 +75,10 @@
 //!
 //! # Features
 //!
-//! - `std` (default) - Enables standard library support
+//! - `std` (default) - Standard library support. Without it the crate is the
+//!   sequential issuing core only: the concurrent issuers, the factory and
+//!   the dilution registry are gated out, construction takes explicit clocks,
+//!   and a signer panic propagates instead of being caught into a result.
 //! - `local-signer` - Enables local key signing with `alloy-signer-local`
 //! - `parallel` - Enables the pipeline's parallel signing engine with rayon
 //! - `unsync` - Relaxes the signer thread-safety bounds on single-threaded
@@ -116,6 +119,8 @@
     )
 )]
 
+extern crate alloc;
+
 // The parallel engine spawns onto rayon and needs real `Send`; `unsync`
 // relaxes that bound away. Enabling both (directly or through feature
 // unification) is a build error with a clear cause rather than a deep one at
@@ -127,12 +132,15 @@ mod counter;
 #[cfg(feature = "std")]
 mod dilute_handler;
 mod error;
+#[cfg(feature = "std")]
 mod factory;
 mod issuer;
 mod pipeline;
 mod prepared;
 mod ring;
+#[cfg(feature = "std")]
 mod sharded;
+#[cfg(feature = "std")]
 mod sharded_ring;
 mod stamper;
 
@@ -154,6 +162,7 @@ pub use dilute_handler::{Dilutable, IssuerRegistry};
 
 // Issuing
 pub use issuer::{MemoryIssuer, MemoryIssuerFor, StampIssuer};
+#[cfg(feature = "std")]
 pub use sharded::{ShardedIssuer, ShardedIssuerFor};
 pub use stamper::{BatchStamper, Stamper};
 
@@ -162,6 +171,7 @@ pub use pipeline::{Eip191, SignPrehash, SignWindow, StampPipeline, StampResult, 
 
 // Mutable (ring) issuing with a type-state reservation guard
 pub use ring::{Reservation, Reserved, RingIssuer, RingIssuerFor, Unreserved};
+#[cfg(feature = "std")]
 pub use sharded_ring::{ShardedRingIssuer, ShardedRingIssuerFor};
 
 // Factory (std only)

--- a/crates/postage-issuer/src/pipeline/mod.rs
+++ b/crates/postage-issuer/src/pipeline/mod.rs
@@ -13,9 +13,9 @@
 //!   is the set of addresses with no Ok result, computable from results
 //!   alone; collecting into a map drops multiplicity. Dedup upstream where
 //!   capacity hygiene matters.
-//! - Every admitted job yields exactly one result on every path; a signer
-//!   panic yields [`SigningError::Dropped`] for the address captured at
-//!   admission.
+//! - Every admitted job yields exactly one result on every path; under `std`
+//!   a signer panic is caught and yields [`SigningError::Dropped`] for the
+//!   address captured at admission. Without `std` a signer panic propagates.
 //! - Fail-fast (default on): a `Signer` or `Dropped` result stops admission.
 //!   Already-admitted completions still yield, Ok and per-item Err alike
 //!   (signed stamps are wire-valid; discarding them burns capacity), then
@@ -29,12 +29,13 @@
 //! - Dropping a [`Stamped`] abandons at most one window of allocated,
 //!   unsigned indices; issuer state is coherent at every yield point.
 
+use alloc::collections::VecDeque;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
 use core::fmt;
 use core::num::NonZeroU16;
-use std::collections::VecDeque;
-#[cfg(not(feature = "parallel"))]
+#[cfg(all(feature = "std", not(feature = "parallel")))]
 use std::panic::{AssertUnwindSafe, catch_unwind};
-use std::sync::Arc;
 #[cfg(feature = "parallel")]
 use std::sync::mpsc::{Receiver, Sender, channel};
 
@@ -427,7 +428,7 @@ where
     }
 
     /// Signs the next admitted digest inline, if any.
-    #[cfg(not(feature = "parallel"))]
+    #[cfg(all(feature = "std", not(feature = "parallel")))]
     fn complete_one(&mut self) -> Option<StampResult> {
         let digest = self.prepared.pop_front()?;
         let address = digest.chunk_address;
@@ -437,6 +438,16 @@ where
             sign_digest(self.pipeline.signer.as_ref(), &digest)
         }))
         .unwrap_or_else(|_| Err(SigningError::Dropped));
+        Some(StampResult { address, result })
+    }
+
+    /// Signs the next admitted digest inline, if any. Without `std` there is
+    /// no unwind boundary: a signer panic propagates.
+    #[cfg(not(any(feature = "std", feature = "parallel")))]
+    fn complete_one(&mut self) -> Option<StampResult> {
+        let digest = self.prepared.pop_front()?;
+        let address = digest.chunk_address;
+        let result = sign_digest(self.pipeline.signer.as_ref(), &digest);
         Some(StampResult { address, result })
     }
 }
@@ -459,10 +470,7 @@ where
             if let Some(result) = self.complete_one() {
                 if self.pipeline.fail_fast
                     && !self.failed
-                    && matches!(
-                        result.result,
-                        Err(SigningError::Signer(_) | SigningError::Dropped)
-                    )
+                    && matches!(&result.result, Err(error) if error.is_systemic())
                 {
                     self.stop_admission();
                 }

--- a/crates/postage-issuer/src/pipeline/signer.rs
+++ b/crates/postage-issuer/src/pipeline/signer.rs
@@ -1,7 +1,8 @@
 //! Sealed prehash signing: the pipeline's only signer seam.
 
-use alloy_primitives::B256;
-use alloy_signer::{Signature, SignerSync};
+use alloy_primitives::{B256, Signature};
+#[cfg(feature = "std")]
+use alloy_signer::SignerSync;
 
 use crate::error::SigningError;
 use nectar_postage::{Stamp, StampDigest};
@@ -16,7 +17,7 @@ mod sealed {
 /// synchronous signer, so the prehash handling is never hand-written.
 pub trait SignPrehash: sealed::Sealed {
     /// Signs `prehash`, the keccak256 stamp digest.
-    fn sign_prehash(&self, prehash: &B256) -> Result<Signature, alloy_signer::Error>;
+    fn sign_prehash(&self, prehash: &B256) -> Result<Signature, SigningError>;
 }
 
 /// EIP-191 personal-message adapter over a synchronous signer.
@@ -37,9 +38,12 @@ impl<S> Eip191<S> {
 
 impl<S> sealed::Sealed for Eip191<S> {}
 
+#[cfg(feature = "std")]
 impl<S: SignerSync> SignPrehash for Eip191<S> {
-    fn sign_prehash(&self, prehash: &B256) -> Result<Signature, alloy_signer::Error> {
-        self.0.sign_message_sync(prehash.as_slice())
+    fn sign_prehash(&self, prehash: &B256) -> Result<Signature, SigningError> {
+        self.0
+            .sign_message_sync(prehash.as_slice())
+            .map_err(SigningError::from)
     }
 }
 

--- a/crates/postage-issuer/src/prepared.rs
+++ b/crates/postage-issuer/src/prepared.rs
@@ -1,5 +1,7 @@
 //! Admission micro-batch: serial digest allocation for the pipeline window.
 
+use alloc::vec::Vec;
+
 use crate::issuer::StampIssuer;
 use crate::stamper::stamp_timestamp;
 use nectar_clock::Clock;

--- a/crates/postage-issuer/src/ring.rs
+++ b/crates/postage-issuer/src/ring.rs
@@ -25,8 +25,6 @@
 //! [`MemoryIssuer`]: crate::MemoryIssuer
 //! [`ShardedIssuer`]: crate::ShardedIssuer
 
-extern crate alloc;
-
 use alloc::collections::BTreeSet;
 use alloc::vec::Vec;
 

--- a/crates/postage-issuer/src/stamper.rs
+++ b/crates/postage-issuer/src/stamper.rs
@@ -10,9 +10,11 @@
 //! rather than `sign_hash_sync`.
 
 use alloy_primitives::Signature;
+#[cfg(feature = "std")]
 use alloy_signer::SignerSync;
 
 use crate::StampIssuer;
+#[cfg(feature = "std")]
 use crate::error::SigningError;
 use nectar_clock::Clock;
 #[cfg(feature = "std")]
@@ -219,6 +221,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<I, S, C> Stamper for BatchStamper<I, S, C>
 where
     I: StampIssuer,

--- a/crates/postage/Cargo.toml
+++ b/crates/postage/Cargo.toml
@@ -19,8 +19,7 @@ workspace = true
 
 [dependencies]
 nectar-primitives = { workspace = true }
-alloy-primitives = { workspace = true }
-alloy-signer = { workspace = true }
+alloy-primitives = { workspace = true, features = ["k256"] }
 derive_more = { workspace = true }
 thiserror = { workspace = true }
 
@@ -28,17 +27,18 @@ thiserror = { workspace = true }
 k256 = { workspace = true }
 
 # optional
+# The signer seam is issuing-side machinery; verification never signs, so the
+# generators are the only consumer.
+alloy-signer = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 rayon = { workspace = true, optional = true }
 arbitrary = { workspace = true, optional = true }
-# wall clock for stamp issuance timestamps; std::time on native, browser clock
-# on wasm32. Only needed with the `std` feature (the no_std path returns 0).
-web-time = { workspace = true, optional = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
 proptest-arbitrary-interop = { workspace = true }
 rand = { workspace = true }
+alloy-signer = { workspace = true }
 alloy-signer-local = { workspace = true }
 alloy-primitives = { workspace = true, features = ["getrandom", "arbitrary"] }
 arbitrary = { workspace = true }
@@ -48,10 +48,9 @@ nectar-testing = { workspace = true, features = ["fixtures"] }
 [features]
 default = [ "std" ]
 
-# Standard library support. Enables BatchStore, BatchFactory, and timestamp functions.
+# Standard library support. Enables BatchStore, BatchFactory, and events.
 std = [
 	"alloy-primitives/std",
-	"dep:web-time",
 	"k256/precomputed-tables",
 	"k256/std",
 	"nectar-primitives/std",
@@ -69,6 +68,7 @@ parallel = [ "dep:rayon", "nectar-primitives/parallel", "std" ]
 # property-based testing and fuzzing.
 arbitrary = [
 	"alloy-primitives/arbitrary",
+	"dep:alloy-signer",
 	"dep:arbitrary",
 	"nectar-primitives/arbitrary",
 	"std",

--- a/crates/postage/src/lib.rs
+++ b/crates/postage/src/lib.rs
@@ -56,10 +56,6 @@
     )
 )]
 
-// k256 is a dependency only to enable the precomputed-tables feature for faster ECDSA
-#[cfg(not(test))]
-use k256 as _;
-
 // `alloc` is required by the stamped-chunk codec (`Vec`). `nectar-primitives`,
 // a hard dependency, also already requires an allocator, so this adds no new
 // constraint to the `no_std` build.
@@ -95,7 +91,7 @@ pub use error::StampError;
 pub use sink::{PutStamped, StampIndifferent, Tee, TeeError};
 pub use stamp::{STAMP_SIZE, Stamp, StampBytes, StampDigest, StampIndex};
 pub use stamped::StampedChunk;
-pub use util::{PostageContext, calculate_bucket, current_timestamp};
+pub use util::{PostageContext, calculate_bucket};
 pub use validation::StampValidator;
 #[cfg(feature = "std")]
 pub use validation::StoreValidator;
@@ -109,4 +105,4 @@ pub use snapshot_store::SnapshotStore;
 pub use store::{BatchStore, BatchStoreError, BatchStoreExt};
 
 // Re-export VerifyingKey for cached pubkey verification optimization
-pub use alloy_signer::k256::ecdsa::VerifyingKey;
+pub use k256::ecdsa::VerifyingKey;

--- a/crates/postage/src/parallel.rs
+++ b/crates/postage/src/parallel.rs
@@ -13,8 +13,7 @@
 //! compared to full ECDSA recovery.
 
 use alloy_primitives::Address;
-use alloy_signer::k256::ecdsa::VerifyingKey;
-use alloy_signer::utils::public_key_to_address;
+use k256::ecdsa::VerifyingKey;
 use rayon::prelude::*;
 
 use crate::{Stamp, StampDigest, StampError};
@@ -133,7 +132,7 @@ pub fn verify_stamps_parallel_with_pubkey(
     stamps: &[(&Stamp, &ChunkAddress)],
     owner_pubkey: &VerifyingKey,
 ) -> Vec<VerifyResult> {
-    let owner_address = public_key_to_address(owner_pubkey);
+    let owner_address = Address::from_public_key(owner_pubkey);
 
     stamps
         .par_iter()
@@ -191,7 +190,7 @@ mod tests {
     use alloy_signer::SignerSync;
     use alloy_signer_local::PrivateKeySigner;
 
-    use crate::{BatchId, Stamp, StampIndex, current_timestamp};
+    use crate::{BatchId, Stamp, StampIndex};
 
     /// Creates a stamp for testing verification.
     fn create_test_stamp(
@@ -200,7 +199,7 @@ mod tests {
         batch_id: BatchId,
     ) -> Stamp {
         let index = StampIndex::new(0, 0);
-        let timestamp = current_timestamp();
+        let timestamp = 1_234_567_890;
         let digest = StampDigest::new(*chunk_address, batch_id, index, timestamp);
         let prehash = digest.to_prehash();
 

--- a/crates/postage/src/stamp.rs
+++ b/crates/postage/src/stamp.rs
@@ -3,7 +3,7 @@
 use alloc::vec::Vec;
 
 use alloy_primitives::{Address, B256, Signature, eip191_hash_message};
-use alloy_signer::k256::ecdsa::VerifyingKey;
+use k256::ecdsa::VerifyingKey;
 use nectar_primitives::{
     ChunkAddress,
     wire::{Cursor, FromCursor, ToWriter, Underrun, Writer},
@@ -420,7 +420,7 @@ impl Stamp {
     /// ```ignore
     /// // First stamp: recover and cache the public key
     /// let pubkey = first_stamp.recover_pubkey(&first_address)?;
-    /// let owner = alloy_signer::utils::public_key_to_address(&pubkey);
+    /// let owner = alloy_primitives::Address::from_public_key(&pubkey);
     ///
     /// // Fast verification for remaining stamps in the same batch
     /// second_stamp.verify_with_pubkey(&second_address, &pubkey)?;
@@ -431,7 +431,7 @@ impl Stamp {
         chunk_address: &ChunkAddress,
         pubkey: &VerifyingKey,
     ) -> Result<(), StampError> {
-        use alloy_signer::k256::ecdsa::signature::hazmat::PrehashVerifier;
+        use k256::ecdsa::signature::hazmat::PrehashVerifier;
 
         let digest = StampDigest::new(*chunk_address, self.batch, self.index, self.timestamp);
         let prehash = digest.to_prehash();
@@ -732,8 +732,6 @@ mod tests {
     /// Test recover_pubkey using the Go interop test vector.
     #[test]
     fn test_recover_pubkey() {
-        use alloy_signer::utils::public_key_to_address;
-
         // Test vector from Go's TestGenerateInteropStamp
         let chunk_addr_bytes =
             hex::decode("0000000000000000000000000000000000000000000000000000000000000002")
@@ -750,7 +748,7 @@ mod tests {
         let pubkey = stamp.recover_pubkey(&chunk_address).unwrap();
 
         // Convert to address and verify
-        let recovered_addr = public_key_to_address(&pubkey);
+        let recovered_addr = Address::from_public_key(&pubkey);
         assert_eq!(recovered_addr, expected_owner);
     }
 

--- a/crates/postage/src/util.rs
+++ b/crates/postage/src/util.rs
@@ -2,37 +2,6 @@
 
 use nectar_primitives::ChunkAddress;
 
-/// Returns the current timestamp in nanoseconds since the Unix epoch.
-///
-/// This is used when creating stamps to record when they were issued.
-/// In `no_std` environments, this returns 0 and callers should provide
-/// timestamps via other means (e.g., `prepare_stamp` with explicit timestamp).
-#[cfg(feature = "std")]
-#[inline]
-pub fn current_timestamp() -> u64 {
-    use web_time::{SystemTime, UNIX_EPOCH};
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        // Nanoseconds since the Unix epoch fit in a `u64` until the year
-        // ~2554; truncation is unreachable in practice.
-        .map(|d| {
-            #[allow(clippy::as_conversions)]
-            {
-                d.as_nanos() as u64
-            }
-        })
-        .unwrap_or(0)
-}
-
-/// Returns 0 in `no_std` environments.
-///
-/// Callers should provide timestamps via other means when `std` is not available.
-#[cfg(not(feature = "std"))]
-#[inline]
-pub const fn current_timestamp() -> u64 {
-    0
-}
-
 /// Calculates which collision bucket a chunk belongs to based on its address.
 ///
 /// The bucket is determined by taking the first `bucket_depth` bits of the

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -30,7 +30,13 @@ alloc = [ "dep:allocation-counter" ]
 
 # Shared split fixtures and SwarmSpec doubles. Encrypted-mode splits ride the
 # mode-generic `split_into`; callers bring their own encryption features.
-fixtures = [ "dep:nectar-file", "dep:nectar-postage", "dep:nectar-primitives" ]
+fixtures = [
+	"dep:nectar-file",
+	"dep:nectar-postage",
+	"dep:nectar-primitives",
+	"nectar-postage?/std",
+	"nectar-primitives?/std",
+]
 
 # The wasm smoke test is the executable proof that a !Send store satisfies the
 # chunk traits on wasm32; the same store cannot compile on native targets.


### PR DESCRIPTION
## What

Puts stamp *verification* on the rv64 proving lane, and gates the issuer's concurrent machinery out of the no_std core. The proving-grade surface is `nectar-postage` (stamp wire types and verification); `nectar-postage-issuer` is not itself a proving surface and rides the lane only because `nectar-postage` depends on it, so it must compile bare-metal for the verification lane to exist. A zkVM guest never issues stamps (a signature proves itself; issuing would put the batch key in the witness), so the concurrent issuer machinery is gated, not ported.

- `nectar-postage`: stamp wire types and verification stay alloc-only and join the rv64/wasm32 no_std CI lane. This is the surface that feeds aggregate stamp-validity proving (#490).
- `nectar-postage-issuer`: `extern crate alloc` at the crate root; `sharded`, `sharded_ring` and `factory` are now `#[cfg(feature = "std")]` (guests never issue, so the concurrent machinery has no no_std caller). The sequential core (`BatchStamper`, the prepare micro-batch, the pipeline inner engine) becomes no_std as a near-free consequence of that gating, with `VecDeque`/`Arc`/`Vec` now from `alloc`; it is on the lane so `nectar-postage` can build bare-metal, not as a capability in its own right.
- `alloy-signer` is now optional and `std`-gated in both crates, because `alloy-signer` 2.0.5 hard-pins `alloy-primitives/std` and cannot enter the rv64 graph. `SigningError::Signer` is `#[cfg(feature = "std")]`; `SigningError::is_systemic()` covers the fail-fast check in both configurations. The pipeline's `catch_unwind` `complete_one` is std-gated; a no_std twin propagates a signer panic instead.
- `nectar_postage::current_timestamp` (the free function that returned 0 under no_std) is deleted outright along with its `web-time` dependency: a wire hazard, since 0 could reach a signed preimage, not a proving feature. no_std construction takes explicit timestamps.
- `VerifyingKey` re-export comes directly from `k256`. Workspace `Cargo.toml` flips `nectar-primitives` and `nectar-postage` to `default-features = false`; downstream consumers opt back into the features they need.

## Why

Closes #488.

The value here is the verification lane plus two hygiene fixes, not a no_std issuing engine. Stamp verification in `nectar-postage` is what a proving guest actually runs (proving a dataset carries valid unexpired stamps, #490); the issuer's allocation state machine has no guest caller and no current wasm consumer, so gating its concurrent parts rather than porting them keeps the rv64 graph free of `alloy-signer`'s hard `std` pin without reimplementing machinery nothing bare-metal uses. The const-0 timestamp deletion closes a real wire hazard on the no_std path.

## Testing

- `cargo check --locked -p nectar-postage -p nectar-postage-issuer --no-default-features` on riscv64imac-unknown-none-elf and wasm32, both green (the CI job this PR adds to `nostd.yml`).
- Full std test suite passes (141 postage-family tests); clippy clean on both crates.
- Every consumer of the `nectar-primitives`/`nectar-postage` default-features flip was audited (feeds, file, manifest, mantaray, postage-usage, benches, examples, integration-tests, manifest-sim, testing).

## AI Assistance

Implemented by fable, reviewed by Opus.
