### PR TITLE
file: bound put concurrency on the borrowed-store split relay

### DIFF
--- a/crates/file/src/split/engine.rs
+++ b/crates/file/src/split/engine.rs
@@ -27,7 +27,7 @@ use crate::num::{fan_out, u64_from_u32, u64_from_usize};
 
 /// Completion payload; the future carries the chunk's address back for the
 /// error context.
-type PutDone<E> = (ChunkAddress, Result<(), E>);
+pub(super) type PutDone<E> = (ChunkAddress, Result<(), E>);
 
 /// Boxed put future; the kernel alias relaxes `Send` off the multi-threaded
 /// targets.

--- a/crates/file/src/split/relay.rs
+++ b/crates/file/src/split/relay.rs
@@ -1,7 +1,11 @@
-//! Borrowed-store split entry point over an internal relay queue.
+//! Borrowed-store split entry point: an internal relay queue drained into a
+//! bounded put window over the borrowed store.
 
 use core::convert::Infallible;
 use core::future::poll_fn;
+use core::task::Poll;
+
+use alloc::boxed::Box;
 
 #[cfg(not(feature = "std"))]
 use alloc::collections::VecDeque;
@@ -14,11 +18,12 @@ use std::collections::VecDeque;
 #[cfg(feature = "std")]
 use std::sync::{Arc, Mutex, PoisonError};
 
+use nectar_kernel::InFlight;
 use nectar_marker::MaybeSync;
 use nectar_primitives::chunk::{AnyChunkSet, Chunk, Verified};
 use nectar_primitives::store::ChunkPut;
 
-use super::engine::Split;
+use super::engine::{PutDone, Split};
 use super::error::SplitError;
 use super::mode::SplitMode;
 use crate::config::PutWindow;
@@ -28,9 +33,10 @@ use crate::config::PutWindow;
 ///
 /// The borrowed-store companion to [`Split::collect`]: where `collect` owns
 /// its store, this drives the split through an internal relay and forwards
-/// each sealed chunk to `store` between poll rounds. At most one put window of
-/// chunks is retained, so the memory bound is the split's own: puts in flight
-/// stay within `window` and buffered chunks within the spine height.
+/// each sealed chunk into a bounded put window borrowing `store`, so up to
+/// `window` puts are concurrently in flight. The memory bound is the split's
+/// own: puts in flight stay within `window` and buffered chunks within the
+/// spine height. The root is delivered only after every put has settled.
 ///
 /// ```
 /// # nectar_testing::run(async {
@@ -58,6 +64,8 @@ where
 {
     let relay = Relay::<B>::default();
     let mut split: Split<Relay<B>, M, B> = Split::new(relay.clone(), window);
+    let mut puts: InFlight<'_, PutDone<T::Error>> = InFlight::new();
+    let limit = usize::from(window.get());
     let mut rest = data;
     while !rest.is_empty() {
         let taken = poll_fn(|cx| split.poll_write(cx, rest))
@@ -65,13 +73,14 @@ where
             .map_err(widen::<T::Error>)?;
         rest = rest.get(taken..).unwrap_or(&[]);
         // Forward every chunk sealed this round before more bytes enter, so
-        // the relay never holds more than the window.
-        drain(&relay, store).await?;
+        // the relay never holds more than one round's seals.
+        drain(&relay, store, &mut puts, limit).await?;
     }
     let root = poll_fn(|cx| split.poll_finish(cx))
         .await
         .map_err(widen::<T::Error>)?;
-    drain(&relay, store).await?;
+    drain(&relay, store, &mut puts, limit).await?;
+    settle(&mut puts).await?;
     Ok(root)
 }
 
@@ -89,25 +98,68 @@ fn widen<E>(error: SplitError<Infallible>) -> SplitError<E> {
     }
 }
 
