### PR TITLE
feat(feeds): rewire latest-update finder onto direct Admission loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2520,6 +2520,7 @@ dependencies = [
  "arbitrary",
  "bytes",
  "derive_more",
+ "futures-util",
  "nectar-feeds",
  "nectar-governor",
  "nectar-primitives 0.4.0",

--- a/crates/feeds/Cargo.toml
+++ b/crates/feeds/Cargo.toml
@@ -24,6 +24,7 @@ alloy-signer-local = { workspace = true, optional = true }
 arbitrary = { workspace = true, optional = true }
 bytes.workspace = true
 derive_more.workspace = true
+futures-util = { workspace = true }
 nectar-governor = { workspace = true }
 nectar-primitives = { workspace = true }
 thiserror.workspace = true
@@ -52,6 +53,7 @@ arbitrary = [
 std = [
 	"alloy-primitives/std",
 	"bytes/std",
+	"futures-util/std",
 	"nectar-primitives/std",
 	"thiserror/std",
 ]

--- a/crates/feeds/src/getter.rs
+++ b/crates/feeds/src/getter.rs
@@ -1,12 +1,11 @@
 //! Read side: fetch, certify and interpret updates over a chunk store.
 
-use core::convert::Infallible;
 use core::fmt;
-use core::future::poll_fn;
 use core::num::{NonZeroU16, NonZeroUsize};
 use std::collections::BTreeSet;
 
-use nectar_governor::{Admission, BoxFuture, Driver, FuturesUnordered, WalkPolicy, Window};
+use futures_util::stream::{FuturesUnordered, StreamExt};
+use nectar_governor::{Admission, Window};
 use nectar_primitives::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{Chunk, IntoVerified, SingleOwnerOnlyChunkSet};
 use nectar_primitives::store::{ChunkGet, ChunkHas};
@@ -121,32 +120,55 @@ where
     /// Only a completed probe answers an index; a speculative answer the
     /// replay never consults is inert, so any width and any completion order
     /// commit the boundary the sequential scan would.
+    ///
+    /// The faulting index leads each round's plan and is the head slot;
+    /// [`Admission`] reserves it a slot, so speculation never starves the
+    /// probe the replay is blocked on and the set never drains verdictless.
     async fn drive(
         &self,
         floor: Sequence,
         resolve: fn(u64, &Answers) -> Step,
     ) -> Result<Latest<BODY_SIZE>> {
-        let mut driver = Driver::new(ProbePolicy::new(
-            &self.feed,
-            &self.store,
-            resolve,
-            floor,
-            self.window,
-        ));
+        let slots = NonZeroU16::try_from(self.window).unwrap_or(NonZeroU16::MAX);
+        let admission = Admission::new(Window::from(slots));
+        let base = floor.get();
+        let mut answers = Answers::new();
+        // Indices probed but not yet landed, and the round's probe plan.
+        let mut outstanding = BTreeSet::new();
+        let mut plan = Vec::new();
+        let mut in_flight = FuturesUnordered::new();
         loop {
-            match poll_fn(|cx| driver.poll(cx, ())).await {
-                Some(Ok(Verdict::Empty)) => {
+            let fault = match resolve(base, &answers) {
+                Step::Empty => {
                     return Ok(Latest {
                         update: None,
                         next: Some(floor),
                     });
                 }
-                Some(Ok(Verdict::Commit(lo))) => return self.found(lo).await,
-                Some(Err(error)) => match error {},
-                // A fault always keeps its own probe in flight, so the set
-                // cannot drain verdictless; resuming over the retained
-                // answers keeps this arm total without a panic path.
-                None => driver = Driver::new(driver.into_policy()),
+                Step::Commit { lo } => return self.found(lo).await,
+                Step::Fault(fault) => fault,
+            };
+            fault.plan(self.window, &mut plan);
+            let head = plan.first().copied();
+            for &index in &plan {
+                if answers.contains_key(&index) || outstanding.contains(&index) {
+                    continue;
+                }
+                let head_served =
+                    head.is_some_and(|head| index == head || outstanding.contains(&head));
+                if !admission.admits(outstanding.len(), head_served) {
+                    break;
+                }
+                let address = self.feed.update_address(&Sequence::new(index));
+                let store = &self.store;
+                outstanding.insert(index);
+                in_flight.push(async move { (index, store.has(&address).await) });
+            }
+            // The head always holds a slot here, so a drained set can only
+            // mean a plan of answers already held: re-resolving is total.
+            if let Some((index, present)) = in_flight.next().await {
+                outstanding.remove(&index);
+                answers.insert(index, present);
             }
         }
     }
@@ -173,121 +195,5 @@ where
     /// [`latest`](Self::latest) applies.
     pub async fn latest_linear_from(&self, floor: Sequence) -> Result<Latest<BODY_SIZE>> {
         self.drive(floor, probe::resolve_linear).await
-    }
-}
-
-/// One landed presence answer, routed by index.
-type Probed = (u64, bool);
-
-/// Terminal outcome of a finder walk.
-enum Verdict {
-    /// The floor slot is absent.
-    Empty,
-    /// The boundary update lives at this index.
-    Commit(u64),
-}
-
-/// Presence-probe walk policy: each landed answer re-resolves the replay and
-/// tops the window back up.
-///
-/// The head slot is the faulting index; [`Admission`] reserves it a slot, so
-/// speculation never starves the probe the replay is blocked on.
-struct ProbePolicy<'a, S, const BODY_SIZE: usize> {
-    feed: &'a Feed<BODY_SIZE>,
-    store: &'a S,
-    resolve: fn(u64, &Answers) -> Step,
-    /// The search floor the resolver replays from.
-    base: u64,
-    /// Probe-plan width; the admission window is its clamp.
-    width: NonZeroUsize,
-    admission: Admission,
-    answers: Answers,
-    /// Indices probed but not yet landed.
-    outstanding: BTreeSet<u64>,
-    /// Scratch for the fault's probe plan.
-    plan: Vec<u64>,
-    /// Staged terminal outcome awaiting hand-over.
-    verdict: Option<Verdict>,
-}
-
-impl<'a, S, const BODY_SIZE: usize> ProbePolicy<'a, S, BODY_SIZE> {
-    fn new(
-        feed: &'a Feed<BODY_SIZE>,
-        store: &'a S,
-        resolve: fn(u64, &Answers) -> Step,
-        floor: Sequence,
-        width: NonZeroUsize,
-    ) -> Self {
-        let slots = NonZeroU16::try_from(width).unwrap_or(NonZeroU16::MAX);
-        Self {
-            feed,
-            store,
-            resolve,
-            base: floor.get(),
-            width,
-            admission: Admission::new(Window::from(slots)),
-            answers: Answers::new(),
-            outstanding: BTreeSet::new(),
-            plan: Vec::new(),
-            verdict: None,
-        }
-    }
-}
-
-impl<'a, S, const BODY_SIZE: usize> WalkPolicy<'a> for ProbePolicy<'a, S, BODY_SIZE>
-where
-    S: ChunkHas,
-{
-    type Fetched = Probed;
-    type Frame = Verdict;
-    type Error = Infallible;
-    type Drain = ();
-
-    fn admit(&mut self, in_flight: &mut FuturesUnordered<BoxFuture<'a, Probed>>) {
-        if self.verdict.is_some() {
-            return;
-        }
-        let fault = match (self.resolve)(self.base, &self.answers) {
-            Step::Empty => {
-                self.verdict = Some(Verdict::Empty);
-                return;
-            }
-            Step::Commit { lo } => {
-                self.verdict = Some(Verdict::Commit(lo));
-                return;
-            }
-            Step::Fault(fault) => fault,
-        };
-        fault.plan(self.width, &mut self.plan);
-        // The faulting index leads the plan: it is the head slot.
-        let head = self.plan.first().copied();
-        for &index in &self.plan {
-            if self.answers.contains_key(&index) || self.outstanding.contains(&index) {
-                continue;
-            }
-            let head_served =
-                head.is_some_and(|head| index == head || self.outstanding.contains(&head));
-            if !self.admission.admits(self.outstanding.len(), head_served) {
-                break;
-            }
-            let address = self.feed.update_address(&Sequence::new(index));
-            let store = self.store;
-            self.outstanding.insert(index);
-            in_flight.push(Box::pin(async move { (index, store.has(&address).await) }));
-        }
-    }
-
-    fn take_ready(&mut self, (): ()) -> Option<Result<Verdict, Infallible>> {
-        self.verdict.take().map(Ok)
-    }
-
-    fn absorb(&mut self, (index, present): Probed) -> Result<(), Infallible> {
-        self.outstanding.remove(&index);
-        self.answers.insert(index, present);
-        Ok(())
-    }
-
-    fn drained(&self) -> Result<(), Infallible> {
-        Ok(())
     }
 }

--- a/crates/feeds/src/getter.rs
+++ b/crates/feeds/src/getter.rs
@@ -131,6 +131,9 @@ where
     ) -> Result<Latest<BODY_SIZE>> {
         let slots = NonZeroU16::try_from(self.window).unwrap_or(NonZeroU16::MAX);
         let admission = Admission::new(Window::from(slots));
+        // One clamped width: planning past what the window admits only grows
+        // the scratch plan, so the clamp binds the plan too.
+        let width = NonZeroUsize::from(slots);
         let base = floor.get();
         let mut answers = Answers::new();
         // Indices probed but not yet landed, and the round's probe plan.
@@ -148,7 +151,7 @@ where
                 Step::Commit { lo } => return self.found(lo).await,
                 Step::Fault(fault) => fault,
             };
-            fault.plan(self.window, &mut plan);
+            fault.plan(width, &mut plan);
             let head = plan.first().copied();
             for &index in &plan {
                 if answers.contains_key(&index) || outstanding.contains(&index) {
@@ -164,8 +167,15 @@ where
                 outstanding.insert(index);
                 in_flight.push(async move { (index, store.has(&address).await) });
             }
-            // The head always holds a slot here, so a drained set can only
-            // mean a plan of answers already held: re-resolving is total.
+            // The head is never already answered and the window always has a
+            // free slot here, so the set is never empty. Were it empty the
+            // re-resolve would repeat verbatim, so the loop would spin without
+            // yielding; the assertion turns that into a test failure rather
+            // than a wedged executor.
+            debug_assert!(
+                !in_flight.is_empty(),
+                "probe set drained with a fault pending"
+            );
             if let Some((index, present)) = in_flight.next().await {
                 outstanding.remove(&index);
                 answers.insert(index, present);

--- a/crates/feeds/src/probe.rs
+++ b/crates/feeds/src/probe.rs
@@ -456,6 +456,21 @@ mod tests {
         assert_eq!(plan, vec![12, 10, 14]);
     }
 
+    /// The stepwise plan is width-bound, not shape-bound: it fills whatever
+    /// width it is handed. The finder must therefore hand it the clamped
+    /// window, never the raw one, or a huge window allocates a huge plan.
+    #[test]
+    fn the_stepwise_plan_fills_the_width() {
+        let answers = Answers::new();
+        let Step::Fault(fault) = resolve_linear(0, &answers) else {
+            panic!("expected a floor fault");
+        };
+        let mut plan = Vec::new();
+        fault.plan(width(4096), &mut plan);
+        assert_eq!(plan.len(), 4096);
+        assert_eq!(plan[4095], 4095);
+    }
+
     #[test]
     fn ladder_near_the_top_plans_the_top_slot_once() {
         let answers = Answers::new();

--- a/crates/feeds/tests/feed_roundtrip.rs
+++ b/crates/feeds/tests/feed_roundtrip.rs
@@ -530,8 +530,8 @@ fn drive_order(
     (latest.update.map(|u| *u.index()), latest.next, gate.peak())
 }
 
-/// The shipped async `ProbePolicy`, driven through the kernel driver under
-/// adversarial out-of-order probe completion, reaches the in-order verdict.
+/// The shipped async finder, under adversarial out-of-order probe completion,
+/// reaches the in-order verdict.
 ///
 /// The property test in `probe.rs` proves this of a model; this pins the real
 /// code, where a divergence surfacing only under true out-of-order landing
@@ -578,6 +578,93 @@ fn probe_policy_holds_under_adversarial_completion_order() {
             );
         }
     }
+}
+
+/// Admission fills the window and stops there: the first round parks the head
+/// slot plus its speculation, never one probe more and never one fewer.
+///
+/// Admitting past the window exceeds the store capacity the window buys;
+/// admitting short of it silently serializes the finder.
+#[test]
+fn probes_fill_exactly_the_window() {
+    let signer = signer();
+    let feed = feed_for(&signer);
+    let store = SocStore::new();
+    run(async {
+        let mut updater = Updater::new(feed, &store, &signer);
+        for n in 0u64..21 {
+            updater.append(n.to_be_bytes().to_vec()).await.unwrap();
+        }
+    });
+
+    for width in [1usize, 2, 7, 15] {
+        for linear in [false, true] {
+            let (index, next, peak) = drive_order(
+                feed,
+                &store,
+                Sequence::ZERO,
+                linear,
+                NonZeroUsize::new(width).unwrap(),
+                |_, parked| parked[0],
+            );
+            assert_eq!(index, Some(Sequence::new(20)), "width {width}");
+            assert_eq!(next, Some(Sequence::new(21)), "width {width}");
+            assert_eq!(peak, width, "width {width}, linear {linear}");
+        }
+    }
+}
+
+/// Store answering presence from a real feed but failing every fetch: the
+/// search converges on probes alone.
+struct ProbeOnly<'a>(&'a SocStore);
+
+impl ChunkGet<SingleOwnerOnlyChunkSet> for ProbeOnly<'_> {
+    type Trust = nectar_primitives::Verified;
+    type Error = ChunkStoreError;
+
+    async fn get(
+        &self,
+        address: &ChunkAddress,
+    ) -> Result<Chunk<nectar_primitives::Verified, SingleOwnerOnlyChunkSet>, Self::Error> {
+        Err(ChunkStoreError::not_found(address))
+    }
+}
+
+impl ChunkHas for ProbeOnly<'_> {
+    async fn has(&self, address: &ChunkAddress) -> bool {
+        ChunkHas::has(self.0, address).await
+    }
+}
+
+/// The fetch of the committed update is the only fallible step of the search,
+/// so its error surfaces at the commit and nowhere earlier: an absent floor
+/// still returns an empty result.
+#[test]
+fn fetch_failure_surfaces_only_at_the_commit() {
+    run(async {
+        let signer = signer();
+        let feed = feed_for(&signer);
+        let store = SocStore::new();
+        let mut updater = Updater::new(feed, &store, &signer);
+        for n in 0u64..5 {
+            updater.append(n.to_be_bytes().to_vec()).await.unwrap();
+        }
+
+        let getter =
+            Getter::new(feed, ProbeOnly(&store)).with_window(NonZeroUsize::new(4).unwrap());
+        assert!(matches!(
+            getter.latest().await.unwrap_err(),
+            FeedError::Store(_)
+        ));
+        assert!(matches!(
+            getter.latest_linear_from(Sequence::ZERO).await.unwrap_err(),
+            FeedError::Store(_)
+        ));
+
+        let empty = getter.latest_from(Sequence::new(5)).await.unwrap();
+        assert!(empty.update.is_none());
+        assert_eq!(empty.next, Some(Sequence::new(5)));
+    });
 }
 
 proptest! {


### PR DESCRIPTION
Closes #626

## Summary

Rewires the feeds latest-update finder off `Driver`/`WalkPolicy` onto a direct `FuturesUnordered` loop admitted by `nectar_governor::Admission`.

`crates/feeds/src/getter.rs`: deletes the `ProbePolicy` `WalkPolicy` impl plus the `Verdict`/`Probed` helper types (about 115 lines) and inlines the loop into `Getter::drive`. The loop keeps the exact same step order the `Driver` enforced: resolve the replay, stage the verdict (`Empty` returns the floor, `Commit` runs the certified fetch through `found`), otherwise plan the round, top the window up in plan order, then await exactly one landed answer and fold it. Admission is unchanged expression-for-expression: head is `plan[0]`, `head_served` is `index == head || outstanding.contains(&head)`, and the loop breaks on the first refusal. The drained-set arm that previously rebuilt the `Driver` over retained answers is now a fallthrough back to the resolve step, which is the same behavior without the rebuild.

`crates/feeds/src/probe.rs`: 15 lines added.

`crates/feeds/tests/feed_roundtrip.rs`: 91 lines added, covering the rewired probe loop.

`crates/feeds/Cargo.toml` and `Cargo.lock`: adds the `futures-util` dependency used for `FuturesUnordered`/`StreamExt`.

## Red-team

Red-teamed `phase0/626-feeds-rewire` (58bfb18) and pushed one fix commit, `b3beab3` (`fix(feeds): clamp the probe plan to the admitted window`). Gate green after the fix: 37/37 nextest for `nectar-feeds`, `clippy --all-features --all-targets` clean for the crate, doctest passes.

DUPLICATES: none. `ProbePolicy`, `Verdict` and `Probed` were all private, so their deletion is not an API change, and no stale reference survives (`crates/feeds-bench` uses only the public API and owns an unrelated `Verdict`). `PutSink` is the write-side twin (bounded `FuturesUnordered` + `Admission`) but is not reusable here.

## Testing

Toolchain: `rustc 1.94.0` / `cargo 1.94.0` inside `nix develop` (matches the `rust-toolchain.toml` pin of `1.94`).

Touched surface: `crates/feeds` only (plus a one-line `Cargo.lock` delta adding `futures-util` to the `nectar-feeds` entry). No crate in `.github/workflows/nostd.yml` was touched, so the bare-metal lanes do not apply; the feeds-specific wasm32 gate in `unit.yml` does and was run.

```
nix develop --command cargo clippy -p nectar-feeds --all-features --all-targets --locked
```
Exit 0. Zero diagnostics originating in `crates/feeds`. The only output is two pre-existing `clippy::doc_lazy_continuation` warnings in `crates/testing/src/lib.rs:40-41`, a crate this branch does not touch (empty diffstat vs `origin/main`); CI's `cargo clippy --workspace --all-targets --locked` passes no `-D warnings` and sets no `RUSTFLAGS`, so these remain warnings in CI.

## AI Assistance

Implement: claude-opus-5. Red-team: claude-opus-5. PR: claude-sonnet-5.
