### PR TITLE
postage-issuer: replace hand-rolled Completion future with nectar-tasks submit_on

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2709,6 +2709,7 @@ dependencies = [
  "alloy-signer-local",
  "futures-channel",
  "futures-core",
+ "futures-util",
  "nectar-clock",
  "nectar-file",
  "nectar-kernel",

--- a/crates/postage-issuer/Cargo.toml
+++ b/crates/postage-issuer/Cargo.toml
@@ -32,6 +32,7 @@ alloy-signer = { workspace = true, optional = true }
 alloy-signer-local = { workspace = true, optional = true }
 futures-channel = { workspace = true, optional = true }
 futures-core = { workspace = true, optional = true }
+futures-util = { workspace = true, optional = true }
 nectar-tasks = { workspace = true, optional = true }
 rayon = { workspace = true, optional = true }
 
@@ -58,10 +59,12 @@ std = [
 	"dep:alloy-signer",
 	"dep:futures-channel",
 	"dep:futures-core",
+	"dep:futures-util",
 	"dep:nectar-tasks",
 	"nectar-clock/std",
 	"nectar-postage/std",
 	"nectar-primitives/std",
+	"nectar-tasks/rayon",
 	"nectar-tasks/std",
 ]
 

--- a/crates/postage-issuer/Cargo.toml
+++ b/crates/postage-issuer/Cargo.toml
@@ -57,7 +57,6 @@ default = [ "std" ]
 # this gate.
 std = [
 	"dep:alloy-signer",
-	"dep:futures-channel",
 	"dep:futures-core",
 	"dep:futures-util",
 	"dep:nectar-tasks",
@@ -74,6 +73,7 @@ local-signer = [ "dep:alloy-signer-local", "std" ]
 # The pipeline's parallel signing engine using rayon. Rayon on wasm32 or
 # under `unsync` is a compile error, never a silent fallback.
 parallel = [
+	"dep:futures-channel",
 	"dep:rayon",
 	"nectar-postage/parallel",
 	"nectar-primitives/parallel",

--- a/crates/postage-issuer/src/pipeline/stamp_sink.rs
+++ b/crates/postage-issuer/src/pipeline/stamp_sink.rs
@@ -12,50 +12,23 @@ use alloc::boxed::Box;
 use alloc::collections::VecDeque;
 use alloc::sync::Arc;
 use core::fmt;
-use core::future::Future;
 use core::pin::Pin;
 use core::task::{Context, Poll, Waker};
 
-use futures_channel::oneshot;
 use futures_core::Stream;
+use futures_util::FutureExt;
 use nectar_clock::Clock;
-use nectar_kernel::{BoxFuture, FuturesUnordered};
+use nectar_kernel::{Admission, BoxFuture, FuturesUnordered};
 use nectar_marker::{MaybeSend, MaybeSync};
 use nectar_postage::StampDigest;
 use nectar_primitives::ChunkAddress;
-use nectar_tasks::{Spawn, TaskHandle};
+use nectar_tasks::{Spawn, submit_on};
 
 use super::task::sign_task;
 use super::{SignPrehash, StampPipeline, StampResult};
 use crate::error::SigningError;
 use crate::issuer::StampIssuer;
 use crate::prepared::prepare_stamps;
-
-/// Awaits one job's completion; dropping it aborts the job.
-///
-/// A cancelled receiver (the sign task dropped before sending) yields a
-/// systemic [`SigningError::Dropped`], so a lost job never wedges the sink.
-struct Completion {
-    address: ChunkAddress,
-    rx: oneshot::Receiver<StampResult>,
-    _task: TaskHandle,
-}
-
-impl Future for Completion {
-    type Output = StampResult;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<StampResult> {
-        let this = self.get_mut();
-        match Pin::new(&mut this.rx).poll(cx) {
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(Ok(result)) => Poll::Ready(result),
-            Poll::Ready(Err(oneshot::Canceled)) => Poll::Ready(StampResult {
-                address: this.address,
-                result: Err(SigningError::Dropped),
-            }),
-        }
-    }
-}
 
 impl<Sg, C> StampPipeline<Sg, C>
 where
@@ -175,7 +148,7 @@ where
                 });
                 return Poll::Ready(());
             }
