### PR TITLE
manifest: build bare-metal on riscv64imac

### DIFF
--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -60,6 +60,15 @@ jobs:
                   cargo check --locked -p nectar-file \
                     --no-default-features --features primitives \
                     --target ${{ matrix.target }}
+            # The manifest core over the file read and split paths. Separate
+            # from the shared list above: the manifest edge pins the file
+            # crate's primitives feature, which unification would leak into
+            # the bare nectar-file pass.
+            - name: Check nectar-manifest without std
+              run: |
+                  cargo check --locked -p nectar-manifest \
+                    --no-default-features \
+                    --target ${{ matrix.target }}
             # The bare-metal core of nectar-primitives. Only in the rv64 lane:
             # the wasm32 shape of the crate is the std build with the wasm
             # target table (wasm-bindgen), not the no_std core.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2592,6 +2592,7 @@ dependencies = [
  "arbitrary",
  "bytes",
  "futures",
+ "futures-util",
  "nectar-file",
  "nectar-manifest",
  "nectar-primitives 0.4.0",

--- a/crates/manifest/Cargo.toml
+++ b/crates/manifest/Cargo.toml
@@ -21,13 +21,14 @@ workspace = true
 alloy-primitives = { workspace = true }
 arbitrary = { workspace = true, optional = true }
 bytes.workspace = true
-futures.workspace = true
+futures-util.workspace = true
 nectar-file = { workspace = true, features = ["primitives"] }
 nectar-primitives = { workspace = true }
 thiserror.workspace = true
 
 [dev-dependencies]
 arbitrary.workspace = true
+futures.workspace = true
 # Self dev-dependency: exposes the `generators` module to integration tests.
 nectar-manifest = { workspace = true, features = ["arbitrary"] }
 nectar-primitives = { workspace = true, features = ["arbitrary"] }
@@ -57,10 +58,14 @@ encryption = []
 std = [
 	"alloy-primitives/std",
 	"bytes/std",
+	"futures-util/std",
 	"nectar-file/std",
 	"nectar-primitives/std",
 	"thiserror/std",
 ]
+# Single-thread send escape: relaxes the boxed fetch futures off `Send` in
+# lockstep with the store traits.
+unsync = [ "nectar-file/unsync", "nectar-primitives/unsync" ]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/manifest/build.rs
+++ b/crates/manifest/build.rs
@@ -1,0 +1,13 @@
+//! Emits the `multi_thread` cfg alias.
+
+fn main() {
+    // Send/Sync bounds apply; wasm32, bare metal, and the `unsync` feature
+    // relax them.
+    println!("cargo::rustc-check-cfg=cfg(multi_thread)");
+    let wasm32 = std::env::var("CARGO_CFG_TARGET_ARCH").as_deref() == Ok("wasm32");
+    let bare_metal = std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("none");
+    let unsync = std::env::var_os("CARGO_FEATURE_UNSYNC").is_some();
+    if !wasm32 && !bare_metal && !unsync {
+        println!("cargo::rustc-cfg=multi_thread");
+    }
+}

--- a/crates/manifest/src/apply.rs
+++ b/crates/manifest/src/apply.rs
@@ -17,7 +17,9 @@
 //! Peak retained state is O(depth + changeset frontier): the descent holds one
 //! node per level on the current path, never a whole subtree.
 
-use std::collections::BTreeMap;
+use alloc::boxed::Box;
+use alloc::collections::BTreeMap;
+use alloc::vec::Vec;
 
 use bytes::Bytes;
 use nectar_primitives::ChunkAddress;
