### PR TITLE
tasks: implement Future for Handoff and add submit_on

### DIFF
--- a/crates/tasks/Cargo.toml
+++ b/crates/tasks/Cargo.toml
@@ -23,11 +23,11 @@ futures-core = { workspace = true, features = ["alloc"] }
 
 # optional
 futures-channel = { workspace = true, optional = true }
+futures-util = { workspace = true, optional = true }
 rayon = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-futures-util = { workspace = true, optional = true }
 wasm-bindgen-futures = { workspace = true, optional = true }
 
 [dev-dependencies]
@@ -37,8 +37,9 @@ tokio = { workspace = true, features = ["sync"] }
 # Standard library interop: the thread-unpark waker helper.
 std = []
 # Pool handoff over `futures-channel` oneshot: a panic-catching submit seam
-# onto the rayon pool. Implies `std`.
-rayon = [ "dep:futures-channel", "dep:rayon", "std" ]
+# onto the rayon pool. `Handoff` maps the oneshot via `futures-util`. Implies
+# `std`.
+rayon = [ "dep:futures-channel", "dep:futures-util", "dep:rayon", "std" ]
 # Spawner onto the ambient tokio runtime.
 tokio = [ "dep:tokio" ]
 # Spawner onto the browser event loop (wasm32 only).

--- a/crates/tasks/src/handoff.rs
+++ b/crates/tasks/src/handoff.rs
@@ -1,4 +1,4 @@
-//! Bounded handoff from the thread pool back to the polling future.
+//! Bounded handoff from a spawned job back to the polling future.
 
 use core::fmt;
 use core::future::Future;
@@ -7,11 +7,27 @@ use core::task::{Context, Poll};
 
 use std::panic::{AssertUnwindSafe, catch_unwind};
 
-use futures_channel::oneshot;
+use alloc::boxed::Box;
+
+use futures_channel::oneshot::{self, Canceled};
+use futures_util::FutureExt;
+use futures_util::future::Map;
+use nectar_marker::MaybeSend;
+
+use crate::{Spawn, TaskHandle};
+
+/// The oneshot resolves to the reply, or to `None` when the sender dropped
+/// unsent: a caught panic, an aborted task, or a dropped job. Stated here
+/// once; both poll paths route through it.
+type Recovered<T> = Map<oneshot::Receiver<T>, fn(Result<T, Canceled>) -> Option<T>>;
 
 /// Receiving half of one submitted job; polled by the caller's future.
+///
+/// A [`submit_on`] handoff owns the job's abort handle, so dropping it before
+/// the reply arrives aborts the task.
 pub struct Handoff<T> {
-    rx: oneshot::Receiver<T>,
+    inner: Recovered<T>,
+    _guard: Option<TaskHandle>,
 }
 
 impl<T> fmt::Debug for Handoff<T> {
@@ -21,10 +37,29 @@ impl<T> fmt::Debug for Handoff<T> {
 }
 
 impl<T> Handoff<T> {
-    /// Ready with the reply, or `None` when the job finished without one:
-    /// the job panicked, or the pool dropped it.
+    /// Wrap `rx` in the reply-or-`None` map, holding `guard` until drop.
+    fn over(rx: oneshot::Receiver<T>, guard: Option<TaskHandle>) -> Self {
+        let recover: fn(Result<T, Canceled>) -> Option<T> = Result::ok;
+        Self {
+            inner: rx.map(recover),
+            _guard: guard,
+        }
+    }
+
+    /// Ready with the reply, or `None` when the job finished without one.
+    ///
+    /// A thin delegate for poll-native callers; equivalent to polling the
+    /// handoff as a [`Future`].
     pub fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
-        Pin::new(&mut self.rx).poll(cx).map(Result::ok)
+        Pin::new(&mut self.inner).poll(cx)
+    }
+}
+
+impl<T> Future for Handoff<T> {
+    type Output = Option<T>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<T>> {
+        self.get_mut().poll_recv(cx)
     }
 }
 
@@ -45,13 +80,33 @@ where
             drop(tx.send(value));
         }
     });
