### PR TITLE
manifest: window builder and apply puts

### DIFF
--- a/crates/integration-tests/tests/manifest/builder.rs
+++ b/crates/integration-tests/tests/manifest/builder.rs
@@ -4,14 +4,20 @@
 //! buffers track the trie depth rather than the key count, and the files path
 //! splits through BMT and references the stored roots.
 
+use core::convert::Infallible;
+use core::task::Poll;
+
 use anyhow::{Context, Result, anyhow, ensure};
 use bytes::Bytes;
 use nectar_manifest::{
     BuildStats, Builder, Child, Entry, ForkPayload, ForkTable, Key, KeyId, Metadata, Node, NodeGet,
-    Prefix, RootExtension, V1, build_files,
+    Prefix, RootExtension, V1, Window, build_files,
 };
-use nectar_primitives::{ChunkAddress, ChunkOps, ChunkRef, ContentGet, MemoryStore};
-use nectar_testing::{run, split_whole};
+use nectar_primitives::store::ChunkPut;
+use nectar_primitives::{
+    Chunk, ChunkAddress, ChunkOps, ChunkRef, ContentGet, MemoryStore, Verified,
+};
+use nectar_testing::{Drive, GateStore, run, split_whole};
 
 const fn ref32(byte: u8) -> ChunkRef {
     ChunkRef::new(ChunkAddress::new([byte; 32]))
@@ -220,6 +226,81 @@ fn build_files_splits_through_bmt_and_references_the_stored_roots() -> Result<()
         }
         Ok(())
     })
+}
+
+/// A store whose puts park on a gate until released, so the put window's
+/// backpressure and overlap are observable from outside.
+struct GatedStore {
+    inner: MemoryStore,
+    gate: GateStore,
+}
+
+impl ChunkPut for GatedStore {
+    type Error = Infallible;
+
+    async fn put(&self, chunk: Chunk<Verified>) -> Result<(), Self::Error> {
+        self.gate.enter().await;
+        self.inner.put(chunk).await
+    }
+}
+
+/// A key set exercising both spill regimes: 256 single-byte keys spill the
+/// root into segments, and sixteen 80-wide subtrees spill their nodes.
+fn insert_spilling_keys(builder: &mut Builder) {
+    for byte in 0..=255u8 {
+        builder.insert(Key::from(&[byte][..]), Entry::from(ref32(byte)), None);
+    }
+    for hi in 0..16u8 {
+        for lo in 0..80u8 {
+            builder.insert(Key::from(&[hi, lo][..]), Entry::from(ref32(lo)), None);
+        }
+    }
+}
+
+#[test]
+fn spill_puts_overlap_up_to_the_put_window() -> Result<()> {
+    let slots = 4u16;
+    let store = GatedStore {
+        inner: MemoryStore::default(),
+        gate: GateStore::new(),
+    };
+    let mut builder: Builder = Builder::new();
+    insert_spilling_keys(&mut builder);
+    let builder = builder.with_put_window(Window::new(slots).context("window")?);
+
+    let mut build = Drive::new(builder.build(&store));
+    ensure!(build.poll().is_pending(), "puts park on the gate");
+    // The build stalls only once the window is full: exactly `slots` puts
+    // are parked, so independent spills genuinely overlap.
+    ensure!(store.gate.waiting() == usize::from(slots), "window fills");
+
+    let mut delivered = None;
+    for _ in 0..10_000 {
+        store.gate.release(1);
+        if let Poll::Ready(out) = build.poll() {
+            delivered = Some(out?);
+            break;
+        }
+    }
+    let built = delivered.context("build did not complete")?;
+    ensure!(
+        store.gate.peak() <= usize::from(slots),
+        "peak within window"
+    );
+    // Every put settled before the root returned.
+    ensure!(store.gate.waiting() == 0, "drained");
+    ensure!(store.inner.get(built.root()).is_some(), "root stored");
+
+    // Overlap never moves a byte: the windowed root equals a serial build's.
+    let serial_store = MemoryStore::default();
+    let mut serial: Builder = Builder::new();
+    insert_spilling_keys(&mut serial);
+    let serial = serial.with_put_window(Window::new(1).context("window")?);
+    ensure!(
+        built.root() == run(serial.build(&serial_store))?.root(),
+        "windowed root equals a serial build's",
+    );
+    Ok(())
 }
 
 #[test]