@@ -771,6 +773,7 @@ fn common_prefix(a: &[u8], b: &[u8]) -> usize {
 mod tests {
     use core::future::Future;
     use core::pin::Pin;
+    use std::vec;
 
     use nectar_primitives::store::{ContentGet, MemoryStore};
     use nectar_primitives::{ChunkAddress, ChunkRef};

--- a/crates/manifest/src/bounded.rs
+++ b/crates/manifest/src/bounded.rs
@@ -230,6 +230,8 @@ impl<F: Format> TryFrom<usize> for SegmentWeight<F> {
 
 #[cfg(test)]
 mod tests {
+    use std::vec;
+
     use super::*;
 
     #[test]

--- a/crates/manifest/src/builder.rs
+++ b/crates/manifest/src/builder.rs
@@ -7,8 +7,10 @@
 //! key set enters through a sorted map, so the published tree is a pure function
 //! of the keys, identical whatever order the caller streamed them in.
 
+use alloc::boxed::Box;
+use alloc::collections::BTreeMap;
+use alloc::vec::Vec;
 use core::convert::Infallible;
-use std::collections::BTreeMap;
 
 use bytes::Bytes;
 use nectar_file::{Plain, PutWindow, SplitError, collect_into};

--- a/crates/manifest/src/codec.rs
+++ b/crates/manifest/src/codec.rs
@@ -8,6 +8,7 @@
 //! [`U16Le`]. Emission is total, so [`Node::encode`] validates the packing
 //! bounds the types do not carry before any byte is written.
 
+use alloc::vec::Vec;
 use core::mem::size_of;
 
 use bytes::Bytes;
@@ -1128,6 +1129,8 @@ pub fn recanonicalize<F: Format>(payload: &[u8]) -> Result<Vec<u8>, DecodeError>
 
 #[cfg(test)]
 mod tests {
+    use std::vec;
+
     use nectar_primitives::EncryptionKey;
 
     use crate::format::V1;

--- a/crates/manifest/src/count.rs
+++ b/crates/manifest/src/count.rs
@@ -106,6 +106,8 @@ impl ToWriter for SubtreeCount {
 
 #[cfg(test)]
 mod tests {
+    use std::vec::Vec;
+
     use super::*;
 
     fn encode(value: u64) -> Vec<u8> {

--- a/crates/manifest/src/dx.rs
+++ b/crates/manifest/src/dx.rs
@@ -101,6 +101,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::vec;
+
     use bytes::Bytes;
     use nectar_primitives::store::{ContentGet, MemoryStore};
     use nectar_testing::run;

--- a/crates/manifest/src/encryption.rs
+++ b/crates/manifest/src/encryption.rs
@@ -28,6 +28,7 @@
 //!
 //! [`embed`]: crate::embed
 
+use alloc::boxed::Box;
 use core::future::Future;
 
 use alloy_primitives::Keccak256;

--- a/crates/manifest/src/folder.rs
+++ b/crates/manifest/src/folder.rs
@@ -10,6 +10,7 @@
 //! root's typed metadata, so the conventions travel as registered metadata,
 //! never magic keys.
 
+use alloc::vec::Vec;
 use core::mem::size_of;
 
 use bytes::Bytes;
@@ -336,6 +337,9 @@ fn directory_index<F: Format>(path: &[u8], index: &[u8]) -> Key {
 
 #[cfg(test)]
 mod tests {
+    use std::format;
+    use std::vec;
+
     use bytes::Bytes;
     use nectar_primitives::store::{ContentGet, MemoryStore};
     use nectar_primitives::{ChunkAddress, ChunkRef};

--- a/crates/manifest/src/fork.rs
+++ b/crates/manifest/src/fork.rs
@@ -5,7 +5,7 @@
 //! flag bits carry no independent state and are never stored: presence is
 //! derived from the structure at encode time.
 
-use std::collections::BTreeMap;
+use alloc::collections::BTreeMap;
 
 use nectar_primitives::{ChunkAddress, ChunkRef, EncryptedChunkRef};
 
@@ -340,6 +340,9 @@ impl<F: Format> Default for ForkTable<F> {
 
 #[cfg(test)]
 mod tests {
+    use std::vec;
+    use std::vec::Vec;
+
     use bytes::Bytes;
 
     use super::*;

--- a/crates/manifest/src/generators.rs
+++ b/crates/manifest/src/generators.rs
@@ -5,6 +5,9 @@
 //! in `u`, so shrinking and replay work. Bridge to proptest by mapping a
 //! byte-vector strategy through [`arbitrary::Unstructured`].
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 use arbitrary::{Arbitrary, Unstructured};
 use bytes::Bytes;
 use nectar_primitives::EncryptedChunkRef;

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -63,6 +63,7 @@
 //! assert!(prefix.len() <= V1::PLEN_MAX);
 //! ```
 
+#![no_std]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(
@@ -80,6 +81,10 @@
         clippy::as_conversions
     )
 )]
+
+extern crate alloc;
+#[cfg(any(test, feature = "std"))]
+extern crate std;
 
 mod apply;
 mod bounded;

--- a/crates/manifest/src/meta.rs
+++ b/crates/manifest/src/meta.rs
@@ -4,9 +4,9 @@
 //! registered names always travel as their one-byte id, and the encoded
 //! length is bounded by `F::META_MAX` at construction.
 
+use alloc::collections::BTreeMap;
 use core::marker::PhantomData;
 use core::mem::size_of;
-use std::collections::BTreeMap;
 
 use bytes::Bytes;
 
@@ -302,6 +302,9 @@ const fn pair_len<F: Format>(key: &MetadataKey<F>, value: &Bytes) -> usize {
 
 #[cfg(test)]
 mod tests {
+    use std::vec;
+    use std::vec::Vec;
+
     use super::*;
 
     const ALL_IDS: [KeyId; 7] = [

--- a/crates/manifest/src/order.rs
+++ b/crates/manifest/src/order.rs
@@ -9,6 +9,8 @@
 //! fetches one node per referenced hop on the path and never the window it steps
 //! over.
 
+use alloc::vec::Vec;
+
 use bytes::Bytes;
 use nectar_primitives::store::MaybeSync;
 use nectar_primitives::{ChunkAddress, ChunkOps};

--- a/crates/manifest/src/packing.rs
+++ b/crates/manifest/src/packing.rs
@@ -7,6 +7,7 @@
 //! re-rooting a subtree does not churn its cuts. The forced caps and the
 //! single-chunk-node invariant keep every produced node within one chunk.
 
+use alloc::vec::Vec;
 use core::mem::size_of;
 use core::ops::Range;
 
@@ -268,6 +269,8 @@ pub fn spill<F: Format>(forks: &[(Prefix<F>, SegmentWeight<F>)], domain: Domain)
 
 #[cfg(test)]
 mod tests {
+    use std::vec;
+
     use super::*;
     use crate::format::{V1, V1Read};
 

--- a/crates/manifest/src/reader.rs
+++ b/crates/manifest/src/reader.rs
@@ -388,6 +388,8 @@ fn descend<F: Format>(table: &ForkTable<F>, key: &[u8], pos: usize) -> Descent<F
 
 #[cfg(test)]
 mod tests {
+    use std::vec::Vec;
+
     use bytes::Bytes;
     use nectar_primitives::store::{ContentGet, MemoryStore};
     use nectar_primitives::{ChunkAddress, ChunkRef, EncryptedChunkRef, EncryptionKey};

--- a/crates/manifest/src/scan.rs
+++ b/crates/manifest/src/scan.rs
@@ -15,6 +15,7 @@
 //! whole frontier, so peak retained state stays O(depth) at the same fetch
 //! count a serial walk pays.
 
+use alloc::vec::Vec;
 use core::cmp::Ordering;
 
 use bytes::Bytes;
@@ -597,6 +598,7 @@ pub(crate) fn successor(prefix: &[u8]) -> Option<Bytes> {
 #[cfg(test)]
 mod tests {
     use core::task::Poll;
+    use std::vec;
 
     use nectar_primitives::store::{
         ChunkGet, ChunkStoreError, ContentGet, ContentGetError, MemoryStore,

--- a/crates/manifest/src/sched.rs
+++ b/crates/manifest/src/sched.rs
@@ -7,11 +7,14 @@
 //! mirrors the walk's own termination and launches exactly the nodes the
 //! walk fetches, in the order the walk needs them.
 
+use alloc::boxed::Box;
+use alloc::vec;
+use alloc::vec::Vec;
 use core::future::Future;
 use core::pin::Pin;
 
 use bytes::Bytes;
-use futures::stream::{FuturesUnordered, StreamExt};
+use futures_util::stream::{FuturesUnordered, StreamExt};
 
 use crate::format::Format;
 use crate::reader::ReaderError;
@@ -22,27 +25,28 @@ use crate::scan::Step;
 type Completion<T> = (usize, Result<T, ReaderError>);
 
 /// An in-flight fetch. Boxed to hold heterogeneous fetch futures in one
-/// queue; `Send` on native, unbounded on the single-threaded wasm executor.
-#[cfg(not(target_arch = "wasm32"))]
+/// queue; `Send` on multi-threaded targets, unbounded on wasm32 and under
+/// the `unsync` feature.
+#[cfg(multi_thread)]
 type Fetch<'a, T> = Pin<Box<dyn Future<Output = Completion<T>> + Send + 'a>>;
-#[cfg(target_arch = "wasm32")]
+#[cfg(not(multi_thread))]
 type Fetch<'a, T> = Pin<Box<dyn Future<Output = Completion<T>> + 'a>>;
 
-/// Bound on a schedulable fetch: `Send` on native, unbounded on the
-/// single-threaded wasm executor.
-#[cfg(not(target_arch = "wasm32"))]
+/// Bound on a schedulable fetch: `Send` on multi-threaded targets, unbounded
+/// on wasm32 and under the `unsync` feature.
+#[cfg(multi_thread)]
 pub(crate) trait FetchFuture<'a, T>:
     Future<Output = Result<T, ReaderError>> + Send + 'a
 {
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(multi_thread)]
 impl<'a, T, Fut> FetchFuture<'a, T> for Fut where
     Fut: Future<Output = Result<T, ReaderError>> + Send + 'a
 {
 }
-#[cfg(target_arch = "wasm32")]
+#[cfg(not(multi_thread))]
 pub(crate) trait FetchFuture<'a, T>: Future<Output = Result<T, ReaderError>> + 'a {}
-#[cfg(target_arch = "wasm32")]
+#[cfg(not(multi_thread))]
 impl<'a, T, Fut> FetchFuture<'a, T> for Fut where Fut: Future<Output = Result<T, ReaderError>> + 'a {}
 
 /// One chunk's ordered contents plus the walk position within them.

--- a/crates/manifest/src/store.rs
+++ b/crates/manifest/src/store.rs
@@ -10,6 +10,8 @@
 //! seam binds the content-only registry, so a non-content chunk is rejected
 //! at decode rather than decoded as a node.
 
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use core::future::Future;
 
 use nectar_primitives::store::{BoxedError, ChunkPut, MaybeSend, MaybeSync, TrustedGet};

--- a/crates/manifest/src/traverse.rs
+++ b/crates/manifest/src/traverse.rs
@@ -7,7 +7,8 @@
 //! closure: every node chunk, every segment chunk and each entry's referenced
 //! address.
 
-use std::collections::VecDeque;
+use alloc::collections::VecDeque;
+use alloc::vec::Vec;
 
 use bytes::Bytes;
 #[cfg(feature = "encryption")]
@@ -261,6 +262,7 @@ where
 mod tests {
     use core::task::Poll;
     use std::collections::HashSet;
+    use std::vec;
 
     use bytes::Bytes;
     #[cfg(not(feature = "encryption"))]

--- a/crates/manifest/src/value.rs
+++ b/crates/manifest/src/value.rs
@@ -1,5 +1,6 @@
 //! Keys and entry values: what the map stores against each key.
 
+use alloc::vec::Vec;
 use core::marker::PhantomData;
 
 use bytes::Bytes;
@@ -261,6 +262,8 @@ impl<F: Format> TryFrom<Entry<F>> for EntryRef {
 
 #[cfg(any(test, feature = "arbitrary"))]
 mod arbitrary_impls {
+    use alloc::vec::Vec;
+
     use arbitrary::{Arbitrary, Unstructured};
     use bytes::Bytes;
 
@@ -295,6 +298,8 @@ mod arbitrary_impls {
 
 #[cfg(test)]
 mod tests {
+    use std::vec;
+
     use nectar_primitives::EncryptionKey;
 
     use super::*;

--- a/crates/mantaray/Cargo.toml
+++ b/crates/mantaray/Cargo.toml
@@ -71,6 +71,9 @@ arbitrary = [
 encryption = [ "nectar-primitives?/encryption" ]
 # Raw node internals (the `hazmat` module) for fuzz harnesses and benches.
 hazmat = [ "std" ]
+# Single-thread send escape: relaxes the boxed trie futures off `Send` in
+# lockstep with the store traits.
+unsync = [ "nectar-primitives?/unsync" ]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/mantaray/build.rs
+++ b/crates/mantaray/build.rs
@@ -1,0 +1,13 @@
+//! Emits the `multi_thread` cfg alias.
+
+fn main() {
+    // Send/Sync bounds apply; wasm32, bare metal, and the `unsync` feature
+    // relax them.
+    println!("cargo::rustc-check-cfg=cfg(multi_thread)");
+    let wasm32 = std::env::var("CARGO_CFG_TARGET_ARCH").as_deref() == Ok("wasm32");
+    let bare_metal = std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("none");
+    let unsync = std::env::var_os("CARGO_FEATURE_UNSYNC").is_some();
+    if !wasm32 && !bare_metal && !unsync {
+        println!("cargo::rustc-cfg=multi_thread");
+    }
+}

--- a/crates/mantaray/src/cursor.rs
+++ b/crates/mantaray/src/cursor.rs
@@ -111,13 +111,13 @@ type Fetched<const B: usize> = (
     Result<Chunk<Verified, ContentOnlyChunkSet<B>>, CursorError>,
 );
 
-/// Boxed fetch future: `Send` on native, unbounded on wasm32 so `!Send`
-/// browser stores stay usable.
-#[cfg(not(target_arch = "wasm32"))]
+/// Boxed fetch future: `Send` on multi-threaded targets, unbounded on wasm32
+/// and under the `unsync` feature, so `!Send` stores stay usable.
+#[cfg(multi_thread)]
 type BoxFetch<const B: usize> = Pin<Box<dyn Future<Output = Fetched<B>> + Send>>;
-/// Boxed fetch future: `Send` on native, unbounded on wasm32 so `!Send`
-/// browser stores stay usable.
-#[cfg(target_arch = "wasm32")]
+/// Boxed fetch future: `Send` on multi-threaded targets, unbounded on wasm32
+/// and under the `unsync` feature, so `!Send` stores stay usable.
+#[cfg(not(multi_thread))]
 type BoxFetch<const B: usize> = Pin<Box<dyn Future<Output = Fetched<B>>>>;
 
 /// One consumed node in depth-first order.

--- a/crates/mantaray/src/node.rs
+++ b/crates/mantaray/src/node.rs
@@ -17,12 +17,13 @@ use nectar_primitives::store::{MaybeSend, TrustedGet};
 use nectar_primitives::wire::{Cursor, FromCursor, ToWriter, Writer};
 use nectar_primitives::{AnyChunkSet, EncryptedChunkRef, EncryptionKey};
 
-/// Boxed recursion future: `Send` on native, unbounded on wasm32 so `!Send`
-/// browser stores stay usable. `MaybeSend` cannot appear in a `dyn` bound
-/// directly (it is not an auto trait), so the auto trait is cfg-gated here.
-#[cfg(not(target_arch = "wasm32"))]
+/// Boxed recursion future: `Send` on multi-threaded targets, unbounded on
+/// wasm32 and under the `unsync` feature, so `!Send` stores stay usable.
+/// `MaybeSend` cannot appear in a `dyn` bound directly (it is not an auto
+/// trait), so the auto trait is cfg-gated here.
+#[cfg(multi_thread)]
 type RecurseFuture<'a> = Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
-#[cfg(target_arch = "wasm32")]
+#[cfg(not(multi_thread))]
 type RecurseFuture<'a> = Pin<Box<dyn Future<Output = Result<()>> + 'a>>;
 
 /// Inline-only byte buffer for fork prefixes (max 30 bytes).


### PR DESCRIPTION
## What

Flips `nectar-manifest` to `#![no_std]` + `extern crate alloc` (std kept as the default feature, `extern crate std` gated under `any(test, std)`), and migrates the boxed-future type aliases in `crates/mantaray/src/node.rs` (`RecurseFuture`), `crates/mantaray/src/cursor.rs` (`BoxFetch`), and `crates/manifest/src/sched.rs` (`Fetch`/`FetchFuture`) off raw `target_arch = "wasm32"` cfg forks onto a new `multi_thread` cfg alias.

Adds `crates/mantaray/build.rs` and `crates/manifest/build.rs`, mirroring the existing `nectar-file`/`nectar-primitives` build scripts: `multi_thread` is emitted unless the target is `wasm32`, the target OS is `none` (bare metal), or the new `unsync` feature is set. Both crates gain an `unsync` feature forwarding to `nectar-primitives?/unsync` (manifest also forwards `nectar-file/unsync`).

`nectar-manifest`'s prod dependency swaps from `futures` to `futures-util` (the workspace pin is alloc-only; the crate's `std` feature forwards `futures-util/std`), with `futures` moved to dev-dependencies. `.github/workflows/nostd.yml` gains a `cargo check -p nectar-manifest --no-default-features` step on the rv64 no_std lane.

Closes #469.

## Why

`nectar-manifest` was the last of the affected crates still pulling in `std` unconditionally, blocking the riscv64imac bare-metal build target used by the zkVM-guest no_std programme. The `target_arch = "wasm32"` forks in the boxed-future aliases were a proxy for "single-threaded executor", which is also true of bare metal and now the explicit `unsync` opt-out; keying them on one build-script-derived `multi_thread` cfg keeps the three crates' escape hatches consistent instead of re-deriving the same match per file.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked`
- `cargo clippy -p nectar-manifest --all-targets --features encryption --locked`
- `cargo nextest run --workspace --locked`
- `cargo test --doc --workspace --locked`
- `cargo nextest run -p nectar-manifest --features encryption --locked`
- `cargo check -p nectar-manifest --no-default-features --target riscv64gc-unknown-none-elf --locked` (bare-metal no_std lane)

All green under `nix develop` (rustc/cargo 1.94.0, matching `rust-toolchain.toml` and CI's pin).

## AI Assistance

Implemented by fable, reviewed by opus, per github.com/nxm-rs/.github CONTRIBUTING.md.
