### PR TITLE
kernel: add shared bounded-admission walk driver

### DIFF
--- a/crates/file/src/walk/engine.rs
+++ b/crates/file/src/walk/engine.rs
@@ -8,7 +8,8 @@ use core::task::{Context, Poll};
 
 use bytes::{Bytes, BytesMut};
 use nectar_kernel::{
-    Admission, AdmitPolicy, BoxFuture, FromFn, InFlight, Observations, from_fn, get_verified,
+    Admission, AdmitPolicy, BoxFuture, Driver, FromFn, InFlight, Observations, WalkPolicy, from_fn,
+    get_verified,
 };
 use nectar_primitives::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{Chunk, ChunkAddress, ChunkOps, ContentOnlyChunkSet, Verified};
@@ -67,6 +68,18 @@ where
     S: TrustedGet<ContentOnlyChunkSet<B>>,
     M: WalkMode,
 {
+    driver: Driver<FileWalkPolicy<S, M, B>, Fetched<M, S::Error, B>>,
+}
+
+/// The file walk's [`WalkPolicy`]: the two-lane branch/leaf frontier, its
+/// head-reserved admission, byte-offset ordering, eager-terminal error, and
+/// clip/expand completion fold. The kernel driver owns only the loop and the
+/// in-flight set.
+struct FileWalkPolicy<S, M, const B: usize>
+where
+    S: TrustedGet<ContentOnlyChunkSet<B>>,
+    M: WalkMode,
+{
     store: S,
     range_start: u64,
     range_end: u64,
@@ -83,7 +96,6 @@ where
     /// Discovered intermediates awaiting descent, ascending by key; the
     /// flattened frame stack of the serial walk.
     branch_frontier: VecDeque<Node<M>>,
-    in_flight: InFlight<Fetched<M, S::Error, B>>,
     /// Keys of in-flight leaf fetches, counted per key.
     leaf_keys: BTreeMap<u64, usize>,
     /// Keys of in-flight branch fetches, counted per key.
@@ -94,11 +106,210 @@ where
     ready: BTreeMap<u64, Bytes>,
     /// Staging buffer the mode's body decoder reuses across nodes.
     scratch: BytesMut,
-    done: bool,
     stats: WalkStats,
 }
 
 impl<S, M, const B: usize> Walk<S, M, B>
