### PR TITLE
tasks: extract shared pool-to-poll handoff and block_on primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2549,7 +2549,6 @@ dependencies = [
  "arbitrary",
  "bytes",
  "futures",
- "futures-channel",
  "futures-util",
  "nectar-clock",
  "nectar-kernel",

--- a/crates/file/Cargo.toml
+++ b/crates/file/Cargo.toml
@@ -20,7 +20,6 @@ workspace = true
 [dependencies]
 arbitrary = { workspace = true, optional = true }
 bytes = { workspace = true, optional = true }
-futures-channel = { workspace = true, optional = true }
 futures-util = { workspace = true, optional = true }
 nectar-clock = { workspace = true, optional = true }
 nectar-kernel = { workspace = true }
@@ -66,6 +65,7 @@ std = [
 	"futures-util?/std",
 	"nectar-clock/std",
 	"nectar-primitives?/std",
+	"nectar-tasks?/std",
 	"primitives",
 	"thiserror/std",
 ]
@@ -76,7 +76,7 @@ tokio = [ "dep:nectar-tasks", "dep:tokio", "nectar-tasks/tokio", "std" ]
 # Pool leaf hashing: the split hash window and the read-at ingest. Implies
 # `std`; rayon on wasm32 or under `unsync` is a compile error, never a
 # silent fallback.
-rayon = [ "dep:futures-channel", "dep:rayon", "std" ]
+rayon = [ "dep:nectar-tasks", "dep:rayon", "std" ]
 
 # The shared malformed-walk oracle, the structural-regime body generators
 # and the stable seed replays. Never reachable from `default` or any

--- a/crates/file/src/split/engine.rs
+++ b/crates/file/src/split/engine.rs
@@ -14,11 +14,13 @@ use nectar_primitives::DEFAULT_BODY_SIZE;
 use nectar_primitives::bmt::SPAN_SIZE;
 use nectar_primitives::chunk::{AnyChunkSet, Chunk, ChunkAddress, Verified};
 use nectar_primitives::store::ChunkPut;
+#[cfg(feature = "rayon")]
+use nectar_tasks::Handoff;
 
 use super::SplitStats;
 use super::error::{SealError, SplitError};
 #[cfg(feature = "rayon")]
-use super::handoff::{self, Handoff};
+use super::handoff;
 use super::mode::{Sealed, SplitMode};
 #[cfg(feature = "rayon")]
 use crate::config::HashWindow;

--- a/crates/file/src/split/handoff.rs
+++ b/crates/file/src/split/handoff.rs
@@ -1,114 +1,33 @@
 //! Bounded handoff from the thread pool back to the polling future.
 
-use core::future::Future;
-use core::pin::Pin;
-use core::task::{Context, Poll};
-
-use std::panic::{AssertUnwindSafe, catch_unwind};
-
-use futures_channel::oneshot;
-
-/// Receiving half of one submitted job; polled by the split engine.
-pub(super) struct Handoff<T> {
-    rx: oneshot::Receiver<T>,
-}
-
-impl<T> Handoff<T> {
-    /// Ready with the reply, or `None` when the job finished without one:
-    /// the job panicked, or the pool dropped it.
-    pub(super) fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
-        Pin::new(&mut self.rx).poll(cx).map(Result::ok)
-    }
-}
+use nectar_tasks::{Handoff, handoff};
 
 /// Queue `job` on the pool, returning the handoff its reply arrives on.
 ///
 /// Submission only enqueues, so neither building nor polling the caller's
