### PR TITLE
ci: close the stage 1 loose ends

### DIFF
--- a/.github/banner.src.svg
+++ b/.github/banner.src.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 320" width="1280" height="320" role="img" aria-label="Nexum nectar — low-level Swarm primitives in Rust" font-family="'JetBrains Mono','IBM Plex Mono',ui-monospace,Menlo,Consolas,'Liberation Mono',monospace">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 320" width="1280" height="320" role="img" aria-label="Nexum nectar: low-level Swarm primitives in Rust" font-family="'JetBrains Mono','IBM Plex Mono',ui-monospace,Menlo,Consolas,'Liberation Mono',monospace">
   <rect width="1280" height="320" fill="#0a0b0a"/>
 
   <g stroke="#5e7c4e" stroke-width="1" fill="none">

--- a/.github/banner.svg
+++ b/.github/banner.svg
@@ -4,7 +4,7 @@
    width="1280"
    height="320"
    role="img"
-   aria-label="Nexum nectar — low-level Swarm primitives in Rust"
+   aria-label="Nexum nectar: low-level Swarm primitives in Rust"
    font-family="'JetBrains Mono','IBM Plex Mono',ui-monospace,Menlo,Consolas,'Liberation Mono',monospace"
    version="1.1"
    id="svg12"

--- a/.github/scripts/no-em-dash.sh
+++ b/.github/scripts/no-em-dash.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Fails when U+2014 appears in a scanned file.
+#
+# The pattern lives here rather than in the workflow so that `*.yml` can be
+# scanned: an inline pattern would match its own workflow file forever. Never
+# add `*.sh` to the glob list below for the same reason.
+set -eu
+
+globs=('*.rs' '*.md' '*.toml' '*.yml' '*.yaml' '*.svg')
+
+# git grep exits 1 for no match and above 1 for a scan that broke.
+git grep -nIF -e '—' -- "${globs[@]}" && found=0 || found=$?
+
+case "$found" in
+    0)
+        echo "::error::U+2014 found; house style bans it"
+        exit 1
+        ;;
+    1) ;;
+    *)
+        echo "::error::the U+2014 scan failed with status $found"
+        exit 1
+        ;;
+esac

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -9,10 +9,10 @@ on:
     paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
+  # No paths filter: a required status check that a pull request never produces
+  # waits at Expected forever.
   pull_request:
-    paths:
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
+  merge_group:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -242,3 +242,18 @@ jobs:
                           --title "chore(fuzz): refresh the committed minimized corpus" \
                           --body "$(printf 'Nightly-minimized fuzz corpus, committed so accumulated coverage survives actions/cache eviction. Hash-named files sit next to the curated seeds and replay through the existing stable seed-replay tests.\n\n%s' "$summary")"
                   fi
+
+    # The one required context for this workflow: requiring the matrix legs
+    # directly would pin every target name into the branch ruleset. Skipped on a
+    # schedule run, where `smoke` does not run at all.
+    fuzz-success:
+        name: fuzz success
+        if: always() && github.event_name != 'schedule'
+        needs: [build, smoke]
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        steps:
+            - name: Decide whether the needed jobs succeeded or failed
+              uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # release/v1
+              with:
+                  jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -85,7 +85,7 @@ jobs:
               run: cargo clippy --locked --all-targets -p nectar-postage-issuer -- -D warnings
             # `unused_crate_dependencies` is enforced per-library via `cargo
             # rustc` (not `[workspace.lints]`) so the flag applies only to each
-            # crate's own lib target — never to benches/examples/tests (which
+            # crate's own lib target, never to benches/examples/tests (which
             # inherit the package's full dependency set and would false-positive)
             # or to third-party crates. cargo-machete (below) is the broader gate
             # that also covers non-lib targets.
@@ -204,23 +204,10 @@ jobs:
             # `fuzz/` carries its own `[workspace]` table, so the sweep above misses it.
             - name: cargo fmt (fuzz)
               run: cargo fmt --manifest-path fuzz/Cargo.toml --all --check
-            # Wider than the hook's `.rs`/`.md` scope on purpose. Never widen to
-            # `*.yml`: the pattern sits in this file and would match itself forever.
+            # Wider than the hook's `.rs`/`.md` scope on purpose. The pattern
+            # lives in the script so this file can be scanned too.
             - name: no em dashes
-              run: |
-                  # git grep exits 1 for a clean tree and >1 for a scan that broke.
-                  git grep -nIF -e '—' -- '*.rs' '*.md' '*.toml' && found=0 || found=$?
-                  case "$found" in
-                      0)
-                          echo "::error::U+2014 found; house style bans it"
-                          exit 1
-                          ;;
-                      1) ;;
-                      *)
-                          echo "::error::the U+2014 scan failed with status $found"
-                          exit 1
-                          ;;
-                  esac
+              run: .github/scripts/no-em-dash.sh
 
     # The one required context for this workflow: later jobs append to `needs`
     # rather than to the branch ruleset.

--- a/.github/workflows/zepter.yml
+++ b/.github/workflows/zepter.yml
@@ -4,8 +4,9 @@
 name: zepter
 
 on:
+    # No paths filter: a required status check that a pull request never
+    # produces waits at Expected forever.
     pull_request:
-        paths: ['**/Cargo.toml', 'zepter.yaml']
     merge_group:
     push:
         branches: [main]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,3 +115,25 @@ Use short sentences, the active voice, and one idea per sentence.
 In markdown files, put each sentence on its own line and do not wrap within a sentence; GitHub reflows the file when it displays it.
 This keeps a diff to one changed line per changed sentence.
 In PR and issue bodies, keep one line per paragraph, because GitHub renders single newlines in a comment as line breaks.
