### PR TITLE
postage-issuer: dedup sync stamp admission engine

### DIFF
--- a/crates/postage-issuer/src/pipeline/bridge.rs
+++ b/crates/postage-issuer/src/pipeline/bridge.rs
@@ -1,0 +1,97 @@
+//! Blocking-bridge machinery: the unpark waker and the sink spawner the
+//! [`Stamped`](super::Stamped) iterator drives the poll-native sink with.
+
+use alloc::sync::Arc;
+use core::task::{Context, Waker};
+use std::task::Wake;
+use std::thread::{self, Thread};
+
+use nectar_tasks::{BoxFuture, Spawn, TaskHandle};
+
+/// Waker that unparks the thread which registered it.
+struct Unpark(Thread);
+
+impl Wake for Unpark {
+    fn wake(self: Arc<Self>) {
+        self.0.unpark();
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.0.unpark();
+    }
+}
+
+/// Waker for the calling thread; a completion unparks it.
+pub(super) fn unpark_current() -> Waker {
+    Waker::from(Arc::new(Unpark(thread::current())))
+}
+
+/// Runs one sign job to completion.
+fn drive(mut task: BoxFuture<'static, ()>) {
+    let mut cx = Context::from_waker(Waker::noop());
+    let poll = task.as_mut().poll(&mut cx);
+    // Sign jobs are single-poll futures.
+    debug_assert!(poll.is_ready(), "sign job pended");
+}
+
+/// The blocking iterator's spawner: signs on the rayon pool.
+#[cfg(feature = "parallel")]
+pub(super) struct BlockingSpawn;
+
+#[cfg(feature = "parallel")]
+impl Spawn for BlockingSpawn {
+    fn spawn(&self, task: BoxFuture<'static, ()>) -> TaskHandle {
+        rayon::spawn(move || drive(task));
+        TaskHandle::new(|| {})
+    }
+}
+
+#[cfg(not(feature = "parallel"))]
+use alloc::collections::VecDeque;
+#[cfg(not(feature = "parallel"))]
+use std::sync::{Mutex, PoisonError};
+
+/// Queued sign jobs the bridge runs inline, one per pending poll, so `next`
+/// blocks for at most one signer round-trip.
+#[cfg(not(feature = "parallel"))]
+#[derive(Clone, Default)]
+pub(super) struct Jobs(Arc<Mutex<VecDeque<BoxFuture<'static, ()>>>>);
+
+#[cfg(not(feature = "parallel"))]
+impl Jobs {
+    /// Runs one queued job; reports whether one was queued.
+    pub(super) fn run_one(&self) -> bool {
+        let job = self
+            .0
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .pop_front();
+        job.map(drive).is_some()
+    }
+}
+
+/// The blocking iterator's spawner: queues each sign job on [`Jobs`] for
+/// the bridge to run inline.
+#[cfg(not(feature = "parallel"))]
+#[derive(Default)]
+pub(super) struct BlockingSpawn(Jobs);
+
+#[cfg(not(feature = "parallel"))]
+impl BlockingSpawn {
+    /// The queue this spawner feeds.
+    pub(super) fn jobs(&self) -> Jobs {
+        self.0.clone()
+    }
+}
+
+#[cfg(not(feature = "parallel"))]
+impl Spawn for BlockingSpawn {
+    fn spawn(&self, task: BoxFuture<'static, ()>) -> TaskHandle {
+        self.0
+            .0
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .push_back(task);
+        TaskHandle::new(|| {})
+    }
+}

--- a/crates/postage-issuer/src/pipeline/mod.rs
+++ b/crates/postage-issuer/src/pipeline/mod.rs
@@ -33,41 +33,44 @@ use alloc::collections::VecDeque;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::fmt;
-#[cfg(all(feature = "std", not(feature = "parallel")))]
-use std::panic::{AssertUnwindSafe, catch_unwind};
-#[cfg(feature = "parallel")]
-use std::sync::mpsc::{Receiver, Sender, channel};
+#[cfg(feature = "std")]
+use core::task::{Context, Poll};
 
 use nectar_clock::Clock;
 #[cfg(feature = "std")]
 use nectar_clock::SystemClock;
 use nectar_kernel::Window;
 use nectar_marker::{MaybeSend, MaybeSync};
-use nectar_postage::{Stamp, StampDigest};
+use nectar_postage::Stamp;
+#[cfg(not(feature = "std"))]
+use nectar_postage::StampDigest;
 use nectar_primitives::ChunkAddress;
 
 use crate::error::SigningError;
 use crate::issuer::StampIssuer;
+#[cfg(not(feature = "std"))]
 use crate::prepared::prepare_stamps;
 
+#[cfg(feature = "std")]
+mod bridge;
 mod signer;
+#[cfg(feature = "std")]
+mod stamp_sink;
 // The shared cell behind the decorator: a mutex under std, a cell wherever
 // the Send/Sync bounds relax. Hosted no-std builds without `unsync` have
 // neither, so the surface is absent there.
 #[cfg(any(feature = "std", not(multi_thread)))]
 mod stamped_put;
 #[cfg(feature = "std")]
-mod stamp_sink;
-#[cfg(feature = "std")]
 mod task;
 
-#[cfg(not(feature = "parallel"))]
+#[cfg(not(feature = "std"))]
 use signer::sign_digest;
 pub use signer::{Eip191, SignPrehash};
-#[cfg(any(feature = "std", not(multi_thread)))]
-pub use stamped_put::{IssuedBound, StampedPut, StampedPutError};
 #[cfg(feature = "std")]
 pub use stamp_sink::StampSink;
+#[cfg(any(feature = "std", not(multi_thread)))]
+pub use stamped_put::{IssuedBound, StampedPut, StampedPutError};
 
 /// A completed stamping attempt, tagged with its input address.
 #[derive(Debug)]
@@ -241,25 +244,34 @@ where
             "stamp must not be called from a rayon pool thread"
         );
 
