### PR TITLE
manifest: seam-owned ManifestError<F> taxonomy (#652)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2692,6 +2692,7 @@ dependencies = [
  "nectar-primitives",
  "nectar-testing",
  "proptest",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/integration-tests/Cargo.toml
+++ b/crates/integration-tests/Cargo.toml
@@ -41,6 +41,7 @@ nectar-postage-usage.workspace = true
 nectar-primitives = { workspace = true, features = ["std"] }
 nectar-testing = { workspace = true, features = ["alloc", "fixtures"] }
 proptest.workspace = true
+thiserror = { workspace = true, features = ["std"] }
 
 [features]
 # Each feature mirrors the underlying crate feature so the `cfg(feature)`

--- a/crates/integration-tests/tests/manifest/dyn_roundtrip.rs
+++ b/crates/integration-tests/tests/manifest/dyn_roundtrip.rs
@@ -6,12 +6,12 @@
 //! lands in each format's own native slot.
 
 use nectar_file::{File, MemSink, Policy};
-use nectar_ldb::{Builder, LdbManifest, Plaintext, Reader as LdbReader, V1};
+use nectar_ldb::{LdbManifest, Reader as LdbReader};
 use nectar_loadsave::NodeLoadSaver;
 use nectar_manifest::{
     DynManifest, ManifestMetadata, ManifestOp, ManifestPath, MetadataView, SiteConfig, WellKnownKey,
 };
-use nectar_mantaray::{ManifestEditor, MantarayManifest, Reader as MantarayReader, metadata};
+use nectar_mantaray::{MantarayManifest, Reader as MantarayReader, metadata};
 use nectar_primitives::store::{ContentGet, MemoryStore};
 use nectar_primitives::{ChunkRef, DEFAULT_BODY_SIZE, StandardChunkSet};
 use nectar_testing::run;
@@ -38,8 +38,9 @@ fn content_type() -> Box<dyn ManifestMetadata> {
     Box::new(MetadataView::new().with(WellKnownKey::ContentType, CONTENT_TYPE))
 }
 
-/// Drive one erased manifest through the whole seam: apply a batch, list the
-/// root and a subdirectory, load an entry's data, then remove it.
+/// Drive one erased manifest through the whole seam: bootstrap the empty
+/// root, apply a batch, list the root and a subdirectory, load an entry's
+/// data, then remove it.
 async fn exercise(manifest: &dyn DynManifest, base: &ChunkRef, file: &ChunkRef, data: &[u8]) {
     let root = manifest
         .dyn_apply(
@@ -192,27 +193,28 @@ async fn exercise(manifest: &dyn DynManifest, base: &ChunkRef, file: &ChunkRef, 
             .unwrap(),
         "the empty path binds nothing"
     );
-}
 
-/// An empty trie manifest, and the seams it is read and written through.
-async fn mantaray(raw: &Raw) -> (Nodes, ChunkRef) {
-    let nodes = NodeLoadSaver::new(Arc::clone(raw));
-    let editor: ManifestEditor<_> = ManifestEditor::new(nodes.clone());
-    let (root, _) = editor.commit().await.unwrap();
-    (nodes, ChunkRef::new(root))
-}
-
-/// An empty key-value manifest.
-async fn ldb(store: &Store) -> ChunkRef {
-    let builder: Builder<V1> = Builder::new();
-    *builder.build(store, &Plaintext).await.unwrap().root()
+    // The taxonomy survives erasure: the seam variants still match structurally.
+    let separator = ManifestPath::from("/");
+    let reserved = manifest
+        .dyn_insert(&root, separator.clone(), *file, content_type())
+        .await
+        .err()
+        .and_then(|e| e.as_reserved().map(|r| r.path().clone()));
+    assert_eq!(reserved, Some(separator), "erased Reserved");
+    let mut sink = MemSink::new();
+    let missing = manifest
+        .dyn_load(&root, &ManifestPath::from("absent.html"), &mut sink)
+        .await
+        .err();
+    assert!(missing.is_some_and(|e| e.is_not_found()), "erased NotFound");
 }
 
 #[test]
 fn both_formats_round_trip_through_one_erased_handle() {
     run(async {
         let raw: Raw = Arc::new(MemoryStore::new());
-        let store = ContentGet::new(Arc::clone(&raw));
+        let store: Store = ContentGet::new(Arc::clone(&raw));
         let data = payload();
         let file = ChunkRef::new(
             File::<_, DEFAULT_BODY_SIZE>::new(&raw, Policy::DEFAULT)
@@ -221,12 +223,13 @@ fn both_formats_round_trip_through_one_erased_handle() {
                 .unwrap(),
         );
 
-        let (nodes, trie_root) = mantaray(&raw).await;
+        let nodes: Nodes = NodeLoadSaver::new(Arc::clone(&raw));
         let trie: Box<dyn DynManifest> = Box::new(
             MantarayManifest::<_, _, DEFAULT_BODY_SIZE>::new(nodes, store.clone()),
         );
-        let kv_root = ldb(&store).await;
+        let trie_root = trie.dyn_empty().await.unwrap();
         let kv: Box<dyn DynManifest> = Box::new(LdbManifest::plain(store.clone()));
+        let kv_root = kv.dyn_empty().await.unwrap();
 
         exercise(trie.as_ref(), &trie_root, &file, &data).await;
         exercise(kv.as_ref(), &kv_root, &file, &data).await;
@@ -238,13 +241,14 @@ fn both_formats_round_trip_through_one_erased_handle() {
 fn the_site_config_lands_in_each_format_native_slot() {
     run(async {
         let raw: Raw = Arc::new(MemoryStore::new());
-        let store = ContentGet::new(Arc::clone(&raw));
+        let store: Store = ContentGet::new(Arc::clone(&raw));
         let config = SiteConfig::new().with_index_document(ManifestPath::from("index.html"));
 
         // The trie keeps the site documents on its root path node, which
         // binds no entry.
-        let (nodes, trie_root) = mantaray(&raw).await;
+        let nodes: Nodes = NodeLoadSaver::new(Arc::clone(&raw));
         let trie = MantarayManifest::<_, _, DEFAULT_BODY_SIZE>::new(nodes.clone(), store.clone());
+        let trie_root = trie.dyn_empty().await.unwrap();
         let root = trie
             .dyn_set_site_config(&trie_root, config.clone())
             .await
@@ -273,8 +277,8 @@ fn the_site_config_lands_in_each_format_native_slot() {
 
         // The key-value database keeps them in the root's typed metadata,
         // which its website view reads.
-        let kv_root = ldb(&store).await;
         let kv = LdbManifest::plain(store.clone());
+        let kv_root = kv.dyn_empty().await.unwrap();
         let root = kv.dyn_set_site_config(&kv_root, config).await.unwrap();
         let reader: LdbReader<_> = LdbReader::new(&store);
         let website = reader.website(&root).await.unwrap();

--- a/crates/integration-tests/tests/manifest/encrypted.rs
+++ b/crates/integration-tests/tests/manifest/encrypted.rs
@@ -9,12 +9,12 @@
 use std::sync::Arc;
 
 use nectar_file::{File, MemSink, Policy};
-use nectar_ldb::{Builder, Encrypted as EncryptedSeal, LdbManifest, V1};
+use nectar_ldb::{Encrypted as EncryptedSeal, LdbManifest, V1};
 use nectar_loadsave::NodeLoadSaver;
 use nectar_manifest::{
     ListEntry, Manifest, ManifestPath, MapEntry, MapView, MapWriter, MetadataView, WellKnownKey,
 };
-use nectar_mantaray::{ManifestEditor, MantarayManifest};
+use nectar_mantaray::MantarayManifest;
 use nectar_primitives::store::{ContentGet, MemoryStore};
 use nectar_primitives::{DEFAULT_BODY_SIZE, EncryptedChunkRef, StandardChunkSet};
 use nectar_testing::run;
@@ -99,18 +99,16 @@ fn both_formats_drive_an_encrypted_manifest() {
             .await
             .unwrap();
 
+        // The seam bootstrap works at the encrypted width too.
         let nodes = NodeLoadSaver::new(Arc::clone(&raw));
-        let editor: ManifestEditor<_, EncryptedChunkRef> =
-            ManifestEditor::new_encrypted(nodes.clone());
-        let (trie_root, _) = editor.commit().await.unwrap();
         let trie: MantarayManifest<_, Store, DEFAULT_BODY_SIZE> =
             MantarayManifest::new(nodes, store.clone());
+        let trie_root: EncryptedChunkRef = trie.empty().await.unwrap();
         exercise(&trie, &trie_root, &file, &data).await;
 
         let seal: EncryptedSeal<'_, V1> = EncryptedSeal::new(SECRET);
-        let builder: Builder<V1> = Builder::new();
-        let kv_root = builder.build(&store, &seal).await.unwrap().root().clone();
         let kv = LdbManifest::new(store.clone(), seal);
+        let kv_root: EncryptedChunkRef = kv.empty().await.unwrap();
         exercise(&kv, &kv_root, &file, &data).await;
     });
 }

--- a/crates/integration-tests/tests/manifest/root_config.rs
+++ b/crates/integration-tests/tests/manifest/root_config.rs
@@ -33,14 +33,14 @@
 use std::ops::Bound;
 use std::sync::Arc;
 
-use nectar_file::MemSink;
+use nectar_file::{DataSink, File, MemSink, Policy};
 use nectar_ldb::{
     Builder, Database, Entry, Key, LdbManifest, Plaintext, Reader as LdbReader, Served, V1, Website,
 };
 use nectar_loadsave::NodeLoadSaver;
 use nectar_manifest::{
-    Manifest, ManifestPath, MapCursor, MapEntry, MapView, MapWriter, MetadataView, WellKnownKey,
-    reserved_key,
+    Manifest, ManifestError, ManifestPath, MapCursor, MapEntry, MapView, MapWriter, MetadataView,
+    WellKnownKey,
 };
 use nectar_mantaray::{ManifestEditor, MantarayManifest};
 use nectar_primitives::store::{ContentGet, MemoryStore};
@@ -51,6 +51,32 @@ use nectar_testing::run;
 /// to reach the same map.
 type Raw = Arc<MemoryStore<StandardChunkSet>>;
 type Store = ContentGet<Raw>;
+type Trie = MantarayManifest<NodeLoadSaver<Raw>, Store, DEFAULT_BODY_SIZE>;
+type Kv = LdbManifest<Store>;
+
+/// Both formats over one raw store, each at its freshly persisted empty root.
+async fn both_formats(raw: &Raw, store: &Store) -> ((Trie, ChunkRef), (Kv, ChunkRef)) {
+    let trie: Trie = MantarayManifest::new(NodeLoadSaver::new(Arc::clone(raw)), store.clone());
+    let trie_empty = trie.empty().await.unwrap();
+    let kv = LdbManifest::plain(store.clone());
+    let kv_empty = kv.empty().await.unwrap();
+    ((trie, trie_empty), (kv, kv_empty))
+}
+
+/// `keys` written through the seam in one batch, each bound to a distinct
+/// reference.
+async fn write_keys<M: Manifest<ChunkRef>>(
+    manifest: &M,
+    empty: &ChunkRef,
+    keys: &[&str],
+) -> ChunkRef {
+    let mut writer = manifest.edit(empty);
+    for (index, key) in keys.iter().enumerate() {
+        let bound = reference(u8::try_from(index).unwrap().saturating_add(1));
+        writer.insert(ManifestPath::from(*key), bound);
+    }
+    writer.commit().await.unwrap()
+}
 
 /// A filename joined below each directory, so relative on purpose.
 const INDEX: &str = "index.html";
@@ -67,10 +93,13 @@ fn text(path: &ManifestPath) -> String {
     String::from_utf8(path.as_bytes().to_vec()).unwrap()
 }
 
-/// The reserved path a refused write names. One matcher over every format.
-fn refused<T, E: std::error::Error + 'static>(result: &Result<T, E>) -> Option<ManifestPath> {
-    let error = result.as_ref().err()?;
-    reserved_key(error).map(|reserved| reserved.path().clone())
+/// The reserved path a refused write names, structurally over every format.
+fn refused<T, F>(result: &Result<T, ManifestError<F>>) -> Option<ManifestPath> {
+    result
+        .as_ref()
+        .err()?
+        .as_reserved()
+        .map(|reserved| reserved.path().clone())
 }
 
 /// One format's answers to one scenario, in a format-independent shape.
@@ -700,17 +729,9 @@ macro_rules! differential {
             run(async {
                 let raw: Raw = Arc::new(MemoryStore::new());
                 let store: Store = ContentGet::new(Arc::clone(&raw));
-
-                let nodes = NodeLoadSaver::new(Arc::clone(&raw));
-                let editor: ManifestEditor<_> = ManifestEditor::new(nodes.clone());
-                let (empty, _) = editor.commit().await.unwrap();
-                let trie = MantarayManifest::<_, _, DEFAULT_BODY_SIZE>::new(nodes, store.clone());
-                let from_trie = $scenario(&trie, &ChunkRef::new(empty)).await;
-
-                let builder: Builder<V1> = Builder::new();
-                let empty = *builder.build(&store, &Plaintext).await.unwrap().root();
-                let kv = LdbManifest::plain(store.clone());
-                let from_kv = $scenario(&kv, &empty).await;
+                let ((trie, trie_empty), (kv, kv_empty)) = both_formats(&raw, &store).await;
+                let from_trie = $scenario(&trie, &trie_empty).await;
+                let from_kv = $scenario(&kv, &kv_empty).await;
 
                 assert_eq!(
                     from_trie, from_kv,
@@ -804,30 +825,9 @@ fn separator_prefixed_content_lists_alike_on_both_formats() {
 async fn both_top_levels(keys: &[&str]) -> (Vec<String>, Vec<String>) {
     let raw: Raw = Arc::new(MemoryStore::new());
     let store: Store = ContentGet::new(Arc::clone(&raw));
-    let bound = |index: usize| reference(u8::try_from(index).unwrap().saturating_add(1));
-
-    let nodes = NodeLoadSaver::new(Arc::clone(&raw));
-    let editor: ManifestEditor<_> = ManifestEditor::new(nodes.clone());
-    let (trie_empty, _) = editor.commit().await.unwrap();
-    let trie = MantarayManifest::<_, _, DEFAULT_BODY_SIZE>::new(nodes, store.clone());
-    let trie_root = {
-        let mut writer = trie.edit(&ChunkRef::new(trie_empty));
-        for (index, key) in keys.iter().enumerate() {
-            writer.insert(ManifestPath::from(*key), bound(index));
-        }
-        writer.commit().await.unwrap()
-    };
-
-    let builder: Builder<V1> = Builder::new();
-    let kv_empty = *builder.build(&store, &Plaintext).await.unwrap().root();
-    let kv = LdbManifest::plain(store.clone());
-    let kv_root = {
-        let mut writer = kv.edit(&kv_empty);
-        for (index, key) in keys.iter().enumerate() {
-            writer.insert(ManifestPath::from(*key), bound(index));
-        }
-        writer.commit().await.unwrap()
-    };
+    let ((trie, trie_empty), (kv, kv_empty)) = both_formats(&raw, &store).await;
+    let trie_root = write_keys(&trie, &trie_empty, keys).await;
+    let kv_root = write_keys(&kv, &kv_empty, keys).await;
 
     let top = ManifestPath::default();
     (
@@ -889,18 +889,96 @@ fn an_insert_replaces_the_whole_binding_on_both_formats() {
     run(async {
         let raw: Raw = Arc::new(MemoryStore::new());
         let store: Store = ContentGet::new(Arc::clone(&raw));
+        let ((trie, trie_empty), (kv, kv_empty)) = both_formats(&raw, &store).await;
+        insert_replaces_the_whole_binding(&trie, &trie_empty).await;
+        insert_replaces_the_whole_binding(&kv, &kv_empty).await;
+    });
+}
+
+/// `empty` equals `native`, holds no path, and reads an absent path as
+/// `ManifestError::NotFound`, structurally.
+async fn assert_empty_bootstrap<M: Manifest<ChunkRef>>(manifest: &M, native: ChunkRef, f: &str) {
+    let empty: ChunkRef = manifest.empty().await.unwrap();
+    assert_eq!(empty, native, "{f}: bootstrap off the native empty root");
+    let view = manifest.at(&empty);
+    let first = view.iter().await.unwrap().next().await.unwrap();
+    assert!(first.is_none(), "{f}: the empty manifest holds no path");
+    let missing = view
+        .load(&ManifestPath::from("missing.html"), &mut MemSink::new())
+        .await
+        .err();
+    assert!(missing.is_some_and(|e| e.is_not_found()), "{f}: NotFound");
+}
+
+/// The seam bootstrap is the format's own: `empty` returns the root the
+/// native builder produces.
+#[test]
+fn the_seam_bootstrap_matches_each_format() {
+    run(async {
+        let raw: Raw = Arc::new(MemoryStore::new());
+        let store: Store = ContentGet::new(Arc::clone(&raw));
 
         let nodes = NodeLoadSaver::new(Arc::clone(&raw));
         let editor: ManifestEditor<_> = ManifestEditor::new(nodes.clone());
-        let (trie_empty, _) = editor.commit().await.unwrap();
+        let (native, _) = editor.commit().await.unwrap();
         let trie = MantarayManifest::<_, _, DEFAULT_BODY_SIZE>::new(nodes, store.clone());
-        insert_replaces_the_whole_binding(&trie, &ChunkRef::new(trie_empty)).await;
+        assert_empty_bootstrap(&trie, ChunkRef::new(native), "trie").await;
 
         let builder: Builder<V1> = Builder::new();
-        let kv_empty = *builder.build(&store, &Plaintext).await.unwrap().root();
-        let kv = LdbManifest::plain(store.clone());
-        insert_replaces_the_whole_binding(&kv, &kv_empty).await;
+        let native = *builder.build(&store, &Plaintext).await.unwrap().root();
+        assert_empty_bootstrap(&LdbManifest::plain(store.clone()), native, "database").await;
     });
+}
+
+/// Insert `file`, load it through a refusing sink, and check the seam
+/// classified the refusal as `Sink` with the refusal kept as the source.
+async fn assert_sink_refusal<M: Manifest<ChunkRef>>(manifest: &M, file: ChunkRef, f: &str) {
+    let path = ManifestPath::from(INDEX);
+    let empty = manifest.empty().await.unwrap();
+    let root = manifest.insert(&empty, path.clone(), file).await.unwrap();
+    let error = manifest
+        .at(&root)
+        .load(&path, &mut RefusingSink)
+        .await
+        .unwrap_err();
+    let sink = matches!(error, ManifestError::Sink(_));
+    assert!(sink, "{f}: wrong variant: {error:?}");
+    let source = std::error::Error::source(&error);
+    let kept = source.is_some_and(|s| s.downcast_ref::<Refused>().is_some());
+    assert!(kept, "{f}: the sink's own error left the chain");
+}
+
+/// A sink refusal is the seam's own `Sink`, never `Data`, on both formats.
+#[test]
+fn a_refused_sink_write_is_sink_on_both_formats() {
+    run(async {
+        let raw: Raw = Arc::new(MemoryStore::new());
+        let store: Store = ContentGet::new(Arc::clone(&raw));
+        let data = vec![7u8; 20_000];
+        let saver = File::<_, DEFAULT_BODY_SIZE>::new(&raw, Policy::DEFAULT);
+        let file = ChunkRef::new(saver.save(&data[..]).await.unwrap());
+
+        let ((trie, _), (kv, _)) = both_formats(&raw, &store).await;
+        assert_sink_refusal(&trie, file, "trie").await;
+        assert_sink_refusal(&kv, file, "database").await;
+    });
+}
+
+/// A sink that refuses every write.
+#[derive(Debug)]
+struct RefusingSink;
+
+/// The refusal [`RefusingSink`] reports; the seam has to keep it reachable.
+#[derive(Debug, thiserror::Error)]
+#[error("the sink refused the write")]
+struct Refused;
+
+impl DataSink for RefusingSink {
+    type Error = Refused;
+
+    fn write_at(&mut self, _offset: u64, _data: &[u8]) -> Result<(), Self::Error> {
+        Err(Refused)
+    }
 }
 
 /// A reserved key planted past the seam is not listed, whatever kind the

--- a/crates/ldb/src/lib.rs
+++ b/crates/ldb/src/lib.rs
@@ -151,7 +151,7 @@ pub use folder::{DirEntry, Listing, Served, Website};
 pub use fork::{Child, ForkPayload, ForkRecord, ForkTable};
 pub use format::{Format, V1, V1Read};
 #[cfg(feature = "manifest")]
-pub use manifest::{LdbCursor, LdbManifest, LdbView, LdbWriter, ManifestError};
+pub use manifest::{LdbCursor, LdbFormatError, LdbManifest, LdbView, LdbWriter};
 pub use meta::{CustomKey, KeyId, Metadata, MetadataKey};
 pub use node::{Node, NodeRef, RootExtension};
 pub use packing::{Directory, SegmentKind, cut, embed, h64, segment, spill};

--- a/crates/ldb/src/manifest.rs
+++ b/crates/ldb/src/manifest.rs
@@ -8,24 +8,25 @@
 //! [`LdbView`] wraps [`Database::at`] and [`LdbWriter`] wraps
 //! [`Database::edit`], with paths in place of keys.
 
-use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::future::Future;
 use core::ops::{Bound, RangeBounds};
 
 use bytes::Bytes;
-use nectar_file::{File, Policy};
+use nectar_file::{File, LoadError, Policy};
 use nectar_manifest::{
-    DataSink, ListEntry, Listing, Manifest, ManifestMetadata, ManifestOp, ManifestPath, MapCursor,
-    MapEntry, MapView, MapWriter, ReservedKey, SinkError, SiteConfig, WellKnownKey,
+    DataSink, ListEntry, Listing, Manifest, ManifestError, ManifestMetadata, ManifestOp,
+    ManifestPath, MapCursor, MapEntry, MapView, MapWriter, ReservedKey, SinkError, SiteConfig,
+    WellKnownKey,
 };
 use nectar_primitives::EntryRef;
 use nectar_primitives::chunk::ContentOnlyChunkSet;
-use nectar_primitives::store::{BoxedError, ChunkPut, MaybeSend, MaybeSync, TrustedGet};
+use nectar_primitives::store::{ChunkPut, MaybeSend, MaybeSync, TrustedGet};
 
 use crate::apply::ApplyError;
+use crate::builder::Builder;
 use crate::db::{Database, Editor, View};
-use crate::error::{MetadataTooLong, NotAReference};
+use crate::error::MetadataTooLong;
 use crate::folder::DirEntry;
 use crate::format::{Format, V1};
 use crate::meta::{KeyId, Metadata};
@@ -35,10 +36,10 @@ use crate::scan::Cursor;
 use crate::store::{Plaintext, Seal};
 use crate::value::{Entry, Key};
 
-/// A failure crossing the manifest seam.
+/// The database's own failures behind [`ManifestError::Format`].
 #[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
-pub enum ManifestError {
+pub enum LdbFormatError {
     /// A lookup or a listing walk failed.
     #[error(transparent)]
     Read(#[from] ReaderError),
@@ -48,38 +49,9 @@ pub enum ManifestError {
     /// The rebuilt metadata block exceeded the format's bound.
     #[error(transparent)]
     Metadata(#[from] MetadataTooLong),
-    /// The entry is bound to inline bytes where a reference was required.
-    #[error(transparent)]
-    NotAReference(#[from] NotAReference),
-    /// The batch staged a write at a key the map reserves, so none of it
-    /// landed.
-    #[error("the batch named a reserved key")]
-    Reserved(#[from] ReservedKey),
-    /// No entry is bound at the requested path.
-    #[error("no entry at {path:?}")]
-    NotFound {
-        /// The path that resolved to nothing.
-        path: ManifestPath,
-    },
-    /// Reading the entry's data through the file pipeline failed.
-    #[error("load entry data")]
-    Data(#[source] BoxedError),
-    /// Writing into the sink failed.
-    #[error("write into the sink")]
-    Sink(#[source] BoxedError),
 }
 
-impl ManifestError {
-    /// Box a data-side failure behind the seam.
-    fn data<E: core::error::Error + MaybeSend + MaybeSync + 'static>(error: E) -> Self {
-        Self::Data(Box::new(error))
-    }
-
-    /// Box a sink failure behind the seam.
-    fn sink<E: core::error::Error + MaybeSend + MaybeSync + 'static>(error: E) -> Self {
-        Self::Sink(Box::new(error))
-    }
-}
+nectar_manifest::format_error_from!(LdbFormatError: ReaderError, ApplyError, MetadataTooLong);
 
 /// The key-value database as a [`Manifest`], keyed by path.
 ///
@@ -131,7 +103,7 @@ where
     /// The database's metadata: the typed key registry, absent as `None`.
     type Metadata = Option<Metadata<V1>>;
 
-    type Error = ManifestError;
+    type FormatError = LdbFormatError;
 
     type View<'a>
         = LdbView<'a, S, R>
@@ -142,6 +114,15 @@ where
         = LdbWriter<'a, S, K, R>
     where
         Self: 'a;
+
+    /// The empty database persisted through the native builder.
+    async fn empty(&self) -> Result<R, ManifestError<LdbFormatError>> {
+        let built = Builder::<V1>::new()
+            .build(self.db.store(), self.db.seal())
+            .await
+            .map_err(ApplyError::from)?;
+        Ok(built.root().clone())
+    }
 
     fn at(&self, root: &R) -> Self::View<'_> {
         LdbView {
@@ -159,7 +140,7 @@ where
     fn metadata_from_view(
         &self,
         view: &dyn ManifestMetadata,
-    ) -> Result<Self::Metadata, Self::Error> {
+    ) -> Result<Self::Metadata, ManifestError<LdbFormatError>> {
         let mut meta: Option<Metadata<V1>> = None;
         for (key, id) in [
             (WellKnownKey::ContentType, KeyId::ContentType),
@@ -194,7 +175,7 @@ where
 {
     type Metadata = Option<Metadata<V1>>;
 
-    type Error = ManifestError;
+    type Error = ManifestError<LdbFormatError>;
 
     type Cursor = LdbCursor<'a, S, R>;
 
@@ -308,19 +289,25 @@ where
                 Some(key) => self.view.get(&key).await?,
                 None => None,
             }
-            .ok_or_else(|| ManifestError::NotFound { path })?;
-            match entry {
-                Entry::Inline(value) => sink
-                    .write_at(0, value.as_bytes())
-                    .map_err(ManifestError::sink)?,
-                bound => {
-                    let reference = EntryRef::try_from(bound)?;
-                    File::new(store, Policy::DEFAULT)
-                        .load(reference, sink)
-                        .await
-                        .map_err(ManifestError::data)?;
+            .ok_or(ManifestError::NotFound(path))?;
+            // An inline value is the data, so it needs no file walk; both
+            // reference widths do.
+            let reference = match entry {
+                Entry::Inline(value) => {
+                    return sink
+                        .write_at(0, value.as_bytes())
+                        .map_err(ManifestError::sink);
                 }
-            }
+                Entry::Ref32(reference) => EntryRef::Plain(reference),
+                Entry::Ref64(reference) => EntryRef::Encrypted(reference),
+            };
+            File::new(store, Policy::DEFAULT)
+                .load(reference, sink)
+                .await
+                .map_err(|error| match error {
+                    LoadError::Sink { source, .. } => ManifestError::sink(source),
+                    data => ManifestError::data(data),
+                })?;
             Ok(())
         }
     }
@@ -360,7 +347,7 @@ where
     S: TrustedGet<ContentOnlyChunkSet> + MaybeSend + MaybeSync,
     R: NodeRef,
 {
-    type Error = ManifestError;
+    type Error = ManifestError<LdbFormatError>;
 
     fn next(
         &mut self,
@@ -410,7 +397,7 @@ where
 {
     type Metadata = Option<Metadata<V1>>;
 
-    type Error = ManifestError;
+    type Error = ManifestError<LdbFormatError>;
 
     /// An insert replaces the whole binding, clearing existing metadata unless
     /// `meta` carries some. A reserved path stages no database op and refuses
@@ -481,7 +468,10 @@ fn is_reserved(key: &Key) -> bool {
 ///
 /// `key` sorts first in its own prefix range, so the probe costs one seek and
 /// at most two steps.
-async fn bound_below<S, R>(view: &View<'_, S, V1, R>, key: &Key) -> Result<bool, ManifestError>
+async fn bound_below<S, R>(
+    view: &View<'_, S, V1, R>,
+    key: &Key,
+) -> Result<bool, ManifestError<LdbFormatError>>
 where
     S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
     R: NodeRef,

--- a/crates/manifest/src/dynamic.rs
+++ b/crates/manifest/src/dynamic.rs
@@ -4,11 +4,11 @@
 //! Erasure costs four things and states each: the futures box, the reference
 //! width is fixed to [`ChunkRef`], metadata crosses as [`ManifestMetadata`]
 //! rather than the format's own type, and an ordered walk stays on the static
-//! path. Every erased call takes the root it reads or writes against.
+//! path. Every erased call takes the root it reads or writes against, and a
+//! failure crosses as [`ErasedManifestError`] with the seam variants intact.
 
 use alloc::boxed::Box;
 use alloc::vec::Vec;
-use core::fmt;
 
 use nectar_file::sink::DataSink;
 use nectar_marker::{MaybeSend, MaybeSync};
@@ -16,6 +16,7 @@ use nectar_primitives::chunk::ChunkRef;
 use nectar_primitives::store::BoxedError;
 use nectar_tasks::BoxFuture;
 
+use crate::error::{ErasedFormat, ErasedManifestError, ManifestError};
 use crate::listing::Listing;
 use crate::meta::ManifestMetadata;
 use crate::op::ManifestOp;
@@ -27,20 +28,9 @@ use crate::{Manifest, SinkError};
 
 /// A sink write that failed behind the erased seam; the concrete error
 /// survives as the source.
-#[derive(Debug)]
-pub struct DynSinkError(BoxedError);
-
-impl fmt::Display for DynSinkError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("erased sink write failed")
-    }
-}
-
-impl core::error::Error for DynSinkError {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        Some(&*self.0)
-    }
-}
+#[derive(Debug, thiserror::Error)]
+#[error("erased sink write failed")]
+pub struct DynSinkError(#[source] BoxedError);
 
 /// Object-safe [`DataSink`]: the same positional, idempotent write with the
 /// error boxed.
@@ -69,9 +59,11 @@ impl DataSink for SinkBridge<'_> {
     }
 }
 
-/// Box a typed error behind the erased seam.
-fn erase<E: core::error::Error + MaybeSend + MaybeSync + 'static>(error: E) -> BoxedError {
-    Box::new(error)
+/// A typed seam failure with its format union boxed.
+fn erase<F: core::error::Error + MaybeSend + MaybeSync + 'static>(
+    error: ManifestError<F>,
+) -> ErasedManifestError {
+    error.map_format(|format| ErasedFormat(Box::new(format)))
 }
 
 /// Object-safe [`Manifest`]: a manifest whose format is decided at runtime.
@@ -79,33 +71,36 @@ fn erase<E: core::error::Error + MaybeSend + MaybeSync + 'static>(error: E) -> B
 /// Blanket-implemented for every `Manifest<ChunkRef>`, so a format implements
 /// the static trait once and is held as `Box<dyn DynManifest>` for free.
 pub trait DynManifest: MaybeSend + MaybeSync {
+    /// The root of the empty manifest, freshly persisted.
+    fn dyn_empty(&self) -> BoxFuture<'_, Result<ChunkRef, ErasedManifestError>>;
+
     /// The entry bound to `path`, or `None` when the path is absent.
     fn dyn_get<'a>(
         &'a self,
         root: &'a ChunkRef,
         path: &'a ManifestPath,
-    ) -> BoxFuture<'a, Result<Option<MapEntry>, BoxedError>>;
+    ) -> BoxFuture<'a, Result<Option<MapEntry>, ErasedManifestError>>;
 
     /// Whether `path` is bound.
     fn dyn_contains_key<'a>(
         &'a self,
         root: &'a ChunkRef,
         path: &'a ManifestPath,
-    ) -> BoxFuture<'a, Result<bool, BoxedError>>;
+    ) -> BoxFuture<'a, Result<bool, ErasedManifestError>>;
 
     /// The greatest bound path `<= path`, with its entry.
     fn dyn_floor<'a>(
         &'a self,
         root: &'a ChunkRef,
         path: &'a ManifestPath,
-    ) -> BoxFuture<'a, Result<Option<(ManifestPath, MapEntry)>, BoxedError>>;
+    ) -> BoxFuture<'a, Result<Option<(ManifestPath, MapEntry)>, ErasedManifestError>>;
 
     /// The immediate children of the directory `dir` names, in path order.
     fn dyn_dir<'a>(
         &'a self,
         root: &'a ChunkRef,
         dir: &'a ManifestPath,
-    ) -> BoxFuture<'a, Result<Listing, BoxedError>>;
+    ) -> BoxFuture<'a, Result<Listing, ErasedManifestError>>;
 
     /// Write the data bound to `path` into `sink`, starting at offset zero.
     fn dyn_load<'a>(
@@ -113,13 +108,13 @@ pub trait DynManifest: MaybeSend + MaybeSync {
         root: &'a ChunkRef,
         path: &'a ManifestPath,
         sink: &'a mut dyn DynSink,
-    ) -> BoxFuture<'a, Result<(), BoxedError>>;
+    ) -> BoxFuture<'a, Result<(), ErasedManifestError>>;
 
     /// The site-level documents the manifest declares, each absent as `None`.
     fn dyn_site_config<'a>(
         &'a self,
         root: &'a ChunkRef,
-    ) -> BoxFuture<'a, Result<SiteConfig, BoxedError>>;
+    ) -> BoxFuture<'a, Result<SiteConfig, ErasedManifestError>>;
 
     /// Replace the site-level documents, returning the new root.
     ///
@@ -128,7 +123,7 @@ pub trait DynManifest: MaybeSend + MaybeSync {
         &'a self,
         root: &'a ChunkRef,
         config: SiteConfig,
-    ) -> BoxFuture<'a, Result<ChunkRef, BoxedError>>;
+    ) -> BoxFuture<'a, Result<ChunkRef, ErasedManifestError>>;
 
     /// Insert one path, returning the new root.
     fn dyn_insert<'a>(
@@ -137,14 +132,14 @@ pub trait DynManifest: MaybeSend + MaybeSync {
         path: ManifestPath,
         reference: ChunkRef,
         meta: Box<dyn ManifestMetadata>,
-    ) -> BoxFuture<'a, Result<ChunkRef, BoxedError>>;
+    ) -> BoxFuture<'a, Result<ChunkRef, ErasedManifestError>>;
 
     /// Remove one path, returning the new root.
     fn dyn_remove<'a>(
         &'a self,
         root: &'a ChunkRef,
         path: ManifestPath,
-    ) -> BoxFuture<'a, Result<ChunkRef, BoxedError>>;
+    ) -> BoxFuture<'a, Result<ChunkRef, ErasedManifestError>>;
 
     /// Fold `ops` into the manifest rooted at `base`, returning the new root.
     ///
@@ -155,15 +150,19 @@ pub trait DynManifest: MaybeSend + MaybeSync {
         &'a self,
         base: &'a ChunkRef,
         ops: Vec<ManifestOp<ChunkRef, Box<dyn ManifestMetadata>>>,
-    ) -> BoxFuture<'a, Result<ChunkRef, BoxedError>>;
+    ) -> BoxFuture<'a, Result<ChunkRef, ErasedManifestError>>;
 }
 
 impl<T: Manifest<ChunkRef>> DynManifest for T {
+    fn dyn_empty(&self) -> BoxFuture<'_, Result<ChunkRef, ErasedManifestError>> {
+        Box::pin(async move { self.empty().await.map_err(erase) })
+    }
+
     fn dyn_get<'a>(
         &'a self,
         root: &'a ChunkRef,
         path: &'a ManifestPath,
-    ) -> BoxFuture<'a, Result<Option<MapEntry>, BoxedError>> {
+    ) -> BoxFuture<'a, Result<Option<MapEntry>, ErasedManifestError>> {
         Box::pin(async move { self.at(root).get(path).await.map_err(erase) })
     }
 
@@ -171,7 +170,7 @@ impl<T: Manifest<ChunkRef>> DynManifest for T {
         &'a self,
         root: &'a ChunkRef,
         path: &'a ManifestPath,
-    ) -> BoxFuture<'a, Result<bool, BoxedError>> {
+    ) -> BoxFuture<'a, Result<bool, ErasedManifestError>> {
         Box::pin(async move { self.at(root).contains_key(path).await.map_err(erase) })
     }
 
@@ -179,7 +178,7 @@ impl<T: Manifest<ChunkRef>> DynManifest for T {
         &'a self,
         root: &'a ChunkRef,
         path: &'a ManifestPath,
-    ) -> BoxFuture<'a, Result<Option<(ManifestPath, MapEntry)>, BoxedError>> {
+    ) -> BoxFuture<'a, Result<Option<(ManifestPath, MapEntry)>, ErasedManifestError>> {
         Box::pin(async move { self.at(root).floor(path).await.map_err(erase) })
     }
 
@@ -187,7 +186,7 @@ impl<T: Manifest<ChunkRef>> DynManifest for T {
         &'a self,
         root: &'a ChunkRef,
         dir: &'a ManifestPath,
-    ) -> BoxFuture<'a, Result<Listing, BoxedError>> {
+    ) -> BoxFuture<'a, Result<Listing, ErasedManifestError>> {
         Box::pin(async move { self.at(root).dir(dir).await.map_err(erase) })
     }
 
