### PR TITLE
kernel: thread a covariant lifetime through the walk driver

### DIFF
--- a/crates/file/src/split/engine.rs
+++ b/crates/file/src/split/engine.rs
@@ -31,7 +31,7 @@ type PutDone<E> = (ChunkAddress, Result<(), E>);
 
 /// Boxed put future; the kernel alias relaxes `Send` off the multi-threaded
 /// targets.
-type BoxPut<E> = BoxFuture<PutDone<E>>;
+type BoxPut<E> = BoxFuture<'static, PutDone<E>>;
 
 /// Handoff carrying one pool leaf seal back to the engine.
 #[cfg(feature = "rayon")]
@@ -117,7 +117,7 @@ where
     spine: Vec<Level<M>>,
     /// Sealed chunks awaiting a put slot; bounded by the spine height.
     pending: VecDeque<Chunk<Verified, AnyChunkSet<B>>>,
-    in_flight: InFlight<PutDone<S::Error>>,
+    in_flight: InFlight<'static, PutDone<S::Error>>,
     /// Pool fan-out for leaf seals; `None` keeps sealing inline.
     #[cfg(feature = "rayon")]
     hash: Option<HashFan<M, B>>,

--- a/crates/file/src/store.rs
+++ b/crates/file/src/store.rs
@@ -26,7 +26,7 @@ pub struct BoxedStoreError(#[source] BoxedError);
 /// Boxed erased fetch future; the kernel alias relaxes `Send` off the
 /// multi-threaded targets.
 type BoxGet<const B: usize> =
-    BoxFuture<Result<Chunk<Verified, ContentOnlyChunkSet<B>>, BoxedStoreError>>;
+    BoxFuture<'static, Result<Chunk<Verified, ContentOnlyChunkSet<B>>, BoxedStoreError>>;
 
 /// Object-safe fetch surface the adapter erases stores through.
 trait ErasedGet<const B: usize>: MaybeSend + MaybeSync {

--- a/crates/file/src/walk/engine.rs
+++ b/crates/file/src/walk/engine.rs
@@ -8,8 +8,8 @@ use core::task::{Context, Poll};
 
 use bytes::{Bytes, BytesMut};
 use nectar_kernel::{
-    Admission, AdmitPolicy, BoxFuture, Driver, FromFn, InFlight, Observations, WalkPolicy, from_fn,
-    get_verified,
+    Admission, AdmitPolicy, BoxFuture, FromFn, InFlight, Observations, StaticDriver, WalkPolicy,
+    from_fn, get_verified,
 };
 use nectar_primitives::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{Chunk, ChunkAddress, ChunkOps, ContentOnlyChunkSet, Verified};
@@ -46,7 +46,7 @@ type Fetched<M, E, const B: usize> = (Node<M>, Result<Chunk<Verified, ContentOnl
 
 /// Boxed fetch future; the kernel alias relaxes `Send` off the
 /// multi-threaded targets.
-type BoxFetch<M, E, const B: usize> = BoxFuture<Fetched<M, E, B>>;
+type BoxFetch<M, E, const B: usize> = BoxFuture<'static, Fetched<M, E, B>>;
 
 /// Which frame a drain takes from the ready set.
 #[derive(Clone, Copy)]
@@ -68,7 +68,7 @@ where
     S: TrustedGet<ContentOnlyChunkSet<B>>,
     M: WalkMode,
 {
-    driver: Driver<FileWalkPolicy<S, M, B>, Fetched<M, S::Error, B>>,
+    driver: StaticDriver<FileWalkPolicy<S, M, B>, Fetched<M, S::Error, B>>,
 }
 
 /// The file walk's [`WalkPolicy`]: the two-lane branch/leaf frontier, its
@@ -157,7 +157,7 @@ where
             span,
         });
         Self {
-            driver: Driver::new(policy),
+            driver: StaticDriver::new(policy),
         }
     }
 
@@ -220,7 +220,7 @@ where
     }
 }
 
