### PR TITLE
postage-issuer: replace completion cells with futures oneshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2706,6 +2706,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
+ "futures-channel",
  "nectar-clock",
  "nectar-file",
  "nectar-kernel",

--- a/crates/postage-issuer/Cargo.toml
+++ b/crates/postage-issuer/Cargo.toml
@@ -30,6 +30,7 @@ thiserror = { workspace = true }
 # The signer stack requires std; the no_std core only allocates digests.
 alloy-signer = { workspace = true, optional = true }
 alloy-signer-local = { workspace = true, optional = true }
+futures-channel = { workspace = true, optional = true }
 nectar-tasks = { workspace = true, optional = true }
 rayon = { workspace = true, optional = true }
 
@@ -54,6 +55,7 @@ default = [ "std" ]
 # this gate.
 std = [
 	"dep:alloy-signer",
+	"dep:futures-channel",
 	"dep:nectar-tasks",
 	"nectar-clock/std",
 	"nectar-postage/std",

--- a/crates/postage-issuer/src/pipeline/stamp_sink.rs
+++ b/crates/postage-issuer/src/pipeline/stamp_sink.rs
@@ -15,8 +15,8 @@ use core::fmt;
 use core::future::Future;
 use core::pin::Pin;
 use core::task::{Context, Poll, Waker};
-use std::sync::{Mutex, MutexGuard, PoisonError};
 
+use futures_channel::oneshot;
 use nectar_clock::Clock;
 use nectar_kernel::InFlight;
 use nectar_marker::{MaybeSend, MaybeSync};
@@ -30,43 +30,13 @@ use crate::error::SigningError;
 use crate::issuer::StampIssuer;
 use crate::prepared::prepare_stamps;
 
-fn lock(mutex: &Mutex<SlotState>) -> MutexGuard<'_, SlotState> {
-    mutex.lock().unwrap_or_else(PoisonError::into_inner)
-}
-
-/// One job's completion cell: at most one result, plus the latest waker.
-#[derive(Default)]
-struct Slot {
-    state: Mutex<SlotState>,
-}
-
-#[derive(Default)]
-struct SlotState {
-    result: Option<StampResult>,
-    waker: Option<Waker>,
-}
-
-impl Slot {
-    /// Stores the result and wakes the latest registered waker.
-    fn complete(&self, result: StampResult) {
-        let waker = {
-            let mut state = lock(&self.state);
-            state.result = Some(result);
-            state.waker.take()
-        };
-        if let Some(waker) = waker {
-            waker.wake();
-        }
-    }
-}
-
 /// Awaits one job's completion; dropping it aborts the job.
 ///
-/// The waker registration is overwritten on every poll: the first poll may
-/// carry a noop waker (a synchronous split-style first poll), and only the
-/// latest waker is entitled to the wakeup.
+/// A cancelled receiver (the sign task dropped before sending) yields a
+/// systemic [`SigningError::Dropped`], so a lost job never wedges the sink.
 struct Completion {
-    slot: Arc<Slot>,
+    address: ChunkAddress,
+    rx: oneshot::Receiver<StampResult>,
     _task: TaskHandle,
 }
 
@@ -74,11 +44,15 @@ impl Future for Completion {
     type Output = StampResult;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<StampResult> {
-        let mut state = lock(&self.slot.state);
-        if state.result.is_none() {
-            state.waker = Some(cx.waker().clone());
+        let this = self.get_mut();
+        match Pin::new(&mut this.rx).poll(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Ok(result)) => Poll::Ready(result),
+            Poll::Ready(Err(oneshot::Canceled)) => Poll::Ready(StampResult {
+                address: this.address,
+                result: Err(SigningError::Dropped),
+            }),
         }
-        state.result.take().map_or(Poll::Pending, Poll::Ready)
     }
 }
 
@@ -250,14 +224,17 @@ where
 
     /// Spawns the sign job and tracks its completion in the in-flight set.
     fn submit(&mut self, digest: StampDigest) {
-        let slot = Arc::new(Slot::default());
-        let completion = Arc::clone(&slot);
+        let (tx, rx) = oneshot::channel();
         let signer = Arc::clone(&self.pipeline.signer);
+        let address = digest.chunk_address;
         let task = self.spawner.spawn(Box::pin(async move {
-            completion.complete(sign_task(signer.as_ref(), &digest));
+            let _ = tx.send(sign_task(signer.as_ref(), &digest));
         }));
-        self.in_flight
-            .push(Box::pin(Completion { slot, _task: task }));
+        self.in_flight.push(Box::pin(Completion {
+            address,
+            rx,
+            _task: task,
+        }));
     }
 
     /// Polls the in-flight set for one completion and applies fail-fast.
