### PR TITLE
feat(primitives)!: single-recovery soc lifecycle and bare-compare hardening

### DIFF
--- a/crates/postage/src/sink.rs
+++ b/crates/postage/src/sink.rs
@@ -18,7 +18,9 @@ use crate::StampedChunk;
 /// The stamp travels in-band with the chunk it pays for. The contract is
 /// delivery only: per-address idempotence belongs to a decorator layered
 /// above the sink, never to this trait. Implementors use interior
-/// mutability, mirroring `ChunkPut`.
+/// mutability, mirroring `ChunkPut`. Ingest ordering: batch existence and
+/// authenticity gates run before chunk certification; the typed decode
+/// takes the stamp structurally before paying the chunk's acceptance rule.
 pub trait PutStamped<const BODY_SIZE: usize = DEFAULT_BODY_SIZE>: MaybeSend + MaybeSync {
     /// Error type for stamped put operations.
     type Error: core::error::Error + MaybeSend + MaybeSync + 'static;

--- a/crates/primitives/examples/wasm-demo/src/lib.rs
+++ b/crates/primitives/examples/wasm-demo/src/lib.rs
@@ -900,19 +900,24 @@ pub fn analyze_chunk(
     let content_result = DefaultContentChunk::try_from(chunk_data);
     let single_owner_result = DefaultSingleOwnerChunk::try_from(chunk_data);
 
-    // Prioritize any successful parse that matches the expected address
+    // Prioritize any parse that certifies at the expected address via the
+    // full acceptance rule; a bare address compare would bless a
+    // garbage-signature single owner chunk. The structural parses below
+    // feed diagnostics only, never the validity bit.
     match (content_result, single_owner_result) {
-        (Ok(content_chunk), _) if content_chunk.address() == &expected => Ok(ChunkAnalysisResult {
-            is_valid: true,
-            chunk_type: ChunkType::Content,
-            address: B256::from(*content_chunk.address()),
-            data: content_chunk.data().to_vec(),
-            id: None,
-            owner: None,
-            signature: None,
-            error_message: None,
-        }),
-        (_, Ok(single_owner_chunk)) if single_owner_chunk.address() == &expected => {
+        (Ok(content_chunk), _) if content_chunk.verify(&expected).is_ok() => {
+            Ok(ChunkAnalysisResult {
+                is_valid: true,
+                chunk_type: ChunkType::Content,
+                address: B256::from(*content_chunk.address()),
+                data: content_chunk.data().to_vec(),
+                id: None,
+                owner: None,
+                signature: None,
+                error_message: None,
+            })
+        }
+        (_, Ok(single_owner_chunk)) if single_owner_chunk.verify(&expected).is_ok() => {
             Ok(ChunkAnalysisResult {
                 is_valid: true,
                 chunk_type: ChunkType::SingleOwner,
@@ -924,7 +929,8 @@ pub fn analyze_chunk(
                 error_message: None,
             })
         }
-        // Return any successful parse with address mismatch
+        // Structural parse only: report the verification failure as a
+        // diagnostic alongside the parsed fields.
         (Ok(content_chunk), _) => Ok(ChunkAnalysisResult {
             is_valid: false,
             chunk_type: ChunkType::Content,
@@ -933,11 +939,10 @@ pub fn analyze_chunk(
             id: None,
             owner: None,
             signature: None,
-            error_message: Some(format!(
-                "Content chunk address mismatch. Expected: 0x{}, Actual: 0x{}",
-                hex::encode(expected.as_bytes()),
-                hex::encode(content_chunk.address().as_bytes())
-            )),
+            error_message: content_chunk
+                .verify(&expected)
+                .err()
+                .map(|e| format!("Content chunk failed verification: {}", e)),
         }),
         (_, Ok(single_owner_chunk)) => Ok(ChunkAnalysisResult {
             is_valid: false,
@@ -947,11 +952,10 @@ pub fn analyze_chunk(
             id: Some(single_owner_chunk.id().into()),
             owner: single_owner_chunk.owner().ok(),
             signature: Some(single_owner_chunk.signature().as_bytes().to_vec()),
-            error_message: Some(format!(
-                "Single owner chunk address mismatch. Expected: 0x{}, Actual: 0x{}",
-                hex::encode(expected.as_bytes()),
-                hex::encode(single_owner_chunk.address().as_bytes())
-            )),
+            error_message: single_owner_chunk
+                .verify(&expected)
+                .err()
+                .map(|e| format!("Single owner chunk failed verification: {}", e)),
         }),
         // Both failed to parse
         (Err(e1), Err(e2)) => Ok(ChunkAnalysisResult {

--- a/crates/primitives/src/chunk/content.rs
+++ b/crates/primitives/src/chunk/content.rs
@@ -4,7 +4,7 @@
 //! carrier under the empty [`CacHeader`], whose address is the hash of the
 //! chunk's own body.
 
-use alloy_primitives::{B256, hex};
+use alloy_primitives::{Address, B256, hex};
 use bytes::{Bytes, BytesMut};
 use core::fmt;
 
@@ -52,12 +52,12 @@ impl ChunkHeader for CacHeader {
         &self,
         body_hash: B256,
         expected: &ChunkAddress,
-    ) -> core::result::Result<(), ChunkError> {
+    ) -> core::result::Result<Option<Address>, ChunkError> {
         let actual = self.commit(body_hash);
         if actual != *expected {
             return Err(ChunkError::verification_failed(*expected, actual));
         }
-        Ok(())
+        Ok(None)
     }
 
     /// The transformed address is the anchor-keyed BMT root itself.
@@ -115,7 +115,8 @@ impl<const BODY_SIZE: usize> ContentChunk<BODY_SIZE> {
             self.verify(&address).is_ok(),
             "a content chunk must certify at its derived address"
         );
-        Chunk::from_verified_parts(address, R::Envelope::from(self))
+        // A content chunk binds no owner: a type fact, seeded for free.
+        Chunk::from_verified_parts_with_owner(address, R::Envelope::from(self), None)
     }
 }
 
@@ -392,6 +393,17 @@ mod tests {
         let expected = b256!("2387e8e7d8a48c2a9339c97c1dc3461a9a7aa07e994c5cb8b38fd7c1b3e6ea48");
         assert_eq!(CacHeader.commit(body_hash), ChunkAddress::from(expected));
         assert!(CacHeader.validate(body_hash, &expected.into()).is_ok());
+    }
+
+    /// A content header binds no owner: validate says so on acceptance.
+    #[test]
+    fn cac_header_validate_returns_no_owner() {
+        let chunk = DefaultContentChunk::new(b"ownerless".to_vec()).unwrap();
+        let body_hash: B256 = chunk.body().hash().into();
+        assert_eq!(
+            CacHeader.validate(body_hash, chunk.address()).unwrap(),
+            None
+        );
     }
 
     #[test]

--- a/crates/primitives/src/chunk/inner.rs
+++ b/crates/primitives/src/chunk/inner.rs
@@ -5,6 +5,7 @@
 //! carrier means there is nowhere to hand-write a divergent address or verify
 //! path per chunk type.
 
+use alloy_primitives::Address;
 use bytes::{Bytes, BytesMut};
 
 use crate::bmt::DEFAULT_BODY_SIZE;
@@ -31,6 +32,9 @@ pub struct ChunkInner<H: ChunkHeader, const BODY_SIZE: usize = DEFAULT_BODY_SIZE
     body: BmtBody<BODY_SIZE>,
     /// Lazily derived `header.commit(body.hash())`; never caller-supplied.
     address: OnceCache<ChunkAddress>,
+    /// Owner bound by the acceptance rule; seeded by `verify`, never
+    /// caller-supplied.
+    owner: OnceCache<Option<Address>>,
 }
 
 impl<H: ChunkHeader, const BODY_SIZE: usize> ChunkInner<H, BODY_SIZE> {
@@ -44,6 +48,26 @@ impl<H: ChunkHeader, const BODY_SIZE: usize> ChunkInner<H, BODY_SIZE> {
             header,
             body,
             address: OnceCache::new(),
+            owner: OnceCache::new(),
+        }
+    }
+
+    /// Assemble with provenance-derived facts pre-seeded.
+    ///
+    /// Crate-internal: the caller must have derived `address` and `owner`
+    /// from the parts themselves (a seal path), never from a claim.
+    #[cfg(feature = "std")]
+    pub(crate) fn from_provenance(
+        header: H,
+        body: BmtBody<BODY_SIZE>,
+        address: ChunkAddress,
+        owner: Option<Address>,
+    ) -> Self {
+        Self {
+            header,
+            body,
+            address: OnceCache::with_value(address),
+            owner: OnceCache::with_value(owner),
         }
     }
 
@@ -84,14 +108,26 @@ impl<H: ChunkHeader, const BODY_SIZE: usize> ChunkOps for ChunkInner<H, BODY_SIZ
         self.body.span()
     }
 
-    fn owner(&self) -> Option<alloy_primitives::Address> {
-        self.header.recover_owner(self.body.hash().into())
+    /// Memoized through the acceptance rule at the committed address, so a
+    /// chunk its own type rejects binds no owner.
+    fn owner(&self) -> Option<Address> {
+        *self.owner.get_or_compute(|| {
+            self.header
+                .validate(self.body.hash().into(), self.address())
+                .ok()
+                .flatten()
+        })
     }
 
     /// Certify through [`ChunkHeader::validate`]: the header's full acceptance
-    /// rule runs, not an address compare against the cached address.
+    /// rule runs, not an address compare against the cached address. On
+    /// acceptance the address and owner caches are seeded from the one run,
+    /// so an accepted chunk never recomputes either fact.
     fn verify(&self, expected: &ChunkAddress) -> Result<()> {
-        Ok(self.header.validate(self.body.hash().into(), expected)?)
+        let owner = self.header.validate(self.body.hash().into(), expected)?;
+        let _ = self.address.get_or_compute(|| *expected);
+        let _ = self.owner.get_or_compute(|| owner);
+        Ok(())
     }
 
     /// Runs on the carrier's borrowed body ([`ChunkInner::body`]), so no
@@ -217,6 +253,21 @@ mod tests {
         let chunk = DefaultSingleOwnerChunk::try_from(wire.as_slice()).unwrap();
         let committed = *chunk.address();
         assert!(chunk.verify(&committed).is_err());
+    }
+
+    /// Acceptance seeds the derived facts: after verify, the address and the
+    /// owner are the values the one validate run produced.
+    #[test]
+    fn verify_seeds_address_and_owner_facts() {
+        let soc = DefaultSingleOwnerChunk::try_from(soc_test_vector().as_slice()).unwrap();
+        let expected = soc.header().commit(soc.body().hash().into());
+
+        soc.verify(&expected).unwrap();
+        assert_eq!(*soc.address(), expected);
+        assert_eq!(
+            ChunkOps::owner(&soc),
+            soc.header().owner(soc.body().hash().into()).ok()
+        );
     }
 
     /// Both aliases round-trip through the one carrier codec.

--- a/crates/primitives/src/chunk/mod.rs
+++ b/crates/primitives/src/chunk/mod.rs
@@ -101,10 +101,10 @@
 //! #         &self,
 //! #         body_hash: B256,
 //! #         expected: &ChunkAddress,
-//! #     ) -> core::result::Result<(), ChunkError> {
+//! #     ) -> core::result::Result<Option<Address>, ChunkError> {
 //! #         let actual = self.commit(body_hash);
 //! #         if actual == *expected {
-//! #             Ok(())
+//! #             Ok(None)
 //! #         } else {
 //! #             Err(ChunkError::verification_failed(*expected, actual))
 //! #         }

--- a/crates/primitives/src/chunk/single_owner.rs
+++ b/crates/primitives/src/chunk/single_owner.rs
@@ -8,7 +8,7 @@
 use alloy_primitives::b256;
 use alloy_primitives::{Address, B256, Keccak256, Signature, address, hex};
 #[cfg(feature = "std")]
-use alloy_signer::SignerSync;
+use alloy_signer::{Signer, SignerSync};
 #[cfg(feature = "std")]
 use alloy_signer_local::PrivateKeySigner;
 use bytes::{Bytes, BytesMut};
@@ -24,8 +24,12 @@ use super::address::ChunkAddress;
 use super::bmt_body::BmtBody;
 use super::content::ContentChunk;
 use super::inner::ChunkInner;
+#[cfg(feature = "std")]
+use super::registry::ChunkRegistry;
 use super::soc_id::SocId;
 use super::traits::ChunkHeader;
+#[cfg(feature = "std")]
+use super::trust::{Chunk, Verified};
 use super::type_id::ChunkTypeId;
 use super::type_tag::ChunkVersion;
 
@@ -111,6 +115,23 @@ impl SocHeader {
         let hash_tail = body_hash.as_slice().split_first().map(|(_, tail)| tail);
         id_tail == hash_tail
     }
+
+    /// Dispersed-replica pin for a known owner: the recovery-free half of
+    /// acceptance.
+    fn pin_replica(&self, owner: Address, body_hash: B256) -> error::Result<()> {
+        if owner == DISPERSED_REPLICA_OWNER && !self.is_valid_replica(body_hash) {
+            return Err(ChunkError::invalid_format("invalid dispersed replica"));
+        }
+        Ok(())
+    }
+
+    /// Intrinsic acceptance: recover the owner and enforce the replica pin.
+    /// Routing (the address compare) stays in [`validate`](ChunkHeader::validate).
+    fn accept(&self, body_hash: B256) -> error::Result<Address> {
+        let owner = self.owner(body_hash)?;
+        self.pin_replica(owner, body_hash)?;
+        Ok(owner)
+    }
 }
 
 impl ChunkHeader for SocHeader {
@@ -130,24 +151,14 @@ impl ChunkHeader for SocHeader {
         &self,
         body_hash: B256,
         expected: &ChunkAddress,
-    ) -> core::result::Result<(), ChunkError> {
-        let owner = self.owner(body_hash)?;
-
-        // If the owner is the replica chunk owner, the ID must adhere to the
-        // dispersed-replica semantics.
-        if owner == DISPERSED_REPLICA_OWNER && !self.is_valid_replica(body_hash) {
-            return Err(ChunkError::invalid_format("invalid dispersed replica"));
-        }
+    ) -> core::result::Result<Option<Address>, ChunkError> {
+        let owner = self.accept(body_hash)?;
 
         let actual = Self::address_for(self.id, owner);
         if actual != *expected {
             return Err(ChunkError::verification_failed(*expected, actual));
         }
-        Ok(())
-    }
-
-    fn recover_owner(&self, body_hash: B256) -> Option<Address> {
-        self.owner(body_hash).ok()
+        Ok(Some(owner))
     }
 
     /// Plain (unprefixed) `keccak256(soc_address || transformed_root)`.
@@ -193,6 +204,47 @@ impl<const BODY_SIZE: usize> SingleOwnerChunk<BODY_SIZE> {
             .with_id(id)
             .with_signer(signer)?
             .build()
+    }
+
+    /// Sign and seal into the verified currency, recovery-free.
+    ///
+    /// Signer-provenance twin of [`ContentChunk::seal`]: the owner is the
+    /// signer's own address, so the sealed address is `keccak256(id || owner)`
+    /// derived here, never caller-supplied, and no signature recovery runs.
+    /// The replica pin still applies; debug builds retain a full verify
+    /// assertion.
+    #[cfg(feature = "std")]
+    #[must_use = "this returns a sealed chunk without modifying the input"]
+    pub fn seal<R>(
+        id: SocId,
+        data: impl Into<Bytes>,
+        signer: &(impl Signer + SignerSync),
+    ) -> Result<Chunk<Verified, R>>
+    where
+        R: ChunkRegistry,
+        R::Envelope: From<Self>,
+    {
+        let body = BmtBody::<BODY_SIZE>::builder()
+            .auto_from_data(data)?
+            .build()?;
+        let body_hash: B256 = body.hash().into();
+        let owner = signer.address();
+        let signature = signer
+            .sign_message_sync(SocHeader::owner_message(id, body_hash).as_ref())
+            .map_err(ChunkError::from)?;
+        let header = SocHeader::new(id, signature);
+        header.pin_replica(owner, body_hash)?;
+        let address = SocHeader::address_for(id, owner);
+        let chunk = Self::from_provenance(header, body, address, Some(owner));
+        debug_assert!(
+            super::traits::ChunkOps::verify(&chunk, &address).is_ok(),
+            "a signer-provenance single-owner chunk must certify at its derived address"
+        );
+        Ok(Chunk::from_verified_parts_with_owner(
+            address,
+            R::Envelope::from(chunk),
+            Some(owner),
+        ))
     }
 
     /// Create a new SingleOwnerChunk with a pre-signed signature.
@@ -813,6 +865,79 @@ mod tests {
         assert!(matches!(
             header.validate(body_hash, &zero_owner_address),
             Err(ChunkError::Signature(_))
+        ));
+    }
+
+    /// Validate returns the owner fact its acceptance run recovered.
+    #[test]
+    fn soc_header_validate_returns_the_recovered_owner() {
+        let chunk = DefaultSingleOwnerChunk::try_from(get_test_chunk_data().as_slice()).unwrap();
+        let body_hash: B256 = chunk.body().hash().into();
+
+        let owner = chunk.header().validate(body_hash, chunk.address()).unwrap();
+        assert_eq!(
+            owner,
+            Some(address!("8d3766440f0d7b949a5e32995d09619a7f86e632"))
+        );
+    }
+
+    /// The owner is an acceptance fact: a chunk its own type rejects binds
+    /// none, even when raw recovery would produce an address.
+    #[test]
+    fn chunk_ops_owner_follows_acceptance() {
+        // Garbage signature: recovery fails, no owner.
+        let mut wire = get_test_chunk_data();
+        wire[ID_SIZE..ID_SIZE + SIGNATURE_SIZE].copy_from_slice(&[0xff; SIGNATURE_SIZE]);
+        let forged = DefaultSingleOwnerChunk::try_from(wire.as_slice()).unwrap();
+        assert_eq!(ChunkOps::owner(&forged), None);
+
+        // Replica-owner signature over a non-replica id: recovery succeeds
+        // but the pin rejects, so no owner is bound.
+        let signer = PrivateKeySigner::from_slice(DISPERSED_REPLICA_OWNER_PK.as_slice()).unwrap();
+        let chunk = DefaultSingleOwnerChunk::new(SocId::ZERO, b"data".to_vec(), &signer).unwrap();
+        assert_eq!(chunk.owner().unwrap(), DISPERSED_REPLICA_OWNER);
+        assert_eq!(ChunkOps::owner(&chunk), None);
+    }
+
+    /// The seal lands exactly where the parse-then-verify route lands, with
+    /// the owner fact seeded from provenance.
+    #[test]
+    fn seal_matches_the_from_envelope_route() {
+        use crate::chunk::{Chunk, StandardChunkSet, Verified};
+
+        let wallet = get_test_wallet();
+        let sealed = DefaultSingleOwnerChunk::seal::<StandardChunkSet>(
+            SocId::ZERO,
+            b"sealed payload".to_vec(),
+            &wallet,
+        )
+        .unwrap();
+
+        let soc =
+            DefaultSingleOwnerChunk::new(SocId::ZERO, b"sealed payload".to_vec(), &wallet).unwrap();
+        let verified = Chunk::<Verified>::from_envelope(soc.into()).unwrap();
+
+        assert_eq!(sealed.address(), verified.address());
+        assert_eq!(sealed.owner(), Some(wallet.address()));
+        assert_eq!(sealed.typed_bytes(), verified.typed_bytes());
+        assert!(sealed.envelope().verify(sealed.address()).is_ok());
+    }
+
+    /// The seal's accept set equals verify's: the replica pin holds on the
+    /// provenance path too, in release builds as well.
+    #[test]
+    fn seal_enforces_the_replica_pin() {
+        use crate::chunk::StandardChunkSet;
+
+        let signer = PrivateKeySigner::from_slice(DISPERSED_REPLICA_OWNER_PK.as_slice()).unwrap();
+        let result = DefaultSingleOwnerChunk::seal::<StandardChunkSet>(
+            SocId::ZERO,
+            b"minted body".to_vec(),
+            &signer,
+        );
+        assert!(matches!(
+            result,
+            Err(PrimitivesError::Chunk(ChunkError::InvalidFormat(_)))
         ));
     }
 

--- a/crates/primitives/src/chunk/traits.rs
+++ b/crates/primitives/src/chunk/traits.rs
@@ -26,7 +26,7 @@ use super::type_tag::ChunkVersion;
 /// in sealing.
 ///
 /// ```
-/// use alloy_primitives::{B256, Keccak256};
+/// use alloy_primitives::{Address, B256, Keccak256};
 /// use nectar_primitives::bytes::BytesMut;
 /// use nectar_primitives::chunk::{ChunkAddress, ChunkError, ChunkHeader};
 /// use nectar_primitives::{ChunkTypeId, ChunkVersion, wire};
@@ -47,10 +47,14 @@ use super::type_tag::ChunkVersion;
 ///         ChunkAddress::from(hasher.finalize())
 ///     }
 ///
-///     fn validate(&self, body_hash: B256, expected: &ChunkAddress) -> Result<(), ChunkError> {
+///     fn validate(
+///         &self,
+///         body_hash: B256,
+///         expected: &ChunkAddress,
+///     ) -> Result<Option<Address>, ChunkError> {
 ///         let actual = self.commit(body_hash);
 ///         if actual == *expected {
-///             Ok(())
+///             Ok(None)
 ///         } else {
 ///             Err(ChunkError::verification_failed(*expected, actual))
 ///         }
@@ -87,21 +91,19 @@ pub trait ChunkHeader: Sized + Send + Sync + 'static {
     /// which [`validate`](Self::validate) then rejects.
     fn commit(&self, body_hash: B256) -> ChunkAddress;
 
-    /// Certify that this header and `body_hash` derive `expected`.
+    /// Certify that this header and `body_hash` derive `expected`, returning
+    /// the owner the acceptance rule bound (`None` for ownerless types).
     ///
     /// Required, deliberately without a default: an address-compare-only
     /// implementation would accept single-owner chunks whose signatures do
     /// not recover, so every header must state its full acceptance rule.
-    fn validate(&self, body_hash: B256, expected: &ChunkAddress) -> Result<(), ChunkError>;
-
-    /// Recover the owner this header binds the body to.
-    ///
-    /// `None` for ownerless types (the default) and for a signature that
-    /// does not recover; [`validate`](Self::validate), not this hook,
-    /// decides whether that is an error.
-    fn recover_owner(&self, _body_hash: B256) -> Option<Address> {
-        None
-    }
+    /// The sole acceptance entry point; the owner is returned here, not
+    /// through a parallel hook, so it cannot drift from acceptance.
+    fn validate(
+        &self,
+        body_hash: B256,
+        expected: &ChunkAddress,
+    ) -> Result<Option<Address>, ChunkError>;
 
     /// Seal the anchor-keyed `transformed_root` of the body into the chunk's
     /// transformed address (the redistribution sampler's re-hash).
@@ -135,8 +137,9 @@ pub trait ChunkOps: Send + Sync + 'static {
     /// underlying body.
     fn span(&self) -> u64;
 
-    /// Get the owner this chunk's type binds, if it has one and the
-    /// signature recovers ([`ChunkHeader::recover_owner`]).
+    /// Get the owner this chunk's type binds, if its acceptance rule admits
+    /// one ([`ChunkHeader::validate`]). `None` for ownerless types and for a
+    /// chunk its own type rejects.
     fn owner(&self) -> Option<Address>;
 
     /// Certify this chunk against an expected address.

--- a/crates/primitives/src/chunk/trust.rs
+++ b/crates/primitives/src/chunk/trust.rs
@@ -150,7 +150,14 @@ impl<R: ChunkRegistry> Chunk<Unverified, R> {
     /// internally consistent lie about the address cannot certify itself.
     pub fn verify(self) -> Result<Chunk<Verified, R>> {
         self.inner.verify(&self.address)?;
-        Ok(Chunk::from_verified_parts(self.address, self.inner))
+        // Acceptance just seeded the envelope's caches, so this owner read
+        // reuses the one recovery rather than paying a second.
+        let owner = self.inner.owner();
+        Ok(Chunk::from_verified_parts_with_owner(
+            self.address,
+            self.inner,
+            owner,
+        ))
     }
 
     /// Take the claimed address on trust: the single gated skip of
@@ -174,6 +181,21 @@ impl<R: ChunkRegistry> Chunk<Verified, R> {
         }
     }
 
+    /// Seed the address fact and the owner fact together, for mints whose
+    /// acceptance run (or provenance) already produced the owner.
+    pub(crate) fn from_verified_parts_with_owner(
+        address: ChunkAddress,
+        inner: R::Envelope,
+        owner: Option<Address>,
+    ) -> Self {
+        Self {
+            address,
+            inner,
+            owner: OnceCache::with_value(owner),
+            _state: PhantomData,
+        }
+    }
+
     /// Certify a locally built envelope at its own derived address.
     ///
     /// For upload paths where the value was constructed, not decoded. The
@@ -185,7 +207,8 @@ impl<R: ChunkRegistry> Chunk<Verified, R> {
     pub fn from_envelope(inner: R::Envelope) -> Result<Self> {
         let address = *inner.address();
         inner.verify(&address)?;
-        Ok(Self::from_verified_parts(address, inner))
+        let owner = inner.owner();
+        Ok(Self::from_verified_parts_with_owner(address, inner, owner))
     }
 
     /// Decode and certify bare wire bytes (no type tag) in one step.
@@ -193,10 +216,9 @@ impl<R: ChunkRegistry> Chunk<Verified, R> {
     /// Without a tag the address is the only member router, so parsing and
     /// certification are inseparable and the result is already verified.
     pub fn decode_wire(address: ChunkAddress, data: Bytes) -> Result<Self> {
-        Ok(Self::from_verified_parts(
-            address,
-            R::decode_wire(&address, data)?,
-        ))
+        let inner = R::decode_wire(&address, data)?;
+        let owner = inner.owner();
+        Ok(Self::from_verified_parts_with_owner(address, inner, owner))
     }
 
     /// The chunk's address: a certified fact, free to read.
@@ -383,6 +405,22 @@ mod tests {
         // Second read serves the memoized value.
         assert_eq!(verified.owner(), owner);
         assert!(verified.envelope().is_single_owner());
+    }
+
+    /// A verify-routed mint seeds the owner fact from its acceptance run;
+    /// reading it never pays a second recovery.
+    #[test]
+    fn verify_routed_mint_seeds_the_owner() {
+        let signer = test_signer();
+        let soc = DefaultSingleOwnerChunk::new(SocId::ZERO, b"seeded".to_vec(), &signer).unwrap();
+        let claimed = *soc.address();
+        let typed = StandardChunkSet::encode_typed(&soc.into());
+
+        let verified = Chunk::<Unverified>::parse(claimed, &typed)
+            .unwrap()
+            .verify()
+            .unwrap();
+        assert_eq!(verified.owner(), Some(signer.address()));
     }
 
     /// Key regression: an internally consistent lie must be rejected. A


### PR DESCRIPTION
## What

`ChunkHeader::validate` is now the sole acceptance entry point, returning `Result<Option<Address>, ChunkError>`; the separate `recover_owner` hook is removed (a 0.5.0 semver-major trait change).
`SocHeader` splits its intrinsic acceptance (`accept`: recover the owner, enforce the dispersed-replica pin) from routing (the address compare), both kept private, with `validate` composing them and returning the recovered owner on success.
`ChunkInner` gains an `owner` `OnceCache<Option<Address>>` alongside the existing address cache; `ChunkOps::owner` now goes through `validate` at the committed address (so a chunk its own type rejects binds no owner) and `verify` seeds both the address cache (from `expected`) and the owner cache from that one `validate` run, so an accepted SOC pays exactly one secp256k1 recovery for its lifetime.
`Chunk<Unverified>::verify`, `Chunk<Verified>::from_envelope`, and `Chunk<Verified>::decode_wire` all seed the trust carrier's owner cache from the same recovery via a new `from_verified_parts_with_owner` constructor.
`ContentChunk::seal` seeds `None` for its ownerless ownership fact for free.
Adds `SingleOwnerChunk::seal(id, data, signer: impl Signer + SignerSync)`, mirroring `ContentChunk::seal`: the owner is the signer's own address (no signature recovery), the address is derived as `address_for(id, owner)`, the replica pin is enforced in release builds, a full `verify` runs as a `debug_assert`, and the resulting `Chunk<Verified>` has its address and owner caches pre-seeded from provenance via `ChunkInner::from_provenance`.
`crates/postage/src/sink.rs` gets a doc-only clarification of `PutStamped` ingest ordering (batch existence/authenticity gates before chunk certification, typed decode takes the stamp structurally before the chunk's acceptance rule runs); no behavioural change.
`crates/primitives/examples/wasm-demo` and the `ChunkHeader` doctests in `chunk/mod.rs` are updated for the new `validate` signature.

## Why

The old split between `validate` (address-only certification) and a separate `recover_owner` hook meant a certified chunk's owner could be read via a second, independent signature recovery that was not itself gated by acceptance, and a rejected chunk could still report an owner if raw recovery happened to succeed. Folding owner recovery into `validate`'s return value makes the owner an acceptance fact rather than a parallel claim, removes the redundant recovery on the read path, and closes the drift window between what a chunk's type accepts and what it reports as its owner.

## Testing

Independently re-ran the full CI-mirror battery on `feat/soc-single-recovery` (tip `1d6b8563`, based on `origin/main`) under the pinned Rust 1.94 dev shell with `RUSTC_WRAPPER=sccache` and a shared target dir. All green; no mechanical fixes were required, so the branch is unchanged.

Lint lane:
- `cargo fmt --all -- --check` — clean.
- `cargo clippy --workspace --all-targets --locked` — pass. (The only clippy output is a pre-existing warn-level `doc_lazy_continuation` in `crates/testing/src/lib.rs`, an untouched file; not deny-level, present on main.)
- `cargo clippy --locked --all-targets -p nectar-primitives --features envelope,encryption` — pass (touched crate's feature-gated pass).
- `cargo clippy --locked --all-targets -p nectar-postage --features serde` — pass (touched crate's feature-gated pass).

Unit lane:
- `cargo nextest run --workspace --locked` — pass.

An independent adversarial red-team pass of this branch found no blocking, major, or minor defects: the single-recovery lifecycle, bare-compare hardening, and seal path were verified to match the spec across all work items, with no wire-byte or acceptance drift, no panic paths, and signing byte-identical between `seal` and the existing signer-based constructor. The deliberate `ChunkOps::owner` None-on-rejection behaviour change was assessed as benign: no production caller depends on the old behaviour, the inherent `SingleOwnerChunk::owner` is unchanged, and a rejected chunk can never reach `Verified`.

Closes #513.

## AI Assistance

Implemented with fable (Claude Sonnet 5); reviewed with Claude Opus.