-            if self.room() > 0 {
+            if self.admits() {
                 self.admit_batch(&[address]);
                 return Poll::Ready(());
             }
@@ -199,7 +172,15 @@ where
         self.harvest(cx)
     }
 
-    /// Window slots currently free.
+    /// Whether the window admits one more job.
+    ///
+    /// Completions yield unordered, so no slot is reserved for a serial head:
+    /// every admission counts as head-served, opening the full window.
+    pub(super) fn admits(&self) -> bool {
+        Admission::new(self.pipeline.window).admits(self.in_flight.len(), true)
+    }
+
+    /// Window slots currently free, sizing a refill micro-batch.
     pub(super) fn room(&self) -> usize {
         usize::from(self.pipeline.window.get()).saturating_sub(self.in_flight.len())
     }
@@ -219,19 +200,25 @@ where
         }
     }
 
-    /// Spawns the sign job and tracks its completion in the in-flight set.
+    /// Submits the sign job and tracks its completion in the in-flight set.
+    ///
+    /// The handoff owns the job's abort handle, so dropping it aborts the
+    /// task; a cancelled handoff (the task dropped before replying) maps to a
+    /// systemic [`SigningError::Dropped`] for the admitted address, so a lost
+    /// job never wedges the sink.
     fn submit(&mut self, digest: StampDigest) {
-        let (tx, rx) = oneshot::channel();
         let signer = Arc::clone(&self.pipeline.signer);
         let address = digest.chunk_address;
-        let task = self.spawner.spawn(Box::pin(async move {
-            let _ = tx.send(sign_task(signer.as_ref(), &digest));
-        }));
-        self.in_flight.push(Box::pin(Completion {
-            address,
-            rx,
-            _task: task,
-        }));
+        let handoff = submit_on(
+            &self.spawner,
+            async move { sign_task(signer.as_ref(), &digest) },
+        );
+        self.in_flight.push(Box::pin(handoff.map(move |reply| {
+            reply.unwrap_or(StampResult {
+                address,
+                result: Err(SigningError::Dropped),
+            })
+        })));
     }
 
     /// Polls the in-flight set for one completion and applies fail-fast.
@@ -257,6 +244,7 @@ mod tests {
     use alloy_signer::SignerSync;
     use core::sync::atomic::{AtomicUsize, Ordering};
     use nectar_kernel::Window;
+    use nectar_tasks::TaskHandle;
     use std::sync::{Mutex, mpsc};
     use std::task::Wake;
     use std::time::{Duration, Instant};


### PR DESCRIPTION
## What

Deletes the bespoke `Completion` struct and its hand-written `impl Future` over a oneshot cell in `crates/postage-issuer/src/pipeline/stamp_sink.rs`.

In-flight sign completions are now built with `nectar_tasks::submit_on(&spawner, job)`, whose returned handoff owns the abort-on-drop task handle.

A `FutureExt::map` closure captures the chunk address and maps a cancelled handoff (`None`, i.e. a dropped reply) to `StampResult { address, result: Err(SigningError::Dropped) }`.

The sink's admission decision now routes through `nectar_kernel::Admission::admits(in_flight, head_served=true)` via a new `admits()` helper, since unordered completion means every candidate is head-served and the full window is usable.

`room()` is retained separately, sizing the refill micro-batch for the synchronous `mod.rs::refill` path.

Adds `futures-util` (for `FutureExt`) and enables `nectar-tasks/rayon` under the `std` feature in `crates/postage-issuer/Cargo.toml`.

## Why

Closes #589.

Removes a hand-maintained `Future` implementation and oneshot-channel plumbing in favour of the shared `nectar-tasks` submit/handoff primitive, so completion handling and abort-on-drop semantics live in one place instead of being reimplemented per call site.

## Testing

All 12 `stamp_sink` guard tests pass under both the default and `--features parallel` configurations.

Doctests pass; clippy is clean; `--locked` is honoured; the `nostd` wasm32 `--no-default-features` check passes.

## AI Assistance

Implemented with Claude Opus, reviewed with Claude Opus.
