### PR TITLE
manifest: implement Manifest directly on ldb Database

### DIFF
--- a/crates/integration-tests/tests/ldb/reader.rs
+++ b/crates/integration-tests/tests/ldb/reader.rs
@@ -8,10 +8,10 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use anyhow::{Result, ensure};
 use bytes::Bytes;
 use nectar_ldb::{
-    Builder, Child, Database, Entry, ForkTable, Key, KeyId, LdbManifest, Metadata, Node, NodePut,
-    Plaintext, Prefix, Reader, V1,
+    Builder, Child, Database, Entry, ForkTable, Key, KeyId, Metadata, Node, NodePut, Plaintext,
+    Prefix, Reader, V1,
 };
-use nectar_manifest::{Manifest, ManifestPath, MapView};
+use nectar_manifest::{Batch, Manifest, ManifestPath, MapView};
 use nectar_primitives::store::{ChunkGet, ContentGet, MemoryStore};
 use nectar_primitives::{Chunk, ChunkAddress, ChunkRef, ContentOnlyChunkSet, Verified};
 use nectar_testing::run;
@@ -262,8 +262,8 @@ fn root_metadata_reads_back_without_a_root_entry() -> Result<()> {
             "the view's website agrees",
         );
 
-        let seam = LdbManifest::plain(store.clone());
-        let seam_view = seam.at(&root);
+        let seam = Database::<_>::plain(store.clone());
+        let seam_view = Manifest::at(&seam, &root);
         ensure!(
             MapView::index_document(&seam_view)
                 .await?
@@ -294,6 +294,69 @@ fn root_metadata_reads_back_without_a_root_entry() -> Result<()> {
         // An absent root entry still reads as absent.
         ensure!(view.get(&Key::empty()).await?.is_none(), "no root entry");
         ensure!(!view.contains_key(&Key::empty()).await?, "no root binding");
+        Ok(())
+    })
+}
+
+/// One `Database` value serves both contracts: the inherent methods keep the
+/// native surface, and the `Manifest` bound reaches the seam.
+///
+/// The seam's `apply` folds the whole batch through one native changeset, so
+/// its root is byte-identical to the one the native editor lands on. A
+/// delegation shell would not compile here, and a drift in the fold moves the
+/// root.
+#[test]
+fn one_database_serves_the_native_and_the_seam_contract() -> Result<()> {
+    let store = ContentGet::new(Arc::new(MemoryStore::default()));
+    run(async {
+        let db: Database<_> = Database::plain(store.clone());
+        let empty: ChunkRef = Manifest::empty(&db).await?;
+
+        let key = Key::from(&b"index.html"[..]);
+        let path = ManifestPath::from("index.html");
+        let reference = ChunkRef::new(ChunkAddress::new([0x11; 32]));
+        let meta = Metadata::<V1>::new(KeyId::ContentType, Bytes::from_static(b"text/html"))?;
+
+        // The seam's write: one batch with an entry, its metadata, and a site
+        // document.
+        let mut batch = Batch::new();
+        batch
+            .insert_with(path.clone(), reference, Some(meta.clone()))
+            .set_index_document(path.clone());
+        let seam_root = Manifest::apply(&db, empty, batch).await?;
+
+        // The native write of the same ops, on the same value.
+        let mut editor = db.edit(&empty);
+        editor.insert_with(key.clone(), Entry::from(reference), meta);
+        editor.set_root_metadata(
+            KeyId::WebsiteIndexDocument,
+            Some(Bytes::from_static(b"index.html")),
+        );
+        let native_root: ChunkRef = editor.commit().await?;
+        ensure!(
+            seam_root == native_root,
+            "the seam's apply and the native editor land on one root"
+        );
+
+        // The inherent `at` still answers the native contract over keys.
+        ensure!(
+            db.at(&seam_root).get(&key).await?.is_some(),
+            "the native view answers over keys"
+        );
+
+        // The trait's `at` answers the seam contract over paths, with the
+        // reserved slots filtered.
+        let view = Manifest::at(&db, &seam_root);
+        ensure!(
+            MapView::get(&view, &path).await?.is_some(),
+            "the seam view answers over paths"
+        );
+        ensure!(
+            MapView::get(&view, &ManifestPath::default())
+                .await?
+                .is_none(),
+            "the seam view keeps the root slot filtered"
+        );
         Ok(())
     })
 }

--- a/crates/integration-tests/tests/manifest/dyn_roundtrip.rs
+++ b/crates/integration-tests/tests/manifest/dyn_roundtrip.rs
@@ -6,7 +6,7 @@
 //! lands in each format's own native slot.
 
 use nectar_file::{File, MemSink, Policy};
