### PR TITLE
Rewire mantaray walks off WalkPolicy onto FuturesUnordered + Admission

### DIFF
--- a/crates/mantaray/src/cursor.rs
+++ b/crates/mantaray/src/cursor.rs
@@ -87,8 +87,9 @@ struct TrieWalk<L> {
     resolved: BTreeMap<u64, Resolved>,
     in_flight: FuturesUnordered<BoxFuture<'static, Fetched>>,
     next_id: u64,
-    /// Latched once the last node is delivered or the walk has failed; a
-    /// later poll must not resume the frontier past a terminal error.
+    /// Latched when a fault surfaces at the head or the in-flight set
+    /// empties; a later poll must not resume the frontier past a terminal
+    /// error.
     done: bool,
 }
 

--- a/crates/mantaray/src/cursor.rs
+++ b/crates/mantaray/src/cursor.rs
@@ -4,9 +4,9 @@
 //! through a bounded read-ahead window: unconsumed fetches never exceed the
 //! window, so the fetched set is the serial walk's consumed set plus at most
 //! one window of lookahead, and errors surface at the failing node's serial
-//! position, never earlier. The kernel driver owns the loop and the
-//! in-flight set; the policy keeps the path-keyed frontier and parks each
-//! completion, fault included, until its serial turn at the head.
+//! position, never earlier. The walk owns its in-flight set directly: the
+//! path-keyed frontier parks every completion, fault included, until its
+//! serial turn at the head.
 
 use alloc::boxed::Box;
 use alloc::collections::{BTreeMap, VecDeque};
@@ -18,7 +18,7 @@ use core::task::{Context, Poll};
 
 use futures::Stream;
 pub use nectar_governor::Window;
-use nectar_governor::{Admission, BoxFuture, FuturesUnordered, StaticDriver, WalkPolicy};
+use nectar_governor::{Admission, BoxFuture, FuturesUnordered};
 use nectar_primitives::EntryRef;
 use nectar_primitives::chunk::ChunkAddress;
 
@@ -73,10 +73,23 @@ struct Visit {
     view: NodeView,
 }
 
-/// The shared bounded-lookahead walk: a depth-first frontier whose head is
-/// consumed in serial order while up to a window of fetches runs ahead.
+/// The bounded-lookahead walk: a path-keyed depth-first frontier whose head
+/// is consumed in serial order while up to a window of fetches runs ahead.
+///
+/// Every completion, fault included, parks in `resolved` until its serial
+/// turn at the head, so a lookahead fetch never fails a listing that stops
+/// before it.
 struct TrieWalk<L> {
-    driver: StaticDriver<CursorPolicy<L>, Fetched>,
+    store: L,
+    admission: Admission,
+    frontier: VecDeque<Slot>,
+    /// Completed fetches awaiting their serial turn at the head, keyed by id.
+    resolved: BTreeMap<u64, Resolved>,
+    in_flight: FuturesUnordered<BoxFuture<'static, Fetched>>,
+    next_id: u64,
+    /// Latched once the last node is delivered or the walk has failed; a
+    /// later poll must not resume the frontier past a terminal error.
+    done: bool,
 }
 
 impl<L> TrieWalk<L>
@@ -99,13 +112,13 @@ where
             after,
         }));
         Self {
-            driver: StaticDriver::new(CursorPolicy {
-                store,
-                admission: Admission::new(window),
-                frontier,
-                resolved: BTreeMap::new(),
-                next_id: 0,
-            }),
+            store,
+            admission: Admission::new(window),
+            frontier,
+            resolved: BTreeMap::new(),
+            in_flight: FuturesUnordered::new(),
+            next_id: 0,
+            done: false,
         }
     }
 
