### PR TITLE
ci(lint): add msrv job derived from declared rust-version

### DIFF
--- a/.github/scripts/declared-msrv-test.sh
+++ b/.github/scripts/declared-msrv-test.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
-# Checks that `declared-msrv.sh` tracks the declaration rather than a literal.
-#
-# A job that hardcoded its toolchain would pass this repository's manifest and
-# fail the raised-declaration case below, which is the drift the `lint / msrv`
-# job exists to catch.
+# Pins `declared-msrv.sh` to the declaration, not to whatever this repository
+# happens to declare today. It does not police how the workflow uses the script;
+# the rustc-version guard in the msrv job does that.
 set -eu
 
 here="$(cd "$(dirname "$0")" && pwd)"

--- a/.github/scripts/declared-msrv-test.sh
+++ b/.github/scripts/declared-msrv-test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Checks that `declared-msrv.sh` tracks the declaration rather than a literal.
+#
+# A job that hardcoded its toolchain would pass this repository's manifest and
+# fail the raised-declaration case below, which is the drift the `lint / msrv`
+# job exists to catch.
+set -eu
+
+here="$(cd "$(dirname "$0")" && pwd)"
+subject="$here/declared-msrv.sh"
+root="$(cd "$here/../.." && pwd)"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+failures=0
+
+pass() { printf 'ok   %s\n' "$1"; }
+fail() { printf 'FAIL %s\n' "$1"; failures=$((failures + 1)); }
+
+# Asserts the printed version for a manifest built from the repository's own,
+# with `edit` applied to it as a sed programme.
+expect_version() {
+    name="$1" want="$2" edit="$3"
+    sed "$edit" "$root/Cargo.toml" > "$work/Cargo.toml"
+    if got="$("$subject" "$work/Cargo.toml")" && [ "$got" = "$want" ]; then
+        pass "$name"
+    else
+        fail "$name (want $want, got ${got:-error})"
+    fi
+}
+
+expect_error() {
+    name="$1" edit="$2"
+    sed "$edit" "$root/Cargo.toml" > "$work/Cargo.toml"
+    if "$subject" "$work/Cargo.toml" > /dev/null 2>&1; then
+        fail "$name"
+    else
+        pass "$name"
+    fi
+}
+
+# The repository as it stands.
+if got="$("$subject" "$root/Cargo.toml")" && [ -n "$got" ]; then
+    pass "reads the workspace manifest ($got)"
+else
+    fail "reads the workspace manifest"
+fi
+
+# The anti-hardcode case: a raised declaration must move the toolchain with it.
+expect_version "follows a raised declaration" "1.99" 's/^rust-version = .*/rust-version = "1.99"/'
+
+# Spacing is not load-bearing.
+expect_version "tolerates unspaced toml" "1.99" 's/^rust-version = .*/rust-version="1.99"/'
+
+# An absent declaration is an error, not an empty string that would leave the
+# toolchain action on the pinned channel.
+expect_error "rejects an absent declaration" '/^rust-version/d'
+
+# A member's own declaration is not the workspace's, so it must not stand in.
+{
+    sed '/^rust-version/d' "$root/Cargo.toml"
+    printf '\n[package]\nrust-version = "1.60"\n'
+} > "$work/member.toml"
+if "$subject" "$work/member.toml" > /dev/null 2>&1; then
+    fail "reads only [workspace.package]"
+else
+    pass "reads only [workspace.package]"
+fi
+
+# The no-argument path the job uses, run in a tree whose pin has moved ahead of
+# the declaration: the answer must stay with the declaration.
+mkdir -p "$work/drift"
+cp "$root/Cargo.toml" "$work/drift/Cargo.toml"
+printf '[toolchain]\nchannel = "1.99"\n' > "$work/drift/rust-toolchain.toml"
+declared="$("$subject" "$root/Cargo.toml")"
+if got="$(cd "$work/drift" && "$subject")" && [ "$got" = "$declared" ]; then
+    pass "ignores a raised rust-toolchain.toml pin"
+else
+    fail "ignores a raised rust-toolchain.toml pin (want $declared, got ${got:-error})"
+fi
+
+printf '\n%s failure(s)\n' "$failures"
+[ "$failures" -eq 0 ]

--- a/.github/scripts/declared-msrv.sh
+++ b/.github/scripts/declared-msrv.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
-# Prints the minimum supported Rust version the workspace declares.
+# Prints the workspace's declared minimum supported Rust version.
 #
-# Only `[workspace.package]` counts: every member inherits the field through
-# `rust-version.workspace = true`, so the root manifest is the whole declaration.
-# An absent field is an error, because a caller that took it as empty would fall
-# back to the pinned channel and report green for an untested declaration.
+# Only `[workspace.package]` counts; members inherit it. An absent field is an
+# error, not an empty string, which a caller would resolve to the pinned channel.
 set -eu
 
 manifest="${1:-Cargo.toml}"

