### PR TITLE
manifest: shared read machinery (S5)

### DIFF
--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -43,12 +43,8 @@ jobs:
                   # verification surface: it carries the BMT, the chunk
                   # carriers and single-owner recovery, and rides both
                   # targets bare.
-                  # nectar-manifest is the format-agnostic manifest seam: the
-                  # trait, the op vocabulary and the erased wrapper, with no
-                  # engine behind them.
                   cargo check --locked \
                     -p nectar-swarms -p nectar-contracts -p nectar-file \
-                    -p nectar-manifest \
                     -p nectar-marker -p nectar-clock -p nectar-governor \
                     -p nectar-postage -p nectar-postage-issuer \
                     -p nectar-primitives-core \
@@ -69,6 +65,12 @@ jobs:
                   cargo check --locked -p nectar-file \
                     --no-default-features --features primitives \
                     --target ${{ matrix.target }}
+            # The manifest seam's shared load lane pins nectar-file/primitives,
+            # which unification would leak into the bare pass above.
+            - name: Check nectar-manifest without std
+              run: |
+                  cargo check --locked -p nectar-manifest \
+                    --no-default-features --target ${{ matrix.target }}
             # The governor's chunk-typed fetch helper pins the primitives core,
             # which unification would leak into the bare pass above.
             - name: Check nectar-governor with the chunk helper

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2703,7 +2703,6 @@ dependencies = [
  "arbitrary",
  "bytes",
  "futures-util",
- "nectar-file",
  "nectar-governor",
  "nectar-ldb",
  "nectar-manifest",
@@ -2748,6 +2747,7 @@ dependencies = [
  "nectar-marker",
  "nectar-primitives",
  "nectar-tasks",
+ "nectar-testing",
  "thiserror",
 ]
 
@@ -2760,7 +2760,6 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "nectar-file",
  "nectar-governor",
  "nectar-manifest",
  "nectar-primitives",

--- a/crates/integration-tests/tests/manifest/common.rs
+++ b/crates/integration-tests/tests/manifest/common.rs
@@ -1,0 +1,56 @@
+//! Shared fixtures for the manifest seam tests.
+#![allow(dead_code)]
+
+use std::sync::Arc;
+
+use nectar_file::{File, Policy};
+use nectar_ldb::Database;
+use nectar_loadsave::NodeLoadSaver;
+use nectar_manifest::{Manifest, ManifestPath};
+use nectar_mantaray::MantarayManifest;
+use nectar_primitives::store::{ContentGet, MemoryStore};
+use nectar_primitives::{ChunkAddress, ChunkRef, DEFAULT_BODY_SIZE, StandardChunkSet};
+
+/// Shared chunk store: `MemoryStore` clones its contents, so every handle in
+/// one test has to reach the same map.
+pub type Raw = Arc<MemoryStore<StandardChunkSet>>;
+pub type Store = ContentGet<Raw>;
+pub type Nodes = NodeLoadSaver<Raw>;
+pub type Trie = MantarayManifest<Nodes, Store, DEFAULT_BODY_SIZE>;
+pub type Kv = Database<Store>;
+
+/// A fresh raw store and its content-addressed read handle.
+pub fn stores() -> (Raw, Store) {
+    let raw: Raw = Arc::new(MemoryStore::new());
+    let store = ContentGet::new(Arc::clone(&raw));
+    (raw, store)
+}
+
+/// Both formats over one raw store, each at its freshly persisted empty root.
+pub async fn both_formats(raw: &Raw, store: &Store) -> ((Trie, ChunkRef), (Kv, ChunkRef)) {
+    let trie: Trie = MantarayManifest::new(NodeLoadSaver::new(Arc::clone(raw)), store.clone());
+    let trie_empty = trie.empty().await.unwrap();
+    let kv = Database::<_>::plain(store.clone());
+    let kv_empty = kv.empty().await.unwrap();
+    ((trie, trie_empty), (kv, kv_empty))
+}
+
+/// `data` saved as a plain file tree, as the reference an entry binds.
+pub async fn save_file(raw: &Raw, data: &[u8]) -> ChunkRef {
+    ChunkRef::new(
+        File::<_, DEFAULT_BODY_SIZE>::new(raw, Policy::DEFAULT)
+            .save(data)
+            .await
+            .unwrap(),
+    )
+}
+
+/// A reference standing in for a file root; no chunk behind it is read.
+pub fn reference(byte: u8) -> ChunkRef {
+    ChunkRef::new(ChunkAddress::new([byte; 32]))
+}
+
+/// A path as text, for a readable assertion message.
+pub fn text(path: &ManifestPath) -> String {
+    String::from_utf8(path.as_bytes().to_vec()).unwrap()
+}

--- a/crates/integration-tests/tests/manifest/dyn_roundtrip.rs
+++ b/crates/integration-tests/tests/manifest/dyn_roundtrip.rs
@@ -5,23 +5,19 @@
 //! calls drive both, and the metadata a caller writes through the erased view
 //! lands in each format's own native slot.
 
-use nectar_file::{File, MemSink, Policy};
+use nectar_file::MemSink;
 use nectar_ldb::{Database, Reader as LdbReader};
 use nectar_loadsave::NodeLoadSaver;
 use nectar_manifest::{
     DynManifest, ManifestOp, ManifestPath, MetadataSource, MetadataView, SiteConfig, WellKnownKey,
 };
 use nectar_mantaray::{MantarayManifest, Reader as MantarayReader, metadata};
-use nectar_primitives::store::{ContentGet, MemoryStore};
-use nectar_primitives::{ChunkRef, DEFAULT_BODY_SIZE, StandardChunkSet};
+use nectar_primitives::{ChunkRef, DEFAULT_BODY_SIZE};
 use nectar_testing::run;
 use std::sync::Arc;
 
-/// The chunk store, shared: `MemoryStore` clones its contents, so every
-/// handle in one test has to reach the same map.
-type Raw = Arc<MemoryStore<StandardChunkSet>>;
-type Store = ContentGet<Raw>;
-type Nodes = NodeLoadSaver<Raw>;
+mod common;
+use common::{Nodes, save_file, stores};
 
 /// The file bytes every manifest entry in this test points at.
 fn payload() -> Vec<u8> {
@@ -233,15 +229,9 @@ async fn exercise(manifest: &dyn DynManifest, base: &ChunkRef, file: &ChunkRef, 
 #[test]
 fn both_formats_round_trip_through_one_erased_handle() {
     run(async {
-        let raw: Raw = Arc::new(MemoryStore::new());
-        let store: Store = ContentGet::new(Arc::clone(&raw));
+        let (raw, store) = stores();
         let data = payload();
-        let file = ChunkRef::new(
-            File::<_, DEFAULT_BODY_SIZE>::new(&raw, Policy::DEFAULT)
-                .save(&data[..])
-                .await
-                .unwrap(),
-        );
+        let file = save_file(&raw, &data).await;
 
         let nodes: Nodes = NodeLoadSaver::new(Arc::clone(&raw));
         let trie: Box<dyn DynManifest> = Box::new(
@@ -260,8 +250,7 @@ fn both_formats_round_trip_through_one_erased_handle() {
 #[test]
 fn the_site_config_lands_in_each_format_native_slot() {
     run(async {
-        let raw: Raw = Arc::new(MemoryStore::new());
-        let store: Store = ContentGet::new(Arc::clone(&raw));
+        let (raw, store) = stores();
         let config = SiteConfig::new().with_index_document(ManifestPath::from("index.html"));
 
         // The trie keeps the site documents on its root path node, which

--- a/crates/integration-tests/tests/manifest/encrypted.rs
+++ b/crates/integration-tests/tests/manifest/encrypted.rs
@@ -16,14 +16,11 @@ use nectar_manifest::{
     WellKnownKey,
 };
 use nectar_mantaray::MantarayManifest;
-use nectar_primitives::store::{ContentGet, MemoryStore};
-use nectar_primitives::{DEFAULT_BODY_SIZE, EncryptedChunkRef, StandardChunkSet};
+use nectar_primitives::{DEFAULT_BODY_SIZE, EncryptedChunkRef};
 use nectar_testing::run;
 
-/// The chunk store, shared: `MemoryStore` clones its contents, so every handle
-/// in one test has to reach the same map.
-type Raw = Arc<MemoryStore<StandardChunkSet>>;
-type Store = ContentGet<Raw>;
+mod common;
+use common::{Store, stores};
 
 /// The secret an encrypted key-value database derives its keys from.
 const SECRET: &[u8] = b"an encrypted database secret";
@@ -86,8 +83,7 @@ async fn exercise<M: Manifest<EncryptedChunkRef>>(
 #[test]
 fn both_formats_drive_an_encrypted_manifest() {
     run(async {
-        let raw: Raw = Arc::new(MemoryStore::new());
-        let store = ContentGet::new(Arc::clone(&raw));
+        let (raw, store) = stores();
         let data: Vec<u8> = (0..9_000u32)
             .map(|i| u8::try_from(i % 241).unwrap())
             .collect();

--- a/crates/integration-tests/tests/manifest/listing.rs
+++ b/crates/integration-tests/tests/manifest/listing.rs
@@ -3,26 +3,24 @@
 //!
 //! A listing is where the two formats are furthest apart internally: the
 //! key-value database seeks past each named subtree, while the trie walks the
-//! whole subtree under the prefix and collapses it in the adapter. The seam is
+//! whole subtree under the prefix and collapses it in the seam. The seam is
 //! only worth holding if those two arrive at the same answer, so the answer is
 //! pinned against a model rather than against either implementation.
 
 use std::collections::BTreeSet;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
-use nectar_file::{File, Policy};
-use nectar_ldb::{Builder, Database, Plaintext, V1};
 use nectar_loadsave::NodeLoadSaver;
-use nectar_manifest::{DynManifest, ManifestOp, ManifestPath, MetadataSource};
-use nectar_mantaray::{ManifestEditor, MantarayManifest};
-use nectar_primitives::store::{ContentGet, MemoryStore};
-use nectar_primitives::{ChunkRef, DEFAULT_BODY_SIZE, StandardChunkSet};
+use nectar_manifest::{
+    Batch, DynManifest, Manifest, ManifestOp, ManifestPath, MapCursor, MapView, MetadataSource,
+};
+use nectar_mantaray::{MantarayManifest, NodeLoader, NodeSaver};
+use nectar_primitives::{ChunkRef, DEFAULT_BODY_SIZE, EntryRef};
 use nectar_testing::run;
 
-/// The chunk store, shared: `MemoryStore` clones its contents, so every handle
-/// in one test has to reach the same map.
-type Raw = Arc<MemoryStore<StandardChunkSet>>;
-type Store = ContentGet<Raw>;
+mod common;
+use common::{Nodes, both_formats, reference, save_file, stores};
 
 /// Key sets that put a byte either side of the separator next to it, name a
 /// directory that is also a file, and nest deeper than one level.
@@ -111,28 +109,14 @@ fn expected(keys: &[&str], dir: &str) -> Vec<String> {
 fn both_formats_list_a_level_the_way_the_model_does() {
     run(async {
         for keys in SETS {
-            let raw: Raw = Arc::new(MemoryStore::new());
-            let store: Store = ContentGet::new(Arc::clone(&raw));
-            let file = ChunkRef::new(
-                File::<_, DEFAULT_BODY_SIZE>::new(&raw, Policy::DEFAULT)
-                    .save(&b"payload"[..])
-                    .await
-                    .unwrap(),
-            );
-
-            let nodes = NodeLoadSaver::new(Arc::clone(&raw));
-            let editor: ManifestEditor<_> = ManifestEditor::new(nodes.clone());
-            let (empty, _) = editor.commit().await.unwrap();
-            let trie = MantarayManifest::<_, _, DEFAULT_BODY_SIZE>::new(nodes, store.clone());
+            let (raw, store) = stores();
+            let file = save_file(&raw, b"payload").await;
+            let ((trie, trie_empty), (kv, kv_empty)) = both_formats(&raw, &store).await;
             let trie_root = trie
-                .dyn_apply(&ChunkRef::new(empty), inserts(keys, &file))
+                .dyn_apply(&trie_empty, inserts(keys, &file))
                 .await
                 .unwrap();
-
-            let builder: Builder<V1> = Builder::new();
-            let empty = *builder.build(&store, &Plaintext).await.unwrap().root();
-            let kv = Database::<_>::plain(store.clone());
-            let kv_root = kv.dyn_apply(&empty, inserts(keys, &file)).await.unwrap();
+            let kv_root = kv.dyn_apply(&kv_empty, inserts(keys, &file)).await.unwrap();
 
             for dir in DIRS {
                 let want = expected(keys, dir);
@@ -140,5 +124,84 @@ fn both_formats_list_a_level_the_way_the_model_does() {
                 assert_eq!(listed(&kv, &kv_root, dir).await, want, "kv {dir:?}");
             }
         }
+    });
+}
+
+/// The trie's node seam, counting every load a walk touches.
+#[derive(Clone)]
+struct Counting {
+    inner: Nodes,
+    loads: Arc<AtomicUsize>,
+}
+
+impl Counting {
+    /// The loads since the last take.
+    fn take(&self) -> usize {
+        self.loads.swap(0, Ordering::SeqCst)
+    }
+}
+
+impl NodeLoader for Counting {
+    type Error = <Nodes as NodeLoader>::Error;
+
+    async fn load(&self, reference: &EntryRef) -> Result<Vec<u8>, Self::Error> {
+        self.loads.fetch_add(1, Ordering::SeqCst);
+        self.inner.load(reference).await
+    }
+}
+
+impl NodeSaver<ChunkRef> for Counting {
+    type Error = <Nodes as NodeSaver<ChunkRef>>::Error;
+
+    async fn save(&self, data: Vec<u8>) -> Result<ChunkRef, Self::Error> {
+        <Nodes as NodeSaver<ChunkRef>>::save(&self.inner, data).await
+    }
+}
+
+/// Listing one directory level costs its own subtree, not the whole map: the
+/// trie seeks to the listed prefix instead of the seam's walking default.
+#[test]
+fn listing_one_level_costs_that_subtree_alone() {
+    run(async {
+        let (raw, store) = stores();
+        let nodes = Counting {
+            inner: NodeLoadSaver::new(Arc::clone(&raw)),
+            loads: Arc::default(),
+        };
+        let trie: MantarayManifest<_, _, DEFAULT_BODY_SIZE> =
+            MantarayManifest::new(nodes.clone(), store);
+
+        // Twenty-six top-level folders, so a walk that starts at the trie
+        // root pays every folder before the listed one.
+        let mut batch: Batch<ChunkRef, _> = Batch::new();
+        for letter in b'a'..=b'z' {
+            for index in 0..8u32 {
+                let path = format!("{0}{0}{0}/{index}.bin", char::from(letter));
+                batch.insert(ManifestPath::from(path.as_str()), reference(letter));
+            }
+        }
+        let root = trie.empty().await.unwrap();
+        let root = trie.apply(root, batch).await.unwrap();
+
+        let view = trie.at(&root);
+        nodes.take();
+        let listing = view.dir(&ManifestPath::from("zzz/")).await.unwrap();
+        let level = nodes.take();
+        assert_eq!(listing.entries().len(), 8);
+
+        let mut cursor = view.iter().await.unwrap();
+        let mut keys = 0;
+        while cursor.next().await.unwrap().is_some() {
+            keys += 1;
+        }
+        let whole = nodes.take();
+        assert_eq!(keys, 26 * 8);
+
+        // The last folder is a twenty-sixth of the map, so a pruned seek is
+        // an order below the full walk. A filtering walk would tie.
+        assert!(
+            level * 4 < whole,
+            "listing loaded {level} nodes, the whole trie {whole}"
+        );
     });
 }

--- a/crates/integration-tests/tests/manifest/metadata.rs
+++ b/crates/integration-tests/tests/manifest/metadata.rs
@@ -14,9 +14,11 @@ use nectar_manifest::{
     DynManifest, ManifestMeta, ManifestPath, MetadataSource, MetadataView, WellKnownKey,
 };
 use nectar_mantaray::{MantarayManifest, Reader as MantarayReader, metadata};
-use nectar_primitives::store::{ContentGet, MemoryStore};
-use nectar_primitives::{ChunkAddress, ChunkRef, DEFAULT_BODY_SIZE, StandardChunkSet};
+use nectar_primitives::{ChunkAddress, ChunkRef, DEFAULT_BODY_SIZE};
 use nectar_testing::run;
+
+mod common;
+use common::stores;
 
 /// The registry rebuilt from `source`.
 fn kv(source: &dyn MetadataSource) -> Option<Metadata<V1>> {
@@ -221,9 +223,8 @@ fn registry_values_cross_as_bytes() {
 #[test]
 fn an_erased_write_lands_the_reference_client_spelling_in_the_trie() {
     run(async {
-        let raw = Arc::new(MemoryStore::<StandardChunkSet>::new());
+        let (raw, store) = stores();
         let nodes = NodeLoadSaver::new(Arc::clone(&raw));
-        let store = ContentGet::new(Arc::clone(&raw));
         let trie = MantarayManifest::<_, _, DEFAULT_BODY_SIZE>::new(nodes.clone(), store);
         let base = trie.dyn_empty().await.unwrap();
         let path = ManifestPath::from("index.html");

--- a/crates/integration-tests/tests/manifest/root_config.rs
+++ b/crates/integration-tests/tests/manifest/root_config.rs
@@ -34,33 +34,20 @@
 use std::ops::Bound;
 use std::sync::Arc;
 
+use bytes::Bytes;
 use nectar_file::{DataSink, File, MemSink, Policy};
 use nectar_ldb::{Builder, Database, Entry, Key, Plaintext, Reader as LdbReader, Served, V1, Website};
 use nectar_loadsave::NodeLoadSaver;
 use nectar_manifest::{
-    Batch, Manifest, ManifestError, ManifestMeta, ManifestOp, ManifestPath, MapCursor, MapEntry,
-    MapView, MetadataView, WellKnownKey,
+    Batch, ListEntry, Manifest, ManifestError, ManifestMeta, ManifestOp, ManifestPath, MapCursor,
+    MapEntry, MapView, MetadataView, WellKnownKey,
 };
 use nectar_mantaray::{ManifestEditor, MantarayManifest};
-use nectar_primitives::store::{ContentGet, MemoryStore};
-use nectar_primitives::{ChunkAddress, ChunkRef, DEFAULT_BODY_SIZE, StandardChunkSet};
+use nectar_primitives::{ChunkRef, DEFAULT_BODY_SIZE, EncryptedChunkRef, EncryptionKey};
 use nectar_testing::run;
 
-/// Shared: `MemoryStore` clones its contents, so every handle in one test has
-/// to reach the same map.
-type Raw = Arc<MemoryStore<StandardChunkSet>>;
-type Store = ContentGet<Raw>;
-type Trie = MantarayManifest<NodeLoadSaver<Raw>, Store, DEFAULT_BODY_SIZE>;
-type Kv = Database<Store>;
-
-/// Both formats over one raw store, each at its freshly persisted empty root.
-async fn both_formats(raw: &Raw, store: &Store) -> ((Trie, ChunkRef), (Kv, ChunkRef)) {
-    let trie: Trie = MantarayManifest::new(NodeLoadSaver::new(Arc::clone(raw)), store.clone());
-    let trie_empty = trie.empty().await.unwrap();
-    let kv = Database::<_>::plain(store.clone());
-    let kv_empty = kv.empty().await.unwrap();
-    ((trie, trie_empty), (kv, kv_empty))
-}
+mod common;
+use common::{both_formats, reference, text};
 
 /// `keys` written through the seam in one batch, each bound to a distinct
 /// reference.
@@ -81,16 +68,6 @@ async fn write_keys<M: Manifest<ChunkRef>>(
 const INDEX: &str = "index.html";
 /// One whole content key.
 const ERROR: &str = "404.html";
-
-/// A reference standing in for a file root; no chunk behind it is read.
-fn reference(byte: u8) -> ChunkRef {
-    ChunkRef::new(ChunkAddress::new([byte; 32]))
-}
-
-/// A path as text, for a readable assertion message.
-fn text(path: &ManifestPath) -> String {
-    String::from_utf8(path.as_bytes().to_vec()).unwrap()
-}
 
 /// The reserved path a refused write names, structurally over every format.
 fn refused<T, F>(result: &Result<T, ManifestError<F>>) -> Option<ManifestPath> {
@@ -703,8 +680,7 @@ macro_rules! differential {
         #[test]
         fn $name() {
             run(async {
-                let raw: Raw = Arc::new(MemoryStore::new());
-                let store: Store = ContentGet::new(Arc::clone(&raw));
+                let (raw, store) = common::stores();
                 let ((trie, trie_empty), (kv, kv_empty)) = both_formats(&raw, &store).await;
                 let from_trie = $scenario(&trie, &trie_empty).await;
                 let from_kv = $scenario(&kv, &kv_empty).await;
@@ -735,8 +711,7 @@ differential!(
 #[test]
 fn a_remove_is_history_independent_on_ldb() {
     run(async {
-        let raw: Raw = Arc::new(MemoryStore::new());
-        let store: Store = ContentGet::new(raw);
+        let (_raw, store) = common::stores();
         let builder: Builder<V1> = Builder::new();
         let empty = *builder.build(&store, &Plaintext).await.unwrap().root();
         let kv = Database::<_>::plain(store.clone());
@@ -811,8 +786,7 @@ where
 #[test]
 fn a_batch_folds_in_submission_order_on_both_formats() {
     run(async {
-        let raw: Raw = Arc::new(MemoryStore::new());
-        let store: Store = ContentGet::new(Arc::clone(&raw));
+        let (raw, store) = common::stores();
         let ((trie, trie_empty), (kv, kv_empty)) = both_formats(&raw, &store).await;
         a_batch_folds_in_submission_order(&trie, &trie_empty).await;
         a_batch_folds_in_submission_order(&kv, &kv_empty).await;
@@ -825,8 +799,7 @@ fn a_batch_folds_in_submission_order_on_both_formats() {
 #[test]
 fn the_reserved_refusal_precedes_the_format() {
     run(async {
-        let raw: Raw = Arc::new(MemoryStore::new());
-        let store: Store = ContentGet::new(Arc::clone(&raw));
+        let (raw, store) = common::stores();
         let ((trie, _), (kv, _)) = both_formats(&raw, &store).await;
         // No chunk lives behind this root.
         let garbage = reference(0xEE);
@@ -925,8 +898,7 @@ fn separator_prefixed_content_lists_alike_on_both_formats() {
 
 /// One key set through both formats' `dir("")`, written through the seam.
 async fn both_top_levels(keys: &[&str]) -> (Vec<String>, Vec<String>) {
-    let raw: Raw = Arc::new(MemoryStore::new());
-    let store: Store = ContentGet::new(Arc::clone(&raw));
+    let (raw, store) = common::stores();
     let ((trie, trie_empty), (kv, kv_empty)) = both_formats(&raw, &store).await;
     let trie_root = write_keys(&trie, &trie_empty, keys).await;
     let kv_root = write_keys(&kv, &kv_empty, keys).await;
@@ -988,8 +960,7 @@ where
 #[test]
 fn an_insert_replaces_the_whole_binding_on_both_formats() {
     run(async {
-        let raw: Raw = Arc::new(MemoryStore::new());
-        let store: Store = ContentGet::new(Arc::clone(&raw));
+        let (raw, store) = common::stores();
         let ((trie, trie_empty), (kv, kv_empty)) = both_formats(&raw, &store).await;
         insert_replaces_the_whole_binding(&trie, &trie_empty).await;
         insert_replaces_the_whole_binding(&kv, &kv_empty).await;
@@ -1016,8 +987,7 @@ async fn assert_empty_bootstrap<M: Manifest<ChunkRef>>(manifest: &M, native: Chu
 #[test]
 fn the_seam_bootstrap_matches_each_format() {
     run(async {
-        let raw: Raw = Arc::new(MemoryStore::new());
-        let store: Store = ContentGet::new(Arc::clone(&raw));
+        let (raw, store) = common::stores();
 
         let nodes = NodeLoadSaver::new(Arc::clone(&raw));
         let editor: ManifestEditor<_> = ManifestEditor::new(nodes.clone());
@@ -1053,8 +1023,7 @@ async fn assert_sink_refusal<M: Manifest<ChunkRef>>(manifest: &M, file: ChunkRef
 #[test]
 fn a_refused_sink_write_is_sink_on_both_formats() {
     run(async {
-        let raw: Raw = Arc::new(MemoryStore::new());
-        let store: Store = ContentGet::new(Arc::clone(&raw));
+        let (raw, store) = common::stores();
         let data = vec![7u8; 20_000];
         let saver = File::<_, DEFAULT_BODY_SIZE>::new(&raw, Policy::DEFAULT);
         let file = ChunkRef::new(saver.save(&data[..]).await.unwrap());
@@ -1093,8 +1062,7 @@ impl DataSink for RefusingSink {
 #[test]
 fn a_planted_separator_key_is_not_listed() {
     run(async {
-        let raw: Raw = Arc::new(MemoryStore::new());
-        let store: Store = ContentGet::new(Arc::clone(&raw));
+        let (raw, store) = common::stores();
         let separator = ManifestPath::from("/");
         let content = ManifestPath::from("a.txt");
 
@@ -1177,8 +1145,7 @@ fn a_planted_separator_key_is_not_listed() {
 #[test]
 fn website_documents_resolve_over_bare_keys() {
     run(async {
-        let raw: Raw = Arc::new(MemoryStore::new());
-        let store: Store = ContentGet::new(raw);
+        let (_raw, store) = common::stores();
         let builder: Builder<V1> = Builder::new();
         let empty = *builder.build(&store, &Plaintext).await.unwrap().root();
         let kv = Database::<_>::plain(store.clone());
@@ -1267,5 +1234,130 @@ fn website_documents_resolve_over_bare_keys() {
             ("missing", String::new()),
             "no documents are declared, so nothing resolves"
         );
+    });
+}
+
+/// The bytes an inline entry carries in the manifest itself.
+const INLINE: &[u8] = b"carried by the manifest itself";
+/// The bytes a plain reference stores behind the manifest.
+const FILE_DATA: &[u8] = b"stored behind a reference";
+
+/// `get` on one path, through the seam.
+async fn got<V: MapView<ChunkRef>>(view: &V, path: &str) -> MapEntry<ChunkRef> {
+    view.get(&ManifestPath::from(path)).await.unwrap().unwrap()
+}
+
+/// `load` on one path, through the seam: the outcome and what reached the sink.
+async fn loaded_bytes<V: MapView<ChunkRef>>(
+    view: &V,
+    path: &str,
+) -> (Result<(), V::Error>, Vec<u8>) {
+    let mut sink = MemSink::new();
+    let result = view.load(&ManifestPath::from(path), &mut sink).await;
+    (result, sink.as_ref().to_vec())
+}
+
+/// `MapEntry::Value` conformance on the key-value format: `get` answers
+/// `Reference`, `Value` or `Opaque`, `load` serves exactly the loadable two,
+/// and every walk carries the kind. An inline value loads from the manifest
+/// itself; a reference the caller's width cannot hold reads as `Opaque` and
+/// loads as `NoData`, before any store fetch.
+#[test]
+fn an_inline_entry_is_a_loadable_value_and_opaque_is_not() {
+    run(async {
+        let (raw, store) = common::stores();
+        let file = common::save_file(&raw, FILE_DATA).await;
+        let wide = EncryptedChunkRef::new(*file.address(), EncryptionKey::from([0x5a; 32]));
+        let db = Database::plain(store.clone());
+        let empty: ChunkRef = db.empty().await.unwrap();
+        let mut editor = db.edit(&empty);
+        editor
+            .insert(
+                Key::from(&b"docs/inline.txt"[..]),
+                Entry::inline(Bytes::from_static(INLINE)).unwrap(),
+            )
+            .insert(Key::from(&b"docs/plain.bin"[..]), Entry::from(file))
+            .insert(Key::from(&b"docs/wide.bin"[..]), Entry::from(wide));
+        let root = editor.commit().await.unwrap();
+        let view = Manifest::<ChunkRef>::at(&db, &root);
+
+        // `get` discriminates the three entry kinds.
+        let inline = got(&view, "docs/inline.txt").await;
+        assert_eq!(inline, MapEntry::Value);
+        assert!(inline.is_loadable());
+        let opaque = got(&view, "docs/wide.bin").await;
+        assert_eq!(opaque, MapEntry::Opaque);
+        assert!(!opaque.is_loadable());
+        assert!(matches!(
+            got(&view, "docs/plain.bin").await,
+            MapEntry::Reference(_)
+        ));
+
+        // `load` serves exactly the loadable entries.
+        let (result, bytes) = loaded_bytes(&view, "docs/inline.txt").await;
+        result.unwrap();
+        assert_eq!(bytes, INLINE);
+        let (result, bytes) = loaded_bytes(&view, "docs/plain.bin").await;
+        result.unwrap();
+        assert_eq!(bytes, FILE_DATA);
+        let (result, bytes) = loaded_bytes(&view, "docs/wide.bin").await;
+        let err = result.unwrap_err();
+        assert!(matches!(err, ManifestError::NoData(path) if path.as_bytes() == b"docs/wide.bin"));
+        assert!(bytes.is_empty());
+
+        // The full walk yields the three kinds in path order.
+        let expect = |pairs: &[(&str, bool)]| -> Vec<(String, bool)> {
+            pairs.iter().map(|(p, k)| ((*p).to_owned(), *k)).collect()
+        };
+        let mut kinds = Vec::new();
+        let mut cursor = MapView::<ChunkRef>::iter(&view).await.unwrap();
+        while let Some((path, entry)) = cursor.next().await.unwrap() {
+            kinds.push((text(&path), entry.is_loadable()));
+        }
+        assert_eq!(
+            kinds,
+            expect(&[
+                ("docs/inline.txt", true),
+                ("docs/plain.bin", true),
+                ("docs/wide.bin", false),
+            ])
+        );
+
+        // A bounded walk keeps the kind discrimination.
+        let bounds = (
+            Bound::Included(ManifestPath::from("docs/inline.txt")),
+            Bound::Excluded(ManifestPath::from("docs/wide.bin")),
+        );
+        assert_eq!(
+            drain(&view, bounds).await,
+            ["docs/inline.txt", "docs/plain.bin"]
+        );
+
+        // The folder view lists an inline value and an opaque reference both
+        // as values, never fetching either.
+        let listing = MapView::<ChunkRef>::dir(&view, &ManifestPath::from("docs/"))
+            .await
+            .unwrap();
+        let listed: Vec<(String, bool)> = listing
+            .entries()
+            .iter()
+            .map(|entry| (text(entry.path()), matches!(entry, ListEntry::Value { .. })))
+            .collect();
+        assert_eq!(
+            listed,
+            expect(&[
+                ("docs/inline.txt", true),
+                ("docs/plain.bin", false),
+                ("docs/wide.bin", true),
+            ])
+        );
+
+        // The ordered seek answers with the entry kind too.
+        let floored = MapView::<ChunkRef>::floor(&view, &ManifestPath::from("docs/inline.zzz"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(floored.0.as_bytes(), b"docs/inline.txt");
+        assert_eq!(floored.1, MapEntry::Value);
     });
 }

--- a/crates/ldb/Cargo.toml
+++ b/crates/ldb/Cargo.toml
@@ -24,7 +24,6 @@ bytes.workspace = true
 # The walk substrate: the in-flight set the hand-rolled loops admit into and
 # the `Stream` trait they poll it through.
 futures-util = { workspace = true }
-nectar-file = { workspace = true, optional = true }
 nectar-governor = { workspace = true }
 nectar-manifest = { workspace = true, optional = true }
 nectar-primitives = { workspace = true }
@@ -46,7 +45,6 @@ default = [ "std" ]
 arbitrary = [
 	"alloy-primitives/arbitrary",
 	"dep:arbitrary",
-	"nectar-file?/arbitrary",
 	"nectar-primitives/arbitrary",
 	"std",
 ]
@@ -59,13 +57,12 @@ arbitrary = [
 # the surface opt-in.
 encryption = []
 # The shared `Manifest` seam: the folder view as one implementation of it,
-# with entry data joined through the file pipeline. Implies `std`.
-manifest = [ "dep:nectar-file", "dep:nectar-manifest", "std" ]
+# with entry data joined through the seam's shared load lane. Implies `std`.
+manifest = [ "dep:nectar-manifest", "std" ]
 std = [
 	"alloy-primitives/std",
 	"bytes/std",
 	"futures-util/std",
-	"nectar-file?/std",
 	"nectar-manifest?/std",
 	"nectar-primitives/std",
 	"thiserror/std",
@@ -73,7 +70,6 @@ std = [
 # Single-thread send escape: relaxes the boxed fetch futures off `Send` in
 # lockstep with the store traits.
 unsync = [
-	"nectar-file?/unsync",
 	"nectar-governor/unsync",
 	"nectar-manifest?/unsync",
 	"nectar-primitives/unsync",

--- a/crates/ldb/src/manifest.rs
+++ b/crates/ldb/src/manifest.rs
@@ -4,13 +4,13 @@
 //! concrete types, so a seam call names the trait: `Manifest::at(&db, root)`.
 
 use alloc::vec::Vec;
-use core::ops::{Bound, RangeBounds};
+use core::ops::Bound;
 
 use bytes::Bytes;
-use nectar_file::{File, LoadError, Policy};
 use nectar_manifest::{
     Batch, DataSink, ListEntry, Listing, Manifest, ManifestError, ManifestOp, ManifestPath,
-    MapCursor, MapEntry, MapView, SinkError, SiteConfig,
+    MapCursor, MapEntry, MapView, PathCursor, RawCursor, RawItem, SinkError, SiteConfig,
+    load_reference,
 };
 use nectar_primitives::EntryRef;
 use nectar_primitives::chunk::ContentOnlyChunkSet;
@@ -119,13 +119,13 @@ where
 
     type Error = ManifestError<LdbFormatError>;
 
-    type Cursor = Cursor<'a, S, V1, R>;
+    type Cursor = PathCursor<Cursor<'a, S, V1, R>>;
 
     async fn get(&self, path: &ManifestPath) -> Result<Option<MapEntry<R>>, Self::Error> {
-        let Some(key) = content_key(path) else {
+        let Some(key) = path.content_key().map(Key::from) else {
             return Ok(None);
         };
-        Ok(self.get(&key).await?.map(mapped))
+        Ok(self.get(&key).await?.map(seam_entry))
     }
 
     async fn site_config(&self) -> Result<SiteConfig, Self::Error> {
@@ -137,7 +137,7 @@ where
     }
 
     async fn metadata(&self, path: &ManifestPath) -> Result<Self::Metadata, Self::Error> {
-        let Some(key) = content_key(path) else {
+        let Some(key) = path.content_key().map(Key::from) else {
             return Ok(None);
         };
         Ok(self.metadata(&key).await?)
@@ -151,13 +151,14 @@ where
         let key = Key::from(path.as_bytes());
         match self.floor(&key).await? {
             None => Ok(None),
-            Some((found, entry)) if !is_reserved(&found) => {
-                Ok(Some((path_of(&found), mapped(entry))))
+            Some((found, entry)) if !ManifestPath::is_reserved_bytes(found.as_bytes()) => {
+                Ok(Some((path_of(&found), seam_entry(entry))))
             }
             // The seek landed on a reserved key: the greatest content key
             // below it answers.
             Some(_) => {
-                let mut cursor = self.range((Bound::Unbounded, Bound::Included(key))).await?;
+                let mut cursor =
+                    PathCursor::new(self.range((Bound::Unbounded, Bound::Included(key))).await?);
                 let mut last = None;
                 while let Some(pair) = MapCursor::next(&mut cursor).await? {
                     last = Some(pair);
@@ -174,7 +175,7 @@ where
             // At the bare separator the folder view names both the reserved
             // key and the directory of content below it: hide the slot, list
             // the directory.
-            if is_reserved(item.key()) {
+            if ManifestPath::is_reserved_bytes(item.key().as_bytes()) {
                 let mut probe = self.prefix(item.key()).await?;
                 let mut below = false;
                 while let Some((found, _)) = probe.next().await? {
@@ -197,7 +198,7 @@ where
         path: &ManifestPath,
         sink: &mut T,
     ) -> Result<(), Self::Error> {
-        let entry = match content_key(path) {
+        let entry = match path.content_key().map(Key::from) {
             Some(key) => self.get(&key).await?,
             None => None,
         }
@@ -212,52 +213,44 @@ where
             Entry::Ref32(reference) => EntryRef::Plain(reference),
             Entry::Ref64(reference) => EntryRef::Encrypted(reference),
         };
-        File::new(self.store().clone(), Policy::DEFAULT)
-            .load(reference, sink)
-            .await
-            .map(drop)
-            .map_err(|error| match error {
-                LoadError::Sink { source, .. } => ManifestError::sink(source),
-                data => ManifestError::data(data),
-            })
+        // Load success tracks `get`: a reference the caller's width cannot
+        // hold reads as opaque and loads as no data.
+        let reference =
+            R::from_entry_ref(reference).map_err(|_| ManifestError::NoData(path.clone()))?;
+        load_reference(self.store().clone(), reference.into_entry_ref(), sink).await
     }
 
     async fn iter(&self) -> Result<Self::Cursor, Self::Error> {
-        Ok(self.iter().await?)
+        Ok(PathCursor::new(self.iter().await?))
     }
 
     async fn range(
         &self,
-        bounds: impl RangeBounds<ManifestPath> + MaybeSend,
+        bounds: (Bound<ManifestPath>, Bound<ManifestPath>),
     ) -> Result<Self::Cursor, Self::Error> {
-        let key = |edge: Bound<&ManifestPath>| edge.map(|path| Key::from(path.as_bytes()));
-        Ok(self
-            .range((key(bounds.start_bound()), key(bounds.end_bound())))
-            .await?)
+        let key = |path: ManifestPath| Key::from(path.into_bytes());
+        // The native walk seeks to the bounds, so the seam wrapper only skips
+        // the reserved keys.
+        Ok(PathCursor::new(
+            self.range((bounds.0.map(key), bounds.1.map(key))).await?,
+        ))
     }
 }
 
-/// The native cursor as the seam's ordered walk; reserved keys step over.
-impl<S, R> MapCursor<R> for Cursor<'_, S, V1, R>
+/// The database's raw ordered walk: every stored key, the reserved slots
+/// included.
+impl<S, R> RawCursor<R> for Cursor<'_, S, V1, R>
 where
     S: TrustedGet<ContentOnlyChunkSet> + MaybeSend + MaybeSync,
     R: NodeRef,
 {
     type Error = ManifestError<LdbFormatError>;
 
-    async fn next(&mut self) -> Result<Option<(ManifestPath, MapEntry<R>)>, Self::Error> {
-        while let Some((key, entry)) = Cursor::next(self).await? {
-            if !is_reserved(&key) {
-                return Ok(Some((path_of(&key), mapped(entry))));
-            }
-        }
-        Ok(None)
+    async fn next(&mut self) -> Result<Option<RawItem<R>>, Self::Error> {
+        Ok(Cursor::next(self)
+            .await?
+            .map(|(key, entry)| (key.as_bytes().to_vec(), seam_entry(entry))))
     }
-}
-
-/// The database key `path` addresses verbatim, or `None` on a reserved path.
-fn content_key(path: &ManifestPath) -> Option<Key> {
-    (!path.is_reserved()).then(|| Key::from(path.as_bytes()))
 }
 
 /// One database key as the path a read answers with.
@@ -265,17 +258,10 @@ fn path_of(key: &Key) -> ManifestPath {
     ManifestPath::from(key.as_bytes())
 }
 
-/// Whether `key` is one the map reserves rather than content.
-fn is_reserved(key: &Key) -> bool {
-    matches!(key.as_bytes(), [] | [ManifestPath::SEPARATOR])
-}
-
-/// One bound value as a seam entry; a load still reaches an opaque value.
-fn mapped<R: NodeRef>(entry: Entry<V1>) -> MapEntry<R> {
-    match EntryRef::try_from(entry).map(R::from_entry_ref) {
-        Ok(Ok(reference)) => MapEntry::Reference(reference),
-        Ok(Err(_)) | Err(_) => MapEntry::Opaque,
-    }
+/// One bound value as a seam entry: a reference at the caller's width, the
+/// manifest-carried inline value, or opaque when the width does not fit.
+fn seam_entry<R: NodeRef>(entry: Entry<V1>) -> MapEntry<R> {
+    EntryRef::try_from(entry).map_or(MapEntry::Value, MapEntry::from_entry_ref)
 }
 
 /// One folder-view child as a seam listing entry; an inline or other-width
@@ -287,9 +273,9 @@ fn listed<R: NodeRef>(entry: DirEntry<V1>) -> ListEntry<R> {
         },
         DirEntry::File { key, entry } => {
             let path = path_of(&key);
-            match mapped::<R>(entry) {
+            match seam_entry::<R>(entry) {
                 MapEntry::Reference(reference) => ListEntry::File { path, reference },
-                MapEntry::Opaque => ListEntry::Value { path },
+                MapEntry::Value | MapEntry::Opaque => ListEntry::Value { path },
             }
         }
     }

--- a/crates/manifest/Cargo.toml
+++ b/crates/manifest/Cargo.toml
@@ -20,14 +20,17 @@ workspace = true
 [dependencies]
 auto_impl = { workspace = true }
 derive_more = { workspace = true }
-# The positional sink a load writes into; the bare dependency carries the
-# sink module alone, no engine and no primitives.
-nectar-file = { workspace = true }
+# The shared load lane and the positional sink it writes into: the alloc-only
+# engine core plus the sink module.
+nectar-file = { workspace = true, features = ["primitives"] }
 nectar-marker = { workspace = true }
 # Reference, ChunkRef and the boxed-error alias the erased seam reports through.
 nectar-primitives = { workspace = true }
 nectar-tasks = { workspace = true }
 thiserror = { workspace = true }
+
+[dev-dependencies]
+nectar-testing.workspace = true
 
 [features]
 default = [ "std" ]

--- a/crates/manifest/src/cursor.rs
+++ b/crates/manifest/src/cursor.rs
@@ -1,0 +1,99 @@
+//! Seam-owned walk machinery: a format's raw byte-key cursor lifted into the
+//! ordered path walk.
+
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+use core::future::Future;
+use core::ops::Bound;
+
+use nectar_marker::{MaybeSend, MaybeSync};
+use nectar_primitives::chunk::{ChunkRef, Reference};
+
+use crate::path::ManifestPath;
+use crate::view::{MapCursor, MapEntry};
+
+#[cfg(test)]
+mod tests;
+
+/// One raw walk step: the key bytes and the entry bound at them.
+pub type RawItem<R> = (Vec<u8>, MapEntry<R>);
+
+/// A format's raw ordered walk: byte keys with their entries, reserved keys
+/// included; [`PathCursor`] applies the shared key law on top.
+pub trait RawCursor<R: Reference + MaybeSend = ChunkRef>: MaybeSend {
+    /// Error type a walk fails with.
+    type Error: core::error::Error + MaybeSend + MaybeSync + 'static;
+
+    /// The next `(key bytes, entry)` in byte order.
+    fn next(&mut self)
+    -> impl Future<Output = Result<Option<RawItem<R>>, Self::Error>> + MaybeSend;
+}
+
+/// The seam's [`MapCursor`] over any [`RawCursor`]: skips reserved keys,
+/// filters to bounds, and yields owned paths. A format with a native seek
+/// hands [`new`](Self::new) a pre-bounded raw walk; one without hands
+/// [`bounded`](Self::bounded) a full walk.
+#[derive(Debug)]
+pub struct PathCursor<C> {
+    raw: C,
+    bounds: (Bound<Vec<u8>>, Bound<Vec<u8>>),
+}
+
+impl<C> PathCursor<C> {
+    /// A walk over every key `raw` yields.
+    pub const fn new(raw: C) -> Self {
+        Self {
+            raw,
+            bounds: (Bound::Unbounded, Bound::Unbounded),
+        }
+    }
+
+    /// A walk filtered to `bounds`; a key past the upper bound ends it, so
+    /// the raw walk is never drained past the range.
+    pub fn bounded(raw: C, bounds: (Bound<ManifestPath>, Bound<ManifestPath>)) -> Self {
+        Self {
+            raw,
+            bounds: (
+                bounds.0.map(ManifestPath::into_bytes),
+                bounds.1.map(ManifestPath::into_bytes),
+            ),
+        }
+    }
+}
+
+impl<C, R> MapCursor<R> for PathCursor<C>
+where
+    C: RawCursor<R>,
+    R: Reference + MaybeSend,
+{
+    type Error = C::Error;
+
+    fn next(
+        &mut self,
+    ) -> impl Future<Output = Result<Option<(ManifestPath, MapEntry<R>)>, Self::Error>> + MaybeSend
+    {
+        let (start, end) = (&self.bounds.0, &self.bounds.1);
+        let raw = &mut self.raw;
+        async move {
+            while let Some((key, entry)) = raw.next().await? {
+                if outside(end, &key, Ordering::Greater) {
+                    return Ok(None);
+                }
+                if outside(start, &key, Ordering::Less) || ManifestPath::is_reserved_bytes(&key) {
+                    continue;
+                }
+                return Ok(Some((ManifestPath::new(key), entry)));
+            }
+            Ok(None)
+        }
+    }
+}
+
+/// Whether `key` falls outside `edge` on the side `out` names.
+fn outside(edge: &Bound<Vec<u8>>, key: &[u8], out: Ordering) -> bool {
+    match edge {
+        Bound::Unbounded => false,
+        Bound::Included(bound) => key.cmp(bound.as_slice()) == out,
+        Bound::Excluded(bound) => key.cmp(bound.as_slice()) != out.reverse(),
+    }
+}

--- a/crates/manifest/src/cursor/tests.rs
+++ b/crates/manifest/src/cursor/tests.rs
@@ -1,0 +1,76 @@
+use alloc::vec::Vec;
+use core::convert::Infallible;
+
+use nectar_primitives::chunk::ChunkRef;
+use nectar_testing::run;
+
+use super::*;
+
+/// A scripted raw walk counting the keys it served.
+struct Script(Vec<Vec<u8>>, usize);
+
+impl RawCursor<ChunkRef> for Script {
+    type Error = Infallible;
+
+    async fn next(&mut self) -> Result<Option<RawItem<ChunkRef>>, Infallible> {
+        if self.0.is_empty() {
+            return Ok(None);
+        }
+        self.1 += 1;
+        Ok(Some((self.0.remove(0), MapEntry::Opaque)))
+    }
+}
+
+fn keys(keys: &[&[u8]]) -> Vec<Vec<u8>> {
+    keys.iter().map(|key| key.to_vec()).collect()
+}
+
+/// The paths a bounded walk over `script` yields, plus the keys it pulled.
+fn walk(script: &[&[u8]], bounds: (Bound<&str>, Bound<&str>)) -> (Vec<Vec<u8>>, usize) {
+    let mut cursor = PathCursor::bounded(
+        Script(keys(script), 0),
+        (
+            bounds.0.map(ManifestPath::from),
+            bounds.1.map(ManifestPath::from),
+        ),
+    );
+    let got = run(async {
+        let mut out = Vec::new();
+        while let Some((path, _)) = MapCursor::next(&mut cursor).await.unwrap() {
+            out.push(path.into_bytes());
+        }
+        out
+    });
+    (got, cursor.raw.1)
+}
+
+#[test]
+fn reserved_keys_never_surface() {
+    let script: &[&[u8]] = &[b"", b"/", b"a", b"a/b"];
+    let (got, _) = walk(script, (Bound::Unbounded, Bound::Unbounded));
+    assert_eq!(got, keys(&[b"a", b"a/b"]));
+}
+
+#[test]
+#[allow(clippy::type_complexity)]
+fn bounds_filter_each_edge_kind() {
+    let cases: [(Bound<&str>, Bound<&str>, &[&[u8]]); 4] = [
+        (Bound::Included("b"), Bound::Included("c"), &[b"b", b"c"]),
+        (Bound::Excluded("b"), Bound::Excluded("d"), &[b"c"]),
+        (Bound::Unbounded, Bound::Excluded("b"), &[b"a"]),
+        (Bound::Excluded("d"), Bound::Unbounded, &[]),
+    ];
+    for (start, end, want) in cases {
+        let (got, _) = walk(&[b"a", b"b", b"c", b"d"], (start, end));
+        assert_eq!(got, keys(want), "bounds {start:?}..{end:?}");
+    }
+}
+
+#[test]
+fn the_upper_bound_ends_the_walk_without_draining_the_raw_cursor() {
+    let script: &[&[u8]] = &[b"a", b"b", b"y", b"z"];
+    let (got, served) = walk(script, (Bound::Unbounded, Bound::Included("b")));
+    assert_eq!(got, keys(&[b"a", b"b"]));
+    // The walk stopped at "y": "z" was never pulled.
+    assert_eq!(served, 3);
+}

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -20,6 +20,10 @@
 //! at either refuses the whole batch as [`ReservedKey`], in the seam, before
 //! the format runs.
 //!
+//! The shared read machinery is seam-owned too: [`PathCursor`] lifts a
+//! format's [`RawCursor`] into the ordered path walk, [`MapView::dir`]
+//! defaults to [`collapse_dir`], and [`load_reference`] is the one data lane.
+//!
 //! Each format keeps its own metadata type: the static path erases nothing.
 //! [`DynManifest`] is the object-safe wrapper for a runtime-detected format,
 //! and unifies metadata behind the enumerable [`MetadataSource`]: a
@@ -80,6 +84,7 @@
 extern crate alloc;
 
 mod batch;
+mod cursor;
 mod dynamic;
 mod error;
 mod listing;
@@ -91,15 +96,16 @@ mod site;
 mod view;
 
 pub use batch::{Batch, CheckedBatch};
+pub use cursor::{PathCursor, RawCursor, RawItem};
 pub use dynamic::{DynManifest, DynSink, DynSinkError};
 pub use error::{ErasedFormat, ErasedManifestError, ManifestError};
-pub use listing::{ListEntry, Listing};
+pub use listing::{ListEntry, Listing, collapse_dir};
 pub use meta::{ManifestMeta, MetadataBlock, MetadataSource, MetadataView, WellKnownKey};
 pub use op::ManifestOp;
 pub use path::ManifestPath;
 pub use reserved::{ReservedKey, reserved_key};
 pub use site::SiteConfig;
-pub use view::{MapCursor, MapEntry, MapView};
+pub use view::{MapCursor, MapEntry, MapView, load_reference};
 
 // The positional sink a load writes into is the file crate's, re-exported so
 // a manifest consumer needs no second dependency to name it.

--- a/crates/manifest/src/listing.rs
+++ b/crates/manifest/src/listing.rs
@@ -3,9 +3,11 @@
 
 use alloc::vec::Vec;
 
+use nectar_marker::MaybeSend;
 use nectar_primitives::chunk::{ChunkRef, Reference};
 
 use crate::path::ManifestPath;
+use crate::view::{MapCursor, MapEntry};
 
 /// One immediate child of a listed directory.
 ///
@@ -22,7 +24,8 @@ pub enum ListEntry<R: Reference = ChunkRef> {
         /// The reference the path resolves to.
         reference: R,
     },
-    /// A path bound to bytes the manifest carries itself, not to a reference.
+    /// A path bound to bytes the manifest carries itself, or to nothing the
+    /// caller's reference width can hold.
     Value {
         /// The value's full path.
         path: ManifestPath,
@@ -118,5 +121,131 @@ impl<R: Reference> IntoIterator for Listing<R> {
 impl<R: Reference> FromIterator<ListEntry<R>> for Listing<R> {
     fn from_iter<I: IntoIterator<Item = ListEntry<R>>>(entries: I) -> Self {
         Self::new(entries.into_iter().collect())
+    }
+}
+
+/// Collapse the ordered walk `cursor`, which starts at `prefix`, into the
+/// directory level below `prefix`; the first path outside the prefix ends it.
+pub async fn collapse_dir<R, C>(prefix: ManifestPath, mut cursor: C) -> Result<Listing<R>, C::Error>
+where
+    R: Reference + MaybeSend,
+    C: MapCursor<R>,
+{
+    let mut entries = Vec::new();
+    let mut last_dir = None;
+    while let Some((path, entry)) = cursor.next().await? {
+        if !path.as_bytes().starts_with(prefix.as_bytes()) {
+            break;
+        }
+        if let Some(listed) = collapse_level(prefix.as_bytes(), path, entry, &mut last_dir) {
+            entries.push(listed);
+        }
+    }
+    Ok(Listing::new(entries))
+}
+
+/// Fold one walked `(path, entry)` into the level below `prefix`, collapsing
+/// deeper paths at the next separator; the walk is in path order, so
+/// `last_dir` deduplicates consecutive subdirectory paths.
+fn collapse_level<R: Reference>(
+    prefix: &[u8],
+    path: ManifestPath,
+    entry: MapEntry<R>,
+    last_dir: &mut Option<Vec<u8>>,
+) -> Option<ListEntry<R>> {
+    let bytes = path.as_bytes();
+    let suffix = bytes.strip_prefix(prefix)?;
+    // The directory itself is not one of its own children.
+    if suffix.is_empty() {
+        return None;
+    }
+    let Some(cut) = suffix
+        .iter()
+        .position(|&byte| byte == ManifestPath::SEPARATOR)
+    else {
+        return Some(match entry {
+            MapEntry::Reference(reference) => ListEntry::File { path, reference },
+            MapEntry::Value | MapEntry::Opaque => ListEntry::Value { path },
+        });
+    };
+    let through = prefix.len().saturating_add(cut).saturating_add(1);
+    let dir = bytes.get(..through).unwrap_or(bytes).to_vec();
+    if last_dir.as_deref() == Some(dir.as_slice()) {
+        return None;
+    }
+    *last_dir = Some(dir.clone());
+    Some(ListEntry::Dir {
+        path: ManifestPath::new(dir),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::format;
+    use alloc::string::String;
+    use alloc::vec::Vec;
+
+    use nectar_primitives::chunk::ChunkAddress;
+
+    use super::*;
+
+    fn reference(byte: u8) -> ChunkRef {
+        ChunkRef::new(ChunkAddress::new([byte; 32]))
+    }
+
+    /// Fold a scripted level; a listed entry reads `kind:path`, a file also
+    /// carrying its reference byte.
+    fn fold(prefix: &[u8], walked: &[(&str, MapEntry<ChunkRef>)]) -> Vec<String> {
+        let mut last_dir = None;
+        walked
+            .iter()
+            .filter_map(|(path, entry)| {
+                collapse_level(
+                    prefix,
+                    ManifestPath::from(*path),
+                    entry.clone(),
+                    &mut last_dir,
+                )
+            })
+            .map(|listed| {
+                let path = String::from_utf8_lossy(listed.path().as_bytes());
+                match &listed {
+                    ListEntry::File { reference, .. } => {
+                        format!("F{}:{path}", reference.address().as_ref()[0])
+                    }
+                    ListEntry::Value { .. } => format!("V:{path}"),
+                    ListEntry::Dir { .. } => format!("D:{path}"),
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn one_level_collapses_and_deduplicates() {
+        let got = fold(
+            b"a/",
+            &[
+                ("a/", MapEntry::Reference(reference(0))),
+                ("a/file", MapEntry::Reference(reference(1))),
+                ("a/sub/x", MapEntry::Reference(reference(2))),
+                ("a/sub/y", MapEntry::Reference(reference(3))),
+                ("a/value", MapEntry::Value),
+                ("a/wide", MapEntry::Opaque),
+                ("b", MapEntry::Reference(reference(4))),
+            ],
+        );
+        assert_eq!(got, ["F1:a/file", "D:a/sub/", "V:a/value", "V:a/wide"]);
+    }
+
+    #[test]
+    fn a_bare_prefix_matches_bytes_not_directories() {
+        let got = fold(
+            b"img",
+            &[
+                ("img/logo.png", MapEntry::Reference(reference(1))),
+                ("imgx.png", MapEntry::Reference(reference(2))),
+            ],
+        );
+        assert_eq!(got, ["D:img/", "F2:imgx.png"]);
     }
 }

--- a/crates/manifest/src/path.rs
+++ b/crates/manifest/src/path.rs
@@ -78,8 +78,22 @@ impl ManifestPath {
     /// read at either is absent and a write at either is
     /// [`ReservedKey`](crate::ReservedKey).
     #[must_use]
-    pub fn is_reserved(&self) -> bool {
-        matches!(self.0.as_slice(), [] | [Self::SEPARATOR])
+    pub const fn is_reserved(&self) -> bool {
+        Self::is_reserved_bytes(self.0.as_slice())
+    }
+
+    /// [`is_reserved`](Self::is_reserved) over raw key bytes, for walks that
+    /// have not wrapped them yet.
+    #[must_use]
+    pub const fn is_reserved_bytes(bytes: &[u8]) -> bool {
+        matches!(bytes, [] | [Self::SEPARATOR])
+    }
+
+    /// The content key the path addresses, byte-verbatim, or `None` when the
+    /// path is reserved.
+    #[must_use]
+    pub fn content_key(&self) -> Option<&[u8]> {
+        (!self.is_reserved()).then_some(self.0.as_slice())
     }
 
     /// Whether the path names a directory: the empty path, or a trailing
@@ -152,6 +166,19 @@ mod tests {
         assert_eq!(ManifestPath::default().join("a").as_bytes(), b"a");
         assert_eq!(ManifestPath::from("img/").join("a").as_bytes(), b"img/a");
         assert_eq!(ManifestPath::from("img").join("a").as_bytes(), b"img/a");
+    }
+
+    #[test]
+    fn only_the_two_reserved_paths_name_no_content_key() {
+        for reserved in ["", "/"] {
+            let path = ManifestPath::from(reserved);
+            assert!(path.is_reserved());
+            assert!(ManifestPath::is_reserved_bytes(path.as_bytes()));
+            assert_eq!(path.content_key(), None);
+        }
+        let path = ManifestPath::from("a/");
+        assert!(!path.is_reserved());
+        assert_eq!(path.content_key(), Some(&b"a/"[..]));
     }
 
     #[test]

--- a/crates/manifest/src/view.rs
+++ b/crates/manifest/src/view.rs
@@ -1,37 +1,57 @@
 //! The read handle: one immutable root, the map verbs over it.
 
 use core::future::Future;
-use core::ops::RangeBounds;
+use core::ops::Bound;
 
+use nectar_file::{File, LoadError, Policy};
 use nectar_marker::{MaybeSend, MaybeSync};
-use nectar_primitives::chunk::{ChunkRef, Reference};
+use nectar_primitives::EntryRef;
+use nectar_primitives::chunk::{ChunkRef, ContentOnlyChunkSet, Reference};
+use nectar_primitives::store::TrustedGet;
 
-use crate::listing::Listing;
+use crate::error::ManifestError;
+use crate::listing::{Listing, collapse_dir};
 use crate::path::ManifestPath;
 use crate::site::SiteConfig;
 use crate::{DataSink, SinkError};
 
-/// What a bound path resolves to. Opaque bytes stay reachable through
-/// [`MapView::load`].
+/// What a bound path resolves to. [`load`](MapView::load) success is
+/// predictable from it: exactly a loadable entry loads.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum MapEntry<R: Reference = ChunkRef> {
-    /// A chunk reference of the requested width.
+    /// A chunk reference of the requested width; a load joins it from the store.
     Reference(R),
-    /// The path is bound, but not to a reference of the requested width.
+    /// The manifest itself carries the bytes; a load serves them, no store read.
+    Value,
+    /// The path is bound, but to nothing this caller can read; a load fails
+    /// as [`NoData`](crate::ManifestError::NoData).
     Opaque,
 }
 
 impl<R: Reference> MapEntry<R> {
+    /// The entry a raw reference resolves to at width `R`: the reference when
+    /// the width fits, opaque otherwise.
+    #[must_use]
+    pub fn from_entry_ref(entry: EntryRef) -> Self {
+        R::from_entry_ref(entry).map_or(Self::Opaque, Self::Reference)
+    }
+
     /// The bound reference.
     #[must_use]
     pub const fn reference(&self) -> Option<&R> {
         match self {
             Self::Reference(reference) => Some(reference),
-            Self::Opaque => None,
+            Self::Value | Self::Opaque => None,
         }
     }
 
-    /// Whether the entry names no reference of the requested width.
+    /// Whether [`load`](MapView::load) serves this entry.
+    #[must_use]
+    pub const fn is_loadable(&self) -> bool {
+        matches!(self, Self::Reference(_) | Self::Value)
+    }
+
+    /// Whether the entry names nothing this caller can read.
     #[must_use]
     pub const fn is_opaque(&self) -> bool {
         matches!(self, Self::Opaque)
@@ -118,11 +138,18 @@ pub trait MapView<R: Reference + MaybeSend = ChunkRef>: MaybeSend {
     /// also lists `imgx.png`, where `img/` does not. The empty path lists the
     /// top level.
     ///
+    /// The default runs [`collapse_dir`] over [`range`](Self::range); a
+    /// format with a native folder view or a prefix-pruned walk overrides it.
+    ///
     /// [`ListEntry::Dir`]: crate::ListEntry::Dir
     fn dir(
         &self,
         dir: &ManifestPath,
-    ) -> impl Future<Output = Result<Listing<R>, Self::Error>> + MaybeSend;
+    ) -> impl Future<Output = Result<Listing<R>, Self::Error>> + MaybeSend {
+        let prefix = dir.clone();
+        let walk = self.range((Bound::Included(dir.clone()), Bound::Unbounded));
+        async move { collapse_dir(prefix, walk.await?).await }
+    }
 
     /// The greatest bound path `<= path`, with its entry.
     ///
@@ -133,7 +160,7 @@ pub trait MapView<R: Reference + MaybeSend = ChunkRef>: MaybeSend {
         path: &ManifestPath,
     ) -> impl Future<Output = Result<Option<(ManifestPath, MapEntry<R>)>, Self::Error>> + MaybeSend
     {
-        let walk = self.range(..=path.clone());
+        let walk = self.range((Bound::Unbounded, Bound::Included(path.clone())));
         async move {
             let mut cursor = walk.await?;
             let mut last = None;
@@ -146,7 +173,9 @@ pub trait MapView<R: Reference + MaybeSend = ChunkRef>: MaybeSend {
 
     /// Write the data bound to `path` into `sink`, starting at offset zero.
     ///
-    /// The writes are idempotent overwrites: rerun a failed load in full.
+    /// Serves exactly what [`get`](Self::get) reports loadable; an opaque
+    /// entry fails as [`NoData`](crate::ManifestError::NoData). The writes
+    /// are idempotent overwrites: rerun a failed load in full.
     fn load<K: DataSink<Error: SinkError> + MaybeSend>(
         &self,
         path: &ManifestPath,
@@ -161,6 +190,57 @@ pub trait MapView<R: Reference + MaybeSend = ChunkRef>: MaybeSend {
     /// byte strings.
     fn range(
         &self,
-        bounds: impl RangeBounds<ManifestPath> + MaybeSend,
+        bounds: (Bound<ManifestPath>, Bound<ManifestPath>),
     ) -> impl Future<Output = Result<Self::Cursor, Self::Error>> + MaybeSend;
+}
+
+/// Drain the file at `reference` into `sink`: the one data-load lane every
+/// format shares, reporting through the seam's taxonomy.
+pub async fn load_reference<S, K, F, const B: usize>(
+    store: S,
+    reference: EntryRef,
+    sink: &mut K,
+) -> Result<(), ManifestError<F>>
+where
+    S: TrustedGet<ContentOnlyChunkSet<B>> + Clone + MaybeSend + MaybeSync + 'static,
+    K: DataSink<Error: SinkError> + MaybeSend,
+{
+    File::<S, B>::new(store, Policy::DEFAULT)
+        .load(reference, sink)
+        .await
+        .map(drop)
+        .map_err(|error| match error {
+            LoadError::Sink { source, .. } => ManifestError::sink(source),
+            data => ManifestError::data(data),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use nectar_primitives::chunk::ChunkAddress;
+    use nectar_primitives::{EncryptedChunkRef, EncryptionKey};
+
+    use super::*;
+
+    #[test]
+    fn from_entry_ref_keeps_the_width_and_exactly_reference_and_value_load() {
+        let plain = EntryRef::Plain(ChunkRef::new(ChunkAddress::new([1; 32])));
+        let wide = EntryRef::Encrypted(EncryptedChunkRef::new(
+            ChunkAddress::new([2; 32]),
+            EncryptionKey::from([3; 32]),
+        ));
+        let narrow = MapEntry::<ChunkRef>::from_entry_ref(plain.clone());
+        assert!(narrow.reference().is_some());
+        assert!(narrow.is_loadable() && !narrow.is_opaque());
+        assert!(MapEntry::<ChunkRef>::from_entry_ref(wide.clone()).is_opaque());
+        assert!(matches!(
+            MapEntry::<EncryptedChunkRef>::from_entry_ref(wide),
+            MapEntry::Reference(_)
+        ));
+        assert!(MapEntry::<EncryptedChunkRef>::from_entry_ref(plain).is_opaque());
+        assert!(MapEntry::<ChunkRef>::Value.is_loadable());
+        assert!(MapEntry::<ChunkRef>::Value.reference().is_none());
+        assert!(!MapEntry::<ChunkRef>::Opaque.is_loadable());
+        assert!(MapEntry::<ChunkRef>::Opaque.is_opaque());
+    }
 }

--- a/crates/mantaray/Cargo.toml
+++ b/crates/mantaray/Cargo.toml
@@ -21,7 +21,6 @@ workspace = true
 alloy-primitives = { workspace = true, features = ["map"], optional = true }
 bitflags = { workspace = true, optional = true }
 futures-util = { workspace = true, optional = true }
-nectar-file = { workspace = true, optional = true }
 nectar-governor = { workspace = true, optional = true }
 nectar-manifest = { workspace = true, optional = true }
 nectar-primitives = { workspace = true, optional = true }
@@ -57,7 +56,6 @@ std = [
 	"dep:serde_json",
 	"dep:thiserror",
 	"futures-util?/std",
-	"nectar-file?/std",
 	"nectar-manifest?/std",
 	"nectar-primitives?/std",
 	"serde_json?/std",
@@ -71,20 +69,18 @@ rand = [ "dep:rand", "std" ]
 arbitrary = [
 	"alloy-primitives?/arbitrary",
 	"dep:arbitrary",
-	"nectar-file?/arbitrary",
 	"nectar-primitives?/arbitrary",
 	"std",
 ]
-encryption = [ "nectar-file?/encryption", "nectar-primitives?/encryption" ]
+encryption = [ "nectar-primitives?/encryption" ]
 # The shared `Manifest` seam: the trie as one implementation of it, with entry
-# data joined through the file pipeline. Implies `std`.
-manifest = [ "dep:nectar-file", "dep:nectar-manifest", "std" ]
+# data joined through the seam's shared load lane. Implies `std`.
+manifest = [ "dep:nectar-manifest", "std" ]
 # Raw node internals (the `hazmat` module) for fuzz harnesses and benches.
 hazmat = [ "std" ]
 # Single-thread send escape: relaxes the boxed trie futures off `Send` in
 # lockstep with the store traits.
 unsync = [
-	"nectar-file?/unsync",
 	"nectar-governor?/unsync",
 	"nectar-manifest?/unsync",
 	"nectar-primitives?/unsync",

--- a/crates/mantaray/src/manifest.rs
+++ b/crates/mantaray/src/manifest.rs
@@ -1,5 +1,5 @@
 //! The [`Manifest`] seam over the trie: paths to references, batched writes,
-//! and data loads through the file pipeline.
+//! and data loads through the seam's shared load lane.
 //!
 //! Two seams meet here and stay separate: nodes persist through the trie's own
 //! [`NodeLoader`]/[`NodeSaver`] adapter, while an entry's data is joined
@@ -7,20 +7,18 @@
 //! and whose data lives behind another is therefore expressible, and the
 //! common case passes the same store twice.
 //!
-//! [`TrieView`] reads one root through the depth-guarded reader and the
-//! ordered cursor; [`Manifest::apply`] replays the checked batch through
-//! [`ManifestEditor`].
+//! [`TrieView`] reads one root through the depth-guarded reader; the walks are
+//! the raw [`TrieCursor`] under the seam's [`PathCursor`]. [`Manifest::apply`]
+//! replays the checked batch through [`ManifestEditor`].
 
 use alloc::collections::BTreeMap;
 use alloc::string::String;
-use alloc::vec::Vec;
 use core::future::Future;
-use core::ops::{Bound, RangeBounds};
+use core::ops::Bound;
 
-use nectar_file::{File, LoadError, Policy};
 use nectar_manifest::{
-    Batch, DataSink, ListEntry, Listing, Manifest, ManifestError, ManifestOp, ManifestPath,
-    MapCursor, MapEntry, MapView, SinkError, SiteConfig,
+    Batch, DataSink, Listing, Manifest, ManifestError, ManifestOp, ManifestPath, MapEntry, MapView,
+    PathCursor, RawCursor, RawItem, SinkError, SiteConfig, collapse_dir, load_reference,
 };
 use nectar_primitives::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{ContentOnlyChunkSet, Reference};
@@ -176,7 +174,7 @@ where
         &self,
         path: &ManifestPath,
     ) -> Result<Option<Entry>, ManifestError<TrieFormatError>> {
-        let Some(key) = content_key(path) else {
+        let Some(key) = path.content_key() else {
             return Ok(None);
         };
         let reader = Reader::new(self.nodes.clone());
@@ -194,11 +192,12 @@ where
             .await?)
     }
 
-    /// An ordered walk of the whole trie, bounded to `bounds`.
-    fn walk(&self, bounds: (Bound<Vec<u8>>, Bound<Vec<u8>>)) -> TrieCursor<L, R> {
+    /// The raw ordered walk of the keys under `prefix`, which the trie prunes
+    /// to. An empty prefix walks the whole trie.
+    fn walk(&self, prefix: &[u8]) -> TrieCursor<L, R> {
         TrieCursor {
-            cursor: Cursor::new(self.nodes.clone(), self.root.clone().into_entry_ref()),
-            bounds,
+            cursor: Cursor::new(self.nodes.clone(), self.root.clone().into_entry_ref())
+                .with_prefix(prefix),
             _reference: core::marker::PhantomData,
         }
     }
@@ -214,14 +213,14 @@ where
 
     type Error = ManifestError<TrieFormatError>;
 
-    type Cursor = TrieCursor<L, R>;
+    type Cursor = PathCursor<TrieCursor<L, R>>;
 
     fn get(
         &self,
         path: &ManifestPath,
     ) -> impl Future<Output = Result<Option<MapEntry<R>>, Self::Error>> + MaybeSend {
         let path = path.clone();
-        async move { Ok(self.entry(&path).await?.map(|entry| mapped(&entry))) }
+        async move { Ok(self.entry(&path).await?.map(|entry| seam_entry(&entry))) }
     }
 
     async fn site_config(&self) -> Result<SiteConfig, Self::Error> {
@@ -253,24 +252,13 @@ where
         }
     }
 
+    /// The trie prunes to the listed prefix, so a level costs its own subtree
+    /// rather than every key before it.
     fn dir(
         &self,
         dir: &ManifestPath,
     ) -> impl Future<Output = Result<Listing<R>, Self::Error>> + MaybeSend {
-        let mut cursor = Cursor::new(self.nodes.clone(), self.root.clone().into_entry_ref())
-            .with_prefix(dir.as_bytes());
-        let prefix = dir.as_bytes().to_vec();
-        async move {
-            let mut entries = Vec::new();
-            let mut last_dir: Option<Vec<u8>> = None;
-            while let Some(entry) = cursor.next().await.transpose()? {
-                let Some(listed) = collapse(&prefix, &entry, &mut last_dir) else {
-                    continue;
-                };
-                entries.push(listed);
-            }
-            Ok(Listing::new(entries))
-        }
+        collapse_dir(dir.clone(), PathCursor::new(self.walk(dir.as_bytes())))
     }
 
     fn load<K: DataSink<Error: SinkError> + MaybeSend>(
@@ -285,47 +273,41 @@ where
                 .entry(&path)
                 .await?
                 .ok_or_else(|| ManifestError::NotFound(path.clone()))?;
+            // Load success tracks `get`: only a reference of the caller's
+            // width names data here.
             let reference = entry
                 .reference()
                 .cloned()
+                .and_then(|reference| R::from_entry_ref(reference).ok())
                 .ok_or(ManifestError::NoData(path))?;
-            File::<S, B>::new(store, Policy::DEFAULT)
-                .load(reference, sink)
-                .await
-                .map_err(|error| match error {
-                    LoadError::Sink { source, .. } => ManifestError::sink(source),
-                    data => ManifestError::data(data),
-                })?;
-            Ok(())
+            load_reference::<_, _, _, B>(store, reference.into_entry_ref(), sink).await
         }
     }
 
     fn iter(&self) -> impl Future<Output = Result<Self::Cursor, Self::Error>> + MaybeSend {
-        let cursor = self.walk((Bound::Unbounded, Bound::Unbounded));
+        let cursor = PathCursor::new(self.walk(&[]));
         async move { Ok(cursor) }
     }
 
     fn range(
         &self,
-        bounds: impl RangeBounds<ManifestPath> + MaybeSend,
+        bounds: (Bound<ManifestPath>, Bound<ManifestPath>),
     ) -> impl Future<Output = Result<Self::Cursor, Self::Error>> + MaybeSend {
-        let cursor = self.walk((owned(bounds.start_bound()), owned(bounds.end_bound())));
+        let cursor = PathCursor::bounded(self.walk(&[]), bounds);
         async move { Ok(cursor) }
     }
 }
 
-/// The seam's ordered walk over a trie.
-///
-/// The trie has no ordered seek, so a bounded walk filters an ordered full
-/// walk: the cost of a lower bound is the nodes before it.
+/// The trie's raw ordered walk: every stored key under the walk's prefix,
+/// the site-config node included. The trie has no ordered seek, so a bounded
+/// walk is the seam's filter over a full one.
 #[derive(Debug)]
 pub struct TrieCursor<L, R: Reference> {
     cursor: Cursor<L>,
-    bounds: (Bound<Vec<u8>>, Bound<Vec<u8>>),
     _reference: core::marker::PhantomData<R>,
 }
 
-impl<L, R> MapCursor<R> for TrieCursor<L, R>
+impl<L, R> RawCursor<R> for TrieCursor<L, R>
 where
     L: NodeLoader + Clone + MaybeSend + 'static,
     R: Reference + MaybeSend + MaybeSync,
@@ -334,126 +316,30 @@ where
 
     fn next(
         &mut self,
-    ) -> impl Future<Output = Result<Option<(ManifestPath, MapEntry<R>)>, Self::Error>> + MaybeSend
-    {
-        let (start, end) = (&self.bounds.0, &self.bounds.1);
+    ) -> impl Future<Output = Result<Option<RawItem<R>>, Self::Error>> + MaybeSend {
         let cursor = &mut self.cursor;
         async move {
-            while let Some(entry) = cursor.next().await.transpose()? {
-                let path = entry.path();
-                if past_end(end, path) {
-                    return Ok(None);
-                }
-                if before_start(start, path) {
-                    continue;
-                }
-                // The site-config node is not a content key.
-                if is_site_config(path) {
-                    continue;
-                }
-                return Ok(Some((ManifestPath::new(path.to_vec()), mapped(&entry))));
-            }
-            Ok(None)
+            Ok(cursor
+                .next()
+                .await
+                .transpose()?
+                .map(|entry| (entry.path().to_vec(), seam_entry(&entry))))
         }
     }
 }
 
-/// One path bound, owned for the walk that filters on it.
-fn owned(edge: Bound<&ManifestPath>) -> Bound<Vec<u8>> {
-    match edge {
-        Bound::Unbounded => Bound::Unbounded,
-        Bound::Included(path) => Bound::Included(path.as_bytes().to_vec()),
-        Bound::Excluded(path) => Bound::Excluded(path.as_bytes().to_vec()),
-    }
-}
-
-/// Whether `path` falls short of the walk's lower bound.
-fn before_start(start: &Bound<Vec<u8>>, path: &[u8]) -> bool {
-    match start {
-        Bound::Unbounded => false,
-        Bound::Included(bound) => path < bound.as_slice(),
-        Bound::Excluded(bound) => path <= bound.as_slice(),
-    }
-}
-
-/// Whether `path` reaches the walk's upper bound, which ends it.
-fn past_end(end: &Bound<Vec<u8>>, path: &[u8]) -> bool {
-    match end {
-        Bound::Unbounded => false,
-        Bound::Included(bound) => path > bound.as_slice(),
-        Bound::Excluded(bound) => path >= bound.as_slice(),
-    }
-}
-
-/// One trie entry as a seam entry: a reference of the caller's width, or an
-/// opaque value.
-///
-/// A metadata-only node, or a reference of the other width, names no reference
-/// the caller can read on its own.
-fn mapped<R: Reference>(entry: &Entry) -> MapEntry<R> {
-    match entry.reference().cloned().map(R::from_entry_ref) {
-        Some(Ok(reference)) => MapEntry::Reference(reference),
-        Some(Err(_)) | None => MapEntry::Opaque,
-    }
-}
-
-/// The trie key `path` addresses, or `None` when it names no content key.
-///
-/// A content key is the path bytes verbatim. The empty path and
-/// [`metadata::ROOT_PATH`] are reserved: neither is read, written or walked as
-/// a key.
-fn content_key(path: &ManifestPath) -> Option<&[u8]> {
-    (!path.is_reserved()).then(|| path.as_bytes())
-}
-
-/// Whether `key` is the trie's site-config node rather than content.
-fn is_site_config(key: &[u8]) -> bool {
-    key == metadata::ROOT_PATH.as_bytes()
+/// One trie entry at the caller's width: a metadata-only node, or a reference
+/// of the other width, is opaque.
+fn seam_entry<R: Reference>(entry: &Entry) -> MapEntry<R> {
+    entry
+        .reference()
+        .cloned()
+        .map_or(MapEntry::Opaque, MapEntry::from_entry_ref)
 }
 
 /// The seam reserves the lone separator, where the trie keys its site-config
-/// node.
+/// node, so the shared reserved skip hides it from every walk.
 const _: () = assert!(matches!(
     metadata::ROOT_PATH.as_bytes(),
     [ManifestPath::SEPARATOR]
 ));
-
-/// Fold one listed entry into the directory level below `prefix`, collapsing
-/// deeper paths at the next separator.
-///
-/// `last_dir` carries the previously collapsed subdirectory: the walk is in
-/// path order, so every path under one subdirectory arrives consecutively and
-/// a single comparison deduplicates it.
-fn collapse<R: Reference>(
-    prefix: &[u8],
-    entry: &Entry,
-    last_dir: &mut Option<Vec<u8>>,
-) -> Option<ListEntry<R>> {
-    let path = entry.path();
-    let suffix = path.strip_prefix(prefix)?;
-    // The directory itself is not one of its own children, and the trie's
-    // site-config node is not content, so neither is listed.
-    if suffix.is_empty() || is_site_config(path) {
-        return None;
-    }
-    let Some(cut) = suffix
-        .iter()
-        .position(|&byte| byte == ManifestPath::SEPARATOR)
-    else {
-        let path = ManifestPath::new(path.to_vec());
-        return Some(match mapped::<R>(entry) {
-            // A width the caller did not ask for lists as an opaque value.
-            MapEntry::Reference(reference) => ListEntry::File { path, reference },
-            MapEntry::Opaque => ListEntry::Value { path },
-        });
-    };
-    let through = prefix.len().saturating_add(cut).saturating_add(1);
-    let dir = path.get(..through).unwrap_or(path).to_vec();
-    if last_dir.as_deref() == Some(dir.as_slice()) {
-        return None;
-    }
-    *last_dir = Some(dir.clone());
-    Some(ListEntry::Dir {
-        path: ManifestPath::new(dir),
-    })
-}

--- a/zepter.yaml
+++ b/zepter.yaml
@@ -16,10 +16,6 @@ workflows:
         # (transcrypt, keccak, the ref types), so the feature deliberately
         # enables no primitives feature.
         "--ignore-missing-propagate=nectar-ldb/encryption:nectar-primitives/encryption",
-        # Database encryption is node-level; the build bridge splits files in
-        # plain mode only, so it deliberately leaves the file crate's
-        # encrypted split mode off.
-        "--ignore-missing-propagate=nectar-ldb/encryption:nectar-file/encryption",
         "--workspace",
         "--show-path",
         "--quiet",


### PR DESCRIPTION
Closes #657

## Summary

Implements the S5 shared read machinery on top of `manifest/656-ldb-database`. `MapEntry` becomes `{Reference(R), Value, Opaque}` with `from_entry_ref` and `is_loadable`, which makes `load()` success predictable directly from `get()`: an ldb inline entry reads as `Value` and loads from the manifest itself, and a reference outside the caller's width reads as `Opaque` and fails to load as `NoData` on both formats.

The seam (`nectar-manifest`) gains:

- `crates/manifest/src/cursor.rs` (new): the `RawCursor` trait and `PathCursor`, which owns the reserved-key skip, the bound filter (absorbed into `PathCursor::bounded`) and the path conversion; the `RawItem` alias.
- `crates/manifest/src/view.rs`: `MapView::range` now takes concrete `(Bound<ManifestPath>, Bound<ManifestPath>)`; `dir` becomes a provided default that folds `collapse_dir` over `range`; `load_reference` is the one data-load lane with the shared Sink/Data error mapping.
- `crates/manifest/src/listing.rs`: adds `collapse_dir` (with the private `collapse_level` fold).
- `crates/manifest/src/path.rs`: adds `ManifestPath::is_reserved_bytes` / `content_key`.

`crates/ldb/src/manifest.rs` and `crates/mantaray/src/manifest.rs` are rewired onto this shared machinery: both adapters drop their `nectar-file` dependency, their local bound/collapse/content-key helpers, and their hand-rolled reserved skips (210 adapter lines deleted against ~180 seam lines added). The manifest crate carries no `encryption` feature: joining an encrypted reference through the load lane is unconditional, so `zepter.yaml` only loses the stale ldb-to-file ignore rule.

New coverage lands on a shared harness in `crates/integration-tests/tests/manifest/common.rs` (stores, both-formats bootstrap, file saving, reference/text helpers), which every manifest test file now uses. The dir-cost pin (a level costs its own subtree, counted in node loads) merges into `tests/manifest/listing.rs`, and the inline-value/opaque conformance suite merges into `tests/manifest/root_config.rs`.

## Diff stat (vs `manifest/656-ldb-database`)

```
 .github/workflows/nostd.yml                        |   9 +-
 Cargo.lock                                         |   3 +-
 crates/integration-tests/Cargo.toml                |   1 +
 crates/integration-tests/tests/manifest/common.rs  |  56 +++++
 .../tests/manifest/dyn_roundtrip.rs                |  25 +--
 .../integration-tests/tests/manifest/encrypted.rs  |  12 +-
 crates/integration-tests/tests/manifest/listing.rs | 123 ++++++++---
 .../integration-tests/tests/manifest/metadata.rs   |   9 +-
 .../tests/manifest/root_config.rs                  | 186 ++++++++++++----
 crates/ldb/Cargo.toml                              |   8 +-
 crates/ldb/src/manifest.rs                         |  92 ++++----
 crates/manifest/Cargo.toml                         |   8 +-
 crates/manifest/src/cursor.rs                      | 104 +++++++++
 crates/manifest/src/cursor/tests.rs                |  76 +++++++
 crates/manifest/src/lib.rs                         |  10 +-
 crates/manifest/src/listing.rs                     | 131 +++++++++++-
 crates/manifest/src/path.rs                        |  31 ++-
 crates/manifest/src/view.rs                        | 106 ++++++++--
 crates/mantaray/Cargo.toml                         |  10 +-
 crates/mantaray/src/manifest.rs                    | 200 ++++--------------
 20 files changed, 841 insertions(+), 363 deletions(-)
```

## Red-team

The branch is a net de-duplication: the bound filter, the level collapse, `content_key`, and the load lane each collapse two prior copies into one, seam-owned. `RawCursor` mirrors the pre-existing `MapCursor` shape rather than inventing a new substrate, and nothing hand-rolls a future-set, waker, or channel.

## Testing

All commands ran inside `nix develop --command` on `manifest/657-read-machinery` (9f3d14b0) against base `origin/manifest/656-ldb-database` (49f0abd3).

- `cargo clippy --workspace --all-targets -- -D warnings` clean, 0 warnings.
- `cargo nextest run --workspace`: 1230 passed, 1 skipped.
- `cargo nextest run -p nectar-integration-tests --features encryption` over the manifest suites: 25 passed.
- `cargo test --doc --workspace`: all doctests pass.
- no_std: `cargo check --no-default-features` for nectar-manifest, nectar-ldb, and nectar-mantaray (by manifest path) on riscv64imac-unknown-none-elf and wasm32-unknown-unknown, all clean.
- `cargo check --workspace --locked` clean; `cargo fmt` clean on every touched file.

## AI Assistance

Implement: claude-fable-5