-        Stamped {
-            pipeline: self,
-            issuer,
-            input: addresses.into_iter(),
-            input_done: false,
-            failed: false,
-            ready: VecDeque::new(),
-            not_admitted: VecDeque::new(),
-            #[cfg(feature = "parallel")]
-            channel: channel(),
-            #[cfg(feature = "parallel")]
-            in_flight: 0,
-            #[cfg(not(feature = "parallel"))]
-            prepared: VecDeque::new(),
-        }
+        Stamped::new(self, issuer, addresses.into_iter())
     }
 }
 
 /// Unordered completion stream returned by [`StampPipeline::stamp`].
+///
+/// A blocking bridge over [`StampSink`]: admission, windowing and fail-fast
+/// live in the sink; this iterator feeds input in window-sized batches,
+/// parks between completions and orders the fail-fast tail after the
+/// admitted results.
+#[cfg(feature = "std")]
+#[must_use = "iterators are lazy; nothing is admitted until polled"]
+pub struct Stamped<'p, Sg, C, I: ?Sized, A> {
+    sink: StampSink<'p, Sg, C, I, bridge::BlockingSpawn>,
+    /// Sign jobs the bridge runs inline, one per pending poll.
+    #[cfg(not(feature = "parallel"))]
+    jobs: bridge::Jobs,
+    input: A,
+    input_done: bool,
+    /// The fail-fast tail: addresses never admitted.
+    not_admitted: VecDeque<ChunkAddress>,
+}
+
+/// Unordered completion stream returned by [`StampPipeline::stamp`].
+///
+/// Without `std` there is no executor seam: admitted digests sign inline,
+/// one per `next`.
+#[cfg(not(feature = "std"))]
 #[must_use = "iterators are lazy; nothing is admitted until polled"]
 pub struct Stamped<'p, Sg, C, I: ?Sized, A> {
     pipeline: &'p StampPipeline<Sg, C>,
@@ -271,22 +283,26 @@ pub struct Stamped<'p, Sg, C, I: ?Sized, A> {
     ready: VecDeque<StampResult>,
     /// The fail-fast tail: addresses never admitted.
     not_admitted: VecDeque<ChunkAddress>,