--- a/.github/scripts/declared-msrv.sh
+++ b/.github/scripts/declared-msrv.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Prints the minimum supported Rust version the workspace declares.
+#
+# Only `[workspace.package]` counts: every member inherits the field through
+# `rust-version.workspace = true`, so the root manifest is the whole declaration.
+# An absent field is an error, because a caller that took it as empty would fall
+# back to the pinned channel and report green for an untested declaration.
+set -eu
+
+manifest="${1:-Cargo.toml}"
+
+msrv="$(awk '
+    /^\[workspace\.package\]/ { in_section = 1; next }
+    /^\[/                     { in_section = 0 }
+    in_section && /^rust-version[ \t]*=/ {
+        if (match($0, /"[^"]+"/)) {
+            print substr($0, RSTART + 1, RLENGTH - 2)
+            exit
+        }
+    }' "$manifest")"
+
+if [ -z "$msrv" ]; then
+    echo "no rust-version in [workspace.package] of $manifest" >&2
+    exit 1
+fi
+
+echo "$msrv"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,6 @@
-# Clippy (runtime-safety restriction lints), unused-dependency checks, and the
-# cargo-deny supply-chain gate (advisories, bans, sources, licences).
+# Clippy (runtime-safety restriction lints), unused-dependency checks, the
+# cargo-deny supply-chain gate (advisories, bans, sources, licences), and the
+# MSRV compile on the declared `rust-version`.
 name: lint
 
 on:
@@ -141,13 +142,64 @@ jobs:
                   RUSTUP_TOOLCHAIN: "1.94"
               run: cargo deny --all-features --locked check advisories bans sources licenses
 
+    # Compiles the workspace on the `rust-version` it declares, so the published
+    # metadata of every crate is a claim CI has tested. The toolchain comes from
+    # that field, never from a literal here: declaration and pin both sit at 1.94
+    # today, so a hardcoded job would stop testing the declaration at the exact
+    # moment the two part, which is the drift this job exists to catch.
+    msrv:
+        name: msrv
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+            # Fails here, rather than at the next MSRV bump, if an edit swaps the
+            # derivation for a literal.
+            - name: test the derivation
+              run: .github/scripts/declared-msrv-test.sh
+            - name: read the declared rust-version
+              id: declared
+              # Assigned first, never inlined into the echo: a substitution that
+              # fails inside `echo` leaves the step green and the toolchain input
+              # empty, which resolves to the pinned channel.
+              run: |
+                  msrv="$(.github/scripts/declared-msrv.sh)"
+                  echo "version=$msrv" >> "$GITHUB_OUTPUT"
+            # Not `rust-setup`: rustup resolves `rust-toolchain.toml` at cargo
+            # time, so the file's channel wins over any `toolchain:` input.
+            # `RUSTUP_TOOLCHAIN` on the check step does override the file.
+            - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88  # master 2026-03-27
+              with:
+                  toolchain: ${{ steps.declared.outputs.version }}
+            # Default features and `--locked`, so this covers the committed graph
+            # alone. A consumer who enables an optional feature, or who resolves
+            # afresh, may pull a dependency that wants a newer compiler; the job
+            # makes no claim about either case.
+            - name: cargo check
+              env:
+                  RUSTUP_TOOLCHAIN: ${{ steps.declared.outputs.version }}
+                  MSRV: ${{ steps.declared.outputs.version }}
+              run: |
+                  # Guards the override: were the toolchain file to win, the job
+                  # would check on the pinned channel and report green for a
+                  # declaration it never compiled.
+                  actual="$(rustc --version | cut -d' ' -f2)"
+                  case "$actual" in
+                      "$MSRV" | "$MSRV".*) ;;
+                      *)
+                          echo "::error::checking on $actual, not the declared $MSRV"
+                          exit 1
+                          ;;
+                  esac
+                  cargo check --workspace --all-targets --locked
+
     # The one required context for this workflow: later jobs append to `needs`
     # rather than to the branch ruleset.
     lint-success:
         name: lint success
         runs-on: ubuntu-latest
         if: always()
-        needs: [clippy, unused-deps, deny]
+        needs: [clippy, unused-deps, deny, msrv]
         timeout-minutes: 30
         steps:
             - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -168,7 +168,7 @@ jobs:
             # Not `rust-setup`: rustup resolves `rust-toolchain.toml` at cargo
             # time, so the file's channel wins over any `toolchain:` input.
             # `RUSTUP_TOOLCHAIN` on the check step does override the file.