+where
+    S: TrustedGet<ContentOnlyChunkSet<B>> + Clone + 'static,
+    M: WalkMode,
+{
+    /// Walk `range` of the tree under `root`, whose total `span` the caller
+    /// read from the root chunk. The engine re-fetches the root as its first
+    /// node, so the fetch set stays identical to a cold serial walk.
+    pub fn new(
+        store: S,
+        root: ChunkAddress,
+        context: M::Context,
+        span: u64,
+        range: Range<u64>,
+        window: Window,
+    ) -> Self {
+        const { FileWalkPolicy::<S, M, B>::PROFILE };
+        let body = u64_from_usize(B);
+        let branches = fan_out(body, u64_from_u32(M::MODE.ref_size()));
+        let range_end = range.end.min(span);
+        let range_start = range.start.min(range_end);
+        let mut policy = FileWalkPolicy {
+            store,
+            range_start,
+            range_end,
+            body,
+            branches,
+            admission: Admission::new(window),
+            branch_budget: branch_budget(window, branches),
+            policy: None,
+            completed: 0,
+            leaf_frontier: VecDeque::new(),
+            branch_frontier: VecDeque::new(),
+            leaf_keys: BTreeMap::new(),
+            branch_keys: BTreeMap::new(),
+            leaf_in_flight: 0,
+            branch_in_flight: 0,
+            ready: BTreeMap::new(),
+            scratch: BytesMut::new(),
+            stats: WalkStats::default(),
+        };
+        policy.enqueue(Node {
+            address: root,
+            context,
+            start: 0,
+            span,
+        });
+        Self {
+            driver: Driver::new(policy),
+        }
+    }
+
+    /// Adaptive cap: `policy` recomputes the window between admission
+    /// rounds, seeded with the built window. Occupancy above a shrunk cap
+    /// drains by attrition; the head stays admissible at any depth.
+    #[must_use]
+    pub fn with_policy(mut self, policy: WindowPolicyFn) -> Self {
+        self.driver.policy_mut().policy = Some(from_fn(policy));
+        self
+    }
+
+    /// Detach the policy with its accumulated state; a successor walk
+    /// re-arms it.
+    pub(crate) fn take_policy(&mut self) -> Option<WindowPolicyFn> {
+        self.driver
+            .policy_mut()
+            .policy
+            .take()
+            .map(FromFn::into_inner)
+    }
+
+    /// Clipped absolute byte range this walk delivers.
+    pub const fn range(&self) -> Range<u64> {
+        let policy = self.driver.policy();
+        policy.range_start..policy.range_end
+    }
+
+    /// Occupancy witnesses accumulated so far.
+    pub const fn stats(&self) -> WalkStats {
+        self.driver.policy().stats
+    }
+
+    /// Whether the walk has delivered its last frame or failed.
+    pub const fn is_finished(&self) -> bool {
+        self.driver.is_finished()
+    }
+
+    /// Deliver the next frame in file order: consecutive frames tile the
+    /// range gaplessly.
+    ///
+    /// Cancel-safe: all progress lives in `self`, so an abandoned call loses
+    /// nothing. `Ready(None)` after the last in-range byte or after a
+    /// terminal error.
+    pub fn poll_next_ordered(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame, WalkError<S::Error>>>> {
+        self.driver.poll(cx, Drain::Ordered)
+    }
+
+    /// Deliver the next frame in completion order, lowest ready offset
+    /// first. Same contract as [`poll_next_ordered`](Self::poll_next_ordered)
+    /// without the ordering guarantee.
+    pub fn poll_next_any(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame, WalkError<S::Error>>>> {
+        self.driver.poll(cx, Drain::Any)
+    }
+}
+
+impl<S, M, const B: usize> WalkPolicy for FileWalkPolicy<S, M, B>
+where
+    S: TrustedGet<ContentOnlyChunkSet<B>> + Clone + 'static,
+    M: WalkMode,
+{
+    type Fetched = Fetched<M, S::Error, B>;
+    type Frame = Frame;
+    type Error = WalkError<S::Error>;
+    type Drain = Drain;
+
+    #[inline]
+    fn admit(&mut self, in_flight: &mut InFlight<Self::Fetched>) {
+        self.retune();
+        loop {
+            let Some(head) = self.head_key() else { return };
+            let branch = self.try_admit_branch(head, in_flight);
+            let leaf = self.try_admit_leaf(head, in_flight);
+            if !branch && !leaf {
+                return;
+            }
+        }
+    }
+
+    #[inline]
+    fn take_ready(&mut self, drain: Drain) -> Option<Frame> {
+        if let Drain::Ordered = drain {
+            let head = self.head_key()?;
+            let (&key, _) = self.ready.first_key_value()?;
+            if key != head {
+                return None;
+            }
+        }
+        self.ready
+            .pop_first()
+            .map(|(offset, data)| Frame { offset, data })
+    }
+
+    #[inline]
+    fn absorb(&mut self, (node, fetched): Self::Fetched) -> Result<(), Self::Error> {
+        let leaf = node.span <= self.body;
+        let key = node.key(self.range_start);
+        self.retire(key, leaf);
+        let chunk = fetched.map_err(|source| WalkError::Fetch {
+            address: node.address,
+            source,
+        })?;
+        let data = chunk.into_envelope().data().clone();
+        let take = self.plaintext_len(&node, leaf);
+        let data =
+            M::decode_body(&node.context, B, take, data, &mut self.scratch).map_err(|source| {
+                WalkError::Decode {
+                    offset: node.start,
+                    source,
+                }
+            })?;
+        if leaf {
+            let len = u64_from_usize(data.len());
+            if len != node.span {
+                return Err(ShapeError::LeafLength {
+                    offset: node.start,
+                    span: node.span,
+                    len,
+                }
+                .into());
+            }
+            self.ready.insert(key, self.clip(&node, data));
+            Ok(())
+        } else {
+            self.expand(&node, &data).map_err(WalkError::from)
+        }
+    }
+
+    #[inline]
+    fn drained(&self) -> Result<(), Self::Error> {
+        let pending = self
+            .leaf_frontier
+            .len()
+            .saturating_add(self.branch_frontier.len());
+        if pending == 0 && self.ready.is_empty() {
+            Ok(())
+        } else {
+            Err(WalkError::Stalled {
+                pending,
+                occupancy: self.occupancy(),
+            })
+        }
+    }
+}
+
+impl<S, M, const B: usize> FileWalkPolicy<S, M, B>
 where
     S: TrustedGet<ContentOnlyChunkSet<B>> + Clone + 'static,
     M: WalkMode,
@@ -113,145 +324,6 @@ where
         let fan_out = fan_out(u64_from_usize(B), u64_from_u32(M::MODE.ref_size()));
         assert!(fan_out >= 2, "fan-out must be at least two");
     };
-
-    /// Walk `range` of the tree under `root`, whose total `span` the caller
-    /// read from the root chunk. The engine re-fetches the root as its first
-    /// node, so the fetch set stays identical to a cold serial walk.
-    pub fn new(
-        store: S,
-        root: ChunkAddress,
-        context: M::Context,
-        span: u64,
-        range: Range<u64>,
-        window: Window,
-    ) -> Self {
-        const { Self::PROFILE };
-        let body = u64_from_usize(B);
-        let branches = fan_out(body, u64_from_u32(M::MODE.ref_size()));
-        let range_end = range.end.min(span);
-        let range_start = range.start.min(range_end);
-        let mut walk = Self {
-            store,
-            range_start,
-            range_end,
-            body,
-            branches,
-            admission: Admission::new(window),
-            branch_budget: branch_budget(window, branches),
-            policy: None,
-            completed: 0,
-            leaf_frontier: VecDeque::new(),
-            branch_frontier: VecDeque::new(),
-            in_flight: InFlight::new(),
-            leaf_keys: BTreeMap::new(),
-            branch_keys: BTreeMap::new(),
-            leaf_in_flight: 0,
-            branch_in_flight: 0,
-            ready: BTreeMap::new(),
-            scratch: BytesMut::new(),
-            done: false,
-            stats: WalkStats::default(),
-        };
-        walk.enqueue(Node {
-            address: root,
-            context,
-            start: 0,
-            span,
-        });
-        walk
-    }
-
-    /// Adaptive cap: `policy` recomputes the window between admission
-    /// rounds, seeded with the built window. Occupancy above a shrunk cap
-    /// drains by attrition; the head stays admissible at any depth.
-    #[must_use]
-    pub fn with_policy(mut self, policy: WindowPolicyFn) -> Self {
-        self.policy = Some(from_fn(policy));
-        self
-    }
-
-    /// Detach the policy with its accumulated state; a successor walk
-    /// re-arms it.
-    pub(crate) fn take_policy(&mut self) -> Option<WindowPolicyFn> {
-        self.policy.take().map(FromFn::into_inner)
-    }
-
-    /// Clipped absolute byte range this walk delivers.
-    pub const fn range(&self) -> Range<u64> {
-        self.range_start..self.range_end
-    }
-
-    /// Occupancy witnesses accumulated so far.
-    pub const fn stats(&self) -> WalkStats {
-        self.stats
-    }
-
-    /// Whether the walk has delivered its last frame or failed.
-    pub const fn is_finished(&self) -> bool {
-        self.done
-    }
-
-    /// Deliver the next frame in file order: consecutive frames tile the
-    /// range gaplessly.
-    ///
-    /// Cancel-safe: all progress lives in `self`, so an abandoned call loses
-    /// nothing. `Ready(None)` after the last in-range byte or after a
-    /// terminal error.
-    pub fn poll_next_ordered(
-        &mut self,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Frame, WalkError<S::Error>>>> {
-        self.poll_frame(cx, Drain::Ordered)
-    }
-
-    /// Deliver the next frame in completion order, lowest ready offset
-    /// first. Same contract as [`poll_next_ordered`](Self::poll_next_ordered)
-    /// without the ordering guarantee.
-    pub fn poll_next_any(
-        &mut self,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Frame, WalkError<S::Error>>>> {
-        self.poll_frame(cx, Drain::Any)
-    }
-
-    fn poll_frame(
-        &mut self,
-        cx: &mut Context<'_>,
-        drain: Drain,
-    ) -> Poll<Option<Result<Frame, WalkError<S::Error>>>> {
-        if self.done {
-            return Poll::Ready(None);
-        }
-        loop {
-            self.admit();
-            if let Some(frame) = self.take_ready(drain) {
-                return Poll::Ready(Some(Ok(frame)));
-            }
-            match self.in_flight.poll(cx) {
-                Poll::Ready(Some((node, fetched))) => {
-                    if let Err(error) = self.absorb(node, fetched) {
-                        self.done = true;
-                        return Poll::Ready(Some(Err(error)));
-                    }
-                }
-                Poll::Ready(None) => {
-                    self.done = true;
-                    let pending = self
-                        .leaf_frontier
-                        .len()
-                        .saturating_add(self.branch_frontier.len());
-                    if pending == 0 && self.ready.is_empty() {
-                        return Poll::Ready(None);
-                    }
-                    return Poll::Ready(Some(Err(WalkError::Stalled {
-                        pending,
-                        occupancy: self.occupancy(),
-                    })));
-                }
-                Poll::Pending => return Poll::Pending,
-            }
-        }
-    }
 
     /// Let the policy recompute the window; a change re-derives the branch
     /// budget.
@@ -270,19 +342,6 @@ where
         if window != self.admission.window() {
             self.admission = Admission::new(window);
             self.branch_budget = branch_budget(window, self.branches);
-        }
-    }
-
-    /// Admit queued nodes until neither lane may proceed.
-    fn admit(&mut self) {
-        self.retune();
-        loop {
-            let Some(head) = self.head_key() else { return };
-            let branch = self.try_admit_branch(head);
-            let leaf = self.try_admit_leaf(head);
-            if !branch && !leaf {
-                return;
-            }
         }
     }
 
@@ -323,7 +382,11 @@ where
     /// Admit the lowest queued branch. The head branch only needs a budget
     /// slot (liveness over the reference cap); any other branch also needs
     /// absorption room.
-    fn try_admit_branch(&mut self, head: u64) -> bool {
+    fn try_admit_branch(
+        &mut self,
+        head: u64,
+        in_flight: &mut InFlight<Fetched<M, S::Error, B>>,
+    ) -> bool {
         if self.branch_in_flight >= self.branch_budget {
             return false;
         }
@@ -336,13 +399,17 @@ where
         let Some(node) = self.branch_frontier.pop_front() else {
             return false;
         };
-        self.dispatch(node);
+        self.dispatch(node, in_flight);
         true
     }
 
     /// Admit the lowest queued leaf. The head leaf may take the last window
     /// slot; any other leaf must leave it free until the head holds one.
-    fn try_admit_leaf(&mut self, head: u64) -> bool {
+    fn try_admit_leaf(
+        &mut self,
+        head: u64,
+        in_flight: &mut InFlight<Fetched<M, S::Error, B>>,
+    ) -> bool {
         let Some(front) = self.leaf_frontier.front() else {
             return false;
         };
@@ -362,7 +429,7 @@ where
         let Some(node) = self.leaf_frontier.pop_front() else {
             return false;
         };
-        self.dispatch(node);
+        self.dispatch(node, in_flight);
         true
     }
 
@@ -380,7 +447,7 @@ where
 
     /// Start one fetch, moving the node into its future; the completion
     /// carries it back.
-    fn dispatch(&mut self, node: Node<M>) {
+    fn dispatch(&mut self, node: Node<M>, in_flight: &mut InFlight<Fetched<M, S::Error, B>>) {
         let key = node.key(self.range_start);
         if node.span <= self.body {
             let slot = self.leaf_keys.entry(key).or_insert(0);
@@ -397,7 +464,7 @@ where
         self.stats.fetches = self.stats.fetches.saturating_add(1);
         let store = self.store.clone();
         let fetch: BoxFetch<M, S::Error, B> = Box::pin(get_verified(store, node.address, node));
-        self.in_flight.push(fetch);
+        in_flight.push(fetch);
     }
 
     /// Retire a completed fetch from the in-flight accounting.
@@ -418,47 +485,6 @@ where
             self.completed = self.completed.saturating_add(1);
         } else {
             self.branch_in_flight = self.branch_in_flight.saturating_sub(1);
-        }
-    }
-
-    /// Fold one completion back into the walk: buffer a leaf body or expand
-    /// an intermediate. The trusted store bound answers for the requested
-    /// address; an untrusted medium is lifted through `VerifyingStore`.
-    fn absorb(
-        &mut self,
-        node: Node<M>,
-        fetched: Result<Chunk<Verified, ContentOnlyChunkSet<B>>, S::Error>,
-    ) -> Result<(), WalkError<S::Error>> {
-        let leaf = node.span <= self.body;
-        let key = node.key(self.range_start);
-        self.retire(key, leaf);
-        let chunk = fetched.map_err(|source| WalkError::Fetch {
-            address: node.address,
-            source,
-        })?;
-        let data = chunk.into_envelope().data().clone();
-        let take = self.plaintext_len(&node, leaf);
-        let data =
-            M::decode_body(&node.context, B, take, data, &mut self.scratch).map_err(|source| {
-                WalkError::Decode {
-                    offset: node.start,
-                    source,
-                }
-            })?;
-        if leaf {
-            let len = u64_from_usize(data.len());
-            if len != node.span {
-                return Err(ShapeError::LeafLength {
-                    offset: node.start,
-                    span: node.span,
-                    len,
-                }
-                .into());
-            }
-            self.ready.insert(key, self.clip(&node, data));
-            Ok(())
-        } else {
-            self.expand(&node, &data).map_err(WalkError::from)
         }
     }
 
@@ -536,20 +562,6 @@ where
         let high = clamp_index(self.range_end.saturating_sub(node.start), len).max(low);
         data.slice(low..high)
     }
-
-    /// Take the next deliverable frame, if the drain permits one.
-    fn take_ready(&mut self, drain: Drain) -> Option<Frame> {
-        if let Drain::Ordered = drain {
-            let head = self.head_key()?;
-            let (&key, _) = self.ready.first_key_value()?;
-            if key != head {
-                return None;
-            }
-        }
-        self.ready
-            .pop_first()
-            .map(|(offset, data)| Frame { offset, data })
-    }
 }
 
 impl<S, M, const B: usize> fmt::Debug for Walk<S, M, B>
@@ -558,15 +570,16 @@ where
     M: WalkMode,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let policy = self.driver.policy();
         f.debug_struct("Walk")
-            .field("range_start", &self.range_start)
-            .field("range_end", &self.range_end)
-            .field("window", &self.admission.window())
-            .field("branch_budget", &self.branch_budget)
-            .field("policy", &self.policy.is_some())
-            .field("leaf_in_flight", &self.leaf_in_flight)
-            .field("branch_in_flight", &self.branch_in_flight)
-            .field("done", &self.done)
+            .field("range_start", &policy.range_start)
+            .field("range_end", &policy.range_end)
+            .field("window", &policy.admission.window())
+            .field("branch_budget", &policy.branch_budget)
+            .field("policy", &policy.policy.is_some())
+            .field("leaf_in_flight", &policy.leaf_in_flight)
+            .field("branch_in_flight", &policy.branch_in_flight)
+            .field("done", &self.driver.is_finished())
             .finish_non_exhaustive()
     }
 }

