### PR TITLE
chore(tasks,mantaray): ungate submit_on; document editor commit residency

### DIFF
--- a/crates/mantaray/src/editor.rs
+++ b/crates/mantaray/src/editor.rs
@@ -7,6 +7,10 @@
 //! ops are never reordered or batched. Nodes persist through a
 //! [`NodeSaver`], so the storage layout and any put concurrency are the
 //! adapter's.
+//!
+//! Commit cost is O(touched trie), not O(whole trie): a deliberate trade for
+//! the submission-order pin. Bulk construction should use the manifest 1.0
+//! builder instead.
 
 use alloc::boxed::Box;
 use alloc::collections::BTreeMap;

--- a/crates/tasks/Cargo.toml
+++ b/crates/tasks/Cargo.toml
@@ -36,10 +36,11 @@ tokio = { workspace = true, features = ["sync"] }
 [features]
 # Standard library interop: the thread-unpark waker helper.
 std = []
-# Pool handoff over `futures-channel` oneshot: a panic-catching submit seam
-# onto the rayon pool. `Handoff` maps the oneshot via `futures-util`. Implies
-# `std`.
-rayon = [ "dep:futures-channel", "dep:futures-util", "dep:rayon", "std" ]
+# Spawn-generic job handoff over a `futures-channel` oneshot: [`Handoff`] and
+# [`submit_on`], mapped via `futures-util`. Implies `std`.
+handoff = [ "dep:futures-channel", "dep:futures-util", "std" ]
+# Panic-catching [`submit`] onto the rayon pool. Implies `handoff`.
+rayon = [ "dep:rayon", "handoff" ]
 # Spawner onto the ambient tokio runtime.
 tokio = [ "dep:tokio" ]
 # Spawner onto the browser event loop (wasm32 only).

--- a/crates/tasks/src/handoff.rs
+++ b/crates/tasks/src/handoff.rs
@@ -5,6 +5,7 @@ use core::future::Future;
 use core::pin::Pin;
 use core::task::{Context, Poll};
 
+#[cfg(feature = "rayon")]
 use std::panic::{AssertUnwindSafe, catch_unwind};
 
 use alloc::boxed::Box;
@@ -68,6 +69,7 @@ impl<T> Future for Handoff<T> {
 /// future ever blocks on the pool. A panicking job is caught here and drops
 /// its sender unsent, so the receiver sees a dropped job instead of a
 /// process abort.
+#[cfg(feature = "rayon")]
 pub fn submit<T, F>(job: F) -> Handoff<T>
 where
     T: Send + 'static,
@@ -158,6 +160,7 @@ mod tests {
     }
 
     /// The pool path end to end: a panicking job reads as a drop.
+    #[cfg(feature = "rayon")]
     #[test]
     fn a_panicking_job_reads_as_a_drop() {
         let handoff = submit(|| panic!("job panicked"));

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -5,8 +5,10 @@
 //! # Features
 //!
 //! - `std`: [`unpark_current`], a thread-unpark waker for blocking bridges
-//! - `rayon`: [`submit`]/[`submit_on`]/[`Handoff`], a panic-catching pool
-//!   handoff over a oneshot channel; [`Handoff`] is itself a `Future`
+//! - `handoff`: [`submit_on`]/[`Handoff`], a `Spawn`-generic job handoff
+//!   over a oneshot channel; [`Handoff`] is itself a `Future`
+//! - `rayon`: [`submit`], a panic-catching submit onto the rayon pool;
+//!   implies `handoff`
 //! - `tokio`: `TokioSpawner`, spawns onto the ambient tokio runtime
 //! - `wasm` (wasm32 only): `WasmSpawner`, spawns onto the browser event
 //!   loop
@@ -38,7 +40,7 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-#[cfg(feature = "rayon")]
+#[cfg(feature = "handoff")]
 mod handoff;
 #[cfg(all(feature = "tokio", multi_thread))]
 mod tokio;
@@ -48,7 +50,9 @@ mod wake;
 mod wasm;
 
 #[cfg(feature = "rayon")]
-pub use self::handoff::{Handoff, submit, submit_on};
+pub use self::handoff::submit;
+#[cfg(feature = "handoff")]
+pub use self::handoff::{Handoff, submit_on};
 #[cfg(all(feature = "tokio", multi_thread))]
 pub use self::tokio::TokioSpawner;
 #[cfg(feature = "std")]


### PR DESCRIPTION
## What
- `crates/tasks`: split the `rayon` feature into `handoff` (submit_on/Handoff, needs only Spawn + oneshot + futures-util) and `rayon` (submit, needs rayon + catch_unwind); `rayon` implies `handoff`.
- `crates/mantaray`: terse module-doc note on the editor's O(touched-trie) commit residency (submission-order pin) and a pointer to the manifest 1.0 builder for bulk construction.

## Why
`submit_on` never needed rayon; gating it behind that feature blocked non-rayon consumers from reaching it.

## Testing
- `cargo build -p nectar-tasks --locked` (default and `--features rayon`)
- `cargo build -p nectar-mantaray --locked`
- `cargo nextest run -p nectar-tasks --locked` (default and `--features rayon`)
- `cargo machete` (workspace-wide, clean)
- `cargo fmt -- --check`
- `tools/reinvention-gate.sh`