-    Handoff { rx }
+    Handoff::over(rx, None)
+}
+
+/// Spawn `job` on `spawner`, returning the handoff its output arrives on.
+///
+/// The `Spawn`-generic sibling of [`submit`]: the returned handoff holds the
+/// task's abort handle, so dropping it before the job resolves aborts the
+/// task, and that drop then reads as `None`.
+pub fn submit_on<S, F, T>(spawner: &S, job: F) -> Handoff<T>
+where
+    S: Spawn,
+    F: Future<Output = T> + MaybeSend + 'static,
+    T: MaybeSend + 'static,
+{
+    let (tx, rx) = oneshot::channel();
+    let handle = spawner.spawn(Box::pin(async move {
+        drop(tx.send(job.await));
+    }));
+    Handoff::over(rx, Some(handle))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    use alloc::sync::Arc;
+    use core::sync::atomic::{AtomicU32, Ordering};
     use core::time::Duration;
     use std::thread;
     use std::time::Instant;
@@ -81,7 +136,10 @@ mod tests {
         for _ in 0..1_000 {
             let (tx, rx) = oneshot::channel::<u32>();
             let sender = thread::spawn(move || drop(tx));
-            assert_eq!(recv_before(Handoff { rx }, Duration::from_secs(10)), None);
+            assert_eq!(
+                recv_before(Handoff::over(rx, None), Duration::from_secs(10)),
+                None
+            );
             sender.join().unwrap();
         }
     }
@@ -93,7 +151,7 @@ mod tests {
             let (tx, rx) = oneshot::channel::<u32>();
             let sender = thread::spawn(move || tx.send(7).unwrap());
             assert_eq!(
-                recv_before(Handoff { rx }, Duration::from_secs(10)),
+                recv_before(Handoff::over(rx, None), Duration::from_secs(10)),
                 Some(7)
             );
             sender.join().unwrap();
@@ -105,5 +163,64 @@ mod tests {
     fn a_panicking_job_reads_as_a_drop() {
         let handoff = submit(|| panic!("job panicked"));
         assert_eq!(recv_before::<u32>(handoff, Duration::from_secs(10)), None);
+    }
+
+    /// A handoff resolves through its `Future` impl as it does through
+    /// [`Handoff::poll_recv`].
+    #[test]
+    fn drives_as_a_future() {
+        let (tx, rx) = oneshot::channel::<u32>();
+        tx.send(9).unwrap();
+        let mut handoff = Handoff::over(rx, None);
+        let waker = crate::unpark_current();
+        let mut cx = Context::from_waker(&waker);
+        assert_eq!(Pin::new(&mut handoff).poll(&mut cx), Poll::Ready(Some(9)));
+    }
+
+    /// Spawner that never runs the task and records its abort.
+    struct RecordingSpawner {
+        aborts: Arc<AtomicU32>,
+    }
+
+    impl Spawn for RecordingSpawner {
+        fn spawn(&self, task: crate::BoxFuture<'static, ()>) -> TaskHandle {
+            drop(task);
+            let aborts = Arc::clone(&self.aborts);
+            TaskHandle::new(move || {
+                aborts.fetch_add(1, Ordering::Relaxed);
+            })
+        }
+    }
+
+    /// Spawner that polls the task once; a ready future completes inline.
+    struct InlineSpawner;
+
+    impl Spawn for InlineSpawner {
+        fn spawn(&self, mut task: crate::BoxFuture<'static, ()>) -> TaskHandle {
+            let waker = crate::unpark_current();
+            let mut cx = Context::from_waker(&waker);
+            let _ = task.as_mut().poll(&mut cx);
+            TaskHandle::new(|| {})
+        }
+    }
+
+    /// `submit_on` delivers the spawned job's output on its handoff.
+    #[test]
+    fn submit_on_delivers_the_job_output() {
+        let handoff = submit_on(&InlineSpawner, async { 4_u32 });
+        assert_eq!(recv_before(handoff, Duration::from_secs(10)), Some(4));
+    }
+
+    /// Dropping the handoff aborts the task through the captured handle.
+    #[test]
+    fn dropping_a_submit_on_handoff_aborts_the_task() {
+        let aborts = Arc::new(AtomicU32::new(0));
+        let spawner = RecordingSpawner {
+            aborts: Arc::clone(&aborts),
+        };
+        let handoff = submit_on(&spawner, async { 1_u32 });
+        assert_eq!(aborts.load(Ordering::Relaxed), 0);
+        drop(handoff);
+        assert_eq!(aborts.load(Ordering::Relaxed), 1);
     }
 }

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -5,8 +5,8 @@
 //! # Features
 //!
 //! - `std`: [`unpark_current`], a thread-unpark waker for blocking bridges
-//! - `rayon`: [`submit`]/[`Handoff`], a panic-catching pool handoff over a
-//!   oneshot channel
+//! - `rayon`: [`submit`]/[`submit_on`]/[`Handoff`], a panic-catching pool
+//!   handoff over a oneshot channel; [`Handoff`] is itself a `Future`
 //! - `tokio`: `TokioSpawner`, spawns onto the ambient tokio runtime
 //! - `wasm` (wasm32 only): `WasmSpawner`, spawns onto the browser event
 //!   loop
@@ -48,7 +48,7 @@ mod wake;
 mod wasm;
 
 #[cfg(feature = "rayon")]
-pub use self::handoff::{Handoff, submit};
+pub use self::handoff::{Handoff, submit, submit_on};
 #[cfg(all(feature = "tokio", multi_thread))]
 pub use self::tokio::TokioSpawner;
 #[cfg(feature = "std")]


### PR DESCRIPTION
## What

`crates/tasks/src/handoff.rs`: `Handoff<T>` now wraps its oneshot receiver in a `Map<oneshot::Receiver<T>, fn(Result<T, Canceled>) -> Option<T>>` (a `Recovered<T>` type alias), built once by the private `Handoff::over` constructor, plus an `Option<TaskHandle>` drop-guard field. `Handoff<T>` implements `Future<Output = Option<T>>`, delegating to the existing `poll_recv`, which itself now just polls the inner map.

Adds `submit_on<S: Spawn, F: Future<Output = T> + MaybeSend + 'static, T: MaybeSend + 'static>(spawner: &S, job: F) -> Handoff<T>`: spawns `async { drop(tx.send(job.await)) }` through the `Spawn` seam and stores the returned `TaskHandle` in the handoff's guard, so dropping the handoff before the reply arrives aborts the task.

`crates/tasks/Cargo.toml`: `futures-util` moves from the wasm32-only target dependency table to an optional workspace dependency, and is added to the `rayon` feature's dependency list (`Handoff` now needs it unconditionally under that feature, not just on wasm32).

`crates/tasks/src/lib.rs`: re-exports `submit_on` alongside `Handoff`/`submit`, and updates the module-level feature doc comment accordingly.

## Why

Closes #583.

`Handoff` previously exposed only the poll-native `poll_recv` method, requiring callers to hand-roll a `Future` wrapper to `.await` a handoff or to compose it with combinators. Implementing `Future` directly removes that boilerplate. `submit_on` extends the existing rayon-pool `submit` handoff pattern to any `Spawn` implementation, with the handoff owning the task's abort handle so drop-to-cancel behaviour is uniform across spawners.

## Testing

- `drives_as_a_future`: a resolved oneshot polls to `Some` through the `Future` impl, matching `poll_recv`.
- `submit_on_delivers_the_job_output`: an inline-polling `Spawn` impl proves `submit_on` delivers the spawned job's output on its handoff.
- `dropping_a_submit_on_handoff_aborts_the_task`: a recording `Spawn` impl proves dropping the handoff invokes the captured `TaskHandle`'s abort exactly once.
- Existing `Handoff`-construction tests updated to go through `Handoff::over` rather than constructing the struct directly.

## AI Assistance

Implemented with Claude Opus, reviewed with Claude Opus.