-            - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88  # master 2026-03-27
+            - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88  # master 2026-06-30
               with:
                   toolchain: ${{ steps.declared.outputs.version }}
             # Default features and `--locked`, so this covers the committed graph

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -142,47 +142,39 @@ jobs:
                   RUSTUP_TOOLCHAIN: "1.94"
               run: cargo deny --all-features --locked check advisories bans sources licenses
 
-    # Compiles the workspace on the `rust-version` it declares, so the published
-    # metadata of every crate is a claim CI has tested. The toolchain comes from
-    # that field, never from a literal here: declaration and pin both sit at 1.94
-    # today, so a hardcoded job would stop testing the declaration at the exact
-    # moment the two part, which is the drift this job exists to catch.
+    # Compiles on the declared `rust-version`, read from the manifest rather than
+    # written here: declaration and pin both sit at 1.94, so a literal would stop
+    # testing the declaration the moment they part.
     msrv:
         name: msrv
         runs-on: ubuntu-latest
         timeout-minutes: 30
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-            # Fails here, rather than at the next MSRV bump, if an edit swaps the
-            # derivation for a literal.
             - name: test the derivation
               run: .github/scripts/declared-msrv-test.sh
             - name: read the declared rust-version
               id: declared
-              # Assigned first, never inlined into the echo: a substitution that
-              # fails inside `echo` leaves the step green and the toolchain input
-              # empty, which resolves to the pinned channel.
+              # Assigned, not inlined: a failed substitution inside `echo` leaves
+              # the step green and the toolchain input empty.
               run: |
                   msrv="$(.github/scripts/declared-msrv.sh)"
                   echo "version=$msrv" >> "$GITHUB_OUTPUT"
             # Not `rust-setup`: rustup resolves `rust-toolchain.toml` at cargo
-            # time, so the file's channel wins over any `toolchain:` input.
-            # `RUSTUP_TOOLCHAIN` on the check step does override the file.
+            # time, so the file beats any `toolchain:` input. `RUSTUP_TOOLCHAIN`
+            # on the check step does override it.
             - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88  # master 2026-06-30
               with:
                   toolchain: ${{ steps.declared.outputs.version }}
-            # Default features and `--locked`, so this covers the committed graph
-            # alone. A consumer who enables an optional feature, or who resolves
-            # afresh, may pull a dependency that wants a newer compiler; the job
-            # makes no claim about either case.
+            # Default features and `--locked`: the committed graph only, no claim
+            # about a fresh resolve or an optional feature.
             - name: cargo check
               env:
                   RUSTUP_TOOLCHAIN: ${{ steps.declared.outputs.version }}
                   MSRV: ${{ steps.declared.outputs.version }}
               run: |
-                  # Guards the override: were the toolchain file to win, the job
-                  # would check on the pinned channel and report green for a
-                  # declaration it never compiled.
+                  # Catches the toolchain file winning, which would check on the
+                  # pinned channel and report green.
                   actual="$(rustc --version | cut -d' ' -f2)"
                   case "$actual" in
                       "$MSRV" | "$MSRV".*) ;;

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 version = "0.4.0"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.94"
 authors = ["Nexum Contributors"]
 license = "AGPL-3.0-or-later"
 homepage = "https://nxm-rs.github.io/nectar"


### PR DESCRIPTION
Closes #702

Corrects `[workspace.package].rust-version` from `1.92` to `1.94` in the root `Cargo.toml`, and adds a `lint / msrv` job to `.github/workflows/lint.yml` that compiles the workspace on whatever that field declares.

The toolchain number is derived, never hard-coded into the workflow. `.github/scripts/declared-msrv.sh` awk-parses `rust-version` out of the `[workspace.package]` section of the root manifest, and errors if the field is absent, so an empty result cannot silently fall back to the pinned channel and report green for an untested declaration. The job installs that version with the same `dtolnay/rust-toolchain` pin the shared setup action uses, then sets `RUSTUP_TOOLCHAIN` on the check step.

Nothing else in the tree parses the manifest for a version. The other 1.94 sites (`rust-toolchain.toml`, `.github/actions/rust-setup`, `flake.nix`) are literals this job does not try to cover.

Scope note: this range touches no Rust source. The only manifest change is the `rust-version` bump; the rest is the workflow plus the two new scripts. No per-crate clippy selection, feature array, or `nostd.yml` target changed, so those checks were not re-run here.

## Testing

`.github/scripts/declared-msrv-test.sh` passes: 6/6 cases, 0 failures, exit 0. Re-run with `awk` shimmed to both `mawk` and `gawk` to confirm the parsing logic isn't tied to one awk implementation.

## AI Assistance

Implementation: claude-opus-5. Red-team review: claude-opus-5. PR: claude-sonnet-5.
