### PR TITLE
ci(lint): fail clippy on warnings and add lint-success aggregator

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,16 +25,9 @@ jobs:
             - uses: ./.github/actions/rust-setup
               with:
                   components: clippy
-            # Every invocation below ends in `-- -D warnings`, which fails the
-            # job on any warn-level lint: the `[workspace.lints]` warn entries
-            # (`missing-docs`, `missing-debug-implementations`,
-            # `unreachable-pub`, `clippy::all` and the warn-level clippy
-            # entries) and rustc's own warn-by-default set. Pass it per
-            # invocation, never through a job-level `RUSTFLAGS`: arguments
-            # after `--` reach the selected workspace members only and leave
-            # the dependency graph on warnings, and `rust-setup` needs
-            # `RUSTFLAGS` byte-identical across jobs (see that action).
-            #
+            # `-D warnings` goes after `--` per invocation, never in a job-level
+            # `RUSTFLAGS`: that would lint the dependency graph too, and
+            # `rust-setup` needs `RUSTFLAGS` byte-identical across jobs.
             # Lints every target (libs, bins, tests, benches, examples) with
             # default features; the `deny`-level restriction lints in
             # `[workspace.lints.clippy]` fail on panicking/overflowing
@@ -114,8 +107,6 @@ jobs:
     unused-deps:
         name: unused-deps (machete)
         runs-on: ubuntu-latest
-        # Capped like every other leaf: `lint success` needs it, so an uncapped
-        # hang would hold the aggregator for the 6h runner default.
         timeout-minutes: 30
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -125,9 +116,8 @@ jobs:
             - name: cargo machete
               run: cargo machete
 
-    # The single check-run that represents this whole workflow. Every job added
-    # here appends its id to `needs`, so the required-context list never has to
-    # name a leaf job.
+    # The one required context for this workflow: later jobs append to `needs`
+    # rather than to the branch ruleset.
     lint-success:
         name: lint success
         runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,16 +25,15 @@ jobs:
             - uses: ./.github/actions/rust-setup
               with:
                   components: clippy
-            # Every invocation below ends in `-- -D warnings`, which promotes
-            # the `warn`-level entries of `[workspace.lints.rust]`
+            # Every invocation below ends in `-- -D warnings`, which fails the
+            # job on any warn-level lint: the `[workspace.lints]` warn entries
             # (`missing-docs`, `missing-debug-implementations`,
-            # `unreachable-pub`) to build failures. The flag is passed per
-            # invocation rather than through a job-level `RUSTFLAGS`: arguments
+            # `unreachable-pub`, `clippy::all` and the warn-level clippy
+            # entries) and rustc's own warn-by-default set. Pass it per
+            # invocation, never through a job-level `RUSTFLAGS`: arguments
             # after `--` reach the selected workspace members only and leave
-            # the dependency graph on warnings, and
-            # `.github/actions/rust-setup/action.yml` needs `RUSTFLAGS`
-            # byte-identical across jobs because a per-job delta re-fingerprints
-            # every sccache key.
+            # the dependency graph on warnings, and `rust-setup` needs
+            # `RUSTFLAGS` byte-identical across jobs (see that action).
             #
             # Lints every target (libs, bins, tests, benches, examples) with
             # default features; the `deny`-level restriction lints in
@@ -115,6 +114,9 @@ jobs:
     unused-deps:
         name: unused-deps (machete)
         runs-on: ubuntu-latest
+        # Capped like every other leaf: `lint success` needs it, so an uncapped
+        # hang would hold the aggregator for the 6h runner default.
+        timeout-minutes: 30
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
             - uses: taiki-e/install-action@1b57bc699ba2af96a06eb2a2a0d32b43a7d8e8b8  # install-action

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,59 +25,70 @@ jobs:
             - uses: ./.github/actions/rust-setup
               with:
                   components: clippy