@@ -283,7 +260,7 @@ mod tests {
     use alloy_signer::SignerSync;
     use core::sync::atomic::{AtomicUsize, Ordering};
     use nectar_kernel::Window;
-    use std::sync::mpsc;
+    use std::sync::{Mutex, mpsc};
     use std::task::Wake;
     use std::time::{Duration, Instant};
 
@@ -421,6 +398,16 @@ mod tests {
 
         fn chain_id_sync(&self) -> Option<u64> {
             None
+        }
+    }
+
+    /// Drops each job without polling it: the sign task and its sender die
+    /// unrun, cancelling the completion receiver.
+    struct DroppingSpawner;
+
+    impl Spawn for DroppingSpawner {
+        fn spawn(&self, _task: nectar_tasks::BoxFuture<'static, ()>) -> TaskHandle {
+            TaskHandle::new(|| {})
         }
     }
 
@@ -643,6 +630,33 @@ mod tests {
             .iter()
             .filter(|r| matches!(r.result, Err(SigningError::NotAdmitted)))
             .count();
+        assert_eq!(dropped, 4);
+        assert_eq!(not_admitted, 6);
+        assert_eq!(issuer.stamps_issued(), Some(4));
+    }
+
+    /// A sign task dropped before it runs must yield [`SigningError::Dropped`]
+    /// rather than leaving its completion pending forever.
+    #[test]
+    fn dropped_unrun_task_yields_dropped_without_hanging() {
+        let mut issuer = issuer24();
+        let pipeline = StampPipeline::from_signer(FixedSigner).with_window(window(4));
+        let input = addresses(10);
+
+        let mut sink = pipeline.sink(&mut issuer, DroppingSpawner);
+        let results = drive(&mut sink, &input, 4);
+        drop(sink);
+
+        assert_eq!(results.len(), 10);
+        let dropped = results
+            .iter()
+            .filter(|r| matches!(r.result, Err(SigningError::Dropped)))
+            .count();
+        let not_admitted = results
+            .iter()
+            .filter(|r| matches!(r.result, Err(SigningError::NotAdmitted)))
+            .count();
+        // Fail-fast trips after the first window of lost jobs.
         assert_eq!(dropped, 4);
         assert_eq!(not_admitted, 6);
         assert_eq!(issuer.stamps_issued(), Some(4));

--- a/crates/postage-issuer/src/pipeline/stamped_put.rs
+++ b/crates/postage-issuer/src/pipeline/stamped_put.rs
@@ -7,14 +7,14 @@ use alloc::vec::Vec;
 use core::fmt;
 use core::future::{Future, poll_fn};
 use core::num::NonZeroUsize;
-#[cfg(feature = "parallel")]
-use core::task::Context;
 use core::task::{Poll, Waker};
 #[cfg(feature = "std")]
 use std::panic::{AssertUnwindSafe, catch_unwind};
 #[cfg(multi_thread)]
 use std::sync::{Mutex, PoisonError};
 
+#[cfg(feature = "parallel")]
+use futures_channel::oneshot;
 use nectar_clock::Clock;
 #[cfg(feature = "std")]
 use nectar_clock::SystemClock;
@@ -214,45 +214,6 @@ fn sign_now<Sg: SignPrehash + ?Sized>(
     digest: &StampDigest,
 ) -> Result<Stamp, SigningError> {
     sign_digest(signer, digest)
-}
-
-/// The owner put's sign completion slot: waker-per-poll, woken on delivery.
-#[cfg(feature = "parallel")]
-#[derive(Default)]
-struct SignSlot {
-    inner: Mutex<SlotState>,
-}
-
-#[cfg(feature = "parallel")]
-#[derive(Default)]
-struct SlotState {
-    result: Option<Result<Stamp, SigningError>>,
-    waker: Option<Waker>,
-}
-
-#[cfg(feature = "parallel")]
-impl SignSlot {
-    fn complete(&self, result: Result<Stamp, SigningError>) {
-        let waker = {
-            let mut state = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
-            state.result = Some(result);
-            state.waker.take()
-        };
-        if let Some(waker) = waker {
-            waker.wake();
-        }
-    }
-
-    fn poll(&self, cx: &mut Context<'_>) -> Poll<Result<Stamp, SigningError>> {
-        let mut state = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
-        state.result.take().map_or_else(
-            || {
-                state.waker = Some(cx.waker().clone());
-                Poll::Pending
-            },
-            Poll::Ready,
-        )
-    }
 }
 
 /// One step of the put flow, decided under a single lock.
@@ -487,8 +448,7 @@ where
     /// waking duplicate waiters on completion.
     #[cfg(feature = "parallel")]
     async fn sign(&self, digest: StampDigest, tracked: bool) -> Result<Stamp, SigningError> {
-        let slot = Arc::new(SignSlot::default());
-        let job_slot = Arc::clone(&slot);
+        let (tx, rx) = oneshot::channel();
         let signer = Arc::clone(&self.signer);
         let shared = self.shared.clone();
         let address = digest.chunk_address;
@@ -499,9 +459,10 @@ where
                 .unwrap_or_else(|_| Err(SigningError::Dropped));
             let wakers = with_state(&shared, |state| resolve(state, &address, &result, tracked));
             wake_all(wakers);
-            job_slot.complete(result);
+            let _ = tx.send(result);
         });
-        poll_fn(|cx| slot.poll(cx)).await
+        // A cancelled receiver means the job was lost before sending.
+        rx.await.unwrap_or(Err(SigningError::Dropped))
     }
 
     /// Signs an allocated digest inline, resolving the issued map and