@@ -196,7 +195,7 @@ impl<T: Manifest<ChunkRef>> DynManifest for T {
         root: &'a ChunkRef,
         path: &'a ManifestPath,
         sink: &'a mut dyn DynSink,
-    ) -> BoxFuture<'a, Result<(), BoxedError>> {
+    ) -> BoxFuture<'a, Result<(), ErasedManifestError>> {
         Box::pin(async move {
             let mut bridge = SinkBridge(sink);
             self.at(root).load(path, &mut bridge).await.map_err(erase)
@@ -206,7 +205,7 @@ impl<T: Manifest<ChunkRef>> DynManifest for T {
     fn dyn_site_config<'a>(
         &'a self,
         root: &'a ChunkRef,
-    ) -> BoxFuture<'a, Result<SiteConfig, BoxedError>> {
+    ) -> BoxFuture<'a, Result<SiteConfig, ErasedManifestError>> {
         Box::pin(async move { self.at(root).site_config().await.map_err(erase) })
     }
 
@@ -214,7 +213,7 @@ impl<T: Manifest<ChunkRef>> DynManifest for T {
         &'a self,
         root: &'a ChunkRef,
         config: SiteConfig,
-    ) -> BoxFuture<'a, Result<ChunkRef, BoxedError>> {
+    ) -> BoxFuture<'a, Result<ChunkRef, ErasedManifestError>> {
         Box::pin(async move {
             let (index, error) = config.into_parts();
             let mut writer = self.edit(root);
@@ -230,7 +229,7 @@ impl<T: Manifest<ChunkRef>> DynManifest for T {
         path: ManifestPath,
         reference: ChunkRef,
         meta: Box<dyn ManifestMetadata>,
-    ) -> BoxFuture<'a, Result<ChunkRef, BoxedError>> {
+    ) -> BoxFuture<'a, Result<ChunkRef, ErasedManifestError>> {
         Box::pin(async move {
             let meta = self.metadata_from_view(&*meta).map_err(erase)?;
             let mut writer = self.edit(root);
@@ -243,7 +242,7 @@ impl<T: Manifest<ChunkRef>> DynManifest for T {
         &'a self,
         root: &'a ChunkRef,
         path: ManifestPath,
-    ) -> BoxFuture<'a, Result<ChunkRef, BoxedError>> {
+    ) -> BoxFuture<'a, Result<ChunkRef, ErasedManifestError>> {
         Box::pin(async move { self.remove(root, path).await.map_err(erase) })
     }
 
@@ -251,7 +250,7 @@ impl<T: Manifest<ChunkRef>> DynManifest for T {
         &'a self,
         base: &'a ChunkRef,
         ops: Vec<ManifestOp<ChunkRef, Box<dyn ManifestMetadata>>>,
-    ) -> BoxFuture<'a, Result<ChunkRef, BoxedError>> {
+    ) -> BoxFuture<'a, Result<ChunkRef, ErasedManifestError>> {
         Box::pin(async move {
             let mut native = Vec::with_capacity(ops.len());
             for op in ops {

--- a/crates/manifest/src/error.rs
+++ b/crates/manifest/src/error.rs
@@ -1,0 +1,139 @@
+//! The seam-owned failure taxonomy shared by every manifest format.
+
+use alloc::boxed::Box;
+
+use nectar_marker::{MaybeSend, MaybeSync};
+use nectar_primitives::store::BoxedError;
+
+use crate::path::ManifestPath;
+use crate::reserved::ReservedKey;
+
+/// A failure crossing the manifest seam; `F` is the format's own union.
+#[non_exhaustive]
+#[derive(Debug, thiserror::Error)]
+pub enum ManifestError<F> {
+    /// The batch staged a write at a key the map reserves, so none of it landed.
+    #[error("the batch named a reserved key")]
+    Reserved(#[from] ReservedKey),
+    /// No entry is bound at the requested path.
+    #[error("no entry at {0:?}")]
+    NotFound(ManifestPath),
+    /// The entry at the path names no data a load can reach.
+    #[error("the entry at {0:?} names no data")]
+    NoData(ManifestPath),
+    /// Reading the entry's data through the file pipeline failed.
+    #[error("load entry data")]
+    Data(#[source] BoxedError),
+    /// Writing into the sink failed.
+    #[error("write into the sink")]
+    Sink(#[source] BoxedError),
+    /// The format's own failure.
+    #[error(transparent)]
+    Format(F),
+}
+
+/// The boxed format union an erased handle carries.
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct ErasedFormat(#[from] pub(crate) BoxedError);
+
+/// The seam failure of an erased handle.
+pub type ErasedManifestError = ManifestError<ErasedFormat>;
+
+impl<F> ManifestError<F> {
+    /// The reserved key a refused batch names.
+    #[must_use]
+    pub const fn as_reserved(&self) -> Option<&ReservedKey> {
+        match self {
+            Self::Reserved(reserved) => Some(reserved),
+            _ => None,
+        }
+    }
+
+    /// Whether the requested path resolved to nothing.
+    #[must_use]
+    pub const fn is_not_found(&self) -> bool {
+        matches!(self, Self::NotFound(_))
+    }
+
+    /// The same failure with the format union mapped through `map`.
+    #[must_use]
+    pub fn map_format<G>(self, map: impl FnOnce(F) -> G) -> ManifestError<G> {
+        match self {
+            Self::Reserved(reserved) => ManifestError::Reserved(reserved),
+            Self::NotFound(path) => ManifestError::NotFound(path),
+            Self::NoData(path) => ManifestError::NoData(path),
+            Self::Data(source) => ManifestError::Data(source),
+            Self::Sink(source) => ManifestError::Sink(source),
+            Self::Format(source) => ManifestError::Format(map(source)),
+        }
+    }
+
+    /// Box a data-side failure behind the seam.
+    pub fn data<E: core::error::Error + MaybeSend + MaybeSync + 'static>(error: E) -> Self {
+        Self::Data(Box::new(error))
+    }
+
+    /// Box a sink failure behind the seam.
+    pub fn sink<E: core::error::Error + MaybeSend + MaybeSync + 'static>(error: E) -> Self {
+        Self::Sink(Box::new(error))
+    }
+}
+
+/// Route a format's sources into [`ManifestError::Format`] so `?` converts them.
+#[macro_export]
+macro_rules! format_error_from {
+    ($fmt:ty: $($src:ty),+ $(,)?) => {$(
+        impl From<$src> for $crate::ManifestError<$fmt> {
+            fn from(source: $src) -> Self {
+                Self::Format(<$fmt>::from(source))
+            }
+        }
+    )+};
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::string::ToString;
+
+    use super::*;
+    use crate::reserved::reserved_key;
+
+    /// A format union stand-in with one source hop.
+    #[derive(Debug, thiserror::Error)]
+    #[error("union failed")]
+    struct Union(#[source] ReservedKey);
+
+    fn reserved() -> ReservedKey {
+        ReservedKey::new(ManifestPath::from("/"))
+    }
+
+    #[test]
+    fn the_seam_taxonomy_holds_typed_and_erased() {
+        let refused = ManifestError::<Union>::Reserved(reserved());
+        assert_eq!(refused.as_reserved(), Some(&reserved()));
+        assert!(!refused.is_not_found());
+        let missing = ManifestError::<Union>::NotFound(ManifestPath::from("a"));
+        assert_eq!(missing.as_reserved(), None);
+        assert!(missing.is_not_found());
+
+        // `map_format` touches the format variant alone.
+        let mapped = ManifestError::Format(Union(reserved())).map_format(|_| 7u8);
+        assert!(matches!(mapped, ManifestError::Format(7)));
+        assert_eq!(refused.map_format(|_| 7u8).as_reserved(), Some(&reserved()));
+
+        // The format variant is transparent: no chain node of its own.
+        let wrapped = ManifestError::Format(Union(reserved()));
+        assert_eq!(wrapped.to_string(), "union failed");
+        let source = core::error::Error::source(&wrapped);
+        assert!(source.is_some_and(|s| s.downcast_ref::<ReservedKey>().is_some()));
+
+        // The erased convenience still finds the reserved key through a box.
+        let erased: ErasedManifestError =
+            ManifestError::Reserved(reserved()).map_format(|u: Union| ErasedFormat(Box::new(u)));
+        assert_eq!(erased.as_reserved(), Some(&reserved()));
+        let boxed: BoxedError = Box::new(erased);
+        let path = reserved_key(&*boxed).map(ReservedKey::path);
+        assert_eq!(path, Some(&ManifestPath::from("/")));
+    }
+}

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -9,7 +9,8 @@
 //!
 //! [`Manifest::at`] binds a root and hands back a [`MapView`];
 //! [`Manifest::edit`] binds a base root and hands back a [`MapWriter`] whose
-//! `commit` yields the new root.
+//! `commit` yields the new root. [`Manifest::empty`] bootstraps the empty
+//! manifest, and every operation fails with the seam-owned [`ManifestError`].
 //!
 //! The map holds content paths alone. The site index and error documents are
 //! not keys: [`MapView`] reads them as options, and [`MapWriter`] sets them
@@ -83,6 +84,7 @@
 extern crate alloc;
 
 mod dynamic;
+mod error;
 mod listing;
 mod meta;
 mod op;
@@ -93,6 +95,7 @@ mod view;
 mod writer;
 
 pub use dynamic::{DynManifest, DynSink, DynSinkError};
+pub use error::{ErasedFormat, ErasedManifestError, ManifestError};
 pub use listing::{ListEntry, Listing};
 pub use meta::{ManifestMetadata, MetadataView, WellKnownKey};
 pub use op::ManifestOp;
@@ -137,18 +140,23 @@ pub trait Manifest<R: Reference + MaybeSend = ChunkRef>: MaybeSend + MaybeSync {
     /// The format's own metadata for one entry.
     type Metadata: MaybeSend + Default;
 
-    /// Error type for every operation on the manifest.
-    type Error: core::error::Error + MaybeSend + MaybeSync + 'static;
+    /// The format's own failure union, carried in [`ManifestError::Format`].
+    type FormatError: core::error::Error + MaybeSend + MaybeSync + 'static;
 
     /// The read handle [`at`](Self::at) hands back.
-    type View<'a>: MapView<R, Metadata = Self::Metadata, Error = Self::Error>
+    type View<'a>: MapView<R, Metadata = Self::Metadata, Error = ManifestError<Self::FormatError>>
     where
         Self: 'a;
 
     /// The write handle [`edit`](Self::edit) hands back.
-    type Writer<'a>: MapWriter<R, Metadata = Self::Metadata, Error = Self::Error>
+    type Writer<'a>: MapWriter<R, Metadata = Self::Metadata, Error = ManifestError<Self::FormatError>>
     where
         Self: 'a;
+
+    /// The root of the empty manifest, freshly persisted.
+    fn empty(
+        &self,
+    ) -> impl Future<Output = Result<R, ManifestError<Self::FormatError>>> + MaybeSend;
 
     /// The read view of the manifest rooted at `root`. Reaches storage only
     /// when a read is awaited.
@@ -167,7 +175,7 @@ pub trait Manifest<R: Reference + MaybeSend = ChunkRef>: MaybeSend + MaybeSync {
     fn metadata_from_view(
         &self,
         view: &dyn ManifestMetadata,
-    ) -> Result<Self::Metadata, Self::Error>;
+    ) -> Result<Self::Metadata, ManifestError<Self::FormatError>>;
 
     /// Insert one path, clearing any metadata bound at it.
     ///
@@ -177,7 +185,7 @@ pub trait Manifest<R: Reference + MaybeSend = ChunkRef>: MaybeSend + MaybeSync {
         root: &R,
         path: ManifestPath,
         reference: R,
-    ) -> impl Future<Output = Result<R, Self::Error>> + MaybeSend {
+    ) -> impl Future<Output = Result<R, ManifestError<Self::FormatError>>> + MaybeSend {
         let mut writer = self.edit(root);
         writer.insert(path, reference);
         writer.commit()
@@ -189,7 +197,7 @@ pub trait Manifest<R: Reference + MaybeSend = ChunkRef>: MaybeSend + MaybeSync {
         &self,
         root: &R,
         path: ManifestPath,
-    ) -> impl Future<Output = Result<R, Self::Error>> + MaybeSend {
+    ) -> impl Future<Output = Result<R, ManifestError<Self::FormatError>>> + MaybeSend {
         let mut writer = self.edit(root);
         writer.remove(path);
         writer.commit()
@@ -204,7 +212,7 @@ pub trait Manifest<R: Reference + MaybeSend = ChunkRef>: MaybeSend + MaybeSync {
         &self,
         base: &R,
         ops: impl IntoIterator<Item = ManifestOp<R, Self::Metadata>> + MaybeSend,
-    ) -> impl Future<Output = Result<R, Self::Error>> + MaybeSend {
+    ) -> impl Future<Output = Result<R, ManifestError<Self::FormatError>>> + MaybeSend {
         let mut writer = self.edit(base);
         writer.extend(ops);
         writer.commit()

--- a/crates/mantaray/src/editor.rs
+++ b/crates/mantaray/src/editor.rs
@@ -137,6 +137,12 @@ impl<S, R: Reference> ManifestEditor<S, R> {
         Self::with_root(Node::from_reference(root), store)
     }
 
+    /// Editor over an empty manifest at whatever width `R` carries.
+    #[cfg(feature = "manifest")]
+    pub(crate) fn empty_reference(store: S) -> Self {
+        Self::with_root(Node::default(), store)
+    }
+
     const fn with_root(trie: Node<R>, store: S) -> Self {
         Self {
             trie,

--- a/crates/mantaray/src/lib.rs
+++ b/crates/mantaray/src/lib.rs
@@ -173,7 +173,7 @@ pub use error::{
     CursorError, DecodeError, DecodeResult, EditorError, MantarayError, ReaderError, Result,
 };
 #[cfg(feature = "manifest")]
-pub use manifest::{ManifestError, MantarayManifest, TrieCursor, TrieView, TrieWriter};
+pub use manifest::{MantarayManifest, TrieCursor, TrieFormatError, TrieView, TrieWriter};
 #[cfg(feature = "std")]
 pub use node::NodeType;
 pub use obfuscation::ObfuscationKey;

--- a/crates/mantaray/src/manifest.rs
+++ b/crates/mantaray/src/manifest.rs
@@ -10,21 +10,21 @@
 //! [`TrieView`] reads one root through the depth-guarded reader and the ordered
 //! cursor; [`TrieWriter`] records the batch through [`ManifestEditor`].
 
-use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::future::Future;
 use core::ops::{Bound, RangeBounds};
 
-use nectar_file::{File, Policy};
+use nectar_file::{File, LoadError, Policy};
 use nectar_manifest::{
-    DataSink, ListEntry, Listing, Manifest, ManifestMetadata, ManifestOp, ManifestPath, MapCursor,
-    MapEntry, MapView, MapWriter, ReservedKey, SinkError, SiteConfig, WellKnownKey,
+    DataSink, ListEntry, Listing, Manifest, ManifestError, ManifestMetadata, ManifestOp,
+    ManifestPath, MapCursor, MapEntry, MapView, MapWriter, ReservedKey, SinkError, SiteConfig,
+    WellKnownKey,
 };
 use nectar_primitives::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{ContentOnlyChunkSet, Reference};
-use nectar_primitives::store::{BoxedError, MaybeSend, MaybeSync, TrustedGet};
+use nectar_primitives::store::{MaybeSend, MaybeSync, TrustedGet};
 
 use crate::cursor::Cursor;
 use crate::editor::ManifestEditor;
@@ -33,10 +33,10 @@ use crate::persist::{NodeLoader, NodeSaver};
 use crate::reader::Reader;
 use crate::{constants::metadata, entry::Entry};
 
-/// A failure crossing the manifest seam.
+/// The trie's own failures behind [`ManifestError::Format`].
 #[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
-pub enum ManifestError {
+pub enum TrieFormatError {
     /// A path lookup failed.
     #[error(transparent)]
     Read(#[from] ReaderError),
@@ -46,34 +46,9 @@ pub enum ManifestError {
     /// Applying the batch failed.
     #[error(transparent)]
     Edit(#[from] EditorError),
-    /// The batch staged a write at a key the map reserves, so none of it
-    /// landed.
-    #[error("the batch named a reserved key")]
-    Reserved(#[from] ReservedKey),
-    /// No entry is bound at the requested path.
-    #[error("no entry at {path:?}")]
-    NotFound {
-        /// The path that resolved to nothing.
-        path: ManifestPath,
-    },
-    /// The entry at the path carries metadata but no reference, so it names
-    /// no data.
-    #[error("the entry at {path:?} carries no reference")]
-    NoReference {
-        /// The path whose entry names no data.
-        path: ManifestPath,
-    },
-    /// Reading the entry's data through the file pipeline failed.
-    #[error("load entry data")]
-    Data(#[source] BoxedError),
 }
 
-impl ManifestError {
-    /// Box a data-side failure behind the seam.
-    fn data<E: core::error::Error + MaybeSend + MaybeSync + 'static>(error: E) -> Self {
-        Self::Data(Box::new(error))
-    }
-}
+nectar_manifest::format_error_from!(TrieFormatError: ReaderError, CursorError, EditorError);
 
 /// The trie as a [`Manifest`]: a node adapter for the trie itself and a chunk
 /// store for entry data.
@@ -112,7 +87,7 @@ where
     /// The trie's metadata: a string map, stored verbatim on the fork record.
     type Metadata = BTreeMap<String, String>;
 
-    type Error = ManifestError;
+    type FormatError = TrieFormatError;
 
     type View<'a>
         = TrieView<L, S, R, B>
@@ -123,6 +98,15 @@ where
         = TrieWriter<L, R>
     where
         Self: 'a;
+
+    /// The empty trie persisted at width `R` with a zero obfuscation key.
+    fn empty(&self) -> impl Future<Output = Result<R, ManifestError<TrieFormatError>>> + MaybeSend {
+        let editor = ManifestEditor::empty_reference(self.nodes.clone());
+        async move {
+            let (root, _) = editor.commit_reference().await?;
+            Ok(root)
+        }
+    }
 
     fn at(&self, root: &R) -> Self::View<'_> {
         TrieView {
@@ -142,7 +126,7 @@ where
     fn metadata_from_view(
         &self,
         view: &dyn ManifestMetadata,
-    ) -> Result<Self::Metadata, Self::Error> {
+    ) -> Result<Self::Metadata, ManifestError<TrieFormatError>> {
         let mut map = BTreeMap::new();
         for (key, name) in [
             (WellKnownKey::ContentType, metadata::CONTENT_TYPE),
@@ -179,7 +163,10 @@ where
 {
     /// The entry at `path`, which is the trie key verbatim. The structural
     /// root and the site-config node read as absent.
-    async fn entry(&self, path: &ManifestPath) -> Result<Option<Entry>, ManifestError> {
+    async fn entry(
+        &self,
+        path: &ManifestPath,
+    ) -> Result<Option<Entry>, ManifestError<TrieFormatError>> {
         let Some(key) = content_key(path) else {
             return Ok(None);
         };
@@ -188,7 +175,7 @@ where
     }
 
     /// The trie's site-config node, which the reference client keys at `"/"`.
-    async fn root_node(&self) -> Result<Option<Entry>, ManifestError> {
+    async fn root_node(&self) -> Result<Option<Entry>, ManifestError<TrieFormatError>> {
         let reader = Reader::new(self.nodes.clone());
         Ok(reader
             .get(
@@ -216,7 +203,7 @@ where
 {
     type Metadata = BTreeMap<String, String>;
 
-    type Error = ManifestError;
+    type Error = ManifestError<TrieFormatError>;
 
     type Cursor = TrieCursor<L, R>;
 
@@ -288,15 +275,18 @@ where
             let entry = self
                 .entry(&path)
                 .await?
-                .ok_or_else(|| ManifestError::NotFound { path: path.clone() })?;
+                .ok_or_else(|| ManifestError::NotFound(path.clone()))?;
             let reference = entry
                 .reference()
                 .cloned()
-                .ok_or(ManifestError::NoReference { path })?;
+                .ok_or(ManifestError::NoData(path))?;
             File::<S, B>::new(store, Policy::DEFAULT)
                 .load(reference, sink)
                 .await
-                .map_err(ManifestError::data)?;
+                .map_err(|error| match error {
+                    LoadError::Sink { source, .. } => ManifestError::sink(source),
+                    data => ManifestError::data(data),
+                })?;
             Ok(())
         }
     }
@@ -331,7 +321,7 @@ where
     L: NodeLoader + Clone + MaybeSend + 'static,
     R: Reference + MaybeSend + MaybeSync,
 {
-    type Error = ManifestError;
+    type Error = ManifestError<TrieFormatError>;
 
     fn next(
         &mut self,
@@ -395,7 +385,7 @@ where
 {
     type Metadata = BTreeMap<String, String>;
 
-    type Error = ManifestError;
+    type Error = ManifestError<TrieFormatError>;
 
     /// An insert replaces the whole binding, clearing existing metadata unless
     /// `meta` carries some. A reserved path stages no trie op and refuses the


### PR DESCRIPTION
Closes #652

## What

`nectar-manifest` now owns the L2 error taxonomy instead of each format defining its own.

- New `crates/manifest/src/error.rs`: `ManifestError<F>` (`Reserved` / `NotFound` / `NoData` / `Data` / `Sink` / `Format`, `#[non_exhaustive]`, derived via `thiserror` with a transparent `Format` variant), with inherent `as_reserved`, `is_not_found`, `map_format`, and `data`/`sink` boxing constructors.
- `ErasedManifestError = ManifestError<ErasedFormat>`, where `ErasedFormat` is a thin transparent newtype over `BoxedError`, so the erased alias is still a real `core::error::Error` (transparent `source()` through to the boxed format union).
- A `format_error_from!` macro routes each format's own sources into `ManifestError::Format`, replacing per-crate hand-written `From` impls.
- `Manifest` trait: `type Error` is replaced by `type FormatError: core::error::Error + MaybeSend + MaybeSync + 'static`, and the trait gains `fn empty(&self) -> ... Result<R, ManifestError<Self::FormatError>>` so a generic caller can bootstrap an empty manifest without naming a format.
- `DynManifest` gains `dyn_empty` and every method now returns `ErasedManifestError`.
- Both per-format error enums are deleted and replaced:
  - `crates/ldb/src/manifest.rs`: `ManifestError` -> `LdbFormatError` (`Read`/`Apply`/`Metadata` union). `empty()` is implemented via `Builder` so the root equals the native empty build. `LoadError::Sink` is now split out from the rest of the file-load error path.
  - `crates/mantaray/src/manifest.rs`: new `TrieFormatError` (`Read`/`List`/`Edit` union). `empty()` goes through a crate-private width-generic `ManifestEditor::empty_reference` in `crates/mantaray/src/editor.rs`, with zero obfuscation key.
- `crates/manifest/src/lib.rs` updated for the new exports (`ErasedFormat`, `ErasedManifestError`, `ManifestError`) and doc comments.
- `crates/ldb/src/lib.rs` and `crates/mantaray/src/lib.rs` re-export the new format-error types instead of the old per-crate `ManifestError`.

## Diff shape

```
Cargo.lock                                               |   2 +
crates/integration-tests/Cargo.toml                      |   1 +
crates/integration-tests/tests/manifest/dyn_roundtrip.rs |  50 ++---
crates/integration-tests/tests/manifest/encrypted.rs     |  12 +-
crates/integration-tests/tests/manifest/root_config.rs   | 172 ++++++++++++----
crates/ldb/src/lib.rs                                    |   2 +-
crates/ldb/src/manifest.rs                               | 102 ++++-----
crates/manifest/Cargo.toml                               |   3 +-
crates/manifest/src/dynamic.rs                           |  77 +++----
crates/manifest/src/error.rs                             | 139 +++++++++++++
crates/manifest/src/lib.rs                               |  26 ++-
crates/mantaray/src/editor.rs                            |   6 +
crates/mantaray/src/lib.rs                               |   2 +-
crates/mantaray/src/manifest.rs                          |  76 +++----
14 files changed, 443 insertions(+), 227 deletions(-)
```

The previous revision of this branch weighed +617/-180; this one lands the same seam at +443/-227 by leaning on `thiserror` (both format unions, the seam enum, test stand-ins), a `format_error_from!` macro instead of hand-written `From` impls, and shared `both_formats`/`write_keys`/`assert_*` fixtures in the manifest test suite. No assertion or behavior pin was dropped.

## Testing

All commands ran inside `nix develop --command`, once, on 705831fb (branch `manifest/652-seam-errors`), base `origin/phase3/646-manifest-l2-surface` (verified ancestor).

- `cargo clippy --workspace --all-targets -- -D warnings` -> clean, 0 warnings.
- `cargo nextest run --workspace` -> 1212 passed, 0 failed, 1 skipped.
- `cargo test --doc --workspace` -> all doctests pass (nectar-manifest 3, nectar-ldb 4, nectar-mantaray 4).
- no_std: `cargo check --no-default-features` for nectar-manifest, nectar-ldb, and nectar-mantaray (by manifest path) on `riscv64imac-unknown-none-elf` and `wasm32-unknown-unknown` -> clean.
- `rustfmt --check` on every touched file -> clean.

## Red-team

Red-teamed `manifest/652-seam-errors` against `origin/phase3/646-manifest-l2-surface`. The seam design holds up: the error taxonomy mapping was re-derived variant-by-variant against the base with no silent reclassification found (`Read`/`List`/`Edit`/`Apply`/`Metadata` all land in `Format`, `Reserved`/`NotFound` survive, `NoReference`/`NotAReference` collapse to `NoData` per spec, `Data` splits into `Data` plus `Sink` per spec). The implementer's three load-bearing claims were independently verified rather than trusted.

No duplicated tree machinery was found: `ManifestError::data`/`sink` genuinely replace two previously-duplicated per-format constructors rather than adding a third copy.

AI Assistance: implement claude-fable-5, red-team claude-opus-5, PR claude-sonnet-5.