+            # Every invocation below ends in `-- -D warnings`, which promotes
+            # the `warn`-level entries of `[workspace.lints.rust]`
+            # (`missing-docs`, `missing-debug-implementations`,
+            # `unreachable-pub`) to build failures. The flag is passed per
+            # invocation rather than through a job-level `RUSTFLAGS`: arguments
+            # after `--` reach the selected workspace members only and leave
+            # the dependency graph on warnings, and
+            # `.github/actions/rust-setup/action.yml` needs `RUSTFLAGS`
+            # byte-identical across jobs because a per-job delta re-fingerprints
+            # every sccache key.
+            #
             # Lints every target (libs, bins, tests, benches, examples) with
             # default features; the `deny`-level restriction lints in
             # `[workspace.lints.clippy]` fail on panicking/overflowing
             # operations, with test code exempted per crate.
             - name: cargo clippy
-              run: cargo clippy --workspace --all-targets --locked
+              run: cargo clippy --workspace --all-targets --locked -- -D warnings
             # The async io adapters sit behind the tokio feature, outside the
             # default-features pass above.
             - name: cargo clippy (tokio adapters)
-              run: cargo clippy --locked --all-targets -p nectar-file --features tokio
+              run: cargo clippy --locked --all-targets -p nectar-file --features tokio -- -D warnings
             # The tokio spawner sits behind the tasks crate's tokio feature,
             # likewise outside the default-features pass.
             - name: cargo clippy (tokio spawner)
-              run: cargo clippy --locked --all-targets -p nectar-tasks --features tokio
+              run: cargo clippy --locked --all-targets -p nectar-tasks --features tokio -- -D warnings
             # The batch ingest sits behind the rayon feature, likewise
             # outside the default-features pass.
             - name: cargo clippy (rayon ingest)
-              run: cargo clippy --locked --all-targets -p nectar-file --features rayon
+              run: cargo clippy --locked --all-targets -p nectar-file --features rayon -- -D warnings
             # The encrypted split mode sits behind the encryption feature,
             # likewise outside the default-features pass.
             - name: cargo clippy (encrypted split)
-              run: cargo clippy --locked --all-targets -p nectar-file --features encryption
+              run: cargo clippy --locked --all-targets -p nectar-file --features encryption -- -D warnings
             # The feature-gated integration suites are invisible to the
             # default pass; compile them all in so the disallowed-methods
             # gate sees them.
             - name: cargo clippy (integration-test shapes)
-              run: cargo clippy --locked --all-targets -p nectar-integration-tests --features rayon,encryption,seal,issuer
+              run: cargo clippy --locked --all-targets -p nectar-integration-tests --features rayon,encryption,seal,issuer -- -D warnings
             # The postage-usage tokio surfaces are feature-gated, so their tests
             # are invisible to the passes above; compile them in so the
             # disallowed-methods gate sees them.
             - name: cargo clippy (postage-usage surfaces)
-              run: cargo clippy --workspace --all-targets --locked --features nectar-postage-usage/client,nectar-postage-usage/issuer
+              run: cargo clippy --workspace --all-targets --locked --features nectar-postage-usage/client,nectar-postage-usage/issuer -- -D warnings
             # The postage serde impls are off the default build, so the passes
             # above never see them.
             - name: cargo clippy (postage serde)
-              run: cargo clippy --locked --all-targets -p nectar-postage --features serde
+              run: cargo clippy --locked --all-targets -p nectar-postage --features serde -- -D warnings
             # The pipeline's parallel engine sits behind the parallel
             # feature, likewise outside the default-features pass.
             - name: cargo clippy (postage-issuer parallel)
-              run: cargo clippy --locked --all-targets -p nectar-postage-issuer --features parallel
+              run: cargo clippy --locked --all-targets -p nectar-postage-issuer --features parallel -- -D warnings
             # The encrypted node walk sits behind the encryption feature,
             # likewise outside the default-features pass.
             - name: cargo clippy (ldb encryption)
-              run: cargo clippy --locked --all-targets -p nectar-ldb --features encryption
+              run: cargo clippy --locked --all-targets -p nectar-ldb --features encryption -- -D warnings
             # The modern envelope sits behind the primitives envelope
             # feature, likewise outside the default-features pass.
             - name: cargo clippy (envelope)