+
+### How much to write
+
+The default is no comment.
+A comment earns its place only when it says something the code cannot: a non-obvious invariant, a wire or specification constraint, why the obvious approach is wrong, or a footgun.
+One line is the target and three is the ceiling.
+A paragraph belongs in the issue or the pull request body.
+Never restate the signature, narrate the next statement, explain the language, or record rationale.
+Rationale goes in the pull request body, where review can see it and history keeps it.
+Do not add a worked example unless the API is genuinely unobvious.
+The same limit applies to comments in TOML, YAML and shell.
+Apply this test before you keep a comment: if a reviewer learns nothing from it that the identifier and the body already tell them, delete it.
+`crates/tasks/src/lib.rs:143` conforms: one line, and it states the drop behaviour that the signature does not show.
+
+### No project management in source
+
+Source carries no issue numbers, no `owner/repo#NNN` references, no tracker links, no `Tracking:` lines and no `TODO(#N)` markers.
+This applies to every comment, in Rust, TOML, YAML and shell.
+A comment states what is true of the code; where the work is tracked is not, and the reference rots as soon as the issue closes or moves.
+Remove such a reference from any file you edit, not only from the lines you add.
+Three things are not project management and stay: the `repository` field in `Cargo.toml`, links in README files, and identifiers such as RUSTSEC advisory and CVE numbers.
+`deny.toml` conforms: it explains why its ignore list diverges from `.cargo/audit.toml` without naming an issue.


### PR DESCRIPTION
## What

Closes the three items left open after stage 1.

Moves the em dash pattern out of `lint.yml` and into `.github/scripts/no-em-dash.sh`, then widens the scan to `*.yml`, `*.yaml` and `*.svg`. The move is what makes the widening possible: an inline pattern sits in the workflow it scans and would match itself forever. The script is `.sh`, which is deliberately absent from the glob list for the same reason, and the file says so. Removes the three occurrences the old glob set could not see: the `unused_crate_dependencies` comment in `lint.yml`, and the `aria-label` in `.github/banner.svg` and `.github/banner.src.svg`.

Adds a `fuzz success` aggregator to `fuzz.yml`. `fuzz.yml` produces twenty contexts on a pull request, nineteen of them matrix legs, so requiring fuzz without an aggregator would pin every target name into the branch ruleset. The aggregator covers `build` and `smoke`, and does not run on a schedule event, where `smoke` does not run either.

Drops the `paths` filter from the `pull_request` trigger of `audit.yml` and `zepter.yml`, and adds a `merge_group` trigger to `audit.yml`, which had none. A filtered workflow does not run on a pull request that touches neither a manifest nor a lockfile, so its context would wait at `Expected` forever once required, which is a repository-wide outage escapable only by an admin merge or a ruleset edit.

Adds two subsections to the `## Documentation` section of `AGENTS.md`. One states how much to write: the default is no comment, one line is the target and three is the ceiling, rationale belongs in the pull request body rather than in source. The other bans project management in source: no issue numbers, no `owner/repo#NNN`, no tracker links, no `Tracking:` lines, no `TODO(#N)`, in any language. Each cites a conforming example by path so a reviewer can check the claim rather than take it.

## Why

Closes #725
Closes #730

Also completes the deferred half of #703. That issue required three contexts and left `fuzz success`, `audit` and `feature propagation` out, each behind a precondition: fuzz had no aggregator, and the other two were path filtered. This removes all three preconditions. The ruleset edit that adds them to the required list is a separate administrative step and is not part of this pull request.

The two `AGENTS.md` subsections are the durable fix for a standard that existed only inside one contributor's tooling. Nothing written down forbade documentation-grade prose or tracker links in source, so both drifted in and had to be stripped by hand during stage 1.

## Testing

`.github/scripts/no-em-dash.sh` exits 0 on the tree.

Negative test, which is the one that matters because the previous scan could not do this: planting a U+2014 in `.github/workflows/zepter.yml` makes the script report `zepter.yml:33` and exit 1. The old inline scan did not cover `.yml` at all.

All four edited workflows parse as YAML. `pull_request` carries no `paths` key in `audit.yml`, `zepter.yml`, `fuzz.yml` or `lint.yml`, and all four now declare `merge_group`. `fuzz.yml` gains one job, `fuzz-success`, named `fuzz success`.

No Rust source changed, so clippy, doctests, the no_std lanes and the zepter feature-propagation check have no touched crate to run against.

## Follow-up, not done here

Requiring the three new contexts needs a ruleset write on `5744032`, which must be done with repository administration rights:

```
gh api repos/nxm-rs/nectar/rulesets/5744032 | jq '(.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks) += [{context:"fuzz success"},{context:"audit"},{context:"feature propagation"}] | {name,target,enforcement,conditions,bypass_actors,rules}' | gh api -X PUT repos/nxm-rs/nectar/rulesets/5744032 --input -
```

Do that only after this pull request merges and all three contexts have been seen green on a pull request against `main`, per the ordering rule in #703. `audit` and `feature propagation` are single-job workflows, so their check-run names are the leaf names rather than an aggregator; that is a deliberate exception to the aggregator rule, taken because a second no-op runner per pull request is not worth the stability it would buy for a workflow that has one job.

## AI Assistance

Implementation and verification: claude-opus-5.