-/// future ever blocks on the pool. A panicking job is caught here and drops
-/// its sender unsent, so the receiver sees a dropped job instead of a
-/// process abort.
+/// future ever blocks on the pool. A panicking job is caught on the pool
+/// thread, so the receiver sees a dropped job instead of a process abort.
 pub(super) fn submit<T, F>(job: F) -> Handoff<T>
 where
     T: Send + 'static,
     F: FnOnce() -> T + Send + 'static,
 {
-    let (tx, rx) = oneshot::channel();
-    rayon::spawn(move || {
-        if let Ok(value) = catch_unwind(AssertUnwindSafe(job)) {
-            drop(tx.send(value));
-        }
-    });
-    Handoff { rx }
+    let (sender, receiver) = handoff();
+    rayon::spawn(move || sender.run(job));
+    receiver
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    use core::task::Waker;
-    use core::time::Duration;
-    use std::sync::Arc;
-    use std::task::Wake;
-    use std::thread::{self, Thread};
-    use std::time::Instant;
-
-    /// Waker that unparks the thread which registered it.
-    struct Unpark(Thread);
-
-    impl Wake for Unpark {
-        fn wake(self: Arc<Self>) {
-            self.0.unpark();
-        }
-    }
-
-    /// Drives `handoff` off wakes alone, panicking once `budget` is spent so a
-    /// lost wake surfaces as a fast diagnostic rather than a hang.
-    fn recv_before<T>(mut handoff: Handoff<T>, budget: Duration) -> Option<T> {
-        let waker = Waker::from(Arc::new(Unpark(thread::current())));
-        let mut cx = Context::from_waker(&waker);
-        let start = Instant::now();
-        loop {
-            assert!(
-                start.elapsed() < budget,
-                "lost wake: handoff still pending after {budget:?}"
-            );
-            if let Poll::Ready(value) = handoff.poll_recv(&mut cx) {
-                return value;
-            }
-            thread::park_timeout(budget.saturating_sub(start.elapsed()));
-        }
-    }
-
-    /// A sender dropped unsent must always wake the receiver, whatever the
-    /// interleaving against the poll that registered the waker.
-    #[test]
-    fn a_sender_dropped_without_a_value_always_wakes_the_receiver() {
-        for _ in 0..1_000 {
-            let (tx, rx) = oneshot::channel::<u32>();
-            let sender = thread::spawn(move || drop(tx));
-            assert_eq!(recv_before(Handoff { rx }, Duration::from_secs(10)), None);
-            sender.join().unwrap();
-        }
-    }
-
-    /// A value sent before the drop is delivered, never read as a drop.
-    #[test]
-    fn a_sender_carrying_a_value_delivers_it() {
-        for _ in 0..1_000 {
-            let (tx, rx) = oneshot::channel::<u32>();
-            let sender = thread::spawn(move || tx.send(7).unwrap());
-            assert_eq!(
-                recv_before(Handoff { rx }, Duration::from_secs(10)),
-                Some(7)
-            );
-            sender.join().unwrap();
-        }
-    }
+    use core::future::poll_fn;
 
     /// The pool path end to end: a panicking job reads as a drop.
     #[test]
     fn a_panicking_job_reads_as_a_drop() {
-        let handoff = submit(|| panic!("job panicked"));
-        assert_eq!(recv_before::<u32>(handoff, Duration::from_secs(10)), None);
+        let mut handoff = submit(|| -> u32 { panic!("job panicked") });
+        let value = nectar_tasks::block_on(poll_fn(|cx| handoff.poll_recv(cx)));
+        assert_eq!(value, None);
     }
 }

--- a/crates/postage-issuer/Cargo.toml
+++ b/crates/postage-issuer/Cargo.toml
@@ -58,6 +58,7 @@ std = [
 	"nectar-clock/std",
 	"nectar-postage/std",
 	"nectar-primitives/std",
+	"nectar-tasks/std",
 ]
 
 # Local key signing for testing and development

--- a/crates/postage-issuer/src/pipeline/bridge.rs
+++ b/crates/postage-issuer/src/pipeline/bridge.rs
@@ -1,38 +1,7 @@
-//! Blocking-bridge machinery: the unpark waker and the sink spawner the
+//! Blocking-bridge machinery: the sink spawners the
 //! [`Stamped`](super::Stamped) iterator drives the poll-native sink with.
 
-use alloc::sync::Arc;
-use core::task::{Context, Waker};
-use std::task::Wake;
-use std::thread::{self, Thread};
-
-use nectar_tasks::{BoxFuture, Spawn, TaskHandle};
-
-/// Waker that unparks the thread which registered it.
-struct Unpark(Thread);
-
-impl Wake for Unpark {
-    fn wake(self: Arc<Self>) {
-        self.0.unpark();
-    }
-
-    fn wake_by_ref(self: &Arc<Self>) {
-        self.0.unpark();
-    }
-}
-
-/// Waker for the calling thread; a completion unparks it.
-pub(super) fn unpark_current() -> Waker {
-    Waker::from(Arc::new(Unpark(thread::current())))
-}
-
-/// Runs one sign job to completion.
-fn drive(mut task: BoxFuture<'static, ()>) {
-    let mut cx = Context::from_waker(Waker::noop());
-    let poll = task.as_mut().poll(&mut cx);
-    // Sign jobs are single-poll futures.
-    debug_assert!(poll.is_ready(), "sign job pended");
-}
+use nectar_tasks::{BoxFuture, Spawn, TaskHandle, block_on};
 
 /// The blocking iterator's spawner: signs on the rayon pool.
 #[cfg(feature = "parallel")]
