### PR TITLE
file: adaptive read-ahead window from walk occupancy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2550,6 +2550,7 @@ dependencies = [
  "futures",
  "futures-channel",
  "futures-util",
+ "nectar-clock",
  "nectar-kernel",
  "nectar-mantaray 0.4.0",
  "nectar-marker",

--- a/crates/file/Cargo.toml
+++ b/crates/file/Cargo.toml
@@ -22,6 +22,7 @@ arbitrary = { workspace = true, optional = true }
 bytes = { workspace = true, optional = true }
 futures-channel = { workspace = true, optional = true }
 futures-util = { workspace = true, optional = true }
+nectar-clock = { workspace = true, optional = true }
 nectar-kernel = { workspace = true }
 nectar-marker = { workspace = true }
 nectar-primitives = { workspace = true, optional = true }
@@ -60,10 +61,12 @@ primitives = [
 ]
 
 # Standard library interop; the filesystem and io adapters land with the
-# write engine.
+# write engine. Carries the adaptive window controller and its clock.
 std = [
 	"bytes?/std",
+	"dep:nectar-clock",
 	"futures-util?/std",
+	"nectar-clock/std",
 	"nectar-primitives?/std",
 	"primitives",
 	"thiserror/std",
@@ -88,6 +91,7 @@ encryption = [ "dep:zeroize", "nectar-primitives?/encryption" ]
 # Single-thread send escape: relaxes the boxed fetch future off `Send` in
 # lockstep with the primitives store traits.
 unsync = [
+	"nectar-clock?/unsync",
 	"nectar-kernel/unsync",
 	"nectar-marker/unsync",
 	"nectar-primitives?/unsync",

--- a/crates/file/src/lib.rs
+++ b/crates/file/src/lib.rs
@@ -138,6 +138,9 @@ pub use config::{BranchBudget, HashWindow, PutWindow, Window};
 pub use geometry::{DEFAULT_BODY_SIZE, Mode, branches, max_depth};
 #[cfg(feature = "rayon")]
 pub use parallel::{ReadAt, ReadAtError, split_read_at};
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+pub use read::AdaptiveWindow;
 #[cfg(feature = "primitives")]
 pub use read::{
     AnyFile, CollectError, DownloadBuilder, DownloadError, File, FileFrames, FileReader,
@@ -157,5 +160,6 @@ pub use split::{SealError, Sealed, Split, SplitError, SplitMode, SplitStats};
 pub use store::{BoxedStore, BoxedStoreError, DynAnyFile, DynFile, DynFileReader, DynFileStream};
 #[cfg(feature = "primitives")]
 pub use walk::{
-    DecodeError, Encrypted, Frame, Plain, ShapeError, Walk, WalkError, WalkMode, WalkStats,
+    DecodeError, Encrypted, Frame, Observations, Plain, ShapeError, Walk, WalkError, WalkMode,
+    WalkStats, WindowPolicyFn,
 };

--- a/crates/file/src/read/adaptive.rs
+++ b/crates/file/src/read/adaptive.rs
@@ -1,0 +1,307 @@
+//! Closed-loop read-ahead: an EWMA of realized per-fetch latency folded
+//! into a Little's-law window.
+
+use alloc::boxed::Box;
+use core::num::NonZeroUsize;
+use core::time::Duration;
+
+use nectar_clock::Clock;
+
+use crate::config::Window;
+use crate::num::u64_from_usize;
+use crate::walk::{Observations, WindowPolicyFn};
+
+/// Throughput headroom: the cap targets five quarters of the requested
+/// rate, so realized throughput holds the target with margin.
+const MARGIN_NUM: u64 = 5;
+/// Denominator of the headroom ratio.
+const MARGIN_DEN: u64 = 4;
+/// EWMA smoothing denominator: each sample moves the estimate by an eighth
+/// of the gap, at least one nanosecond.
+const ALPHA: u64 = 8;
+/// One sample never exceeds this multiple of the estimate: a stall reading
+/// cannot blow up the cap in one step.
+const SPIKE: u64 = 8;
+
+/// Closed-loop window controller: tracks realized per-fetch latency and
+/// returns the Little's-law cap for the target rate, never past `max` and
+/// never zero. A few integer operations per call, cheap enough for the
+/// poll path.
+///
+/// Growth needs a saturated window (the cap was the constraint); shrink is
+/// always taken. A consumer stall therefore cannot grow the cap, and `max`
+/// bounds memory outright.
+#[derive(Debug)]
+pub struct AdaptiveWindow<C> {
+    clock: C,
+    /// Margined target rate in bytes per second.
+    target: u64,
+    body: NonZeroUsize,
+    max: Window,
+    /// Latency estimate in nanoseconds, never zero.
+    latency_ns: u64,
+    /// Reading consumed by the previous sample; `None` before the first
+    /// call.
+    last_ns: Option<i64>,
+    window: Window,
+}
+
+impl<C: Clock> AdaptiveWindow<C> {
+    /// Controller targeting `bytes_per_second` over `body`-sized fetches,
+    /// seeded with `mean_latency` and capped at `max`.
+    pub fn new(
+        bytes_per_second: u64,
+        mean_latency: Duration,
+        body: NonZeroUsize,
+        max: Window,
+        clock: C,
+    ) -> Self {
+        let target = bytes_per_second
+            .saturating_mul(MARGIN_NUM)
+            .wrapping_div(MARGIN_DEN);
+        let latency_ns = u64::try_from(mean_latency.as_nanos())
+            .unwrap_or(u64::MAX)
+            .max(1);
+        let window = cap(target, latency_ns, body, max);
+        Self {
+            clock,
+            target,
+            body,
+            max,
+            latency_ns,
+            last_ns: None,
+            window,
+        }
+    }
+
+    /// The cap the controller currently holds.
+    pub const fn window(&self) -> Window {
+        self.window
+    }
+
+    /// One controller step: fold the interval into the latency estimate and
+    /// return the cap. Completion-free calls extend the pending interval; a
+    /// non-monotonic reading yields no sample.
+    pub fn observe(&mut self, observations: &Observations) -> Window {
+        let now = self.clock.now_ns();
+        let Some(last) = self.last_ns else {
+            self.last_ns = Some(now);
+            return self.window;
+        };
+        if observations.completions == 0 {
+            return self.window;
+        }
+        self.last_ns = Some(now);
+        let Some(sample) = latency_sample(now.saturating_sub(last), observations) else {
+            return self.window;
+        };
+        let sample = sample.min(self.latency_ns.saturating_mul(SPIKE)).max(1);
+        self.latency_ns = ewma_step(self.latency_ns, sample);
+        let desired = cap(self.target, self.latency_ns, self.body, self.max);
+        let filled = observations
+            .occupancy
+            .saturating_add(observations.completions)
+            >= usize::from(self.window.get());
+        if desired < self.window || filled {
+            self.window = desired;
+        }
+        self.window
+    }
+
+    /// Box into the walk's policy seam.
+    pub fn into_policy(mut self) -> WindowPolicyFn
+    where
+        C: 'static,
+    {
+        Box::new(move |observations: &Observations| self.observe(observations))
+    }
+}
+
+/// Margined Little's-law cap at the current latency estimate.
+fn cap(target: u64, latency_ns: u64, body: NonZeroUsize, max: Window) -> Window {
+    Window::for_throughput(target, Duration::from_nanos(latency_ns), body).min(max)
+}
+
+/// Per-fetch latency over one interval: elapsed time spread across the
+/// slots that were in flight, per completion. `None` without forward time
+/// or completions.
+fn latency_sample(elapsed_ns: i64, observations: &Observations) -> Option<u64> {
+    let elapsed = u64::try_from(elapsed_ns)
+        .ok()
+        .filter(|&elapsed| elapsed > 0)?;
+    let flights = u64_from_usize(
+        observations
+            .in_flight
+            .saturating_add(observations.completions),
+    )
+    .max(1);
+    let completions = u64_from_usize(observations.completions).max(1);
+    elapsed.saturating_mul(flights).checked_div(completions)
+}
+
+/// One EWMA step; a differing sample always moves the estimate, floored at
+/// one nanosecond.
+fn ewma_step(estimate: u64, sample: u64) -> u64 {
+    if sample >= estimate {
+        estimate.saturating_add(sample.saturating_sub(estimate).div_ceil(ALPHA))
+    } else {
+        estimate
+            .saturating_sub(estimate.saturating_sub(sample).div_ceil(ALPHA))
+            .max(1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nectar_clock::ManualClock;
+
+    use super::*;
+
+    const BODY: usize = 4096;
+
+    fn body() -> NonZeroUsize {
+        NonZeroUsize::new(BODY).unwrap()
+    }
+
+    fn controller(
+        bytes_per_second: u64,
+        mean_latency: Duration,
+        max: u16,
+        clock: &ManualClock,
+    ) -> AdaptiveWindow<&ManualClock> {
+        AdaptiveWindow::new(
+            bytes_per_second,
+            mean_latency,
+            body(),
+            Window::new(max).unwrap(),
+            clock,
+        )
+    }
+
+    fn full(controller: &AdaptiveWindow<&ManualClock>, completions: usize) -> Observations {
+        let slots = usize::from(controller.window().get());
+        Observations {
+            completions,
+            occupancy: slots.saturating_sub(completions),
+            in_flight: slots.saturating_sub(completions),
+        }
+    }
+
+    #[test]
+    fn seed_is_the_margined_set_point() {
+        let clock = ManualClock::new(0);
+        // 1 MB/s at 120 ms per fetch is 30 slots unmargined, 37 with the
+        // five-quarters headroom.
+        let controller = controller(1_000_000, Duration::from_millis(120), 100, &clock);
+        assert_eq!(controller.window().get(), 37);
+    }
+
+    #[test]
+    fn seed_respects_max() {
+        let clock = ManualClock::new(0);
+        let controller = controller(1_000_000, Duration::from_millis(120), 8, &clock);
+        assert_eq!(controller.window().get(), 8);
+    }
+
+    #[test]
+    fn converges_toward_realized_latency() {
+        let clock = ManualClock::new(0);
+        // Seeded for 120 ms fetches; the store realizes 15 ms.
+        let mut controller = controller(1_000_000, Duration::from_millis(120), 100, &clock);
+        let seed = controller.window().get();
+        assert_eq!(controller.observe(&full(&controller, 0)).get(), seed);
+        for _ in 0..200 {
+            clock.advance(Duration::from_millis(15));
+            let observations = Observations {
+                completions: usize::from(controller.window().get()),
+                occupancy: 0,
+                in_flight: 0,
+            };
+            controller.observe(&observations);
+        }
+        // 1 MB/s at 15 ms is 4 slots unmargined, 5 margined.
+        assert_eq!(controller.window().get(), 5);
+        assert!(controller.window().get() < seed);
+    }
+
+    #[test]
+    fn grows_only_when_the_window_was_the_constraint() {
+        let clock = ManualClock::new(0);
+        // Seeded for 10 ms fetches; the store realizes 100 ms, but the
+        // window never fills: the consumer, not the cap, is the bound.
+        let mut controller = controller(1_000_000, Duration::from_millis(10), 100, &clock);
+        let seed = controller.window().get();
+        controller.observe(&full(&controller, 0));
+        for _ in 0..50 {
+            clock.advance(Duration::from_millis(100));
+            let observations = Observations {
+                completions: 1,
+                occupancy: 0,
+                in_flight: 0,
+            };
+            controller.observe(&observations);
+        }
+        assert_eq!(controller.window().get(), seed);
+        // A saturated window releases the growth.
+        for _ in 0..200 {
+            clock.advance(Duration::from_millis(100));
+            let observations = full(&controller, 1);
+            controller.observe(&observations);
+        }
+        assert!(controller.window().get() > seed);
+    }
+
+    #[test]
+    fn growth_is_capped_at_max() {
+        let clock = ManualClock::new(0);
+        let mut controller = controller(50_000_000, Duration::from_millis(10), 24, &clock);
+        controller.observe(&full(&controller, 0));
+        for _ in 0..200 {
+            clock.advance(Duration::from_millis(500));
+            let observations = full(&controller, 2);
+            controller.observe(&observations);
+        }
+        assert_eq!(controller.window().get(), 24);
+    }
+
+    #[test]
+    fn rewound_clock_yields_no_sample() {
+        let clock = ManualClock::new(1_000_000_000);
+        let mut controller = controller(1_000_000, Duration::from_millis(120), 100, &clock);
+        let seed = controller.window().get();
+        controller.observe(&full(&controller, 0));
+        clock.set_ns(0);
+        assert_eq!(controller.observe(&full(&controller, 4)).get(), seed);
+        // The rewound reading re-anchors the interval.
+        clock.advance(Duration::from_millis(15));
+        let observations = Observations {
+            completions: 4,
+            occupancy: 0,
+            in_flight: 0,
+        };
+        controller.observe(&observations);
+        assert!(controller.window().get() < seed);
+    }
+
+    #[test]
+    fn spike_cannot_collapse_or_blow_up_in_one_step() {
+        let clock = ManualClock::new(0);
+        let mut controller = controller(1_000_000, Duration::from_millis(10), 200, &clock);
+        let before = controller.latency_ns;
+        controller.observe(&full(&controller, 0));
+        clock.advance(Duration::from_secs(3600));
+        controller.observe(&full(&controller, 1));
+        // One interval moves the estimate by at most spike/alpha of itself.
+        assert!(controller.latency_ns <= before.saturating_mul(2));
+    }
+
+    #[test]
+    fn zero_rate_floors_at_one_slot() {
+        let clock = ManualClock::new(0);
+        let mut controller = controller(0, Duration::from_millis(10), 8, &clock);
+        assert_eq!(controller.window().get(), 1);
+        controller.observe(&full(&controller, 0));
+        clock.advance(Duration::from_millis(10));
+        assert_eq!(controller.observe(&full(&controller, 1)).get(), 1);
+    }
+}

--- a/crates/file/src/read/download.rs
+++ b/crates/file/src/read/download.rs
@@ -16,7 +16,7 @@ use super::frames::FileFrames;
 use crate::config::Window;
 use crate::num::u64_from_usize;
 use crate::sink::DataSink;
-use crate::walk::{Walk, WalkMode};
+use crate::walk::{Walk, WalkMode, WindowPolicyFn};
 
 /// Progress snapshot delivered after each frame lands in the sink.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -80,6 +80,7 @@ pub struct DownloadBuilder<S, M: WalkMode, const B: usize = DEFAULT_BODY_SIZE> {
     context: M::Context,
     span: u64,
     window: Window,
+    policy: Option<WindowPolicyFn>,
     range: Range<u64>,
     progress: Option<ProgressFn>,
 }
@@ -99,6 +100,7 @@ impl<S, M: WalkMode, const B: usize> DownloadBuilder<S, M, B> {
             context,
             span,
             window,
+            policy: None,
             range,
             progress: None,
         }
@@ -120,6 +122,38 @@ impl<S, M: WalkMode, const B: usize> DownloadBuilder<S, M, B> {
             mean_latency,
             body_size::<B>(),
         ))
+    }
+
+    /// Adaptive cap: `policy` recomputes the window between admission
+    /// rounds from realized occupancy; the built window is its seed. The
+    /// policy runs in the poll path and must be cheap and non-blocking.
+    #[must_use]
+    pub fn window_policy(mut self, policy: WindowPolicyFn) -> Self {
+        self.policy = Some(policy);
+        self
+    }
+
+    /// Closed-loop window: seed from the throughput hint and let an
+    /// [`AdaptiveWindow`](super::AdaptiveWindow) controller retune the cap
+    /// against realized latency, never past `max`.
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    #[must_use]
+    pub fn adaptive_throughput(
+        self,
+        bytes_per_second: u64,
+        mean_latency: Duration,
+        max: Window,
+    ) -> Self {
+        let controller = super::AdaptiveWindow::new(
+            bytes_per_second,
+            mean_latency,
+            body_size::<B>(),
+            max,
+            nectar_clock::SystemClock,
+        );
+        let window = controller.window();
+        self.window(window).window_policy(controller.into_policy())
     }
 
     /// Absolute byte range to download, clipped to the file.
@@ -150,14 +184,18 @@ where
         self,
         sink: &mut K,
     ) -> Result<u64, DownloadError<S::Error, K::Error>> {
-        let mut frames: FileFrames<S, M, B> = FileFrames::new(Walk::new(
+        let mut walk = Walk::new(
             self.store,
             self.root,
             self.context,
             self.span,
             self.range,
             self.window,
-        ));
+        );
+        if let Some(policy) = self.policy {
+            walk = walk.with_policy(policy);
+        }
+        let mut frames: FileFrames<S, M, B> = FileFrames::new(walk);
         let clipped = frames.range();
         let total = clipped.end.saturating_sub(clipped.start);
         let mut callback = self.progress;
@@ -182,6 +220,7 @@ impl<S, M: WalkMode, const B: usize> fmt::Debug for DownloadBuilder<S, M, B> {
             .field("root", &self.root)
             .field("span", &self.span)
             .field("window", &self.window)
+            .field("policy", &self.policy.is_some())
             .field("range", &self.range)
             .field("progress", &self.progress.is_some())
             .finish_non_exhaustive()

--- a/crates/file/src/read/mod.rs
+++ b/crates/file/src/read/mod.rs
@@ -12,6 +12,8 @@
 
 use core::num::NonZeroUsize;
 
+#[cfg(feature = "std")]
+mod adaptive;
 #[cfg(test)]
 mod cancel;
 mod download;
@@ -31,6 +33,9 @@ const fn body_size<const B: usize>() -> NonZeroUsize {
     }
 }
 
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+pub use adaptive::AdaptiveWindow;
 pub use download::{DownloadBuilder, Progress, ProgressFn};
 pub use error::{CollectError, DownloadError, OpenError, SeekPastEnd};
 pub use file::{AnyFile, File};

--- a/crates/file/src/read/reader.rs
+++ b/crates/file/src/read/reader.rs
@@ -20,7 +20,7 @@ use super::error::{CollectError, SeekPastEnd};
 use super::frames::FileFrames;
 use crate::config::Window;
 use crate::num::u64_from_usize;
-use crate::walk::{Walk, WalkError, WalkMode, WalkStats};
+use crate::walk::{Walk, WalkError, WalkMode, WalkStats, WindowPolicyFn};
 
 /// Builder of one ordered read; construction is infallible.
 ///
@@ -33,6 +33,7 @@ pub struct ReadBuilder<S, M: WalkMode, const B: usize = DEFAULT_BODY_SIZE> {
     context: M::Context,
     span: u64,
     window: Window,
+    policy: Option<WindowPolicyFn>,
     range: Range<u64>,
 }
 
@@ -51,6 +52,7 @@ impl<S, M: WalkMode, const B: usize> ReadBuilder<S, M, B> {
             context,
             span,
             window,
+            policy: None,
             range,
         }
     }
@@ -73,6 +75,38 @@ impl<S, M: WalkMode, const B: usize> ReadBuilder<S, M, B> {
         ))
     }
 
