### PR TITLE
primitives: complete the store trust seam and retire ad hoc address checks

### DIFF
--- a/crates/file/src/read/error.rs
+++ b/crates/file/src/read/error.rs
@@ -17,15 +17,6 @@ pub enum OpenError<E> {
         /// Store error behind the failure.
         source: E,
     },
-    /// The store completed the root fetch with a chunk at a different
-    /// address.
-    #[error("store returned {returned} for requested {requested}")]
-    AddressMismatch {
-        /// Address the open asked for.
-        requested: ChunkAddress,
-        /// Address of the chunk the store handed back.
-        returned: ChunkAddress,
-    },
     /// The root body cannot be decoded under the mode's reference grammar.
     #[error(transparent)]
     Decode(#[from] DecodeError),

--- a/crates/file/src/read/file.rs
+++ b/crates/file/src/read/file.rs
@@ -215,8 +215,8 @@ impl<S, const B: usize> From<File<S, Encrypted, B>> for AnyFile<S, B> {
     }
 }
 
-/// Fetch the root envelope, insisting the store answered for the requested
-/// address.
+/// Fetch the root envelope; the trusted store bound answers for the
+/// requested address.
 async fn fetch_root<S, const B: usize>(
     store: &S,
     address: ChunkAddress,
@@ -231,13 +231,6 @@ where
         .get(&address)
         .await
         .map_err(|source| OpenError::Fetch { address, source })?;
-    let returned = *chunk.address();
-    if returned != address {
-        return Err(OpenError::AddressMismatch {
-            requested: address,
-            returned,
-        });
-    }
     Ok(chunk.into_envelope())
 }
 

--- a/crates/file/src/walk/engine.rs
+++ b/crates/file/src/walk/engine.rs
@@ -384,7 +384,8 @@ where
     }
 
     /// Fold one completion back into the walk: buffer a leaf body or expand
-    /// an intermediate. Every completion must return the requested address.
+    /// an intermediate. The trusted store bound answers for the requested
+    /// address; an untrusted medium is lifted through `VerifyingStore`.
     fn absorb(
         &mut self,
         node: Node<M>,
@@ -397,13 +398,6 @@ where
             address: node.address,
             source,
         })?;
-        let returned = *chunk.address();
-        if returned != node.address {
-            return Err(WalkError::AddressMismatch {
-                requested: node.address,
-                returned,
-            });
-        }
         let data = chunk.into_envelope().data().clone();
         let take = self.plaintext_len(&node, leaf);
         let data =

--- a/crates/file/src/walk/error.rs
+++ b/crates/file/src/walk/error.rs
@@ -13,14 +13,6 @@ pub enum WalkError<E> {
         /// Store error behind the failure.
         source: E,
     },
-    /// The store completed a fetch with a chunk at a different address.
-    #[error("store returned {returned} for requested {requested}")]
-    AddressMismatch {
-        /// Address the engine asked for.
-        requested: ChunkAddress,
-        /// Address of the chunk the store handed back.
-        returned: ChunkAddress,
-    },
     /// The tree's bytes contradict its declared spans.
     #[error(transparent)]
     Shape(#[from] ShapeError),

--- a/crates/file/src/walk/tests.rs
+++ b/crates/file/src/walk/tests.rs
@@ -10,9 +10,11 @@ use std::vec::Vec;
 
 use bytes::Bytes;
 use nectar_primitives::chunk::{
-    Chunk, ChunkAddress, ChunkOps, ContentChunk, ContentOnlyChunkSet, Verified,
+    Chunk, ChunkAddress, ChunkOps, ContentChunk, ContentOnlyChunkSet, Unverified, Verified,
 };
-use nectar_primitives::store::{ChunkGet, ChunkStoreError, TrustedGet};
+use nectar_primitives::store::{
+    ChunkGet, ChunkStoreError, TrustedGet, VerifyError, VerifyingStore,
+};
 use nectar_testing::{run, yield_now};
 
 use super::{Frame, Plain, ShapeError, Walk, WalkError};
@@ -218,7 +220,8 @@ impl ChunkGet<TinyRegistry> for HeadLast {
     }
 }
 
