### PR TITLE
gate: add streaming-layer deny-rules to reinvention-gate

### DIFF
--- a/crates/postage-issuer/src/pipeline/stamped_put.rs
+++ b/crates/postage-issuer/src/pipeline/stamped_put.rs
@@ -62,10 +62,11 @@ pub enum StampedPutError<E> {
 
 /// One address's stamping progress, shared across clones.
 ///
-/// Kept over a shared signing future: this registry folds in-flight
-/// duplicates onto one allocation, one sign and one delivery, and hands the
-/// retained stamp to the next put when a delivery fails or is cancelled,
-/// which a shared future cannot express.
+/// Sanctioned hand-rolled registry, kept over `futures::Shared`: it folds
+/// in-flight duplicates onto one allocation, one sign and one delivery, and
+/// redelivers the retained stamp to the next put when a delivery fails or is
+/// cancelled, which `Shared`, cloning one output to every waiter, cannot
+/// express.
 enum Issued {
     /// Allocated; signing in flight. Wakers re-poll when it resolves.
     Pending(Vec<Waker>),

--- a/tools/reinvention-gate.sh
+++ b/tools/reinvention-gate.sh
@@ -10,8 +10,10 @@
 # Sanctioned homes:
 #   nectar-testing        the sole block_on entry (`run`) plus its Drive waker
 #   nectar-tasks wake.rs  the shared thread-unpark waker (`unpark_current`)
-#   nectar-tasks handoff  the pool-to-poll blocking bridge
+#   nectar-tasks handoff  the pool-to-poll blocking bridge and pool submit
+#   nectar-kernel PutSink the bounded put window over FuturesUnordered
 #   postage-issuer pump   the Stamped sign-admission pump
+#   postage-issuer task   the sign-job panic boundary
 #   nectar-marker         the sole MaybeSend/MaybeSync cfg dance
 
 set -euo pipefail
@@ -32,6 +34,33 @@ deny() {
         hits=$(printf '%s\n' "$hits" | grep -vE "^${allow}" || true)
     done
     hits=$(printf '%s\n' "$hits" | grep -v '^$' || true)
+    if [ -n "$hits" ]; then
+        printf 'reinvention gate: %s\n' "$label" >&2
+        printf '%s\n' "$hits" | sed 's/^/  /' >&2
+        fail=1
+    fi
+}
+
+# deny_pair <label> <ere-a> <ere-b> [allow-path-prefix ...]
+# Reports every `crates/**/*.rs` FILE matching BOTH patterns outside the
+# allowed paths: a shape whose tell is the co-occurrence, not either line
+# alone, so neither pattern on its own trips it.
+deny_pair() {
+    local label=$1 pat_a=$2 pat_b=$3
+    shift 3
+    local files file allow skip hits=''
+    files=$(grep -rlE --include='*.rs' -- "$pat_a" crates/ | sort -u || true)
+    for file in $files; do
+        grep -qE -- "$pat_b" "$file" || continue
+        skip=0
+        for allow in "$@"; do
+            case "$file" in
+                "$allow"*) skip=1; break ;;
+            esac
+        done
+        [ "$skip" -eq 0 ] && hits="${hits}${file}"$'\n'
+    done
+    hits=$(printf '%s' "$hits" | grep -v '^$' || true)
     if [ -n "$hits" ]; then
         printf 'reinvention gate: %s\n' "$label" >&2
         printf '%s\n' "$hits" | sed 's/^/  /' >&2
@@ -88,6 +117,34 @@ deny 'thread::park executor loop (use nectar_testing::run or nectar_tasks)' \
     'crates/tasks/src/handoff.rs' \
     'crates/postage-issuer/src/pipeline/mod.rs' \
     'crates/postage-issuer/src/pipeline/stamped_put.rs'
+
+# The bounded put window: a fresh `FuturesUnordered` set drained by
+# `settle_one`/`sweep`. The kernel `PutSink` is its sole home; a new in-flight
+# set or a drain-settle loop elsewhere is a copy. Only the sign-admission pump
+# owns its own set. `settle`/`drain` alone (a `Format` fold, `VecDeque::drain`)
+# is not this shape and is left alone.
+deny 'hand-rolled put window (use nectar_kernel::PutSink)' \
+    'fn[[:space:]]+(settle_one|sweep)[[:space:]]*[<(]|FuturesUnordered::new[[:space:]]*\(\)' \
+    'crates/kernel/' \
+    'crates/postage-issuer/src/pipeline/stamp_sink.rs'
+
+# The pool submit: a rayon pool job whose reply arrives on a oneshot. The
+# handoff owns this pairing; `submit`/`submit_on` return it. A bare pool
+# adapter (rayon::spawn, no oneshot) is not this shape and is left alone.
+deny_pair 'hand-rolled pool submit (use nectar_tasks::submit/submit_on)' \
+    'rayon::spawn' \
+    'oneshot::channel' \
+    'crates/tasks/'
+
+# The panic boundary: catch a job's unwind so a poisoned signer or pool worker
+# drops its reply unsent instead of aborting the process. Two boundaries only;
+# the seed-replay harness catches to assert a panic message, not to bound a
+# job, so it stays sanctioned in its own home.
+deny 'catch_unwind panic boundary (use the sanctioned task.rs/handoff.rs)' \
+    'catch_unwind' \
+    'crates/postage-issuer/src/pipeline/task.rs' \
+    'crates/tasks/src/handoff.rs' \
+    'crates/testing/src/seeds.rs'
 
 if [ "$fail" -ne 0 ]; then
     printf '\nreinvention gate failed: see matches above.\n' >&2


### PR DESCRIPTION
## What

Extends `tools/reinvention-gate.sh` with three streaming-layer deny-rules and adds a keep-proof rustdoc note to the `stamped_put` `Issued` registry.

- Hand-rolled put window: denies `fn settle_one`/`fn sweep` or `FuturesUnordered::new()` outside `crates/kernel/`, allowing the sign-admission pump (`stamp_sink.rs`) which legitimately owns its own `FuturesUnordered`.
- Hand-rolled pool submit: a new `deny_pair` helper reports any `crates/` file outside `crates/tasks/` that contains both `rayon::spawn` and `oneshot::channel` (the pool-submit pairing sanctioned in `handoff.rs`), using per-file co-occurrence because line-based grep cannot express "paired".
- catch_unwind panic boundary: restricts the panic boundary to the sanctioned `postage-issuer/src/pipeline/task.rs` and `nectar-tasks/src/handoff.rs`, with the seed-replay harness (`crates/testing/src/seeds.rs`) left sanctioned in its own home.

The `Issued` registry rustdoc note now records why it is kept over `futures::Shared`, which clones one output to every waiter and so cannot redeliver a retained stamp to the next put on failure or cancellation.

Scope fence respected: only `tools/reinvention-gate.sh` and `crates/postage-issuer/src/pipeline/stamped_put.rs` changed.

## Why

Closes #602.

## Testing

Ran the extended gate against the full battery: clean on `main`/HEAD, each of the three new rules fails on a planted violation (rule 1 tested on both its regex branches), and removing each plant restores a pass. Confirmed the precise-pattern requirement holds: `bridge.rs`'s bare `rayon::spawn` adapter is not flagged, and the anchored sweep pattern does not false-positive.

## AI Assistance

Implemented with Claude Opus, reviewed with Claude Opus.