+    /// Adaptive cap: `policy` recomputes the window between admission
+    /// rounds from realized occupancy; the built window is its seed. The
+    /// policy runs in the poll path and must be cheap and non-blocking.
+    #[must_use]
+    pub fn window_policy(mut self, policy: WindowPolicyFn) -> Self {
+        self.policy = Some(policy);
+        self
+    }
+
+    /// Closed-loop window: seed from the throughput hint and let an
+    /// [`AdaptiveWindow`](super::AdaptiveWindow) controller retune the cap
+    /// against realized latency, never past `max`.
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    #[must_use]
+    pub fn adaptive_throughput(
+        self,
+        bytes_per_second: u64,
+        mean_latency: Duration,
+        max: Window,
+    ) -> Self {
+        let controller = super::AdaptiveWindow::new(
+            bytes_per_second,
+            mean_latency,
+            body_size::<B>(),
+            max,
+            nectar_clock::SystemClock,
+        );
+        let window = controller.window();
+        self.window(window).window_policy(controller.into_policy())
+    }
+
     /// Absolute byte range to read, clipped to the file.
     #[must_use]
     pub const fn range(mut self, range: Range<u64>) -> Self {
@@ -88,7 +122,7 @@ where
 {
     /// Build the ordered, seekable reader.
     pub fn build(self) -> FileReader<S, M, B> {
-        let walk = Walk::new(
+        let mut walk = Walk::new(
             self.store.clone(),
             self.root,
             self.context.clone(),
@@ -96,6 +130,9 @@ where
             self.range,
             self.window,
         );
+        if let Some(policy) = self.policy {
+            walk = walk.with_policy(policy);
+        }
         let clipped = walk.range();
         FileReader {
             store: self.store,
@@ -118,14 +155,18 @@ where
 
     /// Build the completion-order frames drain.
     pub fn frames(self) -> FileFrames<S, M, B> {
-        FileFrames::new(Walk::new(
+        let mut walk = Walk::new(
             self.store,
             self.root,
             self.context,
             self.span,
             self.range,
             self.window,
-        ))
+        );
+        if let Some(policy) = self.policy {
+            walk = walk.with_policy(policy);
+        }
+        FileFrames::new(walk)
     }
 
     /// Assemble the clipped range in memory, at most `max` bytes.
@@ -165,6 +206,7 @@ impl<S, M: WalkMode, const B: usize> fmt::Debug for ReadBuilder<S, M, B> {
             .field("root", &self.root)
             .field("span", &self.span)
             .field("window", &self.window)
+            .field("policy", &self.policy.is_some())
             .field("range", &self.range)
             .finish_non_exhaustive()
     }
@@ -231,7 +273,9 @@ where
         let target = self.start.saturating_add(pos);
         if target != self.position {
             self.current = Bytes::new();
-            self.walk = Walk::new(
+            // The policy rides across the re-walk, keeping its estimate warm.
+            let policy = self.walk.take_policy();
+            let mut walk = Walk::new(
                 self.store.clone(),
                 self.root,
                 self.context.clone(),
@@ -239,6 +283,10 @@ where
                 target..self.end,
                 self.window,
             );
+            if let Some(policy) = policy {
+                walk = walk.with_policy(policy);
+            }
+            self.walk = walk;
             self.position = target;
         }
         Ok(())

--- a/crates/file/src/read/tests.rs
+++ b/crates/file/src/read/tests.rs
@@ -880,3 +880,71 @@ mod properties {
         }
     }
 }
+
+#[test]
+fn window_policy_rides_across_a_seek() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let len = 40 * TINY + 9;
+    let data = fill(len);
+    let (root, store) = split_fixture::<TINY>(&data);
+    let calls = Arc::new(AtomicUsize::new(0));
+    let counter = Arc::clone(&calls);
+    run(async {
+        let file = File::<_, Plain, TINY>::open(store, root).await.unwrap();
+        let mut reader = file
+            .read()
+            .window(Window::new(4).unwrap())
+            .window_policy(Box::new(move |_: &crate::walk::Observations| {
+                counter.fetch_add(1, Ordering::Relaxed);
+                Window::new(3).unwrap()
+            }))
+            .build();
+        let mut buf = [0u8; 512];
+        let n = reader.read(&mut buf).await.unwrap();
+        assert!(n > 0);
+        let before = calls.load(Ordering::Relaxed);
+        assert!(before > 0, "the policy must run before the seek");
+        let target = (20 * TINY) as u64;
+        reader.seek(target).unwrap();
+        let mut out = Vec::new();
+        loop {
+            let n = reader.read(&mut buf).await.unwrap();
+            if n == 0 {
+                break;
+            }
+            out.extend_from_slice(&buf[..n]);
+        }
+        assert_eq!(out, &data[20 * TINY..]);
+        assert!(
+            calls.load(Ordering::Relaxed) > before,
+            "the policy must keep running after the seek"
+        );
+        assert!(reader.stats().peak_occupancy <= 3);
+    });
+}
+
+#[test]
+fn download_honours_a_window_policy() {
+    use crate::sink::MemSink;
+
+    let len = 25 * TINY + 3;
+    let data = fill(len);
+    let (root, store) = split_fixture::<TINY>(&data);
+    run(async {
+        let file = File::<_, Plain, TINY>::open(store, root).await.unwrap();
+        let mut sink = MemSink::new();
+        let written = file
+            .download()
+            .window(Window::new(6).unwrap())
+            .window_policy(Box::new(|_: &crate::walk::Observations| {
+                Window::new(2).unwrap()
+            }))
+            .run(&mut sink)
+            .await
+            .unwrap();
+        assert_eq!(written, len as u64);
+        assert_eq!(sink.as_ref(), data.as_slice());
+    });
+}

--- a/crates/file/src/walk/engine.rs
+++ b/crates/file/src/walk/engine.rs
@@ -7,14 +7,16 @@ use core::ops::Range;
 use core::task::{Context, Poll};
 
 use bytes::{Bytes, BytesMut};
-use nectar_kernel::{Admission, BoxFuture, InFlight, get_verified};
+use nectar_kernel::{
+    Admission, AdmitPolicy, BoxFuture, FromFn, InFlight, Observations, from_fn, get_verified,
+};
 use nectar_primitives::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{Chunk, ChunkAddress, ChunkOps, ContentOnlyChunkSet, Verified};
 use nectar_primitives::store::TrustedGet;
 
 use super::error::{ShapeError, WalkError};
 use super::mode::WalkMode;
-use super::{Frame, WalkStats};
+use super::{Frame, WalkStats, WindowPolicyFn};
 use crate::config::{BranchBudget, Window};
 use crate::num::{fan_out, u64_from_u32, u64_from_usize};
 
@@ -72,6 +74,10 @@ where
     branches: u64,
     admission: Admission,
     branch_budget: usize,
+    /// Adaptive cap: retunes the window between admission rounds.
+    policy: Option<FromFn<WindowPolicyFn>>,
+    /// Leaf completions since the last policy call.
+    completed: usize,
     /// Discovered leaves awaiting a window slot, ascending by key.
     leaf_frontier: VecDeque<Node<M>>,
     /// Discovered intermediates awaiting descent, ascending by key; the
@@ -124,7 +130,6 @@ where
         let branches = fan_out(body, u64_from_u32(M::MODE.ref_size()));
         let range_end = range.end.min(span);
         let range_start = range.start.min(range_end);
-        let budget = BranchBudget::derive(window, u32::try_from(branches).unwrap_or(u32::MAX));
         let mut walk = Self {
             store,
             range_start,
@@ -132,7 +137,9 @@ where
             body,
             branches,
             admission: Admission::new(window),
-            branch_budget: usize::try_from(budget.get()).unwrap_or(usize::MAX),
+            branch_budget: branch_budget(window, branches),
+            policy: None,
+            completed: 0,
             leaf_frontier: VecDeque::new(),
             branch_frontier: VecDeque::new(),
             in_flight: InFlight::new(),
@@ -152,6 +159,21 @@ where
             span,
         });
         walk
+    }
+
+    /// Adaptive cap: `policy` recomputes the window between admission
+    /// rounds, seeded with the built window. Occupancy above a shrunk cap
+    /// drains by attrition; the head stays admissible at any depth.
+    #[must_use]
+    pub fn with_policy(mut self, policy: WindowPolicyFn) -> Self {
+        self.policy = Some(from_fn(policy));
+        self
+    }
+
+    /// Detach the policy with its accumulated state; a successor walk
+    /// re-arms it.
+    pub(crate) fn take_policy(&mut self) -> Option<WindowPolicyFn> {
+        self.policy.take().map(FromFn::into_inner)
     }
 
     /// Clipped absolute byte range this walk delivers.
@@ -231,8 +253,29 @@ where
         }
     }
 