### PR DESCRIPTION
## What

Replaces the hand-rolled `Mutex`+waker completion cells in `crates/postage-issuer` with `futures_channel::oneshot`, across both target files.

`stamp_sink.rs`: deletes `Slot`/`SlotState`/the `lock` helper and the old `Completion`. `Completion` is now `{ address, rx: oneshot::Receiver<StampResult>, _task: TaskHandle }`, and its `Future` impl maps a `Canceled` receiver to the systemic `SigningError::Dropped`. `submit()` now creates a oneshot channel and the spawned sign task sends its `StampResult` (`let _ = tx.send(...)`). This removes `std::sync::Mutex` from the sink itself (the cell is now alloc-only). The tests module gains a local `use std::sync::Mutex` (previously inherited from the parent module) plus a new `DroppingSpawner` and a `dropped_unrun_task_yields_dropped_without_hanging` regression test proving no hang (yields `Dropped` x4 / `NotAdmitted` x6 under fail-fast).

`stamped_put.rs`: deletes the parallel-only `SignSlot`/`SlotState`. The `sign` method now creates a oneshot channel, the spawned task sends its result, and the caller awaits the receiver directly, mapping cancellation to `SigningError::Dropped`.

`Cargo.toml`: adds `futures-channel` as an optional dependency, gated under the `std` feature alongside `alloy-signer`/`nectar-tasks`.

Closes #569.

## Why

Part of epic #573: kill reinvented concurrency primitives in favour of ecosystem crates. The hand-rolled `Mutex`+waker completion cells duplicated what `futures_channel::oneshot` already provides correctly, and dropped the `Mutex` dependency from the sink's hot path.

## Testing

Independent verification on HEAD `66d671390` (based on `origin/main`), under `nix develop` (Rust 1.94.0, matching `rust-toolchain.toml`/CI) with sccache and a warm shared target dir:

- `cargo fmt --all -- --check` — clean.
- `cargo clippy --workspace --all-targets --locked` — exit 0 (two pre-existing `doc_lazy_continuation` warnings in `nectar-testing/src/lib.rs`, an untouched crate, not part of this diff).
- `cargo clippy --locked --all-targets -p nectar-postage-issuer --features parallel` — clean (parallel signing engine).
- `cargo clippy --locked --all-targets -p nectar-postage-issuer` — clean (inline engine shape).
- `cargo rustc --locked -p nectar-postage-issuer --lib -- -D unused_crate_dependencies` — clean (the new `futures-channel` dep is actually used).

Red-team review confirmed: full removal of `Slot`/`SignSlot` with no leftovers; correct `Canceled` -> `SigningError::Dropped` mapping (covered by `is_systemic`, trips fail-fast); the new `DroppingSpawner` test is deterministic and regresses on both the wrong-mapping and the hang paths; feature gating is sound (`futures-channel` is alloc-based under `std`; `stamp_sink` is std-only; `stamped_put`'s oneshot use is parallel-only).

## AI Assistance

Implemented with Claude Opus, reviewed with Claude Opus.
