### PR TITLE
feat(manifest): bidirectional enumerable metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2742,6 +2742,7 @@ dependencies = [
 name = "nectar-manifest"
 version = "0.4.0"
 dependencies = [
+ "auto_impl",
  "derive_more",
  "nectar-file",
  "nectar-marker",

--- a/crates/integration-tests/Cargo.toml
+++ b/crates/integration-tests/Cargo.toml
@@ -134,6 +134,10 @@ name = "manifest_listing"
 path = "tests/manifest/listing.rs"
 
 [[test]]
+name = "manifest_metadata"
+path = "tests/manifest/metadata.rs"
+
+[[test]]
 name = "manifest_root_config"
 path = "tests/manifest/root_config.rs"
 

--- a/crates/integration-tests/tests/manifest/dyn_roundtrip.rs
+++ b/crates/integration-tests/tests/manifest/dyn_roundtrip.rs
@@ -9,7 +9,7 @@ use nectar_file::{File, MemSink, Policy};
 use nectar_ldb::{LdbManifest, Reader as LdbReader};
 use nectar_loadsave::NodeLoadSaver;
 use nectar_manifest::{
-    DynManifest, ManifestMetadata, ManifestOp, ManifestPath, MetadataView, SiteConfig, WellKnownKey,
+    DynManifest, ManifestOp, ManifestPath, MetadataSource, MetadataView, SiteConfig, WellKnownKey,
 };
 use nectar_mantaray::{MantarayManifest, Reader as MantarayReader, metadata};
 use nectar_primitives::store::{ContentGet, MemoryStore};
@@ -34,7 +34,7 @@ fn payload() -> Vec<u8> {
 const CONTENT_TYPE: &str = "text/html";
 
 /// Erased metadata carrying one content type.
-fn content_type() -> Box<dyn ManifestMetadata> {
+fn content_type() -> Box<dyn MetadataSource> {
     Box::new(MetadataView::new().with(WellKnownKey::ContentType, CONTENT_TYPE))
 }
 
@@ -61,6 +61,25 @@ async fn exercise(manifest: &dyn DynManifest, base: &ChunkRef, file: &ChunkRef, 
         .await
         .unwrap();
     assert_ne!(&root, base, "the batch produced a new root");
+
+    // The metadata written through the erased seam reads back through it, by
+    // key and enumerably; a bare entry reads back empty.
+    let index = ManifestPath::from("index.html");
+    let meta = manifest.dyn_metadata(&root, &index).await.unwrap();
+    assert_eq!(
+        meta.get(&WellKnownKey::ContentType),
+        Some(CONTENT_TYPE.as_bytes())
+    );
+    let mut enumerated = false;
+    meta.for_each(&mut |key, value| {
+        enumerated |= WellKnownKey::registered(key) == Some(WellKnownKey::ContentType)
+            && value == CONTENT_TYPE.as_bytes();
+    });
+    assert!(enumerated, "the content type enumerates");
+    let logo = ManifestPath::from("img/logo.png");
+    let bare = manifest.dyn_metadata(&root, &logo).await.unwrap();
+    assert_eq!(bare.get(&WellKnownKey::ContentType), None);
+    bare.for_each(&mut |key, _| panic!("a bare entry enumerated {key}"));
 
     // One level: the deeper path collapses into a directory entry, in path
     // order, and neither format fetches the referenced data to list it.
@@ -196,8 +215,9 @@ async fn exercise(manifest: &dyn DynManifest, base: &ChunkRef, file: &ChunkRef, 
 
     // The taxonomy survives erasure: the seam variants still match structurally.
     let separator = ManifestPath::from("/");
+    let meta = content_type();
     let reserved = manifest
-        .dyn_insert(&root, separator.clone(), *file, content_type())
+        .dyn_insert(&root, separator.clone(), *file, meta.as_ref())
         .await
         .err()
         .and_then(|e| e.as_reserved().map(|r| r.path().clone()));

--- a/crates/integration-tests/tests/manifest/encrypted.rs
+++ b/crates/integration-tests/tests/manifest/encrypted.rs
@@ -12,7 +12,8 @@ use nectar_file::{File, MemSink, Policy};
 use nectar_ldb::{Encrypted as EncryptedSeal, LdbManifest, V1};
 use nectar_loadsave::NodeLoadSaver;
 use nectar_manifest::{
-    Batch, ListEntry, Manifest, ManifestPath, MapEntry, MapView, MetadataView, WellKnownKey,
+    Batch, ListEntry, Manifest, ManifestMeta, ManifestPath, MapEntry, MapView, MetadataView,
+    WellKnownKey,
 };
 use nectar_mantaray::MantarayManifest;
 use nectar_primitives::store::{ContentGet, MemoryStore};
@@ -34,9 +35,9 @@ async fn exercise<M: Manifest<EncryptedChunkRef>>(
     file: &EncryptedChunkRef,
     data: &[u8],
 ) {
-    let meta = manifest
-        .metadata_from_view(&MetadataView::new().with(WellKnownKey::ContentType, "text/plain"))
-        .unwrap();
+    let meta = M::Metadata::from_source(
+        &MetadataView::new().with(WellKnownKey::ContentType, "text/plain"),
+    );
     let root = {
         let mut batch = Batch::new();
         batch.insert_with(ManifestPath::from("data.bin"), file.clone(), meta);

--- a/crates/integration-tests/tests/manifest/listing.rs
+++ b/crates/integration-tests/tests/manifest/listing.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use nectar_file::{File, Policy};
 use nectar_ldb::{Builder, LdbManifest, Plaintext, V1};
 use nectar_loadsave::NodeLoadSaver;
-use nectar_manifest::{DynManifest, ManifestMetadata, ManifestOp, ManifestPath};
+use nectar_manifest::{DynManifest, ManifestOp, ManifestPath, MetadataSource};
 use nectar_mantaray::{ManifestEditor, MantarayManifest};
 use nectar_primitives::store::{ContentGet, MemoryStore};
 use nectar_primitives::{ChunkRef, DEFAULT_BODY_SIZE, StandardChunkSet};
@@ -78,12 +78,12 @@ fn model(keys: &[&str], dir: &str) -> Vec<Vec<u8>> {
 }
 
 /// One insert per key, with no metadata.
-fn inserts(keys: &[&str], file: &ChunkRef) -> Vec<ManifestOp<ChunkRef, Box<dyn ManifestMetadata>>> {
+fn inserts(keys: &[&str], file: &ChunkRef) -> Vec<ManifestOp<ChunkRef, Box<dyn MetadataSource>>> {
     keys.iter()
         .map(|key| ManifestOp::Insert {
             path: ManifestPath::from(*key),
             reference: *file,
-            meta: Box::new(()) as Box<dyn ManifestMetadata>,
+            meta: Box::new(()) as Box<dyn MetadataSource>,
         })
         .collect()
 }

--- a/crates/integration-tests/tests/manifest/metadata.rs
+++ b/crates/integration-tests/tests/manifest/metadata.rs
@@ -1,6 +1,7 @@
 //! The bidirectional metadata seam: the seam's own view and key table, and
-//! the cross-format copy `M2::Metadata::from_source(&m1_meta)`, where no
-//! format names the other and what a copy drops is the target's stated limit.
+//! the cross-format copy, where the target rebuilds its own metadata type
+//! from the source's `MetadataSource` pairs. No format names the other, and
+//! what a copy drops is the target's stated limit.
 
 use std::collections::BTreeMap;
 use std::sync::Arc;

--- a/crates/integration-tests/tests/manifest/metadata.rs
+++ b/crates/integration-tests/tests/manifest/metadata.rs
@@ -1,0 +1,250 @@
+//! The bidirectional metadata seam: the seam's own view and key table, and
+//! the cross-format copy `M2::Metadata::from_source(&m1_meta)`, where no
+//! format names the other and what a copy drops is the target's stated limit.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use nectar_ldb::{CustomKey, Format, KeyId, Metadata, MetadataKey, V1};
+use nectar_loadsave::NodeLoadSaver;
+use nectar_manifest::WellKnownKey::{ContentType, Custom, ErrorDocument, Filename, IndexDocument};
+use nectar_manifest::{
+    DynManifest, ManifestMeta, ManifestPath, MetadataSource, MetadataView, WellKnownKey,
+};
+use nectar_mantaray::{MantarayManifest, Reader as MantarayReader, metadata};
+use nectar_primitives::store::{ContentGet, MemoryStore};
+use nectar_primitives::{ChunkAddress, ChunkRef, DEFAULT_BODY_SIZE, StandardChunkSet};
+use nectar_testing::run;
+
+/// The registry rebuilt from `source`.
+fn kv(source: &dyn MetadataSource) -> Option<Metadata<V1>> {
+    <Option<Metadata<V1>>>::from_source(source)
+}
+
+/// The trie's string map rebuilt from `source`.
+fn map(source: &dyn MetadataSource) -> BTreeMap<String, String> {
+    <BTreeMap<String, String>>::from_source(source)
+}
+
+/// `get` as text, for one-line assertions.
+fn text<'a>(source: &'a dyn MetadataSource, key: &WellKnownKey<'_>) -> Option<&'a str> {
+    source.get(key).map(|value| str::from_utf8(value).unwrap())
+}
+
+/// The enumerated pairs, as text.
+fn pairs(source: &dyn MetadataSource) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    source.for_each(&mut |key, value| {
+        out.push((key.to_owned(), String::from_utf8(value.to_vec()).unwrap()));
+    });
+    out
+}
+
+/// Text pairs, owned.
+fn owned(pairs: &[(&str, &str)]) -> Vec<(String, String)> {
+    pairs
+        .iter()
+        .map(|(key, value)| ((*key).to_owned(), (*value).to_owned()))
+        .collect()
+}
+
+/// A string map from text pairs.
+fn text_map(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+    owned(pairs).into_iter().collect()
+}
+
+/// The value the registry stores under the id, as bytes.
+fn stored(kv_meta: &Option<Metadata<V1>>, id: KeyId) -> Option<&[u8]> {
+    kv_meta.as_ref()?.get(&id.into()).map(Bytes::as_ref)
+}
+
+/// Any spelling of a registered name addresses one slot, REGISTERED is the
+/// one exhaustive table, and a round trip never forks the vocabulary.
+#[test]
+fn the_key_table_resolves_every_spelling_to_one_slot() {
+    let view = MetadataView::new()
+        .with(ContentType, "text/html")
+        .with(Custom("etag"), "abc");
+    assert_eq!(text(&view, &ContentType), Some("text/html"));
+    assert_eq!(text(&view, &Custom("etag")), Some("abc"));
+    assert_eq!(view.get(&Custom("missing")), None);
+    let view = MetadataView::new().with(Custom("content-type"), "text/css");
+    assert_eq!(text(&view, &ContentType), Some("text/css"));
+    assert_eq!(Custom("CONTENT-TYPE").resolve(), ContentType);
+    assert_eq!(WellKnownKey::registered("x-note"), None);
+
+    // Exhaustive on purpose: a new variant fails to compile here until it is
+    // placed in REGISTERED, which is what `registered` matches against.
+    const fn slot(key: &WellKnownKey<'_>) -> Option<usize> {
+        match key {
+            ContentType => Some(0),
+            Filename => Some(1),
+            IndexDocument => Some(2),
+            ErrorDocument => Some(3),
+            Custom(_) => None,
+        }
+    }
+    assert_eq!(slot(&Custom("x-note")), None);
+    for (index, key) in WellKnownKey::REGISTERED.iter().enumerate() {
+        assert_eq!(slot(key), Some(index), "{key:?} is out of place");
+        let name = key.name();
+        assert_eq!(WellKnownKey::registered(name), Some(*key));
+        assert_eq!(WellKnownKey::registered(&name.to_lowercase()), Some(*key));
+        assert_eq!(WellKnownKey::registered(&name.to_uppercase()), Some(*key));
+    }
+}
+
+/// The trie's map answers a registered key under either spelling, rebuilds
+/// canonically from any source with zero pair loss, and enumerates verbatim.
+#[test]
+fn a_string_map_is_a_source_and_rebuilds_canonically() {
+    let source = text_map(&[("content-type", "text/css"), ("x-note", "hi")]);
+    assert_eq!(text(&source, &ContentType), Some("text/css"));
+    assert_eq!(text(&source, &Custom("Content-Type")), Some("text/css"));
+    assert_eq!(text(&source, &Custom("x-note")), Some("hi"));
+    assert_eq!(MetadataSource::get(&source, &Custom("gone")), None);
+
+    // A registered key lands under the canonical spelling on rebuild; a
+    // custom pair copies verbatim.
+    let canon = text_map(&[("Content-Type", "text/css"), ("x-note", "hi")]);
+    let rebuilt = map(&source);
+    assert_eq!(rebuilt, canon);
+    assert!(!rebuilt.contains_key("content-type"));
+    let view = MetadataView::new()
+        .with(ContentType, "text/html")
+        .with(Custom("x-note"), "hi");
+    let html = owned(&[("Content-Type", "text/html"), ("x-note", "hi")]);
+    assert_eq!(
+        map(&view),
+        html.clone().into_iter().collect::<BTreeMap<_, _>>()
+    );
+
+    // Case folding collapses two spellings of one name: the copy keeps one
+    // pair, and this pins which - the last enumerated spelling wins.
+    let both = text_map(&[("Content-Type", "a"), ("content-type", "b")]);
+    assert_eq!(map(&both), text_map(&[("Content-Type", "b")]));
+
+    // `for_each` is verbatim, and `()` carries nothing.
+    assert_eq!(pairs(&view), html);
+    assert!(pairs(&()).is_empty());
+    assert_eq!(().get(&ContentType), None);
+}
+
+/// The trie's native map and the key-value registry copy through the seam
+/// with no format naming the other, and the round trip is exact.
+#[test]
+fn metadata_crosses_formats_without_naming_them() {
+    let trie_meta = text_map(&[("Content-Type", "text/html"), ("x-note", "hi")]);
+
+    // Into the registry: the registered key lands as its KeyId, not as a
+    // custom key, and the custom pair survives byte-for-byte.
+    let kv_meta = kv(&trie_meta);
+    let block = kv_meta.as_ref().expect("two pairs crossed");
+    assert_eq!(
+        stored(&kv_meta, KeyId::ContentType),
+        Some("text/html".as_bytes())
+    );
+    let custom: MetadataKey<V1> = CustomKey::try_from(&b"x-note"[..]).unwrap().into();
+    assert_eq!(block.get(&custom), Some(&Bytes::from_static(b"hi")));
+    assert_eq!(block.pair_count(), 2);
+
+    // Back to the trie's map: the registered key keeps the reference-client
+    // spelling, so the round trip is the identity.
+    assert_eq!(map(&kv_meta), trie_meta);
+
+    // The file name crosses the same way: `Filename` in the trie, the
+    // `filename` id in the registry, each side keeping its own spelling.
+    let named = text_map(&[(metadata::FILENAME, "logo.png")]);
+    let kv_meta = kv(&named);
+    assert_eq!(stored(&kv_meta, KeyId::Filename), Some(&b"logo.png"[..]));
+    assert_eq!(map(&kv_meta), named);
+    assert_eq!(text(&kv_meta, &Filename), Some("logo.png"));
+}
+
+/// The seam-registered keys all cross into the registry as ids, driven by
+/// `WellKnownKey::REGISTERED` rather than a per-format table, and the
+/// registry's encoded bound is its stated limit: an over-budget pair is
+/// dropped there, and every pair that fits still lands.
+#[test]
+fn every_registered_key_crosses_and_the_bound_is_the_registrys() {
+    let mut view = MetadataView::new();
+    for key in WellKnownKey::REGISTERED {
+        view.set(key, "value");
+    }
+    let kv_meta = kv(&view);
+    let block = kv_meta.as_ref().expect("every registered key crossed");
+    assert_eq!(block.pair_count(), WellKnownKey::REGISTERED.len());
+    for id in [
+        KeyId::ContentType,
+        KeyId::Filename,
+        KeyId::WebsiteIndexDocument,
+        KeyId::WebsiteErrorDocument,
+    ] {
+        assert!(block.get(&id.into()).is_some(), "{id:?} travelled by name");
+    }
+    for key in WellKnownKey::REGISTERED {
+        assert_eq!(text(&kv_meta, &key), Some("value"));
+    }
+
+    let view = MetadataView::new()
+        .with(ContentType, "text/html")
+        .with(Custom("x-big"), "a".repeat(V1::META_MAX));
+    let kv_meta = kv(&view);
+    let block = kv_meta.as_ref().expect("the fitting pair landed");
+    assert_eq!(block.pair_count(), 1);
+    assert_eq!(text(&kv_meta, &ContentType), Some("text/html"));
+    assert_eq!(kv_meta.get(&Custom("x-big")), None);
+    // The trie's map has no such bound: the same source copies whole.
+    assert_eq!(map(&view).len(), 2);
+}
+
+/// Registry values are bytes: a non-UTF-8 value crosses the erased read
+/// verbatim, and only the trie's text rebuild replaces it.
+#[test]
+fn registry_values_cross_as_bytes() {
+    let block = Metadata::<V1>::new(KeyId::ContentType, Bytes::from_static(&[0xFF, 0xFE])).unwrap();
+    let kv_meta = Some(block);
+    assert_eq!(kv_meta.get(&ContentType), Some(&[0xFF, 0xFE][..]));
+    assert_eq!(map(&kv_meta)["Content-Type"], "\u{FFFD}\u{FFFD}");
+
+    // A custom key that names no UTF-8 string stays behind the static path.
+    let key = CustomKey::try_from(&[0xFF][..]).unwrap();
+    let unnamed = Some(Metadata::<V1>::new(key, Bytes::from_static(b"v")).unwrap());
+    unnamed.for_each(&mut |key, _| panic!("a non-UTF-8 custom key enumerated as {key}"));
+}
+
+/// An erased write into the trie lands the reference client's `Content-Type`
+/// spelling on the fork record, exactly as the native path would, and reads
+/// back through the erased seam by key.
+#[test]
+fn an_erased_write_lands_the_reference_client_spelling_in_the_trie() {
+    run(async {
+        let raw = Arc::new(MemoryStore::<StandardChunkSet>::new());
+        let nodes = NodeLoadSaver::new(Arc::clone(&raw));
+        let store = ContentGet::new(Arc::clone(&raw));
+        let trie = MantarayManifest::<_, _, DEFAULT_BODY_SIZE>::new(nodes.clone(), store);
+        let base = trie.dyn_empty().await.unwrap();
+        let path = ManifestPath::from("index.html");
+        let meta = MetadataView::new().with(ContentType, "text/html");
+        let file = ChunkRef::new(ChunkAddress::new([7; 32]));
+        let root = trie
+            .dyn_insert(&base, path.clone(), file, &meta)
+            .await
+            .unwrap();
+
+        let entry = MantarayReader::new(nodes)
+            .get(root, b"index.html")
+            .await
+            .unwrap()
+            .expect("the erased insert landed");
+        assert_eq!(
+            entry.metadata().get(metadata::CONTENT_TYPE),
+            Some(&"text/html".to_owned()),
+            "the native record carries the reference-client spelling"
+        );
+
+        let read = trie.dyn_metadata(&root, &path).await.unwrap();
+        assert_eq!(text(&*read, &ContentType), Some("text/html"));
+    });
+}

--- a/crates/integration-tests/tests/manifest/root_config.rs
+++ b/crates/integration-tests/tests/manifest/root_config.rs
@@ -40,8 +40,8 @@ use nectar_ldb::{
 };
 use nectar_loadsave::NodeLoadSaver;
 use nectar_manifest::{
-    Batch, Manifest, ManifestError, ManifestOp, ManifestPath, MapCursor, MapEntry, MapView,
-    MetadataView, WellKnownKey,
+    Batch, Manifest, ManifestError, ManifestMeta, ManifestOp, ManifestPath, MapCursor, MapEntry,
+    MapView, MetadataView, WellKnownKey,
 };
 use nectar_mantaray::{ManifestEditor, MantarayManifest};
 use nectar_primitives::store::{ContentGet, MemoryStore};
@@ -945,9 +945,8 @@ where
     M::Metadata: Clone + PartialEq + std::fmt::Debug,
 {
     let page = ManifestPath::from("page.html");
-    let meta = manifest
-        .metadata_from_view(&MetadataView::new().with(WellKnownKey::ContentType, "text/html"))
-        .unwrap();
+    let meta =
+        M::Metadata::from_source(&MetadataView::new().with(WellKnownKey::ContentType, "text/html"));
     assert_ne!(
         meta,
         M::Metadata::default(),

--- a/crates/ldb/src/manifest.rs
+++ b/crates/ldb/src/manifest.rs
@@ -15,8 +15,9 @@ use core::ops::{Bound, RangeBounds};
 use bytes::Bytes;
 use nectar_file::{File, LoadError, Policy};
 use nectar_manifest::{
-    Batch, DataSink, ListEntry, Listing, Manifest, ManifestError, ManifestMetadata, ManifestOp,
-    ManifestPath, MapCursor, MapEntry, MapView, SinkError, SiteConfig, WellKnownKey,
+    Batch, DataSink, ListEntry, Listing, Manifest, ManifestError, ManifestOp, ManifestPath,
+    MapCursor, MapEntry, MapView, MetadataBlock, MetadataSource, SinkError, SiteConfig,
+    WellKnownKey,
 };
 use nectar_primitives::EntryRef;
 use nectar_primitives::chunk::ContentOnlyChunkSet;
@@ -25,10 +26,9 @@ use nectar_primitives::store::{ChunkPut, MaybeSend, MaybeSync, TrustedGet};
 use crate::apply::ApplyError;
 use crate::builder::Builder;
 use crate::db::{Database, View};
-use crate::error::MetadataTooLong;
 use crate::folder::DirEntry;
 use crate::format::{Format, V1};
-use crate::meta::{KeyId, Metadata};
+use crate::meta::{CustomKey, KeyId, Metadata, MetadataKey};
 use crate::node::NodeRef;
 use crate::reader::ReaderError;
 use crate::scan::Cursor;
@@ -45,12 +45,9 @@ pub enum LdbFormatError {
     /// Folding the batch into a new root failed.
     #[error(transparent)]
     Apply(#[from] ApplyError),
-    /// The rebuilt metadata block exceeded the format's bound.
-    #[error(transparent)]
-    Metadata(#[from] MetadataTooLong),
 }
 
-nectar_manifest::format_error_from!(LdbFormatError: ReaderError, ApplyError, MetadataTooLong);
+nectar_manifest::format_error_from!(LdbFormatError: ReaderError, ApplyError);
 
 /// The key-value database as a [`Manifest`], keyed by path.
 ///
@@ -160,29 +157,63 @@ where
         }
         Ok(editor.commit().await?)
     }
+}
 
-    fn metadata_from_view(
-        &self,
-        view: &dyn ManifestMetadata,
-    ) -> Result<Self::Metadata, ManifestError<LdbFormatError>> {
-        let mut meta: Option<Metadata<V1>> = None;
-        for (key, id) in [
-            (WellKnownKey::ContentType, KeyId::ContentType),
-            (WellKnownKey::IndexDocument, KeyId::WebsiteIndexDocument),
-            (WellKnownKey::ErrorDocument, KeyId::WebsiteErrorDocument),
-        ] {
-            let Some(value) = view.get(&key) else {
-                continue;
-            };
-            let value = Bytes::copy_from_slice(value.as_bytes());
-            match meta.as_mut() {
-                Some(block) => {
-                    block.insert(id, value)?;
+/// The typed key `key` names here: any spelling of a registered name promotes
+/// to its [`KeyId`], any other name travels as a custom key when it fits.
+fn meta_key(key: &WellKnownKey<'_>) -> Option<MetadataKey<V1>> {
+    let key = key.resolve();
+    let name = key.name();
+    KeyId::from_name(name.to_ascii_lowercase().as_bytes()).map_or_else(
+        || {
+            CustomKey::try_from(name.as_bytes())
+                .ok()
+                .map(MetadataKey::from)
+        },
+        |id| Some(id.into()),
+    )
+}
+
+/// The erased read of the typed registry; values cross as their stored bytes.
+impl MetadataSource for Metadata<V1> {
+    fn get(&self, key: &WellKnownKey<'_>) -> Option<&[u8]> {
+        let key = meta_key(key)?;
+        Self::get(self, &key).map(Bytes::as_ref)
+    }
+
+    /// A registered id crosses under its registry name; a non-UTF-8 custom
+    /// key names no string, so it stays behind the static path.
+    fn for_each(&self, f: &mut dyn FnMut(&str, &[u8])) {
+        for (key, value) in self.iter() {
+            match key {
+                MetadataKey::Known(id) => f(id.name(), value.as_ref()),
+                MetadataKey::Custom(custom) => {
+                    if let Ok(name) = core::str::from_utf8(custom.as_bytes()) {
+                        f(name, value.as_ref());
+                    }
                 }
-                None => meta = Some(Metadata::new(id, value)?),
             }
         }
-        Ok(meta)
+    }
+}
+
+/// The rebuild keeps registered ids and custom keys alike; a pair past the
+/// format's encoded bound is dropped.
+impl MetadataBlock for Metadata<V1> {
+    fn from_source(source: &dyn MetadataSource) -> Option<Self> {
+        let mut meta: Option<Self> = None;
+        source.for_each(&mut |name, value| {
+            let Some(key) = meta_key(&WellKnownKey::Custom(name)) else {
+                return;
+            };
+            let value = Bytes::copy_from_slice(value);
+            match meta.as_mut() {
+                // An over-budget insert leaves the block unchanged.
+                Some(block) => drop(block.insert(key, value)),
+                None => meta = Self::new(key, value).ok(),
+            }
+        });
+        meta
     }
 }
 

--- a/crates/manifest/Cargo.toml
+++ b/crates/manifest/Cargo.toml
@@ -18,6 +18,7 @@ categories = ["data-structures", "no-std", "asynchronous"]
 workspace = true
 
 [dependencies]
+auto_impl = { workspace = true }
 derive_more = { workspace = true }
 # The positional sink a load writes into; the bare dependency carries the
 # sink module alone, no engine and no primitives.

--- a/crates/manifest/src/dynamic.rs
+++ b/crates/manifest/src/dynamic.rs
@@ -2,7 +2,7 @@
 //! runtime.
 //!
 //! Erasure costs four things and states each: the futures box, the reference
-//! width is fixed to [`ChunkRef`], metadata crosses as [`ManifestMetadata`]
+//! width is fixed to [`ChunkRef`], metadata crosses as a [`MetadataSource`]
 //! rather than the format's own type, and an ordered walk stays on the static
 //! path. Every erased call takes the root it reads or writes against, and a
 //! failure crosses as [`ErasedManifestError`] with the seam variants intact.
@@ -19,7 +19,7 @@ use nectar_tasks::BoxFuture;
 use crate::batch::Batch;
 use crate::error::{ErasedFormat, ErasedManifestError, ManifestError};
 use crate::listing::Listing;
-use crate::meta::ManifestMetadata;
+use crate::meta::{ManifestMeta, MetadataSource};
 use crate::op::ManifestOp;
 use crate::path::ManifestPath;
 use crate::site::SiteConfig;
@@ -125,13 +125,21 @@ pub trait DynManifest: MaybeSend + MaybeSync {
         config: SiteConfig,
     ) -> BoxFuture<'a, Result<ChunkRef, ErasedManifestError>>;
 
-    /// Insert one path, returning the new root.
+    /// The metadata bound to `path`; an absent path reads back empty.
+    fn dyn_metadata<'a>(
+        &'a self,
+        root: &'a ChunkRef,
+        path: &'a ManifestPath,
+    ) -> BoxFuture<'a, Result<Box<dyn MetadataSource>, ErasedManifestError>>;
+
+    /// Insert one path, returning the new root. The format rebuilds `meta`
+    /// into its native type; what it cannot carry is its stated limit.
     fn dyn_insert<'a>(
         &'a self,
         root: &'a ChunkRef,
         path: ManifestPath,
         reference: ChunkRef,
-        meta: Box<dyn ManifestMetadata>,
+        meta: &'a dyn MetadataSource,
     ) -> BoxFuture<'a, Result<ChunkRef, ErasedManifestError>>;
 
     /// Remove one path, returning the new root.
@@ -141,19 +149,19 @@ pub trait DynManifest: MaybeSend + MaybeSync {
         path: ManifestPath,
     ) -> BoxFuture<'a, Result<ChunkRef, ErasedManifestError>>;
 
-    /// Fold `ops` into the manifest rooted at `base`, returning the new root.
-    ///
-    /// Each op's metadata is rebuilt into the format's native type from the
-    /// registered keys of the well-known-key view, so a custom key, or one the
-    /// format cannot carry, is dropped here.
+    /// Fold `ops` into the manifest rooted at `base`, returning the new root;
+    /// each op's metadata crosses through [`ManifestMeta::from_source`].
     fn dyn_apply<'a>(
         &'a self,
         base: &'a ChunkRef,
-        ops: Vec<ManifestOp<ChunkRef, Box<dyn ManifestMetadata>>>,
+        ops: Vec<ManifestOp<ChunkRef, Box<dyn MetadataSource>>>,
     ) -> BoxFuture<'a, Result<ChunkRef, ErasedManifestError>>;
 }
 
-impl<T: Manifest<ChunkRef>> DynManifest for T {
+impl<T: Manifest<ChunkRef>> DynManifest for T
+where
+    T::Metadata: 'static,
+{
     fn dyn_empty(&self) -> BoxFuture<'_, Result<ChunkRef, ErasedManifestError>> {
         Box::pin(async move { self.empty().await.map_err(erase) })
     }
@@ -222,17 +230,28 @@ impl<T: Manifest<ChunkRef>> DynManifest for T {
         })
     }
 
+    fn dyn_metadata<'a>(
+        &'a self,
+        root: &'a ChunkRef,
+        path: &'a ManifestPath,
+    ) -> BoxFuture<'a, Result<Box<dyn MetadataSource>, ErasedManifestError>> {
+        Box::pin(async move {
+            let meta = self.at(root).metadata(path).await.map_err(erase)?;
+            let boxed: Box<dyn MetadataSource> = Box::new(meta);
+            Ok(boxed)
+        })
+    }
+
     fn dyn_insert<'a>(
         &'a self,
         root: &'a ChunkRef,
         path: ManifestPath,
         reference: ChunkRef,
-        meta: Box<dyn ManifestMetadata>,
+        meta: &'a dyn MetadataSource,
     ) -> BoxFuture<'a, Result<ChunkRef, ErasedManifestError>> {
         Box::pin(async move {
-            let meta = self.metadata_from_view(&*meta).map_err(erase)?;
             let mut batch = Batch::new();
-            batch.insert_with(path, reference, meta);
+            batch.insert_with(path, reference, T::Metadata::from_source(meta));
             self.apply(*root, batch).await.map_err(erase)
         })
     }
@@ -248,7 +267,7 @@ impl<T: Manifest<ChunkRef>> DynManifest for T {
     fn dyn_apply<'a>(
         &'a self,
         base: &'a ChunkRef,
-        ops: Vec<ManifestOp<ChunkRef, Box<dyn ManifestMetadata>>>,
+        ops: Vec<ManifestOp<ChunkRef, Box<dyn MetadataSource>>>,
     ) -> BoxFuture<'a, Result<ChunkRef, ErasedManifestError>> {
         Box::pin(async move {
             let mut batch = Batch::new();
@@ -258,10 +277,7 @@ impl<T: Manifest<ChunkRef>> DynManifest for T {
                         path,
                         reference,
                         meta,
-                    } => {
-                        let meta = self.metadata_from_view(&*meta).map_err(erase)?;
-                        batch.insert_with(path, reference, meta)
-                    }
+                    } => batch.insert_with(path, reference, T::Metadata::from_source(&*meta)),
                     ManifestOp::Remove { path } => batch.remove(path),
                 };
             }

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -22,8 +22,8 @@
 //!
 //! Each format keeps its own metadata type: the static path erases nothing.
 //! [`DynManifest`] is the object-safe wrapper for a runtime-detected format,
-//! and unifies metadata behind [`ManifestMetadata`] - the one lossy point in
-//! the design.
+//! and unifies metadata behind the enumerable [`MetadataSource`]: a
+//! cross-format copy is `M2::Metadata::from_source(&m1_meta)`.
 //!
 //! ```
 //! use nectar_manifest::{Batch, ManifestPath, MetadataView, WellKnownKey};
@@ -93,7 +93,7 @@ pub use batch::{Batch, CheckedBatch};
 pub use dynamic::{DynManifest, DynSink, DynSinkError};
 pub use error::{ErasedFormat, ErasedManifestError, ManifestError};
 pub use listing::{ListEntry, Listing};
-pub use meta::{ManifestMetadata, MetadataView, WellKnownKey};
+pub use meta::{ManifestMeta, MetadataBlock, MetadataSource, MetadataView, WellKnownKey};
 pub use op::ManifestOp;
 pub use path::ManifestPath;
 pub use reserved::{ReservedKey, reserved_key};
@@ -132,8 +132,8 @@ impl<T: core::error::Error + MaybeSend + MaybeSync + 'static> SinkError for T {}
 /// lands in the format's own root slot, at a path
 /// [`ManifestPath::is_reserved`] names.
 pub trait Manifest<R: Reference + MaybeSend = ChunkRef>: MaybeSend + MaybeSync {
-    /// The format's own metadata for one entry.
-    type Metadata: MaybeSend + Default;
+    /// The format's own metadata for one entry, enumerable and buildable.
+    type Metadata: ManifestMeta;
 
     /// The format's own failure union, carried in [`ManifestError::Format`].
     type FormatError: core::error::Error + MaybeSend + MaybeSync + 'static;
@@ -163,16 +163,6 @@ pub trait Manifest<R: Reference + MaybeSend = ChunkRef>: MaybeSend + MaybeSync {
         base: R,
         batch: Batch<R, Self::Metadata>,
     ) -> impl Future<Output = Result<R, ManifestError<Self::FormatError>>> + MaybeSend;
-
-    /// Native metadata rebuilt from the erased view, reading the registered
-    /// keys and any custom key the format can carry.
-    ///
-    /// The seam's only lossy step, and the reason it is a method: the format
-    /// decides what it can represent.
-    fn metadata_from_view(
-        &self,
-        view: &dyn ManifestMetadata,
-    ) -> Result<Self::Metadata, ManifestError<Self::FormatError>>;
 
     /// Insert one path, clearing any metadata bound at it; a one-op [`Batch`]
     /// through [`apply`](Self::apply).

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -23,7 +23,8 @@
 //! Each format keeps its own metadata type: the static path erases nothing.
 //! [`DynManifest`] is the object-safe wrapper for a runtime-detected format,
 //! and unifies metadata behind the enumerable [`MetadataSource`]: a
-//! cross-format copy is `M2::Metadata::from_source(&m1_meta)`.
+//! cross-format copy calls [`ManifestMeta::from_source`] on the target's
+//! metadata type with the source's metadata as the argument.
 //!
 //! ```
 //! use nectar_manifest::{Batch, ManifestPath, MetadataView, WellKnownKey};

--- a/crates/manifest/src/meta.rs
+++ b/crates/manifest/src/meta.rs
@@ -73,8 +73,9 @@ pub trait MetadataSource: MaybeSend + MaybeSync {
     fn for_each(&self, f: &mut dyn FnMut(&str, &[u8]));
 }
 
-/// A format's native metadata, so a cross-format copy is
-/// `M2::Metadata::from_source(&m1_meta)`.
+/// A format's native metadata. A cross-format copy goes through
+/// [`MetadataSource`], so the target rebuilds its own type from the source's
+/// pairs and neither format names the other.
 pub trait ManifestMeta: MetadataSource + Default + MaybeSend {
     /// Native metadata rebuilt from `source`; what the format cannot carry is
     /// its stated limit.

--- a/crates/manifest/src/meta.rs
+++ b/crates/manifest/src/meta.rs
@@ -1,25 +1,17 @@
-//! The erased metadata view: the one lossy point in the seam.
-//!
-//! Each format keeps its native metadata on the static path (a string map for
-//! the trie, a typed key registry for the key-value format). Only the erased
-//! path unifies them, and it does so through this well-known-key view, so what
-//! crosses the seam is stated here rather than laundered through strings.
+//! The erased metadata seam: enumerable and bidirectional.
 
 use alloc::collections::BTreeMap;
 use alloc::string::String;
 
 use nectar_marker::{MaybeSend, MaybeSync};
 
-/// A metadata key both formats understand.
-///
-/// The three registered keys are the ones the manifest layer itself acts on. A
-/// [`Custom`](Self::Custom) key travels by name and is looked up verbatim, but
-/// only the registered keys cross the erased apply path, because the view
-/// cannot be enumerated.
+/// A metadata key both formats spell, whatever each stores it as.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum WellKnownKey<'a> {
     /// MIME type of the entry's content.
     ContentType,
+    /// Original file name of the entry's content.
+    Filename,
     /// Site index document, root scope. Not an entry's metadata: set it
     /// through [`Batch::set_index_document`](crate::Batch::set_index_document).
     IndexDocument,
@@ -30,26 +22,89 @@ pub enum WellKnownKey<'a> {
 }
 
 impl WellKnownKey<'_> {
-    /// The key's canonical name; a custom key is its own name.
+    /// Every registered key: the one table the seam matches names against.
+    pub const REGISTERED: [WellKnownKey<'static>; 4] = [
+        WellKnownKey::ContentType,
+        WellKnownKey::Filename,
+        WellKnownKey::IndexDocument,
+        WellKnownKey::ErrorDocument,
+    ];
+
+    /// The key's canonical name, in the reference client's spelling.
     #[must_use]
     pub const fn name(&self) -> &str {
         match self {
-            Self::ContentType => "content-type",
+            Self::ContentType => "Content-Type",
+            Self::Filename => "Filename",
             Self::IndexDocument => "website-index-document",
             Self::ErrorDocument => "website-error-document",
             Self::Custom(name) => name,
         }
     }
+
+    /// The registered key `name` spells, matched ASCII-case-insensitively.
+    #[must_use]
+    pub fn registered(name: &str) -> Option<WellKnownKey<'static>> {
+        Self::REGISTERED
+            .into_iter()
+            .find(|key| key.name().eq_ignore_ascii_case(name))
+    }
+
+    /// This key with a custom spelling of a registered name promoted to its
+    /// variant.
+    #[must_use]
+    pub fn resolve(&self) -> Self {
+        match *self {
+            Self::Custom(name) => Self::registered(name).unwrap_or(Self::Custom(name)),
+            key => key,
+        }
+    }
 }
 
-/// Read access to one entry's metadata, whatever the format stores.
-///
-/// The view answers by key and cannot be enumerated, so the erased apply path
-/// reconstructs native metadata from the registered keys alone: a custom key,
-/// or one the format cannot represent, is dropped there and nowhere else.
-pub trait ManifestMetadata: MaybeSend + MaybeSync {
-    /// The value bound to `key`, or `None` when the entry carries no such key.
-    fn get(&self, key: &WellKnownKey<'_>) -> Option<&str>;
+/// Read access to one entry's metadata, whatever the format stores: by key,
+/// and enumerably. Values are bytes; text is a format's own convention.
+#[auto_impl::auto_impl(&, Box)]
+pub trait MetadataSource: MaybeSend + MaybeSync {
+    /// The value bound to `key`, or `None` when no such key is carried.
+    fn get(&self, key: &WellKnownKey<'_>) -> Option<&[u8]>;
+
+    /// Call `f` once per carried pair, keyed by name in any registered
+    /// spelling.
+    fn for_each(&self, f: &mut dyn FnMut(&str, &[u8]));
+}
+
+/// A format's native metadata, so a cross-format copy is
+/// `M2::Metadata::from_source(&m1_meta)`.
+pub trait ManifestMeta: MetadataSource + Default + MaybeSend {
+    /// Native metadata rebuilt from `source`; what the format cannot carry is
+    /// its stated limit.
+    fn from_source(source: &dyn MetadataSource) -> Self;
+}
+
+/// A non-empty metadata block whose format type is `Option<Self>`: the
+/// orphan-safe route to [`ManifestMeta`], carried by the blanket impls below.
+pub trait MetadataBlock: MetadataSource + Sized + MaybeSend {
+    /// The block `source` rebuilds, or `None` when no pair crosses.
+    fn from_source(source: &dyn MetadataSource) -> Option<Self>;
+}
+
+/// An absent block carries nothing.
+impl<M: MetadataSource> MetadataSource for Option<M> {
+    fn get(&self, key: &WellKnownKey<'_>) -> Option<&[u8]> {
+        self.as_ref()?.get(key)
+    }
+
+    fn for_each(&self, f: &mut dyn FnMut(&str, &[u8])) {
+        if let Some(block) = self {
+            block.for_each(f);
+        }
+    }
+}
+
+impl<M: MetadataBlock> ManifestMeta for Option<M> {
+    fn from_source(source: &dyn MetadataSource) -> Self {
+        M::from_source(source)
+    }
 }
 
 /// Metadata held in the seam's own vocabulary, keyed by canonical name.
@@ -70,9 +125,11 @@ impl MetadataView {
         }
     }
 
-    /// Bind `key` to `value`, replacing any previous binding.
+    /// Bind `key` to `value`, replacing any previous binding; a custom
+    /// spelling of a registered name binds the registered slot.
     pub fn set(&mut self, key: WellKnownKey<'_>, value: impl Into<String>) -> &mut Self {
-        self.pairs.insert(String::from(key.name()), value.into());
+        self.pairs
+            .insert(String::from(key.resolve().name()), value.into());
         self
     }
 
@@ -97,38 +154,56 @@ impl MetadataView {
     }
 }
 
-impl ManifestMetadata for MetadataView {
-    fn get(&self, key: &WellKnownKey<'_>) -> Option<&str> {
-        self.pairs.get(key.name()).map(String::as_str)
+impl MetadataSource for MetadataView {
+    fn get(&self, key: &WellKnownKey<'_>) -> Option<&[u8]> {
+        self.pairs.get(key.resolve().name()).map(String::as_bytes)
+    }
+
+    fn for_each(&self, f: &mut dyn FnMut(&str, &[u8])) {
+        for (key, value) in &self.pairs {
+            f(key, value.as_bytes());
+        }
     }
 }
 
 /// An entry with no metadata at all, for an insert that carries none.
-impl ManifestMetadata for () {
-    fn get(&self, _key: &WellKnownKey<'_>) -> Option<&str> {
+impl MetadataSource for () {
+    fn get(&self, _key: &WellKnownKey<'_>) -> Option<&[u8]> {
         None
+    }
+
+    fn for_each(&self, _f: &mut dyn FnMut(&str, &[u8])) {}
+}
+
+/// The trie's native metadata: a verbatim string map. `get` matches a
+/// registered key under any spelling [`WellKnownKey::registered`] recognises.
+impl MetadataSource for BTreeMap<String, String> {
+    fn get(&self, key: &WellKnownKey<'_>) -> Option<&[u8]> {
+        match key.resolve() {
+            WellKnownKey::Custom(name) => Self::get(self, name).map(String::as_bytes),
+            known => self.iter().find_map(|(name, value)| {
+                (WellKnownKey::registered(name) == Some(known)).then_some(value.as_bytes())
+            }),
+        }
+    }
+
+    fn for_each(&self, f: &mut dyn FnMut(&str, &[u8])) {
+        for (key, value) in self {
+            f(key, value.as_bytes());
+        }
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn a_custom_key_is_looked_up_by_name() {
-        let view = MetadataView::new()
-            .with(WellKnownKey::ContentType, "text/html")
-            .with(WellKnownKey::Custom("etag"), "abc");
-        assert_eq!(view.get(&WellKnownKey::ContentType), Some("text/html"));
-        assert_eq!(view.get(&WellKnownKey::Custom("etag")), Some("abc"));
-        assert_eq!(view.get(&WellKnownKey::Custom("missing")), None);
-    }
-
-    #[test]
-    fn the_content_type_key_is_not_the_custom_spelling_of_its_name() {
-        // A custom key spelled as a registered name must resolve to the same
-        // slot, or a round trip through the view would fork the vocabulary.
-        let view = MetadataView::new().with(WellKnownKey::Custom("content-type"), "text/css");
-        assert_eq!(view.get(&WellKnownKey::ContentType), Some("text/css"));
+/// The map's stated limit is text: a registered key lands under its
+/// canonical spelling and a non-UTF-8 value byte is replaced.
+impl ManifestMeta for BTreeMap<String, String> {
+    fn from_source(source: &dyn MetadataSource) -> Self {
+        let mut map = Self::new();
+        source.for_each(&mut |name, value| {
+            let name = WellKnownKey::registered(name)
+                .map_or_else(|| String::from(name), |known| String::from(known.name()));
+            map.insert(name, String::from_utf8_lossy(value).into_owned());
+        });
+        map
     }
 }

--- a/crates/mantaray/src/manifest.rs
+++ b/crates/mantaray/src/manifest.rs
@@ -19,8 +19,8 @@ use core::ops::{Bound, RangeBounds};
 
 use nectar_file::{File, LoadError, Policy};
 use nectar_manifest::{
-    Batch, DataSink, ListEntry, Listing, Manifest, ManifestError, ManifestMetadata, ManifestOp,
-    ManifestPath, MapCursor, MapEntry, MapView, SinkError, SiteConfig, WellKnownKey,
+    Batch, DataSink, ListEntry, Listing, Manifest, ManifestError, ManifestOp, ManifestPath,
+    MapCursor, MapEntry, MapView, SinkError, SiteConfig,
 };
 use nectar_primitives::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{ContentOnlyChunkSet, Reference};
@@ -153,29 +153,6 @@ where
             let (root, _) = editor.commit_reference().await?;
             Ok(root)
         }
-    }
-
-    fn metadata_from_view(
-        &self,
-        view: &dyn ManifestMetadata,
-    ) -> Result<Self::Metadata, ManifestError<TrieFormatError>> {
-        let mut map = BTreeMap::new();
-        for (key, name) in [
-            (WellKnownKey::ContentType, metadata::CONTENT_TYPE),
-            (
-                WellKnownKey::IndexDocument,
-                metadata::WEBSITE_INDEX_DOCUMENT,
-            ),
-            (
-                WellKnownKey::ErrorDocument,
-                metadata::WEBSITE_ERROR_DOCUMENT,
-            ),
-        ] {
-            if let Some(value) = view.get(&key) {
-                map.insert(String::from(name), String::from(value));
-            }
-        }
-        Ok(map)
     }
 }
 


### PR DESCRIPTION
Closes #654

## Summary

Implements issue #654 (S3): bidirectional enumerable metadata.

- `nectar-manifest` now owns `MetadataSource` (get by `WellKnownKey` returning bytes, plus `for_each` enumeration) and `ManifestMeta` (`from_source` + `Default`); `Manifest::Metadata: ManifestMeta` replaces the deleted `metadata_from_view` on the trait and on both formats.
- Both per-format key tables are gone. `WellKnownKey::REGISTERED` plus ASCII-case-insensitive `registered()`/`resolve()` drive key resolution, and each format rebuilds its view from `for_each`.
- mantaray's `BTreeMap<String, String>` implementations (zero pair loss, registered keys canonicalized to the reference-client `Content-Type` spelling) live in `nectar-manifest` per the orphan rule.
- ldb implements `MetadataSource`/`MetadataBlock` on its local `Metadata<V1>` (lossless `Bytes` values, registered `KeyId`s kept, custom keys preserved), carried to `Option<Metadata<V1>>` by new seam-owned `Option` blankets.
- `DynManifest` gained a `dyn`-erased `dyn_metadata` read path.
- The file-name key is registered end to end, so a key-value-to-trie copy lands the trie's `Filename` spelling rather than the registry spelling `filename` that no reference client reads. The now-unreachable `LdbFormatError::Metadata` is removed (the bound is checked once, via `ApplyError::Metadata`), and tests pin that `REGISTERED` lists every registered variant and that two spellings of one registered name address one slot.

## Compression

Rebuilt as one compressed commit on the compressed `manifest/653-batch-apply` base: `auto_impl` derives the `&T`/`Box<T>` `MetadataSource` forwarding, `KeyId::from_name` replaces the hand-written ldb key match, the `meta.rs` unit tests fold into the consolidated `metadata.rs` suite behind shared helpers, and the erased `dyn_insert` takes `&dyn MetadataSource` instead of a box. Same specification and assertions, +515/-150 against the base versus +698/-139 before.

## Diff

```
Cargo.lock                                                |   1 +
crates/integration-tests/Cargo.toml                       |   4 +
crates/integration-tests/tests/manifest/dyn_roundtrip.rs  |  26 ++-
crates/integration-tests/tests/manifest/encrypted.rs      |   9 +-
crates/integration-tests/tests/manifest/listing.rs        |   6 +-
crates/integration-tests/tests/manifest/metadata.rs       | 250 ++++++++++++++
crates/integration-tests/tests/manifest/root_config.rs    |   9 +-
crates/ldb/src/manifest.rs                                |  85 +++---
crates/manifest/Cargo.toml                                |   1 +
crates/manifest/src/dynamic.rs                            |  54 ++--
crates/manifest/src/lib.rs                                |  20 +-
crates/manifest/src/meta.rs                               | 173 +++++++----
crates/mantaray/src/manifest.rs                           |  27 +--
13 files changed, 515 insertions(+), 150 deletions(-)
```

## Testing

Gate run at `82ec10b8` (branch `manifest/654-metadata`), inside `nix develop`. All green.

- `git merge-base --is-ancestor origin/manifest/653-batch-apply HEAD` -> true; the branch sits on the compressed `manifest/653-batch-apply` tip (`0d55ee69`).
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: clean.
- `cargo nextest run --workspace --locked`: 1220 passed, 1 skipped, 0 failed.
- `cargo test --doc --workspace --locked`: all doctests pass.
- no_std: `cargo check --no-default-features --locked` for `nectar-manifest` and `nectar-ldb` (by package) and `nectar-mantaray` (by manifest path) on `riscv64imac-unknown-none-elf` and `wasm32-unknown-unknown`: all six clean.
- `cargo fmt --check`: no diffs in any touched file.
- Single commit `82ec10b8`, author `mfw78 <mfw78@nxm.rs>`, with the AI-assistance disclosure line and no bot attribution footers.

AI Assistance: implemented by claude-fable-5, red-teamed by claude-opus-5, PR opened by claude-sonnet-5; compression pass by claude-fable-5.