@@ -41,13 +10,16 @@ pub(super) struct BlockingSpawn;
 #[cfg(feature = "parallel")]
 impl Spawn for BlockingSpawn {
     fn spawn(&self, task: BoxFuture<'static, ()>) -> TaskHandle {
-        rayon::spawn(move || drive(task));
+        // Sign jobs are single-poll futures; the driver never parks.
+        rayon::spawn(move || block_on(task));
         TaskHandle::new(|| {})
     }
 }
 
 #[cfg(not(feature = "parallel"))]
 use alloc::collections::VecDeque;
+#[cfg(not(feature = "parallel"))]
+use alloc::sync::Arc;
 #[cfg(not(feature = "parallel"))]
 use std::sync::{Mutex, PoisonError};
 
@@ -66,7 +38,8 @@ impl Jobs {
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
             .pop_front();
-        job.map(drive).is_some()
+        // Sign jobs are single-poll futures; the driver never parks.
+        job.map(block_on).is_some()
     }
 }
 

--- a/crates/postage-issuer/src/pipeline/bridge.rs
+++ b/crates/postage-issuer/src/pipeline/bridge.rs
@@ -1,4 +1,4 @@
-//! Blocking-bridge machinery: the sink spawners the
+//! Blocking-bridge machinery: the sink spawner the
 //! [`Stamped`](super::Stamped) iterator drives the poll-native sink with.
 
 use nectar_tasks::{BoxFuture, Spawn, TaskHandle, block_on};

--- a/crates/postage-issuer/src/pipeline/mod.rs
+++ b/crates/postage-issuer/src/pipeline/mod.rs
@@ -34,7 +34,9 @@ use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::fmt;
 #[cfg(feature = "std")]
-use core::task::{Context, Poll};
+use core::future::poll_fn;
+#[cfg(feature = "std")]
+use core::task::Poll;
 
 use nectar_clock::Clock;
 #[cfg(feature = "std")]
@@ -45,6 +47,8 @@ use nectar_postage::Stamp;
 #[cfg(not(feature = "std"))]
 use nectar_postage::StampDigest;
 use nectar_primitives::ChunkAddress;
+#[cfg(feature = "std")]
+use nectar_tasks::block_on;
 
 use crate::error::SigningError;
 use crate::issuer::StampIssuer;
@@ -380,16 +384,6 @@ where
         self.not_admitted.extend(self.input.by_ref());
         self.input_done = true;
     }
-
-    /// Blocks until the sink can make progress: runs one queued sign job
-    /// inline, or parks until a completion unparks this thread.
-    fn wait(&mut self) {
-        #[cfg(not(feature = "parallel"))]
-        if self.jobs.run_one() {
-            return;
-        }
-        std::thread::park();
-    }
 }
 
 #[cfg(feature = "std")]
