### PR TITLE
refactor(kernel): re-export BoxFuture from futures-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2589,6 +2589,7 @@ dependencies = [
 name = "nectar-kernel"
 version = "0.4.0"
 dependencies = [
+ "futures-core",
  "nectar-marker",
  "nectar-primitives 0.4.0",
  "nectar-testing",
@@ -2829,6 +2830,7 @@ name = "nectar-tasks"
 version = "0.4.0"
 dependencies = [
  "futures-channel",
+ "futures-core",
  "futures-util",
  "nectar-marker",
  "rayon",

--- a/crates/kernel/Cargo.toml
+++ b/crates/kernel/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 
 [dependencies]
 nectar-marker = { workspace = true }
+futures-core = { workspace = true, features = ["alloc"] }
 
 # optional
 nectar-primitives = { workspace = true, optional = true }

--- a/crates/kernel/src/future.rs
+++ b/crates/kernel/src/future.rs
@@ -1,25 +1,17 @@
 //! The boxed-future alias every bounded set holds.
 
-use alloc::boxed::Box;
-use core::future::Future;
-use core::pin::Pin;
-
-/// Boxed future capturing no more than `'a`: `Send` on multi-threaded
-/// targets, unbounded on wasm32, bare metal, and under the `unsync` feature,
-/// mirroring the marker traits.
+/// Boxed future capturing no more than `'a`, `Send` on multi-threaded
+/// targets: the futures-core alias, re-exported for `.boxed()` interop.
 ///
-/// Feature unification: `unsync` enabled by any crate in a build relaxes
-/// the alias for every consumer in that build.
+/// Feature unification: `unsync`, wasm32, or a bare-metal target relaxes
+/// the alias off `Send` for every consumer in that build.
 #[cfg(multi_thread)]
-pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
-/// Boxed future capturing no more than `'a`: `Send` on multi-threaded
-/// targets, unbounded on wasm32, bare metal, and under the `unsync` feature,
-/// mirroring the marker traits.
-///
-/// Feature unification: `unsync` enabled by any crate in a build relaxes
-/// the alias for every consumer in that build.
+pub use futures_core::future::BoxFuture;
+/// Boxed future capturing no more than `'a`, unbounded on wasm32, bare
+/// metal, and under `unsync`: the futures-core alias, re-exported for
+/// `.boxed_local()` interop.
 #[cfg(not(multi_thread))]
-pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
+pub use futures_core::future::LocalBoxFuture as BoxFuture;
 
 // The default build keeps the alias `Send`; only `unsync` or a
 // single-threaded target may relax it.

--- a/crates/tasks/Cargo.toml
+++ b/crates/tasks/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 
 [dependencies]
 nectar-marker = { workspace = true }
+futures-core = { workspace = true, features = ["alloc"] }
 
 # optional
 futures-channel = { workspace = true, optional = true }

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -59,19 +59,17 @@ pub use self::wasm::WasmSpawner;
 use alloc::boxed::Box;
 use alloc::sync::Arc;
 use core::fmt;
-use core::future::Future;
-use core::pin::Pin;
 
 use nectar_marker::{MaybeSend, MaybeSync};
 
-/// Boxed future: `Send` on multi-threaded targets, unbounded on wasm32 and
-/// under the `unsync` feature.
+/// Boxed future, `Send` on multi-threaded targets: the futures-core alias,
+/// re-exported for `.boxed()`/`.boxed_local()` interop.
 #[cfg(multi_thread)]
-pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
-/// Boxed future: `Send` on multi-threaded targets, unbounded on wasm32 and
-/// under the `unsync` feature.
+pub use futures_core::future::BoxFuture;
+/// Boxed future, unbounded on wasm32, bare metal, and under `unsync`: the
+/// futures-core alias, re-exported for `.boxed_local()` interop.
 #[cfg(not(multi_thread))]
-pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
+pub use futures_core::future::LocalBoxFuture as BoxFuture;
 
 /// Abort callback: `Send` on multi-threaded targets, unbounded on wasm32
 /// and under the `unsync` feature.

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -66,8 +66,8 @@ use nectar_marker::{MaybeSend, MaybeSync};
 /// re-exported for `.boxed()`/`.boxed_local()` interop.
 #[cfg(multi_thread)]
 pub use futures_core::future::BoxFuture;
-/// Boxed future, unbounded on wasm32, bare metal, and under `unsync`: the
-/// futures-core alias, re-exported for `.boxed_local()` interop.
+/// Boxed future, unbounded on wasm32 and under `unsync`: the futures-core
+/// alias, re-exported for `.boxed_local()` interop.
 #[cfg(not(multi_thread))]
 pub use futures_core::future::LocalBoxFuture as BoxFuture;
 


### PR DESCRIPTION
## What

Replaces the hand-written boxed-future type aliases in `crates/kernel/src/future.rs` and `crates/tasks/src/lib.rs` with cfg'd re-exports of `futures_core::future::BoxFuture` / `LocalBoxFuture`, gated on the existing `multi_thread` cfg.

Both crates' `Cargo.toml` gain `futures-core = { workspace = true, features = ["alloc"] }` (the workspace dependency was already present with `default-features = false`, so only the `alloc` feature is newly enabled).

The duplicate alias definition in `crates/tasks/src/lib.rs` is removed; it now re-exports the same futures-core alias rather than redefining it locally.

## Why

The two hand-rolled `Pin<Box<dyn Future<Output = T> (+ Send) + 'a>>` aliases were byte-identical to what futures-core already ships, so maintaining them locally was pure duplication with no behavioural difference to justify it.

## Testing

Verified all three CI lanes (native `multi_thread` with tests, wasm32, riscv64imac no_std) plus the `unsync` feature arm build and pass, and `clippy --all-targets` is clean on both touched crates (only pre-existing nectar-testing doc warnings remain, correctly untouched).

Confirmed the futures-core 0.3.32 `BoxFuture`/`LocalBoxFuture` aliases are byte-identical to the aliases they replace, and that no second `BoxFuture` type/re-export definition remains in `crates/tasks`.

Closes #570.

## AI Assistance

Implemented with Claude (Opus) and reviewed with Claude (Opus), per nxm-rs/.github CONTRIBUTING.md.