--- a/crates/manifest/src/apply.rs
+++ b/crates/manifest/src/apply.rs
@@ -15,18 +15,21 @@
 //! merged keys agree bit for bit (invariant I6 under updates).
 //!
 //! Peak retained state is O(depth + changeset frontier): the descent holds one
-//! node per level on the current path, never a whole subtree.
+//! node per level on the current path, never a whole subtree. Rewritten-node
+//! addresses are content-derived at seal time, so their puts overlap under a
+//! bounded window and all settle before the new root returns.
 
 use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 
 use bytes::Bytes;
+use nectar_kernel::Window;
 use nectar_primitives::ChunkAddress;
 use nectar_primitives::store::{ChunkPut, MaybeSync};
 
 use crate::bounded::Prefix;
-use crate::builder::{BuildError, BuildStats, Item, build_table, emit_node, resolve};
+use crate::builder::{BuildError, BuildStats, Item, PutSink, build_table, emit_node, resolve};
 use crate::count::SubtreeCount;
 use crate::error::{ForkPrefixEmpty, PrefixTooLong};
 use crate::fork::{Child, ForkPayload, ForkRecord, ForkTable};
@@ -178,8 +181,9 @@ where
         .collect();
 
     let mut stats = BuildStats::default();
+    let mut puts = PutSink::new(store, Window::DEFAULT);
     let forks = Box::pin(apply_forks(
-        store,
+        &mut puts,
         node.forks().clone(),
         0,
         &changes,
@@ -187,7 +191,9 @@ where
     ))
     .await?;
     let new_node = Node::new(root_ext, forks);
-    Ok(emit_node(store, &new_node, &mut stats).await?)
+    let address = emit_node(&mut puts, &new_node, &mut stats).await?;
+    puts.drain().await?;
+    Ok(address)
 }
 
 /// One staged update paired with its key, borrowed for the length of the apply.
@@ -213,7 +219,7 @@ impl<F: Format> Change<'_, F> {
 /// Every change shares the `consumed`-byte prefix that reaches this table, so a
 /// change group is the contiguous run sharing the byte at `consumed`.
 async fn apply_forks<'c, S, F>(
-    store: &S,
+    puts: &mut PutSink<'_, S>,
     mut table: ForkTable<F>,
     consumed: usize,
     changes: &[Change<'c, F>],
@@ -237,7 +243,7 @@ where
         let group = changes.get(i..j).ok_or(ApplyError::Internal)?;
         let existing = table.remove(byte);
         if let Some(record) =
-            Box::pin(reconcile(store, consumed, byte, existing, group, stats)).await?
+            Box::pin(reconcile(puts, consumed, byte, existing, group, stats)).await?
         {
             table.insert_record(byte, record);
         }
@@ -249,7 +255,7 @@ where
 /// Reconcile the fork indexed under `byte` with its change group, returning the
 /// rewritten fork or `None` when it collapses away.
 async fn reconcile<'c, S, F>(
-    store: &S,
+    puts: &mut PutSink<'_, S>,
     consumed: usize,
     byte: u8,
     existing: Option<ForkRecord<F>>,
@@ -268,7 +274,7 @@ where
             if items.is_empty() {
                 return Ok(None);
             }
-            let mut fresh = build_table(store, &items, consumed, stats).await?;
+            let mut fresh = build_table(puts, &items, consumed, stats).await?;
             return Ok(fresh.remove(byte));
         }
     };
@@ -291,19 +297,16 @@ where
     }
 
     if cut < edge.len() {
-        split(store, consumed, &edge, cut, existing, group, stats).await
+        split(puts, consumed, &edge, cut, existing, group, stats).await
     } else {
-        Box::pin(descend(
-            store, consumed, &edge, plen, existing, group, stats,
-        ))
-        .await
+        Box::pin(descend(puts, consumed, &edge, plen, existing, group, stats)).await
     }
 }
 
 /// The existing edge stays intact: update the terminal value and fold the
 /// deeper updates into the child.
 async fn descend<'c, S, F>(
-    store: &S,
+    puts: &mut PutSink<'_, S>,
     consumed: usize,
     edge: &[u8],
     plen: usize,
@@ -345,7 +348,7 @@ where
         // build would have run on into the edge; nothing else here can.
         if new_entry.is_none()
             && let Some((merged, absorbed)) =
