### PR TITLE
feat(manifest): fetch spilled-node segments under a bounded window

### DIFF
--- a/crates/manifest/src/store.rs
+++ b/crates/manifest/src/store.rs
@@ -12,15 +12,17 @@
 
 use alloc::boxed::Box;
 use alloc::vec::Vec;
-use core::future::Future;
+use core::future::{Future, poll_fn};
+use core::mem;
 
+use nectar_kernel::{Admission, InFlight, Window};
 use nectar_primitives::store::{BoxedError, ChunkPut, MaybeSend, MaybeSync, TrustedGet};
 use nectar_primitives::{
     Chunk, ChunkAddress, ChunkOps, ContentChunk, ContentOnlyChunkSet, EncryptionKey, Verified,
     transcrypt_in_place,
 };
 
-use crate::codec::{DecodeError, DecodedChunk, EncodeError};
+use crate::codec::{DecodeError, DecodedChunk, EncodeError, SegmentDir};
 use crate::fork::ForkTable;
 use crate::format::Format;
 use crate::node::Node;
@@ -84,9 +86,9 @@ pub trait NodeGet: TrustedGet<ContentOnlyChunkSet> {
     /// Load and decode the node at `address`, materializing a spilled node's
     /// forks from its segments so the caller always sees one logical node.
     ///
-    /// Reassembling a segmented node fetches its segment chunks and holds only
-    /// that one node's forks, bounded by the fork count, so peak retained state
-    /// stays O(depth).
+    /// Reassembling a segmented node fetches its segment chunks under a
+    /// bounded window and holds only that one node's forks, bounded by the
+    /// fork count, so peak retained state stays O(depth).
     fn get_node<F: Format>(
         &self,
         address: &ChunkAddress,
@@ -133,14 +135,8 @@ where
         DecodedChunk::Node(node) => Ok((node, Vec::new())),
         DecodedChunk::Segmented(root, dir) => {
             let mut trace = Vec::with_capacity(dir.descriptors.len());
-            let forks = Box::pin(collect_segment_forks::<S, F>(
-                store,
-                &dir,
-                key.is_some(),
-                0,
-                &mut trace,
-            ))
-            .await?;
+            let forks =
+                collect_segment_forks::<S, F>(store, &dir, key.is_some(), &mut trace).await?;
             Ok((Node::new(root, forks), trace))
         }
         // A fork child reference names a node, never a bare segment.
@@ -165,53 +161,207 @@ fn decode_fetched<F: Format>(
     )
 }
 
-/// Gather every fork of a spilled node by fetching the segments its directory
-/// routes to, descending one directory level at a time and recording each
-/// segment chunk address into `trace`.
+/// Bounds a spilled node's concurrent segment fetches.
+const SEGMENT_WINDOW: Window = Window::DEFAULT;
+
+/// A malformed segment structure.
+const fn segment_context() -> StoreError {
+    StoreError::Decode(DecodeError::SegmentContext)
+}
+
+/// A segment fetch routed back by slot index.
+type SegmentFetch = (usize, Result<FetchedChunk, StoreError>);
+
+/// Fetch progress of one segment slot.
+enum SlotState {
+    /// Not yet admitted.
+    Queued,
+    /// Admitted into the in-flight set.
+    Launched,
+    /// Fetch complete, buffered for the in-order drain; boxed to keep the
+    /// slot vector slim.
+    Landed(Box<Result<FetchedChunk, StoreError>>),
+    /// Drained.
+    Spent,
+}
+
+/// One segment descriptor in the bounded join: its fetch identity, nesting
+/// depth and successor in directory order.
+struct SegmentSlot {
+    /// The segment chunk address.
+    address: ChunkAddress,
+    /// The segment's decryption key, when the directory carries keys.
+    key: Option<EncryptionKey>,
+    /// Nesting depth of the directory holding this descriptor.
+    depth: usize,
+    /// The slot that follows in directory order; `None` ends the join.
+    next: Option<usize>,
+    /// Fetch progress.
+    state: SlotState,
+}
+
+impl SegmentSlot {
+    /// The landed outcome, once; `None` while queued, in flight or spent.
+    fn take_landed(&mut self) -> Option<Result<FetchedChunk, StoreError>> {
+        match mem::replace(&mut self.state, SlotState::Spent) {
+            SlotState::Landed(outcome) => Some(*outcome),
+            state => {
+                self.state = state;
+                None
+            }
+        }
+    }
+}
+
+/// Queue `dir`'s descriptors as slots in directory order ahead of `tail`;
+/// returns the head of the spliced run, or `tail` when the directory is
+/// empty.
+fn splice_directory(
+    slots: &mut Vec<SegmentSlot>,
+    dir: &SegmentDir,
+    depth: usize,
+    tail: Option<usize>,
+) -> Option<usize> {
+    let base = slots.len();
+    let last = base.saturating_add(dir.descriptors.len().saturating_sub(1));
+    for (index, descriptor) in dir.descriptors.iter().enumerate() {
+        let position = base.saturating_add(index);
+        let next = if position < last {
+            Some(position.saturating_add(1))
+        } else {
+            tail
+        };
+        slots.push(SegmentSlot {
+            address: descriptor.address,
+            key: descriptor.key.clone(),
+            depth,
+            next,
+            state: SlotState::Queued,
+        });
+    }
+    if dir.descriptors.is_empty() {
+        tail
+    } else {
+        Some(base)
+    }
+}
+
+/// Fill the window: admit queued fetches from `head` onward in directory
+/// order, stopping at the first denial. The head always launches, so the
+/// in-order drain never waits on an unlaunched slot.
+fn launch_segments<'a, S>(
+    store: &'a S,
+    admission: Admission,
+    slots: &mut [SegmentSlot],
+    head: usize,
+    in_flight: &mut InFlight<'a, SegmentFetch>,
+    buffered: usize,
+) where
+    S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
+{
+    let mut cursor = Some(head);
+    let mut head_served = false;
+    while let Some(index) = cursor {
+        let Some(slot) = slots.get_mut(index) else {
+            return;
+        };
+        if matches!(slot.state, SlotState::Queued) {
+            let occupancy = in_flight.len().saturating_add(buffered);
+            if !admission.admits(occupancy, head_served || index == head) {
+                return;
+            }
+            let address = slot.address;
+            slot.state = SlotState::Launched;
+            in_flight.push(Box::pin(async move {
+                (index, store.get(&address).await.map_err(StoreError::store))
+            }));
+        }
+        head_served = true;
+        cursor = slot.next;
+    }
+}
+
+/// Gather every fork of a spilled node: fetch the segments its directory
+/// routes to under [`SEGMENT_WINDOW`], folding completions strictly in
+/// directory order and recording each segment chunk address into `trace`.
+///
+/// Only the fetches overlap; the width checks, the record fold and the trace
+/// all run in directory order, so the reassembled node matches a serial
+/// gather exactly.
 async fn collect_segment_forks<S, F>(
     store: &S,
-    dir: &crate::codec::SegmentDir,
+    dir: &SegmentDir,
     encrypted: bool,
-    depth: usize,
     trace: &mut Vec<ChunkAddress>,
 ) -> Result<ForkTable<F>, StoreError>
 where
     S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
     F: Format,
 {
-    if depth >= MAX_DIR_DEPTH {
-        return Err(StoreError::Decode(DecodeError::SegmentContext));
-    }
+    let mut slots = Vec::with_capacity(dir.descriptors.len());
+    let mut head = splice_directory(&mut slots, dir, 0, None);
+    let admission = Admission::new(SEGMENT_WINDOW);
+    let mut in_flight = InFlight::new();
+    let mut buffered: usize = 0;
     let mut table = ForkTable::new();
-    for descriptor in &dir.descriptors {
-        // Descriptor width must match the arrival on both sides.
-        if descriptor.key.is_some() != encrypted {
-            return Err(StoreError::Decode(DecodeError::SegmentContext));
-        }
-        trace.push(descriptor.address);
-        let chunk = store
-            .get(&descriptor.address)
-            .await
-            .map_err(StoreError::store)?;
-        let sub = match decode_fetched::<F>(&chunk, descriptor.key.as_ref())? {
-            DecodedChunk::Leaf(sub) => sub,
-            DecodedChunk::Directory(inner) => {
-                Box::pin(collect_segment_forks::<S, F>(
-                    store,
-                    &inner,
-                    encrypted,
-                    depth.saturating_add(1),
-                    trace,
-                ))
-                .await?
+    while let Some(current) = head {
+        launch_segments(
+            store,
+            admission,
+            &mut slots,
+            current,
+            &mut in_flight,
+            buffered,
+        );
+        let landed = slots.get_mut(current).and_then(|slot| {
+            slot.take_landed().map(|outcome| {
+                (
+                    outcome,
+                    slot.address,
+                    slot.key.clone(),
+                    slot.depth,
+                    slot.next,
+                )
+            })
+        });
+        let Some((outcome, address, key, depth, next)) = landed else {
+            // The head is launched before every wait, so an empty set here is
+            // a lost completion, not a legal drain.
+            let Some((index, outcome)) = poll_fn(|cx| in_flight.poll(cx)).await else {
+                return Err(segment_context());
+            };
+            if let Some(slot) = slots.get_mut(index) {
+                slot.state = SlotState::Landed(Box::new(outcome));
+                buffered = buffered.saturating_add(1);
             }
-            DecodedChunk::Node(_) | DecodedChunk::Segmented(_, _) => {
-                return Err(StoreError::Decode(DecodeError::SegmentContext));
-            }
+            continue;
         };
-        for (first, record) in sub.into_records() {
-            if table.insert_record(first, record).is_some() {
-                return Err(StoreError::Decode(DecodeError::SegmentContext));
+        buffered = buffered.saturating_sub(1);
+        // Descriptor width must match the arrival on both sides.
+        if key.is_some() != encrypted {
+            return Err(segment_context());
+        }
+        trace.push(address);
+        let chunk = outcome?;
+        match decode_fetched::<F>(&chunk, key.as_ref())? {
+            DecodedChunk::Leaf(sub) => {
+                for (first, record) in sub.into_records() {
+                    if table.insert_record(first, record).is_some() {
+                        return Err(segment_context());
+                    }
+                }
+                head = next;
+            }
+            DecodedChunk::Directory(inner) => {
+                let child_depth = depth.saturating_add(1);
+                if child_depth >= MAX_DIR_DEPTH {
+                    return Err(segment_context());
+                }
+                head = splice_directory(&mut slots, &inner, child_depth, next);
+            }
+            // A segment chunk is a leaf or an inner directory, never a node.
+            DecodedChunk::Node(_) | DecodedChunk::Segmented(_, _) => {
+                return Err(segment_context());
             }
         }
     }
@@ -245,15 +395,24 @@ impl<T: ChunkPut> NodePut for T {}
 
 #[cfg(test)]
 mod tests {
+    use core::pin::Pin;
+    use core::sync::atomic::{AtomicUsize, Ordering};
+    use core::task::{Context, Poll};
+    use std::vec;
+
     use bytes::Bytes;
-    use nectar_primitives::store::{ContentGet, MemoryStore};
+    use nectar_primitives::store::{ChunkGet, ChunkPut, ContentGet, MemoryStore};
     use nectar_primitives::{ChunkAddress, ChunkRef, DefaultContentChunk};
     use nectar_testing::run;
 
     use crate::bounded::Prefix;
+    use crate::builder::Builder;
+    use crate::codec::{encode_dir_segment, encode_leaf_segment, encode_segmented_node};
+    use crate::count::SubtreeCount;
+    use crate::format::V1;
     use crate::meta::{KeyId, Metadata};
     use crate::node::RootExtension;
-    use crate::value::Entry;
+    use crate::value::{Entry, Key};
 
     use super::*;
 
@@ -312,5 +471,179 @@ mod tests {
         let store = ContentGet::new(MemoryStore::default());
         let err = run(store.get_node::<crate::V1>(&ChunkAddress::new([0; 32]))).unwrap_err();
         assert!(matches!(err, StoreError::Store(_)));
+    }
+
+    fn addr(byte: u8) -> ChunkAddress {
+        ChunkAddress::new([byte; 32])
+    }
+
+    fn entry(byte: u8) -> Entry {
+        ChunkRef::new(addr(byte)).into()
+    }
+
+    fn prefix(bytes: &[u8]) -> Prefix {
+        Prefix::try_from(bytes).unwrap()
+    }
+
+    /// Seal a raw payload as a content chunk and store it.
+    fn put_raw(store: &ContentGet<MemoryStore>, payload: Vec<u8>) -> ChunkAddress {
+        let content = ContentChunk::new(payload).unwrap();
+        let chunk: NodeChunk = Chunk::from_envelope(content.into()).unwrap();
+        let address = *chunk.address();
+        run(ChunkPut::put(store, chunk)).unwrap();
+        address
+    }
+
+    /// Build a spilled 256-fork manifest root, returning its address.
+    fn spilled_root(store: &ContentGet<MemoryStore>) -> ChunkAddress {
+        let mut builder = Builder::<V1>::new();
+        for byte in 0u8..=255 {
+            builder.insert(Key::from(&[byte][..]), entry(byte), None);
+        }
+        *run(builder.build(store)).unwrap().root()
+    }
+
+    /// A serial reference gather: fetch each segment in directory order,
+    /// depth first, folding records and recording the trace.
+    fn serial_gather(
+        store: &ContentGet<MemoryStore>,
+        dir: &SegmentDir,
+        table: &mut ForkTable,
+        trace: &mut Vec<ChunkAddress>,
+    ) {
+        for descriptor in &dir.descriptors {
+            trace.push(descriptor.address);
+            let chunk = store.inner().get(&descriptor.address).unwrap();
+            match Node::<V1>::decode_chunk(chunk.envelope().data()).unwrap() {
+                DecodedChunk::Leaf(sub) => {
+                    for (first, record) in sub.into_records() {
+                        assert!(table.insert_record(first, record).is_none());
+                    }
+                }
+                DecodedChunk::Directory(inner) => serial_gather(store, &inner, table, trace),
+                DecodedChunk::Node(_) | DecodedChunk::Segmented(_, _) => {
+                    panic!("a segment decodes to a leaf or a directory")
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn spilled_reassembly_matches_a_serial_gather() {
+        let store = ContentGet::new(MemoryStore::default());
+        let root = spilled_root(&store);
+
+        let chunk = store.inner().get(&root).unwrap();
+        let DecodedChunk::Segmented(root_ext, dir) =
+            Node::<V1>::decode_chunk(chunk.envelope().data()).unwrap()
+        else {
+            panic!("a 256-fork root must spill");
+        };
+        assert!(dir.descriptors.len() > 1);
+        let mut expected = ForkTable::new();
+        let mut expected_trace = Vec::new();
+        serial_gather(&store, &dir, &mut expected, &mut expected_trace);
+
+        let (node, trace) = run(materialize_traced::<_, V1>(&store, &root, None)).unwrap();
+        assert_eq!(node, Node::new(root_ext, expected));
+        assert_eq!(trace, expected_trace);
+    }
+
+    /// Completes on its second poll, so counted fetches genuinely overlap
+    /// under the single-threaded test executor.
+    struct YieldOnce(bool);
+
+    impl Future for YieldOnce {
+        type Output = ();
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+            if self.0 {
+                Poll::Ready(())
+            } else {
+                self.0 = true;
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+        }
+    }
+
+    /// A trusted store recording the peak number of concurrent `get` calls.
+    struct GatedStore {
+        inner: ContentGet<MemoryStore>,
+        inflight: AtomicUsize,
+        peak: AtomicUsize,
+    }
+
+    impl ChunkGet<ContentOnlyChunkSet> for GatedStore {
+        type Trust = Verified;
+        type Error = <ContentGet<MemoryStore> as ChunkGet<ContentOnlyChunkSet>>::Error;
+
+        async fn get(&self, address: &ChunkAddress) -> Result<FetchedChunk, Self::Error> {
+            let now = self.inflight.fetch_add(1, Ordering::Relaxed) + 1;
+            self.peak.fetch_max(now, Ordering::Relaxed);
+            YieldOnce(false).await;
+            let chunk = ChunkGet::get(&self.inner, address).await;
+            self.inflight.fetch_sub(1, Ordering::Relaxed);
+            chunk
+        }
+    }
+
+    #[test]
+    fn segment_fetches_overlap_under_the_window() {
+        let inner = ContentGet::new(MemoryStore::default());
+        let root = spilled_root(&inner);
+        let store = GatedStore {
+            inner,
+            inflight: AtomicUsize::new(0),
+            peak: AtomicUsize::new(0),
+        };
+
+        let node: Node = run(store.get_node(&root)).unwrap();
+        assert_eq!(node.forks().len(), 256);
+
+        let peak = store.peak.load(Ordering::Relaxed);
+        assert!(peak > 1, "segment fetches overlapped, peak {peak}");
+        assert!(peak <= usize::from(SEGMENT_WINDOW.get()));
+    }
+
+    #[test]
+    fn a_depth_two_directory_reassembles_in_directory_order() {
+        let store = ContentGet::new(MemoryStore::default());
+        let leaf = |bytes: &[u8]| {
+            let mut table = ForkTable::new();
+            for &byte in bytes {
+                table
+                    .insert(prefix(&[byte]), entry(byte).into(), None)
+                    .unwrap();
+            }
+            put_raw(&store, encode_leaf_segment(&table))
+        };
+        let leaf_a = leaf(&[0x10, 0x11]);
+        let leaf_b = leaf(&[0x20, 0x21]);
+        let leaf_c = leaf(&[0x30]);
+        let leaf_d = leaf(&[0x40, 0x41]);
+        let inner = SegmentDir::plain(vec![
+            (0x20, leaf_b, SubtreeCount::new(2)),
+            (0x30, leaf_c, SubtreeCount::new(1)),
+        ]);
+        let inner_dir = put_raw(&store, encode_dir_segment::<V1>(&inner));
+        let top = SegmentDir::plain(vec![
+            (0x10, leaf_a, SubtreeCount::new(2)),
+            (0x20, inner_dir, SubtreeCount::new(3)),
+            (0x40, leaf_d, SubtreeCount::new(2)),
+        ]);
+        let root = put_raw(&store, encode_segmented_node::<V1>(None, &top));
+
+        let (node, trace) = run(materialize_traced::<_, V1>(&store, &root, None)).unwrap();
+        // Depth-first, directory order: the inner directory's leaves land
+        // between its siblings.
+        assert_eq!(trace, vec![leaf_a, inner_dir, leaf_b, leaf_c, leaf_d]);
+        let mut expected = ForkTable::new();
+        for byte in [0x10, 0x11, 0x20, 0x21, 0x30, 0x40, 0x41] {
+            expected
+                .insert(prefix(&[byte]), entry(byte).into(), None)
+                .unwrap();
+        }
+        assert_eq!(node, Node::new(None, expected));
     }
 }

--- a/crates/manifest/src/store.rs
+++ b/crates/manifest/src/store.rs
@@ -87,8 +87,8 @@ pub trait NodeGet: TrustedGet<ContentOnlyChunkSet> {
     /// forks from its segments so the caller always sees one logical node.
     ///
     /// Reassembling a segmented node fetches its segment chunks under a
-    /// bounded window and holds only that one node's forks, bounded by the
-    /// fork count, so peak retained state stays O(depth).
+    /// bounded window and reassembles one node's forks, so peak retained
+    /// state stays bounded by the fork count and that window.
     fn get_node<F: Format>(
         &self,
         address: &ChunkAddress,
@@ -161,8 +161,12 @@ fn decode_fetched<F: Format>(
     )
 }
 
-/// Bounds a spilled node's concurrent segment fetches.
-const SEGMENT_WINDOW: Window = Window::DEFAULT;
+/// The concurrent segment-fetch window: the format's read-ahead saturated
+/// into a nonzero window, matching the enclosing scan and traverse walks.
+fn segment_window<F: Format>() -> Window {
+    let slots = u16::try_from(F::READ_AHEAD).unwrap_or(u16::MAX);
+    Window::new(slots).unwrap_or(Window::DEFAULT)
+}
 
 /// A malformed segment structure.
 const fn segment_context() -> StoreError {
@@ -282,8 +286,9 @@ fn launch_segments<'a, S>(
 }
 
 /// Gather every fork of a spilled node: fetch the segments its directory
-/// routes to under [`SEGMENT_WINDOW`], folding completions strictly in
-/// directory order and recording each segment chunk address into `trace`.
+/// routes to under the format's read-ahead window, folding completions
+/// strictly in directory order and recording each segment chunk address into
+/// `trace`.
 ///
 /// Only the fetches overlap; the width checks, the record fold and the trace
 /// all run in directory order, so the reassembled node matches a serial
@@ -300,7 +305,7 @@ where
 {
     let mut slots = Vec::with_capacity(dir.descriptors.len());
     let mut head = splice_directory(&mut slots, dir, 0, None);
-    let admission = Admission::new(SEGMENT_WINDOW);
+    let admission = Admission::new(segment_window::<F>());
     let mut in_flight = InFlight::new();
     let mut buffered: usize = 0;
     let mut table = ForkTable::new();
@@ -603,7 +608,7 @@ mod tests {
 
         let peak = store.peak.load(Ordering::Relaxed);
         assert!(peak > 1, "segment fetches overlapped, peak {peak}");
-        assert!(peak <= usize::from(SEGMENT_WINDOW.get()));
+        assert!(peak <= usize::from(segment_window::<V1>().get()));
     }
 
     #[test]


### PR DESCRIPTION
## What

Reworks `collect_segment_forks` in `crates/manifest/src/store.rs` from a serial recursive fetch into a bounded-concurrency, in-order join. Segment descriptors are queued as slots in directory order (a slab with DFS next-links), fetches are admitted from the head under the kernel `Admission`/`Window` predicate into a borrow-lifetime `InFlight`, and completions are buffered then drained strictly in directory order. Width checks, trace recording, record folds and depth guards all run at the in-order drain, so the reassembled node, its segment trace and every error class match the serial gather exactly. A landed inner directory splices its children ahead of its successor, preserving DFS preorder.

The fetch window is derived from the format's read-ahead (`segment_window::<F>()`), saturated into a nonzero `Window`, rather than a hardcoded constant.

## Why

Closes #557. Segment reassembly for spilled manifest nodes was strictly serial, one fetch at a time. Bounding concurrency under the existing kernel `Admission`/`Window` seam lets segment fetches overlap while keeping peak retained state bounded, matching the pattern already used by the scan and traverse walks, without changing observable behaviour (fork order, trace order, error classes).

## Testing

Verified pass.

## AI Assistance

Implementation by Claude (fable/Sonnet 5); adversarial review by Claude (opus).
