### PR TITLE
tooling: gate ad-hoc executors, Mutex+waker cells, and cfg-dance copies

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -110,3 +110,14 @@ jobs:
                   tool: cargo-machete
             - name: cargo machete
               run: cargo machete
+
+    reinvention-gate:
+        name: reinvention-gate
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+            # Source-only grep gate; fails if a burnt-down concurrency primitive
+            # (hand-rolled executor, Mutex+waker cell, boxed-future alias)
+            # reappears outside its sanctioned home. Needs no toolchain.
+            - name: reinvention gate
+              run: bash tools/reinvention-gate.sh

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,6 +1,9 @@
 # Async test discipline: futures run through `nectar_testing::run` (the one
 # sanctioned executor entry point, allowed at its call site) or a manual-poll
-# `Drive`; ad-hoc executors and runtime-blocking calls are disallowed.
+# `Drive`; ad-hoc executors and runtime-blocking calls are disallowed. The
+# park-loop block_on shortcuts (pollster, futures-lite) are named here so a
+# hand-rolled executor cannot slip in by way of a different crate; the
+# structural park loop itself is gated by tools/reinvention-gate.sh.
 disallowed-methods = [
     { path = "futures_executor::block_on", reason = "use nectar_testing::run" },
     { path = "futures::executor::block_on", reason = "use nectar_testing::run" },
@@ -8,6 +11,10 @@ disallowed-methods = [
     { path = "futures::executor::block_on_stream", reason = "use nectar_testing::run and drive the stream inside the future" },
     { path = "futures_executor::LocalPool::run_until", reason = "use nectar_testing::run" },
     { path = "futures::executor::LocalPool::run_until", reason = "use nectar_testing::run" },
+    { path = "futures_executor::LocalPool::run", reason = "use nectar_testing::run" },
+    { path = "futures::executor::LocalPool::run", reason = "use nectar_testing::run" },
+    { path = "pollster::block_on", reason = "use nectar_testing::run" },
+    { path = "futures_lite::future::block_on", reason = "use nectar_testing::run" },
     { path = "tokio::runtime::Runtime::block_on", reason = "use #[tokio::test] in a tokio adapter module or nectar_testing::run" },
     { path = "tokio::runtime::Handle::block_on", reason = "use #[tokio::test] in a tokio adapter module or nectar_testing::run" },
     { path = "tokio::task::yield_now", reason = "use nectar_testing::yield_now so the yield budget stays deterministic" },

--- a/tools/reinvention-gate.sh
+++ b/tools/reinvention-gate.sh
@@ -12,6 +12,7 @@
 #   nectar-tasks wake.rs  the shared thread-unpark waker (`unpark_current`)
 #   nectar-tasks handoff  the pool-to-poll blocking bridge
 #   postage-issuer pump   the Stamped sign-admission pump
+#   nectar-marker         the sole MaybeSend/MaybeSync cfg dance
 
 set -euo pipefail
 
@@ -42,6 +43,13 @@ deny() {
 # Re-exports use `pub use`; a `type BoxFuture = ...` is always a reinvention.
 deny 'hand-rolled BoxFuture alias (re-export futures_core::future::BoxFuture)' \
     'type[[:space:]]+(Local)?BoxFuture[[:space:]]*[<=]'
+
+# The Send/Sync cfg dance re-declared instead of consumed from nectar-marker.
+# The marker traits live in exactly one home; a fresh declaration elsewhere is
+# a copy. Re-exports use `pub use` and do not match `trait`.
+deny 'copied MaybeSend/MaybeSync marker (consume from nectar_marker)' \
+    'trait[[:space:]]+Maybe(Send|Sync)' \
+    'crates/marker/src/lib.rs'
 
 # A completion cell: a waker parked inside a mutex, woken on result. Use
 # futures_channel::oneshot.

--- a/tools/reinvention-gate.sh
+++ b/tools/reinvention-gate.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Reinvention gate: fails if a deleted concurrency primitive creeps back.
+#
+# The burn-down replaced hand-rolled executors, completion cells, and boxed
+# future aliases with ecosystem crates. Each shape below is now sanctioned in
+# exactly one home; a copy anywhere else is a reinvention and fails the gate.
+# clippy.toml gates the block_on entry points in parallel; this covers the
+# structural shapes clippy cannot name.
+#
+# Sanctioned homes:
+#   nectar-testing        the sole block_on entry (`run`) plus its Drive waker
+#   nectar-tasks wake.rs  the shared thread-unpark waker (`unpark_current`)
+#   nectar-tasks handoff  the pool-to-poll blocking bridge
+#   postage-issuer pump   the Stamped sign-admission pump
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+fail=0
+
+# deny <label> <ere> [allow-path-prefix ...]
+# Reports every `crates/**/*.rs` line matching <ere> outside the allowed paths.
+deny() {
+    local label=$1 pattern=$2
+    shift 2
+    local hits
+    hits=$(grep -rEn --include='*.rs' -- "$pattern" crates/ || true)
+    local allow
+    for allow in "$@"; do
+        hits=$(printf '%s\n' "$hits" | grep -vE "^${allow}" || true)
+    done
+    hits=$(printf '%s\n' "$hits" | grep -v '^$' || true)
+    if [ -n "$hits" ]; then
+        printf 'reinvention gate: %s\n' "$label" >&2
+        printf '%s\n' "$hits" | sed 's/^/  /' >&2
+        fail=1
+    fi
+}
+
+# A boxed-future alias hand-rolled instead of re-exported from futures-core.
+# Re-exports use `pub use`; a `type BoxFuture = ...` is always a reinvention.
+deny 'hand-rolled BoxFuture alias (re-export futures_core::future::BoxFuture)' \
+    'type[[:space:]]+(Local)?BoxFuture[[:space:]]*[<=]'
+
+# A completion cell: a waker parked inside a mutex, woken on result. Use
+# futures_channel::oneshot.
+deny 'Mutex-guarded waker cell (use futures_channel::oneshot)' \
+    'Mutex[[:space:]]*<[^>]*Waker'
+
+# The same cell by its waker slot; the pump keeps one cooperative slot.
+deny 'hand-rolled completion-cell waker slot (use futures_channel::oneshot)' \
+    '[A-Za-z_]*waker[[:space:]]*:[[:space:]]*Option[[:space:]]*<[[:space:]]*Waker' \
+    'crates/postage-issuer/src/pipeline/'
+
+# The thread-unpark waker copied out of nectar-tasks.
+deny 'copied Unpark waker (use nectar_tasks::unpark_current)' \
+    'struct[[:space:]]+Unpark[[:space:]]*\([[:space:]]*Thread' \
+    'crates/tasks/src/wake.rs' \
+    'crates/postage-issuer/src/pipeline/'
+
+# Any ad-hoc waker/executor: a fresh Wake impl outside the sanctioned homes.
+deny 'ad-hoc Wake impl (route through nectar_testing/nectar_tasks)' \
+    'impl[[:space:]]+Wake[[:space:]]+for[[:space:]]' \
+    'crates/testing/src/lib.rs' \
+    'crates/tasks/src/wake.rs' \
+    'crates/postage-issuer/src/pipeline/'
+
+# A hand-rolled oneshot by name; the sanctioned oneshot is futures_channel's.
+deny 'hand-rolled oneshot type (use futures_channel::oneshot)' \
+    'struct[[:space:]]+[A-Za-z_]*[Oo]ne[Ss]hot'
+
+# A park-loop executor: poll-then-park on the calling thread. Bridges belong in
+# nectar-tasks; futures run through nectar_testing::run.
+deny 'thread::park executor loop (use nectar_testing::run or nectar_tasks)' \
+    'thread::park(_timeout)?[[:space:]]*\(' \
+    'crates/tasks/src/handoff.rs' \
+    'crates/postage-issuer/src/pipeline/'
+
+if [ "$fail" -ne 0 ]; then
+    printf '\nreinvention gate failed: see matches above.\n' >&2
+    exit 1
+fi
+
+printf 'reinvention gate: clean.\n'


### PR DESCRIPTION
## What

Adds a reinvention gate that stops burnt-down concurrency primitives from creeping back into the tree.

- `clippy.toml`: adds the park-loop `block_on` shortcuts `pollster::block_on`, `futures_lite::future::block_on`, and `futures(_executor)::LocalPool::run` to `disallowed-methods`, so an ad-hoc executor cannot re-enter via another crate. `nectar_testing::run` stays the sole sanctioned `block_on`.
- `tools/reinvention-gate.sh`: a toolchain-free grep gate over `crates/**/*.rs` that fails when a burnt-down shape reappears outside its sanctioned home: a hand-rolled `BoxFuture`/`LocalBoxFuture` alias (re-exports and differently-named aliases pass), a `Mutex`-guarded or slot-based waker completion cell, a copied `struct Unpark(Thread)`, a fresh `impl Wake for`, a hand-rolled `*oneshot` type, and a `thread::park` executor loop.
- `.github/workflows/lint.yml`: wires the gate script into CI as its own job (checkout + run, no toolchain needed).

No runtime or crate source touched; `Cargo.lock` unchanged.

## Why

Closes #572.

Epic #573's burn-down replaced hand-rolled executors, completion cells, and boxed-future aliases with ecosystem crates. Without a gate, any of those shapes can silently reappear in a future PR. `clippy.toml` covers the named `block_on` entry points; the shell script covers the structural shapes clippy cannot name, each pinned to exactly one sanctioned home (`nectar-testing`, `nectar-tasks` `wake.rs`/handoff, `postage-issuer` pump, `nectar-marker`).

## Testing

Verified on `feat/reinvention-gate` @ `1077ac2d1` under `nix develop` (rustc 1.94.0, CI pin) with sccache and a shared target dir: the gate is clean on the tree, fails on planted violations of every shape it claims, and each allowlist is load-bearing against the real sanctioned homes. Confirmed the absent-crate clippy paths (`pollster`, `futures_lite`) are silently ignored by clippy 1.94 and do not break CI.

## AI Assistance

Implemented with Claude Opus, reviewed with Claude Opus.