@@ -403,31 +397,39 @@ where
     type Item = StampResult;
 
     fn next(&mut self) -> Option<StampResult> {
-        let waker = bridge::unpark_current();
-        let mut cx = Context::from_waker(&waker);
-        loop {
-            self.refill();
-            match self.sink.poll_next(&mut cx) {
-                Poll::Ready(Some(result)) => {
-                    if self.sink.is_failed() && !self.input_done {
-                        self.stop_admission();
+        block_on(poll_fn(|cx| {
+            loop {
+                self.refill();
+                match self.sink.poll_next(cx) {
+                    Poll::Ready(Some(result)) => {
+                        if self.sink.is_failed() && !self.input_done {
+                            self.stop_admission();
+                        }
+                        return Poll::Ready(Some(result));
                     }
-                    return Some(result);
+                    Poll::Ready(None) => {
+                        if let Some(address) = self.not_admitted.pop_front() {
+                            return Poll::Ready(Some(StampResult {
+                                address,
+                                result: Err(SigningError::NotAdmitted),
+                            }));
+                        }
+                        if self.input_done {
+                            return Poll::Ready(None);
+                        }
+                    }
+                    Poll::Pending => {
+                        // Run one queued sign job inline, then re-poll; the
+                        // driver parks only when nothing is queued.
+                        #[cfg(not(feature = "parallel"))]
+                        if self.jobs.run_one() {
+                            continue;
+                        }
+                        return Poll::Pending;
+                    }
                 }
-                Poll::Ready(None) => {
-                    if let Some(address) = self.not_admitted.pop_front() {
-                        return Some(StampResult {
-                            address,
-                            result: Err(SigningError::NotAdmitted),
-                        });
-                    }
-                    if self.input_done {
-                        return None;
-                    }
-                }
-                Poll::Pending => self.wait(),
             }
-        }
+        }))
     }
 }
 

--- a/crates/postage-issuer/src/pipeline/stamp_sink.rs
+++ b/crates/postage-issuer/src/pipeline/stamp_sink.rs
@@ -12,75 +12,21 @@ use alloc::boxed::Box;
 use alloc::collections::VecDeque;
 use alloc::sync::Arc;
 use core::fmt;
-use core::future::Future;
-use core::pin::Pin;
+use core::future::poll_fn;
 use core::task::{Context, Poll, Waker};
-use std::sync::{Mutex, MutexGuard, PoisonError};
 
 use nectar_clock::Clock;
 use nectar_kernel::InFlight;
 use nectar_marker::{MaybeSend, MaybeSync};
 use nectar_postage::StampDigest;
 use nectar_primitives::ChunkAddress;
-use nectar_tasks::{Spawn, TaskHandle};
+use nectar_tasks::{Spawn, handoff};
 
 use super::task::sign_task;
 use super::{SignPrehash, StampPipeline, StampResult};
 use crate::error::SigningError;
 use crate::issuer::StampIssuer;
 use crate::prepared::prepare_stamps;
-
-fn lock(mutex: &Mutex<SlotState>) -> MutexGuard<'_, SlotState> {
-    mutex.lock().unwrap_or_else(PoisonError::into_inner)
-}
-
-/// One job's completion cell: at most one result, plus the latest waker.
-#[derive(Default)]
-struct Slot {
-    state: Mutex<SlotState>,
-}
-
-#[derive(Default)]
-struct SlotState {
-    result: Option<StampResult>,
-    waker: Option<Waker>,
-}
-
-impl Slot {
-    /// Stores the result and wakes the latest registered waker.
-    fn complete(&self, result: StampResult) {
-        let waker = {
-            let mut state = lock(&self.state);
-            state.result = Some(result);
-            state.waker.take()
-        };
-        if let Some(waker) = waker {
-            waker.wake();
-        }
-    }
-}
-
-/// Awaits one job's completion; dropping it aborts the job.
-///
-/// The waker registration is overwritten on every poll: the first poll may
-/// carry a noop waker (a synchronous split-style first poll), and only the
-/// latest waker is entitled to the wakeup.
-struct Completion {
-    slot: Arc<Slot>,
-    _task: TaskHandle,
-}
-
-impl Future for Completion {
-    type Output = StampResult;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<StampResult> {
-        let mut state = lock(&self.slot.state);
-        if state.result.is_none() {
-            state.waker = Some(cx.waker().clone());
-        }
-        state.result.take().map_or(Poll::Pending, Poll::Ready)
-    }
-}
 
 impl<Sg, C> StampPipeline<Sg, C>
 where
@@ -249,15 +195,25 @@ where
     }
 
     /// Spawns the sign job and tracks its completion in the in-flight set.
+    /// Dropping the collector drops the task handle, aborting the job; a
+    /// job dropped unrun reads as [`SigningError::Dropped`] for the address
+    /// captured at admission.
     fn submit(&mut self, digest: StampDigest) {
-        let slot = Arc::new(Slot::default());
-        let completion = Arc::clone(&slot);
+        let (sender, mut receiver) = handoff();
         let signer = Arc::clone(&self.pipeline.signer);
+        let address = digest.chunk_address;
         let task = self.spawner.spawn(Box::pin(async move {
-            completion.complete(sign_task(signer.as_ref(), &digest));
+            sender.complete(sign_task(signer.as_ref(), &digest));
         }));
-        self.in_flight
-            .push(Box::pin(Completion { slot, _task: task }));
+        self.in_flight.push(Box::pin(async move {
+            let _task = task;
+            poll_fn(|cx| receiver.poll_recv(cx))
+                .await
+                .unwrap_or_else(|| StampResult {
+                    address,
+                    result: Err(SigningError::Dropped),
+                })
+        }));
     }
 
     /// Polls the in-flight set for one completion and applies fail-fast.
