### PR TITLE
chore(dev): AGENTS.md guiding principles + Claude hooks + dev-shell tooling

### DIFF
--- a/.claude/hooks/content-lint.sh
+++ b/.claude/hooks/content-lint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# PostToolUse(Write|Edit): flag edits that introduce banned tokens (house style).
+# dipper bans em-dashes in source, rustdoc, and markdown (AGENTS.md).
+set -u
+f=$(jq -r '.tool_input.file_path // .tool_response.filePath // empty' 2>/dev/null) || exit 0
+case "$f" in *.rs|*.md) ;; *) exit 0 ;; esac
+[ -f "$f" ] || exit 0
+if rg -qF $'\xe2\x80\x94' "$f"; then
+  printf '{"decision":"block","reason":%s}\n' \
+    "$(jq -Rn --arg r "Em-dash found in $f. This repo bans em-dashes (AGENTS.md): use ASCII hyphens or split the sentence." '$r')"
+fi
+exit 0

--- a/.claude/hooks/nextest-on-stop.sh
+++ b/.claude/hooks/nextest-on-stop.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Stop hook: run `cargo nextest run` for the workspace crates that have
+# uncommitted .rs changes. Non-blocking; reports a pass/fail summary. No-op when
+# nothing relevant changed or cargo/nextest are unavailable.
+set -u
+root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+cd "$root" || exit 0
+command -v cargo >/dev/null 2>&1 || exit 0
+cargo nextest --version >/dev/null 2>&1 || exit 0
+
+changed=$(git status --porcelain=v1 2>/dev/null | awk '{print $NF}' | rg '\.rs$' || true)
+[ -z "$changed" ] && exit 0
+
+meta=$(cargo metadata --no-deps --format-version 1 2>/dev/null) || exit 0
+pkgs=$(printf '%s\n' "$changed" | while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  printf '%s' "$meta" | jq -r --arg f "$root/$f" \
+    '.packages[] | (.manifest_path | rtrimstr("Cargo.toml")) as $d | select($f | startswith($d)) | .name'
+done | sort -u)
+[ -z "$pkgs" ] && exit 0
+
+args=(); while IFS= read -r p; do [ -n "$p" ] && args+=(-p "$p"); done <<< "$pkgs"
+list=$(printf '%s' "$pkgs" | tr '\n' ' ')
+if out=$(cargo nextest run --no-tests=warn "${args[@]}" 2>&1); then
+  printf '{"systemMessage":%s,"suppressOutput":true}\n' "$(jq -Rn --arg m "nextest OK for touched crates: $list" '$m')"
+else
+  fails=$(printf '%s' "$out" | rg -N 'FAIL|error\[|test result: FAILED|panicked' | tail -15)
+  printf '{"systemMessage":%s}\n' "$(jq -Rn --arg m "nextest FAILED for touched crates ($list):
+$fails" '$m')"
+fi
+exit 0

--- a/.claude/hooks/rustfmt-on-edit.sh
+++ b/.claude/hooks/rustfmt-on-edit.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# PostToolUse(Write|Edit): format the edited Rust file with rustfmt (edition 2024).
+# Fast per-file format; no-op for non-.rs paths or when rustfmt is unavailable.
+set -u
+f=$(jq -r '.tool_input.file_path // .tool_response.filePath // empty' 2>/dev/null) || exit 0
+case "$f" in *.rs) ;; *) exit 0 ;; esac
+[ -f "$f" ] || exit 0
+command -v rustfmt >/dev/null 2>&1 || exit 0
+rustfmt --edition 2024 "$f" 2>/dev/null || true
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,32 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/rustfmt-on-edit.sh",
+            "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/content-lint.sh",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/nextest-on-stop.sh",
+            "timeout": 600
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,12 @@ cspell.json
 # Nix
 .direnv/
 