-                absorb(store, consumed, edge, existing.child()).await?
+                absorb(puts.store(), consumed, edge, existing.child()).await?
         {
             let child = Counted {
                 child: absorbed.child().cloned(),
@@ -365,7 +368,7 @@ where
             child: existing.child().cloned(),
             count: existing.child_count(),
         };
-        return finish(store, consumed, edge, new_entry, new_meta, child, stats).await;
+        return finish(puts, consumed, edge, new_entry, new_meta, child, stats).await;
     }
 
     let child_table = match existing.child() {
@@ -375,7 +378,7 @@ where
                 // A deletion of an absent deeper key: the fork is unchanged bar
                 // its terminal value.
                 return finish(
-                    store,
+                    puts,
                     consumed,
                     edge,
                     new_entry,
@@ -385,15 +388,15 @@ where
                 )
                 .await;
             }
-            build_table(store, &items, plen, stats).await?
+            build_table(puts, &items, plen, stats).await?
         }
         Some(Child::Embedded(inner)) => {
-            Box::pin(apply_forks(store, inner.clone(), plen, &deeper, stats)).await?
+            Box::pin(apply_forks(puts, inner.clone(), plen, &deeper, stats)).await?
         }
         Some(Child::Ref32(reference)) => {
-            let node = store.get_node::<F>(reference.address()).await?;
+            let node = puts.store().get_node::<F>(reference.address()).await?;
             Box::pin(apply_forks(
-                store,
+                puts,
                 node.forks().clone(),
                 plen,
                 &deeper,
@@ -404,7 +407,7 @@ where
         Some(Child::Ref64(_)) => return Err(ApplyError::EncryptedChild),
     };
     assemble(
-        store,
+        puts,
         consumed,
         edge,
         new_entry,
@@ -441,7 +444,7 @@ impl<F: Format> Counted<F> {
 /// The single-fork merge runs before the child is resolved, so a lone branch
 /// re-inlines whatever its size would spill to.
 async fn assemble<S, F>(
-    store: &S,
+    puts: &mut PutSink<'_, S>,
     at: usize,
     edge: &[u8],
     entry: Option<Entry<F>>,
@@ -454,7 +457,7 @@ where
     F: Format,
 {
     if table.is_empty() {
-        return finish(store, at, edge, entry, meta, Counted::none(), stats).await;
+        return finish(puts, at, edge, entry, meta, Counted::none(), stats).await;
     }
     // Edge-compaction: a child-only fork over a single-fork child merges into
     // one edge, exactly as a from-scratch build would compact the shared run.
@@ -462,20 +465,20 @@ where
         && table.len() == 1
         && let Some((first, record)) = table.iter().next()
     {
-        return compact(store, at, edge, first, record, stats).await;
+        return compact(puts, at, edge, first, record, stats).await;
     }
-    let resolved = resolve(store, table, stats).await?;
+    let resolved = resolve(puts, table, stats).await?;
     let child = Counted {
         count: resolved.child_count(),
         child: Some(resolved.into_child()),
     };
-    finish(store, at, edge, entry, meta, child, stats).await
+    finish(puts, at, edge, entry, meta, child, stats).await
 }
 
 /// An insertion diverges within the edge: branch at the divergence, re-rooting
 /// the existing subtree verbatim under the edge remainder.
 async fn split<'c, S, F>(
-    store: &S,
+    puts: &mut PutSink<'_, S>,
     consumed: usize,
     edge: &[u8],
     cut: usize,
@@ -518,9 +521,9 @@ where
     if let Some(record) = reroot(remainder, existing)? {
         branch.insert_record(first, record);
     }
-    let table = Box::pin(apply_forks(store, branch, boundary, &remaining, stats)).await?;
+    let table = Box::pin(apply_forks(puts, branch, boundary, &remaining, stats)).await?;
     assemble(
-        store,
+        puts,
         consumed,
         new_edge,
         split_entry,
@@ -553,7 +556,7 @@ fn reroot<F: Format>(
 /// so a deletion that strips a fork's terminal value re-inlines its lone
 /// remaining branch exactly as a from-scratch build would.
 async fn finish<S, F>(
-    store: &S,
+    puts: &mut PutSink<'_, S>,
     at: usize,
     edge: &[u8],
     entry: Option<Entry<F>>,
@@ -570,7 +573,7 @@ where
         && table.len() == 1
         && let Some((first, record)) = table.iter().next()
     {
-        return compact(store, at, edge, first, record, stats).await;
+        return compact(puts, at, edge, first, record, stats).await;
     }
     settle(edge, entry, meta, child)
 }
@@ -599,7 +602,7 @@ fn settle<F: Format>(
 /// absolute offsets a build places, so the merged run re-segments into a
 /// canonical chain and the record's own boundary stays where it was.
 async fn compact<S, F>(
-    store: &S,
+    puts: &mut PutSink<'_, S>,
     at: usize,
     edge: &[u8],
     first: u8,
@@ -614,7 +617,7 @@ where
     merged.push(first);
     merged.extend_from_slice(record.tail().as_bytes());
     chain(
-        store,
+        puts,
         at,
         &merged,
         record.payload().clone(),
@@ -684,7 +687,7 @@ where
 /// innermost fork carries the payload and its metadata; every wrapping fork
 /// carries only the continuation.
 async fn chain<S, F>(
-    store: &S,
+    puts: &mut PutSink<'_, S>,
     at: usize,
     prefix: &[u8],
     payload: ForkPayload<F>,
@@ -704,7 +707,7 @@ where
     let rest = prefix.get(allowed..).ok_or(ApplyError::Internal)?;
     let &first = rest.first().ok_or(ApplyError::Internal)?;
     let inner = Box::pin(chain(
-        store,
+        puts,
         at.saturating_add(allowed),
         rest,
         payload,
@@ -718,7 +721,7 @@ where
     table.insert_record(first, inner);
     // The wrapping child-only fork routes the same subtree; its reference count
     // is recomputed from the resolved table, not the terminal payload's.
-    let resolved = resolve(store, table, stats).await?;
+    let resolved = resolve(puts, table, stats).await?;
     let count = resolved.child_count();
     let child = resolved.into_child();
     make_fork(head, ForkPayload::Child(child), None, count)

--- a/crates/manifest/src/builder.rs
+++ b/crates/manifest/src/builder.rs
@@ -2,18 +2,23 @@
 //!
 //! The trie is assembled bottom-up over an explicit stack of open nodes. Each
 //! finished node is embedded into its parent when the packing predicate allows,
-//! otherwise sealed and spilled to the store the moment it is complete, so the
-//! peak retained node buffer count is the stack depth, never the key count. The
-//! key set enters through a sorted map, so the published tree is a pure function
-//! of the keys, identical whatever order the caller streamed them in.
+//! otherwise sealed and spilled the moment it is complete, so the peak retained
+//! node buffer count is the stack depth, never the key count. Spilled node and
+//! segment addresses are content-derived at seal time, so their puts are
+//! order-free: they overlap under a bounded window and all settle before the
+//! root is returned. The key set enters through a sorted map that the build
+//! consumes without a copy, so the published tree is a pure function of the
+//! keys, identical whatever order the caller streamed them in.
 
 use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 use core::convert::Infallible;
+use core::future::poll_fn;
 
 use bytes::Bytes;
 use nectar_file::{Plain, PutWindow, SplitError, collect_into};
+use nectar_kernel::{Admission, InFlight, Window};
 use nectar_primitives::store::{BoxedError, ChunkPut, MaybeSend, MaybeSync};
 use nectar_primitives::{
     Chunk, ChunkAddress, ChunkRef, ContentChunk, DEFAULT_BODY_SIZE, PrimitivesError,
@@ -31,7 +36,7 @@ use crate::format::{Format, V1};
 use crate::meta::Metadata;
 use crate::node::{Node, RootExtension};
 use crate::packing::{Domain, cut_allowance, embed, spill};
-use crate::store::{NodePut, StoreError};
+use crate::store::{NodeChunk, StoreError};
 use crate::value::{Entry, Key};
 
 /// A build or publish failure.
@@ -135,6 +140,7 @@ pub struct Builder<F: Format = V1> {
     keys: BTreeMap<Bytes, (Entry<F>, Option<Metadata<F>>)>,
     root_entry: Option<Entry<F>>,
     root_metadata: Option<Metadata<F>>,
+    put_window: Window,
 }
 
 impl<F: Format> Default for Builder<F> {
@@ -143,6 +149,7 @@ impl<F: Format> Default for Builder<F> {
             keys: BTreeMap::new(),
             root_entry: None,
             root_metadata: None,
+            put_window: Window::DEFAULT,
         }
     }
 }
@@ -180,29 +187,103 @@ impl<F: Format> Builder<F> {
         self
     }
 
+    /// Replace the put window: the cap on node and segment puts in flight
+    /// while [`build`](Self::build) publishes.
+    #[must_use]
+    pub const fn with_put_window(mut self, window: Window) -> Self {
+        self.put_window = window;
+        self
+    }
+
     /// Assemble and publish the manifest, returning the root address.
     ///
-    /// Peak retained node buffers stay at the trie's node depth: a finished
-    /// subtree is embedded or spilled to `store` before the next sibling opens.
-    pub async fn build<S>(&self, store: &S) -> Result<Built, BuildError>
+    /// Consumes the builder, so the key set is never copied. Peak retained
+    /// node buffers stay at the trie's node depth: a finished subtree is
+    /// embedded or spilled before the next sibling opens. Spill puts overlap
+    /// up to the put window and all settle before the root is returned;
+    /// addresses are content-derived, so the published bytes equal a serial
+    /// build's.
+    pub async fn build<S>(self, store: &S) -> Result<Built, BuildError>
     where
         S: ChunkPut + MaybeSync,
     {
-        let items: Vec<Item<F>> = self
-            .keys
-            .iter()
-            .map(|(key, (entry, meta))| Item {
-                key: key.clone(),
-                entry: entry.clone(),
-                meta: meta.clone(),
-            })
+        let Self {
+            keys,
+            root_entry,
+            root_metadata,
+            put_window,
+        } = self;
+        let items: Vec<Item<F>> = keys
+            .into_iter()
+            .map(|(key, (entry, meta))| Item { key, entry, meta })
             .collect();
-        let root_ext = RootExtension::new(self.root_entry.clone(), self.root_metadata.clone());
+        let root_ext = RootExtension::new(root_entry, root_metadata);
         let mut stats = BuildStats::default();
-        let table = build_table(store, &items, 0, &mut stats).await?;
+        let mut puts = PutSink::new(store, put_window);
+        let table = build_table(&mut puts, &items, 0, &mut stats).await?;
         let node = Node::new(root_ext, table);
-        let root = emit_node(store, &node, &mut stats).await?;
+        let root = emit_node(&mut puts, &node, &mut stats).await?;
+        puts.drain().await?;
         Ok(Built { root, stats })
+    }
+}
+
+/// Bounded put window over a borrowed store.
+///
+/// A chunk's address is content-derived at seal time, so assembly proceeds
+/// the moment a put dispatches; completions settle when the window is full
+/// and at the final drain, surfacing the first failure.
+pub(crate) struct PutSink<'a, S> {
+    store: &'a S,
+    admission: Admission,
+    in_flight: InFlight<'a, Result<(), BuildError>>,
+}
+
+impl<'a, S> PutSink<'a, S>
+where
+    S: ChunkPut + MaybeSync,
+{
+    /// A sink over `store` holding at most `window` puts in flight.
+    pub(crate) const fn new(store: &'a S, window: Window) -> Self {
+        Self {
+            store,
+            admission: Admission::new(window),
+            in_flight: InFlight::new(),
+        }
+    }
+
+    /// The borrowed store, for reads beside the put window.
+    pub(crate) const fn store(&self) -> &'a S {
+        self.store
+    }
+
+    /// Dispatch one sealed chunk, settling completions until the window
+    /// admits; a settled put's failure surfaces here.
+    pub(crate) async fn put(&mut self, chunk: NodeChunk) -> Result<(), BuildError> {
+        // Puts are order-free, so there is no serial head to reserve a slot
+        // for: the whole window admits.
+        while !self.admission.admits(self.in_flight.len(), true) {
+            match poll_fn(|cx| self.in_flight.poll(cx)).await {
+                Some(done) => done?,
+                None => break,
+            }
+        }
+        let store = self.store;
+        self.in_flight.push(Box::pin(async move {
+            store
+                .put(chunk)
+                .await
+                .map_err(|error| BuildError::Store(StoreError::store(error)))
+        }));
+        Ok(())
+    }
+
+    /// Settle every outstanding put.
+    pub(crate) async fn drain(&mut self) -> Result<(), BuildError> {
+        while let Some(done) = poll_fn(|cx| self.in_flight.poll(cx)).await {
+            done?;
+        }
+        Ok(())
     }
 }
 
@@ -212,7 +293,7 @@ impl<F: Format> Builder<F> {
 /// The returned table is the caller's to wrap: a root wears its extension and
 /// always spills, a subtree defers its own embed decision to [`resolve`].
 pub(crate) async fn build_table<S, F>(
-    store: &S,
+    puts: &mut PutSink<'_, S>,
     items: &[Item<F>],
     consumed: usize,
     stats: &mut BuildStats,
@@ -242,7 +323,7 @@ where
                 if stack.is_empty() {
                     return Ok(frame.table);
                 }
-                returned = Some(resolve(store, frame.table, stats).await?);
+                returned = Some(resolve(puts, frame.table, stats).await?);
             }
         }
     }
@@ -452,7 +533,7 @@ fn common_prefix_len(a: &Bytes, b: &Bytes, consumed: usize, cap: usize) -> usize
 /// The embed decision is child-local: it reads the subtree's flat length alone,
 /// so it is stable under re-rooting and history-independent.
 pub(crate) async fn resolve<S, F>(
-    store: &S,
+    puts: &mut PutSink<'_, S>,
     table: ForkTable<F>,
     stats: &mut BuildStats,
 ) -> Result<Resolved<F>, BuildError>
@@ -471,7 +552,7 @@ where
     // before the table is consumed; the parent stamps it on the reference.
     let count = Some(SubtreeCount::new(table_count(&table)));
     let node = Node::new(None, table);
-    let address = emit_node(store, &node, stats).await?;
+    let address = emit_node(puts, &node, stats).await?;
     Ok(Resolved::Reference(ChunkRef::new(address), count))
 }
 
@@ -484,7 +565,7 @@ where
 /// `OverBudget` guard on [`Node::encode`] therefore stays unreachable on this
 /// path, kept only as a fail-closed backstop for a future parameter drift.
 pub(crate) async fn emit_node<S, F>(
-    store: &S,
+    puts: &mut PutSink<'_, S>,
     node: &Node<F>,
     stats: &mut BuildStats,
 ) -> Result<ChunkAddress, BuildError>
@@ -493,15 +574,15 @@ where
     F: Format,
 {
     if body_len(node) <= F::BUDGET {
-        return put_counted(store, node, stats).await;
+        return put_counted(puts, node, stats).await;
     }
-    spill_node(store, node, stats).await
+    spill_node(puts, node, stats).await
 }
 
 /// Spill an over-budget node into a `<=` depth-two segment directory, storing
 /// each leaf and directory segment and returning the segmented node's address.
 async fn spill_node<S, F>(
-    store: &S,
+    puts: &mut PutSink<'_, S>,
     node: &Node<F>,
     stats: &mut BuildStats,
 ) -> Result<ChunkAddress, BuildError>
@@ -535,7 +616,7 @@ where
         // its covered forks' counts, so a reader descends by rank without a
         // fetch.
         let seg_count = descriptor_count(slice.iter().map(|(_, record)| fork_count(record)));
-        let address = put_payload(store, encode_leaf_segment(&leaf), stats).await?;
+        let address = put_payload(puts, encode_leaf_segment(&leaf), stats).await?;
         leaf_descs.push((first_key, address, seg_count));
     }
 
@@ -549,7 +630,7 @@ where
             let &(first_key, _, _) = group.first().ok_or(BuildError::Internal)?;
             let seg_count = descriptor_count(group.iter().map(|(_, _, count)| count.get()));
             let address = put_payload(
-                store,
+                puts,
                 encode_dir_segment::<F>(&SegmentDir::plain(group.to_vec())),
                 stats,
             )
@@ -559,7 +640,7 @@ where
         SegmentDir::plain(dir_descs)
     };
 
-    put_payload(store, encode_segmented_node::<F>(node.root(), &top), stats).await
+    put_payload(puts, encode_segmented_node::<F>(node.root(), &top), stats).await
 }
 
 /// The subtree count a segment descriptor routes: the sum of the covered
@@ -568,9 +649,9 @@ fn descriptor_count(counts: impl Iterator<Item = u64>) -> SubtreeCount {
     SubtreeCount::new(counts.fold(0, u64::saturating_add))
 }
 
-/// Seal a ready payload into a content chunk, store it, and count it.
+/// Seal a ready payload into a content chunk, dispatch its put, and count it.
 async fn put_payload<S>(
-    store: &S,
+    puts: &mut PutSink<'_, S>,
     payload: Vec<u8>,
     stats: &mut BuildStats,
 ) -> Result<ChunkAddress, BuildError>
@@ -580,14 +661,14 @@ where
     let content = ContentChunk::new(payload).map_err(BuildError::Seal)?;
     let chunk = Chunk::from_envelope(content.into()).map_err(BuildError::Seal)?;
     let address = *chunk.address();
-    store.put(chunk).await.map_err(BuildError::backend)?;
+    puts.put(chunk).await?;
     stats.nodes_written = stats.nodes_written.saturating_add(1);
     Ok(address)
 }
 
-/// Spill one node to the store, counting it.
+/// Seal one node, dispatch its put, and count it.
 async fn put_counted<S, F>(
-    store: &S,
+    puts: &mut PutSink<'_, S>,
     node: &Node<F>,
     stats: &mut BuildStats,
 ) -> Result<ChunkAddress, BuildError>
@@ -595,7 +676,9 @@ where
     S: ChunkPut + MaybeSync,
     F: Format,
 {
-    let address = store.put_node(node).await?;
+    let chunk = node.to_chunk()?;
+    let address = *chunk.address();
+    puts.put(chunk).await?;
     stats.nodes_written = stats.nodes_written.saturating_add(1);
     Ok(address)
 }

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -134,6 +134,7 @@ pub use folder::{DirEntry, Listing, Served, Website};
 pub use fork::{Child, ForkPayload, ForkRecord, ForkTable};
 pub use format::{Format, V1, V1Read};
 pub use meta::{CustomKey, KeyId, Metadata, MetadataKey};
+pub use nectar_kernel::Window;
 pub use node::{Node, RootExtension};
 pub use packing::{Directory, Domain, SegmentKind, cut, embed, h64, segment, spill};
 pub use reader::{Reader, ReaderError};


### PR DESCRIPTION
## What

Adds a bounded put window to `nectar-manifest`'s build and apply paths.

`builder.rs` gains a `pub(crate)` `PutSink<'a, S>`, built from kernel `Admission` + `InFlight<'a>` + `Window`, that dispatches sealed chunk puts into an overlapping window instead of awaiting each inline, with a final drain before the root returns.
`emit_node`, `resolve`, `spill_node`, `put_payload`, and `put_counted` seal chunks (content-derived addresses) and dispatch through the sink.
`Builder::build(self, store)` now consumes the sorted key map so its `BTreeMap` entries move into the descent array without a clone, and `Builder` gains `with_put_window(Window)` (defaulting to `Window::DEFAULT`), mirroring the mantaray editor's commit window.
`nectar_kernel::Window` is re-exported from the manifest crate root.

`apply.rs`, the shared trio's other caller, is carried onto the same seam: `PutSink` is threaded through `apply_forks`/`reconcile`/`split`/`descend`, reads go via `puts.store()`, and the apply drains before its new root returns.

Closes #555

## Why

Node and segment puts are order-free once addresses are content-derived at seal time, so awaiting each one inline serialises work that has no ordering dependency. A bounded window lets independent spills overlap while keeping the retained put count capped, without introducing dyn dispatch or spawned tasks.

## Testing

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --locked`: clean (only pre-existing `doc_lazy_continuation` warnings in untouched `crates/testing`).
- New integration test `spill_puts_overlap_up_to_the_put_window` (`crates/integration-tests/tests/manifest/builder.rs`) drives the build against a gated store to observe that puts genuinely overlap up to the configured window, that the window caps peak concurrency, that every put settles before the root returns, and that the windowed root equals a serial build's.
- Existing `apply_equals_rebuild` oracle re-run and passing.

Independent adversarial review found no correctness, wire-byte, panic, lint-suppression, or house-rule defects: addresses are content-derived locally before dispatch so bytes are order-independent, drain and full-window polls propagate the first put failure with no silent drops, and apply reads only pre-existing old-tree nodes so there is no read-after-write hazard against in-flight puts.

## AI Assistance

Implemented by fable, reviewed by opus.
