### PR TITLE
refactor(manifest): rewire walk sites off Driver/WalkPolicy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2619,6 +2619,7 @@ dependencies = [
  "arbitrary",
  "bytes",
  "futures",
+ "futures-core",
  "nectar-governor",
  "nectar-manifest",
  "nectar-primitives 0.4.0",

--- a/crates/manifest/Cargo.toml
+++ b/crates/manifest/Cargo.toml
@@ -21,6 +21,8 @@ workspace = true
 alloy-primitives = { workspace = true }
 arbitrary = { workspace = true, optional = true }
 bytes.workspace = true
+# The `Stream` trait the hand-rolled walk loops poll their in-flight set through.
+futures-core = { workspace = true }
 nectar-governor = { workspace = true }
 nectar-primitives = { workspace = true }
 thiserror.workspace = true

--- a/crates/manifest/src/apply.rs
+++ b/crates/manifest/src/apply.rs
@@ -24,11 +24,13 @@
 use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
-use core::convert::Infallible;
 use core::future::poll_fn;
+use core::pin::Pin;
+use core::task::Poll;
 
 use bytes::Bytes;
-use nectar_governor::{Admission, BoxFuture, Driver, FuturesUnordered, WalkPolicy, Window};
+use futures_core::Stream;
+use nectar_governor::{Admission, BoxFuture, FuturesUnordered, Window};
 use nectar_primitives::ChunkAddress;
 use nectar_primitives::store::{ChunkPut, MaybeSync};
 
@@ -872,60 +874,13 @@ fn child_window<F: Format>() -> Window {
 /// One landed child prefetch: its request slot and the fetched node.
 type Prefetched<F> = (usize, Result<Node<F>, StoreError>);
 
-/// Drives concurrent child fetches on one bounded window, landing each node in
-/// its request slot. Reads are order-free, so the whole window admits.
-struct PrefetchPolicy<'a, S, F: Format> {
-    store: &'a S,
-    /// Outstanding `(slot, address)` requests, drained as the window admits.
-    queue: Vec<(usize, ChunkAddress)>,
-    admission: Admission,
-    /// Landed nodes indexed by request slot.
-    landed: Vec<Option<Result<Node<F>, StoreError>>>,
-}
-
-impl<'a, S, F> WalkPolicy<'a> for PrefetchPolicy<'a, S, F>
-where
-    S: NodeGet + MaybeSync,
-    F: Format,
-{
-    type Fetched = Prefetched<F>;
-    type Frame = ();
-    type Error = Infallible;
-    type Drain = ();
-
-    fn admit(&mut self, in_flight: &mut FuturesUnordered<BoxFuture<'a, Prefetched<F>>>) {
-        while self.admission.admits(in_flight.len(), true) {
-            let Some((slot, address)) = self.queue.pop() else {
-                return;
-            };
-            let store = self.store;
-            in_flight.push(Box::pin(async move {
-                (slot, store.get_node::<F>(&address).await)
-            }));
-        }
-    }
-
-    fn take_ready(&mut self, (): ()) -> Option<Result<(), Infallible>> {
-        // Nothing streams: completions land in their slots and are read back
-        // once the window drains.
-        None
-    }
-
-    fn absorb(&mut self, (slot, outcome): Prefetched<F>) -> Result<(), Infallible> {
-        if let Some(cell) = self.landed.get_mut(slot) {
-            *cell = Some(outcome);
-        }
-        Ok(())
-    }
-
-    fn drained(&self) -> Result<(), Infallible> {
-        Ok(())
-    }
-}
-
 /// Prefetch each requested child node concurrently, returning the landed nodes
 /// indexed by slot; `slots` sizes the result and every slot without a request
 /// stays `None`.
+///
+/// Nothing streams: the window admits freely because reads are order-free,
+/// and every completion lands in its own slot, so the result is independent
+/// of completion order.
 async fn prefetch_children<S, F>(
     store: &S,
     requests: impl Iterator<Item = (usize, ChunkAddress)>,
@@ -935,18 +890,36 @@ where
     S: NodeGet + MaybeSync,
     F: Format,
 {
-    let queue: Vec<(usize, ChunkAddress)> = requests.collect();
+    let mut landed: Vec<Option<Result<Node<F>, StoreError>>> = (0..slots).map(|_| None).collect();
+    let mut queue: Vec<(usize, ChunkAddress)> = requests.collect();
     if queue.is_empty() {
-        return (0..slots).map(|_| None).collect();
+        return landed;
     }
-    let mut driver = Driver::new(PrefetchPolicy {
-        store,
-        queue,
-        admission: Admission::new(child_window::<F>()),
-        landed: (0..slots).map(|_| None).collect(),
-    });
-    while poll_fn(|cx| driver.poll(cx, ())).await.is_some() {}
-    driver.into_policy().landed
+    let admission = Admission::new(child_window::<F>());
+    let mut in_flight: FuturesUnordered<BoxFuture<'_, Prefetched<F>>> = FuturesUnordered::new();
+    poll_fn(|cx| {
+        loop {
+            while admission.admits(in_flight.len(), true) {
+                let Some((slot, address)) = queue.pop() else {
+                    break;
+                };
+                in_flight.push(Box::pin(async move {
+                    (slot, store.get_node::<F>(&address).await)
+                }));
+            }
+            match Pin::new(&mut in_flight).poll_next(cx) {
+                Poll::Ready(Some((slot, outcome))) => {
+                    if let Some(cell) = landed.get_mut(slot) {
+                        *cell = Some(outcome);
+                    }
+                }
+                Poll::Ready(None) => return Poll::Ready(()),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    })
+    .await;
+    landed
 }
 
 #[cfg(test)]
@@ -1410,6 +1383,139 @@ mod tests {
         let peak = store.peak.load(Ordering::Relaxed);
         assert!(peak > 1, "disjoint subtree reads overlapped, peak {peak}");
         assert!(peak <= usize::from(child_window::<V1>().get()));
+    }
+
+    /// Yields once per round before completing, so a test picks the order
+    /// concurrent prefetches land in.
+    struct Yields(usize);
+
+    impl Future for Yields {
+        type Output = ();
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+            if self.0 == 0 {
+                Poll::Ready(())
+            } else {
+                self.0 -= 1;
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+        }
+    }
+
+    /// A store that delays each address by its own round count and records the
+    /// order reads resolve in; puts pass straight through.
+    struct SkewedStore {
+        inner: ContentGet<MemoryStore>,
+        rounds: BTreeMap<ChunkAddress, usize>,
+        arrivals: std::sync::Mutex<Vec<ChunkAddress>>,
+    }
+
+    impl ChunkGet<ContentOnlyChunkSet> for SkewedStore {
+        type Trust = Verified;
+        type Error = <ContentGet<MemoryStore> as ChunkGet<ContentOnlyChunkSet>>::Error;
+
+        async fn get(
+            &self,
+            address: &ChunkAddress,
+        ) -> Result<Chunk<Verified, ContentOnlyChunkSet>, Self::Error> {
+            Yields(self.rounds.get(address).copied().unwrap_or(0)).await;
+            self.arrivals.lock().unwrap().push(*address);
+            ChunkGet::get(&self.inner, address).await
+        }
+    }
+
+    impl ChunkPut for SkewedStore {
+        type Error = <ContentGet<MemoryStore> as ChunkPut>::Error;
+
+        async fn put(&self, chunk: Chunk<Verified>) -> Result<(), Self::Error> {
+            self.inner.put(chunk).await
+        }
+    }
+
+    #[test]
+    fn out_of_order_child_prefetches_land_in_their_request_slots() {
+        let inner = ContentGet::new(MemoryStore::default());
+        // Four top-level subtrees, each wide enough to spill to a reference and
+        // each holding different values, so a misrouted child is visible in the
+        // rewritten root.
+        let mut builder = Builder::<V1>::new();
+        for p in 0u8..4 {
+            for x in 0u8..44 {
+                builder.insert(Key::from(&[p, x][..]), entry(x.wrapping_add(p)), None);
+            }
+        }
+        let root = *run(builder.build(&inner)).unwrap().root();
+        let node: Node<V1> = run(inner.get_node(&root)).unwrap();
+        let children: Vec<ChunkAddress> = node
+            .forks()
+            .iter()
+            .filter_map(|(_, record)| match record.child() {
+                Some(Child::Ref32(reference)) => Some(*reference.address()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(children.len(), 4, "each subtree spilled to a reference");
+        assert_eq!(
+            children
+                .iter()
+                .map(|address| (*address, ()))
+                .collect::<BTreeMap<_, _>>()
+                .len(),
+            4,
+            "the four children are distinct nodes"
+        );
+
+        // Round counts scrambling the completions into slot order 2, 0, 3, 1:
+        // neither the request order nor its reverse, so only routing by slot
+        // pairs each child with its own group.
+        let rounds = children
+            .iter()
+            .copied()
+            .zip([4usize, 8, 2, 6])
+            .collect::<BTreeMap<_, _>>();
+        let store = SkewedStore {
+            inner,
+            rounds,
+            arrivals: std::sync::Mutex::new(Vec::new()),
+        };
+
+        // A deeper insert under each subtree descends into all four referenced
+        // children at once, so all four ride one prefetch.
+        let mut cs = Changeset::<V1>::new();
+        for p in 0u8..4 {
+            cs.put(Key::from(&[p, 0, 9][..]), entry(99), None);
+        }
+        let applied = run(apply(&store, &root, &cs)).unwrap();
+
+        // The skew held: the children landed scrambled, so a fold that filled
+        // slots in completion order would misroute three of the four.
+        let landed: Vec<ChunkAddress> = store
+            .arrivals
+            .lock()
+            .unwrap()
+            .iter()
+            .copied()
+            .filter(|address| children.contains(address))
+            .collect();
+        assert_eq!(
+            landed,
+            vec![children[2], children[0], children[3], children[1]]
+        );
+
+        let mut scratch = Builder::<V1>::new();
+        for p in 0u8..4 {
+            for x in 0u8..44 {
+                scratch.insert(Key::from(&[p, x][..]), entry(x.wrapping_add(p)), None);
+            }
+            scratch.insert(Key::from(&[p, 0, 9][..]), entry(99), None);
+        }
+        let expected = *run(scratch.build(&ContentGet::new(MemoryStore::default())))
+            .unwrap()
+            .root();
+        // Each prefetched child reconciled with its own group, whatever the
+        // completion order.
+        assert_eq!(applied, expected, "apply must match a from-scratch build");
     }
 
     #[test]

--- a/crates/manifest/src/apply.rs
+++ b/crates/manifest/src/apply.rs
@@ -1382,7 +1382,55 @@ mod tests {
 
         let peak = store.peak.load(Ordering::Relaxed);
         assert!(peak > 1, "disjoint subtree reads overlapped, peak {peak}");
+        // Four requests never reach the window; the fan-out test below is what
+        // pins the cap.
         assert!(peak <= usize::from(child_window::<V1>().get()));
+    }
+
+    #[test]
+    fn the_child_window_bounds_the_prefetch_fan_out() {
+        let inner = ContentGet::new(MemoryStore::default());
+        // More referenced children under the root than the window has slots,
+        // each wide enough to spill to a reference, so an unbounded prefetch
+        // would launch the whole group at once.
+        let mut builder = Builder::<V1>::new();
+        for p in 0u8..24 {
+            for x in 0u8..44 {
+                builder.insert(Key::from(&[p, x][..]), entry(x), None);
+            }
+        }
+        let root = *run(builder.build(&inner)).unwrap().root();
+        let node: Node<V1> = run(inner.get_node(&root)).unwrap();
+        let children = node
+            .forks()
+            .iter()
+            .filter(|(_, record)| matches!(record.child(), Some(Child::Ref32(_))))
+            .count();
+        let window = usize::from(child_window::<V1>().get());
+        assert!(
+            children > window,
+            "the frontier must outgrow the window, {children} children"
+        );
+
+        let store = GatedStore {
+            inner,
+            inflight: AtomicUsize::new(0),
+            peak: AtomicUsize::new(0),
+        };
+        // A deeper insert under every subtree descends into all of them at
+        // once, so the whole group rides one prefetch.
+        let mut cs = Changeset::<V1>::new();
+        for p in 0u8..24 {
+            cs.put(Key::from(&[p, 0, 9][..]), entry(99), None);
+        }
+        run(apply(&store, &root, &cs)).unwrap();
+
+        let peak = store.peak.load(Ordering::Relaxed);
+        // The cap is what bounds the fan-out: a lost window would show up here.
+        assert_eq!(
+            peak, window,
+            "peak in-flight {peak} is not the child window {window}"
+        );
     }
 
     /// Yields once per round before completing, so a test picks the order

--- a/crates/manifest/src/frontier.rs
+++ b/crates/manifest/src/frontier.rs
@@ -1,6 +1,5 @@
-//! Frontier bookkeeping shared by the manifest walk policies: per-step
-//! prefetch tags and the bounded fill that admits fetches into the kernel
-//! in-flight set.
+//! Frontier bookkeeping shared by the manifest walks: per-step prefetch tags
+//! and the bounded fill that admits fetches into a walk's own in-flight set.
 //!
 //! The walker owns the walk; the fill owns the window. Each policy plans one
 //! step at a time, so admission mirrors the walk's own termination and

--- a/crates/manifest/src/frontier.rs
+++ b/crates/manifest/src/frontier.rs
@@ -1,7 +1,7 @@
 //! Frontier bookkeeping shared by the manifest walks: per-step prefetch tags
 //! and the bounded fill that admits fetches into a walk's own in-flight set.
 //!
-//! The walker owns the walk; the fill owns the window. Each policy plans one
+//! The walker owns the walk; the fill owns the window. Each walk plans one
 //! step at a time, so admission mirrors the walk's own termination and
 //! launches exactly the nodes the walk fetches, in the order the walk needs
 //! them.

--- a/crates/manifest/src/scan.rs
+++ b/crates/manifest/src/scan.rs
@@ -17,11 +17,13 @@
 
 use alloc::vec::Vec;
 use core::cmp::Ordering;
-use core::convert::Infallible;
 use core::future::poll_fn;
+use core::pin::Pin;
+use core::task::{Context, Poll};
 
 use bytes::Bytes;
-use nectar_governor::{BoxFuture, Driver, FuturesUnordered, WalkPolicy};
+use futures_core::Stream;
+use nectar_governor::{BoxFuture, FuturesUnordered};
 use nectar_primitives::ChunkAddress;
 #[cfg(feature = "encryption")]
 use nectar_primitives::EncryptedChunkRef;
@@ -101,10 +103,27 @@ type Turn<F> = Result<Option<(Key, Entry<F>)>, ReaderError>;
 ///
 /// Cancel-safe: a descent's step is consumed only after its fetch completes,
 /// so a dropped [`next`](Self::next) future replays the same descent.
+///
+/// Every fault is non-terminal (a failed descent replays, an encrypted edge
+/// is stepped past), so a fault rides the delivered turn rather than ending
+/// the walk. The walk advances inside [`admit`](Self::admit), where the
+/// launch a fresh descent needs is reachable.
 #[derive(Debug)]
 pub struct Cursor<'a, S, F: Format = V1> {
-    /// The walk, advanced by the policy and driven by the kernel driver.
-    driver: Driver<'a, ScanPolicy<'a, S, F>, Fetched<F>>,
+    store: &'a S,
+    /// One frame per referenced hop on the current path.
+    stack: Vec<Frame<F>>,
+    /// Exclusive upper bound on yielded keys.
+    end: Option<Bytes>,
+    /// Node fetches launched ahead of the walk.
+    in_flight: FuturesUnordered<BoxFuture<'a, Fetched<F>>>,
+    /// Completions that arrived before the descent awaiting them; drained by
+    /// sequence id and bounded with the in-flight set by the window.
+    ready: Vec<Fetched<F>>,
+    /// The next fetch sequence id to hand out.
+    next_seq: usize,
+    /// The turn advanced to under `admit`, awaiting hand-over.
+    staged: Option<Turn<F>>,
     done: bool,
     /// Remaining yields a paginated cursor may return; `None` is unbounded.
     remaining: Option<usize>,
@@ -124,39 +143,16 @@ enum Advance<F: Format> {
     Encrypted(Vec<u8>),
 }
 
-/// The cursor's walk policy over the kernel driver.
-///
-/// Every fault is non-terminal (a failed descent replays, an encrypted edge
-/// is stepped past), so faults ride the delivered turn and the driver error
-/// is uninhabited. The walk advances inside `admit`, where the launch a
-/// fresh descent needs is reachable; `take_ready` hands over the staged
-/// turn.
-struct ScanPolicy<'a, S, F: Format> {
-    store: &'a S,
-    /// One frame per referenced hop on the current path.
-    stack: Vec<Frame<F>>,
-    /// Exclusive upper bound on yielded keys.
-    end: Option<Bytes>,
-    /// Completions that arrived before the descent awaiting them; drained by
-    /// sequence id and bounded with the in-flight set by the window.
-    ready: Vec<Fetched<F>>,
-    /// The next fetch sequence id to hand out.
-    next_seq: usize,
-    /// The turn advanced to under `admit`, awaiting hand-over.
-    staged: Option<Turn<F>>,
-}
-
-impl<'a, S, F> WalkPolicy<'a> for ScanPolicy<'a, S, F>
+impl<'a, S, F> Cursor<'a, S, F>
 where
     S: NodeGet + MaybeSync,
     F: Format,
 {
-    type Fetched = Fetched<F>;
-    type Frame = Turn<F>;
-    type Error = Infallible;
-    type Drain = ();
-
-    fn admit(&mut self, in_flight: &mut FuturesUnordered<BoxFuture<'a, Fetched<F>>>) {
+    /// Stage the next turn, then launch the read-ahead the walk needs.
+    ///
+    /// Staging first is what makes a fresh descent reachable: the fill only
+    /// launches what the staged walk position asks for.
+    fn admit(&mut self) {
         if self.staged.is_none() {
             self.staged = self.advance();
         }
@@ -167,7 +163,7 @@ where
             self.ready.len(),
             &mut self.next_seq,
             &mut self.stack,
-            in_flight,
+            &mut self.in_flight,
             |base, step| {
                 let key = join(base, step.suffix());
                 if end.is_some_and(|end| key.as_slice() >= end.as_ref()) {
@@ -193,25 +189,24 @@ where
         );
     }
 
-    fn take_ready(&mut self, (): ()) -> Option<Result<Turn<F>, Infallible>> {
-        self.staged.take().map(Ok)
+    /// One poll of the bounded-admission walk: admit, hand over a staged
+    /// turn, else fold one completion. `None` ends the walk.
+    ///
+    /// All state lives in `self`, so a dropped poll replays.
+    fn poll_turn(&mut self, cx: &mut Context<'_>) -> Poll<Option<Turn<F>>> {
+        loop {
+            self.admit();
+            if let Some(turn) = self.staged.take() {
+                return Poll::Ready(Some(turn));
+            }
+            match Pin::new(&mut self.in_flight).poll_next(cx) {
+                Poll::Ready(Some(completion)) => self.ready.push(completion),
+                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
     }
 
-    fn absorb(&mut self, completion: Fetched<F>) -> Result<(), Infallible> {
-        self.ready.push(completion);
-        Ok(())
-    }
-
-    fn drained(&self) -> Result<(), Infallible> {
-        Ok(())
-    }
-}
-
-impl<S, F> ScanPolicy<'_, S, F>
-where
-    S: NodeGet + MaybeSync,
-    F: Format,
-{
     /// Advance the walk to its next deliverable turn: pop spent frames, yield
     /// values, and descend once a child's fetch has landed. `None` parks the
     /// walk on the head fetch the fill launches.
@@ -292,13 +287,7 @@ where
     fn past_end(&self, key: &[u8]) -> bool {
         self.end.as_ref().is_some_and(|end| key >= end.as_ref())
     }
-}
 
-impl<'a, S, F> Cursor<'a, S, F>
-where
-    S: NodeGet + MaybeSync,
-    F: Format,
-{
     /// Position a cursor at the least key `>= start`, streaming forward until
     /// `end` (exclusive), descending only the referenced hops on the seek path.
     pub(crate) async fn seek(
@@ -361,14 +350,13 @@ where
             }
         }
         Ok(Self {
-            driver: Driver::new(ScanPolicy {
-                store,
-                stack,
-                end,
-                ready: Vec::new(),
-                next_seq: 0,
-                staged: None,
-            }),
+            store,
+            stack,
+            end,
+            in_flight: FuturesUnordered::new(),
+            ready: Vec::new(),
+            next_seq: 0,
+            staged: None,
             done: false,
             remaining: None,
         })
@@ -378,14 +366,13 @@ where
     /// starts past the last key.
     pub(crate) fn exhausted(store: &'a S) -> Self {
         Self {
-            driver: Driver::new(ScanPolicy {
-                store,
-                stack: Vec::new(),
-                end: None,
-                ready: Vec::new(),
-                next_seq: 0,
-                staged: None,
-            }),
+            store,
+            stack: Vec::new(),
+            end: None,
+            in_flight: FuturesUnordered::new(),
+            ready: Vec::new(),
+            next_seq: 0,
+            staged: None,
             done: true,
             remaining: None,
         }
@@ -411,25 +398,22 @@ where
             self.done = true;
             return Ok(None);
         }
-        let Some(turn) = poll_fn(|cx| self.driver.poll(cx, ())).await else {
+        let Some(turn) = poll_fn(|cx| self.poll_turn(cx)).await else {
             self.done = true;
             return Ok(None);
         };
         match turn {
-            Ok(turn) => match turn {
-                Ok(Some((key, entry))) => {
-                    if let Some(left) = self.remaining {
-                        self.remaining = Some(left.saturating_sub(1));
-                    }
-                    Ok(Some((key, entry)))
+            Ok(Some((key, entry))) => {
+                if let Some(left) = self.remaining {
+                    self.remaining = Some(left.saturating_sub(1));
                 }
-                Ok(None) => {
-                    self.done = true;
-                    Ok(None)
-                }
-                Err(error) => Err(error),
-            },
-            Err(error) => match error {},
+                Ok(Some((key, entry)))
+            }
+            Ok(None) => {
+                self.done = true;
+                Ok(None)
+            }
+            Err(error) => Err(error),
         }
     }
 }

--- a/crates/manifest/src/store.rs
+++ b/crates/manifest/src/store.rs
@@ -14,8 +14,11 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::future::{Future, poll_fn};
 use core::mem;
+use core::pin::Pin;
+use core::task::{Context, Poll};
 
-use nectar_governor::{Admission, BoxFuture, Driver, FuturesUnordered, WalkPolicy, Window};
+use futures_core::Stream;
+use nectar_governor::{Admission, BoxFuture, FuturesUnordered, Window};
 use nectar_primitives::store::{BoxedError, ChunkPut, MaybeSend, MaybeSync, TrustedGet};
 use nectar_primitives::{
     Chunk, ChunkAddress, ChunkOps, ContentChunk, ContentOnlyChunkSet, EncryptionKey, Verified,
@@ -285,20 +288,22 @@ fn launch_segments<'a, S>(
     }
 }
 
-/// The segment join as a [`WalkPolicy`]: a directory-order frontier of slots
-/// over the kernel driver's in-flight set.
+/// The segment join: a directory-order frontier of slots over its own
+/// in-flight set.
 ///
 /// `admit` grows the frontier by splicing a decoded inner directory, then
-/// launches queued fetches from the head; `absorb` lands a completion in its
-/// slot; `take_ready` drains the head slot strictly in directory order,
-/// folding leaf records and parking an inner directory for the next admit;
-/// `drained` reports a lost completion. The in-order fold is the reassembly's
-/// byte-exact semantics, not head-of-line blocking: only the fetches overlap.
-struct SegmentJoinPolicy<'a, S, F: Format> {
+/// launches queued fetches from the head; `poll_turn` folds the head slot
+/// strictly in directory order, parks an inner directory for the next admit,
+/// and reports a lost completion once the set drains. The in-order fold is
+/// the reassembly's byte-exact semantics, not head-of-line blocking: only the
+/// fetches overlap.
+struct SegmentJoin<'a, S, F: Format> {
     store: &'a S,
     /// Descriptor slots in directory order; grows as inner directories splice.
     slots: Vec<SegmentSlot>,
     admission: Admission,
+    /// Fetches launched ahead of the in-order fold.
+    in_flight: FuturesUnordered<BoxFuture<'a, SegmentFetch>>,
     /// The slot to drain next; `None` once the join is complete.
     head: Option<usize>,
     /// Completions landed but not yet drained.
@@ -314,7 +319,7 @@ struct SegmentJoinPolicy<'a, S, F: Format> {
     trace: Vec<ChunkAddress>,
 }
 
-impl<'a, S, F> SegmentJoinPolicy<'a, S, F>
+impl<'a, S, F> SegmentJoin<'a, S, F>
 where
     S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
     F: Format,
@@ -327,6 +332,7 @@ where
             store,
             slots,
             admission: Admission::new(segment_window::<F>()),
+            in_flight: FuturesUnordered::new(),
             head,
             buffered: 0,
             encrypted,
@@ -340,19 +346,10 @@ where
     fn into_parts(self) -> (ForkTable<F>, Vec<ChunkAddress>) {
         (self.table, self.trace)
     }
-}
 
-impl<'a, S, F> WalkPolicy<'a> for SegmentJoinPolicy<'a, S, F>
-where
-    S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
-    F: Format,
-{
-    type Fetched = SegmentFetch;
-    type Frame = ();
-    type Error = StoreError;
-    type Drain = ();
-
-    fn admit(&mut self, in_flight: &mut FuturesUnordered<BoxFuture<'a, SegmentFetch>>) {
+    /// Splice any parked inner directory onto the frontier, then launch the
+    /// queued fetches the window admits.
+    fn admit(&mut self) {
         if let Some((inner, depth, next)) = self.pending.take() {
             self.head = splice_directory(&mut self.slots, &inner, depth, next);
         }
@@ -362,13 +359,44 @@ where
                 self.admission,
                 &mut self.slots,
                 head,
-                in_flight,
+                &mut self.in_flight,
                 self.buffered,
             );
         }
     }
 
-    fn take_ready(&mut self, (): ()) -> Option<Result<(), StoreError>> {
+    /// One poll of the bounded join: admit, fold the head slot if it has
+    /// landed, else absorb one completion. `None` ends the join.
+    ///
+    /// All state lives in `self`, so a dropped poll replays.
+    fn poll_turn(&mut self, cx: &mut Context<'_>) -> Poll<Option<Result<(), StoreError>>> {
+        loop {
+            self.admit();
+            if let Some(outcome) = self.take_ready() {
+                return Poll::Ready(Some(outcome));
+            }
+            match Pin::new(&mut self.in_flight).poll_next(cx) {
+                Poll::Ready(Some((index, outcome))) => {
+                    if let Some(slot) = self.slots.get_mut(index) {
+                        slot.state = SlotState::Landed(Box::new(outcome));
+                        self.buffered = self.buffered.saturating_add(1);
+                    }
+                }
+                // The head launches before every wait, so an empty set with
+                // work still owed is a lost completion, not a legal drain.
+                Poll::Ready(None) => {
+                    return Poll::Ready(
+                        (self.head.is_some() || self.pending.is_some())
+                            .then(|| Err(segment_context())),
+                    );
+                }
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+
+    /// Fold the head slot once its fetch has landed, in directory order.
+    fn take_ready(&mut self) -> Option<Result<(), StoreError>> {
         let head = self.head?;
         let slot = self.slots.get_mut(head)?;
         let outcome = slot.take_landed()?;
@@ -413,25 +441,6 @@ where
             Err(error) => Some(Err(error.into())),
         }
     }
-
-    fn absorb(&mut self, fetched: SegmentFetch) -> Result<(), StoreError> {
-        let (index, outcome) = fetched;
-        if let Some(slot) = self.slots.get_mut(index) {
-            slot.state = SlotState::Landed(Box::new(outcome));
-            self.buffered = self.buffered.saturating_add(1);
-        }
-        Ok(())
-    }
-
-    fn drained(&self) -> Result<(), StoreError> {
-        // The head launches before every wait, so an empty set with work still
-        // owed is a lost completion, not a legal drain.
-        if self.head.is_some() || self.pending.is_some() {
-            Err(segment_context())
-        } else {
-            Ok(())
-        }
-    }
 }
 
 /// Gather every fork of a spilled node: fetch the segments its directory
@@ -452,11 +461,11 @@ where
     S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
     F: Format,
 {
-    let mut driver = Driver::new(SegmentJoinPolicy::<S, F>::new(store, dir, encrypted));
-    while let Some(turn) = poll_fn(|cx| driver.poll(cx, ())).await {
+    let mut join = SegmentJoin::<S, F>::new(store, dir, encrypted);
+    while let Some(turn) = poll_fn(|cx| join.poll_turn(cx)).await {
         turn?;
     }
-    let (table, segments) = driver.into_policy().into_parts();
+    let (table, segments) = join.into_parts();
     trace.extend(segments);
     Ok(table)
 }
@@ -733,6 +742,90 @@ mod tests {
         assert_eq!(trace, vec![leaf_a, inner_dir, leaf_b, leaf_c, leaf_d]);
         let mut expected = ForkTable::new();
         for byte in [0x10, 0x11, 0x20, 0x21, 0x30, 0x40, 0x41] {
+            expected
+                .insert(prefix(&[byte]), entry(byte).into(), None)
+                .unwrap();
+        }
+        assert_eq!(node, Node::new(None, expected));
+    }
+
+    /// Yields once per round before completing, so a test picks the order
+    /// concurrent fetches land in.
+    struct Yields(usize);
+
+    impl Future for Yields {
+        type Output = ();
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+            if self.0 == 0 {
+                Poll::Ready(())
+            } else {
+                self.0 -= 1;
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+        }
+    }
+
+    /// A trusted store that delays each address by its own round count and
+    /// records the order fetches resolve in.
+    struct SkewedStore {
+        inner: ContentGet<MemoryStore>,
+        rounds: alloc::collections::BTreeMap<ChunkAddress, usize>,
+        arrivals: std::sync::Mutex<Vec<ChunkAddress>>,
+    }
+
+    impl ChunkGet<ContentOnlyChunkSet> for SkewedStore {
+        type Trust = Verified;
+        type Error = <ContentGet<MemoryStore> as ChunkGet<ContentOnlyChunkSet>>::Error;
+
+        async fn get(&self, address: &ChunkAddress) -> Result<FetchedChunk, Self::Error> {
+            Yields(self.rounds.get(address).copied().unwrap_or(0)).await;
+            self.arrivals.lock().unwrap().push(*address);
+            ChunkGet::get(&self.inner, address).await
+        }
+    }
+
+    /// A leaf segment over `bytes`, stored and addressed.
+    fn leaf_segment(store: &ContentGet<MemoryStore>, bytes: &[u8]) -> ChunkAddress {
+        let mut table = ForkTable::<V1>::new();
+        for &byte in bytes {
+            table
+                .insert(prefix(&[byte]), entry(byte).into(), None)
+                .unwrap();
+        }
+        put_raw(store, encode_leaf_segment(&table))
+    }
+
+    #[test]
+    fn out_of_order_completions_still_fold_in_directory_order() {
+        let store = ContentGet::new(MemoryStore::default());
+        let leaf_a = leaf_segment(&store, &[0x10, 0x11]);
+        let leaf_b = leaf_segment(&store, &[0x20, 0x21]);
+        let leaf_c = leaf_segment(&store, &[0x30, 0x31]);
+        let dir = SegmentDir::plain(vec![
+            (0x10, leaf_a, SubtreeCount::new(2)),
+            (0x20, leaf_b, SubtreeCount::new(2)),
+            (0x30, leaf_c, SubtreeCount::new(2)),
+        ]);
+        let root = put_raw(&store, encode_segmented_node::<V1>(None, &dir));
+
+        // The three fetches overlap and land last-first, so a fold in
+        // completion order would invert the trace.
+        let skewed = SkewedStore {
+            rounds: [(leaf_a, 6), (leaf_b, 4), (leaf_c, 2)].into_iter().collect(),
+            inner: store,
+            arrivals: std::sync::Mutex::new(Vec::new()),
+        };
+        let (node, trace) = run(materialize_traced::<_, V1>(&skewed, &root, None)).unwrap();
+        // The skew held: the segments really did land back to front.
+        assert_eq!(
+            skewed.arrivals.lock().unwrap().as_slice(),
+            [root, leaf_c, leaf_b, leaf_a]
+        );
+        assert_eq!(trace, vec![leaf_a, leaf_b, leaf_c]);
+        let mut expected = ForkTable::new();
+        for byte in [0x10, 0x11, 0x20, 0x21, 0x30, 0x31] {
             expected
                 .insert(prefix(&[byte]), entry(byte).into(), None)
                 .unwrap();

--- a/crates/manifest/src/traverse.rs
+++ b/crates/manifest/src/traverse.rs
@@ -9,11 +9,13 @@
 
 use alloc::collections::VecDeque;
 use alloc::vec::Vec;
-use core::convert::Infallible;
 use core::future::poll_fn;
+use core::pin::Pin;
+use core::task::{Context, Poll};
 
 use bytes::Bytes;
-use nectar_governor::{BoxFuture, Driver, FuturesUnordered, WalkPolicy};
+use futures_core::Stream;
+use nectar_governor::{BoxFuture, FuturesUnordered};
 use nectar_primitives::ChunkAddress;
 #[cfg(feature = "encryption")]
 use nectar_primitives::EncryptedChunkRef;
@@ -78,29 +80,24 @@ enum Advance {
 /// retains O(depth) frames at the serial fetch count. Cancel-safe: all
 /// progress lives in `self`, and a step is consumed only once its fetch has
 /// completed, so a dropped [`next`](Self::next) future loses no addresses.
+///
+/// Every fault is non-terminal (a failed descent replays, an encrypted edge
+/// re-errors), so a fault rides the delivered turn rather than ending the
+/// walk. The walk advances inside [`admit`](Self::admit), where the launch a
+/// fresh descent needs is reachable.
 #[derive(Debug)]
 pub struct AddressStream<'a, S, F: Format = V1> {
     store: &'a S,
     /// The root reference, pending its visit.
     root: Option<Root>,
     done: bool,
-    /// The walk, advanced by the policy and driven by the kernel driver.
-    driver: Driver<'a, TraversePolicy<'a, S, F>, Fetched<F>>,
-}
-
-/// The stream's walk policy over the kernel driver.
-///
-/// Every fault is non-terminal (a failed descent replays, an encrypted edge
-/// re-errors), so faults ride the delivered turn and the driver error is
-/// uninhabited. The walk advances inside `admit`, where the launch a fresh
-/// descent needs is reachable; `take_ready` hands over the staged turn.
-struct TraversePolicy<'a, S, F: Format> {
-    store: &'a S,
     /// Addresses discovered ahead of delivery: a visited node's own chunk
     /// and its segment chunks.
     pending: VecDeque<ChunkAddress>,
     /// One frame per referenced hop on the current path.
     stack: Vec<Frame<F>>,
+    /// Node fetches launched ahead of the walk.
+    in_flight: FuturesUnordered<BoxFuture<'a, Fetched<F>>>,
     /// Completions that arrived before the descent awaiting them; drained by
     /// sequence id and bounded with the in-flight set by the window.
     ready: Vec<Fetched<F>>,
@@ -110,17 +107,16 @@ struct TraversePolicy<'a, S, F: Format> {
     staged: Option<Turn>,
 }
 
-impl<'a, S, F> WalkPolicy<'a> for TraversePolicy<'a, S, F>
+impl<'a, S, F> AddressStream<'a, S, F>
 where
     S: NodeGet + MaybeSync,
     F: Format,
 {
-    type Fetched = Fetched<F>;
-    type Frame = Turn;
-    type Error = Infallible;
-    type Drain = ();
-
-    fn admit(&mut self, in_flight: &mut FuturesUnordered<BoxFuture<'a, Fetched<F>>>) {
+    /// Stage the next turn, then launch the read-ahead the walk needs.
+    ///
+    /// Staging first is what makes a fresh descent reachable: the fill only
+    /// launches what the staged walk position asks for.
+    fn admit(&mut self) {
         if self.staged.is_none() {
             self.staged = self.advance();
         }
@@ -130,7 +126,7 @@ where
             self.ready.len(),
             &mut self.next_seq,
             &mut self.stack,
-            in_flight,
+            &mut self.in_flight,
             |_base, step| {
                 let target = match step {
                     Step::Value { .. } => None,
@@ -156,25 +152,24 @@ where
         );
     }
 
-    fn take_ready(&mut self, (): ()) -> Option<Result<Turn, Infallible>> {
-        self.staged.take().map(Ok)
+    /// One poll of the bounded-admission walk: admit, hand over a staged
+    /// turn, else fold one completion. `None` ends the walk.
+    ///
+    /// All state lives in `self`, so a dropped poll replays.
+    fn poll_turn(&mut self, cx: &mut Context<'_>) -> Poll<Option<Turn>> {
+        loop {
+            self.admit();
+            if let Some(turn) = self.staged.take() {
+                return Poll::Ready(Some(turn));
+            }
+            match Pin::new(&mut self.in_flight).poll_next(cx) {
+                Poll::Ready(Some(completion)) => self.ready.push(completion),
+                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
     }
 
-    fn absorb(&mut self, completion: Fetched<F>) -> Result<(), Infallible> {
-        self.ready.push(completion);
-        Ok(())
-    }
-
-    fn drained(&self) -> Result<(), Infallible> {
-        Ok(())
-    }
-}
-
-impl<S, F> TraversePolicy<'_, S, F>
-where
-    S: NodeGet + MaybeSync,
-    F: Format,
-{
     /// Advance the walk to its next deliverable turn: deliver queued
     /// addresses, pop spent frames, and descend once a child's fetch has
     /// landed. `None` parks the walk on the head fetch the fill launches.
@@ -251,27 +246,19 @@ where
         self.pending.extend(segments);
         self.stack.push(Frame::new(Bytes::new(), steps, 0));
     }
-}
 
-impl<'a, S, F> AddressStream<'a, S, F>
-where
-    S: NodeGet + MaybeSync,
-    F: Format,
-{
     /// A stream positioned before its root visit.
     fn start(store: &'a S, root: Root) -> Self {
         Self {
             store,
             root: Some(root),
             done: false,
-            driver: Driver::new(TraversePolicy {
-                store,
-                pending: VecDeque::new(),
-                stack: Vec::new(),
-                ready: Vec::new(),
-                next_seq: 0,
-                staged: None,
-            }),
+            pending: VecDeque::new(),
+            stack: Vec::new(),
+            in_flight: FuturesUnordered::new(),
+            ready: Vec::new(),
+            next_seq: 0,
+            staged: None,
         }
     }
 
@@ -289,21 +276,13 @@ where
             let (node, segments) =
                 materialize_traced::<S, F>(self.store, &address, key.as_ref()).await?;
             self.root = None;
-            self.driver
-                .policy_mut()
-                .enter(address, segments, flatten(&node, true));
+            self.enter(address, segments, flatten(&node, true));
         }
-        let Some(turn) = poll_fn(|cx| self.driver.poll(cx, ())).await else {
+        let Some(turn) = poll_fn(|cx| self.poll_turn(cx)).await else {
             self.done = true;
             return Ok(None);
         };
-        match turn {
-            Ok(turn) => match turn {
-                Ok(address) => Ok(Some(address)),
-                Err(error) => Err(error),
-            },
-            Err(error) => match error {},
-        }
+        turn.map(Some)
     }
 }
 
@@ -676,6 +655,69 @@ mod tests {
             }
             assert_eq!(out, vec![root, addr(0xAA), addr(0xAB), leaf, addr(0xBA)]);
         });
+    }
+
+    /// A trusted store recording the peak number of concurrent `get` calls.
+    struct GatedStore {
+        inner: ContentGet<MemoryStore>,
+        inflight: core::sync::atomic::AtomicUsize,
+        peak: core::sync::atomic::AtomicUsize,
+    }
+
+    impl ChunkGet<ContentOnlyChunkSet> for GatedStore {
+        type Trust = Verified;
+        type Error = <ContentGet<MemoryStore> as ChunkGet<ContentOnlyChunkSet>>::Error;
+
+        async fn get(
+            &self,
+            address: &ChunkAddress,
+        ) -> Result<Chunk<Verified, ContentOnlyChunkSet>, Self::Error> {
+            use core::sync::atomic::Ordering;
+            let now = self.inflight.fetch_add(1, Ordering::Relaxed) + 1;
+            self.peak.fetch_max(now, Ordering::Relaxed);
+            yield_once().await;
+            let chunk = ChunkGet::get(&self.inner, address).await;
+            self.inflight.fetch_sub(1, Ordering::Relaxed);
+            chunk
+        }
+    }
+
+    #[test]
+    fn read_ahead_bounds_the_in_flight_node_fetches() {
+        use core::sync::atomic::{AtomicUsize, Ordering};
+
+        let inner = ContentGet::new(MemoryStore::default());
+        // More top-level subtrees than the read-ahead window has slots, each
+        // wide enough to spill into a referenced child, so an unbounded
+        // frontier would launch past the cap.
+        let mut builder = Builder::<V1>::new();
+        for p in 0u8..24 {
+            for x in 0u8..44 {
+                builder.insert(Key::from(&[p, x][..]), entry(x.wrapping_add(p)), None);
+            }
+        }
+        let root = *run(builder.build(&inner)).unwrap().root();
+        let store = GatedStore {
+            inner,
+            inflight: AtomicUsize::new(0),
+            peak: AtomicUsize::new(0),
+        };
+
+        let reader: Reader<_> = Reader::new(&store);
+        drain(reader.addresses(&root));
+
+        let peak = store.peak.load(Ordering::Relaxed);
+        // The window overlapped fetches, and never past the read-ahead cap:
+        // the frontier is bounded, not O(width).
+        assert!(peak > 1, "read-ahead ran node fetches concurrently, {peak}");
+        assert!(
+            peak <= V1::READ_AHEAD,
+            "peak in-flight {peak} exceeded the read-ahead cap {}",
+            V1::READ_AHEAD
+        );
+        // The frontier is wider than the window, so the cap is what bounds the
+        // walk: a lost window would show up here.
+        assert_eq!(peak, V1::READ_AHEAD);
     }
 
     #[test]


### PR DESCRIPTION
Closes #627

## What

All four manifest walk sites (`scan.rs`, `traverse.rs`, `apply.rs`'s prefetch, and its segment join) move off `Driver`/`WalkPolicy` onto per-site `FuturesUnordered` plus `nectar_governor::Admission` loops. Every `WalkPolicy` impl in the crate is deleted; `crates/governor/src/driver.rs` is untouched (#630 owns it).

- `scan.rs`: `ScanPolicy` is dissolved into `Cursor`, which now owns `store`, `stack`, `end`, `in_flight`, `ready`, `next_seq`, and `staged`. `admit` stages the next turn then runs the existing `frontier::fill`; `poll_turn` is the hand-rolled loop (admit, hand over a staged turn, else fold one completion, `None` when the set drains). The `Infallible` driver error and its `match error {}` arm are gone.
- `traverse.rs`: the same shape, dissolved into `AddressStream`.
- `apply.rs`: `PrefetchPolicy` removed; `prefetch_children` is a bare `poll_fn` loop over `FuturesUnordered` with an `Admission` window.

## Why

Phase 0 of the cruft-cut roadmap (#610): delete the shared `Driver`/`WalkPolicy` walk loop so each site drives its own bounded fan-out on `FuturesUnordered` plus the governor.

## Testing

The rewrite was re-derived against `origin/main` rather than trusting the implementer's report. The four loops are faithful transcriptions of `Driver::poll` (admit, hand over a ready frame, else fold one completion, else drain), verified arm by arm. The `done` latch is genuinely subsumed: `scan`/`traverse` keep their own `done` set in `next()`, and the errors that latched it were `Infallible`; the segment join's caller `?`s out on the first error, so no post-error poll exists. `prefetch_children`'s rewrite is equivalent to the deleted policy (same slot count, same all-`None` content).

Gated inside `nix develop`: clippy `--all-features` and doctests for `nectar-manifest`, with the integration-tests manifest scan/order/conformance suites as the behavioural oracle. CI runs the full nextest, clippy, and no_std matrix on this PR.

## AI Assistance

Implement: claude-opus-5. Red-team: claude-opus-5. PR: claude-sonnet-5.