-/// Forward every queued chunk to the borrowed store in seal order, capturing
-/// each address before the put consumes the chunk.
-async fn drain<T, const B: usize>(relay: &Relay<B>, store: &T) -> Result<(), SplitError<T::Error>>
+/// Forward every queued chunk into the put window in seal order, parking on a
+/// completion whenever the window is full, then start the new puts without
+/// parking.
+async fn drain<'a, T, const B: usize>(
+    relay: &Relay<B>,
+    store: &'a T,
+    puts: &mut InFlight<'a, PutDone<T::Error>>,
+    limit: usize,
+) -> Result<(), SplitError<T::Error>>
 where
     T: ChunkPut<AnyChunkSet<B>> + MaybeSync,
 {
     while let Some(chunk) = relay.pop() {
-        let address = *chunk.address();
-        store
-            .put(chunk)
-            .await
-            .map_err(|source| SplitError::Put { address, source })?;
+        while puts.len() >= limit {
+            settle_one(puts).await?;
+        }
+        puts.push(Box::pin(async move {
+            let address = *chunk.address();
+            (address, store.put(chunk).await)
+        }));
+    }
+    sweep(puts).await
+}
+
+/// Await one completion; an empty window is a no-op.
+async fn settle_one<E>(puts: &mut InFlight<'_, PutDone<E>>) -> Result<(), SplitError<E>> {
+    match poll_fn(|cx| puts.poll(cx)).await {
+        Some((address, result)) => result.map_err(|source| SplitError::Put { address, source }),
+        None => Ok(()),
+    }
+}
+
+/// Await every outstanding put, so the root covers a fully stored tree.
+async fn settle<E>(puts: &mut InFlight<'_, PutDone<E>>) -> Result<(), SplitError<E>> {
+    while !puts.is_empty() {
+        settle_one(puts).await?;
     }
     Ok(())
 }
 
+/// Fold settled puts without parking: every live put is polled once with the
+/// task's waker, so freshly admitted puts start before more bytes enter.
+async fn sweep<E>(puts: &mut InFlight<'_, PutDone<E>>) -> Result<(), SplitError<E>> {
+    poll_fn(|cx| {
+        loop {
+            match puts.poll(cx) {
+                Poll::Ready(Some((address, result))) => {
+                    if let Err(source) = result {
+                        return Poll::Ready(Err(SplitError::Put { address, source }));
+                    }
+                }
+                Poll::Ready(None) | Poll::Pending => return Poll::Ready(Ok(())),
+            }
+        }
+    })
+    .await
+}
+
 /// Shared put queue bridging a borrowed store to the owned-handle store the
 /// split clones per put: relay puts land here in seal order and [`drain`]
