### PR TITLE
test: ruleset probe, deliberate lint failure (do not merge)

### DIFF
--- a/crates/clock/src/lib.rs
+++ b/crates/clock/src/lib.rs
@@ -96,3 +96,8 @@ mod tests {
         assert_eq!(Clock::now_ns(&by_ref), 43);
     }
 }
+
+/* ruleset verification: intentionally undocumented pub item */
+pub fn ruleset_gate_probe() -> u8 {
+    0
+}


### PR DESCRIPTION
Temporary probe verifying the `required_status_checks` rule added to ruleset 5744032.

Plants an undocumented `pub fn` in `nectar-clock`, which `missing_docs` reports and `-D warnings` promotes to a failure, so `lint / clippy` fails and the `lint success` aggregator fails with it.

Expected result: `mergeable_state: blocked`. This pull request will be closed and its branch deleted once observed; it must never be merged.