-use nectar_ldb::{LdbManifest, Reader as LdbReader};
+use nectar_ldb::{Database, Reader as LdbReader};
 use nectar_loadsave::NodeLoadSaver;
 use nectar_manifest::{
     DynManifest, ManifestOp, ManifestPath, MetadataSource, MetadataView, SiteConfig, WellKnownKey,
@@ -248,7 +248,7 @@ fn both_formats_round_trip_through_one_erased_handle() {
             MantarayManifest::<_, _, DEFAULT_BODY_SIZE>::new(nodes, store.clone()),
         );
         let trie_root = trie.dyn_empty().await.unwrap();
-        let kv: Box<dyn DynManifest> = Box::new(LdbManifest::plain(store.clone()));
+        let kv: Box<dyn DynManifest> = Box::new(Database::<_>::plain(store.clone()));
         let kv_root = kv.dyn_empty().await.unwrap();
 
         exercise(trie.as_ref(), &trie_root, &file, &data).await;
@@ -297,7 +297,7 @@ fn the_site_config_lands_in_each_format_native_slot() {
 
         // The key-value database keeps them in the root's typed metadata,
         // which its website view reads.
-        let kv = LdbManifest::plain(store.clone());
+        let kv = Database::<_>::plain(store.clone());
         let kv_root = kv.dyn_empty().await.unwrap();
         let root = kv.dyn_set_site_config(&kv_root, config).await.unwrap();
         let reader: LdbReader<_> = LdbReader::new(&store);

--- a/crates/integration-tests/tests/manifest/encrypted.rs
+++ b/crates/integration-tests/tests/manifest/encrypted.rs
@@ -9,7 +9,7 @@
 use std::sync::Arc;
 
 use nectar_file::{File, MemSink, Policy};
-use nectar_ldb::{Encrypted as EncryptedSeal, LdbManifest, V1};
+use nectar_ldb::{Database, Encrypted as EncryptedSeal, V1};
 use nectar_loadsave::NodeLoadSaver;
 use nectar_manifest::{
     Batch, ListEntry, Manifest, ManifestMeta, ManifestPath, MapEntry, MapView, MetadataView,
@@ -106,7 +106,7 @@ fn both_formats_drive_an_encrypted_manifest() {
         exercise(&trie, &trie_root, &file, &data).await;
 
         let seal: EncryptedSeal<'_, V1> = EncryptedSeal::new(SECRET);
-        let kv = LdbManifest::new(store.clone(), seal);
+        let kv: Database<_, _> = Database::new(store.clone(), seal);
         let kv_root: EncryptedChunkRef = kv.empty().await.unwrap();
         exercise(&kv, &kv_root, &file, &data).await;
     });

--- a/crates/integration-tests/tests/manifest/listing.rs
+++ b/crates/integration-tests/tests/manifest/listing.rs
@@ -11,7 +11,7 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use nectar_file::{File, Policy};
-use nectar_ldb::{Builder, LdbManifest, Plaintext, V1};
+use nectar_ldb::{Builder, Database, Plaintext, V1};
 use nectar_loadsave::NodeLoadSaver;
 use nectar_manifest::{DynManifest, ManifestOp, ManifestPath, MetadataSource};
 use nectar_mantaray::{ManifestEditor, MantarayManifest};
@@ -131,7 +131,7 @@ fn both_formats_list_a_level_the_way_the_model_does() {
 
             let builder: Builder<V1> = Builder::new();
             let empty = *builder.build(&store, &Plaintext).await.unwrap().root();
-            let kv = LdbManifest::plain(store.clone());
+            let kv = Database::<_>::plain(store.clone());
             let kv_root = kv.dyn_apply(&empty, inserts(keys, &file)).await.unwrap();
 
             for dir in DIRS {

--- a/crates/integration-tests/tests/manifest/root_config.rs
+++ b/crates/integration-tests/tests/manifest/root_config.rs
@@ -35,9 +35,7 @@ use std::ops::Bound;
 use std::sync::Arc;
 
 use nectar_file::{DataSink, File, MemSink, Policy};
-use nectar_ldb::{
-    Builder, Database, Entry, Key, LdbManifest, Plaintext, Reader as LdbReader, Served, V1, Website,
-};
+use nectar_ldb::{Builder, Database, Entry, Key, Plaintext, Reader as LdbReader, Served, V1, Website};
 use nectar_loadsave::NodeLoadSaver;
 use nectar_manifest::{
     Batch, Manifest, ManifestError, ManifestMeta, ManifestOp, ManifestPath, MapCursor, MapEntry,
@@ -53,13 +51,13 @@ use nectar_testing::run;
 type Raw = Arc<MemoryStore<StandardChunkSet>>;
 type Store = ContentGet<Raw>;
 type Trie = MantarayManifest<NodeLoadSaver<Raw>, Store, DEFAULT_BODY_SIZE>;
-type Kv = LdbManifest<Store>;
+type Kv = Database<Store>;
 
 /// Both formats over one raw store, each at its freshly persisted empty root.
 async fn both_formats(raw: &Raw, store: &Store) -> ((Trie, ChunkRef), (Kv, ChunkRef)) {
     let trie: Trie = MantarayManifest::new(NodeLoadSaver::new(Arc::clone(raw)), store.clone());
     let trie_empty = trie.empty().await.unwrap();
-    let kv = LdbManifest::plain(store.clone());
+    let kv = Database::<_>::plain(store.clone());
     let kv_empty = kv.empty().await.unwrap();
     ((trie, trie_empty), (kv, kv_empty))
 }
@@ -741,13 +739,13 @@ fn a_remove_is_history_independent_on_ldb() {
         let store: Store = ContentGet::new(raw);
         let builder: Builder<V1> = Builder::new();
         let empty = *builder.build(&store, &Plaintext).await.unwrap().root();
-        let kv = LdbManifest::plain(store.clone());
+        let kv = Database::<_>::plain(store.clone());
 
         let keys = removal_keys();
         let base = build(&kv, &empty, &keys).await;
 
         for (index, (path, _)) in keys.iter().enumerate() {
-            let removed = kv.remove(&base, path.clone()).await.unwrap();
+            let removed = Manifest::remove(&kv, &base, path.clone()).await.unwrap();
             assert_ne!(removed, base, "removing {:?} moves the root", text(path));
 
             assert_eq!(
@@ -760,17 +758,20 @@ fn a_remove_is_history_independent_on_ldb() {
 
         // The order the two keys go in does not reach the root either.
         let (first, second) = (keys[0].0.clone(), keys[4].0.clone());
-        let forwards = kv
-            .remove(
-                &kv.remove(&base, first.clone()).await.unwrap(),
-                second.clone(),
-            )
-            .await
-            .unwrap();
-        let backwards = kv
-            .remove(&kv.remove(&base, second).await.unwrap(), first)
-            .await
-            .unwrap();
+        let forwards = Manifest::remove(
+            &kv,
+            &Manifest::remove(&kv, &base, first.clone()).await.unwrap(),
+            second.clone(),
+        )
+        .await
+        .unwrap();
+        let backwards = Manifest::remove(
+            &kv,
+            &Manifest::remove(&kv, &base, second).await.unwrap(),
+            first,
+        )
+        .await
+        .unwrap();
         assert_eq!(forwards, backwards, "two removals commute on the root");
     });
 }
@@ -1026,7 +1027,7 @@ fn the_seam_bootstrap_matches_each_format() {
 
         let builder: Builder<V1> = Builder::new();
         let native = *builder.build(&store, &Plaintext).await.unwrap().root();
-        assert_empty_bootstrap(&LdbManifest::plain(store.clone()), native, "database").await;
+        assert_empty_bootstrap(&Database::<_>::plain(store.clone()), native, "database").await;
     });
 }
 
@@ -1117,7 +1118,7 @@ fn a_planted_separator_key_is_not_listed() {
             "the raw layer holds the planted key"
         );
 
-        let kv = LdbManifest::plain(store.clone());
+        let kv = Database::<_>::plain(store.clone());
         let view = kv.at(&planted);
         assert_eq!(
             listing(&view, &ManifestPath::default()).await,
@@ -1125,7 +1126,7 @@ fn a_planted_separator_key_is_not_listed() {
             "the top level lists content alone, and never the planted key"
         );
         assert_eq!(
-            view.get(&separator).await.unwrap(),
+            MapView::get(&view, &separator).await.unwrap(),
             None,
             "and no read reaches it either"
         );
@@ -1161,7 +1162,7 @@ fn a_planted_separator_key_is_not_listed() {
             "the directory of the content below the separator is listed"
         );
         assert_eq!(
-            view.get(&separator).await.unwrap(),
+            MapView::get(&view, &separator).await.unwrap(),
             None,
             "and the planted key itself still reads absent"
         );
@@ -1180,7 +1181,7 @@ fn website_documents_resolve_over_bare_keys() {
         let store: Store = ContentGet::new(raw);
         let builder: Builder<V1> = Builder::new();
         let empty = *builder.build(&store, &Plaintext).await.unwrap().root();
-        let kv = LdbManifest::plain(store.clone());
+        let kv = Database::<_>::plain(store.clone());
 
         let root = {
             let mut batch = Batch::new();

--- a/crates/ldb/src/lib.rs
+++ b/crates/ldb/src/lib.rs
@@ -65,6 +65,11 @@
 //! magic keys. A listing collapses deeper keys at the next separator and seeks
 //! past each named subtree, so it stays O(depth) and fetches no value chunk.
 //!
+//! The `manifest` feature puts the shared `Manifest` seam on [`Database`]
+//! itself, keyed by path over the same handle. The inherent methods win on a
+//! concrete database, so a seam call names the trait: `Manifest::at(&db,
+//! root)`, or a generic bound.
+//!
 //! PRIVACY: an encrypted reference IS a read capability for its whole
 //! subtree. Confidentiality rests solely on the outermost reference being
 //! distributed privately. See the `encryption` module.
@@ -151,7 +156,7 @@ pub use folder::{DirEntry, Listing, Served, Website};
 pub use fork::{Child, ForkPayload, ForkRecord, ForkTable};
 pub use format::{Format, V1, V1Read};
 #[cfg(feature = "manifest")]
-pub use manifest::{LdbCursor, LdbFormatError, LdbManifest, LdbView};
+pub use manifest::LdbFormatError;
 pub use meta::{CustomKey, KeyId, Metadata, MetadataKey};
 pub use node::{Node, NodeRef, RootExtension};
 pub use packing::{Directory, SegmentKind, cut, embed, h64, segment, spill};

--- a/crates/ldb/src/manifest.rs
+++ b/crates/ldb/src/manifest.rs
@@ -1,23 +1,16 @@
-//! The [`Manifest`] seam over the key-value database, read through its folder
-//! view.
-//!
-//! One store serves both roles: the trie nodes and the entry data behind a
-//! reference. A key bound to inline bytes carries its own data, so a load of
-//! it never reaches the file pipeline.
-//!
-//! [`LdbView`] wraps [`Database::at`], and [`Manifest::apply`] folds the
-//! checked batch through [`Database::edit`], with paths in place of keys.
+//! The [`Manifest`] seam, implemented directly on [`Database`], [`View`] and
+//! [`Cursor`]: keyed by path, reserved keys filtered, a checked batch folded
+//! through one [`Database::edit`] changeset. Inherent methods win on the
+//! concrete types, so a seam call names the trait: `Manifest::at(&db, root)`.
 
 use alloc::vec::Vec;
-use core::future::Future;
 use core::ops::{Bound, RangeBounds};
 
 use bytes::Bytes;
 use nectar_file::{File, LoadError, Policy};
 use nectar_manifest::{
     Batch, DataSink, ListEntry, Listing, Manifest, ManifestError, ManifestOp, ManifestPath,
-    MapCursor, MapEntry, MapView, MetadataBlock, MetadataSource, SinkError, SiteConfig,
-    WellKnownKey,
+    MapCursor, MapEntry, MapView, SinkError, SiteConfig,
 };
 use nectar_primitives::EntryRef;
 use nectar_primitives::chunk::ContentOnlyChunkSet;
@@ -28,11 +21,11 @@ use crate::builder::Builder;
 use crate::db::{Database, View};
 use crate::folder::DirEntry;
 use crate::format::{Format, V1};
-use crate::meta::{CustomKey, KeyId, Metadata, MetadataKey};
+use crate::meta::{KeyId, Metadata};
 use crate::node::NodeRef;
 use crate::reader::ReaderError;
 use crate::scan::Cursor;
-use crate::store::{Plaintext, Seal};
+use crate::store::Seal;
 use crate::value::{Entry, Key};
 
 /// The database's own failures behind [`ManifestError::Format`].
@@ -49,181 +42,75 @@ pub enum LdbFormatError {
 
 nectar_manifest::format_error_from!(LdbFormatError: ReaderError, ApplyError);
 
-/// The key-value database as a [`Manifest`], keyed by path.
-///
-/// The seal is the write-side secret: [`Plaintext`], or the sealer carrying
-/// the secret the base tree was built under. Reads need none, since an
-/// encrypted reference carries its own key.
-#[derive(Clone, Copy, Debug)]
-pub struct LdbManifest<S, K = Plaintext> {
-    db: Database<S, K, V1>,
-}
-
-impl<S, K> LdbManifest<S, K> {
-    /// A manifest over `store`, publishing rewritten nodes through `seal`.
-    pub const fn new(store: S, seal: K) -> Self {
-        Self {
-            db: Database::new(store, seal),
-        }
-    }
-
-    /// The backing database.
-    pub const fn db(&self) -> &Database<S, K, V1> {
-        &self.db
-    }
-
-    /// The backing store.
-    pub const fn store(&self) -> &S {
-        self.db.store()
-    }
-
-    /// The write-side sealer.
-    pub const fn seal(&self) -> &K {
-        self.db.seal()
-    }
-}
-
-impl<S> LdbManifest<S, Plaintext> {
-    /// A plaintext manifest over `store`.
-    pub const fn plain(store: S) -> Self {
-        Self::new(store, Plaintext)
-    }
-}
-
-impl<S, K, R> Manifest<R> for LdbManifest<S, K>
+/// The database as a [`Manifest`], keyed by path.
+impl<S, K, R> Manifest<R> for Database<S, K, V1>
 where
     S: TrustedGet<ContentOnlyChunkSet> + ChunkPut + Clone + MaybeSend + MaybeSync + 'static,
     K: Seal<R> + MaybeSend + MaybeSync,
     R: NodeRef,
 {
-    /// The database's metadata: the typed key registry, absent as `None`.
+    /// The typed key registry, absent as `None`.
     type Metadata = Option<Metadata<V1>>;
 
     type FormatError = LdbFormatError;
 
     type View<'a>
-        = LdbView<'a, S, R>
+        = View<'a, S, V1, R>
     where
         Self: 'a;
 
     /// The empty database persisted through the native builder.
     async fn empty(&self) -> Result<R, ManifestError<LdbFormatError>> {
         let built = Builder::<V1>::new()
-            .build(self.db.store(), self.db.seal())
+            .build(self.store(), self.seal())
             .await
             .map_err(ApplyError::from)?;
         Ok(built.root().clone())
     }
 
     fn at(&self, root: &R) -> Self::View<'_> {
-        LdbView {
-            view: self.db.at(root),
-        }
+        // Inherent resolution wins, so this is the native `Database::at`.
+        Self::at(self, root)
     }
 
-    /// The checked batch folded through the database's own editor: order never
-    /// reaches the produced root, so the replay is one changeset.
+    /// The checked batch folded through one changeset: order never reaches
+    /// the produced root.
     async fn apply(
         &self,
         base: R,
         batch: Batch<R, Self::Metadata>,
     ) -> Result<R, ManifestError<LdbFormatError>> {
         let checked = batch.into_checked().map_err(ManifestError::Reserved)?;
-        let mut editor = self.db.edit(&base);
+        let mut editor = self.edit(&base);
         for op in checked.ops {
             match op {
                 ManifestOp::Insert {
                     path,
                     reference,
                     meta,
-                } => editor.insert_with(
-                    Key::from(path.as_bytes()),
-                    Entry::from(reference.into_entry_ref()),
-                    meta,
-                ),
+                } => {
+                    let entry = Entry::from(reference.into_entry_ref());
+                    editor.insert_with(Key::from(path.as_bytes()), entry, meta)
+                }
                 ManifestOp::Remove { path } => editor.remove(Key::from(path.as_bytes())),
             };
         }
-        // The site documents are a merge into the root manifest metadata:
-        // untouched stages nothing, `Some(None)` clears the key.
+        // Site documents: untouched stages nothing, `Some(None)` clears.
         for (id, delta) in [
             (KeyId::WebsiteIndexDocument, checked.index_document),
             (KeyId::WebsiteErrorDocument, checked.error_document),
         ] {
             if let Some(path) = delta {
-                let value = path.map(|path| Bytes::copy_from_slice(path.as_bytes()));
-                editor.set_root_metadata(id, value);
+                editor.set_root_metadata(id, path.map(|p| Bytes::copy_from_slice(p.as_bytes())));
             }
         }
         Ok(editor.commit().await?)
     }
 }
 
-/// The typed key `key` names here: any spelling of a registered name promotes
-/// to its [`KeyId`], any other name travels as a custom key when it fits.
-fn meta_key(key: &WellKnownKey<'_>) -> Option<MetadataKey<V1>> {
-    let key = key.resolve();
-    let name = key.name();
-    KeyId::from_name(name.to_ascii_lowercase().as_bytes()).map_or_else(
-        || {
-            CustomKey::try_from(name.as_bytes())
-                .ok()
-                .map(MetadataKey::from)
-        },
-        |id| Some(id.into()),
-    )
-}
-
-/// The erased read of the typed registry; values cross as their stored bytes.
-impl MetadataSource for Metadata<V1> {
-    fn get(&self, key: &WellKnownKey<'_>) -> Option<&[u8]> {
-        let key = meta_key(key)?;
-        Self::get(self, &key).map(Bytes::as_ref)
-    }
-
-    /// A registered id crosses under its registry name; a non-UTF-8 custom
-    /// key names no string, so it stays behind the static path.
-    fn for_each(&self, f: &mut dyn FnMut(&str, &[u8])) {
-        for (key, value) in self.iter() {
-            match key {
-                MetadataKey::Known(id) => f(id.name(), value.as_ref()),
-                MetadataKey::Custom(custom) => {
-                    if let Ok(name) = core::str::from_utf8(custom.as_bytes()) {
-                        f(name, value.as_ref());
-                    }
-                }
-            }
-        }
-    }
-}
-
-/// The rebuild keeps registered ids and custom keys alike; a pair past the
-/// format's encoded bound is dropped.
-impl MetadataBlock for Metadata<V1> {
-    fn from_source(source: &dyn MetadataSource) -> Option<Self> {
-        let mut meta: Option<Self> = None;
-        source.for_each(&mut |name, value| {
-            let Some(key) = meta_key(&WellKnownKey::Custom(name)) else {
-                return;
-            };
-            let value = Bytes::copy_from_slice(value);
-            match meta.as_mut() {
-                // An over-budget insert leaves the block unchanged.
-                Some(block) => drop(block.insert(key, value)),
-                None => meta = Self::new(key, value).ok(),
-            }
-        });
-        meta
-    }
-}
-
-/// The seam's read view: the database's own view, keyed by path.
-#[derive(Debug)]
-pub struct LdbView<'a, S, R: NodeRef> {
-    view: View<'a, S, V1, R>,
-}
-
-impl<'a, S, R> MapView<R> for LdbView<'a, S, R>
+/// The native view as the seam's read handle, keyed by path. Each body's
+/// key-typed call resolves to the inherent method.
+impl<'a, S, R> MapView<R> for View<'a, S, V1, R>
 where
     S: TrustedGet<ContentOnlyChunkSet> + Clone + MaybeSend + MaybeSync + 'static,
     R: NodeRef,
@@ -232,210 +119,150 @@ where
 
     type Error = ManifestError<LdbFormatError>;
 
-    type Cursor = LdbCursor<'a, S, R>;
+    type Cursor = Cursor<'a, S, V1, R>;
 
-    fn get(
-        &self,
-        path: &ManifestPath,
-    ) -> impl Future<Output = Result<Option<MapEntry<R>>, Self::Error>> + MaybeSend {
-        let key = content_key(path);
-        async move {
-            let Some(key) = key else { return Ok(None) };
-            Ok(self.view.get(&key).await?.map(mapped))
-        }
+    async fn get(&self, path: &ManifestPath) -> Result<Option<MapEntry<R>>, Self::Error> {
+        let Some(key) = content_key(path) else {
+            return Ok(None);
+        };
+        Ok(self.get(&key).await?.map(mapped))
     }
 
     async fn site_config(&self) -> Result<SiteConfig, Self::Error> {
-        let site = self.view.website().await?;
+        let site = self.website().await?;
         let document = |bytes: Option<&[u8]>| bytes.map(ManifestPath::from);
         Ok(SiteConfig::new()
             .with_index_document(document(site.index()))
             .with_error_document(document(site.error())))
     }
 
-    fn metadata(
-        &self,
-        path: &ManifestPath,
-    ) -> impl Future<Output = Result<Self::Metadata, Self::Error>> + MaybeSend {
-        let key = content_key(path);
-        async move {
-            let Some(key) = key else {
-                return Ok(None);
-            };
-            Ok(self.view.metadata(&key).await?)
-        }
-    }
-
-    fn contains_key(
-        &self,
-        path: &ManifestPath,
-    ) -> impl Future<Output = Result<bool, Self::Error>> + MaybeSend {
-        let key = content_key(path);
-        async move {
-            let Some(key) = key else { return Ok(false) };
-            Ok(self.view.contains_key(&key).await?)
-        }
+    async fn metadata(&self, path: &ManifestPath) -> Result<Self::Metadata, Self::Error> {
+        let Some(key) = content_key(path) else {
+            return Ok(None);
+        };
+        Ok(self.metadata(&key).await?)
     }
 
     /// One O(depth) descent, in place of the default's walk.
-    fn floor(
+    async fn floor(
         &self,
         path: &ManifestPath,
-    ) -> impl Future<Output = Result<Option<(ManifestPath, MapEntry<R>)>, Self::Error>> + MaybeSend
-    {
+    ) -> Result<Option<(ManifestPath, MapEntry<R>)>, Self::Error> {
         let key = Key::from(path.as_bytes());
-        let view = self.view.clone();
-        async move {
-            let found = view.floor(&key).await?;
-            match found {
-                None => Ok(None),
-                Some((found, entry)) if !is_reserved(&found) => {
-                    Ok(Some((floored(found), mapped(entry))))
+        match self.floor(&key).await? {
+            None => Ok(None),
+            Some((found, entry)) if !is_reserved(&found) => {
+                Ok(Some((path_of(&found), mapped(entry))))
+            }
+            // The seek landed on a reserved key: the greatest content key
+            // below it answers.
+            Some(_) => {
+                let mut cursor = self.range((Bound::Unbounded, Bound::Included(key))).await?;
+                let mut last = None;
+                while let Some(pair) = MapCursor::next(&mut cursor).await? {
+                    last = Some(pair);
                 }
-                // The seek landed on a reserved key, so the greatest content
-                // key below it is the answer.
-                Some(_) => {
-                    let mut cursor = view.range((Bound::Unbounded, Bound::Included(key))).await?;
-                    let mut last = None;
-                    while let Some((found, entry)) = cursor.next().await? {
-                        if !is_reserved(&found) {
-                            last = Some((floored(found), mapped(entry)));
-                        }
-                    }
-                    Ok(last)
-                }
+                Ok(last)
             }
         }
     }
 
-    fn dir(
-        &self,
-        dir: &ManifestPath,
-    ) -> impl Future<Output = Result<Listing<R>, Self::Error>> + MaybeSend {
-        let key = Key::from(dir.as_bytes());
-        async move {
-            let mut listing = self.view.dir(&key).await?;
-            let mut entries = Vec::new();
-            while let Some(item) = listing.next().await? {
-                // At the bare separator the folder view names both the
-                // reserved key and the directory of content below it. What is
-                // bound strictly under it tells the two apart: hide the slot,
-                // list the directory.
-                let hidden = is_reserved(item.key())
-                    && !(item.is_dir() && bound_below(&self.view, item.key()).await?);
-                if hidden {
+    async fn dir(&self, dir: &ManifestPath) -> Result<Listing<R>, Self::Error> {
+        let mut listing = self.dir(&Key::from(dir.as_bytes())).await?;
+        let mut entries = Vec::new();
+        while let Some(item) = listing.next().await? {
+            // At the bare separator the folder view names both the reserved
+            // key and the directory of content below it: hide the slot, list
+            // the directory.
+            if is_reserved(item.key()) {
+                let mut probe = self.prefix(item.key()).await?;
+                let mut below = false;
+                while let Some((found, _)) = probe.next().await? {
+                    if found.as_bytes() != item.key().as_bytes() {
+                        below = true;
+                        break;
+                    }
+                }
+                if !(item.is_dir() && below) {
                     continue;
                 }
-                entries.push(listed(item));
             }
-            Ok(Listing::new(entries))
+            entries.push(listed(item));
         }
+        Ok(Listing::new(entries))
     }
 
-    fn load<T: DataSink<Error: SinkError> + MaybeSend>(
+    async fn load<T: DataSink<Error: SinkError> + MaybeSend>(
         &self,
         path: &ManifestPath,
         sink: &mut T,
-    ) -> impl Future<Output = Result<(), Self::Error>> + MaybeSend {
-        let path = path.clone();
-        let store = self.view.store().clone();
-        async move {
-            let entry = match content_key(&path) {
-                Some(key) => self.view.get(&key).await?,
-                None => None,
+    ) -> Result<(), Self::Error> {
+        let entry = match content_key(path) {
+            Some(key) => self.get(&key).await?,
+            None => None,
+        }
+        .ok_or_else(|| ManifestError::NotFound(path.clone()))?;
+        // An inline value is its own data; references take the file walk.
+        let reference = match entry {
+            Entry::Inline(value) => {
+                return sink
+                    .write_at(0, value.as_bytes())
+                    .map_err(ManifestError::sink);
             }
-            .ok_or(ManifestError::NotFound(path))?;
-            // An inline value is the data, so it needs no file walk; both
-            // reference widths do.
-            let reference = match entry {
-                Entry::Inline(value) => {
-                    return sink
-                        .write_at(0, value.as_bytes())
-                        .map_err(ManifestError::sink);
-                }
-                Entry::Ref32(reference) => EntryRef::Plain(reference),
-                Entry::Ref64(reference) => EntryRef::Encrypted(reference),
-            };
-            File::new(store, Policy::DEFAULT)
-                .load(reference, sink)
-                .await
-                .map_err(|error| match error {
-                    LoadError::Sink { source, .. } => ManifestError::sink(source),
-                    data => ManifestError::data(data),
-                })?;
-            Ok(())
-        }
-    }
-
-    fn iter(&self) -> impl Future<Output = Result<Self::Cursor, Self::Error>> + MaybeSend {
-        // The walk takes its own copy rather than borrowing the handle.
-        let view = self.view.clone();
-        async move {
-            Ok(LdbCursor {
-                cursor: view.iter().await?,
+            Entry::Ref32(reference) => EntryRef::Plain(reference),
+            Entry::Ref64(reference) => EntryRef::Encrypted(reference),
+        };
+        File::new(self.store().clone(), Policy::DEFAULT)
+            .load(reference, sink)
+            .await
+            .map(drop)
+            .map_err(|error| match error {
+                LoadError::Sink { source, .. } => ManifestError::sink(source),
+                data => ManifestError::data(data),
             })
-        }
     }
 
-    fn range(
+    async fn iter(&self) -> Result<Self::Cursor, Self::Error> {
+        Ok(self.iter().await?)
+    }
+
+    async fn range(
         &self,
         bounds: impl RangeBounds<ManifestPath> + MaybeSend,
-    ) -> impl Future<Output = Result<Self::Cursor, Self::Error>> + MaybeSend {
-        let bounds = key_bounds(&bounds);
-        let view = self.view.clone();
-        async move {
-            Ok(LdbCursor {
-                cursor: view.range(bounds).await?,
-            })
-        }
+    ) -> Result<Self::Cursor, Self::Error> {
+        let key = |edge: Bound<&ManifestPath>| edge.map(|path| Key::from(path.as_bytes()));
+        Ok(self
+            .range((key(bounds.start_bound()), key(bounds.end_bound())))
+            .await?)
     }
 }
 
-/// The seam's ordered walk: the database's own cursor, keyed by path.
-#[derive(Debug)]
-pub struct LdbCursor<'a, S, R: NodeRef> {
-    cursor: Cursor<'a, S, V1, R>,
-}
-
-impl<S, R> MapCursor<R> for LdbCursor<'_, S, R>
+/// The native cursor as the seam's ordered walk; reserved keys step over.
+impl<S, R> MapCursor<R> for Cursor<'_, S, V1, R>
 where
     S: TrustedGet<ContentOnlyChunkSet> + MaybeSend + MaybeSync,
     R: NodeRef,
 {
     type Error = ManifestError<LdbFormatError>;
 
-    fn next(
-        &mut self,
-    ) -> impl Future<Output = Result<Option<(ManifestPath, MapEntry<R>)>, Self::Error>> + MaybeSend
-    {
-        let cursor = &mut self.cursor;
-        async move {
-            // No reserved key is content, so the map steps over it.
-            while let Some((key, entry)) = cursor.next().await? {
-                if is_reserved(&key) {
-                    continue;
-                }
-                return Ok(Some((
-                    ManifestPath::new(key.as_bytes().to_vec()),
-                    mapped(entry),
-                )));
+    async fn next(&mut self) -> Result<Option<(ManifestPath, MapEntry<R>)>, Self::Error> {
+        while let Some((key, entry)) = Cursor::next(self).await? {
+            if !is_reserved(&key) {
+                return Ok(Some((path_of(&key), mapped(entry))));
             }
-            Ok(None)
         }
+        Ok(None)
     }
 }
 
-/// The database key `path` addresses, or `None` when it names no content key.
-///
-/// The key bytes are the path bytes verbatim. Neither reserved path is read,
-/// written or walked as a key.
+/// The database key `path` addresses verbatim, or `None` on a reserved path.
 fn content_key(path: &ManifestPath) -> Option<Key> {
     (!path.is_reserved()).then(|| Key::from(path.as_bytes()))
 }
 
 /// One database key as the path a read answers with.
-fn floored(key: Key) -> ManifestPath {
-    ManifestPath::new(key.as_bytes().to_vec())
+fn path_of(key: &Key) -> ManifestPath {
+    ManifestPath::from(key.as_bytes())
 }
 
 /// Whether `key` is one the map reserves rather than content.
@@ -443,43 +270,7 @@ fn is_reserved(key: &Key) -> bool {
     matches!(key.as_bytes(), [] | [ManifestPath::SEPARATOR])
 }
 
-/// Whether the database binds anything strictly below `key`.
-///
-/// `key` sorts first in its own prefix range, so the probe costs one seek and
-/// at most two steps.
-async fn bound_below<S, R>(
-    view: &View<'_, S, V1, R>,
-    key: &Key,
-) -> Result<bool, ManifestError<LdbFormatError>>
-where
-    S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
-    R: NodeRef,
-{
-    let mut cursor = view.prefix(key).await?;
-    while let Some((found, _)) = cursor.next().await? {
-        if found.as_bytes() != key.as_bytes() {
-            return Ok(true);
-        }
-    }
-    Ok(false)
-}
-
-/// The key bounds a path range selects, in the database's own key type.
-fn key_bounds(bounds: &impl RangeBounds<ManifestPath>) -> (Bound<Key>, Bound<Key>) {
-    (bound(bounds.start_bound()), bound(bounds.end_bound()))
-}
-
-/// One path bound as a key bound.
-fn bound(edge: Bound<&ManifestPath>) -> Bound<Key> {
-    match edge {
-        Bound::Unbounded => Bound::Unbounded,
-        Bound::Included(path) => Bound::Included(Key::from(path.as_bytes())),
-        Bound::Excluded(path) => Bound::Excluded(Key::from(path.as_bytes())),
-    }
-}
-
-/// One bound value as a seam entry: a reference of the caller's width, or an
-/// opaque value. A load still reaches an opaque value's bytes.
+/// One bound value as a seam entry; a load still reaches an opaque value.
 fn mapped<R: NodeRef>(entry: Entry<V1>) -> MapEntry<R> {
     match EntryRef::try_from(entry).map(R::from_entry_ref) {
         Ok(Ok(reference)) => MapEntry::Reference(reference),
@@ -487,15 +278,15 @@ fn mapped<R: NodeRef>(entry: Entry<V1>) -> MapEntry<R> {
     }
 }
 
-/// One folder-view child as a seam listing entry. A key bound to inline bytes,
-/// or to a reference of the other width, lists as a value.
+/// One folder-view child as a seam listing entry; an inline or other-width
+/// binding lists as a value.
 fn listed<R: NodeRef>(entry: DirEntry<V1>) -> ListEntry<R> {
     match entry {
         DirEntry::Dir { key } => ListEntry::Dir {
-            path: ManifestPath::new(key.as_bytes().to_vec()),
+            path: path_of(&key),
         },
         DirEntry::File { key, entry } => {
-            let path = ManifestPath::new(key.as_bytes().to_vec());
+            let path = path_of(&key);
             match mapped::<R>(entry) {
                 MapEntry::Reference(reference) => ListEntry::File { path, reference },
                 MapEntry::Opaque => ListEntry::Value { path },

--- a/crates/ldb/src/meta.rs
+++ b/crates/ldb/src/meta.rs
@@ -314,6 +314,66 @@ const fn pair_len<F: Format>(key: &MetadataKey<F>, value: &Bytes) -> usize {
         .saturating_add(value.len())
 }
 
+/// The typed key `key` names: a registered name promotes to its [`KeyId`],
+/// any other travels as a custom key when it fits.
+#[cfg(feature = "manifest")]
+fn meta_key(key: &nectar_manifest::WellKnownKey<'_>) -> Option<MetadataKey<V1>> {
+    let key = key.resolve();
+    let name = key.name();
+    KeyId::from_name(name.to_ascii_lowercase().as_bytes()).map_or_else(
+        || {
+            CustomKey::try_from(name.as_bytes())
+                .ok()
+                .map(MetadataKey::from)
+        },
+        |id| Some(id.into()),
+    )
+}
+
+/// The erased read of the typed registry; values cross as their stored bytes.
+#[cfg(feature = "manifest")]
+impl nectar_manifest::MetadataSource for Metadata<V1> {
+    fn get(&self, key: &nectar_manifest::WellKnownKey<'_>) -> Option<&[u8]> {
+        let key = meta_key(key)?;
+        Self::get(self, &key).map(Bytes::as_ref)
+    }
+
+    /// A registered id crosses under its registry name; a non-UTF-8 custom
+    /// key names no string and stays behind the static path.
+    fn for_each(&self, f: &mut dyn FnMut(&str, &[u8])) {
+        for (key, value) in self.iter() {
+            let name = match key {
+                MetadataKey::Known(id) => Some(id.name()),
+                MetadataKey::Custom(custom) => core::str::from_utf8(custom.as_bytes()).ok(),
+            };
+            if let Some(name) = name {
+                f(name, value.as_ref());
+            }
+        }
+    }
+}
+
+/// The rebuild keeps registered ids and custom keys alike; a pair past the
+/// format's encoded bound is dropped.
+#[cfg(feature = "manifest")]
+impl nectar_manifest::MetadataBlock for Metadata<V1> {
+    fn from_source(source: &dyn nectar_manifest::MetadataSource) -> Option<Self> {
+        let mut meta: Option<Self> = None;
+        source.for_each(&mut |name, value| {
+            let Some(key) = meta_key(&nectar_manifest::WellKnownKey::Custom(name)) else {
+                return;
+            };
+            let value = Bytes::copy_from_slice(value);
+            match meta.as_mut() {
+                // An over-budget insert leaves the block unchanged.
+                Some(block) => drop(block.insert(key, value)),
+                None => meta = Self::new(key, value).ok(),
+            }
+        });
+        meta
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::vec;


### PR DESCRIPTION
Closes #656

## What

Implements `Manifest<R>` directly on ldb `Database<S, K, V1>` and deletes the `LdbManifest` delegation shell (struct, constructors, accessors, and its `lib.rs` export). The read side follows the same move: `MapView` is implemented directly on the native `View` and `MapCursor` on the native `Cursor`, so the `LdbView` and `LdbCursor` wrapper structs are gone too. The seam keeps its reserved-key filtering in the trait methods, keeps the `floor` and `dir` overrides, and drops the redundant `contains_key` override because the seam default (`get().is_some()`) is semantically identical. `apply` still folds the checked `Batch` through the native `Editor` (one `Changeset`, one commit); `empty` still persists via the native `Builder`. The native `Database`/`View`/`Editor` surface is unchanged, and inherent methods keep winning on concrete receivers, so native callers see no difference.

The `Metadata<V1>` seam impls (`MetadataSource`, `MetadataBlock`, and their key promotion) moved next to the type in `meta.rs`, feature-gated on `manifest`.

All test call sites moved from `LdbManifest::plain`/`new` to `Database::plain`/`new`, with `Manifest::`-qualified calls where names clash with inherent `remove`/`at`.

## Diff

- `crates/ldb/src/lib.rs`: drops the `LdbManifest`, `LdbView`, and `LdbCursor` exports and names the seam in the crate docs.
- `crates/ldb/src/manifest.rs` (299 lines, was 508): deletes the delegation shell and both wrapper structs; the three seam impls ride the native types.
- `crates/ldb/src/meta.rs`: receives the `Metadata<V1>` seam impls, gated on the `manifest` feature.
- `crates/integration-tests/tests/ldb/reader.rs`: adds a regression test pinning that one `Database` value serves both the native and the seam contract on one root.
- `crates/integration-tests/tests/manifest/dyn_roundtrip.rs`, `encrypted.rs`, `listing.rs`, `root_config.rs`: call sites updated.

8 files changed, 284 insertions(+), 364 deletions(-).

## Testing

All checks run in the nix dev shell on `49f0abd3` (== `origin/manifest/656-ldb-database`).

- `git merge-base --is-ancestor origin/manifest/654-metadata HEAD` -> true (base `82ec10b8`).
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: clean.
- `cargo nextest run --workspace --locked`: 1221 passed, 1 skipped, 0 failed (mantaray bee vectors and the ldb wire pins green).
- `cargo test --doc --workspace --locked`: all doctests pass.
- no_std checks (`--no-default-features`) on `riscv64imac-unknown-none-elf` and `wasm32-unknown-unknown` for `nectar-manifest`, `nectar-ldb`, and `nectar-mantaray` (by manifest path): all pass.
- `cargo fmt`: touched files clean and stable.
- Diff scope is confined to the ldb crate and ldb/manifest integration tests. No `Cargo.toml` and no `Cargo.lock` delta.

## Red-team

Red-teamed the earlier tip of this branch (diff vs `origin/manifest/654-metadata`) and found no correctness defect. The current tip re-applies the same behavior in less code; two structural worries from that review still hold:

1. `Self::at(self, root)` cannot silently self-recurse: inherent resolution wins on the concrete `Database`, so only the native `Database::at` is reachable there, and the returned `View<'_, S, V1, R>` is exactly the trait's `View<'a>`.
2. Dropping the `contains_key` override is exactly equivalent to the seam default.

AI Assistance: Implement: claude-fable-5
