### PR TITLE
ci: add cargo-deny job (advisories, bans, sources, licenses)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -13,7 +13,11 @@ ignore = [
     # (via `ark-ff`) that is never enabled by the feature set alloy-primitives
     # requests, so it is not in the resolved build graph at all; it only
     # appears in Cargo.lock. cargo-audit scans the whole lockfile, which is
-    # why it surfaces here. Tracking: nxm-rs/nectar#19.
+    # why it surfaces here. deny.toml deliberately does not carry this entry:
+    # cargo deny walks the resolved graph, so the advisory never matches there
+    # and listing it would earn an `advisory-not-detected` warning. Removing it
+    # from this file would turn the `audit` job red, because derivative is still
+    # an entry in both Cargo.lock and fuzz/Cargo.lock. Tracking: nxm-rs/nectar#19.
     "RUSTSEC-2024-0388", # derivative unmaintained - optional ark-ff dep of ruint, not in build graph
 
     # paste is unmaintained (archived by its author). It is a compile-time

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -6,22 +6,21 @@
 # through the alloy stack. None of them are direct nectar dependencies, and
 # none are reachable at runtime or in the shipped wasm artifact. They are
 # kept here (rather than removed) because there is no released upstream
-# version that drops them yet. Each ignore links the upstream tracking issue
-# so it can be revisited once alloy publishes a release with the fix.
+# version that drops them yet. Revisit on each alloy bump.
 ignore = [
     # derivative is unmaintained. It is an *optional* dependency of `ruint`
     # (via `ark-ff`) that is never enabled by the feature set alloy-primitives
     # requests, so it is not in the resolved build graph at all; it only
     # appears in Cargo.lock. cargo-audit scans the whole lockfile, which is
     # why it surfaces here and why deny.toml omits it. Do not remove: it is
-    # still in both lockfiles. Tracking: nxm-rs/nectar#19.
+    # still in both lockfiles.
     "RUSTSEC-2024-0388", # derivative unmaintained - optional ark-ff dep of ruint, not in build graph
 
     # paste is unmaintained (archived by its author). It is a compile-time
     # proc-macro dependency of alloy-sol-macro-input / syn-solidity. The latest
     # released alloy-core (1.6.0) still depends on it; the drop to a maintained
     # alternative only exists on alloy-core's unreleased main branch. Build-time
-    # only, never shipped. Tracking: nxm-rs/nectar#20.
+    # only, never shipped.
     "RUSTSEC-2024-0436", # paste unmaintained - via alloy-sol-macro-input / syn-solidity
 
     # proc-macro-error2 is unmaintained but pulled in by alloy-sol-macro &

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -13,11 +13,8 @@ ignore = [
     # (via `ark-ff`) that is never enabled by the feature set alloy-primitives
     # requests, so it is not in the resolved build graph at all; it only
     # appears in Cargo.lock. cargo-audit scans the whole lockfile, which is
-    # why it surfaces here. deny.toml deliberately does not carry this entry:
-    # cargo deny walks the resolved graph, so the advisory never matches there
-    # and listing it would earn an `advisory-not-detected` warning. Removing it
-    # from this file would turn the `audit` job red, because derivative is still
-    # an entry in both Cargo.lock and fuzz/Cargo.lock. Tracking: nxm-rs/nectar#19.
+    # why it surfaces here and why deny.toml omits it. Do not remove: it is
+    # still in both lockfiles. Tracking: nxm-rs/nectar#19.
     "RUSTSEC-2024-0388", # derivative unmaintained - optional ark-ff dep of ruint, not in build graph
 
     # paste is unmaintained (archived by its author). It is a compile-time

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -123,14 +123,22 @@ jobs:
         timeout-minutes: 30
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-            # No `rust-setup`: this job compiles nothing.
+            # Not `rust-setup`: this job compiles nothing, so warming the shared
+            # registry cache with an empty ~/.cargo would cost the compiling jobs.
+            - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88  # master 2026-06-30
+              with:
+                  toolchain: "1.94"
             - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853  # v2.83.2
               with:
                   tool: cargo-deny
             # `--all-features` so the graph reaches feature-gated dependencies.
             # `bans` cannot fail while deny.toml keeps its warn-level settings;
             # it is wired up so a future ban needs no CI change.
+            # `RUSTUP_TOOLCHAIN` beats `rust-toolchain.toml`, whose `components`
+            # would otherwise pull rustfmt and clippy in for `cargo metadata`.
             - name: cargo deny
+              env:
+                  RUSTUP_TOOLCHAIN: "1.94"
               run: cargo deny --all-features --locked check advisories bans sources licenses
 
     # The one required context for this workflow: later jobs append to `needs`

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,5 @@
-# Clippy (runtime-safety restriction lints) + unused-dependency checks.
+# Clippy (runtime-safety restriction lints), unused-dependency checks, and the
+# cargo-deny supply-chain gate (advisories, bans, sources, licences).
 name: lint
 
 on:
@@ -116,13 +117,38 @@ jobs:
             - name: cargo machete
               run: cargo machete
 
+    deny:
+        name: deny
+        runs-on: ubuntu-latest
+        # Capped like every other leaf: `lint success` needs it.
+        timeout-minutes: 30
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+            # Prebuilt binary, same pattern as `audit.yml`. No `rust-setup`: this
+            # job compiles nothing, so it needs neither sccache nor a components
+            # install. cargo-deny does shell out to `cargo metadata`, which the
+            # runner's preinstalled rustup resolves against `rust-toolchain.toml`.
+            - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853  # v2.83.2
+              with:
+                  tool: cargo-deny
+            # `--all-features` so the graph covers the feature-gated dependencies
+            # the default build never pulls in, and `--locked` so a manifest that
+            # has outgrown `Cargo.lock` fails here rather than being resolved
+            # afresh and silently passing.
+            #
+            # `advisories` overlaps the daily `audit` workflow, but that one only
+            # runs on lockfile-touching pull requests. New here: `bans`,
+            # `sources`, `licenses`, and `yanked = "deny"` on every pull request.
+            - name: cargo deny
+              run: cargo deny --all-features --locked check advisories bans sources licenses
+
     # The one required context for this workflow: later jobs append to `needs`
     # rather than to the branch ruleset.
     lint-success:
         name: lint success
         runs-on: ubuntu-latest
         if: always()
-        needs: [clippy, unused-deps]
+        needs: [clippy, unused-deps, deny]
         timeout-minutes: 30
         steps:
             - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -137,8 +137,11 @@ jobs:
             # afresh and silently passing.
             #
             # `advisories` overlaps the daily `audit` workflow, but that one only
-            # runs on lockfile-touching pull requests. New here: `bans`,
-            # `sources`, `licenses`, and `yanked = "deny"` on every pull request.
+            # runs on lockfile-touching pull requests. New here: `sources`,
+            # `licenses`, and `yanked = "deny"` on every pull request. `bans` is
+            # checked too but cannot fail the job while `deny.toml` keeps
+            # `multiple-versions = "warn"`, `wildcards = "allow"` and an empty
+            # deny list; it is wired up so a future ban lands with no CI change.
             - name: cargo deny
               run: cargo deny --all-features --locked check advisories bans sources licenses
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -120,28 +120,16 @@ jobs:
     deny:
         name: deny
         runs-on: ubuntu-latest
-        # Capped like every other leaf: `lint success` needs it.
         timeout-minutes: 30
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-            # Prebuilt binary, same pattern as `audit.yml`. No `rust-setup`: this
-            # job compiles nothing, so it needs neither sccache nor a components
-            # install. cargo-deny does shell out to `cargo metadata`, which the
-            # runner's preinstalled rustup resolves against `rust-toolchain.toml`.
+            # No `rust-setup`: this job compiles nothing.
             - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853  # v2.83.2
               with:
                   tool: cargo-deny
-            # `--all-features` so the graph covers the feature-gated dependencies
-            # the default build never pulls in, and `--locked` so a manifest that
-            # has outgrown `Cargo.lock` fails here rather than being resolved
-            # afresh and silently passing.
-            #
-            # `advisories` overlaps the daily `audit` workflow, but that one only
-            # runs on lockfile-touching pull requests. New here: `sources`,
-            # `licenses`, and `yanked = "deny"` on every pull request. `bans` is
-            # checked too but cannot fail the job while `deny.toml` keeps
-            # `multiple-versions = "warn"`, `wildcards = "allow"` and an empty
-            # deny list; it is wired up so a future ban lands with no CI change.
+            # `--all-features` so the graph reaches feature-gated dependencies.
+            # `bans` cannot fail while deny.toml keeps its warn-level settings;
+            # it is wired up so a future ban needs no CI change.
             - name: cargo deny
               run: cargo deny --all-features --locked check advisories bans sources licenses
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,34 +1,20 @@
 # cargo-deny configuration
 # https://embarkstudios.github.io/cargo-deny/
 #
-# Scope: advisory, ban, source and licence hygiene ahead of a crates.io publish.
-# Run by the `deny` job of .github/workflows/lint.yml as
-# `cargo deny --all-features --locked check advisories bans sources licenses`.
-#
-# The ignore list below does not mirror .cargo/audit.toml, and cannot. cargo
-# deny resolves the feature graph and only sees crates that are actually built;
-# cargo audit reads every entry in Cargo.lock whether or not it is reachable. An
-# advisory that only matches a lockfile entry therefore belongs in
-# .cargo/audit.toml alone, because listing it here earns an
-# `advisory-not-detected` warning. An advisory that matches a built crate
-# belongs in both files, or the two gates disagree and one of them is noise.
+# The ignore list below deliberately does not mirror .cargo/audit.toml: deny
+# resolves the feature graph, audit reads every Cargo.lock entry. An advisory
+# matching only a lockfile entry belongs in audit.toml alone.
 
 [advisories]
-# Fail on any advisory that is not explicitly ignored below. `yanked = "deny"`
-# also fails on a dependency yanked from crates.io, which cargo audit does not
-# report.
 yanked = "deny"
 ignore = [
     # Both entries are build-time-only, transitive dependencies pulled in
-    # through the alloy stack. Neither is a direct nectar dependency, neither is
-    # reachable at runtime or in the shipped wasm artifact, and neither has a
-    # released upstream version that drops it yet. Revisit on each alloy bump.
+    # through the alloy stack. Neither is reachable at runtime or in the shipped
+    # wasm artifact. Revisit on each alloy bump.
     #
-    # RUSTSEC-2024-0388 (derivative unmaintained) is deliberately absent here
-    # while .cargo/audit.toml still carries it. ruint 1.20.0 dropped the
-    # optional ark-ff path that pulled derivative in, so it left the resolved
-    # graph, but it is still an entry in Cargo.lock and fuzz/Cargo.lock, which
-    # is what cargo audit scans. Tracking: nxm-rs/nectar#19.
+    # RUSTSEC-2024-0388 (derivative) is absent on purpose: ruint 1.20.0 dropped
+    # it from the resolved graph, but it remains in both lockfiles, so
+    # .cargo/audit.toml still carries it. Tracking: nxm-rs/nectar#19.
 
     # paste unmaintained (archived). Compile-time proc-macro dep of
     # alloy-sol-macro-input / syn-solidity. Latest released alloy-core (1.6.0)
@@ -49,38 +35,26 @@ multiple-versions = "warn"
 wildcards = "allow"
 
 [licenses]
-# Reviewed allow list, not a blanket `allow-osi-fsf-free`. The workspace is
-# AGPL-3.0-or-later and publishes seven crates, so an unreviewed dependency
-# licence is a release risk rather than a style question.
-#
-# Every entry was measured with `cargo deny --all-features list` and is
-# load-bearing: dropping any one of them fails `check licenses`. cargo-deny
-# evaluates the full SPDX expression, so a licence that a crate offers only as
-# one arm of an `OR` needs no entry once the other arm is allowed. That is why
-# `Apache-2.0 WITH LLVM-exception` (rustix, wasi), `BSD-2-Clause` (zerocopy),
-# `LGPL-2.1-or-later` (r-efi), `Unlicense` (memchr), `CC0-1.0` and `MIT-0`
-# (dunce) are all absent despite appearing in the graph.
+# Reviewed allow list, not a blanket `allow-osi-fsf-free`. Every entry is
+# load-bearing. A licence offered as one arm of an SPDX `OR` needs no entry once
+# another arm is allowed, which is why LLVM-exception, BSD-2-Clause, LGPL-2.1,
+# Unlicense, CC0-1.0 and MIT-0 are absent despite appearing in the graph.
 allow = [
-    # The workspace's own crates, plus keccak-batch and the wasm demo.
     "AGPL-3.0-or-later",
-    # The bulk of the graph, most of it dual `MIT OR Apache-2.0`. These two also
-    # satisfy every permissive `OR` arm listed above.
     "MIT",
     "Apache-2.0",
-    # Sole licence of subtle, keccak-asm and sha3-asm. num_enum reaches it
-    # through an `OR` that MIT already covers.
+    # Sole licence of subtle, keccak-asm and sha3-asm.
     "BSD-3-Clause",
-    # unicode-ident is `(MIT OR Apache-2.0) AND Unicode-3.0`. The `AND` is what
-    # makes this mandatory: no permissive allow above satisfies it.
+    # unicode-ident is `(MIT OR Apache-2.0) AND Unicode-3.0`; the `AND` makes
+    # this mandatory.
     "Unicode-3.0",
-    # Sole licence of foldhash, hashbrown's default hasher.
+    # Sole licence of foldhash.
     "Zlib",
 ]
 
 [sources]
-# Every dependency must resolve to crates.io. Both defaults are `deny`, but they
-# are written out because a vendored git dependency is the change this section
-# exists to catch, and a silent default is easy to relax by accident.
+# A vendored git dependency is what this section exists to catch; the defaults
+# are spelled out so relaxing one is a visible diff.
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/deny.toml
+++ b/deny.toml
@@ -14,11 +14,11 @@ ignore = [
     #
     # RUSTSEC-2024-0388 (derivative) is absent on purpose: ruint 1.20.0 dropped
     # it from the resolved graph, but it remains in both lockfiles, so
-    # .cargo/audit.toml still carries it. Tracking: nxm-rs/nectar#19.
+    # .cargo/audit.toml still carries it.
 
     # paste unmaintained (archived). Compile-time proc-macro dep of
     # alloy-sol-macro-input / syn-solidity. Latest released alloy-core (1.6.0)
-    # still depends on it. Tracking: nxm-rs/nectar#20.
+    # still depends on it.
     "RUSTSEC-2024-0436",
 
     # proc-macro-error2 unmaintained. Compile-time proc-macro dep of

--- a/deny.toml
+++ b/deny.toml
@@ -1,22 +1,34 @@
 # cargo-deny configuration
 # https://embarkstudios.github.io/cargo-deny/
 #
-# Scope: advisory hygiene ahead of a crates.io publish. The ignore list mirrors
-# .cargo/audit.toml so `cargo audit` and `cargo deny check advisories` agree.
+# Scope: advisory, ban, source and licence hygiene ahead of a crates.io publish.
+# Run by the `deny` job of .github/workflows/lint.yml as
+# `cargo deny --all-features --locked check advisories bans sources licenses`.
+#
+# The ignore list below does not mirror .cargo/audit.toml, and cannot. cargo
+# deny resolves the feature graph and only sees crates that are actually built;
+# cargo audit reads every entry in Cargo.lock whether or not it is reachable. An
+# advisory that only matches a lockfile entry therefore belongs in
+# .cargo/audit.toml alone, because listing it here earns an
+# `advisory-not-detected` warning. An advisory that matches a built crate
+# belongs in both files, or the two gates disagree and one of them is noise.
 
 [advisories]
-# Fail on any advisory that is not explicitly ignored below.
+# Fail on any advisory that is not explicitly ignored below. `yanked = "deny"`
+# also fails on a dependency yanked from crates.io, which cargo audit does not
+# report.
 yanked = "deny"
 ignore = [
-    # All three entries are build-time-only, transitive dependencies pulled in
-    # through the alloy stack. None are direct nectar dependencies, none are
-    # reachable at runtime or in the shipped wasm artifact, and none have a
-    # released upstream version that drops them yet. Revisit on each alloy bump.
-
-    # derivative unmaintained. Optional ark-ff dep of ruint, not enabled by the
-    # feature set alloy-primitives requests, so not in the resolved build graph.
-    # Tracking: nxm-rs/nectar#19.
-    "RUSTSEC-2024-0388",
+    # Both entries are build-time-only, transitive dependencies pulled in
+    # through the alloy stack. Neither is a direct nectar dependency, neither is
+    # reachable at runtime or in the shipped wasm artifact, and neither has a
+    # released upstream version that drops it yet. Revisit on each alloy bump.
+    #
+    # RUSTSEC-2024-0388 (derivative unmaintained) is deliberately absent here
+    # while .cargo/audit.toml still carries it. ruint 1.20.0 dropped the
+    # optional ark-ff path that pulled derivative in, so it left the resolved
+    # graph, but it is still an entry in Cargo.lock and fuzz/Cargo.lock, which
+    # is what cargo audit scans. Tracking: nxm-rs/nectar#19.
 
     # paste unmaintained (archived). Compile-time proc-macro dep of
     # alloy-sol-macro-input / syn-solidity. Latest released alloy-core (1.6.0)
@@ -35,3 +47,40 @@ ignore = [
 # scope for advisory hygiene.
 multiple-versions = "warn"
 wildcards = "allow"
+
+[licenses]
+# Reviewed allow list, not a blanket `allow-osi-fsf-free`. The workspace is
+# AGPL-3.0-or-later and publishes seven crates, so an unreviewed dependency
+# licence is a release risk rather than a style question.
+#
+# Every entry was measured with `cargo deny --all-features list` and is
+# load-bearing: dropping any one of them fails `check licenses`. cargo-deny
+# evaluates the full SPDX expression, so a licence that a crate offers only as
+# one arm of an `OR` needs no entry once the other arm is allowed. That is why
+# `Apache-2.0 WITH LLVM-exception` (rustix, wasi), `BSD-2-Clause` (zerocopy),
+# `LGPL-2.1-or-later` (r-efi), `Unlicense` (memchr), `CC0-1.0` and `MIT-0`
+# (dunce) are all absent despite appearing in the graph.
+allow = [
+    # The workspace's own crates, plus keccak-batch and the wasm demo.
+    "AGPL-3.0-or-later",
+    # The bulk of the graph, most of it dual `MIT OR Apache-2.0`. These two also
+    # satisfy every permissive `OR` arm listed above.
+    "MIT",
+    "Apache-2.0",
+    # Sole licence of subtle, keccak-asm and sha3-asm. num_enum reaches it
+    # through an `OR` that MIT already covers.
+    "BSD-3-Clause",
+    # unicode-ident is `(MIT OR Apache-2.0) AND Unicode-3.0`. The `AND` is what
+    # makes this mandatory: no permissive allow above satisfies it.
+    "Unicode-3.0",
+    # Sole licence of foldhash, hashbrown's default hasher.
+    "Zlib",
+]
+
+[sources]
+# Every dependency must resolve to crates.io. Both defaults are `deny`, but they
+# are written out because a vendored git dependency is the change this section
+# exists to catch, and a silent default is easy to relax by accident.
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
Closes #700
Closes #729

## Summary

Adds a `deny` job to `.github/workflows/lint.yml` running `cargo deny --all-features --locked check advisories bans sources licenses`, installed through the same pinned `taiki-e/install-action@43aecc8d…  # v2.83.2` that `audit.yml` uses, on a pinned `dtolnay/rust-toolchain` at 1.94 rather than `rust-setup` (the job compiles nothing, so warming the shared registry cache with an empty `~/.cargo` would cost the compiling jobs). Its id is appended to the `lint success` aggregator's `needs` list; the list is now `[clippy, unused-deps, deny]`.

Writes the `[licenses]` section `deny.toml` never had. The allow list was derived from a local `cargo deny --all-features list` run in the dev shell, and every entry is load-bearing (dropping it fails `check licenses`): `AGPL-3.0-or-later` (the workspace's own crates), `MIT` and `Apache-2.0` (the bulk of the graph), `BSD-3-Clause` (sole licence of subtle, keccak-asm, sha3-asm), `Unicode-3.0` (mandatory because unicode-ident is `(MIT OR Apache-2.0) AND Unicode-3.0`), and `Zlib` (sole licence of foldhash).

Adds a `[sources]` section requiring every dependency resolve to crates.io (`unknown-registry = "deny"`, `unknown-git = "deny"`, `allow-registry` limited to the crates.io index), written out explicitly rather than relying on the (already-deny) defaults.

Reworks the `[advisories]` ignore list so it no longer mirrors `.cargo/audit.toml`. `RUSTSEC-2024-0388` (derivative, unmaintained) is dropped from `deny.toml` because cargo-deny walks the resolved feature graph and derivative is no longer reachable there since ruint 1.20.0 dropped the optional ark-ff path; keeping the entry would only earn an `advisory-not-detected` warning. `.cargo/audit.toml` keeps the entry, with an updated comment explaining why the two files now diverge: cargo audit scans the whole `Cargo.lock` (including `fuzz/Cargo.lock`), where derivative is still present as an unreachable lockfile entry. The `paste` and `proc-macro-error2` unmaintained ignores are unchanged.

## Folded in from #729

The `deny` job originally had no toolchain step at all, relying on the runner's preinstalled rustup resolving `rust-toolchain.toml` to give `cargo metadata` a cargo binary. That worked, but it reinstalled 1.94 plus the `rustfmt` and `clippy` components the job never uses on every run, and left the result dependent on the runner image. The job now pins the toolchain explicitly and sets `RUSTUP_TOOLCHAIN` on the `cargo deny` step. The environment variable is required, not belt-and-braces: `rust-toolchain.toml` declares `components = ["rustfmt", "clippy"]` and wins over an installed default at cargo time, so without the override the component install returns. This is the same override the `msrv` job uses for the same reason.

The second half of #729 is deliberately not done. It proposed replacing the bare `AGPL-3.0-or-later` allow with `[licenses] exceptions` enumerating the workspace members, so a third-party AGPL dependency could not pass unreviewed. That is real churn, it needs an edit every time a crate is added or removed, and it changes review signal rather than compliance, since the workspace licence is AGPL either way. Recorded here as a decision rather than an oversight; reopen if the trade-off is judged differently.

## Testing

`cargo deny --all-features --locked check advisories bans sources licenses` (the exact command the new `deny` job runs) exits 0.

`actionlint` is clean on `.github/workflows/lint.yml`, and the `deny` job's step list parses as checkout, toolchain, install-action, `cargo deny`, with `RUSTUP_TOOLCHAIN: "1.94"` on the final step.

## AI Assistance

Implementation: claude-opus-5. Red-team: claude-opus-5. PR: claude-sonnet-5.