-    /// Both ends held: the sender half keeps the channel connected while
-    /// tasks are in flight, so the drain counts instead of detecting
-    /// disconnects.
-    #[cfg(feature = "parallel")]
-    channel: (Sender<StampResult>, Receiver<StampResult>),
-    #[cfg(feature = "parallel")]
-    in_flight: usize,
     /// Admitted digests awaiting the inline signing step.
-    #[cfg(not(feature = "parallel"))]
     prepared: VecDeque<StampDigest>,
 }
 
+#[cfg(feature = "std")]
 impl<Sg, C, I: ?Sized, A> fmt::Debug for Stamped<'_, Sg, C, I, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Stamped")
-            .field("in_window", &self.in_window())
+            .field("sink", &self.sink)
+            .field("not_admitted", &self.not_admitted.len())
+            .field("input_done", &self.input_done)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<Sg, C, I: ?Sized, A> fmt::Debug for Stamped<'_, Sg, C, I, A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Stamped")
+            .field("in_window", &self.prepared.len())
             .field("ready", &self.ready.len())
             .field("not_admitted", &self.not_admitted.len())
             .field("input_done", &self.input_done)
@@ -295,20 +311,38 @@ impl<Sg, C, I: ?Sized, A> fmt::Debug for Stamped<'_, Sg, C, I, A> {
     }
 }
 
