### PR TITLE
build(manifest): drop the now-unused futures-core dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2617,7 +2617,6 @@ dependencies = [
  "arbitrary",
  "bytes",
  "futures",
- "futures-core",
  "nectar-file",
  "nectar-kernel",
  "nectar-manifest",

--- a/crates/manifest/Cargo.toml
+++ b/crates/manifest/Cargo.toml
@@ -21,7 +21,6 @@ workspace = true
 alloy-primitives = { workspace = true }
 arbitrary = { workspace = true, optional = true }
 bytes.workspace = true
-futures-core = { workspace = true }
 nectar-file = { workspace = true, features = ["primitives"] }
 nectar-kernel = { workspace = true }
 nectar-primitives = { workspace = true }
@@ -59,7 +58,6 @@ encryption = []
 std = [
 	"alloy-primitives/std",
 	"bytes/std",
-	"futures-core/std",
 	"nectar-file/std",
 	"nectar-primitives/std",
 	"thiserror/std",


### PR DESCRIPTION
## What
Removes the `futures-core` dependency from `nectar-manifest` (both the direct dependency line and the `futures-core/std` entry in the `std` feature), and regenerates `Cargo.lock`.

## Why
`cargo machete` flags `futures-core` as unused in `nectar-manifest` — no `futures_core` reference exists anywhere in `crates/manifest/src`. The crate gets `BoxFuture` via the `nectar-kernel` re-export instead, so the direct dependency is dead weight.

## Testing
- `cargo machete` reports no unused dependencies workspace-wide.
- `cargo build -p nectar-manifest --locked` and `cargo build -p nectar-manifest --locked --all-features` both succeed.
- `cargo check --workspace --locked` succeeds.
- `cargo nextest run -p nectar-manifest --locked`: 183 passed, 0 failed.