### PR TITLE
docs: land the production plan and clear the roadmap citations

### DIFF
--- a/docs/PHASE-0-GOVERNOR.md
+++ b/docs/PHASE-0-GOVERNOR.md
@@ -1,14 +1,17 @@
 # Phase 0 governor: home and API
 
-Design note for the cruft-cut roadmap Phase 0 (issues #610, #611).
+Historical.
+Both issues it covers (#610, #611) are closed and `nectar-kernel` appears nowhere in the tree, so this file records how the decision was reached rather than work outstanding.
+The plan it was written against never merged; `docs/PRODUCTION-PLAN.md` supersedes it.
+
+Design note for Phase 0 (issues #610, #611).
 It fixes the one decision that gates every consumer rewire: where the bounded-admission governor lives once the `nectar-kernel` name goes away, and what its surface is.
-Read it against `docs/CRUFT-CUT-ROADMAP.md` §Phase 0.
 
 ## 1. What Phase 0 actually deletes
 
 `nectar-kernel` is not a reinvented executor.
 It holds no `RawWaker`, no manual poll loop, and no hand-rolled future set: it already re-exports `futures_util::stream::FuturesUnordered` and `futures_core::future::BoxFuture`.
-It is five pieces, and the roadmap standards keep most of them.
+It is five pieces, and the standards of the time keep most of them.
 
 | Module | Item | Verdict |
 |---|---|---|
@@ -41,7 +44,7 @@ Two viable homes once `nectar-kernel` (a name that reads as an executor) retires
 - The `Window`/`Admission` proptest liveness suite stays put under (A); (B) forces it to move.
 - `BoxFuture` still centralises in `nectar-tasks` under (A). That is #611, and it is independent of the home choice.
 
-Distributing the governor into each consumer (no shared crate) is rejected: it re-scatters the exact per-walker hand-rolling the shared `Admission` predicate removed, and it contradicts the roadmap's one-bounded-concurrency-substrate standard.
+Distributing the governor into each consumer (no shared crate) is rejected: it re-scatters the exact per-walker hand-rolling the shared `Admission` predicate removed, and it contradicts the one-bounded-concurrency-substrate standard.
 
 ## 3. Consumer rewire surface
 
@@ -60,7 +63,7 @@ Only the `Driver`/`WalkPolicy` users carry real work; the rest is a one-line imp
 - `PutSink` users: `file/src/split/{engine,relay}.rs`
 - `Admission` / `Window` users: `postage-issuer/src/pipeline/*`, `ldb/src/{builder,frontier}.rs`, `file/src/{store,config}.rs`
 
-`file/src/inflight.rs` does not exist; the roadmap's step 0.2 wording is stale.
+`file/src/inflight.rs` does not exist; the step 0.2 wording of the time was stale.
 The file fan-out already sits in `walk/engine.rs` (`StaticDriver`) and `split/{engine,relay}.rs` (`PutSink`).
 Only `walk/engine.rs` needs the loop rebuilt; the split engines keep `PutSink`.
 

--- a/docs/PRODUCTION-PLAN.md
+++ b/docs/PRODUCTION-PLAN.md
@@ -1,0 +1,154 @@
+# nectar: production plan
+
+Status as of 2026-08-12.
+This document supersedes the cruft-cut roadmap that lived only inside draft pull request #609, which itself superseded the #474 wave plan.
+Neither of those ever merged, so this file is the first plan of record in the tree.
+
+## Decisions that shape this plan
+
+1. Priority order is architecture completion and interop correctness together, then release, then new capability.
+2. The manifest stack lands in order.
+3. Decruft is aggressive, targeting 12 to 14 publishable crates.
+4. The novel formats get written specifications, and the ldb wire format is renamed to "ldb v1".
+5. Agents pre-review the stack and post findings to the pull requests, and the maintainer spot-checks the flagged items.
+6. There is no v0.4.1, and the next release is 0.5.0.
+
+## Where the repository stands
+
+The code quality bar is high.
+There is one `unsafe` function in the workspace.
+The workspace denies the whole panic lint family.
+There are no TODO, FIXME or `todo!()` sites.
+Clippy is clean across the workspace, and now fails the build on any warning.
+
+The problems are structural rather than local, and the plan below is ordered to avoid paying for the same work twice.
+
+## Ordering rules
+
+Apply these to any issue filed later, not only to the ones listed here.
+
+1. Delete before you refactor.
+   An issue that removes a crate, a module, a type or a dependency comes before any issue that touches the same code for quality reasons.
+   This one rule reordered six scheduled items when the plan was written.
+2. Turn a gate on before the work it guards, and require an aggregator rather than the leaf jobs.
+   A later job appended to the aggregator becomes blocking with no second ruleset edit.
+3. Put a design decision before the code that depends on it, and a rename before the specification that describes it.
+   A specification written first is written twice.
+4. Give workspace-wide sweeps their own window.
+   A change that edits one line in fifty files conflicts with everything, and is cheap to redo but expensive to merge.
+5. Write anything that enumerates the tree last.
+   A crate count, a publish order or a README table written before the member set settles is wrong on the day it is read.
+6. Scope from the tree, never from the issue body.
+   Six bodies were provably stale against HEAD when this plan was written, and three more were found overstated during stage 1.
+
+## The stages
+
+### Stage 0: decide and clear the dead work
+
+In progress.
+Land this document, write the error section in `AGENTS.md` (#686), and clear the tracker of work that no longer applies.
+
+Closed as part of this stage: #522 (drained, every roll-up child landed), #646 (superseded by the manifest KV decision, which deliberately kept map vocabulary), #558 (folded into #645), and pull request #649 (depends on the dissolved `nectar-loadsave`, re-cut as #680).
+
+Gate: this document exists in the tree, `AGENTS.md` has an error section, and no in-tree citation of the unmerged roadmap survives.
+
+### Stage 1: turn the merge gate on
+
+Complete.
+#698, #700, #702 and #699 landed as pull requests #724, #726, #727 and #728, followed by #733 which closed the loose ends.
+
+`lint.yml` now fails on any clippy warning across all twelve invocations, runs `cargo deny` over advisories, bans, sources and licences, compiles the declared minimum Rust version, and enforces formatting and the em dash ban.
+All five leaves report through one `lint success` aggregator, so a later job becomes blocking by appending to a `needs` list rather than by editing the branch ruleset.
+
+Ruleset 5744032 requires six contexts: `unit success`, `no_std success`, `lint success`, `fuzz success`, `audit` and `feature propagation`.
+Strict mode is off, because it would serialize every merge behind a rebase.
+
+Two decisions were taken during this stage.
+The declared minimum Rust version became 1.94, matching the version the repository actually builds, because nothing had ever compiled the declared 1.92.
+The `nectar-swarms` crate folds into `nectar-primitives` and is deprecated (#679), rather than being kept as a consumer-only crate.
+
+Verified rather than assumed: a pull request carrying a deliberate lint failure reported `BLOCKED`, and a pull request touching only markdown produced all required contexts rather than stranding one at `Expected`.
+
+### Stage 2: delete
+
+#681 and #678 run in parallel, because `governor` and `postage-issuer` share no file.
+#618, then #679 execution, then #680 run in series, because all three edit the workspace member list and the two CI crate lists.
+
+#678 alone removes over two thousand lines carrying six `calculate_bucket` call sites, the hand-written `RingExhausted` producer and two shard cursors that three later issues would otherwise refactor first.
+
+Gate: `cargo metadata` reports the final member count and it is written down.
+
+### Stage 3: the breaking trains
+
+#685, #687, #689 and #688 in that order, in parallel with #683 then #682, in parallel with #708.
+The three tracks share no file.
+
+The design question in #689 is settled: `StampIndex` gains the spec parameter and carries a `Bucket<S>` rather than a bare integer.
+The generic is viral, so `Stamp` and its codec impls are expected to gain it too.
+The change must be visible in the type system and invisible on the wire.
+
+Gate: no public postage API takes a raw `u8` depth, `NodeGet` and `NodePut` are gone, and one `Listing`, one `Cursor` and one `AddressStream` remain.
+
+### Stage 4: vectors and specifications
+
+Against the settled names: #671 first, then #669, #670, #672, #673, #675, #674, #710, #712 and #707.
+
+This is the largest gap between what nectar claims and what it proves.
+Only three capabilities are anchored to bytes the reference client produced, and everything else rests on constants nectar generated for itself.
+
+Gate: every wire format nectar ships has at least one vector whose expected bytes came from the reference client, every test vector carries a provenance header, and every `spec N.N` citation in `crates/ldb` resolves.
+
+### Stage 5: the quiet window
+
+Workspace-wide sweeps, with nothing else in flight: #319, #690, #691, #699 follow-ups and #701.
+
+Gate: no public error variant carries a bare `String`, and every public error enum is `non_exhaustive`.
+
+### Stage 6: the streaming seam
+
+#568, #645, #692 and #615.
+Decide at the head of this stage whether #645 lands or `nectar-manifest` ships with `publish = false`.
+
+Gate: a memory-bounded read and write of a large manifest completes with peak live bytes bounded.
+
+### Stage 7: release paperwork, then cut 0.5.0
+
+#716, #713 and #715.
+All three enumerate the tree, so all three go last, per ordering rule 5.
+
+Gate: the milestone is empty and the tag fires.
+
+### Stage 8: after the tag
+
+#717, #718, #719 and #720, then #230 and the long tail.
+
+## The critical path
+
+#678, #685, #687, #689, #688, then #319 in the quiet window.
+
+Nothing parallelizes it.
+All of them edit `crates/postage/src/batch.rs`, `postage/src/util.rs`, `postage-issuer/src/counter.rs` and `postage-usage/src/table.rs`.
+
+One cost stated plainly: #669 is a live correctness bug and this order delays it to stage 4, because it shares `crates/file/src/read/file.rs` with #708.
+Until then a redundancy-enabled root reports about 9.2 exabytes, because the reference client sets `span[7] = level | 0x80` and nectar decodes the span as a plain little-endian integer.
+
+## One hazard to handle by hand
+
+Strike the clause "a grep over the layer-2 crates shows no `pub fn get` or `pub fn put`" from #683 before stage 3 opens.
+
+Applied to the tree it renames away `ManifestView::get`, `Database::get`, `Reader::get`, `Metadata::get` and `ForkTable::get`, which is the map vocabulary the seam deliberately landed and `AGENTS.md` now mandates.
+The same reasoning closed #646.
+
+## Deferred
+
+These are real gaps, and none is on the critical path.
+
+- Erasure coding, both the write side and the recovery getter.
+  This is the one large item.
+- Dispersed replica production and the racing getter.
+- Access control trie.
+- PSS trojan packaging and target mining.
+  The cryptographic envelope is about 60 percent done.
+- Epoch feeds.
+  The sequential path is complete.
+- Cross-format traversal, the legacy v1 feed payload, batch time-to-live estimation, per-chunk stamp reuse and a keystore.


### PR DESCRIPTION
## What

Adds `docs/PRODUCTION-PLAN.md` as the first plan of record in the tree, and clears the three in-tree citations of a path that never existed.

The plan supersedes the cruft-cut roadmap that lives only inside draft pull request #609, which itself superseded the #474 wave plan. Neither ever merged, so `docs/PHASE-0-GOVERNOR.md` has been pointing at `docs/CRUFT-CUT-ROADMAP.md` since it was written, and that link has never resolved for anyone reading the repository.

`docs/PHASE-0-GOVERNOR.md` is marked historical in its opening lines rather than rewritten. Both issues it covers (#610, #611) are closed and `nectar-kernel` appears nowhere in the tree, so it records how a decision was reached rather than work outstanding. Its three roadmap references are repointed or reworded: the `CRUFT-CUT-ROADMAP.md` link is replaced by a pointer to this plan, and the two prose references to "the roadmap's" wording become plain statements, since the document they cited does not exist.

## Why

Closes #706

The plan is landed as current rather than as written. Stage 1 completed while this issue sat open, so the document records it as complete with the ruleset state it produced, rather than describing it as pending. Three decisions taken since the plan was drafted are written into it: the declared minimum Rust version became 1.94, `nectar-swarms` folds into `nectar-primitives` and is deprecated, and `StampIndex` gains the spec parameter. Recording them here means stage 3 does not relitigate them.

The `#659` hazard the draft carried is gone, because that issue is closed and the audit workflow is green. The `#683` hazard remains and is restated, because it is still live and still needs handling by hand before stage 3 opens.

## Testing

No code changes, so the compiling gates have no touched crate.

`rg -n "CRUFT-CUT-ROADMAP"` returns nothing in the tree.

Every relative markdown link under `docs/` resolves against the filesystem.

`.github/scripts/no-em-dash.sh` exits 0, which matters because `*.md` is in its glob set, so this document is subject to the em dash gate that landed in #733.

The new document is one sentence per line, per AGENTS.md, verified by a scan that strips list markers before counting sentence boundaries. `docs/PHASE-0-GOVERNOR.md` already held that convention on all 85 lines and still does.

## Follow-up, not done here

Two closures belong to this issue and are left for after the merge, so the plan is in the tree before the things it replaces are retired: draft pull request #609 closes unmerged, and #474 closes with a comment naming `docs/PRODUCTION-PLAN.md` as its replacement.

## AI Assistance

Implementation and verification: claude-opus-5.