-# Agent / local worktrees (created under these paths; never tracked)
-.claude/
+# Agent config: track shared Claude settings + hooks, ignore personal/session state.
+.claude/*
+!.claude/settings.json
+!.claude/hooks/
+.claude/settings.local.json
+.claude/worktrees/
 .worktrees/
 
 # feeds finder benchmark output (generated on demand, never committed)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,84 @@
+# AGENTS.md
+
+Guidance for agents and contributors working in nectar. Terse by design. When in
+doubt, two gates win over anything written here: `cargo clippy -- -D warnings` and
+`tools/reinvention-gate.sh`.
+
+`CLAUDE.md` at the same level is a symlink to this file.
+
+## What nectar is
+
+Low-level Ethereum Swarm primitives in Rust: content addressing (BMT), chunks,
+proofs, postage stamps, manifest tries, feeds, contract bindings. A Cargo
+workspace of `nectar-*` crates published to crates.io. Pre-1.0; APIs may shift
+between minor versions. Consumed by the vertex Swarm node. AGPL-3.0-or-later.
+
+## Direction
+
+nectar is converging on one set of layering, concurrency, gating, and packaging
+standards. The moves below are in progress; prefer them for new code and align
+existing code when you touch it.
+
+- One concurrency substrate. The bespoke kernel and hand-rolled in-flight
+  tracking are being removed; every fan-out consumer runs on
+  `futures_util::stream::FuturesUnordered` plus a thin bounded-admission
+  governor. Delete reinvented machinery rather than extend it.
+- Layer discipline. Layer 1 is the single chunk: `get` / `put` / `has` only, over
+  the store traits in `nectar-primitives::store`. `get` / `put` exist nowhere
+  else. Layer 2 (files, feeds, manifests) never uses `get` / `put`: the read
+  handle is uniformly `Reader`; the write verb is domain-specific (`save` /
+  `publish` / `build`).
+- Packaging. A no_std `nectar-primitives-core` carries the verify subset (BMT
+  verify, keccak, SOC address, ecrecover) for the proving lane. The on-swarm KV
+  database is `nectar-ldb`; `nectar-manifest` is the trait crate holding the
+  `Manifest` trait and shared vocabulary. Benches and examples fold back into
+  their crates rather than living as standalone members.
+- Parallelism is opt-in, per-workload cargo features, off by default. The default
+  build links no rayon. Native uses rayon; wasm stays serial unless a threads
+  feature is set; no_std stays serial. SIMD (keccak-batch) is the real heavy-CPU
+  path, not rayon.
+
+## Invariants (do not regress)
+
+- One concurrency substrate: `FuturesUnordered` plus the governor. No hand-rolled
+  future-set, executor, waker, oneshot, or channel. The no_std excuse is bogus:
+  futures-core / util / channel are no_std + alloc and compile for wasm32 and
+  riscv64. `nectar-tasks` is the one sanctioned spawn seam and owns the single
+  `BoxFuture` alias.
+- The reinvention gate (`tools/reinvention-gate.sh`) fails CI if a deleted
+  primitive creeps back: hand-rolled `BoxFuture` aliases, copied `MaybeSend` /
+  `MaybeSync`, `Mutex<Waker>` cells, `waker: Option<Waker>` slots, copied
+  `Unpark` wakers, ad-hoc `impl Wake`, hand-rolled one-shots, `thread::park`
+  loops, stray `FuturesUnordered::new()` put-windows, unpaired rayon + oneshot
+  submits, stray `catch_unwind`. Each shape has exactly one sanctioned home; a
+  copy elsewhere is a reinvention.
+- Panic-free production code. The clippy deny set forbids `unwrap` / `expect`,
+  indexing / slicing, `as` casts, arithmetic overflow, `panic` / `todo` /
+  `unimplemented` and friends. Test code is exempt via
+  `#![cfg_attr(test, allow(...))]`. A provably-safe internal site gets a
+  justified `#[allow(...)]`; untrusted and parse paths are hardened for real.
+- Async tests run through `nectar_testing::run` (or `#[tokio::test]` in a tokio
+  adapter module). `clippy.toml` bans every other `block_on` entry point.
+
+## Workflow
+
+- `cargo fmt`; `cargo clippy --all-targets -- -D warnings` (clean); `cargo nextest
+  run` (a per-test 60s slow-timeout kills hangs by name). Run
+  `tools/reinvention-gate.sh` before pushing concurrency changes.
+- Doctests and the wasm smoke test stay on `cargo test` (`--doc`, and the
+  wasm-bindgen runner); nextest drives the native host tests.
+- Conventional Commits. Open an issue before non-trivial PRs. Tests for
+  protocol-touching changes are non-optional; wire-format decoders are fuzzed.
+  CLA in `CLA.md`.
+- No em-dashes in source, rustdoc, or markdown; `.claude/hooks/content-lint.sh`
+  blocks any edit that introduces one. Keep commits, PR bodies, and chat
+  em-dash-free too.
+- Disclose AI assistance (nxm-rs org policy): add an honest `AI Assistance:` line
+  to PR bodies and commit messages. Never the `Co-Authored-By: Claude Code` or
+  `Generated with Claude Code` boilerplate footer.
+
+## Claude hooks
+
+`.claude/` ships shared hooks: `rustfmt` on every `.rs` edit, `cargo nextest run`
+on touched crates when a turn ends, and the content-lint above. They no-op
+outside the dev shell.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/flake.nix
+++ b/flake.nix
@@ -59,6 +59,9 @@
             git-cliff
             cargo-deny
             cargo-audit
+            # Agent tooling: fast code search (ripgrep) and structural search (ast-grep).
+            ripgrep
+            ast-grep
           ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.mold ];
 
           OPENSSL_DIR = "${pkgs.openssl.dev}";


### PR DESCRIPTION
## What

Add developer/agent tooling to nectar, mirroring the setup already used in the sibling repos.

- **AGENTS.md** (new) captures the current layering, concurrency, gating, and packaging direction, plus the non-regression invariants enforced by the reinvention gate and the panic-free clippy deny set. `CLAUDE.md` is a symlink to it, matching the vertex convention.
- **Shared Claude hooks** under `.claude/`: `rustfmt-on-edit` (rustfmt on every `.rs` edit), `nextest-on-stop` (`cargo nextest run` on touched crates when a turn ends), and `content-lint` (blocks edits that introduce em-dashes). They no-op outside the dev shell.
- **.gitignore** now tracks the shared `.claude/settings.json` and `.claude/hooks/` while keeping personal and session state (`settings.local.json`, worktrees) ignored.
- **flake.nix** default devShell gains `ripgrep` and `ast-grep` for agent code search and structural search. The wasm and fuzz shells are untouched.

No nextest migration is needed: nectar already runs on nextest and `.config/nextest.toml` is unchanged. CI is unchanged.

## Validation

- `jq -e .` on `.claude/settings.json` parses.
- `nix-instantiate --parse flake.nix` succeeds.
- `bash -n` clean on all three hooks; content-lint blocks an em-dash sample and passes clean ASCII.
- AGENTS.md is em-dash-free.

AI Assistance: Claude Opus used for scaffolding the hooks, drafting AGENTS.md, and wiring the devShell tooling.

Closes #619


## Update

AGENTS.md is now rewritten to the ASD-STE100 Simplified Technical English documentation standard, with one sentence per line and no wrapping within a sentence so a diff touches one line per changed sentence. All sections, rules, crate names, and invariants are preserved, and a new Documentation section states the standard itself.