@@ -283,7 +239,8 @@ mod tests {
     use alloy_signer::SignerSync;
     use core::sync::atomic::{AtomicUsize, Ordering};
     use nectar_kernel::Window;
-    use std::sync::mpsc;
+    use nectar_tasks::TaskHandle;
+    use std::sync::{Mutex, mpsc};
     use std::task::Wake;
     use std::time::{Duration, Instant};
 

--- a/crates/postage-issuer/src/pipeline/stamped_put.rs
+++ b/crates/postage-issuer/src/pipeline/stamped_put.rs
@@ -7,8 +7,6 @@ use alloc::vec::Vec;
 use core::fmt;
 use core::future::{Future, poll_fn};
 use core::num::NonZeroUsize;
-#[cfg(feature = "parallel")]
-use core::task::Context;
 use core::task::{Poll, Waker};
 #[cfg(feature = "std")]
 use std::panic::{AssertUnwindSafe, catch_unwind};
@@ -193,9 +191,9 @@ impl<I> Drop for DeliveryGuard<'_, I> {
     }
 }
 
-/// Signs one digest inline, converting a signer panic into
+/// Signs one digest, converting a signer panic into
 /// [`SigningError::Dropped`].
-#[cfg(all(feature = "std", not(feature = "parallel")))]
+#[cfg(feature = "std")]
 fn sign_now<Sg: SignPrehash + ?Sized>(
     signer: &Sg,
     digest: &StampDigest,
@@ -208,51 +206,12 @@ fn sign_now<Sg: SignPrehash + ?Sized>(
 
 /// Signs one digest inline. Without `std` there is no unwind boundary: a
 /// signer panic propagates.
-#[cfg(not(any(feature = "std", feature = "parallel")))]
+#[cfg(not(feature = "std"))]
 fn sign_now<Sg: SignPrehash + ?Sized>(
     signer: &Sg,
     digest: &StampDigest,
 ) -> Result<Stamp, SigningError> {
     sign_digest(signer, digest)
-}
-
-/// The owner put's sign completion slot: waker-per-poll, woken on delivery.
-#[cfg(feature = "parallel")]
-#[derive(Default)]
-struct SignSlot {
-    inner: Mutex<SlotState>,
-}
-
-#[cfg(feature = "parallel")]
-#[derive(Default)]
-struct SlotState {
-    result: Option<Result<Stamp, SigningError>>,
-    waker: Option<Waker>,
-}
-
-#[cfg(feature = "parallel")]
-impl SignSlot {
-    fn complete(&self, result: Result<Stamp, SigningError>) {
-        let waker = {
-            let mut state = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
-            state.result = Some(result);
-            state.waker.take()
-        };
-        if let Some(waker) = waker {
-            waker.wake();
-        }
-    }
-
-    fn poll(&self, cx: &mut Context<'_>) -> Poll<Result<Stamp, SigningError>> {
-        let mut state = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
-        state.result.take().map_or_else(
-            || {
-                state.waker = Some(cx.waker().clone());
-                Poll::Pending
-            },
-            Poll::Ready,
-        )
-    }
 }
 
 /// One step of the put flow, decided under a single lock.
@@ -487,21 +446,19 @@ where
     /// waking duplicate waiters on completion.
     #[cfg(feature = "parallel")]
     async fn sign(&self, digest: StampDigest, tracked: bool) -> Result<Stamp, SigningError> {
-        let slot = Arc::new(SignSlot::default());
-        let job_slot = Arc::clone(&slot);
+        let (sender, mut receiver) = nectar_tasks::handoff();
         let signer = Arc::clone(&self.signer);
         let shared = self.shared.clone();
         let address = digest.chunk_address;
         rayon::spawn(move || {
-            // The signer outlives a caught panic; its interior state across
-            // that panic is the caller's contract.
-            let result = catch_unwind(AssertUnwindSafe(|| sign_digest(signer.as_ref(), &digest)))
-                .unwrap_or_else(|_| Err(SigningError::Dropped));
+            let result = sign_now(signer.as_ref(), &digest);
             let wakers = with_state(&shared, |state| resolve(state, &address, &result, tracked));
             wake_all(wakers);
-            job_slot.complete(result);
+            sender.complete(result);
         });
-        poll_fn(|cx| slot.poll(cx)).await
+        poll_fn(|cx| receiver.poll_recv(cx))
+            .await
+            .unwrap_or(Err(SigningError::Dropped))
     }
 
     /// Signs an allocated digest inline, resolving the issued map and
@@ -912,18 +869,8 @@ mod tests {
     fn concurrent_duplicates_share_one_allocation_and_delivery() {
         use core::pin::pin;
         use core::task::{Context, Poll, Waker};
-        use std::task::Wake;
-        use std::thread::{self, Thread};
+        use std::thread;
         use std::time::{Duration, Instant};
-
-        /// Waker that unparks the thread which registered it.
-        struct Unpark(Thread);
-
-        impl Wake for Unpark {
-            fn wake(self: Arc<Self>) {
-                self.0.unpark();
-            }
-        }
 
         /// Signs after a delay, pinning the pending window open.
         struct SlowSigner;
@@ -955,7 +902,7 @@ mod tests {
         assert!(owner.as_mut().poll(noop).is_pending());
         assert!(waiter.as_mut().poll(noop).is_pending());
 
-        let waker = Waker::from(Arc::new(Unpark(thread::current())));
+        let waker = nectar_tasks::unpark_waker();
         let cx = &mut Context::from_waker(&waker);
         let budget = Duration::from_secs(10);
         let start = Instant::now();

--- a/crates/tasks/Cargo.toml
+++ b/crates/tasks/Cargo.toml
@@ -31,6 +31,8 @@ wasm-bindgen-futures = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["sync"] }
 
 [features]
+# The pool-to-poll oneshot handoff and the block-on sync driver.
+std = []
 # Spawner onto the ambient tokio runtime.
 tokio = [ "dep:tokio" ]
 # Spawner onto the browser event loop (wasm32 only).
@@ -43,5 +45,5 @@ unsync = [ "nectar-marker/unsync" ]
 # mutually exclusive, so the doc build names the tokio feature rather than
 # enabling all at once (which would hide the tokio spawner).
 [package.metadata.docs.rs]
-features = ["tokio"]
+features = ["std", "tokio"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/tasks/src/block_on.rs
+++ b/crates/tasks/src/block_on.rs
@@ -1,0 +1,66 @@
+//! Current-thread sync driver: park the calling thread between wakes.
+
+use alloc::sync::Arc;
+use core::future::Future;
+use core::pin::pin;
+use core::task::{Context, Poll, Waker};
+use std::task::Wake;
+use std::thread::{self, Thread};
+
+/// Waker that unparks the thread which registered it.
+struct Unpark(Thread);
+
+impl Wake for Unpark {
+    fn wake(self: Arc<Self>) {
+        self.0.unpark();
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.0.unpark();
+    }
+}
+
+/// Waker for the calling thread; a wake unparks it.
+pub fn unpark_waker() -> Waker {
+    Waker::from(Arc::new(Unpark(thread::current())))
+}
+
+/// Drives `future` to completion on the calling thread, parking between
+/// wakes.
+pub fn block_on<F: Future>(future: F) -> F::Output {
+    let mut future = pin!(future);
+    let waker = unpark_waker();
+    let mut cx = Context::from_waker(&waker);
+    loop {
+        match future.as_mut().poll(&mut cx) {
+            Poll::Ready(output) => return output,
+            Poll::Pending => thread::park(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::future::poll_fn;
+    use core::time::Duration;
+    use std::thread;
+
+    use super::block_on;
+    use crate::handoff;
+
+    #[test]
+    fn a_ready_future_returns_without_parking() {
+        assert_eq!(block_on(async { 7 }), 7);
+    }
+
+    #[test]
+    fn a_cross_thread_wake_unparks_the_driver() {
+        let (tx, mut rx) = handoff::<u32>();
+        let worker = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(10));
+            tx.complete(9);
+        });
+        assert_eq!(block_on(poll_fn(|cx| rx.poll_recv(cx))), Some(9));
+        worker.join().unwrap();
+    }
+}

--- a/crates/tasks/src/handoff.rs
+++ b/crates/tasks/src/handoff.rs
@@ -1,0 +1,208 @@
+//! Oneshot pool-to-poll handoff: one job's result crosses from a worker
+//! closure back into a poll future.
+
+use alloc::sync::Arc;
+use core::fmt;
+use core::task::{Context, Poll, Waker};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::{Mutex, MutexGuard, PoisonError};
+
+/// One job's completion cell: at most one value, plus the latest waker.
+struct Slot<T> {
+    state: Mutex<State<T>>,
+}
+
+struct State<T> {
+    value: Option<T>,
+    /// Sender gone; no further value can arrive.
+    closed: bool,
+    waker: Option<Waker>,
+}
+
+fn lock<T>(slot: &Slot<T>) -> MutexGuard<'_, State<T>> {
+    slot.state.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+/// Creates a connected [`HandoffSender`] and [`Handoff`] for one value.
+pub fn handoff<T>() -> (HandoffSender<T>, Handoff<T>) {
+    let slot = Arc::new(Slot {
+        state: Mutex::new(State {
+            value: None,
+            closed: false,
+            waker: None,
+        }),
+    });
+    (
+        HandoffSender {
+            slot: Arc::clone(&slot),
+        },
+        Handoff { slot },
+    )
+}
+
+/// Sending half: delivers at most one value. Dropping it without a value
+/// closes the handoff, so the receiver reads a dropped job.
+pub struct HandoffSender<T> {
+    slot: Arc<Slot<T>>,
+}
+
+impl<T> HandoffSender<T> {
+    /// Delivers `value`; the drop that follows wakes the receiver.
+    pub fn complete(self, value: T) {
+        lock(&self.slot).value = Some(value);
+    }
+
+    /// Runs `job` and delivers its value; a caught panic reads as a dropped
+    /// job. The job's interior state across a caught panic is the
+    /// submitter's contract.
+    pub fn run<F: FnOnce() -> T>(self, job: F) {
+        if let Ok(value) = catch_unwind(AssertUnwindSafe(job)) {
+            self.complete(value);
+        }
+    }
+}
+
+impl<T> Drop for HandoffSender<T> {
+    fn drop(&mut self) {
+        let waker = {
+            let mut state = lock(&self.slot);
+            state.closed = true;
+            state.waker.take()
+        };
+        if let Some(waker) = waker {
+            waker.wake();
+        }
+    }
+}
+
+impl<T> fmt::Debug for HandoffSender<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HandoffSender").finish_non_exhaustive()
+    }
+}
+
+/// Receiving half of one submitted job; polled by the collecting future.
+///
+/// The waker registration is overwritten on every poll: the first poll may
+/// carry a noop waker, and only the latest waker is entitled to the wakeup.
+pub struct Handoff<T> {
+    slot: Arc<Slot<T>>,
+}
+
+impl<T> Handoff<T> {
+    /// Ready with the value, or `None` when the job finished without one:
+    /// the job panicked, or the pool dropped it.
+    pub fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
+        let mut state = lock(&self.slot);
+        if let Some(value) = state.value.take() {
+            return Poll::Ready(Some(value));
+        }
+        if state.closed {
+            return Poll::Ready(None);
+        }
+        state.waker = Some(cx.waker().clone());
+        Poll::Pending
+    }
+}
+
+impl<T> fmt::Debug for Handoff<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Handoff").finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use core::time::Duration;
+    use std::sync::mpsc;
+    use std::task::Wake;
+    use std::thread;
+    use std::time::Instant;
+
+    use crate::unpark_waker;
+
+    /// Drives `handoff` off wakes alone, panicking once `budget` is spent so
+    /// a lost wake surfaces as a fast diagnostic rather than a hang.
+    fn recv_before<T>(mut handoff: Handoff<T>, budget: Duration) -> Option<T> {
+        let waker = unpark_waker();
+        let mut cx = Context::from_waker(&waker);
+        let start = Instant::now();
+        loop {
+            assert!(
+                start.elapsed() < budget,
+                "lost wake: handoff still pending after {budget:?}"
+            );
+            if let Poll::Ready(value) = handoff.poll_recv(&mut cx) {
+                return value;
+            }
+            thread::park_timeout(budget.saturating_sub(start.elapsed()));
+        }
+    }
+
+    /// A sender dropped unsent must always wake the receiver, whatever the
+    /// interleaving against the poll that registered the waker.
+    #[test]
+    fn a_sender_dropped_without_a_value_always_wakes_the_receiver() {
+        for _ in 0..1_000 {
+            let (tx, rx) = handoff::<u32>();
+            let sender = thread::spawn(move || drop(tx));
+            assert_eq!(recv_before(rx, Duration::from_secs(10)), None);
+            sender.join().unwrap();
+        }
+    }
+
+    /// A value delivered before the drop arrives, never read as a drop.
+    #[test]
+    fn a_sender_carrying_a_value_delivers_it() {
+        for _ in 0..1_000 {
+            let (tx, rx) = handoff::<u32>();
+            let sender = thread::spawn(move || tx.complete(7));
+            assert_eq!(recv_before(rx, Duration::from_secs(10)), Some(7));
+            sender.join().unwrap();
+        }
+    }
+
+    /// The runner catches the panic: the receiver reads a drop, the worker
+    /// thread survives.
+    #[test]
+    fn a_panicking_job_reads_as_a_drop() {
+        let (tx, rx) = handoff::<u32>();
+        let worker = thread::spawn(move || tx.run(|| panic!("job panicked")));
+        assert_eq!(recv_before(rx, Duration::from_secs(10)), None);
+        worker.join().unwrap();
+    }
+
+    /// Signals each wake over a channel.
+    struct SignalWaker(mpsc::Sender<()>);
+
+    impl Wake for SignalWaker {
+        fn wake(self: Arc<Self>) {
+            let _ = self.0.send(());
+        }
+    }
+
+    /// The completion wakes the latest registered waker, not the first.
+    #[test]
+    fn completion_wakes_the_latest_registration_not_first() {
+        let (tx, mut rx) = handoff::<u32>();
+        assert!(
+            rx.poll_recv(&mut Context::from_waker(Waker::noop()))
+                .is_pending()
+        );
+
+        let (wake_tx, wake_rx) = mpsc::channel();
+        let waker = Waker::from(Arc::new(SignalWaker(wake_tx)));
+        assert!(rx.poll_recv(&mut Context::from_waker(&waker)).is_pending());
+
+        tx.complete(9);
+        wake_rx
+            .recv_timeout(Duration::from_secs(10))
+            .expect("completion must wake the latest registered waker");
+        assert_eq!(
+            rx.poll_recv(&mut Context::from_waker(Waker::noop())),
+            Poll::Ready(Some(9))
+        );
+    }
+}

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -4,6 +4,7 @@
 //!
 //! # Features
 //!
+//! - `std`: the pool-to-poll `handoff` and the `block_on` sync driver
 //! - `tokio`: `TokioSpawner`, spawns onto the ambient tokio runtime
 //! - `wasm` (wasm32 only): `WasmSpawner`, spawns onto the browser event
 //!   loop
@@ -32,12 +33,22 @@
 )]
 
 extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
 
