### PR TITLE
kernel: add shared bounded put-sink

### DIFF
--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -1,8 +1,8 @@
 //! Bounded-admission kernel beneath the streaming walkers: the shared
 //! [`Driver`] loop over a [`WalkPolicy`], the [`FuturesUnordered`] in-flight
-//! set it drains, the read-ahead [`Window`], the head-slot [`Admission`]
-//! predicate, the [`AdmitPolicy`] adaptive-window seam, and the [`BoxFuture`]
-//! alias the sets hold.
+//! set it drains, the write-side [`PutSink`] over the same set, the read-ahead
+//! [`Window`], the head-slot [`Admission`] predicate, the [`AdmitPolicy`]
+//! adaptive-window seam, and the [`BoxFuture`] alias the sets hold.
 //!
 //! The driver owns the `admit`/`take`/`poll` loop; each walker's frontier,
 //! ordering, and completion fold stay bespoke as a [`WalkPolicy`] impl in its
@@ -42,6 +42,7 @@ mod chunk;
 mod driver;
 mod future;
 mod policy;
+mod put_sink;
 mod window;
 
 pub use admission::Admission;
@@ -52,4 +53,5 @@ pub use driver::{Driver, StaticDriver, WalkPolicy};
 pub use future::BoxFuture;
 pub use futures_util::stream::FuturesUnordered;
 pub use policy::{AdmitPolicy, Fixed, FromFn, Observations, from_fn};
+pub use put_sink::PutSink;
 pub use window::Window;

