### PR TITLE
docs: tighten streaming-layer comments

### DIFF
--- a/crates/file/src/split/engine.rs
+++ b/crates/file/src/split/engine.rs
@@ -425,8 +425,8 @@ where
         if !self.leaf.is_empty() || self.stats.bytes == 0 {
             self.begin_leaf();
             let mut payload = mem::take(&mut self.leaf);
-            // The tail rarely fills the reserved body; give the slack back
-            // before the payload is pinned inside the sealed chunk.
+            // Give the reserved slack back before the payload is pinned in
+            // the sealed chunk.
             payload.shrink_to_fit();
             self.spill_leaf(payload)?;
         }

--- a/crates/kernel/src/put_sink.rs
+++ b/crates/kernel/src/put_sink.rs
@@ -16,11 +16,10 @@ use crate::window::Window;
 /// Bounded set of in-flight puts, order-free within `window` slots.
 ///
 /// Every put is admitted head-served, so the whole window is usable and
-/// completions surface in any order; the caller keeps its own error mapping
-/// and stats over `C`. Opening polls run on a noop waker, so a synchronously
-/// ready put settles inline and never occupies a slot; a parked put is driven
-/// only by [`poll_step`](Self::poll_step) and the wrappers over it under the
-/// caller's waker.
+/// completions surface in any order. Opening polls run on a noop waker, so a
+/// synchronously ready put settles inline and never occupies a slot; a parked
+/// put is driven only by [`poll_step`](Self::poll_step) and the wrappers over
+/// it under the caller's waker.
 pub struct PutSink<'a, C> {
     in_flight: FuturesUnordered<BoxFuture<'a, C>>,
     admission: Admission,

--- a/crates/manifest/src/builder.rs
+++ b/crates/manifest/src/builder.rs
@@ -63,8 +63,8 @@ pub enum BuildError {
     #[error(transparent)]
     EmptyPrefix(#[from] ForkPrefixEmpty),
     /// A single fork record outweighed a whole segment. Unreachable under the
-    /// frozen bounds (worst record weight 2952 <= CAP_FORK 4091); the guard
-    /// stays so a future parameter drift fails loud rather than silently.
+    /// frozen bounds (worst record weight 2952 <= CAP_FORK 4091); a parameter
+    /// drift trips it rather than corrupting silently.
     #[error(transparent)]
     Weight(#[from] WeightOverBudget),
     /// A stack invariant did not hold; a builder bug rather than bad input.
@@ -232,9 +232,8 @@ fn put_window<F: Format>() -> Window {
 /// A chunk's address is content-derived at seal, so a parent references a
 /// child the moment it seals while the child's put still rides the window.
 /// Puts are order-free, so the whole window admits; every put is settled
-/// before the root is returned. The window itself is the shared kernel
-/// put-sink; this wrapper only seals chunks, maps faults to [`BuildError`],
-/// and records the peak occupancy.
+/// before the root is returned. Wraps the shared kernel put-sink, sealing
+/// chunks and mapping faults to [`BuildError`].
 struct PutSink<'s, S: ChunkPut + MaybeSync> {
     store: &'s S,
     sink: nectar_kernel::PutSink<'s, Result<(), BuildError>>,
@@ -623,7 +622,7 @@ where
 /// `F::BUDGET` seals as one node, and a wider body partitions at content-defined
 /// boundaries into leaf and directory segments no larger than one chunk. The
 /// `OverBudget` guard on [`Node::encode`] therefore stays unreachable on this
-/// path, kept only as a fail-closed backstop for a future parameter drift.
+/// path.
 pub(crate) async fn emit_node<S, F>(
     store: &S,
     node: &Node<F>,

--- a/crates/postage-issuer/src/pipeline/stamped_put.rs
+++ b/crates/postage-issuer/src/pipeline/stamped_put.rs
@@ -62,11 +62,9 @@ pub enum StampedPutError<E> {
 
 /// One address's stamping progress, shared across clones.
 ///
-/// Sanctioned hand-rolled registry, kept over `futures::Shared`: it folds
-/// in-flight duplicates onto one allocation, one sign and one delivery, and
-/// redelivers the retained stamp to the next put when a delivery fails or is
-/// cancelled, which `Shared`, cloning one output to every waiter, cannot
-/// express.
+/// Hand-rolled over `futures::Shared`: folds duplicates onto one allocation,
+/// sign and delivery, and redelivers the retained stamp on failure or
+/// cancellation, which `Shared` can't express.
 enum Issued {
     /// Allocated; signing in flight. Wakers re-poll when it resolves.
     Pending(Vec<Waker>),
@@ -243,16 +241,14 @@ enum Step {
 /// # Contracts
 ///
 /// - Clone-shared state: every clone drives one issuer watermark and one
-///   issued map. A value-cloned issuer would allocate duplicate indices,
-///   so the issuer is held behind a shared handle and never cloned.
+///   issued map. The issuer is held behind a shared handle and never cloned.
 /// - Per-address idempotence: the issued map is consulted before
 ///   allocation. A duplicate put reuses the signed stamp, or returns
 ///   without a second sink put once the first succeeded; in-flight
 ///   duplicates share one allocation and one sink delivery, a failed or
-///   cancelled delivery handing the signed stamp to the next put. A
-///   bucket-capacity-exceeding run of identical chunks (a large zeroed
-///   region) would otherwise refuse with `BucketFull`. Cost is ~145 B per
-///   unique address; see [`IssuedBound`] for the bound and off switches.
+///   cancelled delivery handing the signed stamp to the next put. Cost is
+///   ~145 B per unique address; see [`IssuedBound`] for the bound and off
+///   switches.
 /// - The decorator stamps per put, not per reachable chunk: a wrapped
 ///   re-commit stamps only newly-put chunks.
 /// - Transport retries compose below [`PutStamped`], reusing the already

--- a/crates/tasks/src/handoff.rs
+++ b/crates/tasks/src/handoff.rs
@@ -17,8 +17,7 @@ use nectar_marker::MaybeSend;
 use crate::{Spawn, TaskHandle};
 
 /// The oneshot resolves to the reply, or to `None` when the sender dropped
-/// unsent: a caught panic, an aborted task, or a dropped job. Stated here
-/// once; both poll paths route through it.
+/// unsent: a caught panic, an aborted task, or a dropped job.
 type Recovered<T> = Map<oneshot::Receiver<T>, fn(Result<T, Canceled>) -> Option<T>>;
 
 /// Receiving half of one submitted job; polled by the caller's future.


### PR DESCRIPTION
Comment-terseness sweep over the streaming-consolidation surface. Deletes rationale-essay and narration from rustdoc and inline comments while keeping the terse intent plus non-obvious invariant.

Comments and doc prose only; no code, signature, test, or doctest-code changes.

## Testing

`cargo build --workspace --locked`, `cargo test --doc` over the five touched crates, and `cargo fmt --check` all green.