+#[cfg(feature = "std")]
+mod block_on;
+#[cfg(feature = "std")]
+mod handoff;
 #[cfg(all(feature = "tokio", multi_thread))]
 mod tokio;
 #[cfg(all(feature = "wasm", target_arch = "wasm32"))]
 mod wasm;
 
+#[cfg(feature = "std")]
+pub use self::block_on::{block_on, unpark_waker};
+#[cfg(feature = "std")]
+pub use self::handoff::{Handoff, HandoffSender, handoff};
 #[cfg(all(feature = "tokio", multi_thread))]
 pub use self::tokio::TokioSpawner;
 #[cfg(all(feature = "wasm", target_arch = "wasm32"))]


### PR DESCRIPTION
## What

Adds a `std` feature to `nectar-tasks` with two extracted primitives: `crates/tasks/src/handoff.rs` (`Handoff<T>`/`HandoffSender<T>`/`handoff()`, a latest-waker-wins oneshot slot with a `catch_unwind` runner that maps a panic to a dropped job) and `crates/tasks/src/block_on.rs` (`Unpark(Thread)` waker via `unpark_waker()`, plus the `block_on` park/poll driver).

The six duplicated copies across the workspace are deleted and folded onto the shared primitives: `crates/file/src/split/handoff.rs` becomes a thin rayon submit over the shared pair, dropping the `futures-channel` dependency from `crates/file/Cargo.toml`; `crates/postage-issuer/src/pipeline/stamp_sink.rs` drops its own `Slot`/`SlotState`/`Completion` in favour of a handoff-collecting async future; `crates/postage-issuer/src/pipeline/stamped_put.rs` drops its `SignSlot`/`SlotState`; and `crates/postage-issuer/src/pipeline/bridge.rs` drops its own `Unpark`/`unpark_current`/`drive`, running sign jobs via `block_on` instead. `Cargo.lock` loses the now-unused `futures-channel` line.

Closes #560

## Why

Six independent, near-identical copies of the same oneshot pool-to-poll handoff and the same thread-park sync driver had accumulated across `nectar-file` and `nectar-postage-issuer`. Consolidating them into `nectar-tasks` removes the duplication and gives every consumer the same verified panic/wake semantics instead of six subtly different reimplementations.

## Testing

`nix develop` shell, rust 1.94, sccache. Reviewed independently: verified the new handoff has no lost-wake race (wake-on-drop after complete, value-before-closed poll order), the `Stamped::next` loop rewrite is behaviourally equivalent to the old `wait()`, the `sign_now` cfg widening is safe (parallel implies std) and reproduces the old `catch_unwind` -> `Dropped` mapping, and feature plumbing reaches every consumer.

## AI Assistance

Implemented with Claude (Fable), reviewed with Claude (Opus), per github.com/nxm-rs/.github CONTRIBUTING.md.