--- a/crates/kernel/src/driver.rs
+++ b/crates/kernel/src/driver.rs
@@ -38,8 +38,12 @@ pub trait WalkPolicy {
 /// else poll one completion into the policy. All state lives in the policy
 /// and the in-flight set, so every poll is cancel-safe.
 ///
-/// `F` is the policy's `Fetched` type, named separately so the accessors need
-/// no [`WalkPolicy`] bound; [`poll`](Self::poll) ties the two together.
+/// `F` is `P::Fetched`, kept a separate parameter ON PURPOSE so a holder names
+/// the in-flight set at the policy's own bounds: borrow-based walkers must not
+/// inherit the file walk's `Clone + 'static`. Do NOT collapse to `Driver<P>`
+/// (projecting `P::Fetched` in the field virally widens every holder). Holders
+/// embed `Driver<Policy, Policy's Fetched alias>` as a private field and land
+/// the poll delegation with it.
 pub struct Driver<P, F> {
     policy: P,
     in_flight: InFlight<F>,
@@ -47,15 +51,6 @@ pub struct Driver<P, F> {
 }
 
 impl<P, F> Driver<P, F> {
-    /// Drive `policy` from an empty in-flight set.
-    pub const fn new(policy: P) -> Self {
-        Self {
-            policy,
-            in_flight: InFlight::new(),
-            done: false,
-        }
-    }
-
     /// The driven policy.
     pub const fn policy(&self) -> &P {
         &self.policy
@@ -66,6 +61,11 @@ impl<P, F> Driver<P, F> {
         &mut self.policy
     }
 
+    /// Consume the driver, recovering the policy (and any store it owns).
+    pub fn into_policy(self) -> P {
+        self.policy
+    }
+
     /// Whether the last frame has been delivered or the walk has failed.
     pub const fn is_finished(&self) -> bool {
         self.done
@@ -73,6 +73,16 @@ impl<P, F> Driver<P, F> {
 }
 
 impl<P: WalkPolicy> Driver<P, P::Fetched> {
+    /// Drive `policy` from an empty in-flight set. Bounded so `F` can only be
+    /// `P::Fetched`: a mismatched `Driver` has no constructor.
+    pub const fn new(policy: P) -> Self {
+        Self {
+            policy,
+            in_flight: InFlight::new(),
+            done: false,
+        }
+    }
+
     /// Deliver the next frame under `drain`. `Ready(None)` after the last
     /// frame or a terminal error; a later poll after either stays `None`.
     #[inline]

--- a/crates/kernel/src/driver.rs
+++ b/crates/kernel/src/driver.rs
@@ -1,0 +1,119 @@
+//! The shared bounded-admission walk loop.
+
+use core::fmt;
+use core::task::{Context, Poll};
+
+use crate::inflight::InFlight;
+
+/// Per-walker divergence beneath the shared driver: the frontier and its
+/// admission, the ready ordering, the completion fold with its error timing,
+/// and the drain outcome. The driver owns only the loop and the in-flight
+/// set; every semantic decision stays here, so a monomorphised [`Driver`] is
+/// the hand-rolled walk.
+pub trait WalkPolicy {
+    /// One completed fetch, carrying its own routing back.
+    type Fetched;
+    /// One delivered unit of the walk.
+    type Frame;
+    /// Terminal fault the walk surfaces.
+    type Error;
+    /// Ready-ordering selector passed per poll.
+    type Drain: Copy;
+
+    /// Dispatch queued work into `in_flight` until neither lane may proceed.
+    fn admit(&mut self, in_flight: &mut InFlight<Self::Fetched>);
+
+    /// Take the next deliverable frame, if the drain permits one.
+    fn take_ready(&mut self, drain: Self::Drain) -> Option<Self::Frame>;
+
+    /// Fold one completion; an error terminates the walk at its own timing.
+    fn absorb(&mut self, fetched: Self::Fetched) -> Result<(), Self::Error>;
+
+    /// Outcome once the in-flight set empties: `Ok` is clean completion,
+    /// `Err` is a stall with work still owed.
+    fn drained(&self) -> Result<(), Self::Error>;
+}
+
+/// The one bounded-admission walk loop: `admit`, then drain a ready frame,
+/// else poll one completion into the policy. All state lives in the policy
+/// and the in-flight set, so every poll is cancel-safe.
+///
+/// `F` is the policy's `Fetched` type, named separately so the accessors need
+/// no [`WalkPolicy`] bound; [`poll`](Self::poll) ties the two together.
+pub struct Driver<P, F> {
+    policy: P,
+    in_flight: InFlight<F>,
+    done: bool,
+}
+
+impl<P, F> Driver<P, F> {
+    /// Drive `policy` from an empty in-flight set.
+    pub const fn new(policy: P) -> Self {
+        Self {
+            policy,
+            in_flight: InFlight::new(),
+            done: false,
+        }
+    }
+
+    /// The driven policy.
+    pub const fn policy(&self) -> &P {
+        &self.policy
+    }
+
+    /// The driven policy, mutably.
+    pub const fn policy_mut(&mut self) -> &mut P {
+        &mut self.policy
+    }
+
+    /// Whether the last frame has been delivered or the walk has failed.
+    pub const fn is_finished(&self) -> bool {
+        self.done
+    }
+}
+
+impl<P: WalkPolicy> Driver<P, P::Fetched> {
+    /// Deliver the next frame under `drain`. `Ready(None)` after the last
+    /// frame or a terminal error; a later poll after either stays `None`.
+    #[inline]
+    pub fn poll(
+        &mut self,
+        cx: &mut Context<'_>,
+        drain: P::Drain,
+    ) -> Poll<Option<Result<P::Frame, P::Error>>> {
+        if self.done {
+            return Poll::Ready(None);
+        }
+        loop {
+            self.policy.admit(&mut self.in_flight);
+            if let Some(frame) = self.policy.take_ready(drain) {
+                return Poll::Ready(Some(Ok(frame)));
+            }
+            match self.in_flight.poll(cx) {
+                Poll::Ready(Some(fetched)) => {
+                    if let Err(error) = self.policy.absorb(fetched) {
+                        self.done = true;
+                        return Poll::Ready(Some(Err(error)));
+                    }
+                }
+                Poll::Ready(None) => {
+                    self.done = true;
+                    return match self.policy.drained() {
+                        Ok(()) => Poll::Ready(None),
+                        Err(error) => Poll::Ready(Some(Err(error))),
+                    };
+                }
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+}
+
+impl<P, F> fmt::Debug for Driver<P, F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Driver")
+            .field("in_flight", &self.in_flight.len())
+            .field("done", &self.done)
+            .finish_non_exhaustive()
+    }
+}

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -1,10 +1,12 @@
-//! Bounded-admission kernel beneath the streaming walkers: the
-//! fixed-membership [`InFlight`] set, the read-ahead [`Window`], the
-//! head-slot [`Admission`] predicate, the [`AdmitPolicy`] adaptive-window
-//! seam, and the [`BoxFuture`] alias the sets hold.
+//! Bounded-admission kernel beneath the streaming walkers: the shared
+//! [`Driver`] loop over a [`WalkPolicy`], the fixed-membership [`InFlight`]
+//! set, the read-ahead [`Window`], the head-slot [`Admission`] predicate, the
+//! [`AdmitPolicy`] adaptive-window seam, and the [`BoxFuture`] alias the sets
+//! hold.
 //!
-//! The walker engines stay bespoke in their own crates; this crate carries
-//! only the admission layer they share.
+//! The driver owns the `admit`/`take`/`poll` loop; each walker's frontier,
+//! ordering, and completion fold stay bespoke as a [`WalkPolicy`] impl in its
+//! own crate, and a monomorphised driver is the hand-rolled walk.
 
 #![no_std]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
@@ -38,6 +40,7 @@ use nectar_marker as _;
 mod admission;
 #[cfg(feature = "chunk")]
 mod chunk;
+mod driver;
 mod future;
 mod inflight;
 mod policy;
@@ -47,6 +50,7 @@ pub use admission::Admission;
 #[cfg(feature = "chunk")]
 #[cfg_attr(docsrs, doc(cfg(feature = "chunk")))]
 pub use chunk::get_verified;
+pub use driver::{Driver, WalkPolicy};
 pub use future::BoxFuture;
 pub use inflight::InFlight;
 pub use policy::{AdmitPolicy, Fixed, FromFn, Observations, from_fn};


### PR DESCRIPTION
## What

Adds a shared bounded-admission walk driver in `nectar-kernel` and migrates the file read walk onto it.

`crates/kernel/src/driver.rs` introduces a `WalkPolicy` trait (associated types `Fetched`/`Frame`/`Error`/`Drain`) that carries each walker's own frontier, admission, ready-ordering, completion fold, and drained/stalled outcome, and a generic `Driver<P, F>` that owns the `loop { admit; take_ready; poll(InFlight) }` and the kernel `InFlight` set. Both are re-exported from `nectar-kernel`.

`crates/file/src/walk/engine.rs` renames the former `Walk` struct fields into a new `FileWalkPolicy<S, M, B>` implementing `WalkPolicy`, and `Walk<S, M, B>` becomes a thin wrapper holding `Driver<FileWalkPolicy<S, M, B>, Fetched<M, S::Error, B>>`. The compile-time `PROFILE` guard, the two-lane branch/leaf frontier, head-reserved admission, byte-offset ordering, and the public `Walk` method signatures (`with_policy`, `take_policy`, `range`, `stats`, `is_finished`, and the two poll methods) are all preserved, now delegating to the driver.

Closes #545

## Why

Wave 1 of epic #542: the file walk's `admit`/`take_ready`/`poll(InFlight)` loop was hand-rolled and about to be duplicated by further walkers. Extracting it into a `WalkPolicy`-driven `Driver<P, F>` in the kernel lets each walker keep only its own frontier and ordering semantics as a policy impl, while the loop, the in-flight set, and the cancel-safety invariant live in one place.

## Testing

- `cargo test -p nectar-kernel -p nectar-file`
- `cargo clippy -p nectar-kernel -p nectar-file --all-targets`
- `cargo fmt --check` on the touched files

## AI Assistance

Implemented with Claude Opus, reviewed with Claude Opus.

