### PR TITLE
ci(lint): add a format and content-lint job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 # Clippy (runtime-safety restriction lints), unused-dependency checks, the
-# cargo-deny supply-chain gate (advisories, bans, sources, licences), and the
-# MSRV compile on the declared `rust-version`.
+# cargo-deny supply-chain gate (advisories, bans, sources, licences), the
+# MSRV compile on the declared `rust-version`, and the format/content sweep.
 name: lint
 
 on:
@@ -185,13 +185,45 @@ jobs:
                   esac
                   cargo check --workspace --all-targets --locked
 
+    # Backstop for the agent hooks: `.claude/hooks/rustfmt-on-edit.sh` exits 0
+    # without formatting whenever `rustfmt` is off `PATH`, so drift lands silently
+    # from outside the dev shell.
+    format:
+        name: format
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+            # Compiles nothing, so `rustfmt` is the only component.
+            - uses: ./.github/actions/rust-setup
+              with:
+                  components: rustfmt
+            - name: cargo fmt
+              run: cargo fmt --all --check
+            # Wider than the hook's `.rs`/`.md` scope on purpose, and never widened to
+            # `*.yml`: the pattern sits in this file and would match itself forever.
+            # `git grep`, not `rg`: ripgrep is absent from the runner image.
+            - name: no em dashes
+              run: |
+                  # A scan error is indistinguishable from a clean tree, so plant a match.
+                  mkdir em-probe
+                  printf '—\n' > em-probe/probe.md
+                  if ! git grep --no-index -qF -e '—' -- em-probe; then
+                      echo "::error::the scan misses a planted U+2014; it is not scanning"
+                      exit 1
+                  fi
+                  if git grep -nIF -e '—' -- '*.rs' '*.md' '*.toml'; then
+                      echo "::error::U+2014 found; house style bans it"
+                      exit 1
+                  fi
+
     # The one required context for this workflow: later jobs append to `needs`
     # rather than to the branch ruleset.
     lint-success:
         name: lint success
         runs-on: ubuntu-latest
         if: always()
-        needs: [clippy, unused-deps, deny, msrv]
+        needs: [clippy, unused-deps, deny, msrv, format]
         timeout-minutes: 30
         steps:
             - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -185,37 +185,42 @@ jobs:
                   esac
                   cargo check --workspace --all-targets --locked
 
-    # Backstop for the agent hooks: `.claude/hooks/rustfmt-on-edit.sh` exits 0
-    # without formatting whenever `rustfmt` is off `PATH`, so drift lands silently
-    # from outside the dev shell.
+    # Backstop for `.claude/hooks/rustfmt-on-edit.sh`, which exits 0 without
+    # formatting whenever `rustfmt` is off `PATH`.
     format:
         name: format
         runs-on: ubuntu-latest
         timeout-minutes: 30
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-            # Compiles nothing, so `rustfmt` is the only component.
-            - uses: ./.github/actions/rust-setup
+            # Not `rust-setup`: this job compiles nothing, so it would beat the
+            # compiling jobs to the shared registry cache key with an empty ~/.cargo.
+            - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88  # master 2026-06-30
               with:
+                  toolchain: "1.94"
                   components: rustfmt
             - name: cargo fmt
               run: cargo fmt --all --check
-            # Wider than the hook's `.rs`/`.md` scope on purpose, and never widened to
+            # `fuzz/` carries its own `[workspace]` table, so the sweep above misses it.
+            - name: cargo fmt (fuzz)
+              run: cargo fmt --manifest-path fuzz/Cargo.toml --all --check
+            # Wider than the hook's `.rs`/`.md` scope on purpose. Never widen to
             # `*.yml`: the pattern sits in this file and would match itself forever.
-            # `git grep`, not `rg`: ripgrep is absent from the runner image.
             - name: no em dashes
               run: |
-                  # A scan error is indistinguishable from a clean tree, so plant a match.
-                  mkdir em-probe
-                  printf '—\n' > em-probe/probe.md
-                  if ! git grep --no-index -qF -e '—' -- em-probe; then
-                      echo "::error::the scan misses a planted U+2014; it is not scanning"
-                      exit 1
-                  fi
-                  if git grep -nIF -e '—' -- '*.rs' '*.md' '*.toml'; then
-                      echo "::error::U+2014 found; house style bans it"
-                      exit 1
-                  fi
+                  # git grep exits 1 for a clean tree and >1 for a scan that broke.
+                  git grep -nIF -e '—' -- '*.rs' '*.md' '*.toml' && found=0 || found=$?
+                  case "$found" in
+                      0)
+                          echo "::error::U+2014 found; house style bans it"
+                          exit 1
+                          ;;
+                      1) ;;
+                      *)
+                          echo "::error::the U+2014 scan failed with status $found"
+                          exit 1
+                          ;;
+                  esac
 
     # The one required context for this workflow: later jobs append to `needs`
     # rather than to the branch ruleset.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