+    /// Let the policy recompute the window; a change re-derives the branch
+    /// budget.
+    fn retune(&mut self) {
+        let occupancy = self.occupancy();
+        let Some(policy) = self.policy.as_mut() else {
+            return;
+        };
+        let observations = Observations {
+            completions: self.completed,
+            occupancy,
+            in_flight: self.leaf_in_flight,
+        };
+        self.completed = 0;
+        let window = policy.window(&observations);
+        if window != self.admission.window() {
+            self.admission = Admission::new(window);
+            self.branch_budget = branch_budget(window, self.branches);
+        }
+    }
+
     /// Admit queued nodes until neither lane may proceed.
     fn admit(&mut self) {
+        self.retune();
         loop {
             let Some(head) = self.head_key() else { return };
             let branch = self.try_admit_branch(head);
@@ -303,8 +346,17 @@ where
         let Some(front) = self.leaf_frontier.front() else {
             return false;
         };
-        let head_served = front.key(self.range_start) == head || self.head_holds_slot(head);
-        if !self.admission.admits(self.occupancy(), head_served) {
+        let head_candidate = front.key(self.range_start) == head;
+        let head_holds = self.head_holds_slot(head);
+        // An unserved head is admitted at any occupancy: a shrunk cap may
+        // sit below the buffered frames, and only the head drains them.
+        // With a fixed window an unserved head implies a free slot, so this
+        // never lifts the fixed bound.
+        let admitted = (head_candidate && !head_holds)
+            || self
+                .admission
+                .admits(self.occupancy(), head_candidate || head_holds);
+        if !admitted {
             return false;
         }
         let Some(node) = self.leaf_frontier.pop_front() else {
@@ -363,6 +415,7 @@ where
         }
         if leaf {
             self.leaf_in_flight = self.leaf_in_flight.saturating_sub(1);
+            self.completed = self.completed.saturating_add(1);
         } else {
             self.branch_in_flight = self.branch_in_flight.saturating_sub(1);
         }
@@ -510,11 +563,18 @@ where
             .field("range_end", &self.range_end)
             .field("window", &self.admission.window())
             .field("branch_budget", &self.branch_budget)
+            .field("policy", &self.policy.is_some())
             .field("leaf_in_flight", &self.leaf_in_flight)
             .field("branch_in_flight", &self.branch_in_flight)
             .field("done", &self.done)
             .finish_non_exhaustive()
     }
+}
+
+/// Branch budget for `window`, widened into the engine's counter type.
+fn branch_budget(window: Window, branches: u64) -> usize {
+    let budget = BranchBudget::derive(window, u32::try_from(branches).unwrap_or(u32::MAX));
+    usize::try_from(budget.get()).unwrap_or(usize::MAX)
 }
 
 /// Child span under a parent covering `span` bytes: the smallest

--- a/crates/file/src/walk/mod.rs
+++ b/crates/file/src/walk/mod.rs
@@ -23,6 +23,10 @@
 //!    any window depth.
 //! 4. No retries: every store error is terminal and typed; retry policy
 //!    composes beneath the store seam.
+//!
+//! A [`WindowPolicyFn`] may retune the window between admission rounds;
+//! occupancy above a shrunk cap drains by attrition and never exceeds the
+//! largest cap held.
 
 mod engine;
 mod error;
@@ -30,11 +34,29 @@ mod mode;
 #[cfg(test)]
 mod tests;
 
+use alloc::boxed::Box;
+
 use bytes::Bytes;
+pub use nectar_kernel::Observations;
+
+use crate::config::Window;
 
 pub use engine::Walk;
 pub use error::{DecodeError, ShapeError, WalkError};
 pub use mode::{Encrypted, Plain, WalkMode};
+
+/// Boxed window policy: recomputes the leaf admission cap between admission
+/// rounds from the walk's [`Observations`]. Runs in the poll path, so it
+/// must be cheap and non-blocking. `Send` on multi-threaded targets,
+/// unbounded on wasm32 and under the `unsync` feature.
+#[cfg(multi_thread)]
+pub type WindowPolicyFn = Box<dyn FnMut(&Observations) -> Window + Send>;
+/// Boxed window policy: recomputes the leaf admission cap between admission
+/// rounds from the walk's [`Observations`]. Runs in the poll path, so it
+/// must be cheap and non-blocking. `Send` on multi-threaded targets,
+/// unbounded on wasm32 and under the `unsync` feature.
+#[cfg(not(multi_thread))]
+pub type WindowPolicyFn = Box<dyn FnMut(&Observations) -> Window>;
 
 /// One delivered run of file bytes.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/file/src/walk/tests.rs
+++ b/crates/file/src/walk/tests.rs
@@ -3,6 +3,7 @@
 
 use core::future::poll_fn;
 use core::ops::Range;
+use std::boxed::Box;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::vec;
@@ -697,4 +698,91 @@ fn encrypted_decode_reclaims_the_scratch_between_frames() {
     let third = <Encrypted as WalkMode>::decode_body(&key, TINY, TINY, body, &mut scratch).unwrap();
     assert_eq!(second.as_ref(), plain.as_slice());
     assert_eq!(third.as_ref(), plain.as_slice());
+}
+
+#[test]
+fn policy_shrink_to_one_stays_live_and_byte_exact() {
+    let data = fill(60 * TINY + 13);
+    let tree = build_tree(&data);
+    let store = Recording::new(&tree, 2);
+    // Built at eight slots, the policy pins the cap to one before the first
+    // admission round.
+    let mut walk = walk_range(store, &tree, 0..tree.span, 8)
+        .with_policy(Box::new(|_: &super::Observations| Window::new(1).unwrap()));
+    let frames = collect_ordered(&mut walk).unwrap();
+    assert_tiles(&frames, 0, &data);
+    assert!(walk.stats().peak_occupancy <= 1);
+}
+
+#[test]
+fn policy_sees_every_leaf_completion() {
+    let data = fill(40 * TINY + 5);
+    let tree = build_tree(&data);
+    let store = Recording::new(&tree, 2);
+    let seen = Arc::new(Mutex::new(0usize));
+    let sink = Arc::clone(&seen);
+    let mut walk = walk_range(store, &tree, 0..tree.span, 4).with_policy(Box::new(
+        move |observations: &super::Observations| {
+            *sink.lock().unwrap() += observations.completions;
+            assert!(observations.in_flight <= observations.occupancy);
+            Window::new(4).unwrap()
+        },
+    ));
+    let frames = collect_ordered(&mut walk).unwrap();
+    assert_tiles(&frames, 0, &data);
+    let leaves = data.len().div_ceil(TINY);
+    assert_eq!(*seen.lock().unwrap(), leaves);
+}
+
+#[test]
+fn policy_grows_the_window_mid_walk() {
+    let data = fill(100 * TINY);
+    let tree = build_tree(&data);
+    let store = Recording::new(&tree, 3);
+    let completed = Arc::new(Mutex::new(0usize));
+    let sink = Arc::clone(&completed);
+    let mut walk = walk_range(store, &tree, 0..tree.span, 2).with_policy(Box::new(
+        move |observations: &super::Observations| {
+            let mut total = sink.lock().unwrap();
+            *total += observations.completions;
+            Window::new(if *total < 10 { 2 } else { 8 }).unwrap()
+        },
+    ));
+    let frames = collect_ordered(&mut walk).unwrap();
+    assert_tiles(&frames, 0, &data);
+    let stats = walk.stats();
+    assert!(stats.peak_occupancy > 2, "growth must widen the pipe");
+    assert!(stats.peak_occupancy <= 8);
+}
+
+#[test]
+fn policy_shrink_mid_walk_drains_by_attrition() {
+    let data = fill(100 * TINY + 41);
+    let tree = build_tree(&data);
+    let store = Recording::new(&tree, 3);
+    let completed = Arc::new(Mutex::new(0usize));
+    let sink = Arc::clone(&completed);
+    let mut walk = walk_range(store, &tree, 0..tree.span, 8).with_policy(Box::new(
+        move |observations: &super::Observations| {
+            let mut total = sink.lock().unwrap();
+            *total += observations.completions;
+            Window::new(if *total < 20 { 8 } else { 2 }).unwrap()
+        },
+    ));
+    let frames = collect_ordered(&mut walk).unwrap();
+    assert_tiles(&frames, 0, &data);
+    // Occupancy never exceeds the largest cap held.
+    assert!(walk.stats().peak_occupancy <= 8);
+}
+
+#[test]
+fn policy_any_drain_survives_a_shrunk_cap() {
+    let data = fill(50 * TINY + 7);
+    let tree = build_tree(&data);
+    let store = Recording::new(&tree, 2);
+    let mut walk = walk_range(store, &tree, 0..tree.span, 6)
+        .with_policy(Box::new(|_: &super::Observations| Window::new(1).unwrap()));
+    let mut frames = collect_any(&mut walk).unwrap();
+    frames.sort_by_key(|frame| frame.offset);
+    assert_tiles(&frames, 0, &data);
 }

--- a/crates/kernel/src/policy.rs
+++ b/crates/kernel/src/policy.rs
@@ -51,6 +51,13 @@ impl AdmitPolicy for Fixed {
 /// Policy wrapping a closure; built by [`from_fn`].
 pub struct FromFn<F>(F);
 
+impl<F> FromFn<F> {
+    /// Unwrap the closure with its accumulated state.
+    pub fn into_inner(self) -> F {
+        self.0
+    }
+}
+
 /// Policy from `f`, called once per admission round.
 pub const fn from_fn<F>(f: F) -> FromFn<F>
 where
@@ -91,6 +98,21 @@ mod tests {
         };
         assert_eq!(policy.window(&observations), window);
         assert_eq!(policy.window(&Observations::default()), window);
+    }
+
+    #[test]
+    fn into_inner_keeps_closure_state() {
+        let mut policy = from_fn(|observations: &Observations| {
+            Window::new(u16::try_from(observations.completions.max(1)).unwrap()).unwrap()
+        });
+        assert_eq!(policy.window(&Observations::default()).get(), 1);
+        let mut closure = policy.into_inner();
+        let observations = Observations {
+            completions: 3,
+            occupancy: 0,
+            in_flight: 0,
+        };
+        assert_eq!(closure(&observations).get(), 3);
     }
 
     #[test]


### PR DESCRIPTION
## What

Implements #403: the walk engine now accepts a boxed `WindowPolicyFn` wired through the kernel's `AdmitPolicy::FromFn` seam (`Walk::with_policy`), invoked between admission rounds with kernel `Observations` (leaf completions since last call, occupancy, in-flight).
A window change re-derives the branch budget, a shrunk cap drains by attrition, and an unserved head is always admissible so ordered drains never stall.
`ReadBuilder` and `DownloadBuilder` gain `window_policy` plus a std-gated `adaptive_throughput` sugar method.
`FileReader::seek` carries the policy (and its warm estimate) across the re-walk via `Walk::take_policy`, backed by a new kernel `FromFn::into_inner`.
The stock controller lives in `crates/file/src/read/adaptive.rs` (std-gated), an EWMA per-fetch-latency controller producing a margined Little's-law cap, with the clock injected via `nectar-clock`.

## Why

Fixed read-ahead windows either under-fetch on high-latency stores or over-fetch and waste concurrency budget on fast ones. An adaptive controller that retunes the window from observed walk occupancy and completions lets throughput track the store's actual latency without a fixed knob per deployment.

## Testing

- `cargo fmt --all -- --check` clean.
- `cargo clippy --workspace --all-targets --locked` exit 0 (only pre-existing `doc_lazy_continuation` warnings in untouched `nectar-testing`, not deny-level); per-feature passes on `nectar-file` (`tokio`, `rayon`, `encryption`) all exit 0.
- `cargo nextest run --workspace --locked --no-tests=warn --no-fail-fast`: 1108 passed, 1 skipped. `cargo test --doc --workspace --locked` clean.
- Isolated `-p nectar-kernel`: 14 passed (incl. new `into_inner_keeps_closure_state`). `nectar-file` feature suites pass across default/std/unsync/primitives/all-features and std+unsync arms (88 tests, incl. 8 controller unit tests and 6 new walk/read integration tests).

Closes #403.

## AI Assistance

Implementation by fable, review by opus.
