### PR TITLE
issuer: use unpark_current in duplicate-share test; close reinvention-gate test hole

### DIFF
--- a/crates/postage-issuer/src/pipeline/stamped_put.rs
+++ b/crates/postage-issuer/src/pipeline/stamped_put.rs
@@ -873,18 +873,8 @@ mod tests {
     fn concurrent_duplicates_share_one_allocation_and_delivery() {
         use core::pin::pin;
         use core::task::{Context, Poll, Waker};
-        use std::task::Wake;
-        use std::thread::{self, Thread};
+        use std::thread;
         use std::time::{Duration, Instant};
-
-        /// Waker that unparks the thread which registered it.
-        struct Unpark(Thread);
-
-        impl Wake for Unpark {
-            fn wake(self: Arc<Self>) {
-                self.0.unpark();
-            }
-        }
 
         /// Signs after a delay, pinning the pending window open.
         struct SlowSigner;
@@ -916,7 +906,7 @@ mod tests {
         assert!(owner.as_mut().poll(noop).is_pending());
         assert!(waiter.as_mut().poll(noop).is_pending());
 
-        let waker = Waker::from(Arc::new(Unpark(thread::current())));
+        let waker = nectar_tasks::unpark_current();
         let cx = &mut Context::from_waker(&waker);
         let budget = Duration::from_secs(10);
         let start = Instant::now();

--- a/tools/reinvention-gate.sh
+++ b/tools/reinvention-gate.sh
@@ -56,16 +56,17 @@ deny 'copied MaybeSend/MaybeSync marker (consume from nectar_marker)' \
 deny 'Mutex-guarded waker cell (use futures_channel::oneshot)' \
     'Mutex[[:space:]]*<[^>]*Waker'
 
-# The same cell by its waker slot; the pump keeps one cooperative slot.
+# The same cell by its waker slot; the pump keeps one cooperative slot. Only
+# the pump sink is sanctioned; test modules must not grow one.
 deny 'hand-rolled completion-cell waker slot (use futures_channel::oneshot)' \
     '[A-Za-z_]*waker[[:space:]]*:[[:space:]]*Option[[:space:]]*<[[:space:]]*Waker' \
-    'crates/postage-issuer/src/pipeline/'
+    'crates/postage-issuer/src/pipeline/stamp_sink.rs'
 
-# The thread-unpark waker copied out of nectar-tasks.
+# The thread-unpark waker copied out of nectar-tasks. Sanctioned in exactly one
+# home; a copy anywhere else, test modules included, is a reinvention.
 deny 'copied Unpark waker (use nectar_tasks::unpark_current)' \
     'struct[[:space:]]+Unpark[[:space:]]*\([[:space:]]*Thread' \
-    'crates/tasks/src/wake.rs' \
-    'crates/postage-issuer/src/pipeline/'
+    'crates/tasks/src/wake.rs'
 
 # Any ad-hoc waker/executor: a fresh Wake impl outside the sanctioned homes.
 deny 'ad-hoc Wake impl (route through nectar_testing/nectar_tasks)' \
@@ -79,11 +80,14 @@ deny 'hand-rolled oneshot type (use futures_channel::oneshot)' \
     'struct[[:space:]]+[A-Za-z_]*[Oo]ne[Ss]hot'
 
 # A park-loop executor: poll-then-park on the calling thread. Bridges belong in
-# nectar-tasks; futures run through nectar_testing::run.
+# nectar-tasks; futures run through nectar_testing::run. The pump admission loop
+# and the duplicate-share test driver each park against unpark_current; every
+# other file, test modules included, is a reinvention.
 deny 'thread::park executor loop (use nectar_testing::run or nectar_tasks)' \
     'thread::park(_timeout)?[[:space:]]*\(' \
     'crates/tasks/src/handoff.rs' \
-    'crates/postage-issuer/src/pipeline/'
+    'crates/postage-issuer/src/pipeline/mod.rs' \
+    'crates/postage-issuer/src/pipeline/stamped_put.rs'
 
 if [ "$fail" -ne 0 ]; then
     printf '\nreinvention gate failed: see matches above.\n' >&2


### PR DESCRIPTION
## What

Retire the last hand-rolled `struct Unpark(Thread)` + `impl Wake` from the `concurrent_duplicates_share_one_allocation_and_delivery` test in `stamped_put.rs`; it now takes `nectar_tasks::unpark_current`, the sanctioned thread-unpark waker. Its now-unused `std::task::Wake` and `Thread` imports go with it.

Tighten `tools/reinvention-gate.sh`: the Unpark, completion-cell-slot, and park-loop shapes previously excluded the whole `crates/postage-issuer/src/pipeline/` directory, so a reinvention hiding in a test module escaped. The exclusions now name the sanctioned files (`wake.rs` for Unpark, `stamp_sink.rs` for the pump waker slot, `mod.rs`/`stamped_put.rs`/`handoff.rs` for the park sites) instead of a whole directory.

## Why

Last two loose ends of the reinvention burn-down. The test copy of the thread-unpark waker was the final live duplicate outside `nectar-tasks`, and the directory-wide gate exclusion meant the gate could not have caught it. Naming the sanctioned files closes that test-module hole while leaving the legitimate pump and bridge homes intact.

## Testing

- `git grep -n 'struct Unpark' -- crates` now shows only `crates/tasks/src/wake.rs`.
- Gate before/after: planting `struct Unpark(Thread);` in the test module makes `tools/reinvention-gate.sh` fail (`copied Unpark waker ... stamped_put.rs`); removing it returns to `reinvention gate: clean.`
- `cargo nextest run -p nectar-postage-issuer --locked` and `--features parallel`: 100/100 green each.
- `cargo clippy -p nectar-postage-issuer --all-targets --locked` (and `--features parallel`): clean.
- `cargo fmt -- --check`: clean.

Closes #580