-  <img src=".github/banner.svg" alt="Nexum · nectar — low-level Swarm primitives in Rust" width="100%" />
+  <img src=".github/banner.svg" alt="Nexum · nectar: low-level Swarm primitives in Rust" width="100%" />
 </p>
 
-**Low-level Ethereum Swarm primitives in Rust** — the tedious bits that make the magic happen. Content addressing, chunk management, postage stamps, manifest tries, contract bindings.
+**Low-level Ethereum Swarm primitives in Rust**: the tedious bits that make the magic happen. Content addressing, chunk management, postage stamps, manifest tries, contract bindings.
 
 Used by [`nxm-rs/vertex`](https://github.com/nxm-rs/vertex) (the Rust Swarm node) and available for anyone building Swarm-powered Rust applications who'd rather import a vetted primitives crate than re-implement the wire format.
 
@@ -54,7 +54,7 @@ nectar-primitives = { git = "https://github.com/nxm-rs/nectar", rev = "..." }
 
 ## Contributing
 
-Open an issue before non-trivial PRs. Conventional Commits, `cargo fmt`, `cargo clippy -- -D warnings`. Tests for protocol-touching changes are non-optional — wire-format regressions are expensive to debug after the fact. The wire-format decoders are also fuzzed continuously; see [`fuzz/README.md`](./fuzz/README.md) for the cargo-fuzz harness. CLA in [`CLA.md`](./CLA.md).
+Open an issue before non-trivial PRs. Conventional Commits, `cargo fmt`, `cargo clippy -- -D warnings`. Tests for protocol-touching changes are non-optional; wire-format regressions are expensive to debug after the fact. The wire-format decoders are also fuzzed continuously; see [`fuzz/README.md`](./fuzz/README.md) for the cargo-fuzz harness. CLA in [`CLA.md`](./CLA.md).
 
 ## Security
 

--- a/crates/benches/benches/upload_pipeline.rs
+++ b/crates/benches/benches/upload_pipeline.rs
@@ -59,10 +59,9 @@ impl ReadAt for SharedBuf {
 /// Sequential streaming split of the whole buffer.
 fn split_sequential(data: &[u8]) -> (ChunkAddress, Vec<SealedChunk>) {
     let sink = Collect::default();
-    let root = run(
-        File::<Collect, DEFAULT_BODY_SIZE>::new(sink.clone(), Policy::DEFAULT).save(data),
-    )
-    .unwrap();
+    let root =
+        run(File::<Collect, DEFAULT_BODY_SIZE>::new(sink.clone(), Policy::DEFAULT).save(data))
+            .unwrap();
     let chunks = std::mem::take(&mut *sink.0.lock().unwrap());
     (root, chunks)
 }

--- a/crates/file/src/handle.rs
+++ b/crates/file/src/handle.rs
@@ -344,7 +344,11 @@ where
     }
 
     /// One read builder wired to this handle's policy.
-    fn reads<M: WalkMode>(&self, file: &Opened<S, M, B>, range: Range<u64>) -> ReadBuilder<S, M, B> {
+    fn reads<M: WalkMode>(
+        &self,
+        file: &Opened<S, M, B>,
+        range: Range<u64>,
+    ) -> ReadBuilder<S, M, B> {
         let builder = file.read().window(self.policy.window).range(range);
         #[cfg(feature = "std")]
         if let Some(adaptive) = self.policy.adaptive {
@@ -412,7 +416,10 @@ where
     }
 
     /// Split `src` under an explicit reference grammar.
-    pub async fn save_as<M, Src>(&self, src: Src) -> Result<M::Root, SaveError<S::Error, Src::Error>>
+    pub async fn save_as<M, Src>(
+        &self,
+        src: Src,
+    ) -> Result<M::Root, SaveError<S::Error, Src::Error>>
     where
         M: SplitMode + Default,
         Src: Source,
@@ -485,14 +492,22 @@ where
 macro_rules! dispatch {
     ($self:expr, $reader:ident => $body:expr) => {
         match &$self.inner {
-            ReaderInner::Plain { reader: $reader, .. } => $body,
-            ReaderInner::Encrypted { reader: $reader, .. } => $body,
+            ReaderInner::Plain {
+                reader: $reader, ..
+            } => $body,
+            ReaderInner::Encrypted {
+                reader: $reader, ..
+            } => $body,
         }
     };
     (mut $self:expr, $reader:ident => $body:expr) => {
         match &mut $self.inner {
-            ReaderInner::Plain { reader: $reader, .. } => $body,
-            ReaderInner::Encrypted { reader: $reader, .. } => $body,
+            ReaderInner::Plain {
+                reader: $reader, ..
+            } => $body,
+            ReaderInner::Encrypted {
+                reader: $reader, ..
+            } => $body,
         }
     };
 }

--- a/crates/file/src/handle/tests.rs
+++ b/crates/file/src/handle/tests.rs
@@ -343,7 +343,10 @@ fn a_read_failure_is_typed_with_its_offset() {
         PutWindow::DEFAULT,
     ))
     .unwrap_err();
-    let SaveError::Source { source: ReadAtError::Read { offset, .. } } = error else {
+    let SaveError::Source {
+        source: ReadAtError::Read { offset, .. },
+    } = error
+    else {
         panic!("expected a read error, got {error:?}");
     };
     assert_eq!(offset, u64::try_from(TINY).unwrap());
@@ -378,7 +381,10 @@ fn a_source_ending_early_is_a_short_read() {
         PutWindow::DEFAULT,
     ))
     .unwrap_err();
-    let SaveError::Source { source: ReadAtError::ShortRead { offset, remaining } } = error else {
+    let SaveError::Source {
+        source: ReadAtError::ShortRead { offset, remaining },
+    } = error
+    else {
         panic!("expected a short read, got {error:?}");
     };
     assert_eq!(offset, u64::try_from(TINY + 100).unwrap());
@@ -437,7 +443,12 @@ fn a_sizing_failure_is_typed() {
     ))
     .unwrap_err();
     assert!(
-        matches!(error, SaveError::Source { source: ReadAtError::Length { .. } }),
+        matches!(
+            error,
+            SaveError::Source {
+                source: ReadAtError::Length { .. }
+            }
+        ),
         "got {error:?}"
     );
 }
@@ -484,10 +495,12 @@ impl crate::source::Source for OverReportingSource {
 #[test]
 fn an_over_reporting_source_is_clamped_to_the_buffer() {
     let store = TestStore::<TINY>::new(0);
-    let root = run(File::<_, TINY>::new(store, Policy::DEFAULT).save(OverReportingSource {
-        byte: 0x5a,
-        sent: false,
-    }))
+    let root = run(
+        File::<_, TINY>::new(store, Policy::DEFAULT).save(OverReportingSource {
+            byte: 0x5a,
+            sent: false,
+        }),
+    )
     .unwrap();
     // Clamped, so the tree is exactly one body of the reported byte; an
     // unclamped driver would see an empty round and save nothing.
@@ -536,11 +549,10 @@ fn a_constructed_key_source_seals_every_chunk() {
     let mode = Encrypted::new(SeededKeys {
         next: std::sync::atomic::AtomicU64::new(SEED),
     });
-    let (root, stats) = run(
-        File::<_, TINY>::new(store.clone(), Policy::DEFAULT)
-            .save_with_mode(mode, data.as_slice()),
-    )
-    .unwrap();
+    let (root, stats) =
+        run(File::<_, TINY>::new(store.clone(), Policy::DEFAULT)
+            .save_with_mode(mode, data.as_slice()))
+        .unwrap();
 
     // The root is the last seal, so its key is the last draw of the stream.
     let mut last = [0u8; 8];

--- a/crates/file/src/read/cancel.rs
+++ b/crates/file/src/read/cancel.rs
@@ -20,7 +20,7 @@ use nectar_testing::{run, split_fixture, yield_now};
 #[cfg(feature = "encryption")]
 use crate::testutil::split_encrypted_fixture;
 
-use super::{Opened, FileReader, FileStream};
+use super::{FileReader, FileStream, Opened};
 use crate::config::Window;
 #[cfg(feature = "encryption")]
 use crate::walk::Encrypted;

--- a/crates/file/src/read/download.rs
+++ b/crates/file/src/read/download.rs
@@ -140,7 +140,10 @@ where
     ///
     /// Frames land in completion order, each written once at its
     /// range-relative offset; any error is terminal for this run.
-    pub async fn run<K: DataSink>(self, sink: &mut K) -> Result<u64, LoadError<S::Error, K::Error>> {
+    pub async fn run<K: DataSink>(
+        self,
+        sink: &mut K,
+    ) -> Result<u64, LoadError<S::Error, K::Error>> {
         let mut walk = Walk::new(
             self.store,
             self.root,

--- a/crates/file/src/read/reader.rs
+++ b/crates/file/src/read/reader.rs
@@ -348,7 +348,6 @@ where
             walk: self.walk,
         }
     }
-
 }
 
 impl<S, M, const B: usize> fmt::Debug for FileReader<S, M, B>

--- a/crates/file/src/read/tests.rs
+++ b/crates/file/src/read/tests.rs
@@ -21,7 +21,7 @@ use nectar_testing::{run, split_fixture};
 #[cfg(feature = "encryption")]
 use crate::testutil::split_encrypted_fixture;
 
-use super::{AnyOpened, CollectError, Opened, FileReader, OpenError, SeekPastEnd};
+use super::{AnyOpened, CollectError, FileReader, OpenError, Opened, SeekPastEnd};
 use crate::config::Window;
 use crate::geometry::Mode;
 use crate::walk::{DecodeError, Encrypted, Plain, WalkError, WalkMode};
@@ -179,7 +179,10 @@ fn encrypted_range_reads_match_the_source_slices() {
     let len = 33 * TINY + 17;
     let data = fill(len);
     let (root_ref, store) = split_encrypted_fixture::<TINY>(&data);
-    let file = run(Opened::<_, Encrypted, TINY>::open_encrypted(store, root_ref)).unwrap();
+    let file = run(Opened::<_, Encrypted, TINY>::open_encrypted(
+        store, root_ref,
+    ))
+    .unwrap();
 
     for range in ranges(len as u64) {
         let expect =
@@ -360,7 +363,10 @@ fn stream_tiles_the_range_and_carries_reader_leftovers() {
 fn next_segment_is_gapless_and_zero_copy_sized() {
     let data = fill(6 * TINY + 30);
     let (root_ref, store) = split_encrypted_fixture::<TINY>(&data);
-    let file = run(Opened::<_, Encrypted, TINY>::open_encrypted(store, root_ref)).unwrap();
+    let file = run(Opened::<_, Encrypted, TINY>::open_encrypted(
+        store, root_ref,
+    ))
+    .unwrap();
     let mut reader = file.read().build();
     let collected = run(async {
         let mut out = Vec::new();
@@ -460,7 +466,10 @@ fn debug_never_leaks_the_decryption_key() {
         assert!(!rendered.contains("key"), "{rendered}");
     };
     let (root_ref, store) = split_encrypted_fixture::<TINY>(&data);
-    let file = run(Opened::<_, Encrypted, TINY>::open_encrypted(store, root_ref)).unwrap();
+    let file = run(Opened::<_, Encrypted, TINY>::open_encrypted(
+        store, root_ref,
+    ))
+    .unwrap();
     key_free(std::format!("{file:?}"));
     key_free(std::format!("{:?}", file.read()));
     key_free(std::format!("{:?}", file.read().build()));
@@ -551,7 +560,10 @@ fn encrypted_download_overwrites_a_prefilled_sink() {
 
     let data = fill(11 * TINY + 63);
     let (root_ref, store) = split_encrypted_fixture::<TINY>(&data);
-    let enc_file = run(Opened::<_, Encrypted, TINY>::open_encrypted(store, root_ref)).unwrap();
+    let enc_file = run(Opened::<_, Encrypted, TINY>::open_encrypted(
+        store, root_ref,
+    ))
+    .unwrap();
 
     let mut sink = MemSink::new();
     sink.write_at(0, &vec![0xa5; data.len()]).unwrap();
@@ -620,7 +632,10 @@ fn collect_assembles_the_clipped_range() {
 fn encrypted_collect_assembles_the_file() {
     let data = fill(9 * TINY + 21);
     let (root_ref, store) = split_encrypted_fixture::<TINY>(&data);
-    let enc_file = run(Opened::<_, Encrypted, TINY>::open_encrypted(store, root_ref)).unwrap();
+    let enc_file = run(Opened::<_, Encrypted, TINY>::open_encrypted(
+        store, root_ref,
+    ))
+    .unwrap();
     assert_eq!(run(enc_file.collect(u64::MAX)).unwrap(), data);
 }
 

--- a/crates/file/src/source.rs
+++ b/crates/file/src/source.rs
@@ -47,7 +47,8 @@ impl Source for &[u8] {
         buf: &mut [u8],
     ) -> Poll<Result<usize, Infallible>> {
         let take = <[u8]>::len(self).min(buf.len());
-        let (Some(head), Some((dst, _))) = (self.get(..take), buf.split_at_mut_checked(take)) else {
+        let (Some(head), Some((dst, _))) = (self.get(..take), buf.split_at_mut_checked(take))
+        else {
             return Poll::Ready(Ok(0));
         };
         dst.copy_from_slice(head);

--- a/crates/file/src/split/tests.rs
+++ b/crates/file/src/split/tests.rs
@@ -1210,10 +1210,11 @@ fn huge_stream_root_matches_the_batch_ingest() {
         }
     }
 
-    let batch_root = run(
-        File::<Discard, B>::new(Discard, Policy::DEFAULT.with_put_window(PutWindow::new(16).unwrap()))
-            .save_as::<Plain, _>(ReadAtSource::new(Pattern { len: size })),
+    let batch_root = run(File::<Discard, B>::new(
+        Discard,
+        Policy::DEFAULT.with_put_window(PutWindow::new(16).unwrap()),
     )
+    .save_as::<Plain, _>(ReadAtSource::new(Pattern { len: size })))
     .unwrap();
 
     let mut split: Split<'_, Discard, Plain, B> = Split::new(Discard, PutWindow::new(16).unwrap());

--- a/crates/file/src/tokio/tests.rs
+++ b/crates/file/src/tokio/tests.rs
@@ -214,10 +214,7 @@ async fn an_async_read_source_saves_the_same_root_as_a_slice() {
         let data = fill(len);
         let store = SharedStore::default();
         let file = File::<_, TINY>::new(store.clone(), Policy::DEFAULT);
-        let root = file
-            .save(AsyncReadSource::new(&data[..]))
-            .await
-            .unwrap();
+        let root = file.save(AsyncReadSource::new(&data[..])).await.unwrap();
         let (expected, _) = split_fixture::<TINY>(&data);
         assert_eq!(root, expected, "diverged at {len}");
 

--- a/crates/integration-tests/tests/file/alloc_probe.rs
+++ b/crates/integration-tests/tests/file/alloc_probe.rs
@@ -36,9 +36,8 @@ fn probe(leaves: usize) -> AllocationInfo {
     let store: Store = Arc::new(store);
 
     let file: File<Store, BODY> = File::new(store, Policy::DEFAULT);
-    let (out, info) = measure_allocations(|| {
-        run(async { file.collect(root.into(), u64::MAX).await.unwrap() })
-    });
+    let (out, info) =
+        measure_allocations(|| run(async { file.collect(root.into(), u64::MAX).await.unwrap() }));
 
     assert_eq!(out, data, "plaintext diverged at {leaves} leaves");
     info

--- a/crates/integration-tests/tests/file/membound.rs
+++ b/crates/integration-tests/tests/file/membound.rs
@@ -453,8 +453,7 @@ fn collect_refuses_an_oversized_range_before_any_fetch() {
 
     // One byte under the length: a typed refusal before the walk fetches.
     let store = built.fresh(0);
-    let error =
-        run(reader_at(store.clone(), 4).collect(root.into(), size as u64 - 1)).unwrap_err();
+    let error = run(reader_at(store.clone(), 4).collect(root.into(), size as u64 - 1)).unwrap_err();
     match error {
         CollectError::TooLarge { len, max } => {
             assert_eq!((len, max), (size as u64, size as u64 - 1));
@@ -583,7 +582,9 @@ mod encrypted {
     use core::sync::atomic::{AtomicU64, Ordering};
     use std::sync::Arc;
 
-    use nectar_file::{Encrypted, File, KeyError, KeySource, Policy, PutWindow, SplitStats, Window};
+    use nectar_file::{
+        Encrypted, File, KeyError, KeySource, Policy, PutWindow, SplitStats, Window,
+    };
     use nectar_primitives::chunk::encryption::{EncryptedChunkRef, EncryptionKey};
     use nectar_primitives::store::ContentGet;
     use nectar_testing::run;

--- a/crates/integration-tests/tests/file/plain_alloc_probe.rs
+++ b/crates/integration-tests/tests/file/plain_alloc_probe.rs
@@ -31,8 +31,8 @@ fn fill(len: usize) -> Vec<u8> {
 /// Stream `data` through a plain save into a fresh memory store.
 fn split_plain(data: &[u8]) -> (ChunkAddress, Store) {
     let store: Store = Arc::new(MemoryStore::new());
-    let root = run(File::<Store, BODY>::new(Arc::clone(&store), Policy::DEFAULT).save(data))
-        .unwrap();
+    let root =
+        run(File::<Store, BODY>::new(Arc::clone(&store), Policy::DEFAULT).save(data)).unwrap();
     (root, store)
 }
 

--- a/crates/integration-tests/tests/file/split_membound.rs
+++ b/crates/integration-tests/tests/file/split_membound.rs
@@ -114,12 +114,7 @@ fn split_peak(total: usize) -> u64 {
     );
     let ((), info) = measure_allocations(|| {
         run(async {
-            file.save(Splitmix {
-                produced: 0,
-                total,
-            })
-            .await
-            .unwrap();
+            file.save(Splitmix { produced: 0, total }).await.unwrap();
         })
     });
     info.bytes_max

--- a/crates/integration-tests/tests/ldb/bridge.rs
+++ b/crates/integration-tests/tests/ldb/bridge.rs
@@ -22,10 +22,9 @@ async fn build_files(
 ) -> Result<Built> {
     let mut builder: Builder = Builder::new();
     for (key, data) in files {
-        let root =
-            File::<_, DEFAULT_BODY_SIZE>::new(store, Policy::DEFAULT)
-                .save(&data[..])
-                .await?;
+        let root = File::<_, DEFAULT_BODY_SIZE>::new(store, Policy::DEFAULT)
+            .save(&data[..])
+            .await?;
         builder.insert(key, Entry::from(ChunkRef::new(root)), None);
     }
     Ok(builder.build(store, &Plaintext).await?)

--- a/crates/integration-tests/tests/ldb/builder.rs
+++ b/crates/integration-tests/tests/ldb/builder.rs
@@ -28,10 +28,9 @@ async fn build_files(
 ) -> Result<Built> {
     let mut builder: Builder = Builder::new();
     for (key, data) in files {
-        let root =
-            File::<_, DEFAULT_BODY_SIZE>::new(store, Policy::DEFAULT)
-                .save(&data[..])
-                .await?;
+        let root = File::<_, DEFAULT_BODY_SIZE>::new(store, Policy::DEFAULT)
+            .save(&data[..])
+            .await?;
         builder.insert(key, Entry::from(ChunkRef::new(root)), None);
     }
     Ok(builder.build(store, &Plaintext).await?)

--- a/crates/integration-tests/tests/ldb/conformance.rs
+++ b/crates/integration-tests/tests/ldb/conformance.rs
@@ -8,9 +8,8 @@ use alloy_primitives::{b256, keccak256};
 use anyhow::{Context, Result, ensure};
 use bytes::Bytes;
 use nectar_ldb::{
-    Child, CustomKeyError, DecodeError, Entry, ForkPayload, ForkTable, Format, KeyId,
-    Metadata, Node, Prefix, RootExtension, SegmentKind, SegmentWeight, V1, cut, embed, h64,
-    segment,
+    Child, CustomKeyError, DecodeError, Entry, ForkPayload, ForkTable, Format, KeyId, Metadata,
+    Node, Prefix, RootExtension, SegmentKind, SegmentWeight, V1, cut, embed, h64, segment,
 };
 use nectar_primitives::{ChunkAddress, ChunkRef, EncryptedChunkRef, EncryptionKey};
 
@@ -273,10 +272,7 @@ fn child_embedding_gates_on_inline_max() -> Result<()> {
         embed::<V1>(123),
         "the worked child within INLINE_MAX embeds",
     );
-    ensure!(
-        embed::<V1>(V1::INLINE_MAX),
-        "a body at INLINE_MAX embeds",
-    );
+    ensure!(embed::<V1>(V1::INLINE_MAX), "a body at INLINE_MAX embeds",);
     ensure!(
         !embed::<V1>(V1::INLINE_MAX + 1),
         "a body over INLINE_MAX spills",

--- a/crates/integration-tests/tests/ldb/determinism.rs
+++ b/crates/integration-tests/tests/ldb/determinism.rs
@@ -12,8 +12,8 @@ use std::collections::BTreeMap;
 use anyhow::{Context, Result, ensure};
 use arbitrary::Unstructured;
 use nectar_ldb::{
-    Builder, Entry, ForkTable, Format, Key, Node, Plaintext, Prefix, SegmentKind,
-    SegmentWeight, V1, cut, generators, h64, segment, spill,
+    Builder, Entry, ForkTable, Format, Key, Node, Plaintext, Prefix, SegmentKind, SegmentWeight,
+    V1, cut, generators, h64, segment, spill,
 };
 use nectar_primitives::store::MemoryStore;
 use nectar_primitives::{ChunkAddress, ChunkOps, ChunkRef};

--- a/crates/mantaray/src/cursor.rs
+++ b/crates/mantaray/src/cursor.rs
@@ -184,16 +184,15 @@ where
             };
             let store = self.store.clone();
             let reference = pending.reference.clone();
-            let fetch: BoxFuture<'static, Fetched> =
-                Box::pin(async move {
-                    let fetched = store.collect_with_addresses(&reference).await.map_err(|e| {
-                        CursorError::Store {
-                            address: *reference.address(),
-                            source: Arc::new(e),
-                        }
-                    });
-                    (id, pending, fetched)
+            let fetch: BoxFuture<'static, Fetched> = Box::pin(async move {
+                let fetched = store.collect_with_addresses(&reference).await.map_err(|e| {
+                    CursorError::Store {
+                        address: *reference.address(),
+                        source: Arc::new(e),
+                    }
                 });
+                (id, pending, fetched)
+            });
             self.in_flight.push(fetch);
             occupancy = occupancy.saturating_add(1);
             if index == 0 {

--- a/crates/mantaray/src/lib.rs
+++ b/crates/mantaray/src/lib.rs
@@ -178,10 +178,10 @@ pub use manifest::{MantarayManifest, TrieCursor, TrieFormatError, TrieView};
 #[cfg(feature = "std")]
 pub use node::NodeType;
 pub use obfuscation::ObfuscationKey;
-#[cfg(feature = "manifest")]
-pub use persist::{NodeCollectError, NodeLoadSaver};
 #[cfg(feature = "std")]
 pub use persist::{MAX_NODE_BYTES, NodeLoader, NodeSaver};
+#[cfg(feature = "manifest")]
+pub use persist::{NodeCollectError, NodeLoadSaver};
 #[cfg(feature = "std")]
 pub use reader::{DEFAULT_MAX_DEPTH, Reader};
 #[cfg(feature = "std")]

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -115,7 +115,7 @@ std = [
 	"nectar-primitives-core/std",
 ]
 # WASM thread pool via wasm-bindgen-rayon. OFF by default so the default wasm
-# build needs no SharedArrayBuffer / cross-origin isolation — letting it run on
+# build needs no SharedArrayBuffer / cross-origin isolation, letting it run on
 # hosts that can't set COOP/COEP (e.g. the eth.limo ENS gateway). Enable it
 # (`--features wasm-threads`) only to export `initThreadPool` for a consumer
 # that drives rayon itself: this crate's own parallel BMT path is gated to

--- a/crates/primitives/src/wasm.rs
+++ b/crates/primitives/src/wasm.rs
@@ -24,7 +24,7 @@
 // Gated behind the `wasm-threads` feature (default-off). The mere PRESENCE of
 // this re-export in the linked artifact makes wasm-bindgen run its threads
 // transform and require a SharedArrayBuffer memory (hence COOP/COEP on the
-// host) — independent of whether JS ever calls it. Without `wasm-threads`, the
+// host), independent of whether JS ever calls it. Without `wasm-threads`, the
 // wasm needs no shared memory; the plain `rayon` code paths run inline.
 #[cfg(feature = "wasm-threads")]
 pub use wasm_bindgen_rayon::init_thread_pool;

--- a/crates/testing/src/fixtures.rs
+++ b/crates/testing/src/fixtures.rs
@@ -28,9 +28,10 @@ where
     M: SplitMode + Default,
 {
     let store = Arc::new(MemoryStore::new());
-    let root = File::<Arc<MemoryStore<AnyChunkSet<B>>>, B>::new(Arc::clone(&store), Policy::DEFAULT)
-        .save_as::<M, _>(data)
-        .await?;
+    let root =
+        File::<Arc<MemoryStore<AnyChunkSet<B>>>, B>::new(Arc::clone(&store), Policy::DEFAULT)
+            .save_as::<M, _>(data)
+            .await?;
     let store = Arc::into_inner(store).ok_or("split still holds the store")?;
     let chunks = store
         .into_chunks()

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,7 +1,7 @@
 # Fuzzing nectar
 
 [cargo-fuzz](https://rust-fuzz.github.io/book/cargo-fuzz.html) (libFuzzer)
-harness for nectar's wire-format decoders — the code that parses untrusted
+harness for nectar's wire-format decoders: the code that parses untrusted
 bytes off the Swarm network. This directory is an **independent cargo
 workspace** (it carries its own `[workspace]` table), so the stable toolchain
 building the parent workspace never touches the nightly-only fuzz crate.
@@ -24,7 +24,7 @@ cargo fuzz coverage stamp_decode                            # llvm-cov profdata
 New corpus entries are written to the **first** directory passed to
 `cargo fuzz run`; further directories (the seeds) are read-only inputs.
 `cargo fuzz coverage` finds `llvm-profdata`/`llvm-cov` through the rustc
-sysroot — the fuzz shell's nightly ships the `llvm-tools` component.
+sysroot; the fuzz shell's nightly ships the `llvm-tools` component.
 
 Release-profile `overflow-checks` and `debug-assertions` are enabled in
 `Cargo.toml`, so arithmetic overflow and `debug_assert!` violations are fuzz
@@ -32,8 +32,8 @@ oracles, not silent wraps.
 
 ## Target catalogue
 
-Decode targets take raw `&[u8]` — the decoder itself is the structure
-recoverer — and a returned `Err` is success; the invariant is *no panic, no
+Decode targets take raw `&[u8]`, because the decoder itself is the structure
+recoverer, and a returned `Err` is success; the invariant is *no panic, no
 OOM, no hang*:
 
 | Target | Entry point | Invariant |
@@ -48,7 +48,7 @@ OOM, no hang*:
 Round-trip targets take a structured value via valid-by-construction
 generators and `arbitrary::Arbitrary` impls (behind each crate's `arbitrary`
 feature), so the
-invariant is stronger — encode must decode back to an equal value, and where
+invariant is stronger: encode must decode back to an equal value, and where
 the encoding is canonical, re-encoding must be byte-identical. The one
 exception is `mantaray_record_roundtrip`, which takes raw `&[u8]` and is seeded
 from the `mantaray_node_decode` corpus: the encoder emits v0.2 only, so it
@@ -135,11 +135,11 @@ the replay tests (bridged from the `Arbitrary` layer via
 
 `.github/workflows/fuzz.yml` (existing `unit.yml`/`audit.yml` are untouched):
 
-- **Every PR / push to main** — `fuzz build` compiles all targets (the
+- **Every PR / push to main**: `fuzz build` compiles all targets (the
   harness can't rot), and `fuzz smoke` runs each target for 60 s
   (`-rss_limit_mb=2048`) on a per-target cached corpus with the committed
   seeds merged in. Crash artifacts are uploaded on failure.
-- **Nightly cron** — 10 minutes per target on the same corpus caches,
+- **Nightly cron**: 10 minutes per target on the same corpus caches,
   followed by a merge-minimize over corpus plus seeds; the minimized set is
   then committed back into `fuzz/seeds/` by an automated PR.
 
@@ -148,7 +148,7 @@ the replay tests (bridged from the `Arbitrary` layer via
 - Use `nix develop .#fuzz`. `libfuzzer-sys` compiles the libFuzzer C++
   runtime through the `cc` crate, which is why the shell carries `clang`;
   outside the shell the build fails at that step.
-- Don't force `lld`/`mold` via `RUSTFLAGS` for fuzz builds — the sanitizer
+- Don't force `lld`/`mold` via `RUSTFLAGS` for fuzz builds; the sanitizer
   runtimes are linked by rustc's defaults and alternative-linker flags are a
   recurring source of broken ASan link steps. Plain defaults work.
 - If an ASan-instrumented run dies immediately with an endlessly repeating

--- a/fuzz/fuzz_targets/ldb_apply_rebuild.rs
+++ b/fuzz/fuzz_targets/ldb_apply_rebuild.rs
@@ -58,7 +58,12 @@ fuzz_target!(
             }
         }
 
-        let applied = run(apply(&ContentGet::new(&store), &Plaintext, &root, &changeset));
+        let applied = run(apply(
+            &ContentGet::new(&store),
+            &Plaintext,
+            &root,
+            &changeset,
+        ));
         let rebuilt = build(&merged).map(|(_, root)| root);
 
         if let (Ok(applied), Some(rebuilt)) = (applied, rebuilt) {

--- a/fuzz/fuzz_targets/ldb_build_roundtrip.rs
+++ b/fuzz/fuzz_targets/ldb_build_roundtrip.rs
@@ -49,7 +49,8 @@ fuzz_target!(|input: Vec<(Vec<u8>, Val)>| {
             "chunk {} bytes exceeds one chunk body",
             payload.len(),
         );
-        let reencoded = recanonicalize::<V1, ChunkRef>(payload.as_ref()).expect("a stored chunk must decode");
+        let reencoded =
+            recanonicalize::<V1, ChunkRef>(payload.as_ref()).expect("a stored chunk must decode");
         assert_eq!(
             reencoded.as_slice(),
             payload.as_ref(),


### PR DESCRIPTION
Closes #699

## What

Adds a `format` job to `.github/workflows/lint.yml` that backstops `.claude/hooks/rustfmt-on-edit.sh` (which exits 0 without formatting whenever `rustfmt` is off `PATH`).
The job runs three checks: `cargo fmt --all --check` on the main workspace, `cargo fmt --manifest-path fuzz/Cargo.toml --all --check` on the fuzz crate's independent `[workspace]`, and a `git grep` scan for the U+2014 em dash character over `*.rs`, `*.md` and `*.toml` that fails the job if a house-style-banned occurrence is found (the pattern deliberately excludes `*.yml` since it would match its own occurrence in this file). `lint-success` now waits on `format` alongside `clippy`, `unused-deps`, `deny` and `msrv`.

Five commits get the tree and the fuzz workspace clean enough for that job to pass:

- `style: sweep the workspace with cargo fmt` (773d01a3): mechanical `cargo fmt --all`, import reordering and call-chain rewrapping, mostly in test modules across `benches`, `file`, `mantaray`, `testing` and `integration-tests`. Verified by restoring `crates/` from the base and re-running `cargo fmt --all`: reproduces this commit byte for byte.
- `docs: drop the thirteen em dashes the house style bans` (e4582e5f): all thirteen U+2014 occurrences replaced with a colon, a semicolon or a restructured clause, in `README.md`, `fuzz/README.md` and `crates/primitives/Cargo.toml`. `README.md`'s alt text keeps its own `:` form ("Nexum · nectar: low-level Swarm primitives in Rust").
- `ci(lint): add a format and content-lint job` (cb751478): the workflow change described above.
- `style(fuzz): sweep the fuzz workspace with cargo fmt` (80922335): brings the independent `fuzz/` workspace under `cargo fmt --manifest-path fuzz/Cargo.toml --all --check` so the new fuzz-fmt check passes.
- `ci(lint): cover the fuzz workspace and fail on a broken em dash scan` (6a9c4a36): hardens the em-dash check so a `git grep` failure (exit status > 1) fails the job instead of being read as "clean."

## Testing

All commands run inside `nix develop --command`.

Format and content sweep (the job this PR adds):
- `cargo fmt --all --check`: no output.
- `cargo fmt --manifest-path fuzz/Cargo.toml --all --check`: no output.
- `git grep -nIF` for the U+2014 em dash over `*.rs`, `*.md` and `*.toml`: no matches (and `rg -nF` over the same globs agrees).

Clippy, every pass in `lint.yml` that covers a touched crate, all `-D warnings` and all clean:
- `cargo clippy --workspace --all-targets --locked`
- `cargo clippy --locked --all-targets -p nectar-file --features tokio` / `--features rayon` / `--features encryption`
- `cargo clippy --locked --all-targets -p nectar-integration-tests --features rayon,encryption,seal,issuer`
- `cargo clippy --locked --all-targets -p nectar-primitives --features envelope,encryption`

## AI Assistance

Implement: claude-opus-5. Red-team: claude-opus-5. PR: claude-sonnet-5.