-impl<Sg, C, I: ?Sized, A> Stamped<'_, Sg, C, I, A> {
-    /// Allocated, unsigned stamps currently held in flight.
+#[cfg(feature = "std")]
+impl<'p, Sg, C, I, A> Stamped<'p, Sg, C, I, A>
+where
+    Sg: SignPrehash + MaybeSend + MaybeSync + 'static,
+    C: Clock,
+    I: StampIssuer + ?Sized,
+{
     #[cfg(feature = "parallel")]
-    const fn in_window(&self) -> usize {
-        self.in_flight
+    const fn new(pipeline: &'p StampPipeline<Sg, C>, issuer: &'p mut I, input: A) -> Self {
+        Self {
+            sink: pipeline.sink(issuer, bridge::BlockingSpawn),
+            input,
+            input_done: false,
+            not_admitted: VecDeque::new(),
+        }
     }
 
-    /// Allocated, unsigned stamps currently held in flight.
     #[cfg(not(feature = "parallel"))]
-    fn in_window(&self) -> usize {
-        self.prepared.len()
+    fn new(pipeline: &'p StampPipeline<Sg, C>, issuer: &'p mut I, input: A) -> Self {
+        let spawn = bridge::BlockingSpawn::default();
+        let jobs = spawn.jobs();
+        Self {
+            sink: pipeline.sink(issuer, spawn),
+            jobs,
+            input,
+            input_done: false,
+            not_admitted: VecDeque::new(),
+        }
     }
 }
 
+#[cfg(feature = "std")]
 impl<Sg, C, I, A> Stamped<'_, Sg, C, I, A>
 where
     Sg: SignPrehash + MaybeSend + MaybeSync + 'static,
@@ -316,13 +350,117 @@ where
     I: StampIssuer + ?Sized,
     A: Iterator<Item = ChunkAddress>,
 {
-    /// Refills the window: allocates a micro-batch with one clock read and
-    /// submits every successful allocation for signing.
+    /// Refills the sink's window: one micro-batch, one clock read.
+    fn refill(&mut self) {
+        if self.input_done || self.sink.is_failed() {
+            return;
+        }
+        let room = self.sink.room();
+        if room == 0 {
+            return;
+        }
+        let mut batch = Vec::with_capacity(room);
+        while batch.len() < room {
+            match self.input.next() {
+                Some(address) => batch.push(address),
+                None => {
+                    self.input_done = true;
+                    break;
+                }
+            }
+        }
+        if !batch.is_empty() {
+            self.sink.admit_batch(&batch);
+        }
+    }
+
+    /// Fail-fast: consumes the rest of the input as the never-admitted
+    /// tail, yielded after the admitted completions drain.
+    fn stop_admission(&mut self) {
+        self.not_admitted.extend(self.input.by_ref());
+        self.input_done = true;
+    }
+
+    /// Blocks until the sink can make progress: runs one queued sign job
+    /// inline, or parks until a completion unparks this thread.
+    fn wait(&mut self) {
+        #[cfg(not(feature = "parallel"))]
+        if self.jobs.run_one() {
+            return;
+        }
+        std::thread::park();
+    }
+}
+
+#[cfg(feature = "std")]
+impl<Sg, C, I, A> Iterator for Stamped<'_, Sg, C, I, A>
+where
+    Sg: SignPrehash + MaybeSend + MaybeSync + 'static,
+    C: Clock,
+    I: StampIssuer + ?Sized,
+    A: Iterator<Item = ChunkAddress>,
+{
+    type Item = StampResult;
+
+    fn next(&mut self) -> Option<StampResult> {
+        let waker = bridge::unpark_current();
+        let mut cx = Context::from_waker(&waker);
+        loop {
+            self.refill();
+            match self.sink.poll_next(&mut cx) {
+                Poll::Ready(Some(result)) => {
+                    if self.sink.is_failed() && !self.input_done {
+                        self.stop_admission();
+                    }
+                    return Some(result);
+                }
+                Poll::Ready(None) => {
+                    if let Some(address) = self.not_admitted.pop_front() {
+                        return Some(StampResult {
+                            address,
+                            result: Err(SigningError::NotAdmitted),
+                        });
+                    }
+                    if self.input_done {
+                        return None;
+                    }
+                }
+                Poll::Pending => self.wait(),
+            }
+        }
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<'p, Sg, C, I: ?Sized, A> Stamped<'p, Sg, C, I, A> {
+    const fn new(pipeline: &'p StampPipeline<Sg, C>, issuer: &'p mut I, input: A) -> Self {
+        Self {
+            pipeline,
+            issuer,
+            input,
+            input_done: false,
+            failed: false,
+            ready: VecDeque::new(),
+            not_admitted: VecDeque::new(),
+            prepared: VecDeque::new(),
+        }
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<Sg, C, I, A> Stamped<'_, Sg, C, I, A>
+where
+    Sg: SignPrehash + MaybeSend + MaybeSync + 'static,
+    C: Clock,
+    I: StampIssuer + ?Sized,
+    A: Iterator<Item = ChunkAddress>,
+{
+    /// Refills the window: allocates a micro-batch with one clock read.
     fn admit(&mut self) {
         if self.failed || self.input_done {
             return;
         }
-        let room = usize::from(self.pipeline.window.get()).saturating_sub(self.in_window());
+        let room = usize::from(self.pipeline.window.get()).saturating_sub(self.prepared.len());
         if room == 0 {
             return;
         }
@@ -341,7 +479,7 @@ where
         }
         for preparation in prepare_stamps(&mut *self.issuer, &batch, &self.pipeline.clock) {
             match preparation.result {
-                Ok(digest) => self.submit(digest),
+                Ok(digest) => self.prepared.push_back(digest),
                 Err(error) => self.ready.push_back(StampResult {
                     address: preparation.address,
                     result: Err(SigningError::Stamp(error)),
@@ -358,58 +496,8 @@ where
         self.input_done = true;
     }
 
-    #[cfg(feature = "parallel")]
-    fn submit(&mut self, digest: StampDigest) {
-        task::spawn_sign(
-            Arc::clone(&self.pipeline.signer),
-            digest,
-            self.channel.0.clone(),
-        );
-        self.in_flight = self.in_flight.saturating_add(1);
-    }
-
-    #[cfg(not(feature = "parallel"))]
-    fn submit(&mut self, digest: StampDigest) {
-        self.prepared.push_back(digest);
-    }
-
-    /// Blocks for the next in-flight completion, if any.
-    #[cfg(feature = "parallel")]
-    fn complete_one(&mut self) -> Option<StampResult> {
-        if self.in_flight == 0 {
-            return None;
-        }
-        match self.channel.1.recv() {
-            Ok(result) => {
-                self.in_flight = self.in_flight.saturating_sub(1);
-                Some(result)
-            }
-            // Unreachable: self.channel.0 keeps the channel connected. Treat
-            // it as a drained window rather than panicking.
-            Err(_) => {
-                self.in_flight = 0;
-                None
-            }
-        }
-    }
-
-    /// Signs the next admitted digest inline, if any.
-    #[cfg(all(feature = "std", not(feature = "parallel")))]
-    fn complete_one(&mut self) -> Option<StampResult> {
-        let digest = self.prepared.pop_front()?;
-        let address = digest.chunk_address;
-        // The signer outlives a caught panic; its interior state across that
-        // panic is the caller's contract.
-        let result = catch_unwind(AssertUnwindSafe(|| {
-            sign_digest(self.pipeline.signer.as_ref(), &digest)
-        }))
-        .unwrap_or_else(|_| Err(SigningError::Dropped));
-        Some(StampResult { address, result })
-    }
-
-    /// Signs the next admitted digest inline, if any. Without `std` there is
-    /// no unwind boundary: a signer panic propagates.
-    #[cfg(not(any(feature = "std", feature = "parallel")))]
+    /// Signs the next admitted digest inline, if any. There is no unwind
+    /// boundary: a signer panic propagates.
     fn complete_one(&mut self) -> Option<StampResult> {
         let digest = self.prepared.pop_front()?;
         let address = digest.chunk_address;
@@ -418,6 +506,7 @@ where
     }
 }
 
+#[cfg(not(feature = "std"))]
 impl<Sg, C, I, A> Iterator for Stamped<'_, Sg, C, I, A>
 where
     Sg: SignPrehash + MaybeSend + MaybeSync + 'static,
@@ -546,6 +635,26 @@ mod tests {
             } else {
                 Ok(fixed_signature())
             }
+        }
+
+        fn chain_id_sync(&self) -> Option<u64> {
+            None
+        }
+    }
+
+    /// Counts signing calls.
+    #[cfg(not(feature = "parallel"))]
+    struct CountingSigner(Arc<AtomicUsize>);
+
+    #[cfg(not(feature = "parallel"))]
+    impl SignerSync for CountingSigner {
+        fn sign_hash_sync(&self, _hash: &B256) -> Result<Signature, alloy_signer::Error> {
+            Ok(fixed_signature())
+        }
+
+        fn sign_message_sync(&self, _message: &[u8]) -> Result<Signature, alloy_signer::Error> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            Ok(fixed_signature())
         }
 
         fn chain_id_sync(&self) -> Option<u64> {
@@ -809,6 +918,25 @@ mod tests {
         }
     }
 
+    /// The inline engine signs lazily: admission allocates a window, but
+    /// each `next` performs exactly one signer round-trip.
+    #[cfg(not(feature = "parallel"))]
+    #[test]
+    fn next_signs_one_digest_per_call() {
+        let mut issuer = issuer24();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let pipeline =
+            StampPipeline::from_signer(CountingSigner(Arc::clone(&calls))).with_window(window(8));
+
+        let mut stream = pipeline.stamp(&mut issuer, addresses(20));
+        for expected in 1..=5 {
+            assert!(stream.next().is_some());
+            assert_eq!(calls.load(Ordering::SeqCst), expected);
+        }
+        drop(stream);
+        assert_eq!(calls.load(Ordering::SeqCst), 5);
+    }
+
     #[test]
     fn manual_clock_sets_timestamps() {
         let mut issuer = issuer24();
@@ -865,7 +993,7 @@ mod tests {
 
     #[test]
     fn eip191_signature_recovers_to_signer() {
-        use nectar_postage::StampIndex;
+        use nectar_postage::{StampDigest, StampIndex};
 
         let mut issuer = issuer24();
         let signer = PrivateKeySigner::random();

--- a/crates/postage-issuer/src/pipeline/mod.rs
+++ b/crates/postage-issuer/src/pipeline/mod.rs
@@ -965,6 +965,14 @@ mod tests {
 
         assert_eq!(results.len(), 64);
         assert!(max.load(Ordering::SeqCst) <= 4);
+        // A serialised window collapses the peak to 1; >= 2 proves genuine
+        // overlap without demanding the full window on few-core CI. Gated
+        // because the non-parallel build signs inline (peak 1 is correct).
+        #[cfg(feature = "parallel")]
+        assert!(
+            max.load(Ordering::SeqCst) >= 2,
+            "blocking iterator serialised the window"
+        );
         assert_eq!(issuer.stamps_issued(), Some(64));
     }
 

--- a/crates/postage-issuer/src/pipeline/stamp_sink.rs
+++ b/crates/postage-issuer/src/pipeline/stamp_sink.rs
@@ -204,8 +204,8 @@ where
                 });
                 return Poll::Ready(());
             }
-            if self.in_flight.len() < usize::from(self.pipeline.window.get()) {
-                self.admit(address);
+            if self.room() > 0 {
+                self.admit_batch(&[address]);
                 return Poll::Ready(());
             }
             match self.harvest(cx) {
@@ -228,11 +228,16 @@ where
         self.harvest(cx)
     }
 
-    /// Allocates a digest for `address` and submits it for signing; an
-    /// allocation failure queues its result instead.
-    fn admit(&mut self, address: ChunkAddress) {
-        let batch = [address];
-        for preparation in prepare_stamps(&mut *self.issuer, &batch, &self.pipeline.clock) {
+    /// Window slots currently free.
+    pub(super) fn room(&self) -> usize {
+        usize::from(self.pipeline.window.get()).saturating_sub(self.in_flight.len())
+    }
+
+    /// Allocates a digest per address with one clock read and submits each
+    /// for signing; an allocation failure queues its result instead. The
+    /// batch must not exceed [`room`](Self::room).
+    pub(super) fn admit_batch(&mut self, batch: &[ChunkAddress]) {
+        for preparation in prepare_stamps(&mut *self.issuer, batch, &self.pipeline.clock) {
             match preparation.result {
                 Ok(digest) => self.submit(digest),
                 Err(error) => self.ready.push_back(StampResult {

--- a/crates/postage-issuer/src/pipeline/stamp_sink.rs
+++ b/crates/postage-issuer/src/pipeline/stamp_sink.rs
@@ -281,6 +281,7 @@ mod tests {
     use alloc::vec::Vec;
     use alloy_primitives::{B256, Signature, U256};
     use alloy_signer::SignerSync;
+    use core::sync::atomic::{AtomicUsize, Ordering};
     use nectar_kernel::Window;
     use std::sync::mpsc;
     use std::task::Wake;
@@ -399,6 +400,30 @@ mod tests {
         }
     }
 
+    /// Tracks the highest number of concurrent signing calls.
+    struct Gauge {
+        current: Arc<AtomicUsize>,
+        max: Arc<AtomicUsize>,
+    }
+
+    impl SignerSync for Gauge {
+        fn sign_hash_sync(&self, _hash: &B256) -> Result<Signature, alloy_signer::Error> {
+            Ok(fixed_signature())
+        }
+
+        fn sign_message_sync(&self, _message: &[u8]) -> Result<Signature, alloy_signer::Error> {
+            let now = self.current.fetch_add(1, Ordering::SeqCst) + 1;
+            self.max.fetch_max(now, Ordering::SeqCst);
+            std::thread::sleep(Duration::from_millis(1));
+            self.current.fetch_sub(1, Ordering::SeqCst);
+            Ok(fixed_signature())
+        }
+
+        fn chain_id_sync(&self) -> Option<u64> {
+            None
+        }
+    }
+
     /// Runs each job on its own thread.
     struct ThreadSpawner;
 
@@ -496,6 +521,32 @@ mod tests {
             sorted(input)
         );
         assert_eq!(issuer.stamps_issued(), Some(50));
+    }
+
+    /// The threaded sink must overlap sign jobs, not serialise the window.
+    #[test]
+    fn threaded_sink_reaches_window_concurrency() {
+        let mut issuer = issuer24();
+        let max = Arc::new(AtomicUsize::new(0));
+        let gauge = Gauge {
+            current: Arc::new(AtomicUsize::new(0)),
+            max: Arc::clone(&max),
+        };
+        let pipeline = StampPipeline::from_signer(gauge).with_window(window(4));
+
+        let mut sink = pipeline.sink(&mut issuer, ThreadSpawner);
+        let results = drive(&mut sink, &addresses(64), 4);
+        drop(sink);
+
+        assert_eq!(results.len(), 64);
+        assert!(max.load(Ordering::SeqCst) <= 4);
+        // A serialised window collapses the peak to 1; >= 2 proves genuine
+        // overlap without demanding the full window on few-core CI.
+        assert!(
+            max.load(Ordering::SeqCst) >= 2,
+            "async sink serialised the window"
+        );
+        assert_eq!(issuer.stamps_issued(), Some(64));
     }
 
     #[test]

--- a/crates/postage-issuer/src/pipeline/task.rs
+++ b/crates/postage-issuer/src/pipeline/task.rs
@@ -1,16 +1,10 @@
-//! The sign job: one unit per admitted digest, shared by every engine.
+//! The sign job: one unit per admitted digest.
 
 use std::panic::{AssertUnwindSafe, catch_unwind};
-#[cfg(feature = "parallel")]
-use std::sync::Arc;
-#[cfg(feature = "parallel")]
-use std::sync::mpsc::Sender;
 
 use super::StampResult;
 use super::signer::{SignPrehash, sign_digest};
 use crate::error::SigningError;
-#[cfg(feature = "parallel")]
-use nectar_marker::{MaybeSend, MaybeSync};
 use nectar_postage::StampDigest;
 
 /// Runs one sign job to its tagged result.
@@ -27,17 +21,4 @@ where
     let result = catch_unwind(AssertUnwindSafe(|| sign_digest(signer, digest)))
         .unwrap_or_else(|_| Err(SigningError::Dropped));
     StampResult { address, result }
-}
-
-/// Spawns one sign job onto the rayon pool.
-///
-/// A dropped receiver discards the send.
-#[cfg(feature = "parallel")]
-pub(crate) fn spawn_sign<Sg>(signer: Arc<Sg>, digest: StampDigest, results: Sender<StampResult>)
-where
-    Sg: SignPrehash + MaybeSend + MaybeSync + 'static,
-{
-    rayon::spawn(move || {
-        let _ = results.send(sign_task(signer.as_ref(), &digest));
-    });
 }


### PR DESCRIPTION
## What

Rebuilds the sync `Stamped` blocking iterator (`crates/postage-issuer/src/pipeline/mod.rs`) as a thread-parking-waker bridge over `StampSink`/`InFlight`, deleting the duplicate `std::mpsc`+rayon admission engine (`task.rs::spawn_sign` removed).

`StampSink` gains a crate-internal `room()`/`admit_batch()` seam so the bridge refills the window in micro-batches, preserving the one-clock-read-per-batch contract.

The signing offload now goes through the sink's `Spawn` seam via a new `pipeline/bridge.rs`: rayon under the `parallel` feature, otherwise a bridge-drained job queue that keeps `next()` to at most one signer round-trip, guarded by a new `cfg(not(parallel))` test.

## Why

Two admission engines (the async `StampSink`/`InFlight` machinery and a separate sync `std::mpsc`+rayon path) existed side by side for the same job. Collapsing the sync iterator onto the one poll-native sink removes the duplicate engine while keeping the public sync API and its ordering/multiset guarantees unchanged.

Fail-fast tail ordering (admitted completions then `NotAdmitted`), multiset 1:1, and drop-abandons-at-most-one-window all hold across the rebuild; all 13 pre-existing pipeline tests pass unchanged in both engine shapes.

Closes #561.

## Testing

- `cargo nextest run --workspace --locked`: 1140 passed, 1 skipped.
- `cargo test --doc --workspace --locked`: pass.
- `-p nectar-postage-issuer --features parallel`: 98 passed.
- `-p nectar-postage-issuer` (default/inline): 98 passed.
- `cargo clippy --workspace --all-targets --locked`: clean (only a pre-existing warn-level `doc_lazy_continuation` in untouched `nectar-testing`).
- `clippy -p nectar-postage-issuer` on both `parallel` and inline shapes: clean, no new lint suppressions.
- `cargo check --no-default-features` (no_std): compiles.
- `cargo fmt --all -- --check`: clean.

Run under `nix develop` (rustc 1.94.0, matching CI), single commit `1fa3828`.

## AI Assistance

Implemented with Fable (Claude Sonnet 5); reviewed with Claude Opus 4.8.