-/// forwards them, so the split never parks and its memory bound carries over.
+/// forwards them into the bounded window borrowing the real store, so the
+/// split never parks and its put concurrency lands on the borrowed store.
 #[derive(Clone, Default)]
 struct Relay<const B: usize> {
     #[cfg(feature = "std")]

--- a/crates/file/src/split/tests.rs
+++ b/crates/file/src/split/tests.rs
@@ -1239,6 +1239,121 @@ fn huge_stream_root_matches_the_batch_ingest() {
     assert_eq!(split.stats().bytes, size);
 }
 
+/// Relay oracles: borrowed-store roots byte-identical to the owned engine,
+/// bounded concurrent puts against the borrowed store, and fault surfacing.
+#[cfg(any(feature = "std", not(multi_thread)))]
+mod relay {
+    use std::sync::Mutex;
+
+    use nectar_primitives::chunk::{AnyChunkSet, Chunk, Verified};
+    use nectar_primitives::store::{ChunkPut, ChunkStoreError};
+    use nectar_testing::{run, yield_now};
+
+    use super::{TINY, TINY_ROOTS, TestStore, fill, pinned, sorted, stream_split};
+    use crate::config::PutWindow;
+    use crate::split::{SplitError, collect_into};
+    use crate::testutil::failing_at;
+    use crate::walk::Plain;
+
+    /// Store counting concurrent put occupancy behind a yield delay.
+    struct OverlapStore<const B: usize> {
+        /// Live puts and their peak.
+        counts: Mutex<(usize, usize)>,
+        delay: usize,
+    }
+
+    impl<const B: usize> OverlapStore<B> {
+        fn new(delay: usize) -> Self {
+            Self {
+                counts: Mutex::default(),
+                delay,
+            }
+        }
+
+        fn peak(&self) -> usize {
+            self.counts.lock().unwrap().1
+        }
+    }
+
+    impl<const B: usize> ChunkPut<AnyChunkSet<B>> for OverlapStore<B> {
+        type Error = ChunkStoreError;
+
+        async fn put(&self, _chunk: Chunk<Verified, AnyChunkSet<B>>) -> Result<(), Self::Error> {
+            {
+                let mut counts = self.counts.lock().unwrap();
+                counts.0 += 1;
+                counts.1 = counts.1.max(counts.0);
+            }
+            for _ in 0..self.delay {
+                yield_now().await;
+            }
+            self.counts.lock().unwrap().0 -= 1;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn borrowed_roots_and_chunk_sets_match_the_owned_engine() {
+        for &(size, root_hex) in TINY_ROOTS {
+            let data = fill(size);
+            let store = TestStore::<TINY>::new(1);
+            let root = run(collect_into::<_, Plain, TINY>(
+                &store,
+                PutWindow::new(4).unwrap(),
+                &data,
+            ))
+            .unwrap();
+            assert_eq!(root, pinned(root_hex), "root diverged at {size}");
+            let (_, owned, _) = stream_split::<TINY>(&data, 4, 719, 1);
+            assert_eq!(
+                sorted(store.log()),
+                sorted(owned.log()),
+                "chunk set diverged at {size}"
+            );
+        }
+    }
+
+    #[test]
+    fn borrowed_puts_overlap_within_the_window() {
+        let data = fill(40 * TINY + 63);
+        let (owned_root, _, _) = stream_split::<TINY>(&data, 4, 719, 1);
+        for window in [1u16, 2, 4] {
+            let store = OverlapStore::<TINY>::new(3);
+            let root = run(collect_into::<_, Plain, TINY>(
+                &store,
+                PutWindow::new(window).unwrap(),
+                &data,
+            ))
+            .unwrap();
+            assert_eq!(root, owned_root);
+            assert!(
+                store.peak() <= usize::from(window),
+                "puts in flight {} exceeded the window {window}",
+                store.peak()
+            );
+            if window > 1 {
+                assert!(
+                    store.peak() > 1,
+                    "the borrowed path put one chunk at a time under window {window}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_borrowed_put_failure_surfaces_typed() {
+        let data = fill(3 * TINY);
+        let store = failing_at::<_, TINY>(TestStore::<TINY>::new(0), 3);
+        let error = run(collect_into::<_, Plain, TINY>(
+            &store,
+            PutWindow::new(2).unwrap(),
+            &data,
+        ))
+        .unwrap_err();
+        assert!(matches!(error, SplitError::Put { .. }), "got {error:?}");
+    }
+}
+
 /// Shrinking stable coverage: root idempotence over write segmentation,
 /// composed from the structural-regime generators.
 mod properties {


### PR DESCRIPTION
## What

Replaces the serial-awaited `drain` on the borrowed-store split path (`crates/file/src/split/relay.rs`) with a bounded put window: relay-queued chunks are forwarded into a kernel `InFlight<'a, PutDone<T::Error>>` whose futures borrow the store directly, parking on one completion only when the window is full (`settle_one`), then sweeping every live put once with the task's waker so freshly admitted puts start before more bytes enter (`sweep`). `collect_into` now settles all outstanding puts (`settle`) before delivering the root.

The relay queue seam itself is unchanged: the engine still requires an owned `Clone + 'static` store handle, which a borrowing store cannot supply, so chunks still land in the `Relay` queue first. What changes is that `drain` no longer awaits each put serially; it drives them concurrently through the borrowed-store put window.

`crates/file/src/split/engine.rs` widens `PutDone<E>` from private to `pub(super)` so `relay.rs` can name it.

Bounds carried over from the design: puts in flight stay `<= PutWindow`, the relay buffer stays `<= one poll round's seals` (spine height), one `Box::pin` per put (matching the owned engine), no `dyn` beyond the existing kernel `BoxFuture` alias, no spawns.

## Why

The borrowed-store split path had zero put concurrency: `drain` awaited each queued chunk's `store.put` one at a time, so a borrowing store could never keep more than one put in flight regardless of `PutWindow`, unlike the owned engine's `collect`.

## Testing

Three new relay tests added in `crates/file/src/split/tests.rs`: borrowed-store roots and chunk sets match the owned engine across the tiny-root oracle set; bounded concurrent put occupancy against an `OverlapStore` that tracks live/peak puts behind a yield delay; and fault surfacing through the window. The `collect_into` doctest also runs.

## AI Assistance

Implemented with Claude (Fable/Sonnet 5), reviewed with Claude (Opus 4.8).

Closes #554