--- a/crates/kernel/src/put_sink.rs
+++ b/crates/kernel/src/put_sink.rs
@@ -1,0 +1,313 @@
+//! The shared bounded put window: a [`FuturesUnordered`] set capped by
+//! [`Admission`], generic over each put's completion.
+
+use core::fmt;
+use core::future::poll_fn;
+use core::pin::Pin;
+use core::task::{Context, Poll, Waker};
+
+use futures_core::Stream;
+use futures_util::stream::FuturesUnordered;
+
+use crate::admission::Admission;
+use crate::future::BoxFuture;
+use crate::window::Window;
+
+/// Bounded set of in-flight puts, order-free within `window` slots.
+///
+/// Every put is admitted head-served, so the whole window is usable and
+/// completions surface in any order; the caller keeps its own error mapping
+/// and stats over `C`. Opening polls run on a noop waker, so a synchronously
+/// ready put settles inline and never occupies a slot; a parked put is driven
+/// only by [`poll_step`](Self::poll_step) and the wrappers over it under the
+/// caller's waker.
+pub struct PutSink<'a, C> {
+    in_flight: FuturesUnordered<BoxFuture<'a, C>>,
+    admission: Admission,
+}
+
+impl<'a, C> PutSink<'a, C> {
+    /// A put window `window` slots wide.
+    pub fn new(window: Window) -> Self {
+        Self {
+            in_flight: FuturesUnordered::new(),
+            admission: Admission::new(window),
+        }
+    }
+
+    /// Puts currently in flight; the caller's peak-occupancy stat.
+    pub fn len(&self) -> usize {
+        self.in_flight.len()
+    }
+
+    /// Whether no put is in flight.
+    pub fn is_empty(&self) -> bool {
+        self.in_flight.is_empty()
+    }
+
+    /// The window admitted against.
+    pub const fn window(&self) -> Window {
+        self.admission.window()
+    }
+
+    /// Whether the window admits another put now.
+    pub fn admits(&self) -> bool {
+        self.admission.admits(self.in_flight.len(), true)
+    }
+
+    /// Admit `put`, driving its opening poll on a noop waker: a ready put
+    /// settles inline as `Some(completion)` and never occupies a slot, a
+    /// pending one parks in the window as `None`.
+    ///
+    /// Secure a slot with [`admit`](Self::admit) first; this does not bound
+    /// the window.
+    pub fn push(&mut self, put: BoxFuture<'a, C>) -> Option<C> {
+        let mut put = put;
+        match put.as_mut().poll(&mut Context::from_waker(Waker::noop())) {
+            Poll::Ready(completion) => Some(completion),
+            Poll::Pending => {
+                self.in_flight.push(put);
+                None
+            }
+        }
+    }
+
+    /// Poll one settled put out of the window. `Ready(None)` once empty;
+    /// `Pending` leaves the window untouched.
+    pub fn poll_step(&mut self, cx: &mut Context<'_>) -> Poll<Option<C>> {
+        Pin::new(&mut self.in_flight).poll_next(cx)
+    }
+
+    /// Secure a slot. `Ready(None)` when a slot is free to [`push`](Self::push)
+    /// into; `Ready(Some(completion))` after settling one to make room;
+    /// `Pending` when full and none ready, consuming nothing.
+    pub fn poll_admit(&mut self, cx: &mut Context<'_>) -> Poll<Option<C>> {
+        if self.admits() {
+            return Poll::Ready(None);
+        }
+        // The window is full, so the set is non-empty and never yields `None`.
+        self.poll_step(cx)
+    }
+
+    /// Await one completion; `None` when the window is empty.
+    pub async fn settle_one(&mut self) -> Option<C> {
+        poll_fn(|cx| self.poll_step(cx)).await
+    }
+
+    /// Secure a slot, parking until one is free. Returns the completion that
+    /// freed it, or `None` when a slot was already free.
+    pub async fn admit(&mut self) -> Option<C> {
+        poll_fn(|cx| self.poll_admit(cx)).await
+    }
+
+    /// Fold every outstanding completion, stopping on the first `fold` error.
+    pub async fn settle<E>(&mut self, mut fold: impl FnMut(C) -> Result<(), E>) -> Result<(), E> {
+        while let Some(completion) = self.settle_one().await {
+            fold(completion)?;
+        }
+        Ok(())
+    }
+
+    /// Fold the completions ready now without parking, stopping on the first
+    /// `fold` error: newly admitted puts start under the caller's waker before
+    /// more work enters.
+    pub async fn sweep<E>(&mut self, mut fold: impl FnMut(C) -> Result<(), E>) -> Result<(), E> {
+        poll_fn(move |cx| {
+            loop {
+                match self.poll_step(cx) {
+                    Poll::Ready(Some(completion)) => {
+                        if let Err(error) = fold(completion) {
+                            return Poll::Ready(Err(error));
+                        }
+                    }
+                    Poll::Ready(None) | Poll::Pending => return Poll::Ready(Ok(())),
+                }
+            }
+        })
+        .await
+    }
+}
+
+impl<C> fmt::Debug for PutSink<'_, C> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PutSink")
+            .field("in_flight", &self.in_flight.len())
+            .field("window", &self.admission.window())
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::future::Future;
+    use core::sync::atomic::{AtomicUsize, Ordering};
+
+    use std::boxed::Box;
+    use std::sync::Arc;
+    use std::vec;
+    use std::vec::Vec;
+
+    use super::*;
+
+    /// A completion that stays pending for `left` polls, waking itself each
+    /// time, before yielding `id`: a latency injector for genuine overlap.
+    struct Delay {
+        left: u32,
+        id: usize,
+    }
+
+    impl Future for Delay {
+        type Output = usize;
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<usize> {
+            if self.left == 0 {
+                return Poll::Ready(self.id);
+            }
+            self.left -= 1;
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        }
+    }
+
+    fn delayed(id: usize, left: u32) -> BoxFuture<'static, usize> {
+        Box::pin(Delay { left, id })
+    }
+
+    fn window(slots: u16) -> Window {
+        Window::new(slots).unwrap()
+    }
+
+    #[test]
+    fn synchronous_put_settles_inline_without_a_slot() {
+        let mut sink: PutSink<'static, usize> = PutSink::new(window(4));
+        assert_eq!(sink.push(delayed(7, 0)), Some(7));
+        assert_eq!(sink.len(), 0);
+        assert!(sink.is_empty());
+    }
+
+    #[test]
+    fn peak_stays_within_the_window_and_overlaps() {
+        nectar_testing::run(async {
+            let mut sink: PutSink<'static, usize> = PutSink::new(window(4));
+            let mut peak = 0;
+            let mut done = Vec::new();
+            for id in 0..20 {
+                if let Some(completion) = sink.admit().await {
+                    done.push(completion);
+                }
+                assert!(sink.admits());
+                if let Some(completion) = sink.push(delayed(id, 3)) {
+                    done.push(completion);
+                }
+                peak = peak.max(sink.len());
+            }
+            sink.settle(|completion| {
+                done.push(completion);
+                Ok::<(), ()>(())
+            })
+            .await
+            .unwrap();
+
+            // Bounded: the window is never exceeded.
+            assert!(peak <= 4, "peak {peak} exceeded the window");
+            // Genuine overlap: more than one put ran concurrently.
+            assert!(peak > 1, "peak {peak} shows no overlap");
+            // Byte-safety: every put settled exactly once.
+            done.sort_unstable();
+            assert_eq!(done, (0..20).collect::<Vec<_>>());
+        });
+    }
+
+    #[test]
+    fn completions_are_order_free() {
+        nectar_testing::run(async {
+            let mut sink: PutSink<'static, usize> = PutSink::new(window(8));
+            // Later ids finish first: submission order is not completion order.
+            for id in 0..6 {
+                let latency = u32::try_from(6 - id).unwrap();
+                assert!(sink.push(delayed(id, latency)).is_none());
+            }
+            let mut order = Vec::new();
+            sink.settle(|completion| {
+                order.push(completion);
+                Ok::<(), ()>(())
+            })
+            .await
+            .unwrap();
+
+            assert_ne!(order, (0..6).collect::<Vec<_>>());
+            order.sort_unstable();
+            assert_eq!(order, (0..6).collect::<Vec<_>>());
+        });
+    }
+
+    #[test]
+    fn settle_stops_on_the_first_fold_error() {
+        nectar_testing::run(async {
+            let mut sink: PutSink<'static, usize> = PutSink::new(window(4));
+            for id in 0..4 {
+                assert!(sink.push(delayed(id, 1)).is_none());
+            }
+            let mut seen = 0;
+            let outcome = sink
+                .settle(|_| {
+                    seen += 1;
+                    Err::<(), usize>(seen)
+                })
+                .await;
+            assert_eq!(outcome, Err(1));
+            assert_eq!(seen, 1);
+        });
+    }
+
+    #[test]
+    fn sweep_folds_ready_puts_without_parking() {
+        nectar_testing::run(async {
+            let mut sink: PutSink<'static, usize> = PutSink::new(window(4));
+            // One ready-after-a-poll and one long-lived put.
+            assert!(sink.push(delayed(1, 1)).is_none());
+            assert!(sink.push(delayed(2, 1000)).is_none());
+            let mut swept = Vec::new();
+            // The first sweep may see nothing ready yet; keep sweeping until
+            // the short put lands, proving sweep never parks on the long one.
+            while swept.is_empty() {
+                sink.sweep(|completion| {
+                    swept.push(completion);
+                    Ok::<(), ()>(())
+                })
+                .await
+                .unwrap();
+            }
+            assert_eq!(swept, vec![1]);
+            assert_eq!(sink.len(), 1);
+        });
+    }
+
+    #[test]
+    fn dropping_mid_flight_aborts_every_put() {
+        let alive = Arc::new(AtomicUsize::new(0));
+        let mut sink: PutSink<'static, usize> = PutSink::new(window(8));
+        for id in 0..3 {
+            let alive = Arc::clone(&alive);
+            alive.fetch_add(1, Ordering::SeqCst);
+            sink.push(Box::pin(async move {
+                let _guard = Guard(alive);
+                core::future::pending::<()>().await;
+                id
+            }));
+        }
+        assert_eq!(sink.len(), 3);
+        assert_eq!(alive.load(Ordering::SeqCst), 3);
+
+        drop(sink);
+        // Every parked put was dropped, none ran to completion.
+        assert_eq!(alive.load(Ordering::SeqCst), 0);
+
+        struct Guard(Arc<AtomicUsize>);
+        impl Drop for Guard {
+            fn drop(&mut self) {
+                self.0.fetch_sub(1, Ordering::SeqCst);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Extracts one shared bounded put-sink into `nectar-kernel`: a new `put_sink` module, exported as `PutSink`, alongside `Driver`/`Admission`/`Window`, so the three hand-rolled put-window copies elsewhere can fold onto it later.

`PutSink<'a, C>` wraps a `FuturesUnordered<BoxFuture<'a, C>>` capped by `Admission` and is generic over each put's completion `C`, so the caller keeps its own error mapping (e.g. `SplitError` vs `BuildError`) and stats (peak-in-flight via `len()`).

Poll-native core: `poll_step` (poll one completion) and `poll_admit` (secure a slot; `Ready(None)` = slot free, `Ready(Some)` = settled-to-make-room, `Pending` consumes nothing). `push()` drives the opening poll on `Waker::noop()` so a synchronously-ready put settles inline and never occupies a slot.

Thin `poll_fn` async wrappers mirror the existing `relay.rs` shape: `settle_one`, `admit`, `settle`, `sweep`. `settle`/`sweep` take an `impl FnMut(C) -> Result<(), E>` fold so the caller's error mapping stays generic.

`crates/kernel/src/lib.rs` gains the `put_sink` module wiring and the `PutSink` re-export, plus a doc-comment update naming it alongside the other kernel primitives.

## Why

Three walkers currently hand-roll their own bounded put-window bookkeeping. Landing one shared, poll-native primitive in `nectar-kernel` lets each of those copies fold onto it in a follow-up, without forcing a shared error or stats type on the callers.

## Testing

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --locked`: no errors; `nectar-kernel` itself is clippy-clean (the only warnings present are pre-existing `clippy::doc_lazy_continuation` in `crates/testing/src/lib.rs`, untouched by this branch).
- Diff scope verified as `crates/kernel/src/lib.rs` and `crates/kernel/src/put_sink.rs` only; no `Cargo.toml`/`Cargo.lock`/`zepter.yaml` touched.
- Unit tests in `put_sink.rs` cover: synchronous put settling inline without occupying a slot, peak in-flight staying within the window under latency injection with genuine overlap, order-free completions, `settle` stopping on the first fold error, `sweep` folding ready puts without parking, and drop-mid-flight cancel-safety.

Closes #582

## AI Assistance

Implemented with Claude Opus, reviewed with Claude Opus, per github.com/nxm-rs/.github CONTRIBUTING.md.