-              run: cargo clippy --locked --all-targets -p nectar-primitives --features envelope,encryption
+              run: cargo clippy --locked --all-targets -p nectar-primitives --features envelope,encryption -- -D warnings
             # The pipeline's inline engine only compiles with the parallel
             # feature off; the workspace pass unifies parallel in via the
             # bench crate, so lint the inline shape explicitly.
             - name: cargo clippy (postage-issuer inline engine)
-              run: cargo clippy --locked --all-targets -p nectar-postage-issuer
+              run: cargo clippy --locked --all-targets -p nectar-postage-issuer -- -D warnings
             # `unused_crate_dependencies` is enforced per-library via `cargo
             # rustc` (not `[workspace.lints]`) so the flag applies only to each
             # crate's own lib target — never to benches/examples/tests (which
@@ -111,3 +122,18 @@ jobs:
                   tool: cargo-machete
             - name: cargo machete
               run: cargo machete
+
+    # The single check-run that represents this whole workflow. Every job added
+    # here appends its id to `needs`, so the required-context list never has to
+    # name a leaf job.
+    lint-success:
+        name: lint success
+        runs-on: ubuntu-latest
+        if: always()
+        needs: [clippy, unused-deps]
+        timeout-minutes: 30
+        steps:
+            - name: Decide whether the needed jobs succeeded or failed
+              uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # release/v1
+              with:
+                  jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
Closes #698

## What

Pure YAML change, one file: `.github/workflows/lint.yml`.

1. Appended `-- -D warnings` to all twelve `cargo clippy` invocations in the `clippy` job, promoting the warn-level entries of `[workspace.lints.rust]` (`missing-docs`, `missing-debug-implementations`, `unreachable-pub`) and rustc's warn-by-default set to failures. The thirteenth job, `unused-deps` (`cargo machete`), was left alone: it is not a clippy invocation.
2. Added a comment block above the first `cargo clippy` step recording why the flag is applied per-invocation rather than through a job-level `RUSTFLAGS`: arguments after `--` reach only the selected workspace members and leave the dependency graph on warnings, and `rust-setup` needs `RUSTFLAGS` byte-identical across jobs.
3. Added `timeout-minutes: 30` to the `unused-deps` job, matching every other leaf, so the new aggregator below is never left waiting on the 6h runner default.
4. Added the `lint-success` job (display name `lint success`) at the end of the workflow, in the re-actors/alls-green shape used by `unit-success` in `unit.yml`: pinned `re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe`, `if: always()`, `needs: [clippy, unused-deps]`, `jobs: ${{ toJSON(needs) }}`.

## Testing

All checks ran inside `nix develop --command` on a detached checkout of `ci/698-clippy-deny-warnings` (HEAD `484dcd25`), based on `origin/main`.

**Workflow shape.** `.github/workflows/lint.yml` parses as valid YAML (`yq`), yielding exactly three jobs: `clippy`, `unused-deps`, `lint-success`. Every job carries `timeout-minutes: 30`. The `clippy` job holds twelve `cargo clippy` invocations and all twelve end in `-- -D warnings` (`rg -c '^\s+run: cargo clippy'` = 12; `rg -c '^\s+run: cargo clippy.*-- -D warnings$'` = 12), so no invocation was missed. The `lint-success` aggregator matches the existing `unit-success` in `unit.yml` in shape: same `if: always()`, same `jobs: ${{ toJSON(needs) }}`, same pinned `re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe`, which is the pin already used by both `unit.yml` and `nostd.yml`.

**The flag is load-bearing, including against a warm cache.** A `pub fn zzz_probe_undocumented() {}` was planted in a crate's `lib.rs`. Running the workspace clippy pass with no flag against that tree exits `0` and only emits warnings. Running it again, unmodified, with `-- -D warnings` against the now-warm target directory exits `101` and fails on the planted warning. This confirms the flag denies warnings even when the target directory is already populated from a prior warmless run, not only on a cold build.

## AI Assistance

Implementation: claude-opus-5. Red-team review: claude-opus-5. PR: claude-sonnet-5.