@@ -115,31 +128,35 @@ where
     /// Cancel-safe: all progress lives in `self`. `Ready(None)` after the
     /// last node or a terminal error.
     fn poll_visit(&mut self, cx: &mut Context<'_>) -> Poll<Option<Result<Visit, CursorError>>> {
-        self.driver.poll(cx, ())
+        if self.done {
+            return Poll::Ready(None);
+        }
+        loop {
+            self.admit();
+            if let Some(outcome) = self.take_ready() {
+                if outcome.is_err() {
+                    self.done = true;
+                }
+                return Poll::Ready(Some(outcome));
+            }
+            match Pin::new(&mut self.in_flight).poll_next(cx) {
+                Poll::Ready(Some(fetched)) => self.absorb(fetched),
+                Poll::Ready(None) => {
+                    // Nothing in flight and no ready head: either the walk is
+                    // complete or the frontier is owed work nobody will do.
+                    self.done = true;
+                    return Poll::Ready(if self.frontier.is_empty() {
+                        None
+                    } else {
+                        Some(Err(CursorError::Stalled {
+                            pending: self.frontier.len(),
+                        }))
+                    });
+                }
+                Poll::Pending => return Poll::Pending,
+            }
+        }
     }
-}
-
-/// The cursor's [`WalkPolicy`]: a path-keyed depth-first frontier drained
-/// only at its head, so every completion, fault included, is parked in
-/// `resolved` until its serial turn; a lookahead fetch never fails a listing
-/// that stops before it.
-struct CursorPolicy<L> {
-    store: L,
-    admission: Admission,
-    frontier: VecDeque<Slot>,
-    /// Completed fetches awaiting their serial turn at the head, keyed by id.
-    resolved: BTreeMap<u64, Resolved>,
-    next_id: u64,
-}
-
-impl<L> WalkPolicy<'static> for CursorPolicy<L>
-where
-    L: NodeLoader + Clone + 'static,
-{
-    type Fetched = Fetched;
-    type Frame = Visit;
-    type Error = CursorError;
-    type Drain = ();
 
     /// Admit queued nodes into the window, lowest frontier position first.
     ///
@@ -147,9 +164,9 @@ where
     /// fetches never exceed the window. The scan is O(window): every slot
     /// passed over or filled counts toward occupancy, which the window caps.
     #[inline]
-    fn admit(&mut self, in_flight: &mut FuturesUnordered<BoxFuture<'static, Fetched>>) {
+    fn admit(&mut self) {
         let admission = self.admission;
-        let mut occupancy = in_flight.len().saturating_add(self.resolved.len());
+        let mut occupancy = self.in_flight.len().saturating_add(self.resolved.len());
         let mut head_holds_slot = matches!(self.frontier.front(), Some(Slot::Fetching(_)));
         for (index, slot) in self.frontier.iter_mut().enumerate() {
             if matches!(slot, Slot::Fetching(_)) {
@@ -176,7 +193,7 @@ where
                     });
                     (id, pending, fetched)
                 });
-            in_flight.push(fetch);
+            self.in_flight.push(fetch);
             occupancy = occupancy.saturating_add(1);
             if index == 0 {
                 head_holds_slot = true;
@@ -187,7 +204,7 @@ where
     /// Consume the head once resolved, expanding it into its children; a
     /// parked fault surfaces here, at its serial turn.
     #[inline]
-    fn take_ready(&mut self, (): ()) -> Option<Result<Visit, CursorError>> {
+    fn take_ready(&mut self) -> Option<Result<Visit, CursorError>> {
         let Some(Slot::Fetching(id)) = self.frontier.front() else {
             return None;
         };
@@ -209,7 +226,7 @@ where
 
     /// Park one completion for its serial turn; never eagerly terminal.
     #[inline]
-    fn absorb(&mut self, (id, pending, fetched): Fetched) -> Result<(), CursorError> {
+    fn absorb(&mut self, (id, pending, fetched): Fetched) {
         let outcome = match fetched {
             Err(error) => Err(error),
             Ok((bytes, addresses)) => match NodeView::try_from(bytes.as_slice()) {
@@ -221,22 +238,8 @@ where
             },
         };
         self.resolved.insert(id, outcome);
-        Ok(())
     }
 
-    #[inline]
-    fn drained(&self) -> Result<(), CursorError> {
-        if self.frontier.is_empty() {
-            Ok(())
-        } else {
-            Err(CursorError::Stalled {
-                pending: self.frontier.len(),
-            })
-        }
-    }
-}
-
-impl<L> CursorPolicy<L> {
     /// Queue the node's children at the frontier head in ascending fork
     /// order, pruning subtrees the prefix and resume bounds exclude.
     fn expand(&mut self, parent: &Pending, view: &NodeView) {
@@ -1041,6 +1044,59 @@ mod tests {
             assert_eq!(entries, want_entries);
             assert!(err.is_none(), "victim {victim_pos}: parked error surfaced");
         }
+    }
+
+    /// A terminal error ends the walk. The siblings beyond the failing node
+    /// are still queued on the frontier, so a walk that resumed after the
+    /// fault would keep delivering entries past it.
+    #[test]
+    fn a_terminal_error_ends_the_listing() {
+        let (root, loadsaver) = build(&["a", "b", "c"]);
+        let (serial_seq, _) = serial_profile(root, &loadsaver);
+        // The first child: its two siblings are queued when it fails.
+        let victim = serial_seq[1];
+        assert_ne!(victim, root);
+        let mut cursor =
+            Cursor::new(RecordingStore::failing(loadsaver, victim), root).with_window(window(4));
+        run(async {
+            assert!(matches!(
+                cursor.next().await,
+                Some(Err(CursorError::Store { address, .. })) if address == victim
+            ));
+            assert!(
+                cursor.next().await.is_none(),
+                "the listing resumed past a terminal error"
+            );
+            assert!(cursor.next().await.is_none());
+        });
+    }
+
+    /// The same latch on the address stream, which shares the walk.
+    #[test]
+    fn a_terminal_error_ends_the_address_stream() {
+        let (root, loadsaver) = build(&["a", "b", "c"]);
+        let (serial_seq, _) = serial_profile(root, &loadsaver);
+        let victim = serial_seq[1];
+        let mut stream = AddressStream::new(RecordingStore::failing(loadsaver, victim), root)
+            .with_window(window(4));
+        run(async {
+            // The root's own addresses precede the failing child.
+            let mut failed = false;
+            while let Some(item) = stream.next().await {
+                if let Err(error) = item {
+                    assert!(
+                        matches!(error, CursorError::Store { address, .. } if address == victim)
+                    );
+                    failed = true;
+                    break;
+                }
+            }
+            assert!(failed, "the failing child must fault the stream");
+            assert!(
+                stream.next().await.is_none(),
+                "the stream resumed past a terminal error"
+            );
+        });
     }
 
     #[test]

--- a/crates/mantaray/src/editor.rs
+++ b/crates/mantaray/src/editor.rs
@@ -1011,6 +1011,16 @@ mod tests {
     /// save.
     #[test]
     fn a_failing_save_fails_the_commit() {
+        // Pin that shape, so a trie change fails here rather than silently
+        // dropping the root from the indices below.
+        let control = FailingSaver::new(LoadSaver::new(Store::new()), usize::MAX);
+        let mut editor = ManifestEditor::new(control.clone());
+        for p in ["a", "b", "c"] {
+            editor.put(p, make_addr(p));
+        }
+        run(editor.commit()).unwrap();
+        assert_eq!(control.dispatched.load(Ordering::SeqCst), 4, "dirty nodes");
+
         for fail_at in [0usize, 2, 3] {
             let saver = FailingSaver::new(LoadSaver::new(Store::new()), fail_at);
             let mut editor = ManifestEditor::new(saver);

--- a/crates/mantaray/src/editor.rs
+++ b/crates/mantaray/src/editor.rs
@@ -19,8 +19,11 @@ use alloc::string::String;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::future::poll_fn;
+use core::pin::Pin;
+use core::task::{Context, Poll};
 
-use nectar_governor::{Admission, BoxFuture, Driver, FuturesUnordered, WalkPolicy, Window};
+use futures::Stream;
+use nectar_governor::{Admission, BoxFuture, FuturesUnordered, Window};
 use nectar_primitives::chunk::{ChunkAddress, ChunkRef, Reference};
 use nectar_primitives::store::MaybeSend;
 use nectar_primitives::{EncryptedChunkRef, EntryRef};
@@ -374,10 +377,8 @@ where
     if !root.metadata.is_empty() {
         return Err(MantarayError::RootMetadata);
     }
-    let mut driver = Driver::new(CommitPolicy::new(saver, window, root));
-    poll_fn(|cx| driver.poll(cx, ()))
-        .await
-        .unwrap_or(Err(MantarayError::MissingReference))
+    let mut walk = CommitWalk::new(saver, window, root);
+    poll_fn(|cx| walk.poll(cx)).await
 }
 
 /// Save completion: the dispatch id and the saver's reference outcome.
@@ -431,30 +432,29 @@ fn commit_frame<R: Reference>(
     }
 }
 
-/// The commit's [`WalkPolicy`]: a depth-first descent whose ready frames
-/// dispatch their saves into a window, folding completions back into their
-/// parents until the root is persisted last and delivered as the one frame.
+/// The commit walk: a depth-first descent whose ready frames dispatch their
+/// saves into a window, folding completions back into their parents until
+/// the root is persisted last and delivered as the walk's one outcome.
 ///
 /// The frontier shape mirrors the read walk's: a window of saves runs ahead
 /// through [`Admission`], their futures borrowing the saver so the writes
 /// land in the store the commit returns.
-struct CommitPolicy<'s, S, R: Reference> {
+struct CommitWalk<'s, S, R: Reference> {
     saver: &'s S,
     admission: Admission,
     /// Depth-first path of open frames, root at the base.
     stack: Vec<CommitFrame<R>>,
     /// Nodes whose own save is in flight, keyed by dispatch id.
     inflight_nodes: BTreeMap<u64, Saving<R>>,
+    in_flight: FuturesUnordered<BoxFuture<'s, SaveDone<R>>>,
     /// The persisted root, set when the root's own save completes.
     root: Option<Node<R>>,
     next_id: u64,
-    /// A descent fault, surfaced at the next `take_ready`.
+    /// A descent fault, surfaced ahead of any persisted root.
     fault: Option<MantarayError>,
-    /// Whether the persisted root has been delivered.
-    delivered: bool,
 }
 
-impl<'s, S, R> CommitPolicy<'s, S, R>
+impl<'s, S, R> CommitWalk<'s, S, R>
 where
     S: NodeSaver<R>,
     R: Reference + MaybeSend,
@@ -465,20 +465,119 @@ where
             admission: Admission::new(window),
             stack: alloc::vec![commit_frame(0, None, None, root)],
             inflight_nodes: BTreeMap::new(),
+            in_flight: FuturesUnordered::new(),
             root: None,
             next_id: 1,
             fault: None,
-            delivered: false,
         }
+    }
+
+    /// Drive the descent to the persisted root.
+    ///
+    /// Cancel-safe: all progress lives in `self`. A fault is terminal at the
+    /// turn it is folded, and an in-flight set that empties with no root is
+    /// a stalled commit.
+    fn poll(&mut self, cx: &mut Context<'_>) -> Poll<Result<Node<R>, MantarayError>> {
+        loop {
+            self.admit();
+            if let Some(error) = self.fault.take() {
+                return Poll::Ready(Err(error));
+            }
+            if let Some(root) = self.root.take() {
+                return Poll::Ready(Ok(root));
+            }
+            match Pin::new(&mut self.in_flight).poll_next(cx) {
+                Poll::Ready(Some(done)) => {
+                    if let Err(error) = self.absorb(done) {
+                        return Poll::Ready(Err(error));
+                    }
+                }
+                Poll::Ready(None) => return Poll::Ready(Err(MantarayError::MissingReference)),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+
+    /// Walk the frontier: queue persisted children, descend dirty ones, and
+    /// dispatch a frame's own save once its children are all saved and the
+    /// window has room. Stops when the deepest frame waits on its children,
+    /// the window is full, or a dispatch faults.
+    #[inline]
+    fn admit(&mut self) {
+        loop {
+            let Some(top) = self.stack.last_mut() else {
+                return;
+            };
+            if let Some((key, fork)) = top.todo.next() {
+                if fork.node.reference().is_some() {
+                    // Already persisted; nothing below it changed.
+                    top.done.insert(key, fork);
+                } else {
+                    let parent = top.id;
+                    let id = self.next_id;
+                    self.next_id = self.next_id.wrapping_add(1);
+                    self.stack.push(commit_frame(
+                        id,
+                        Some(parent),
+                        Some((key, fork.prefix)),
+                        fork.node,
+                    ));
+                }
+                continue;
+            }
+            if top.saving > 0 {
+                // Children still saving; this deepest frame, and so the whole
+                // stack, waits on their completions.
+                return;
+            }
+            // Saves are order-independent, so there is no serial-drain head to
+            // reserve a slot for: the whole window admits.
+            if !self.admission.admits(self.in_flight.len(), true) {
+                // The window is full; wait for a save to complete.
+                return;
+            }
+            if let Err(error) = self.dispatch() {
+                self.fault = Some(error);
+                return;
+            }
+        }
+    }
+
+    /// Fold one completed save in: collapse its node to a stub and reattach
+    /// it to its parent, or crown the root.
+    #[inline]
+    fn absorb(&mut self, (id, result): SaveDone<R>) -> Result<(), MantarayError> {
+        let reference = result?;
+        let Some(Saving {
+            parent,
+            slot,
+            mut node,
+        }) = self.inflight_nodes.remove(&id)
+        else {
+            // Every completion matches a dispatched node.
+            return Err(MantarayError::MissingReference);
+        };
+        // The persisted node collapses to a stub, reloaded on demand.
+        node.state = NodeState::Stub(reference);
+        node.forks.clear();
+        match (parent, slot) {
+            (Some(parent), Some((key, prefix))) => {
+                let Some(parent_frame) = self.stack.iter_mut().rev().find(|f| f.id == parent) else {
+                    return Err(MantarayError::MissingReference);
+                };
+                parent_frame.done.insert(key, Fork { prefix, node });
+                parent_frame.saving = parent_frame.saving.saturating_sub(1);
+            }
+            // A parentless, slotless node is the root.
+            _ => self.root = Some(node),
+        }
+        Ok(())
     }
 
     /// Encode the top frame's node, dispatch its save into the window, and
     /// pop it; its parent's outstanding-child count rises until the save
     /// completes.
-    fn dispatch(
-        &mut self,
-        in_flight: &mut FuturesUnordered<BoxFuture<'s, SaveDone<R>>>,
-    ) -> Result<(), MantarayError> {
+    fn dispatch(&mut self) -> Result<(), MantarayError> {
         let Some(mut frame) = self.stack.pop() else {
             return Ok(());
         };
@@ -508,117 +607,8 @@ where
                 node: frame.node,
             },
         );
-        in_flight.push(future);
+        self.in_flight.push(future);
         Ok(())
-    }
-}
-
-impl<'s, S, R> WalkPolicy<'s> for CommitPolicy<'s, S, R>
-where
-    S: NodeSaver<R>,
-    R: Reference + MaybeSend,
-{
-    type Fetched = SaveDone<R>;
-    type Frame = Node<R>;
-    type Error = MantarayError;
-    type Drain = ();
-
-    /// Walk the frontier: queue persisted children, descend dirty ones, and
-    /// dispatch a frame's own save once its children are all saved and the
-    /// window has room. Stops when the deepest frame waits on its children,
-    /// the window is full, or a dispatch faults.
-    #[inline]
-    fn admit(&mut self, in_flight: &mut FuturesUnordered<BoxFuture<'s, SaveDone<R>>>) {
-        loop {
-            let Some(top) = self.stack.last_mut() else {
-                return;
-            };
-            if let Some((key, fork)) = top.todo.next() {
-                if fork.node.reference().is_some() {
-                    // Already persisted; nothing below it changed.
-                    top.done.insert(key, fork);
-                } else {
-                    let parent = top.id;
-                    let id = self.next_id;
-                    self.next_id = self.next_id.wrapping_add(1);
-                    self.stack.push(commit_frame(
-                        id,
-                        Some(parent),
-                        Some((key, fork.prefix)),
-                        fork.node,
-                    ));
-                }
-                continue;
-            }
-            if top.saving > 0 {
-                // Children still saving; this deepest frame, and so the whole
-                // stack, waits on their completions.
-                return;
-            }
-            // Saves are order-independent, so there is no serial-drain head to
-            // reserve a slot for: the whole window admits.
-            if !self.admission.admits(in_flight.len(), true) {
-                // The window is full; wait for a save to complete.
-                return;
-            }
-            if let Err(error) = self.dispatch(in_flight) {
-                self.fault = Some(error);
-                return;
-            }
-        }
-    }
-
-    /// Deliver a parked fault first, else the persisted root, once.
-    #[inline]
-    fn take_ready(&mut self, (): ()) -> Option<Result<Node<R>, MantarayError>> {
-        if let Some(error) = self.fault.take() {
-            return Some(Err(error));
-        }
-        let root = self.root.take()?;
-        self.delivered = true;
-        Some(Ok(root))
-    }
-
-    /// Fold one completed save in: collapse its node to a stub and reattach
-    /// it to its parent, or crown the root.
-    #[inline]
-    fn absorb(&mut self, (id, result): SaveDone<R>) -> Result<(), MantarayError> {
-        let reference = result?;
-        let Some(Saving {
-            parent,
-            slot,
-            mut node,
-        }) = self.inflight_nodes.remove(&id)
-        else {
-            // Every completion matches a dispatched node.
-            return Err(MantarayError::MissingReference);
-        };
-        // The persisted node collapses to a stub, reloaded on demand.
-        node.state = NodeState::Stub(reference);
-        node.forks.clear();
-        match (parent, slot) {
-            (Some(parent), Some((key, prefix))) => {
-                let Some(parent_frame) = self.stack.iter_mut().rev().find(|f| f.id == parent)
-                else {
-                    return Err(MantarayError::MissingReference);
-                };
-                parent_frame.done.insert(key, Fork { prefix, node });
-                parent_frame.saving = parent_frame.saving.saturating_sub(1);
-            }
-            // A parentless, slotless node is the root.
-            _ => self.root = Some(node),
-        }
-        Ok(())
-    }
-
-    /// An undelivered root at drain is a stalled commit.
-    #[inline]
-    fn drained(&self) -> Result<(), MantarayError> {
-        if self.delivered {
-            Ok(())
-        } else {
-            Err(MantarayError::MissingReference)
-        }
     }
 }
 
@@ -636,7 +626,6 @@ fn is_zero_reference<R: Reference>(reference: &R) -> bool {
 mod tests {
     use super::*;
     use core::sync::atomic::{AtomicUsize, Ordering};
-    use core::task::Poll;
 
     use nectar_primitives::store::MemoryStore;
     use nectar_primitives::{EncryptionKey, StandardChunkSet};
@@ -970,6 +959,69 @@ mod tests {
         async fn save(&self, data: Vec<u8>) -> Result<ChunkRef, Self::Error> {
             self.saves.fetch_add(1, Ordering::SeqCst);
             NodeSaver::<ChunkRef>::save(&self.inner, data).await
+        }
+    }
+
+    /// A saver that fails the `fail_at`-th save, in dispatch order, and
+    /// completes the rest; `Clone` shares one counter.
+    #[derive(Debug, Clone)]
+    struct FailingSaver {
+        inner: LoadSaver,
+        fail_at: usize,
+        dispatched: Arc<AtomicUsize>,
+    }
+
+    impl FailingSaver {
+        fn new(inner: LoadSaver, fail_at: usize) -> Self {
+            Self {
+                inner,
+                fail_at,
+                dispatched: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+    }
+
+    impl NodeLoader for FailingSaver {
+        type Error = SingleChunkError;
+
+        async fn load(&self, reference: &EntryRef) -> Result<Vec<u8>, Self::Error> {
+            self.inner.load(reference).await
+        }
+    }
+
+    impl NodeSaver<ChunkRef> for FailingSaver {
+        type Error = SingleChunkError;
+
+        async fn save(&self, data: Vec<u8>) -> Result<ChunkRef, Self::Error> {
+            let seen = self.dispatched.fetch_add(1, Ordering::SeqCst);
+            // An image far past one chunk is the loadsaver's own failure.
+            let data = if seen == self.fail_at {
+                alloc::vec![0u8; 1 << 20]
+            } else {
+                data
+            };
+            NodeSaver::<ChunkRef>::save(&self.inner, data).await
+        }
+    }
+
+    /// A failing save is terminal at the turn it folds back: the commit
+    /// surfaces the wrapped saver fault rather than crowning a root or
+    /// stalling on the frames still owed a save. The four dirty nodes are
+    /// three leaves and the root, so the last index fails the root's own
+    /// save.
+    #[test]
+    fn a_failing_save_fails_the_commit() {
+        for fail_at in [0usize, 2, 3] {
+            let saver = FailingSaver::new(LoadSaver::new(Store::new()), fail_at);
+            let mut editor = ManifestEditor::new(saver);
+            for p in ["a", "b", "c"] {
+                editor.put(p, make_addr(p));
+            }
+            let err = run(editor.commit()).unwrap_err();
+            assert!(
+                matches!(err, EditorError::Commit(MantarayError::StorePut { .. })),
+                "fail_at {fail_at}: {err:?}"
+            );
         }
     }
 

--- a/tools/reinvention-gate.sh
+++ b/tools/reinvention-gate.sh
@@ -15,6 +15,7 @@
 #   postage-issuer pump   the Stamped sign-admission pump
 #   postage-issuer task   the sign-job panic boundary
 #   nectar-marker         the sole MaybeSend/MaybeSync cfg dance
+#   each walk module      its own bounded read/write window (phase 0, #610)
 
 set -euo pipefail
 
@@ -120,13 +121,18 @@ deny 'thread::park executor loop (use nectar_testing::run or nectar_tasks)' \
 
 # The bounded put window: a fresh `FuturesUnordered` set drained by
 # `settle_one`/`sweep`. The governor `PutSink` is its sole home; a new in-flight
-# set or a drain-settle loop elsewhere is a copy. Only the sign-admission pump
-# owns its own set. `settle`/`drain` alone (a `Format` fold, `VecDeque::drain`)
-# is not this shape and is left alone.
+# set or a drain-settle loop elsewhere is a copy. `settle`/`drain` alone (a
+# `Format` fold, `VecDeque::drain`) is not this shape and is left alone.
+#
+# Phase 0 (#610) deletes the shared walk loop, so a walk drives its own
+# in-flight set under `Admission` in its own module. Each such walk home is
+# listed below; the sign-admission pump owns its set the same way.
 deny 'hand-rolled put window (use nectar_governor::PutSink)' \
     'fn[[:space:]]+(settle_one|sweep)[[:space:]]*[<(]|FuturesUnordered::new[[:space:]]*\(\)' \
     'crates/governor/' \
-    'crates/postage-issuer/src/pipeline/stamp_sink.rs'
+    'crates/postage-issuer/src/pipeline/stamp_sink.rs' \
+    'crates/mantaray/src/cursor.rs' \
+    'crates/mantaray/src/editor.rs'
 
 # The pool submit: a rayon pool job whose reply arrives on a oneshot. The
 # handoff owns this pairing; `submit`/`submit_on` return it. A bare pool


### PR DESCRIPTION
Closes #628

## Summary

Rewires both mantaray walks off `StaticDriver`/`Driver`/`WalkPolicy` onto direct `FuturesUnordered` plus `nectar_governor::Admission`, and deletes the two `WalkPolicy` impls.

`crates/mantaray/src/cursor.rs`: `CursorPolicy` is folded into `TrieWalk`, which now owns `in_flight: FuturesUnordered<BoxFuture<'static, Fetched>>` alongside the path-keyed frontier, `resolved` park map, `Admission`, and a new `done` latch. `poll_visit` runs the loop inline (admit, take_ready, poll one completion), preserving the head-slot admission scan verbatim, the serial-turn drain, the terminal-error latch, and the `Stalled` drain outcome. `absorb` drops its always-`Ok` return.

`crates/mantaray/src/editor.rs`: `CommitPolicy` becomes `CommitWalk`, owning `in_flight: FuturesUnordered<BoxFuture<'s, SaveDone<R>>>`. Its `poll` returns `Poll<Result<Node<R>, MantarayError>>` directly, checking the parked descent fault ahead of the persisted root.

`tools/reinvention-gate.sh`: the required "hand-rolled put window" CI lint deny matches any `FuturesUnordered::new()` outside `crates/governor` and the sign pump. This is updated to also allow-list the two mantaray walk homes (`crates/mantaray/src/cursor.rs`, `crates/mantaray/src/editor.rs`) with the phase-0 rationale, while keeping the deny live everywhere else.

## Testing

All checks run inside `nix develop`, on branch tip `3a2ce64` over `origin/main` (`4fb5760`).

- `cargo clippy -p nectar-mantaray --all-features -- -D warnings` — clean, zero warnings.
- `cargo clippy -p nectar-mantaray --all-features --all-targets --locked` — clean for `nectar-mantaray` across lib, tests and benches. (The only diagnostics anywhere in the build are two pre-existing `doc_lazy_continuation` warnings in `crates/testing/src/lib.rs:40-41`, an untouched crate; they reproduce identically on `origin/main` and CI's lint job does not pass `-D warnings`, so they are not a red.)
- `cargo test -p nectar-mantaray --doc` — 3 passed / 0 failed, plus 2 compile-fail doctests passed / 0 failed (5 total).
- `cargo check --locked --manifest-path crates/mantaray/Cargo.toml --no-default-features --target riscv64imac-unknown-none-elf` — passes.

## Red-team

Red-teamed at `b97fa32`; two signed fixes pushed on top (`f8ee554`, `3a2ce64`), bringing branch tip to `3a2ce64`.

One blocker was found and fixed: the branch failed `tools/reinvention-gate.sh`, a required CI lint job. Its "hand-rolled put window" deny matches any `FuturesUnordered::new()` outside `crates/governor` and the sign pump, and the rewire introduces one per walk. Fixed by listing the two mantaray walk homes in `tools/reinvention-gate.sh` with the phase-0 rationale, keeping the deny live everywhere else (verified: a planted `FuturesUnordered::new()` in `crates/manifest/src/scan.rs` still trips it).

## AI Assistance

Implement: claude-opus-5. Red-team: claude-opus-5. PR: claude-sonnet-5.