-/// Hostile store: answers `from` with the chunk stored at `to`.
+/// Misrouting store: answers `from` with the chunk stored at `to`, declared
+/// untrusted so the verifying boundary is the guard.
 #[derive(Clone)]
 struct Swapped {
     chunks: Arc<HashMap<ChunkAddress, TinyChunk>>,
@@ -227,20 +230,24 @@ struct Swapped {
 }
 
 impl ChunkGet<TinyRegistry> for Swapped {
-    type Trust = Verified;
+    type Trust = Unverified;
     type Error = ChunkStoreError;
 
-    async fn get(&self, address: &ChunkAddress) -> Result<TinyChunk, ChunkStoreError> {
+    async fn get(
+        &self,
+        address: &ChunkAddress,
+    ) -> Result<Chunk<Unverified, TinyRegistry>, ChunkStoreError> {
         let target = if *address == self.from {
             self.to
         } else {
             *address
         };
-        self.chunks
+        let chunk = self
+            .chunks
             .as_ref()
             .get(&target)
-            .cloned()
-            .ok_or_else(|| ChunkStoreError::not_found(address))
+            .ok_or_else(|| ChunkStoreError::not_found(address))?;
+        Ok(Chunk::parse(*chunk.address(), &chunk.typed_bytes()).unwrap())
     }
 }
 
@@ -408,29 +415,42 @@ fn tail_read_fetches_one_path() {
 }
 
 #[test]
-fn address_mismatch_is_detected() {
+fn misrouting_is_caught_at_the_verifying_boundary() {
     let data = fill(10 * TINY);
     let tree = build_tree(&data);
     let mut offsets: Vec<(u64, ChunkAddress)> = tree.leaves.iter().map(|(a, o)| (*o, *a)).collect();
     offsets.sort();
     let requested = offsets[3].1;
     let substituted = offsets[4].1;
-    let store = Swapped {
+    let store = VerifyingStore::new(Swapped {
         chunks: Arc::new(tree.chunks.clone()),
         from: requested,
         to: substituted,
-    };
+    });
     let mut walk = walk_range(store, &tree, 0..tree.span, 4);
-    let error = collect_ordered(&mut walk).unwrap_err();
+    let error = run(async {
+        loop {
+            match poll_fn(|cx| walk.poll_next_ordered(cx)).await {
+                Some(Ok(_)) => {}
+                Some(Err(error)) => break error,
+                None => panic!("walk completed over a misrouting store"),
+            }
+        }
+    });
     match error {
-        WalkError::AddressMismatch {
-            requested: want,
-            returned,
+        WalkError::Fetch {
+            address,
+            source:
+                VerifyError::AddressMismatch {
+                    requested: want,
+                    returned,
+                },
         } => {
+            assert_eq!(address, requested);
             assert_eq!(want, requested);
             assert_eq!(returned, substituted);
         }
-        other => panic!("expected AddressMismatch, got {other:?}"),
+        other => panic!("expected a boundary mismatch, got {other:?}"),
     }
 }
 

--- a/crates/mantaray/src/cursor.rs
+++ b/crates/mantaray/src/cursor.rs
@@ -278,23 +278,13 @@ where
         self.in_flight_count = self.in_flight_count.saturating_sub(1);
         let outcome = match fetched {
             Err(error) => Err(error),
-            Ok(chunk) => {
-                let returned = *chunk.address();
-                if returned == pending.address {
-                    match NodeView::try_from(chunk.envelope().data().as_ref()) {
-                        Ok(view) => Ok((pending, view)),
-                        Err(source) => Err(CursorError::Corrupt {
-                            address: pending.address,
-                            source,
-                        }),
-                    }
-                } else {
-                    Err(CursorError::AddressMismatch {
-                        requested: pending.address,
-                        returned,
-                    })
-                }
-            }
+            Ok(chunk) => match NodeView::try_from(chunk.envelope().data().as_ref()) {
+                Ok(view) => Ok((pending, view)),
+                Err(source) => Err(CursorError::Corrupt {
+                    address: pending.address,
+                    source,
+                }),
+            },
         };
         self.resolved.insert(id, outcome);
     }
@@ -612,8 +602,12 @@ mod tests {
 
     use bytes::Bytes;
     use nectar_primitives::chunk::{ChunkRef, ContentChunk};
-    use nectar_primitives::store::{ChunkGet, ChunkPut, ContentGet, MemoryStore};
-    use nectar_primitives::{EncryptedChunkRef, EncryptionKey, EntryRef, StandardChunkSet};
+    use nectar_primitives::store::{
+        ChunkGet, ChunkPut, ContentGet, MemoryStore, VerifyError, VerifyingStore,
+    };
+    use nectar_primitives::{
+        EncryptedChunkRef, EncryptionKey, EntryRef, StandardChunkSet, Unverified,
+    };
     use nectar_testing::run;
 
     use crate::ManifestEditor;
@@ -718,7 +712,6 @@ mod tests {
         peak: AtomicUsize,
         delay: bool,
         fail: Option<ChunkAddress>,
-        lie: Option<(ChunkAddress, ChunkAddress)>,
     }
 
     impl RecordingStore {
@@ -731,7 +724,6 @@ mod tests {
                     peak: AtomicUsize::new(0),
                     delay,
                     fail,
-                    lie: None,
                 }),
             }
         }
@@ -746,12 +738,6 @@ mod tests {
 
         fn failing(store: Store, fail: ChunkAddress) -> Self {
             Self::with(store, false, Some(fail))
-        }
-
-        fn lying(store: Store, at: ChunkAddress, with: ChunkAddress) -> Self {
-            let mut this = Self::with(store, false, None);
-            std::sync::Arc::get_mut(&mut this.inner).unwrap().lie = Some((at, with));
-            this
         }
 
         fn fetched(&self) -> Vec<ChunkAddress> {
@@ -799,10 +785,6 @@ mod tests {
             }
             let result = if self.inner.fail == Some(*address) {
                 ChunkGet::get(&self.inner.store, &make_addr("absent-sentinel")).await
-            } else if let Some((at, with)) = self.inner.lie
-                && at == *address
-            {
-                ChunkGet::get(&self.inner.store, &with).await
             } else {
                 ChunkGet::get(&self.inner.store, address).await
             };
@@ -1143,19 +1125,56 @@ mod tests {
         assert!(matches!(err, Some(CursorError::Corrupt { address, .. }) if address == gaddr));
     }
 
+    /// Misrouting store: answers `at` with the chunk stored at `with`,
+    /// declared untrusted so the verifying boundary is the guard.
+    #[derive(Clone)]
+    struct MisroutedStore {
+        store: ContentGet<Store>,
+        at: ChunkAddress,
+        with: ChunkAddress,
+    }
+
+    type MisrouteError = VerifyError<<ContentGet<Store> as ChunkGet<ContentOnlyChunkSet>>::Error>;
+
+    impl ChunkGet<ContentOnlyChunkSet> for MisroutedStore {
+        type Trust = Unverified;
+        type Error = <ContentGet<Store> as ChunkGet<ContentOnlyChunkSet>>::Error;
+
+        async fn get(
+            &self,
+            address: &ChunkAddress,
+        ) -> Result<Chunk<Unverified, ContentOnlyChunkSet>, Self::Error> {
+            let target = if *address == self.at {
+                self.with
+            } else {
+                *address
+            };
+            let chunk = ChunkGet::get(&self.store, &target).await?;
+            Ok(Chunk::parse(*chunk.address(), &chunk.typed_bytes()).unwrap())
+        }
+    }
+
     #[test]
-    fn lying_store_is_an_address_mismatch() {
+    fn misrouted_store_is_caught_at_the_verifying_boundary() {
         let (root, store) = build(&["a", "b"]);
         let (serial_seq, _) = serial_profile(root, &store);
         let other = *serial_seq.last().unwrap();
         assert_ne!(other, root);
-        let rec = RecordingStore::lying(store, root, other);
-        let (entries, err) = collect_until_err(Cursor::new(rec, root));
+        let lifted = VerifyingStore::new(MisroutedStore {
+            store: ContentGet::new(store),
+            at: root,
+            with: other,
+        });
+        let (entries, err) = collect_until_err(Cursor::new(lifted, root));
         assert!(entries.is_empty());
+        let Some(CursorError::Store { address, source }) = err else {
+            panic!("expected a store error, got {err:?}");
+        };
+        assert_eq!(address, root);
         assert!(matches!(
-            err,
-            Some(CursorError::AddressMismatch { requested, returned })
-                if requested == root && returned == other
+            source.downcast_ref::<MisrouteError>(),
+            Some(VerifyError::AddressMismatch { requested, returned })
+                if *requested == root && *returned == other
         ));
     }
 

--- a/crates/mantaray/src/error.rs
+++ b/crates/mantaray/src/error.rs
@@ -124,14 +124,6 @@ pub enum CursorError {
         /// The underlying wire decode failure.
         source: DecodeError,
     },
-    /// The store returned a chunk other than the requested one.
-    #[error("address mismatch: requested {requested}, returned {returned}")]
-    AddressMismatch {
-        /// Address the walk requested.
-        requested: ChunkAddress,
-        /// Address of the chunk the store returned.
-        returned: ChunkAddress,
-    },
     /// No fetch in flight while nodes remain queued; the walk cannot
     /// progress.
     #[error("walk stalled with {pending} nodes queued")]

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -167,7 +167,7 @@ pub type DefaultMemoryStore = MemoryStore<StandardChunkSet>;
 // Chunk storage traits
 pub use store::{
     ChunkGet, ChunkHas, ChunkPut, ChunkStoreError, ContentGet, ContentGetError, MemoryStore,
-    SingleOwnerGet, SingleOwnerGetError, TrustedGet,
+    SingleOwnerGet, SingleOwnerGetError, TrustedGet, VerifyError, VerifyingStore,
 };
 #[cfg(feature = "std")]
 pub use store::{RetryConfig, RetryingChunkGet, Sleeper};

--- a/crates/primitives/src/store/memory.rs
+++ b/crates/primitives/src/store/memory.rs
@@ -126,42 +126,6 @@ impl<R: ChunkRegistry> ChunkHas for MemoryStore<R> {
     }
 }
 
-impl<R: ChunkRegistry> ChunkGet<R> for BTreeMap<ChunkAddress, Chunk<Verified, R>> {
-    type Trust = Verified;
-    type Error = ChunkStoreError;
-
-    async fn get(&self, address: &ChunkAddress) -> Result<Chunk<Verified, R>, Self::Error> {
-        self.get(address)
-            .cloned()
-            .ok_or_else(|| ChunkStoreError::not_found(address))
-    }
-}
-
-impl<R: ChunkRegistry> ChunkHas for BTreeMap<ChunkAddress, Chunk<Verified, R>> {
-    async fn has(&self, address: &ChunkAddress) -> bool {
-        self.contains_key(address)
-    }
-}
-
-#[cfg(feature = "std")]
-impl<R: ChunkRegistry> ChunkGet<R> for std::collections::HashMap<ChunkAddress, Chunk<Verified, R>> {
-    type Trust = Verified;
-    type Error = ChunkStoreError;
-
-    async fn get(&self, address: &ChunkAddress) -> Result<Chunk<Verified, R>, Self::Error> {
-        self.get(address)
-            .cloned()
-            .ok_or_else(|| ChunkStoreError::not_found(address))
-    }
-}
-
-#[cfg(feature = "std")]
-impl<R: ChunkRegistry> ChunkHas for std::collections::HashMap<ChunkAddress, Chunk<Verified, R>> {
-    async fn has(&self, address: &ChunkAddress) -> bool {
-        self.contains_key(address)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/primitives/src/store/mod.rs
+++ b/crates/primitives/src/store/mod.rs
@@ -10,6 +10,7 @@ mod memory;
 mod retry;
 mod single_owner;
 mod typed;
+mod verify;
 
 pub use crate::marker::{MaybeSend, MaybeSync};
 pub use content::{ContentGet, ContentGetError};
@@ -18,6 +19,7 @@ pub use memory::MemoryStore;
 pub use retry::{RetryConfig, RetryingChunkGet, Sleeper};
 pub use single_owner::{SingleOwnerGet, SingleOwnerGetError};
 pub use typed::{ChunkGet, ChunkHas, ChunkPut, TrustedGet};
+pub use verify::{VerifyError, VerifyingStore};
 
 use alloc::boxed::Box;
 

--- a/crates/primitives/src/store/verify.rs
+++ b/crates/primitives/src/store/verify.rs
@@ -1,0 +1,182 @@
+//! Verifying boundary adapter over an untrusted read medium.
+
+use crate::chunk::{Chunk, ChunkAddress, ChunkRegistry, Unverified, Verified};
+use crate::error::PrimitivesError;
+
+use super::typed::{ChunkGet, ChunkHas, ChunkPut};
+
+/// Lifts an untrusted medium to `Trust = Verified`: every get runs the
+/// member's full acceptance rule against the requested address, so a
+/// misrouted chunk fails exactly like a tampered one.
+///
+/// The inner `Trust = Unverified` bound makes wrapping an already trusted
+/// store a compile error, so the acceptance rule never runs twice.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct VerifyingStore<S>(S);
+
+impl<S> VerifyingStore<S> {
+    /// Wrap an untrusted store.
+    pub const fn new(inner: S) -> Self {
+        Self(inner)
+    }
+
+    /// Borrow the inner store.
+    pub const fn inner(&self) -> &S {
+        &self.0
+    }
+
+    /// Consume into the inner store.
+    pub fn into_inner(self) -> S {
+        self.0
+    }
+}
+
+/// Failure of a verifying get.
+#[derive(Debug, thiserror::Error)]
+pub enum VerifyError<E> {
+    /// The inner store failed.
+    #[error(transparent)]
+    Store(E),
+    /// The store answered with a chunk claiming a different address.
+    #[error("store returned {returned} for requested {requested}")]
+    AddressMismatch {
+        /// Address the get asked for.
+        requested: ChunkAddress,
+        /// Address the returned chunk claims.
+        returned: ChunkAddress,
+    },
+    /// The returned bytes fail the acceptance rule at the requested address.
+    #[error(transparent)]
+    Chunk(PrimitivesError),
+}
+
+impl<R: ChunkRegistry, S: ChunkGet<R, Trust = Unverified>> ChunkGet<R> for VerifyingStore<S> {
+    type Trust = Verified;
+    type Error = VerifyError<S::Error>;
+
+    async fn get(&self, address: &ChunkAddress) -> Result<Chunk<Verified, R>, Self::Error> {
+        let claimed = self.0.get(address).await.map_err(VerifyError::Store)?;
+        let returned = *claimed.claimed_address();
+        if returned != *address {
+            return Err(VerifyError::AddressMismatch {
+                requested: *address,
+                returned,
+            });
+        }
+        claimed.verify().map_err(VerifyError::Chunk)
+    }
+}
+
+// Writes carry sealed chunks already, so they pass through untouched.
+impl<R: ChunkRegistry, S: ChunkPut<R>> ChunkPut<R> for VerifyingStore<S> {
+    type Error = S::Error;
+
+    async fn put(&self, chunk: Chunk<Verified, R>) -> Result<(), Self::Error> {
+        self.0.put(chunk).await
+    }
+}
+
+impl<S: ChunkHas> ChunkHas for VerifyingStore<S> {
+    async fn has(&self, address: &ChunkAddress) -> bool {
+        self.0.has(address).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::boxed::Box;
+    use alloc::collections::BTreeMap;
+    use alloc::vec::Vec;
+
+    use nectar_testing::run;
+
+    use super::super::{ChunkStoreError, TrustedGet};
+    use super::*;
+    use crate::chunk::{ChunkOps, ContentChunk, StandardChunkSet};
+
+    /// Untrusted byte store: answers a request with a claimed address and
+    /// typed bytes it is free to lie about.
+    struct RawStore {
+        entries: BTreeMap<ChunkAddress, (ChunkAddress, Vec<u8>)>,
+    }
+
+    impl ChunkGet<StandardChunkSet> for RawStore {
+        type Trust = Unverified;
+        type Error = ChunkStoreError;
+
+        async fn get(
+            &self,
+            address: &ChunkAddress,
+        ) -> Result<Chunk<Unverified, StandardChunkSet>, Self::Error> {
+            let (claimed, bytes) = self
+                .entries
+                .get(address)
+                .ok_or_else(|| ChunkStoreError::not_found(address))?;
+            Chunk::parse(*claimed, bytes).map_err(|e| ChunkStoreError::Other(Box::new(e)))
+        }
+    }
+
+    fn sealed(payload: &'static [u8]) -> (ChunkAddress, Vec<u8>) {
+        let content = ContentChunk::new(payload).unwrap();
+        let address = *content.address();
+        (address, StandardChunkSet::encode_typed(&content.into()))
+    }
+
+    fn assert_trusted<S: TrustedGet>(_: &S) {}
+
+    #[test]
+    fn honest_answer_certifies_at_the_requested_address() {
+        let (address, typed) = sealed(b"honest bytes");
+        let store = VerifyingStore::new(RawStore {
+            entries: BTreeMap::from([(address, (address, typed))]),
+        });
+        // The lift satisfies the trusted bound.
+        assert_trusted(&store);
+
+        let chunk = run(store.get(&address)).unwrap();
+        assert_eq!(chunk.address(), &address);
+    }
+
+    #[test]
+    fn misrouted_claim_is_an_address_mismatch() {
+        let (address, _) = sealed(b"asked for");
+        let (other, other_typed) = sealed(b"answered with");
+        // Internally consistent chunk, wrong slot.
+        let store = VerifyingStore::new(RawStore {
+            entries: BTreeMap::from([(address, (other, other_typed))]),
+        });
+
+        assert!(matches!(
+            run(store.get(&address)),
+            Err(VerifyError::AddressMismatch { requested, returned })
+                if requested == address && returned == other
+        ));
+    }
+
+    #[test]
+    fn misrouted_bytes_fail_the_acceptance_rule() {
+        let (address, _) = sealed(b"asked for");
+        let (_, other_typed) = sealed(b"answered with");
+        // The claim matches the request, the bytes do not.
+        let store = VerifyingStore::new(RawStore {
+            entries: BTreeMap::from([(address, (address, other_typed))]),
+        });
+
+        assert!(matches!(
+            run(store.get(&address)),
+            Err(VerifyError::Chunk(_))
+        ));
+    }
+
+    #[test]
+    fn inner_store_errors_pass_through() {
+        let store = VerifyingStore::new(RawStore {
+            entries: BTreeMap::new(),
+        });
+
+        assert!(matches!(
+            run(store.get(&ChunkAddress::default())),
+            Err(VerifyError::Store(ChunkStoreError::NotFound(_)))
+        ));
+    }
+}


### PR DESCRIPTION
## What

Adds `VerifyingStore`, a boundary adapter in `nectar-primitives::store` that lifts an `Unverified` medium to `Trust = Verified`: it compares the returned chunk's `claimed_address()` against the requested address, then runs `verify()` against that same requested address, so a misrouted chunk fails exactly like a tampered one.

Retires the three hand-rolled `returned != requested` compares in `crates/file/src/walk/engine.rs`, `crates/file/src/read/file.rs`, and `crates/mantaray/src/cursor.rs`, replacing them with the `TrustedGet` bound now that the acceptance rule lives at the store boundary.

Lifts the mantaray cursor's untrusted test double through `VerifyingStore` (new `MisroutedStore` test type) so its misrouting test asserts on `VerifyError::AddressMismatch` at the boundary instead of a bespoke `CursorError::AddressMismatch`.

Deletes the assertion-free `ChunkGet`/`ChunkHas` impls on bare `BTreeMap`/`HashMap` in `crates/primitives/src/store/memory.rs`, which returned `Trust = Verified` chunks with no verification performed.

`verify.rs` builds on `alloc` only, so the new module carries no std-only gating.

## Why

Closes #507.

The trust axis was previously enforced ad hoc at each call site instead of at the store boundary, and the bare-collection `ChunkGet` impls claimed `Verified` trust without doing any verification, an unsound gap in the trust typestate. Consolidating the check into `VerifyingStore` means every untrusted-to-trusted crossing runs the same acceptance rule once, and the compiler rejects double-wrapping an already-trusted store via the `Trust = Unverified` bound on the impl.

## Testing

Independent re-run on branch `feat/trust-seam-complete` @ `f3364c49` via `nix develop` (rustc/cargo 1.94.0, matching `rust-toolchain.toml`/CI), shared `CARGO_TARGET_DIR` + `RUSTC_WRAPPER=sccache`, rv64 and wasm32 targets present.

- `cargo fmt --all --check`: clean.
- `cargo clippy --workspace --all-targets --locked`: passed; only pre-existing `clippy::doc_lazy_continuation` warnings in the untouched `nectar-testing/src/lib.rs`, non-gating.
- Per-feature clippy on `nectar-file` (tokio, rayon, encryption): all passed.
- `cargo nextest run --workspace --locked`: 1068 passed, 1 skipped.
- `cargo test --doc --workspace --locked`: passed.
- `nectar-file` no-std core (primitives), tokio, and rayon+encryption feature combinations all built.

## AI Assistance

Implementation by fable, review by opus.