-impl<S, M, const B: usize> WalkPolicy for FileWalkPolicy<S, M, B>
+impl<S, M, const B: usize> WalkPolicy<'static> for FileWalkPolicy<S, M, B>
 where
     S: TrustedGet<ContentOnlyChunkSet<B>> + Clone + 'static,
     M: WalkMode,
@@ -231,7 +231,7 @@ where
     type Drain = Drain;
 
     #[inline]
-    fn admit(&mut self, in_flight: &mut InFlight<Self::Fetched>) {
+    fn admit(&mut self, in_flight: &mut InFlight<'static, Self::Fetched>) {
         self.retune();
         loop {
             let Some(head) = self.head_key() else { return };
@@ -385,7 +385,7 @@ where
     fn try_admit_branch(
         &mut self,
         head: u64,
-        in_flight: &mut InFlight<Fetched<M, S::Error, B>>,
+        in_flight: &mut InFlight<'static, Fetched<M, S::Error, B>>,
     ) -> bool {
         if self.branch_in_flight >= self.branch_budget {
             return false;
@@ -408,7 +408,7 @@ where
     fn try_admit_leaf(
         &mut self,
         head: u64,
-        in_flight: &mut InFlight<Fetched<M, S::Error, B>>,
+        in_flight: &mut InFlight<'static, Fetched<M, S::Error, B>>,
     ) -> bool {
         let Some(front) = self.leaf_frontier.front() else {
             return false;
@@ -447,7 +447,11 @@ where
 
     /// Start one fetch, moving the node into its future; the completion
     /// carries it back.
-    fn dispatch(&mut self, node: Node<M>, in_flight: &mut InFlight<Fetched<M, S::Error, B>>) {
+    fn dispatch(
+        &mut self,
+        node: Node<M>,
+        in_flight: &mut InFlight<'static, Fetched<M, S::Error, B>>,
+    ) {
         let key = node.key(self.range_start);
         if node.span <= self.body {
             let slot = self.leaf_keys.entry(key).or_insert(0);

--- a/crates/kernel/src/driver.rs
+++ b/crates/kernel/src/driver.rs
@@ -10,7 +10,11 @@ use crate::inflight::InFlight;
 /// and the drain outcome. The driver owns only the loop and the in-flight
 /// set; every semantic decision stays here, so a monomorphised [`Driver`] is
 /// the hand-rolled walk.
-pub trait WalkPolicy {
+///
+/// `'a` bounds the fetch futures a policy admits: an owning policy
+/// implements `WalkPolicy<'static>`, a borrowing policy its store's
+/// lifetime.
+pub trait WalkPolicy<'a> {
     /// One completed fetch, carrying its own routing back.
     type Fetched;
     /// One delivered unit of the walk.
@@ -21,7 +25,7 @@ pub trait WalkPolicy {
     type Drain: Copy;
 
     /// Dispatch queued work into `in_flight` until neither lane may proceed.
-    fn admit(&mut self, in_flight: &mut InFlight<Self::Fetched>);
+    fn admit(&mut self, in_flight: &mut InFlight<'a, Self::Fetched>);
 
     /// Take the next deliverable outcome, if the drain permits one; an `Err`
     /// is a fault surfacing at its serial turn, terminal like any other.
@@ -40,19 +44,25 @@ pub trait WalkPolicy {
 /// else poll one completion into the policy. All state lives in the policy
 /// and the in-flight set, so every poll is cancel-safe.
 ///
+/// `'a` bounds the fetch futures; a clone-based holder writes
+/// [`StaticDriver`].
+///
 /// `F` is `P::Fetched`, kept a separate parameter ON PURPOSE so a holder names
 /// the in-flight set at the policy's own bounds: borrow-based walkers must not
 /// inherit the file walk's `Clone + 'static`. Do NOT collapse to `Driver<P>`
 /// (projecting `P::Fetched` in the field virally widens every holder). Holders
 /// embed `Driver<Policy, Policy's Fetched alias>` as a private field and land
 /// the poll delegation with it.
-pub struct Driver<P, F> {
+pub struct Driver<'a, P, F> {
     policy: P,
-    in_flight: InFlight<F>,
+    in_flight: InFlight<'a, F>,
     done: bool,
 }
 
-impl<P, F> Driver<P, F> {
+/// Driver over `'static` fetch futures, for clone-based policies.
+pub type StaticDriver<P, F> = Driver<'static, P, F>;
+
+impl<P, F> Driver<'_, P, F> {
     /// The driven policy.
     pub const fn policy(&self) -> &P {
         &self.policy
@@ -74,7 +84,7 @@ impl<P, F> Driver<P, F> {
     }
 }
 
-impl<P: WalkPolicy> Driver<P, P::Fetched> {
+impl<'a, P: WalkPolicy<'a>> Driver<'a, P, P::Fetched> {
     /// Drive `policy` from an empty in-flight set. Bounded so `F` can only be
     /// `P::Fetched`: a mismatched `Driver` has no constructor.
     pub const fn new(policy: P) -> Self {
@@ -124,7 +134,7 @@ impl<P: WalkPolicy> Driver<P, P::Fetched> {
     }
 }
 
-impl<P, F> fmt::Debug for Driver<P, F> {
+impl<P, F> fmt::Debug for Driver<'_, P, F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Driver")
             .field("in_flight", &self.in_flight.len())

--- a/crates/kernel/src/future.rs
+++ b/crates/kernel/src/future.rs
@@ -4,27 +4,29 @@ use alloc::boxed::Box;
 use core::future::Future;
 use core::pin::Pin;
 
-/// Boxed future: `Send` on multi-threaded targets, unbounded on wasm32,
-/// bare metal, and under the `unsync` feature, mirroring the marker traits.
+/// Boxed future capturing no more than `'a`: `Send` on multi-threaded
+/// targets, unbounded on wasm32, bare metal, and under the `unsync` feature,
+/// mirroring the marker traits.
 ///
 /// Feature unification: `unsync` enabled by any crate in a build relaxes
 /// the alias for every consumer in that build.
 #[cfg(multi_thread)]
-pub type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
-/// Boxed future: `Send` on multi-threaded targets, unbounded on wasm32,
-/// bare metal, and under the `unsync` feature, mirroring the marker traits.
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+/// Boxed future capturing no more than `'a`: `Send` on multi-threaded
+/// targets, unbounded on wasm32, bare metal, and under the `unsync` feature,
+/// mirroring the marker traits.
 ///
 /// Feature unification: `unsync` enabled by any crate in a build relaxes
 /// the alias for every consumer in that build.
 #[cfg(not(multi_thread))]
-pub type BoxFuture<T> = Pin<Box<dyn Future<Output = T>>>;
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
 
 // The default build keeps the alias `Send`; only `unsync` or a
 // single-threaded target may relax it.
 #[cfg(multi_thread)]
 const _: () = {
     const fn require_send<T: Send>() {}
-    require_send::<BoxFuture<()>>();
+    require_send::<BoxFuture<'static, ()>>();
 };
 
 #[cfg(all(test, multi_thread))]
@@ -35,6 +37,6 @@ mod tests {
 
     #[test]
     fn box_future_is_send_on_the_default_build() {
-        require_send::<BoxFuture<u32>>();
+        require_send::<BoxFuture<'static, u32>>();
     }
 }

--- a/crates/kernel/src/inflight.rs
+++ b/crates/kernel/src/inflight.rs
@@ -22,12 +22,15 @@ use crate::future::BoxFuture;
 ///
 /// The routing contract is payload-in-future: a future carries its own
 /// context back in its output, so completions need no slot identity.
-pub struct InFlight<T> {
-    slots: Vec<Option<BoxFuture<T>>>,
+///
+/// `'a` bounds the held futures' captures and is covariant: an owning walker
+/// uses `InFlight<'static, T>`, a borrowing walker its store's lifetime.
+pub struct InFlight<'a, T> {
+    slots: Vec<Option<BoxFuture<'a, T>>>,
     live: usize,
 }
 
-impl<T> InFlight<T> {
+impl<'a, T> InFlight<'a, T> {
     /// An empty set.
     pub const fn new() -> Self {
         Self {
@@ -47,7 +50,7 @@ impl<T> InFlight<T> {
     }
 
     /// Admit one future, reusing a vacated slot before growing the vector.
-    pub fn push(&mut self, future: BoxFuture<T>) {
+    pub fn push(&mut self, future: BoxFuture<'a, T>) {
         self.live = self.live.saturating_add(1);
         for slot in &mut self.slots {
             if slot.is_none() {
@@ -77,13 +80,13 @@ impl<T> InFlight<T> {
     }
 }
 
-impl<T> Default for InFlight<T> {
+impl<T> Default for InFlight<'_, T> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<T> fmt::Debug for InFlight<T> {
+impl<T> fmt::Debug for InFlight<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("InFlight")
             .field("live", &self.live)
@@ -102,7 +105,7 @@ mod tests {
     fn poll_contract_holds() {
         let waker = Waker::noop();
         let mut cx = Context::from_waker(waker);
-        let mut set: InFlight<u32> = InFlight::new();
+        let mut set: InFlight<'_, u32> = InFlight::new();
         assert!(set.is_empty());
         assert_eq!(set.poll(&mut cx), Poll::Ready(None));
 
@@ -120,5 +123,14 @@ mod tests {
         set.push(Box::pin(ready(3)));
         assert_eq!(set.slots.len(), 3);
         assert_eq!(set.poll(&mut cx), Poll::Ready(Some(3)));
+    }
+
+    #[test]
+    fn lifetime_is_covariant() {
+        fn shorten<'a, T>(set: InFlight<'static, T>) -> InFlight<'a, T> {
+            set
+        }
+        let set: InFlight<'_, u32> = shorten(InFlight::new());
+        assert!(set.is_empty());
     }
 }

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -50,7 +50,7 @@ pub use admission::Admission;
 #[cfg(feature = "chunk")]
 #[cfg_attr(docsrs, doc(cfg(feature = "chunk")))]
 pub use chunk::get_verified;
-pub use driver::{Driver, WalkPolicy};
+pub use driver::{Driver, StaticDriver, WalkPolicy};
 pub use future::BoxFuture;
 pub use inflight::InFlight;
 pub use policy::{AdmitPolicy, Fixed, FromFn, Observations, from_fn};

--- a/crates/mantaray/src/cursor.rs
+++ b/crates/mantaray/src/cursor.rs
@@ -18,7 +18,7 @@ use core::task::{Context, Poll};
 
 use futures::Stream;
 pub use nectar_kernel::Window;
-use nectar_kernel::{Admission, BoxFuture, Driver, InFlight, WalkPolicy};
+use nectar_kernel::{Admission, BoxFuture, InFlight, StaticDriver, WalkPolicy};
 use nectar_primitives::EntryRef;
 use nectar_primitives::chunk::ChunkAddress;
 
@@ -76,7 +76,7 @@ struct Visit {
 /// The shared bounded-lookahead walk: a depth-first frontier whose head is
 /// consumed in serial order while up to a window of fetches runs ahead.
 struct TrieWalk<L> {
-    driver: Driver<CursorPolicy<L>, Fetched>,
+    driver: StaticDriver<CursorPolicy<L>, Fetched>,
 }
 
 impl<L> TrieWalk<L>
@@ -99,7 +99,7 @@ where
             after,
         }));
         Self {
-            driver: Driver::new(CursorPolicy {
+            driver: StaticDriver::new(CursorPolicy {
                 store,
                 admission: Admission::new(window),
                 frontier,
@@ -132,7 +132,7 @@ struct CursorPolicy<L> {
     next_id: u64,
 }
 
-impl<L> WalkPolicy for CursorPolicy<L>
+impl<L> WalkPolicy<'static> for CursorPolicy<L>
 where
     L: NodeLoader + Clone + 'static,
 {
@@ -147,7 +147,7 @@ where
     /// fetches never exceed the window. The scan is O(window): every slot
     /// passed over or filled counts toward occupancy, which the window caps.
     #[inline]
-    fn admit(&mut self, in_flight: &mut InFlight<Fetched>) {
+    fn admit(&mut self, in_flight: &mut InFlight<'static, Fetched>) {
         let admission = self.admission;
         let mut occupancy = in_flight.len().saturating_add(self.resolved.len());
         let mut head_holds_slot = matches!(self.frontier.front(), Some(Slot::Fetching(_)));
@@ -166,7 +166,7 @@ where
             };
             let store = self.store.clone();
             let reference = pending.reference.clone();
-            let fetch: BoxFuture<Fetched> =
+            let fetch: BoxFuture<'static, Fetched> =
                 Box::pin(async move {
                     let fetched = store.load_with_addresses(&reference).await.map_err(|e| {
                         CursorError::Store {

--- a/crates/postage-issuer/src/pipeline/stamp_sink.rs
+++ b/crates/postage-issuer/src/pipeline/stamp_sink.rs
@@ -122,7 +122,7 @@ pub struct StampSink<'p, Sg, C, I: ?Sized, S> {
     pipeline: &'p StampPipeline<Sg, C>,
     issuer: &'p mut I,
     spawner: S,
-    in_flight: InFlight<StampResult>,
+    in_flight: InFlight<'static, StampResult>,
     /// Results complete at admission: allocation failures and `NotAdmitted`.
     ready: VecDeque<StampResult>,
     failed: bool,


### PR DESCRIPTION
## What

Threads a single covariant lifetime `'a` through the walk-driver core: `BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>` (non-`Send` variant off `multi_thread`, the `Send` const guard kept at `'static`), `InFlight<'a, T>`, `WalkPolicy<'a>` with `admit(&mut InFlight<'a, Self::Fetched>)`, and `Driver<'a, P, F>`.

Adds a new `lifetime_is_covariant` regression test guarding `InFlight`'s covariance, and exports `pub type StaticDriver<P, F> = Driver<'static, P, F>` from `crates/kernel/src/lib.rs` for callers that only ever need `'static`.

Retrofits the two clone-based walkers onto the new lifetime parameter (syntactic only, no bound changes): `crates/file/src/walk/engine.rs` (`StaticDriver`, `impl WalkPolicy<'static> for FileWalkPolicy`, `InFlight<'static, ..>` in `admit`/`try_admit_branch`/`try_admit_leaf`/`dispatch`, `BoxFetch = BoxFuture<'static, ..>`) and `crates/mantaray/src/cursor.rs`, plus three extra `'static` holders: `crates/file/src/split/engine.rs`, `crates/file/src/store.rs` (`BoxedStore`), and `crates/postage-issuer/src/pipeline/stamp_sink.rs` (`StampSink`).

## Why

Closes #544.

## Testing

All commands run in the flake dev shell (Rust 1.94, the CI pin) with the warm shared target dir and sccache; the `riscv64imac-unknown-none-elf` and `wasm32-unknown-unknown` no_std targets are installed in the toolchain.

Formatting: `cargo fmt --all -- --check` reports no diffs in any file this branch touches; the only diffs it surfaces are in `editor.rs` and `pipeline/mod.rs`, both untouched by this branch (identical to `origin/main`) and not gated by any workflow, so they are pre-existing and out of scope.

Lint (mirrors `lint.yml`): `cargo clippy --workspace --all-targets --locked` passes; the only output is pre-existing warn-level `doc_lazy_continuation` lints in the untouched `nectar-testing` crate. The touched feature-gated crates also pass their dedicated clippy passes: `nectar-file` with `tokio`, `rayon` and `encryption`; `nectar-postage-issuer` with `parallel` and `inline`; `nectar-kernel` with `chunk`.

All four touched crates pass their test suites, including the new covariance regression guard. The full bare-metal rv64 `no_std` gate and the non-`multi_thread` `BoxFuture` arm both compile. No wire-byte drift, no panics, no new lint suppressions, no manifest or lock changes.

## AI Assistance

Implemented with Claude (Fable), reviewed with Claude (Opus).
