### PR TITLE
refactor: move node persistence seam to nectar-manifest

### DIFF
--- a/crates/integration-tests/tests/mantaray/bmt_nodes.rs
+++ b/crates/integration-tests/tests/mantaray/bmt_nodes.rs
@@ -44,7 +44,7 @@ async fn assert_node_parity(loadsaver: &LoadSaver, root: EntryRef) {
     let mut stack = vec![root];
     let mut visited = 0usize;
     while let Some(reference) = stack.pop() {
-        let bytes = loadsaver.collect(&reference).await.unwrap();
+        let bytes = loadsaver.load(&reference).await.unwrap();
         if bytes.len() <= BODY {
             let chunk = ContentChunk::<BODY>::new(Bytes::from(bytes.clone())).unwrap();
             assert_eq!(
@@ -97,7 +97,7 @@ fn multi_chunk_root_commits_and_reads_back() {
     let (root, loadsaver) = build_wide();
     run(async {
         // The root node image genuinely spans chunks.
-        let bytes = loadsaver.collect(&EntryRef::from(root)).await.unwrap();
+        let bytes = loadsaver.load(&EntryRef::from(root)).await.unwrap();
         assert!(bytes.len() > BODY, "root image is {} bytes", bytes.len());
 
         // Every entry reads back through the adapter.

--- a/crates/ldb/src/apply.rs
+++ b/crates/ldb/src/apply.rs
@@ -31,7 +31,8 @@ use core::task::Poll;
 use bytes::Bytes;
 use futures_util::stream::{FuturesUnordered, Stream};
 use nectar_governor::{Admission, Window};
-use nectar_primitives::store::{ChunkPut, MaybeSync};
+use nectar_primitives::ContentOnlyChunkSet;
+use nectar_primitives::store::{ChunkPut, MaybeSync, TrustedGet};
 use nectar_tasks::BoxFuture;
 
 use crate::bounded::Prefix;
@@ -45,7 +46,7 @@ use crate::format::{Format, V1};
 use crate::meta::{Metadata, MetadataKey};
 use crate::node::{Node, NodeRef, RootExtension};
 use crate::packing::cut_allowance;
-use crate::store::{NodeGet, Seal, StoreError};
+use crate::store::{Seal, StoreError, load_node};
 use crate::value::{Entry, Key};
 
 /// One key's update within a changeset.
@@ -208,7 +209,7 @@ pub async fn apply<S, F, R, K>(
     changeset: &Changeset<F>,
 ) -> Result<R, ApplyError>
 where
-    S: NodeGet + ChunkPut + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + ChunkPut + MaybeSync,
     F: Format,
     R: NodeRef,
     K: Seal<R>,
@@ -216,7 +217,7 @@ where
     if changeset.is_empty() {
         return Ok(root.clone());
     }
-    let node = store.get_node::<F, R>(root).await?;
+    let node = load_node::<_, F, R>(store, root).await?;
 
     // The empty key is the root's own value; every other key descends the trie.
     let mut root_entry = node.entry().cloned();
@@ -296,7 +297,7 @@ async fn apply_forks<'c, S, F, R, K>(
     stats: &mut BuildStats,
 ) -> Result<ForkTable<F, R>, ApplyError>
 where
-    S: NodeGet + ChunkPut + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + ChunkPut + MaybeSync,
     F: Format,
     R: NodeRef,
     K: Seal<R>,
@@ -404,7 +405,7 @@ async fn reconcile<'c, S, F, R, K>(
     stats: &mut BuildStats,
 ) -> Result<Option<ForkRecord<F, R>>, ApplyError>
 where
-    S: NodeGet + ChunkPut + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + ChunkPut + MaybeSync,
     F: Format,
     R: NodeRef,
     K: Seal<R>,
@@ -460,7 +461,7 @@ async fn descend<'c, S, F, R, K>(
     stats: &mut BuildStats,
 ) -> Result<Option<ForkRecord<F, R>>, ApplyError>
 where
-    S: NodeGet + ChunkPut + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + ChunkPut + MaybeSync,
     F: Format,
     R: NodeRef,
     K: Seal<R>,
@@ -547,7 +548,7 @@ where
             // the read runs here.
             let node = match child {
                 Some(node) => node,
-                None => sink.store().get_node::<F, R>(reference).await?,
+                None => load_node::<_, F, R>(sink.store(), reference).await?,
             };
             Box::pin(apply_forks(
                 sink,
@@ -642,7 +643,7 @@ async fn split<'c, S, F, R, K>(
     stats: &mut BuildStats,
 ) -> Result<Option<ForkRecord<F, R>>, ApplyError>
 where
-    S: NodeGet + ChunkPut + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + ChunkPut + MaybeSync,
     F: Format,
     R: NodeRef,
     K: Seal<R>,
@@ -809,7 +810,7 @@ async fn absorb<S, F, R>(
     child: Option<&Child<F, R>>,
 ) -> Result<Option<(Vec<u8>, ForkRecord<F, R>)>, ApplyError>
 where
-    S: NodeGet + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
     F: Format,
     R: NodeRef,
 {
@@ -822,7 +823,7 @@ where
         Some(Child::Ref(reference)) => reference,
         Some(Child::Embedded(_)) | None => return Ok(None),
     };
-    let node = store.get_node::<F, R>(reference).await?;
+    let node = load_node::<_, F, R>(store, reference).await?;
     // A branch below is a boundary a build keeps; only a lone continuation runs
     // on into the edge.
     if node.forks().len() != 1 {
@@ -960,7 +961,7 @@ async fn prefetch_children<S, F, R>(
     slots: usize,
 ) -> Vec<Option<Result<Node<F, R>, StoreError>>>
 where
-    S: NodeGet + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
     F: Format,
     R: NodeRef,
 {
@@ -979,7 +980,7 @@ where
                     break;
                 };
                 in_flight.push(Box::pin(async move {
-                    (slot, store.get_node::<F, R>(&reference).await)
+                    (slot, load_node::<_, F, R>(store, &reference).await)
                 }));
             }
             match Pin::new(&mut in_flight).poll_next(cx) {
@@ -1033,7 +1034,9 @@ mod tests {
                     None => 0,
                     Some(Child::Embedded(inner)) => walk_counts(store, inner).await,
                     Some(Child::Ref(reference)) => {
-                        let node = store.get_node::<V1, ChunkRef>(reference).await.unwrap();
+                        let node = load_node::<_, V1, ChunkRef>(store, reference)
+                            .await
+                            .unwrap();
                         let actual = walk_counts(store, node.forks()).await;
                         assert_eq!(
                             record.child_count(),
@@ -1064,7 +1067,7 @@ mod tests {
             }
         }
         let root = *run(builder.build(&store, &Plaintext)).unwrap().root();
-        let node = run(store.get_node::<V1, ChunkRef>(&root)).unwrap();
+        let node = run(load_node::<_, V1, ChunkRef>(&store, &root)).unwrap();
         let total = u64::from(node.entry().is_some()) + run(walk_counts(&store, node.forks()));
         assert_eq!(total, expected);
     }
@@ -1097,7 +1100,7 @@ mod tests {
         assert_eq!(applied, scratch_root, "apply must match a counted rebuild");
 
         // The applied tree's stored counts still equal the walked subtree sizes.
-        let node = run(store.get_node::<V1, ChunkRef>(&applied)).unwrap();
+        let node = run(load_node::<_, V1, ChunkRef>(&store, &applied)).unwrap();
         let total = u64::from(node.entry().is_some()) + run(walk_counts(&store, node.forks()));
         assert_eq!(total, 64);
     }
@@ -1500,7 +1503,7 @@ mod tests {
             }
         }
         let root = *run(builder.build(&inner, &Plaintext)).unwrap().root();
-        let node: Node<V1> = run(inner.get_node(&root)).unwrap();
+        let node: Node<V1> = run(load_node(&inner, &root)).unwrap();
         let children = node
             .forks()
             .iter()
@@ -1594,7 +1597,7 @@ mod tests {
             }
         }
         let root = *run(builder.build(&inner, &Plaintext)).unwrap().root();
-        let node: Node<V1> = run(inner.get_node(&root)).unwrap();
+        let node: Node<V1> = run(load_node(&inner, &root)).unwrap();
         let children: Vec<ChunkAddress> = node
             .forks()
             .iter()

--- a/crates/ldb/src/db.rs
+++ b/crates/ldb/src/db.rs
@@ -9,8 +9,8 @@ use core::ops::RangeBounds;
 
 use bytes::Bytes;
 
-use nectar_primitives::ChunkRef;
-use nectar_primitives::store::{ChunkPut, MaybeSync};
+use nectar_primitives::store::{ChunkPut, MaybeSync, TrustedGet};
+use nectar_primitives::{ChunkRef, ContentOnlyChunkSet};
 
 use crate::apply::{ApplyError, Changeset, apply};
 use crate::folder::{Listing, Served, Website, dir_at};
@@ -19,7 +19,7 @@ use crate::meta::{Metadata, MetadataKey};
 use crate::node::NodeRef;
 use crate::reader::{Reader, ReaderError};
 use crate::scan::{Cursor, half_open};
-use crate::store::{NodeGet, Plaintext, Seal};
+use crate::store::{Plaintext, Seal};
 use crate::value::{Entry, Key};
 
 /// A key-value database over one store, at whatever root a caller names.
@@ -152,7 +152,7 @@ impl<S, F: Format> Database<S, Plaintext, F> {
 
 impl<S, K, F> Database<S, K, F>
 where
-    S: NodeGet + ChunkPut + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + ChunkPut + MaybeSync,
     F: Format,
 {
     /// Insert one key, clearing any metadata bound at it.
@@ -224,7 +224,7 @@ impl<'a, S, F: Format, R: NodeRef> View<'a, S, F, R> {
 
 impl<S, F, R> View<'_, S, F, R>
 where
-    S: NodeGet + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
     F: Format,
     R: NodeRef,
 {
@@ -273,7 +273,7 @@ where
 
 impl<'a, S, F, R> View<'a, S, F, R>
 where
-    S: NodeGet + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
     F: Format,
     R: NodeRef,
 {
@@ -389,7 +389,7 @@ impl<S, K, F: Format, R: NodeRef> Editor<'_, S, K, F, R> {
 
 impl<S, K, F, R> Editor<'_, S, K, F, R>
 where
-    S: NodeGet + ChunkPut + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + ChunkPut + MaybeSync,
     K: Seal<R>,
     F: Format,
     R: NodeRef,

--- a/crates/ldb/src/encryption.rs
+++ b/crates/ldb/src/encryption.rs
@@ -113,7 +113,7 @@ mod tests {
     use crate::fork::Child;
     use crate::meta::{KeyId, Metadata};
     use crate::node::{Node, RootExtension};
-    use crate::store::{NodeGet, NodePut};
+    use crate::store::{load_node, save_node};
     use crate::value::Entry;
 
     use super::*;
@@ -203,8 +203,8 @@ mod tests {
     fn round_trips_through_a_memory_store() {
         let store = ContentGet::new(MemoryStore::default());
         let node = sample();
-        let reference = run(store.put_node(&node, &seal())).unwrap();
-        let opened: Node<V1, EncryptedChunkRef> = run(store.get_node(&reference)).unwrap();
+        let reference = run(save_node(&store, &node, &seal())).unwrap();
+        let opened: Node<V1, EncryptedChunkRef> = run(load_node(&store, &reference)).unwrap();
         assert_eq!(opened, node);
     }
 
@@ -215,7 +215,7 @@ mod tests {
         // records the reference carries that key in its own bytes.
         let store = ContentGet::new(MemoryStore::default());
         let child = sample();
-        let reference = run(store.put_node(&child, &seal())).unwrap();
+        let reference = run(save_node(&store, &child, &seal())).unwrap();
         assert_eq!(
             reference.key(),
             &derive_key::<V1>(SECRET, &child.encode().unwrap())

--- a/crates/ldb/src/folder.rs
+++ b/crates/ldb/src/folder.rs
@@ -14,15 +14,15 @@ use alloc::vec::Vec;
 use core::mem::size_of;
 
 use bytes::Bytes;
-use nectar_primitives::ChunkRef;
-use nectar_primitives::store::MaybeSync;
+use nectar_primitives::store::{MaybeSync, TrustedGet};
+use nectar_primitives::{ChunkRef, ContentOnlyChunkSet};
 
 use crate::format::{Format, V1};
 use crate::meta::{KeyId, MetadataKey};
 use crate::node::{Node, NodeRef};
 use crate::reader::{Reader, ReaderError};
 use crate::scan::{Cursor, successor};
-use crate::store::NodeGet;
+use crate::store::load_node;
 use crate::value::{Entry, Key};
 
 /// One immediate child of a listed directory.
@@ -87,7 +87,7 @@ pub struct Listing<'a, S, F: Format = V1, R: NodeRef = ChunkRef> {
 
 impl<S, F, R> Listing<'_, S, F, R>
 where
-    S: NodeGet + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
     F: Format,
     R: NodeRef,
 {
@@ -226,7 +226,7 @@ impl<F: Format> Served<F> {
 
 impl<S, F, R> Reader<S, F, R>
 where
-    S: NodeGet + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
     F: Format,
     R: NodeRef,
 {
@@ -243,7 +243,7 @@ where
     /// The manifest's site-level document conventions, read from the root's
     /// typed metadata.
     pub async fn website(&self, root: &R) -> Result<Website, ReaderError> {
-        let node = self.store().get_node::<F, R>(root).await?;
+        let node = load_node::<_, F, R>(self.store(), root).await?;
         Ok(Website {
             index: document(&node, KeyId::WebsiteIndexDocument),
             error: document(&node, KeyId::WebsiteErrorDocument),
@@ -294,7 +294,7 @@ pub(crate) async fn dir_at<'a, S, F, R>(
     dir: &Key,
 ) -> Result<Listing<'a, S, F, R>, ReaderError>
 where
-    S: NodeGet + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
     F: Format,
     R: NodeRef,
 {
@@ -507,7 +507,7 @@ mod tests {
         use crate::bounded::Prefix;
         use crate::fork::{Child, ForkTable};
         use crate::node::Node;
-        use crate::store::NodePut;
+        use crate::store::save_node;
 
         let store = ContentGet::new(MemoryStore::default());
         // A referenced "mg/" subtree holding a nested subdirectory and a file,
@@ -541,7 +541,7 @@ mod tests {
             None,
         )
         .unwrap();
-        let leaf_ref = run(store.put_node(&Node::new(None, leaf), &Plaintext)).unwrap();
+        let leaf_ref = run(save_node(&store, &Node::new(None, leaf), &Plaintext)).unwrap();
 
         let mut forks: ForkTable = ForkTable::new();
         forks
@@ -551,7 +551,7 @@ mod tests {
                 None,
             )
             .unwrap();
-        let root = run(store.put_node(&Node::new(None, forks), &Plaintext)).unwrap();
+        let root = run(save_node(&store, &Node::new(None, forks), &Plaintext)).unwrap();
 
         let reader: Reader<_> = Reader::new(&store);
         let got = entries(run(reader.dir(&root, &Key::from(&b"mg/"[..]))).unwrap());

--- a/crates/ldb/src/lib.rs
+++ b/crates/ldb/src/lib.rs
@@ -162,6 +162,6 @@ pub use node::{Node, NodeRef, RootExtension};
 pub use packing::{Directory, SegmentKind, cut, embed, h64, segment, spill};
 pub use reader::{Reader, ReaderError};
 pub use scan::Cursor;
-pub use store::{NodeChunk, NodeGet, NodePut, Plaintext, Seal, StoreError};
+pub use store::{NodeChunk, Plaintext, Seal, StoreError, load_node, save_node};
 pub use traverse::AddressStream;
 pub use value::{Entry, InlineValue, Key};

--- a/crates/ldb/src/manifest.rs
+++ b/crates/ldb/src/manifest.rs
@@ -4,17 +4,18 @@
 //! concrete types, so a seam call names the trait: `Manifest::at(&db, root)`.
 
 use alloc::vec::Vec;
+use core::future::Future;
 use core::ops::Bound;
 
 use bytes::Bytes;
 use nectar_file::load_reference;
 use nectar_manifest::{
     Batch, DataSink, ListEntry, Listing, Manifest, ManifestCursor, ManifestError, ManifestOp,
-    ManifestPath, ManifestView, MapEntry, PathCursor, RawCursor, RawItem, Served, SinkError,
-    SiteConfig, serve_fallback,
+    ManifestPath, ManifestView, MapEntry, NodeLoader, NodeSaver, PathCursor, RawCursor, RawItem,
+    Served, SinkError, SiteConfig, serve_fallback,
 };
 use nectar_primitives::EntryRef;
-use nectar_primitives::chunk::ContentOnlyChunkSet;
+use nectar_primitives::chunk::{ChunkAddress, ContentOnlyChunkSet};
 use nectar_primitives::store::{ChunkPut, MaybeSend, MaybeSync, TrustedGet};
 
 use crate::apply::ApplyError;
@@ -23,10 +24,10 @@ use crate::db::{Database, View};
 use crate::folder::{DirEntry, Served as NativeServed};
 use crate::format::{Format, V1};
 use crate::meta::{KeyId, Metadata};
-use crate::node::NodeRef;
+use crate::node::{Node, NodeRef};
 use crate::reader::ReaderError;
 use crate::scan::Cursor;
-use crate::store::Seal;
+use crate::store::{Seal, StoreError, load_node, materialize_traced, save_node};
 use crate::value::{Entry, Key};
 
 /// The database's own failures behind [`ManifestError::Format`].
@@ -106,6 +107,51 @@ where
             }
         }
         Ok(editor.commit().await?)
+    }
+}
+
+/// The database as the seam's node store, at the decoded node: a spilled node
+/// has no single stored image, so bytes are not a unit this format can offer.
+impl<S, K, F, R> NodeLoader<Node<F, R>> for Database<S, K, F>
+where
+    S: TrustedGet<ContentOnlyChunkSet> + MaybeSend + MaybeSync,
+    K: MaybeSend + MaybeSync,
+    F: Format,
+    R: NodeRef,
+{
+    type Error = StoreError;
+
+    async fn load(&self, reference: &EntryRef) -> Result<Node<F, R>, StoreError> {
+        let reference = R::from_entry_ref(reference.clone())?;
+        load_node(self.store(), &reference).await
+    }
+
+    async fn load_traced(
+        &self,
+        reference: &EntryRef,
+    ) -> Result<(Node<F, R>, Vec<ChunkAddress>), StoreError> {
+        let reference = R::from_entry_ref(reference.clone())?;
+        let (node, segments) = materialize_traced::<S, F, R>(self.store(), &reference).await?;
+        let mut addresses = Vec::with_capacity(segments.len().saturating_add(1));
+        addresses.push(*reference.address());
+        addresses.extend(segments);
+        Ok((node, addresses))
+    }
+}
+
+/// The database as the seam's node saver, sealing through its own write-side
+/// secret.
+impl<S, K, F, R> NodeSaver<Node<F, R>, R> for Database<S, K, F>
+where
+    S: ChunkPut + MaybeSend + MaybeSync,
+    K: Seal<R> + MaybeSend + MaybeSync,
+    F: Format,
+    R: NodeRef,
+{
+    type Error = StoreError;
+
+    fn save(&self, node: &Node<F, R>) -> impl Future<Output = Result<R, StoreError>> + MaybeSend {
+        save_node(self.store(), node, self.seal())
     }
 }
 

--- a/crates/ldb/src/manifest.rs
+++ b/crates/ldb/src/manifest.rs
@@ -110,8 +110,8 @@ where
     }
 }
 
-/// The database as the seam's node store, at the decoded node: a spilled node
-/// has no single stored image, so bytes are not a unit this format can offer.
+/// The seam at the decoded node: a spilled node has no single stored image,
+/// so bytes are not a unit this format can offer.
 impl<S, K, F, R> NodeLoader<Node<F, R>> for Database<S, K, F>
 where
     S: TrustedGet<ContentOnlyChunkSet> + MaybeSend + MaybeSync,
@@ -139,8 +139,7 @@ where
     }
 }
 
-/// The database as the seam's node saver, sealing through its own write-side
-/// secret.
+/// The seam's write half, sealing through the database's own secret.
 impl<S, K, F, R> NodeSaver<Node<F, R>, R> for Database<S, K, F>
 where
     S: ChunkPut + MaybeSend + MaybeSync,

--- a/crates/ldb/src/order.rs
+++ b/crates/ldb/src/order.rs
@@ -12,8 +12,8 @@
 use alloc::vec::Vec;
 
 use bytes::Bytes;
-use nectar_primitives::store::MaybeSync;
-use nectar_primitives::{ChunkOps, ChunkRef};
+use nectar_primitives::store::{MaybeSync, TrustedGet};
+use nectar_primitives::{ChunkOps, ChunkRef, ContentOnlyChunkSet};
 
 use crate::codec::{DecodeError, DecodedChunk, SegDesc, SegmentDir};
 use crate::fork::{Child, ForkTable};
@@ -21,7 +21,7 @@ use crate::format::Format;
 use crate::node::{NodeRef, RootExtension};
 use crate::reader::{Reader, ReaderError};
 use crate::scan::{Cursor, successor};
-use crate::store::{NodeGet, StoreError, open_chunk};
+use crate::store::{StoreError, open_chunk};
 use crate::value::{Entry, Key};
 
 /// One flattened position of a chunk's fork table, in ascending key order, with
@@ -164,7 +164,7 @@ fn covering_index<R: NodeRef>(dir: &SegmentDir<R>, index: u64) -> Option<(u64, &
 
 impl<S, F, R> Reader<S, F, R>
 where
-    S: NodeGet + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
     F: Format,
     R: NodeRef,
 {
@@ -320,7 +320,7 @@ where
 /// spilled node's segments: the descent routes them itself by `seg_count`.
 async fn decode_at<S, F, R>(store: &S, reference: &R) -> Result<DecodedChunk<F, R>, ReaderError>
 where
-    S: NodeGet + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
     F: Format,
     R: NodeRef,
 {
@@ -341,7 +341,7 @@ async fn on_path<S, F, R>(
     remaining: &[u8],
 ) -> Result<OnPath<F, R>, ReaderError>
 where
-    S: NodeGet + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
     F: Format,
     R: NodeRef,
 {
@@ -364,7 +364,7 @@ async fn route_key<S, F, R>(
     remaining: &[u8],
 ) -> Result<OnPath<F, R>, ReaderError>
 where
-    S: NodeGet + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
     F: Format,
     R: NodeRef,
 {
@@ -409,7 +409,7 @@ async fn index_path<S, F, R>(
     index: &mut u64,
 ) -> Result<Option<Vec<Ranked<F, R>>>, ReaderError>
 where
-    S: NodeGet + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
     F: Format,
     R: NodeRef,
 {
@@ -532,7 +532,7 @@ mod tests {
     use crate::fork::ForkTable;
     use crate::format::V1;
     use crate::node::RootExtension;
-    use crate::store::NodePut;
+    use crate::store::save_node;
     use crate::value::{Entry, Key};
 
     use super::*;
@@ -551,7 +551,12 @@ mod tests {
         let root_ext = RootExtension::new(Some(entry(9)), None);
         let mut forks = ForkTable::new();
         forks.insert(prefix(b"k"), entry(1).into(), None).unwrap();
-        let root = run(store.put_node(&Node::<V1>::new(root_ext, forks), &Plaintext)).unwrap();
+        let root = run(save_node(
+            &store,
+            &Node::<V1>::new(root_ext, forks),
+            &Plaintext,
+        ))
+        .unwrap();
         let reader = Reader::<&ContentGet<MemoryStore>, V1>::new(&store);
 
         // The empty key leads iteration at index 0; "k" follows at index 1.
@@ -620,7 +625,7 @@ mod tests {
     #[test]
     fn an_empty_manifest_has_no_keys() {
         let store = ContentGet::new(MemoryStore::default());
-        let root = run(store.put_node(&Node::<V1>::empty(), &Plaintext)).unwrap();
+        let root = run(save_node(&store, &Node::<V1>::empty(), &Plaintext)).unwrap();
         let reader = Reader::<&ContentGet<MemoryStore>, V1>::new(&store);
         assert_eq!(run(reader.rank(&root, &Key::from(&b"x"[..]))).unwrap(), 0);
         assert_eq!(run(reader.select(&root, 0)).unwrap(), None);

--- a/crates/ldb/src/reader.rs
+++ b/crates/ldb/src/reader.rs
@@ -8,15 +8,15 @@
 
 use core::marker::PhantomData;
 
-use nectar_primitives::store::MaybeSync;
-use nectar_primitives::{ChunkOps, ChunkRef};
+use nectar_primitives::store::{MaybeSync, TrustedGet};
+use nectar_primitives::{ChunkOps, ChunkRef, ContentOnlyChunkSet};
 
 use crate::codec::{DecodedChunk, SegmentDir};
 use crate::fork::{Child, ForkTable};
 use crate::format::{Format, V1};
 use crate::meta::Metadata;
 use crate::node::{NodeRef, RootExtension};
-use crate::store::{NodeGet, StoreError, open_chunk};
+use crate::store::{StoreError, load_node, open_chunk};
 use crate::value::{Entry, Key};
 
 /// A lookup failure.
@@ -68,7 +68,7 @@ impl<S, F: Format, R: NodeRef> Reader<S, F, R> {
 
 impl<S, F: Format, R: NodeRef> Reader<S, F, R>
 where
-    S: NodeGet + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
 {
     /// The value bound to `key` under the database rooted at `root`, or `None`
     /// when the key is absent.
@@ -175,7 +175,7 @@ where
         let mut reference = root.clone();
         let mut base = 0usize;
         loop {
-            let node = self.store.get_node::<F, R>(&reference).await?;
+            let node = load_node::<_, F, R>(&self.store, &reference).await?;
             match subtree_step(node.forks(), prefix, base) {
                 SubtreeStep::Absent => return Ok(None),
                 SubtreeStep::Boundary(found, base) => {
@@ -203,7 +203,7 @@ const fn segment_context() -> ReaderError {
 /// Fetch and decode one chunk, opening it with the key `reference` carries.
 async fn fetch_chunk<S, F, R>(store: &S, reference: &R) -> Result<DecodedChunk<F, R>, ReaderError>
 where
-    S: NodeGet + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
     F: Format,
     R: NodeRef,
 {
@@ -340,7 +340,7 @@ async fn covering_leaf<S, F, R>(
     pos: usize,
 ) -> Result<Option<ForkTable<F, R>>, ReaderError>
 where
-    S: NodeGet + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
     F: Format,
     R: NodeRef,
 {
@@ -436,7 +436,7 @@ mod tests {
     use crate::bounded::Prefix;
     use crate::fork::{Child, ForkPayload, ForkTable};
     use crate::node::Node;
-    use crate::store::NodePut;
+    use crate::store::save_node;
     use crate::value::{Entry, Key};
 
     use super::*;
@@ -457,7 +457,7 @@ mod tests {
         let mut leaf = ForkTable::new();
         leaf.insert(prefix(b"logo.png"), entry(0xBB).into(), None)
             .unwrap();
-        let leaf_ref = run(store.put_node(&Node::new(None, leaf), &Plaintext)).unwrap();
+        let leaf_ref = run(save_node(&store, &Node::new(None, leaf), &Plaintext)).unwrap();
 
         // The root: "index.html" behind an embedded child, "mg/" behind the
         // referenced leaf.
@@ -472,7 +472,7 @@ mod tests {
         forks
             .insert(prefix(b"mg/"), Child::Ref(leaf_ref).into(), None)
             .unwrap();
-        let root = run(store.put_node(&Node::new(None, forks), &Plaintext)).unwrap();
+        let root = run(save_node(&store, &Node::new(None, forks), &Plaintext)).unwrap();
 
         let reader: Reader<_> = Reader::new(&store);
         assert_eq!(
@@ -504,7 +504,7 @@ mod tests {
         forks
             .insert(prefix(b"a"), Child::Embedded(child).into(), None)
             .unwrap();
-        let root = run(store.put_node(&Node::new(None, forks), &Plaintext)).unwrap();
+        let root = run(save_node(&store, &Node::new(None, forks), &Plaintext)).unwrap();
 
         let reader: Reader<_> = Reader::new(&store);
         // "ab" terminates, "a" is only a branch.
@@ -519,7 +519,12 @@ mod tests {
     fn the_empty_key_reads_the_root_extension_value() {
         let store = ContentGet::new(MemoryStore::default());
         let root_ext = crate::node::RootExtension::new(Some(entry(9)), None);
-        let root = run(store.put_node(&Node::new(root_ext, ForkTable::new()), &Plaintext)).unwrap();
+        let root = run(save_node(
+            &store,
+            &Node::new(root_ext, ForkTable::new()),
+            &Plaintext,
+        ))
+        .unwrap();
 
         let reader: Reader<_> = Reader::new(&store);
         assert_eq!(
@@ -537,7 +542,12 @@ mod tests {
         )
         .unwrap();
         let root_ext = crate::node::RootExtension::new(None, Some(meta.clone()));
-        let root = run(store.put_node(&Node::new(root_ext, ForkTable::new()), &Plaintext)).unwrap();
+        let root = run(save_node(
+            &store,
+            &Node::new(root_ext, ForkTable::new()),
+            &Plaintext,
+        ))
+        .unwrap();
 
         let reader: Reader<_> = Reader::new(&store);
         assert_eq!(
@@ -556,7 +566,7 @@ mod tests {
         forks
             .insert(prefix(b"k"), ForkPayload::Entry(value.clone()), None)
             .unwrap();
-        let root = run(store.put_node(&Node::new(None, forks), &Plaintext)).unwrap();
+        let root = run(save_node(&store, &Node::new(None, forks), &Plaintext)).unwrap();
 
         let reader: Reader<_> = Reader::new(&store);
         assert_eq!(
@@ -571,7 +581,7 @@ mod tests {
         let mut leaf = ForkTable::new();
         leaf.insert(prefix(b"logo.png"), entry(0xBB).into(), None)
             .unwrap();
-        let leaf_ref = run(store.put_node(&Node::new(None, leaf), &Plaintext)).unwrap();
+        let leaf_ref = run(save_node(store, &Node::new(None, leaf), &Plaintext)).unwrap();
 
         let mut embedded = ForkTable::new();
         embedded
@@ -584,7 +594,7 @@ mod tests {
         forks
             .insert(prefix(b"mg/"), Child::Ref(leaf_ref).into(), None)
             .unwrap();
-        let root = run(store.put_node(&Node::new(None, forks), &Plaintext)).unwrap();
+        let root = run(save_node(store, &Node::new(None, forks), &Plaintext)).unwrap();
         (root, leaf_ref)
     }
 

--- a/crates/ldb/src/scan.rs
+++ b/crates/ldb/src/scan.rs
@@ -24,8 +24,8 @@ use core::task::{Context, Poll};
 
 use bytes::Bytes;
 use futures_util::stream::{FuturesUnordered, Stream};
-use nectar_primitives::ChunkRef;
-use nectar_primitives::store::MaybeSync;
+use nectar_primitives::store::{MaybeSync, TrustedGet};
+use nectar_primitives::{ChunkRef, ContentOnlyChunkSet};
 use nectar_tasks::BoxFuture;
 
 use crate::fork::{Child, ForkTable};
@@ -33,7 +33,7 @@ use crate::format::{Format, V1};
 use crate::frontier::{Completion, Frame, Plan, claim, fill};
 use crate::node::{Node, NodeRef};
 use crate::reader::{Reader, ReaderError};
-use crate::store::NodeGet;
+use crate::store::load_node;
 use crate::value::{Entry, Key};
 
 /// One resolved position in a chunk's ordered contents.
@@ -131,7 +131,7 @@ enum Advance<F: Format> {
 
 impl<'a, S, F, R> Cursor<'a, S, F, R>
 where
-    S: NodeGet + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
     F: Format,
     R: NodeRef,
 {
@@ -162,8 +162,7 @@ where
                     Step::Ref { reference, .. } => {
                         let reference = reference.clone();
                         Plan::Fetch(async move {
-                            store
-                                .get_node::<F, R>(&reference)
+                            load_node::<_, F, R>(store, &reference)
                                 .await
                                 .map(|node| flatten(&node, false))
                                 .map_err(ReaderError::from)
@@ -276,7 +275,7 @@ where
         let mut reference = root.clone();
         let mut is_root = true;
         loop {
-            let node = store.get_node::<F, R>(&reference).await?;
+            let node = load_node::<_, F, R>(store, &reference).await?;
             let steps = flatten(&node, is_root);
             let remaining = start.get(base.len()..).unwrap_or(&[]);
             if remaining.is_empty() {
@@ -391,7 +390,7 @@ where
 
 impl<S, F, R> Reader<S, F, R>
 where
-    S: NodeGet + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
     F: Format,
     R: NodeRef,
 {
@@ -436,7 +435,7 @@ where
         // level; a deeper left branch always outranks it, so one slot suffices.
         let mut fallback: Option<(Bytes, Step<F, R>)> = None;
         loop {
-            let node = store.get_node::<F, R>(&reference).await?;
+            let node = load_node::<_, F, R>(store, &reference).await?;
             let steps = flatten(&node, is_root);
             let remaining = target.get(base.len()..).unwrap_or(&[]);
             let mut left: Option<Step<F, R>> = None;
@@ -495,7 +494,7 @@ async fn max_key<S, F, R>(
     step: Step<F, R>,
 ) -> Result<Option<(Key, Entry<F>)>, ReaderError>
 where
-    S: NodeGet + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
     F: Format,
     R: NodeRef,
 {
@@ -520,12 +519,12 @@ async fn rightmost<S, F, R>(
     mut reference: R,
 ) -> Result<Option<(Key, Entry<F>)>, ReaderError>
 where
-    S: NodeGet + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
     F: Format,
     R: NodeRef,
 {
     loop {
-        let node = store.get_node::<F, R>(&reference).await?;
+        let node = load_node::<_, F, R>(store, &reference).await?;
         let steps = flatten(&node, false);
         match steps.last() {
             None => return Ok(None),
@@ -649,7 +648,7 @@ mod tests {
     use crate::bounded::Prefix;
     use crate::fork::{Child, ForkTable};
     use crate::node::Node;
-    use crate::store::NodePut;
+    use crate::store::save_node;
     use crate::value::{Entry, Key};
 
     use super::*;
@@ -675,7 +674,7 @@ mod tests {
     fn sample(store: &ContentGet<MemoryStore>) -> ChunkRef {
         let mut leaf = ForkTable::new();
         leaf.insert(prefix(b"a"), entry(0xBA).into(), None).unwrap();
-        let leaf_ref = run(store.put_node(&Node::new(None, leaf), &Plaintext)).unwrap();
+        let leaf_ref = run(save_node(store, &Node::new(None, leaf), &Plaintext)).unwrap();
 
         let mut embedded = ForkTable::new();
         embedded
@@ -691,7 +690,7 @@ mod tests {
         forks
             .insert(prefix(b"b"), Child::Ref(leaf_ref).into(), None)
             .unwrap();
-        run(store.put_node(&Node::new(None, forks), &Plaintext)).unwrap()
+        run(save_node(store, &Node::new(None, forks), &Plaintext)).unwrap()
     }
 
     #[test]
@@ -716,7 +715,7 @@ mod tests {
         let root_ext = crate::node::RootExtension::new(Some(entry(9)), None);
         let mut forks = ForkTable::new();
         forks.insert(prefix(b"k"), entry(1).into(), None).unwrap();
-        let root = run(store.put_node(&Node::new(root_ext, forks), &Plaintext)).unwrap();
+        let root = run(save_node(&store, &Node::new(root_ext, forks), &Plaintext)).unwrap();
         let reader: Reader<_> = Reader::new(&store);
         let got = drain(run(reader.iter(&root)).unwrap());
         assert_eq!(got, vec![(Vec::new(), entry(9)), (b"k".to_vec(), entry(1))]);
@@ -841,7 +840,7 @@ mod tests {
     fn with_ref(store: &ContentGet<MemoryStore>) -> (ChunkRef, ChunkRef) {
         let mut leaf = ForkTable::new();
         leaf.insert(prefix(b"a"), entry(0xBA).into(), None).unwrap();
-        let leaf_addr = run(store.put_node(&Node::new(None, leaf), &Plaintext)).unwrap();
+        let leaf_addr = run(save_node(store, &Node::new(None, leaf), &Plaintext)).unwrap();
         let mut forks = ForkTable::new();
         forks
             .insert(prefix(b"a"), entry(0xA1).into(), None)
@@ -849,7 +848,7 @@ mod tests {
         forks
             .insert(prefix(b"b"), Child::Ref(leaf_addr).into(), None)
             .unwrap();
-        let root = run(store.put_node(&Node::new(None, forks), &Plaintext)).unwrap();
+        let root = run(save_node(store, &Node::new(None, forks), &Plaintext)).unwrap();
         (root, leaf_addr)
     }
 

--- a/crates/ldb/src/store.rs
+++ b/crates/ldb/src/store.rs
@@ -7,9 +7,8 @@
 //! [`Verified`] content chunk, deriving the address rather than trusting one.
 //!
 //! [`load_node`] and [`save_node`] are free functions over the layer-1 store
-//! traits, not verbs hung off a store; the read side binds the content-only
-//! registry, so a non-content chunk is rejected at decode rather than decoded
-//! as a node.
+//! traits. The read side binds the content-only registry, so a non-content
+//! chunk is rejected at decode rather than decoded as a node.
 //!
 //! Both seams are generic over the structural reference width `R`. Reading
 //! needs nothing but the reference: an encrypted one carries its own key, so
@@ -169,12 +168,8 @@ impl<F: Format> Node<F> {
 /// malformed image, not a tree this format ever produces.
 const MAX_DIR_DEPTH: usize = 2;
 
-/// Load and decode the node `reference` reaches, reassembling a spilled node's
-/// forks from its segments so the caller always sees one logical node.
-///
-/// The store's `Trust = Verified` bound is what lets the decode skip
-/// re-hashing. Reassembly fetches segment chunks under a bounded window, so
-/// peak retained state stays bounded by the fork count and that window.
+/// Load the node `reference` reaches, reassembling a spilled node's forks
+/// from its segments under a bounded fetch window.
 pub async fn load_node<S, F, R>(store: &S, reference: &R) -> Result<Node<F, R>, StoreError>
 where
     S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
@@ -516,8 +511,7 @@ where
     Ok(table)
 }
 
-/// Seal `node` with `seal`, store its chunk, and return the reference that
-/// reaches it.
+/// Seal `node`, store its chunk, and return the reference reaching it.
 ///
 /// Sealing happens before the first await, so the returned future never holds
 /// the source node.

--- a/crates/ldb/src/store.rs
+++ b/crates/ldb/src/store.rs
@@ -6,9 +6,10 @@
 //! path never re-hashes. The write path seals a freshly built payload into a
 //! [`Verified`] content chunk, deriving the address rather than trusting one.
 //!
-//! [`NodeGet`] and [`NodePut`] reuse the primitives store traits; the read
-//! seam binds the content-only registry, so a non-content chunk is rejected
-//! at decode rather than decoded as a node.
+//! [`load_node`] and [`save_node`] are free functions over the layer-1 store
+//! traits, not verbs hung off a store; the read side binds the content-only
+//! registry, so a non-content chunk is rejected at decode rather than decoded
+//! as a node.
 //!
 //! Both seams are generic over the structural reference width `R`. Reading
 //! needs nothing but the reference: an encrypted one carries its own key, so
@@ -29,7 +30,7 @@ use nectar_governor::{Admission, Window};
 use nectar_primitives::store::{BoxedError, ChunkPut, MaybeSend, MaybeSync, TrustedGet};
 use nectar_primitives::{
     Chunk, ChunkAddress, ChunkOps, ChunkRef, ContentChunk, ContentOnlyChunkSet, EncryptionKey,
-    EntryRef, Verified, transcrypt_in_place,
+    EntryRef, Verified, WrongRefKind, transcrypt_in_place,
 };
 use nectar_tasks::BoxFuture;
 
@@ -62,6 +63,9 @@ pub enum StoreError {
     /// The backing store failed.
     #[error("store")]
     Store(#[source] BoxedError),
+    /// A runtime reference was of the wrong width for the typed read.
+    #[error(transparent)]
+    Width(#[from] WrongRefKind),
 }
 
 impl StoreError {
@@ -161,38 +165,17 @@ impl<F: Format> Node<F> {
     }
 }
 
-/// Async node retrieval over a trusted store.
-///
-/// Blanket-implemented for every [`TrustedGet`]; the `Trust = Verified`
-/// bound is what lets [`get_node`](Self::get_node) skip re-hashing.
-pub trait NodeGet: TrustedGet<ContentOnlyChunkSet> {
-    /// Load and decode the node `reference` reaches, materializing a spilled
-    /// node's forks from its segments so the caller always sees one logical
-    /// node.
-    ///
-    /// Reassembling a segmented node fetches its segment chunks under a
-    /// bounded window and reassembles one node's forks, so peak retained
-    /// state stays bounded by the fork count and that window.
-    fn get_node<F: Format, R: NodeRef>(
-        &self,
-        reference: &R,
-    ) -> impl Future<Output = Result<Node<F, R>, StoreError>> + MaybeSend
-    where
-        Self: Sized + MaybeSync,
-    {
-        materialize_node::<Self, F, R>(self, reference)
-    }
-}
-
-impl<T: TrustedGet<ContentOnlyChunkSet>> NodeGet for T {}
-
 /// The greatest legal segment-directory depth (spec 5.4); a deeper nesting is a
 /// malformed image, not a tree this format ever produces.
 const MAX_DIR_DEPTH: usize = 2;
 
-/// Load the node `reference` reaches, reassembling a segmented node's forks in
-/// place.
-async fn materialize_node<S, F, R>(store: &S, reference: &R) -> Result<Node<F, R>, StoreError>
+/// Load and decode the node `reference` reaches, reassembling a spilled node's
+/// forks from its segments so the caller always sees one logical node.
+///
+/// The store's `Trust = Verified` bound is what lets the decode skip
+/// re-hashing. Reassembly fetches segment chunks under a bounded window, so
+/// peak retained state stays bounded by the fork count and that window.
+pub async fn load_node<S, F, R>(store: &S, reference: &R) -> Result<Node<F, R>, StoreError>
 where
     S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
     F: Format,
@@ -533,31 +516,29 @@ where
     Ok(table)
 }
 
-/// Async node storage over a chunk putter.
+/// Seal `node` with `seal`, store its chunk, and return the reference that
+/// reaches it.
 ///
-/// Blanket-implemented for every [`ChunkPut`]; sealing happens before the
-/// first await, so the returned future never holds the source node.
-pub trait NodePut: ChunkPut {
-    /// Seal `node` with `seal`, store its chunk, and return the reference that
-    /// reaches it.
-    fn put_node<F: Format, R: NodeRef, K: Seal<R>>(
-        &self,
-        node: &Node<F, R>,
-        seal: &K,
-    ) -> impl Future<Output = Result<R, StoreError>> + MaybeSend
-    where
-        Self: Sized + MaybeSync,
-    {
-        let sealed = node.to_sealed(seal);
-        async move {
-            let (chunk, reference) = sealed?;
-            self.put(chunk).await.map_err(StoreError::store)?;
-            Ok(reference)
-        }
+/// Sealing happens before the first await, so the returned future never holds
+/// the source node.
+pub fn save_node<'a, S, F, R, K>(
+    store: &'a S,
+    node: &Node<F, R>,
+    seal: &K,
+) -> impl Future<Output = Result<R, StoreError>> + MaybeSend + 'a
+where
+    S: ChunkPut + MaybeSync,
+    F: Format,
+    R: NodeRef,
+    K: Seal<R>,
+{
+    let sealed = node.to_sealed(seal);
+    async move {
+        let (chunk, reference) = sealed?;
+        store.put(chunk).await.map_err(StoreError::store)?;
+        Ok(reference)
     }
 }
-
-impl<T: ChunkPut> NodePut for T {}
 
 #[cfg(test)]
 mod tests {
@@ -610,8 +591,8 @@ mod tests {
         let store = ContentGet::new(MemoryStore::default());
         let node = sample();
 
-        let address = run(store.put_node(&node, &Plaintext)).unwrap();
-        let loaded: Node = run(store.get_node(&address)).unwrap();
+        let address = run(save_node(&store, &node, &Plaintext)).unwrap();
+        let loaded: Node = run(load_node(&store, &address)).unwrap();
 
         assert_eq!(loaded, node);
     }
@@ -637,9 +618,11 @@ mod tests {
     #[test]
     fn missing_address_is_a_store_error() {
         let store = ContentGet::new(MemoryStore::default());
-        let err =
-            run(store.get_node::<crate::V1, ChunkRef>(&ChunkRef::new(ChunkAddress::new([0; 32]))))
-                .unwrap_err();
+        let err = run(load_node::<_, crate::V1, ChunkRef>(
+            &store,
+            &ChunkRef::new(ChunkAddress::new([0; 32])),
+        ))
+        .unwrap_err();
         assert!(matches!(err, StoreError::Store(_)));
     }
 
@@ -769,7 +752,7 @@ mod tests {
             peak: AtomicUsize::new(0),
         };
 
-        let node: Node = run(store.get_node(&root)).unwrap();
+        let node: Node = run(load_node(&store, &root)).unwrap();
         assert_eq!(node.forks().len(), 256);
 
         let peak = store.peak.load(Ordering::Relaxed);

--- a/crates/ldb/src/traverse.rs
+++ b/crates/ldb/src/traverse.rs
@@ -16,8 +16,8 @@ use core::task::{Context, Poll};
 
 use bytes::Bytes;
 use futures_util::stream::{FuturesUnordered, Stream};
-use nectar_primitives::store::MaybeSync;
-use nectar_primitives::{ChunkAddress, ChunkRef};
+use nectar_primitives::store::{MaybeSync, TrustedGet};
+use nectar_primitives::{ChunkAddress, ChunkRef, ContentOnlyChunkSet};
 use nectar_tasks::BoxFuture;
 
 use crate::format::{Format, V1};
@@ -25,7 +25,7 @@ use crate::frontier::{Completion, Frame, Plan, claim, fill};
 use crate::node::NodeRef;
 use crate::reader::{Reader, ReaderError};
 use crate::scan::{Step, flatten};
-use crate::store::{NodeGet, materialize_traced};
+use crate::store::materialize_traced;
 
 /// A visited node's completion payload: its steps and the segment chunk
 /// addresses its reassembly visited.
@@ -97,7 +97,7 @@ pub struct AddressStream<'a, S, F: Format = V1, R: NodeRef = ChunkRef> {
 
 impl<'a, S, F, R> AddressStream<'a, S, F, R>
 where
-    S: NodeGet + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
     F: Format,
     R: NodeRef,
 {
@@ -256,7 +256,7 @@ where
 
 impl<S, F, R> Reader<S, F, R>
 where
-    S: NodeGet + MaybeSync,
+    S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
     F: Format,
     R: NodeRef,
 {
@@ -287,7 +287,7 @@ mod tests {
     use crate::fork::{Child, ForkTable};
     use crate::format::V1;
     use crate::node::{Node, RootExtension};
-    use crate::store::{NodePut, Plaintext};
+    use crate::store::{Plaintext, save_node};
     use crate::value::{Entry, Key};
 
     use super::*;
@@ -306,7 +306,7 @@ mod tests {
 
     fn drain<S>(mut stream: AddressStream<'_, S>) -> Vec<ChunkAddress>
     where
-        S: NodeGet + MaybeSync,
+        S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
     {
         run(async {
             let mut out = Vec::new();
@@ -322,7 +322,7 @@ mod tests {
     fn sample(store: &ContentGet<MemoryStore>) -> (ChunkRef, ChunkRef) {
         let mut leaf = ForkTable::new();
         leaf.insert(prefix(b"a"), entry(0xBA).into(), None).unwrap();
-        let leaf_addr = run(store.put_node(&Node::new(None, leaf), &Plaintext)).unwrap();
+        let leaf_addr = run(save_node(store, &Node::new(None, leaf), &Plaintext)).unwrap();
 
         let mut embedded = ForkTable::new();
         embedded
@@ -338,7 +338,7 @@ mod tests {
         forks
             .insert(prefix(b"b"), Child::Ref(leaf_addr).into(), None)
             .unwrap();
-        let root = run(store.put_node(&Node::new(None, forks), &Plaintext)).unwrap();
+        let root = run(save_node(store, &Node::new(None, forks), &Plaintext)).unwrap();
         (root, leaf_addr)
     }
 
@@ -366,7 +366,7 @@ mod tests {
         let root_ext = RootExtension::new(Some(entry(9)), None);
         let mut forks = ForkTable::new();
         forks.insert(prefix(b"k"), entry(1).into(), None).unwrap();
-        let root = run(store.put_node(&Node::new(root_ext, forks), &Plaintext)).unwrap();
+        let root = run(save_node(&store, &Node::new(root_ext, forks), &Plaintext)).unwrap();
         let reader: Reader<_> = Reader::new(&store);
         assert_eq!(
             drain(reader.addresses(&root)),
@@ -385,7 +385,7 @@ mod tests {
                 None,
             )
             .unwrap();
-        let root = run(store.put_node(&Node::new(None, forks), &Plaintext)).unwrap();
+        let root = run(save_node(&store, &Node::new(None, forks), &Plaintext)).unwrap();
         let reader: Reader<_> = Reader::new(&store);
         assert_eq!(drain(reader.addresses(&root)), vec![*root.address()]);
     }
@@ -405,7 +405,7 @@ mod tests {
                 None,
             )
             .unwrap();
-        let root = run(store.put_node(&Node::new(None, forks), &Plaintext)).unwrap();
+        let root = run(save_node(&store, &Node::new(None, forks), &Plaintext)).unwrap();
         let reader: Reader<_> = Reader::new(&store);
         assert_eq!(
             drain(reader.addresses(&root)),
@@ -418,14 +418,14 @@ mod tests {
         let store = ContentGet::new(MemoryStore::default());
         let mut leaf = ForkTable::new();
         leaf.insert(prefix(b"x"), entry(0x33).into(), None).unwrap();
-        let leaf_addr = run(store.put_node(&Node::new(None, leaf), &Plaintext)).unwrap();
+        let leaf_addr = run(save_node(&store, &Node::new(None, leaf), &Plaintext)).unwrap();
         let mut forks = ForkTable::new();
         for first in [b"a", b"b"] {
             forks
                 .insert(prefix(first), Child::Ref(leaf_addr).into(), None)
                 .unwrap();
         }
-        let root = run(store.put_node(&Node::new(None, forks), &Plaintext)).unwrap();
+        let root = run(save_node(&store, &Node::new(None, forks), &Plaintext)).unwrap();
         let reader: Reader<_> = Reader::new(&store);
         assert_eq!(
             drain(reader.addresses(&root)),
@@ -690,7 +690,7 @@ mod tests {
             mut stream: AddressStream<'_, S, V1, EncryptedChunkRef>,
         ) -> Vec<ChunkAddress>
         where
-            S: NodeGet + MaybeSync,
+            S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
         {
             run(async {
                 let mut out = Vec::new();
@@ -712,7 +712,7 @@ mod tests {
                 .forks_mut()
                 .insert(prefix(b"x"), entry(0x11).into(), None)
                 .unwrap();
-            let child_ref = run(store.put_node(&child, &seal())).unwrap();
+            let child_ref = run(save_node(&store, &child, &seal())).unwrap();
 
             let root_ext = RootExtension::new(Some(entry(9)), None);
             let mut forks = ForkTable::new();
@@ -723,7 +723,7 @@ mod tests {
                 .insert(prefix(b"b"), entry(0x22).into(), None)
                 .unwrap();
             let root = Node::new(root_ext, forks);
-            let root_ref = run(store.put_node(&root, &seal())).unwrap();
+            let root_ref = run(save_node(&store, &root, &seal())).unwrap();
 
             let reader = Reader::<&ContentGet<MemoryStore>, V1, EncryptedChunkRef>::new(&store);
             assert_eq!(

--- a/crates/ldb/tests/builder.rs
+++ b/crates/ldb/tests/builder.rs
@@ -12,7 +12,7 @@ use bytes::Bytes;
 use nectar_file::{File, Policy};
 use nectar_ldb::{
     BuildStats, Builder, Built, Child, Entry, ForkPayload, ForkTable, Key, KeyId, Metadata, Node,
-    NodeGet, Plaintext, Prefix, RootExtension, V1,
+    Plaintext, Prefix, RootExtension, V1, load_node,
 };
 use nectar_primitives::store::ChunkPut;
 use nectar_primitives::{
@@ -115,7 +115,7 @@ fn builds_the_worked_example_byte_for_byte() -> Result<()> {
         "root payload",
     );
 
-    let decoded: Node = run(ContentGet::new(&store).get_node(built.root()))?;
+    let decoded: Node = run(load_node(&ContentGet::new(&store), built.root()))?;
     ensure!(decoded == worked_example_node()?, "decoded root");
     Ok(())
 }
@@ -278,7 +278,7 @@ fn the_empty_builder_publishes_the_empty_root() -> Result<()> {
     ensure!(built.stats().peak_open_nodes() == 1, "one open node");
     ensure!(built.stats().nodes_written() == 1, "one node written");
 
-    let node: Node = run(ContentGet::new(&store).get_node(built.root()))?;
+    let node: Node = run(load_node(&ContentGet::new(&store), built.root()))?;
     ensure!(node.is_empty(), "root is the empty map");
     Ok(())
 }
@@ -294,7 +294,7 @@ fn build_files_splits_through_bmt_and_references_the_stored_roots() -> Result<()
     ];
 
     let built = run(build_files(&store, files))?;
-    let node: Node = run(ContentGet::new(&store).get_node(built.root()))?;
+    let node: Node = run(load_node(&ContentGet::new(&store), built.root()))?;
 
     // Each file's manifest entry is its independent BMT root, and every file
     // chunk is present in the same store.
@@ -328,7 +328,7 @@ fn a_key_that_prefixes_another_shares_a_fork() -> Result<()> {
         .insert(Key::from(&b"ab"[..]), Entry::from(ref32(2)), None);
     let built = run(builder.build(&store, &Plaintext))?;
 
-    let node: Node = run(ContentGet::new(&store).get_node(built.root()))?;
+    let node: Node = run(load_node(&ContentGet::new(&store), built.root()))?;
     let record = node.forks().get(b'a').context("missing fork a")?;
     ensure!(record.tail().is_empty(), "single-byte edge");
     // "a" terminates here and the trie continues to "ab".

--- a/crates/ldb/tests/reader.rs
+++ b/crates/ldb/tests/reader.rs
@@ -8,8 +8,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use anyhow::{Result, ensure};
 use bytes::Bytes;
 use nectar_ldb::{
-    Builder, Child, Database, Entry, ForkTable, Key, KeyId, Metadata, Node, NodePut, Plaintext,
-    Prefix, Reader, V1,
+    Builder, Child, Database, Entry, ForkTable, Key, KeyId, Metadata, Node, Plaintext, Prefix,
+    Reader, V1, save_node,
 };
 use nectar_manifest::{Batch, Manifest, ManifestPath, ManifestView};
 use nectar_primitives::store::{ChunkGet, ContentGet, MemoryStore};
@@ -56,14 +56,14 @@ async fn wide_manifest(store: &MemoryStore, width: u16) -> Result<ChunkRef> {
         let first = u8::try_from(first)?;
         let mut leaf = ForkTable::new();
         leaf.insert(Prefix::try_from(&[0xFFu8][..])?, entry(first).into(), None)?;
-        let leaf_ref = store.put_node(&Node::new(None, leaf), &Plaintext).await?;
+        let leaf_ref = save_node(store, &Node::new(None, leaf), &Plaintext).await?;
         forks.insert(
             Prefix::try_from(&[first][..])?,
             Child::Ref(leaf_ref).into(),
             None,
         )?;
     }
-    Ok(store.put_node(&Node::new(None, forks), &Plaintext).await?)
+    Ok(save_node(store, &Node::new(None, forks), &Plaintext).await?)
 }
 
 #[test]

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -25,6 +25,10 @@
 //! defaults to [`collapse_dir`], and [`ManifestView::serve`] resolves a
 //! request path under the site conventions into a [`Served`].
 //!
+//! Node persistence is seam-owned as well: [`NodeLoader`] and [`NodeSaver`]
+//! fix the verbs, and each format instantiates them at its own unit of
+//! transfer.
+//!
 //! Each format keeps its own metadata type: the static path erases nothing.
 //! [`ErasedManifest`] is the object-safe wrapper for a runtime-detected format,
 //! and unifies metadata behind the enumerable [`MetadataSource`]: a
@@ -90,6 +94,7 @@ mod dynamic;
 mod error;
 mod listing;
 mod meta;
+mod node;
 mod op;
 mod path;
 mod reserved;
@@ -102,6 +107,7 @@ pub use dynamic::{DynSink, DynSinkError, DynVisit, ErasedManifest};
 pub use error::{ErasedFormat, ErasedManifestError, ManifestError};
 pub use listing::{ListEntry, Listing, collapse_dir};
 pub use meta::{ManifestMeta, MetadataBlock, MetadataSource, MetadataView, WellKnownKey};
+pub use node::{NodeLoader, NodeSaver};
 pub use op::ManifestOp;
 pub use path::ManifestPath;
 pub use reserved::{ReservedKey, reserved_key};

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -25,9 +25,8 @@
 //! defaults to [`collapse_dir`], and [`ManifestView::serve`] resolves a
 //! request path under the site conventions into a [`Served`].
 //!
-//! Node persistence is seam-owned as well: [`NodeLoader`] and [`NodeSaver`]
-//! fix the verbs, and each format instantiates them at its own unit of
-//! transfer.
+//! [`NodeLoader`] and [`NodeSaver`] fix the node persistence verbs; each
+//! format instantiates them at its own unit of transfer.
 //!
 //! Each format keeps its own metadata type: the static path erases nothing.
 //! [`ErasedManifest`] is the object-safe wrapper for a runtime-detected format,

--- a/crates/manifest/src/node.rs
+++ b/crates/manifest/src/node.rs
@@ -1,0 +1,100 @@
+//! Node persistence seam: the read and write verbs every manifest format
+//! persists its nodes through.
+//!
+//! The unit of transfer `N` is a parameter, not a decision: a format whose
+//! node is one stored image instantiates at that image, and a format whose
+//! stored shape spans chunks instantiates at its decoded node, because no
+//! single image exists for it.
+
+use alloc::vec::Vec;
+use core::future::Future;
+
+use nectar_marker::{MaybeSend, MaybeSync};
+use nectar_primitives::EntryRef;
+use nectar_primitives::chunk::{ChunkAddress, Reference};
+use nectar_primitives::store::{ChunkStoreError, NullLoader};
+
+/// Read seam: the logical node of unit `N` behind a full-width reference.
+///
+/// The reference is the runtime union, not a width parameter: a trie may mix
+/// widths across its own forks, and an encrypted reference carries its key in
+/// band.
+pub trait NodeLoader<N: MaybeSend>: MaybeSend + MaybeSync {
+    /// Loader failure, wrapped by the format into its own errors.
+    type Error: core::error::Error + MaybeSend + MaybeSync + 'static;
+
+    /// The node `reference` reaches.
+    fn load(
+        &self,
+        reference: &EntryRef,
+    ) -> impl Future<Output = Result<N, Self::Error>> + MaybeSend;
+
+    /// The node plus the chunk addresses its stored shape occupies, root
+    /// first.
+    fn load_traced(
+        &self,
+        reference: &EntryRef,
+    ) -> impl Future<Output = Result<(N, Vec<ChunkAddress>), Self::Error>> + MaybeSend {
+        async move {
+            let node = self.load(reference).await?;
+            Ok((node, alloc::vec![*reference.address()]))
+        }
+    }
+}
+
+/// Write seam: persist one logical node of unit `N` under a new reference of
+/// width `R`.
+///
+/// The width is a trait parameter rather than an associated type, so one
+/// saver may mint both plain and encrypted references.
+pub trait NodeSaver<N: ?Sized + MaybeSync, R: Reference>: MaybeSend + MaybeSync {
+    /// Saver failure, wrapped by the format into its own errors.
+    type Error: core::error::Error + MaybeSend + MaybeSync + 'static;
+
+    /// Persist `node` and return the full-width reference reaching it.
+    fn save(&self, node: &N) -> impl Future<Output = Result<R, Self::Error>> + MaybeSend;
+}
+
+/// Purely in-memory manifests: every load is a typed not-found.
+impl<N: MaybeSend> NodeLoader<N> for NullLoader {
+    type Error = ChunkStoreError;
+
+    async fn load(&self, reference: &EntryRef) -> Result<N, Self::Error> {
+        Err(ChunkStoreError::not_found(reference.address()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use nectar_primitives::chunk::ChunkRef;
+    use nectar_testing::run;
+
+    use super::*;
+
+    #[test]
+    fn null_loader_is_not_found() {
+        let reference = EntryRef::from(ChunkRef::new(ChunkAddress::new([7; 32])));
+        let error = run(NodeLoader::<Vec<u8>>::load(&NullLoader, &reference)).unwrap_err();
+        assert!(matches!(error, ChunkStoreError::NotFound(a) if a == *reference.address()));
+    }
+
+    #[test]
+    fn traced_defaults_to_the_node_and_its_root_address() {
+        struct Fixed;
+
+        impl NodeLoader<u8> for Fixed {
+            type Error = ChunkStoreError;
+
+            async fn load(&self, _: &EntryRef) -> Result<u8, Self::Error> {
+                Ok(9)
+            }
+        }
+
+        let reference = EntryRef::from(ChunkRef::new(ChunkAddress::new([3; 32])));
+        let (node, addresses) = run(Fixed.load_traced(&reference)).unwrap();
+        assert_eq!(node, 9);
+        assert_eq!(addresses, vec![*reference.address()]);
+    }
+}

--- a/crates/manifest/src/node.rs
+++ b/crates/manifest/src/node.rs
@@ -1,10 +1,8 @@
 //! Node persistence seam: the read and write verbs every manifest format
 //! persists its nodes through.
 //!
-//! The unit of transfer `N` is a parameter, not a decision: a format whose
-//! node is one stored image instantiates at that image, and a format whose
-//! stored shape spans chunks instantiates at its decoded node, because no
-//! single image exists for it.
+//! `N` is the format's own unit: the whole node image, or the decoded node
+//! where the stored shape spans chunks and no single image exists.
 
 use alloc::vec::Vec;
 use core::future::Future;
@@ -16,11 +14,10 @@ use nectar_primitives::store::{ChunkStoreError, NullLoader};
 
 /// Read seam: the logical node of unit `N` behind a full-width reference.
 ///
-/// The reference is the runtime union, not a width parameter: a trie may mix
-/// widths across its own forks, and an encrypted reference carries its key in
-/// band.
+/// The reference is the runtime union: a trie may mix widths across its own
+/// forks, and an encrypted reference carries its key in band.
 pub trait NodeLoader<N: MaybeSend>: MaybeSend + MaybeSync {
-    /// Loader failure, wrapped by the format into its own errors.
+    /// Loader failure.
     type Error: core::error::Error + MaybeSend + MaybeSync + 'static;
 
     /// The node `reference` reaches.
@@ -45,10 +42,10 @@ pub trait NodeLoader<N: MaybeSend>: MaybeSend + MaybeSync {
 /// Write seam: persist one logical node of unit `N` under a new reference of
 /// width `R`.
 ///
-/// The width is a trait parameter rather than an associated type, so one
-/// saver may mint both plain and encrypted references.
+/// `R` is a trait parameter, so one saver may mint both plain and encrypted
+/// references.
 pub trait NodeSaver<N: ?Sized + MaybeSync, R: Reference>: MaybeSend + MaybeSync {
-    /// Saver failure, wrapped by the format into its own errors.
+    /// Saver failure.
     type Error: core::error::Error + MaybeSend + MaybeSync + 'static;
 
     /// Persist `node` and return the full-width reference reaching it.

--- a/crates/manifest/tests/listing.rs
+++ b/crates/manifest/tests/listing.rs
@@ -140,20 +140,20 @@ impl Counting {
     }
 }
 
-impl NodeLoader for Counting {
-    type Error = <Nodes as NodeLoader>::Error;
+impl NodeLoader<Vec<u8>> for Counting {
+    type Error = <Nodes as NodeLoader<Vec<u8>>>::Error;
 
-    async fn collect(&self, reference: &EntryRef) -> Result<Vec<u8>, Self::Error> {
+    async fn load(&self, reference: &EntryRef) -> Result<Vec<u8>, Self::Error> {
         self.loads.fetch_add(1, Ordering::SeqCst);
-        self.inner.collect(reference).await
+        self.inner.load(reference).await
     }
 }
 
-impl NodeSaver<ChunkRef> for Counting {
-    type Error = <Nodes as NodeSaver<ChunkRef>>::Error;
+impl NodeSaver<[u8], ChunkRef> for Counting {
+    type Error = <Nodes as NodeSaver<[u8], ChunkRef>>::Error;
 
-    async fn save(&self, data: Vec<u8>) -> Result<ChunkRef, Self::Error> {
-        <Nodes as NodeSaver<ChunkRef>>::save(&self.inner, data).await
+    async fn save(&self, data: &[u8]) -> Result<ChunkRef, Self::Error> {
+        <Nodes as NodeSaver<[u8], ChunkRef>>::save(&self.inner, data).await
     }
 }
 

--- a/crates/manifest/tests/node_seam.rs
+++ b/crates/manifest/tests/node_seam.rs
@@ -1,0 +1,233 @@
+//! The node persistence seam over both formats.
+//!
+//! The unit of transfer differs (a whole image for the trie, a decoded node
+//! for the database), so the laws are stated once per adapter: a save round
+//! trips through a load at both reference widths, and a traced load agrees
+//! with a plain one over a non-empty root-first address list.
+
+#![allow(clippy::as_conversions, clippy::unwrap_used)]
+
+use std::sync::Arc;
+
+use nectar_ldb::{Builder, Database, Entry, ForkTable, Key, Node, NodeRef, Prefix, Seal, V1};
+use nectar_manifest::{NodeLoader, NodeSaver};
+use nectar_mantaray::NodeLoadSaver;
+use nectar_primitives::{ChunkAddress, ChunkRef, EntryRef};
+use nectar_testing::run;
+
+mod common;
+use common::{Store, stores};
+
+/// A node image spanning several chunks, so the trie's traced load has more
+/// than a root to report.
+fn image() -> Vec<u8> {
+    (0..20_000u32).map(|i| (i % 251) as u8).collect()
+}
+
+/// A reference standing in for a bound value.
+fn entry(byte: u8) -> Entry {
+    Entry::from(ChunkRef::new(ChunkAddress::new([byte; 32])))
+}
+
+/// A node small enough to seal into one chunk, which is all a per-node save
+/// can express; spilling is the builder's, not the seam's.
+fn plain_node<R: NodeRef>() -> Node<V1, R> {
+    let mut forks = ForkTable::new();
+    for byte in 0u8..4 {
+        forks
+            .insert(
+                Prefix::try_from(&[byte][..]).unwrap(),
+                entry(byte).into(),
+                None,
+            )
+            .unwrap();
+    }
+    Node::new(None, forks)
+}
+
+/// A 256-fork root built natively, so its stored shape spills across segment
+/// chunks and no single image exists for it.
+async fn spilled_root<R: NodeRef, K: Seal<R>>(store: &Store, seal: &K) -> R {
+    let mut builder = Builder::<V1>::new();
+    for byte in 0u8..=255 {
+        builder.insert(Key::from(&[byte][..]), entry(byte), None);
+    }
+    builder.build(store, seal).await.unwrap().root().clone()
+}
+
+#[test]
+fn the_trie_adapter_round_trips_a_node_image() {
+    run(async {
+        let (raw, _) = stores();
+        let nodes = NodeLoadSaver::new(Arc::clone(&raw));
+        let data = image();
+
+        let root = NodeSaver::<[u8], ChunkRef>::save(&nodes, data.as_slice())
+            .await
+            .unwrap();
+        let reference = EntryRef::from(root);
+        assert_eq!(
+            NodeLoader::<Vec<u8>>::load(&nodes, &reference)
+                .await
+                .unwrap(),
+            data
+        );
+
+        let (traced, addresses) = nodes.load_traced(&reference).await.unwrap();
+        assert_eq!(traced, data);
+        assert_eq!(addresses.first(), Some(reference.address()));
+        assert!(
+            addresses.len() > 1,
+            "a multi-chunk image reports every chunk it occupies"
+        );
+    });
+}
+
+#[cfg(feature = "test-encryption")]
+#[test]
+fn the_trie_adapter_round_trips_at_the_encrypted_width() {
+    use nectar_primitives::EncryptedChunkRef;
+
+    run(async {
+        let (raw, _) = stores();
+        let nodes = NodeLoadSaver::new(Arc::clone(&raw));
+        let data = image();
+
+        let root = NodeSaver::<[u8], EncryptedChunkRef>::save(&nodes, data.as_slice())
+            .await
+            .unwrap();
+        let reference = EntryRef::from(root);
+        assert_eq!(
+            NodeLoader::<Vec<u8>>::load(&nodes, &reference)
+                .await
+                .unwrap(),
+            data
+        );
+
+        let (traced, addresses) = nodes.load_traced(&reference).await.unwrap();
+        assert_eq!(traced, data);
+        assert_eq!(addresses.first(), Some(reference.address()));
+        assert!(addresses.len() > 1);
+    });
+}
+
+#[test]
+fn the_database_round_trips_a_decoded_node() {
+    run(async {
+        let (_, store) = stores();
+        let db: Database<_> = Database::plain(store);
+        let node = plain_node::<ChunkRef>();
+
+        let root: ChunkRef = NodeSaver::save(&db, &node).await.unwrap();
+        let reference = EntryRef::from(root);
+        let loaded: Node<V1, ChunkRef> = db.load(&reference).await.unwrap();
+        assert_eq!(loaded, node);
+
+        let (traced, addresses) = NodeLoader::<Node<V1, ChunkRef>>::load_traced(&db, &reference)
+            .await
+            .unwrap();
+        assert_eq!(traced, loaded);
+        assert_eq!(addresses, vec![*reference.address()]);
+    });
+}
+
+#[test]
+fn the_database_traces_a_spilled_node_root_first() {
+    run(async {
+        let (_, store) = stores();
+        let root: ChunkRef = spilled_root(&store, &nectar_ldb::Plaintext).await;
+        let db: Database<_> = Database::plain(store);
+        let reference = EntryRef::from(root);
+
+        let loaded: Node<V1, ChunkRef> = db.load(&reference).await.unwrap();
+        assert_eq!(loaded.forks().len(), 256);
+
+        let (traced, addresses) = NodeLoader::<Node<V1, ChunkRef>>::load_traced(&db, &reference)
+            .await
+            .unwrap();
+        assert_eq!(traced, loaded);
+        assert_eq!(addresses.first(), Some(reference.address()));
+        assert!(
+            addresses.len() > 1,
+            "a spilled node reports its segment chunks after the root"
+        );
+    });
+}
+
+/// The runtime read reference is the one thing the typed native path checks at
+/// compile time, so a width mismatch has to surface as an error rather than a
+/// mis-parse.
+#[cfg(feature = "test-encryption")]
+#[test]
+fn the_database_rejects_a_reference_of_the_wrong_width() {
+    use nectar_primitives::{EncryptedChunkRef, EncryptionKey};
+
+    run(async {
+        let (_, store) = stores();
+        let db: Database<_> = Database::plain(store);
+        let root: ChunkRef = NodeSaver::save(&db, &plain_node::<ChunkRef>())
+            .await
+            .unwrap();
+        let widened = EntryRef::from(EncryptedChunkRef::new(
+            *root.address(),
+            EncryptionKey::from([0u8; EncryptionKey::SIZE]),
+        ));
+
+        let error = NodeLoader::<Node<V1, ChunkRef>>::load(&db, &widened)
+            .await
+            .unwrap_err();
+        assert!(matches!(error, nectar_ldb::StoreError::Width(_)));
+    });
+}
+
+/// The seal is the write-side secret, so an encrypted database mints encrypted
+/// references from the same seam call.
+#[cfg(feature = "test-encryption")]
+#[test]
+fn the_database_round_trips_at_the_encrypted_width() {
+    use nectar_ldb::Encrypted as EncryptedSeal;
+    use nectar_primitives::EncryptedChunkRef;
+
+    run(async {
+        let (_, store) = stores();
+        let seal: EncryptedSeal<'_, V1> = EncryptedSeal::new(b"a node seam secret");
+        let spilled: EncryptedChunkRef = spilled_root(&store, &seal).await;
+        let db: Database<_, _> = Database::new(store, seal);
+
+        let node = plain_node::<EncryptedChunkRef>();
+        let root: EncryptedChunkRef = NodeSaver::save(&db, &node).await.unwrap();
+        let reference = EntryRef::from(root);
+        let loaded: Node<V1, EncryptedChunkRef> = db.load(&reference).await.unwrap();
+        assert_eq!(loaded, node);
+
+        let reference = EntryRef::from(spilled);
+        let (traced, addresses) =
+            NodeLoader::<Node<V1, EncryptedChunkRef>>::load_traced(&db, &reference)
+                .await
+                .unwrap();
+        assert_eq!(traced.forks().len(), 256);
+        assert_eq!(addresses.first(), Some(reference.address()));
+        assert!(addresses.len() > 1);
+    });
+}
+
+/// A trie fork may reference a node of either width, so the read side takes
+/// the runtime union rather than a width parameter.
+#[test]
+fn the_null_loader_answers_not_found_at_any_unit() {
+    use nectar_primitives::store::NullLoader;
+
+    run(async {
+        let reference = EntryRef::from(ChunkRef::new(ChunkAddress::new([4; 32])));
+        assert!(
+            NodeLoader::<Vec<u8>>::load(&NullLoader, &reference)
+                .await
+                .is_err()
+        );
+        assert!(
+            NodeLoader::<Node<V1, ChunkRef>>::load(&NullLoader, &reference)
+                .await
+                .is_err()
+        );
+    });
+}

--- a/crates/manifest/tests/node_seam.rs
+++ b/crates/manifest/tests/node_seam.rs
@@ -1,9 +1,6 @@
-//! The node persistence seam over both formats.
-//!
-//! The unit of transfer differs (a whole image for the trie, a decoded node
-//! for the database), so the laws are stated once per adapter: a save round
-//! trips through a load at both reference widths, and a traced load agrees
-//! with a plain one over a non-empty root-first address list.
+//! The node persistence seam over both formats: a save round trips through a
+//! load at both reference widths, and a traced load agrees with a plain one
+//! over a non-empty root-first address list.
 
 #![allow(clippy::as_conversions, clippy::unwrap_used)]
 
@@ -12,11 +9,11 @@ use std::sync::Arc;
 use nectar_ldb::{Builder, Database, Entry, ForkTable, Key, Node, NodeRef, Prefix, Seal, V1};
 use nectar_manifest::{NodeLoader, NodeSaver};
 use nectar_mantaray::NodeLoadSaver;
-use nectar_primitives::{ChunkAddress, ChunkRef, EntryRef};
+use nectar_primitives::{ChunkRef, EntryRef};
 use nectar_testing::run;
 
 mod common;
-use common::{Store, stores};
+use common::{Store, reference, stores};
 
 /// A node image spanning several chunks, so the trie's traced load has more
 /// than a root to report.
@@ -24,13 +21,12 @@ fn image() -> Vec<u8> {
     (0..20_000u32).map(|i| (i % 251) as u8).collect()
 }
 
-/// A reference standing in for a bound value.
 fn entry(byte: u8) -> Entry {
-    Entry::from(ChunkRef::new(ChunkAddress::new([byte; 32])))
+    Entry::from(reference(byte))
 }
 
 /// A node small enough to seal into one chunk, which is all a per-node save
-/// can express; spilling is the builder's, not the seam's.
+/// can express.
 fn plain_node<R: NodeRef>() -> Node<V1, R> {
     let mut forks = ForkTable::new();
     for byte in 0u8..4 {
@@ -45,8 +41,7 @@ fn plain_node<R: NodeRef>() -> Node<V1, R> {
     Node::new(None, forks)
 }
 
-/// A 256-fork root built natively, so its stored shape spills across segment
-/// chunks and no single image exists for it.
+/// A 256-fork root, whose stored shape spills across segment chunks.
 async fn spilled_root<R: NodeRef, K: Seal<R>>(store: &Store, seal: &K) -> R {
     let mut builder = Builder::<V1>::new();
     for byte in 0u8..=255 {
@@ -154,9 +149,6 @@ fn the_database_traces_a_spilled_node_root_first() {
     });
 }
 
-/// The runtime read reference is the one thing the typed native path checks at
-/// compile time, so a width mismatch has to surface as an error rather than a
-/// mis-parse.
 #[cfg(feature = "test-encryption")]
 #[test]
 fn the_database_rejects_a_reference_of_the_wrong_width() {
@@ -180,8 +172,6 @@ fn the_database_rejects_a_reference_of_the_wrong_width() {
     });
 }
 
-/// The seal is the write-side secret, so an encrypted database mints encrypted
-/// references from the same seam call.
 #[cfg(feature = "test-encryption")]
 #[test]
 fn the_database_round_trips_at_the_encrypted_width() {
@@ -211,14 +201,12 @@ fn the_database_round_trips_at_the_encrypted_width() {
     });
 }
 
-/// A trie fork may reference a node of either width, so the read side takes
-/// the runtime union rather than a width parameter.
 #[test]
 fn the_null_loader_answers_not_found_at_any_unit() {
     use nectar_primitives::store::NullLoader;
 
     run(async {
-        let reference = EntryRef::from(ChunkRef::new(ChunkAddress::new([4; 32])));
+        let reference = EntryRef::from(reference(4));
         assert!(
             NodeLoader::<Vec<u8>>::load(&NullLoader, &reference)
                 .await

--- a/crates/mantaray/Cargo.toml
+++ b/crates/mantaray/Cargo.toml
@@ -56,6 +56,7 @@ std = [
 	"dep:bitflags",
 	"dep:futures-util",
 	"dep:nectar-governor",
+	"dep:nectar-manifest",
 	"dep:nectar-primitives",
 	"dep:nectar-tasks",
 	"dep:serde_json",
@@ -83,7 +84,7 @@ arbitrary = [
 encryption = [ "nectar-file?/encryption", "nectar-primitives?/encryption" ]
 # The shared `Manifest` seam: the trie as one implementation of it, with entry
 # data joined through the file crate's shared load lane. Implies `std`.
-manifest = [ "dep:nectar-file", "dep:nectar-manifest", "std" ]
+manifest = [ "dep:nectar-file", "std" ]
 # Raw node internals (the `hazmat` module) for fuzz harnesses and benches.
 hazmat = [ "std" ]
 # Single-thread send escape: relaxes the boxed trie futures off `Send` in

--- a/crates/mantaray/src/cursor.rs
+++ b/crates/mantaray/src/cursor.rs
@@ -19,6 +19,7 @@ use core::task::{Context, Poll};
 use futures_util::stream::{FuturesUnordered, Stream};
 use nectar_governor::Admission;
 pub use nectar_governor::Window;
+use nectar_manifest::NodeLoader;
 use nectar_primitives::EntryRef;
 use nectar_primitives::chunk::ChunkAddress;
 use nectar_tasks::BoxFuture;
@@ -27,7 +28,6 @@ use crate::entry::Entry;
 use crate::error::CursorError;
 use crate::node::NodeType;
 use crate::view::{ForkView, NodeView};
-use nectar_manifest::NodeLoader;
 
 /// One queued subtree root: the child's full-width reference plus the
 /// filter state its subtree inherits.

--- a/crates/mantaray/src/cursor.rs
+++ b/crates/mantaray/src/cursor.rs
@@ -26,8 +26,8 @@ use nectar_tasks::BoxFuture;
 use crate::entry::Entry;
 use crate::error::CursorError;
 use crate::node::NodeType;
-use crate::persist::NodeLoader;
 use crate::view::{ForkView, NodeView};
+use nectar_manifest::NodeLoader;
 
 /// One queued subtree root: the child's full-width reference plus the
 /// filter state its subtree inherits.
@@ -96,7 +96,7 @@ struct TrieWalk<L> {
 
 impl<L> TrieWalk<L>
 where
-    L: NodeLoader + Clone + 'static,
+    L: NodeLoader<Vec<u8>> + Clone + 'static,
 {
     fn new(
         store: L,
@@ -186,12 +186,13 @@ where
             let store = self.store.clone();
             let reference = pending.reference.clone();
             let fetch: BoxFuture<'static, Fetched> = Box::pin(async move {
-                let fetched = store.collect_with_addresses(&reference).await.map_err(|e| {
-                    CursorError::Store {
+                let fetched = store
+                    .load_traced(&reference)
+                    .await
+                    .map_err(|e| CursorError::Store {
                         address: *reference.address(),
                         source: Arc::new(e),
-                    }
-                });
+                    });
                 (id, pending, fetched)
             });
             self.in_flight.push(fetch);
@@ -359,7 +360,7 @@ impl<L> Cursor<L> {
 
 impl<L> Cursor<L>
 where
-    L: NodeLoader + Clone + 'static,
+    L: NodeLoader<Vec<u8>> + Clone + 'static,
 {
     /// Deliver the next entry in path order.
     ///
@@ -411,7 +412,7 @@ where
 
 impl<L> Stream for Cursor<L>
 where
-    L: NodeLoader + Clone + Unpin + 'static,
+    L: NodeLoader<Vec<u8>> + Clone + Unpin + 'static,
 {
     type Item = Result<Entry, CursorError>;
 
@@ -475,7 +476,7 @@ impl<L> AddressStream<L> {
 
 impl<L> AddressStream<L>
 where
-    L: NodeLoader + Clone + 'static,
+    L: NodeLoader<Vec<u8>> + Clone + 'static,
 {
     /// Deliver the next address in depth-first order.
     ///
@@ -522,7 +523,7 @@ where
 
 impl<L> Stream for AddressStream<L>
 where
-    L: NodeLoader + Clone + Unpin + 'static,
+    L: NodeLoader<Vec<u8>> + Clone + Unpin + 'static,
 {
     type Item = Result<ChunkAddress, CursorError>;
 
@@ -617,7 +618,7 @@ mod tests {
 
     fn collect_entries<L>(mut cursor: Cursor<L>) -> Vec<Entry>
     where
-        L: NodeLoader + Clone + 'static,
+        L: NodeLoader<Vec<u8>> + Clone + 'static,
     {
         run(async {
             let mut out = Vec::new();
@@ -630,7 +631,7 @@ mod tests {
 
     fn collect_until_err<L>(mut cursor: Cursor<L>) -> (Vec<Entry>, Option<CursorError>)
     where
-        L: NodeLoader + Clone + 'static,
+        L: NodeLoader<Vec<u8>> + Clone + 'static,
     {
         run(async {
             let mut out = Vec::new();
@@ -646,7 +647,7 @@ mod tests {
 
     fn collect_addresses<L>(mut stream: AddressStream<L>) -> Vec<ChunkAddress>
     where
-        L: NodeLoader + Clone + 'static,
+        L: NodeLoader<Vec<u8>> + Clone + 'static,
     {
         run(async {
             let mut out = Vec::new();
@@ -728,10 +729,10 @@ mod tests {
         .await;
     }
 
-    impl NodeLoader for RecordingStore {
+    impl NodeLoader<Vec<u8>> for RecordingStore {
         type Error = SingleChunkError;
 
-        async fn collect(&self, reference: &EntryRef) -> Result<Vec<u8>, Self::Error> {
+        async fn load(&self, reference: &EntryRef) -> Result<Vec<u8>, Self::Error> {
             let address = *reference.address();
             self.inner.fetched.lock().unwrap().push(address);
             let level = self.inner.inflight.fetch_add(1, Ordering::SeqCst) + 1;
@@ -742,10 +743,10 @@ mod tests {
             let result = if self.inner.fail == Some(address) {
                 self.inner
                     .store
-                    .collect(&EntryRef::from(make_addr("absent-sentinel")))
+                    .load(&EntryRef::from(make_addr("absent-sentinel")))
                     .await
             } else {
-                self.inner.store.collect(reference).await
+                self.inner.store.load(reference).await
             };
             self.inner.inflight.fetch_sub(1, Ordering::SeqCst);
             result

--- a/crates/mantaray/src/editor.rs
+++ b/crates/mantaray/src/editor.rs
@@ -30,8 +30,8 @@ use nectar_tasks::BoxFuture;
 
 use crate::error::EditorError;
 use crate::node::{Fork, Node, NodeState, Prefix};
-use crate::persist::{NodeLoader, NodeSaver};
 use crate::{MantarayError, metadata};
+use nectar_manifest::{NodeLoader, NodeSaver};
 
 /// One recorded manifest mutation.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -263,7 +263,7 @@ impl<S, R: Reference> ManifestEditor<S, R> {
     }
 }
 
-impl<S: NodeLoader, R: Reference> ManifestEditor<S, R> {
+impl<S: NodeLoader<Vec<u8>>, R: Reference> ManifestEditor<S, R> {
     /// Apply the recorded ops to the trie, one at a time, in submission order.
     async fn apply_ops(&mut self) -> Result<(), EditorError> {
         let ops = core::mem::take(&mut self.ops);
@@ -301,7 +301,7 @@ impl<S: NodeLoader, R: Reference> ManifestEditor<S, R> {
     }
 }
 
-impl<S: NodeLoader + NodeSaver<R>, R: Reference> ManifestEditor<S, R> {
+impl<S: NodeLoader<Vec<u8>> + NodeSaver<[u8], R>, R: Reference> ManifestEditor<S, R> {
     /// Apply the log and persist the trie, returning the root's full-width
     /// reference and the loadsaver.
     ///
@@ -321,7 +321,7 @@ impl<S: NodeLoader + NodeSaver<R>, R: Reference> ManifestEditor<S, R> {
     }
 }
 
-impl<S: NodeLoader + NodeSaver<ChunkRef>> ManifestEditor<S, ChunkRef> {
+impl<S: NodeLoader<Vec<u8>> + NodeSaver<[u8], ChunkRef>> ManifestEditor<S, ChunkRef> {
     /// Apply the log and persist the trie, returning the root chunk address
     /// and the loadsaver.
     pub async fn commit(self) -> Result<(ChunkAddress, S), EditorError> {
@@ -330,7 +330,9 @@ impl<S: NodeLoader + NodeSaver<ChunkRef>> ManifestEditor<S, ChunkRef> {
     }
 }
 
-impl<S: NodeLoader + NodeSaver<EncryptedChunkRef>> ManifestEditor<S, EncryptedChunkRef> {
+impl<S: NodeLoader<Vec<u8>> + NodeSaver<[u8], EncryptedChunkRef>>
+    ManifestEditor<S, EncryptedChunkRef>
+{
     /// Apply the log and persist the trie, returning the root's full-width
     /// reference (address plus decryption key) and the loadsaver.
     pub async fn commit(self) -> Result<(EncryptedChunkRef, S), EditorError> {
@@ -360,7 +362,7 @@ async fn apply_metadata_merge<S, R>(
     store: &S,
 ) -> Result<(), MantarayError>
 where
-    S: NodeLoader,
+    S: NodeLoader<Vec<u8>>,
     R: Reference,
 {
     match merge_descent(trie, path, &key, &value, store).await? {
@@ -384,7 +386,7 @@ async fn apply_metadata_clear<S, R>(
     store: &S,
 ) -> Result<(), MantarayError>
 where
-    S: NodeLoader,
+    S: NodeLoader<Vec<u8>>,
     R: Reference,
 {
     let Some((entry, mut metadata)) = binding_at(trie, path, store).await? else {
@@ -409,7 +411,7 @@ async fn binding_at<S, R>(
     store: &S,
 ) -> Result<Option<(Option<R>, BTreeMap<String, String>)>, MantarayError>
 where
-    S: NodeLoader,
+    S: NodeLoader<Vec<u8>>,
     R: Reference,
 {
     let mut current = trie;
@@ -446,7 +448,7 @@ async fn merge_descent<S, R>(
     store: &S,
 ) -> Result<MergeOutcome, MantarayError>
 where
-    S: NodeLoader,
+    S: NodeLoader<Vec<u8>>,
     R: Reference,
 {
     let mut current = trie;
@@ -490,7 +492,7 @@ async fn commit_trie<S, R>(
     window: Window,
 ) -> Result<Node<R>, MantarayError>
 where
-    S: NodeSaver<R>,
+    S: NodeSaver<[u8], R>,
     R: Reference,
 {
     if root.reference().is_some() {
@@ -580,7 +582,7 @@ struct CommitWalk<'s, S, R: Reference> {
 
 impl<'s, S, R> CommitWalk<'s, S, R>
 where
-    S: NodeSaver<R>,
+    S: NodeSaver<[u8], R>,
     R: Reference,
 {
     fn new(saver: &'s S, window: Window, root: Node<R>) -> Self {
@@ -712,9 +714,12 @@ where
         let id = frame.id;
         let saver = self.saver;
         let future: BoxFuture<'s, SaveDone<R>> = Box::pin(async move {
-            let outcome = saver.save(data).await.map_err(|e| MantarayError::StorePut {
-                source: Arc::new(e),
-            });
+            let outcome = saver
+                .save(&data)
+                .await
+                .map_err(|e| MantarayError::StorePut {
+                    source: Arc::new(e),
+                });
             (id, outcome)
         });
         if let Some(parent) = frame.parent {
@@ -1176,20 +1181,20 @@ mod tests {
         }
     }
 
-    impl NodeLoader for CountingSaver {
+    impl NodeLoader<Vec<u8>> for CountingSaver {
         type Error = SingleChunkError;
 
-        async fn collect(&self, reference: &EntryRef) -> Result<Vec<u8>, Self::Error> {
-            self.inner.collect(reference).await
+        async fn load(&self, reference: &EntryRef) -> Result<Vec<u8>, Self::Error> {
+            self.inner.load(reference).await
         }
     }
 
-    impl NodeSaver<ChunkRef> for CountingSaver {
+    impl NodeSaver<[u8], ChunkRef> for CountingSaver {
         type Error = SingleChunkError;
 
-        async fn save(&self, data: Vec<u8>) -> Result<ChunkRef, Self::Error> {
+        async fn save(&self, data: &[u8]) -> Result<ChunkRef, Self::Error> {
             self.saves.fetch_add(1, Ordering::SeqCst);
-            NodeSaver::<ChunkRef>::save(&self.inner, data).await
+            NodeSaver::<[u8], ChunkRef>::save(&self.inner, data).await
         }
     }
 
@@ -1212,26 +1217,27 @@ mod tests {
         }
     }
 
-    impl NodeLoader for FailingSaver {
+    impl NodeLoader<Vec<u8>> for FailingSaver {
         type Error = SingleChunkError;
 
-        async fn collect(&self, reference: &EntryRef) -> Result<Vec<u8>, Self::Error> {
-            self.inner.collect(reference).await
+        async fn load(&self, reference: &EntryRef) -> Result<Vec<u8>, Self::Error> {
+            self.inner.load(reference).await
         }
     }
 
-    impl NodeSaver<ChunkRef> for FailingSaver {
+    impl NodeSaver<[u8], ChunkRef> for FailingSaver {
         type Error = SingleChunkError;
 
-        async fn save(&self, data: Vec<u8>) -> Result<ChunkRef, Self::Error> {
+        async fn save(&self, data: &[u8]) -> Result<ChunkRef, Self::Error> {
             let seen = self.dispatched.fetch_add(1, Ordering::SeqCst);
             // An image far past one chunk is the loadsaver's own failure.
+            let oversized = alloc::vec![0u8; 1 << 20];
             let data = if seen == self.fail_at {
-                alloc::vec![0u8; 1 << 20]
+                oversized.as_slice()
             } else {
                 data
             };
-            NodeSaver::<ChunkRef>::save(&self.inner, data).await
+            NodeSaver::<[u8], ChunkRef>::save(&self.inner, data).await
         }
     }
 
@@ -1317,18 +1323,18 @@ mod tests {
         }
     }
 
-    impl NodeLoader for WindowSaver {
+    impl NodeLoader<Vec<u8>> for WindowSaver {
         type Error = SingleChunkError;
 
-        async fn collect(&self, reference: &EntryRef) -> Result<Vec<u8>, Self::Error> {
-            self.inner.collect(reference).await
+        async fn load(&self, reference: &EntryRef) -> Result<Vec<u8>, Self::Error> {
+            self.inner.load(reference).await
         }
     }
 
-    impl NodeSaver<ChunkRef> for WindowSaver {
+    impl NodeSaver<[u8], ChunkRef> for WindowSaver {
         type Error = SingleChunkError;
 
-        async fn save(&self, data: Vec<u8>) -> Result<ChunkRef, Self::Error> {
+        async fn save(&self, data: &[u8]) -> Result<ChunkRef, Self::Error> {
             let bytes = data.len();
             self.probe.saves.fetch_add(1, Ordering::SeqCst);
             self.probe.total.fetch_add(bytes, Ordering::SeqCst);
@@ -1339,7 +1345,7 @@ mod tests {
             // Park once so queued siblings ramp their in-flight count before
             // any single save resolves.
             yield_once().await;
-            let result = NodeSaver::<ChunkRef>::save(&self.inner, data).await;
+            let result = NodeSaver::<[u8], ChunkRef>::save(&self.inner, data).await;
             self.probe.resident.fetch_sub(bytes, Ordering::SeqCst);
             self.probe.in_flight.fetch_sub(1, Ordering::SeqCst);
             result

--- a/crates/mantaray/src/editor.rs
+++ b/crates/mantaray/src/editor.rs
@@ -24,6 +24,7 @@ use core::task::{Context, Poll};
 
 use futures_util::stream::{FuturesUnordered, Stream};
 use nectar_governor::{Admission, Window};
+use nectar_manifest::{NodeLoader, NodeSaver};
 use nectar_primitives::chunk::{ChunkAddress, ChunkRef, Reference};
 use nectar_primitives::{EncryptedChunkRef, EntryRef};
 use nectar_tasks::BoxFuture;
@@ -31,7 +32,6 @@ use nectar_tasks::BoxFuture;
 use crate::error::EditorError;
 use crate::node::{Fork, Node, NodeState, Prefix};
 use crate::{MantarayError, metadata};
-use nectar_manifest::{NodeLoader, NodeSaver};
 
 /// One recorded manifest mutation.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1230,9 +1230,10 @@ mod tests {
 
         async fn save(&self, data: &[u8]) -> Result<ChunkRef, Self::Error> {
             let seen = self.dispatched.fetch_add(1, Ordering::SeqCst);
+            let oversized;
             // An image far past one chunk is the loadsaver's own failure.
-            let oversized = alloc::vec![0u8; 1 << 20];
             let data = if seen == self.fail_at {
+                oversized = alloc::vec![0u8; 1 << 20];
                 oversized.as_slice()
             } else {
                 data

--- a/crates/mantaray/src/lib.rs
+++ b/crates/mantaray/src/lib.rs
@@ -20,8 +20,8 @@
 //! - [`ManifestEditor`]: records puts and removes, then commits them in
 //!   submission order.
 //!
-//! All four are generic over the [`persist`] seam ([`NodeLoader`],
-//! [`NodeSaver`]): the trie never touches chunk stores directly, so the
+//! All four are generic over the seam-owned [`NodeLoader`] and [`NodeSaver`],
+//! at a whole node image: the trie never touches chunk stores directly, so the
 //! storage layout is the adapter's. The production `NodeLoadSaver` adapter
 //! (behind the `manifest` feature) adapts a chunk store through the file
 //! pipeline, storing a node larger than one chunk across several, as the
@@ -176,10 +176,12 @@ pub use error::{
 #[cfg(feature = "manifest")]
 pub use manifest::{MantarayManifest, TrieCursor, TrieFormatError, TrieView};
 #[cfg(feature = "std")]
+pub use nectar_manifest::{NodeLoader, NodeSaver};
+#[cfg(feature = "std")]
 pub use node::NodeType;
 pub use obfuscation::ObfuscationKey;
 #[cfg(feature = "std")]
-pub use persist::{MAX_NODE_BYTES, NodeLoader, NodeSaver};
+pub use persist::MAX_NODE_BYTES;
 #[cfg(feature = "manifest")]
 pub use persist::{NodeCollectError, NodeLoadSaver};
 #[cfg(feature = "std")]

--- a/crates/mantaray/src/manifest.rs
+++ b/crates/mantaray/src/manifest.rs
@@ -28,7 +28,9 @@ use nectar_primitives::store::{ContentGet, MaybeSend, MaybeSync, TrustedGet};
 use crate::cursor::Cursor;
 use crate::editor::ManifestEditor;
 use crate::error::{CursorError, EditorError, ReaderError};
-use crate::persist::{NodeLoadSaver, NodeLoader, NodeSaver};
+use nectar_manifest::{NodeLoader, NodeSaver};
+
+use crate::persist::NodeLoadSaver;
 use crate::reader::Reader;
 use crate::{constants::metadata, entry::Entry};
 
@@ -112,7 +114,7 @@ where
 
 impl<L, S, R, const B: usize> Manifest<R> for MantarayManifest<L, S, B>
 where
-    L: NodeLoader + NodeSaver<R> + Clone + 'static,
+    L: NodeLoader<Vec<u8>> + NodeSaver<[u8], R> + Clone + 'static,
     S: TrustedGet<ContentOnlyChunkSet<B>> + Clone + MaybeSend + MaybeSync + 'static,
     R: Reference,
 {
@@ -201,7 +203,7 @@ pub struct TrieView<L, S, R: Reference, const B: usize = DEFAULT_BODY_SIZE> {
 
 impl<L, S, R, const B: usize> TrieView<L, S, R, B>
 where
-    L: NodeLoader + Clone,
+    L: NodeLoader<Vec<u8>> + Clone,
     R: Reference,
 {
     /// The entry at `path`, which is the trie key verbatim. The structural
@@ -241,7 +243,7 @@ where
 
 impl<L, S, R, const B: usize> ManifestView<R> for TrieView<L, S, R, B>
 where
-    L: NodeLoader + Clone + 'static,
+    L: NodeLoader<Vec<u8>> + Clone + 'static,
     S: TrustedGet<ContentOnlyChunkSet<B>> + Clone + MaybeSend + MaybeSync + 'static,
     R: Reference,
 {
@@ -346,7 +348,7 @@ pub struct TrieCursor<L, R: Reference> {
 
 impl<L, R> RawCursor<R> for TrieCursor<L, R>
 where
-    L: NodeLoader + Clone + MaybeSend + 'static,
+    L: NodeLoader<Vec<u8>> + Clone + MaybeSend + 'static,
     R: Reference,
 {
     type Error = ManifestError<TrieFormatError>;

--- a/crates/mantaray/src/manifest.rs
+++ b/crates/mantaray/src/manifest.rs
@@ -19,7 +19,8 @@ use core::ops::Bound;
 use nectar_file::{Policy, load_reference};
 use nectar_manifest::{
     Batch, DataSink, Listing, Manifest, ManifestError, ManifestOp, ManifestPath, ManifestView,
-    MapEntry, PathCursor, RawCursor, RawItem, SinkError, SiteConfig, collapse_dir,
+    MapEntry, NodeLoader, NodeSaver, PathCursor, RawCursor, RawItem, SinkError, SiteConfig,
+    collapse_dir,
 };
 use nectar_primitives::DEFAULT_BODY_SIZE;
 use nectar_primitives::chunk::{ContentOnlyChunkSet, Reference};
@@ -28,8 +29,6 @@ use nectar_primitives::store::{ContentGet, MaybeSend, MaybeSync, TrustedGet};
 use crate::cursor::Cursor;
 use crate::editor::ManifestEditor;
 use crate::error::{CursorError, EditorError, ReaderError};
-use nectar_manifest::{NodeLoader, NodeSaver};
-
 use crate::persist::NodeLoadSaver;
 use crate::reader::Reader;
 use crate::{constants::metadata, entry::Entry};

--- a/crates/mantaray/src/node.rs
+++ b/crates/mantaray/src/node.rs
@@ -11,8 +11,8 @@ use core::pin::Pin;
 
 use crate::error::{DecodeError, DecodeResult, MantarayError, Result};
 use crate::obfuscation::ObfuscationKey;
-use crate::persist::NodeLoader;
 use crate::{PATH_SEPARATOR, PREFIX_MAX_LEN};
+use nectar_manifest::NodeLoader;
 use nectar_primitives::chunk::{ChunkRef, Reference};
 use nectar_primitives::store::MaybeSend;
 use nectar_primitives::wire::{Cursor, FromCursor, ToWriter, Writer};
@@ -417,7 +417,7 @@ impl<R: Reference> Node<R> {
     }
 
     /// Load forks from storage if the node hasn't been loaded yet.
-    pub(crate) async fn ensure_loaded<L: NodeLoader>(&mut self, loader: &L) -> Result<()> {
+    pub(crate) async fn ensure_loaded<L: NodeLoader<Vec<u8>>>(&mut self, loader: &L) -> Result<()> {
         if !self.is_loaded() {
             self.load(loader).await?;
         }
@@ -425,7 +425,7 @@ impl<R: Reference> Node<R> {
     }
 
     /// Load this node through the loader by its full-width reference.
-    pub(crate) async fn load<L: NodeLoader>(&mut self, loader: &L) -> Result<()> {
+    pub(crate) async fn load<L: NodeLoader<Vec<u8>>>(&mut self, loader: &L) -> Result<()> {
         let reference = match &self.state {
             NodeState::Stub(reference) | NodeState::Clean(reference) => reference.clone(),
             // A dirty node holds its content in memory; nothing to fetch.
@@ -434,7 +434,7 @@ impl<R: Reference> Node<R> {
 
         let address = *reference.address();
         let bytes = loader
-            .collect(&reference.clone().into_entry_ref())
+            .load(&reference.clone().into_entry_ref())
             .await
             .map_err(|e| MantarayError::StoreGet {
                 source: alloc::sync::Arc::new(e),
@@ -460,7 +460,7 @@ impl<R: Reference> Node<R> {
     // <= min(prefix.len(), path.len()), bounding every split; the fork at
     // `path[0]` is checked present (`contains_key`) before each get/expect.
     #[allow(clippy::indexing_slicing, clippy::expect_used)]
-    pub(crate) fn add<'a, L: NodeLoader>(
+    pub(crate) fn add<'a, L: NodeLoader<Vec<u8>>>(
         &'a mut self,
         path: &'a [u8],
         entry: Option<R>,
@@ -588,7 +588,7 @@ impl<R: Reference> Node<R> {
     // `path.starts_with(&prefix)` guarantees `prefix.len() <= path.len()`;
     // the fork at `first` is checked present before the get_mut/expect.
     #[allow(clippy::indexing_slicing, clippy::expect_used)]
-    pub(crate) fn remove<'a, L: NodeLoader>(
+    pub(crate) fn remove<'a, L: NodeLoader<Vec<u8>>>(
         &'a mut self,
         path: &'a [u8],
         loader: &'a L,
@@ -645,7 +645,7 @@ impl<R: Reference> Node<R> {
     /// The result decodes exactly the surviving keys, but the root stays
     /// order-dependent: mantaray 0.2 keeps a node where the insert order first
     /// justified one. History independence is `nectar-ldb`'s guarantee.
-    pub(crate) fn clear<'a, L: NodeLoader>(
+    pub(crate) fn clear<'a, L: NodeLoader<Vec<u8>>>(
         &'a mut self,
         path: &'a [u8],
         loader: &'a L,
@@ -837,12 +837,12 @@ mod test_traversal {
 
     use super::{Fork, Node, NodeState, Prefix, common_prefix_len};
     use crate::error::{MantarayError, Result};
-    use crate::persist::{NodeLoader, NodeSaver};
+    use nectar_manifest::{NodeLoader, NodeSaver};
 
     impl<R: Reference> Node<R> {
         /// Look up the node at the given path, loading from storage as needed.
         #[allow(clippy::indexing_slicing)] // `rest` is checked non-empty before `rest[0]`; `c <= rest.len()` from common_prefix_len
-        pub(crate) async fn lookup_node<L: NodeLoader>(
+        pub(crate) async fn lookup_node<L: NodeLoader<Vec<u8>>>(
             &mut self,
             path: &[u8],
             loader: &L,
@@ -875,7 +875,7 @@ mod test_traversal {
         }
 
         /// Look up the entry at the given path, loading from storage as needed.
-        pub(crate) async fn lookup<L: NodeLoader>(
+        pub(crate) async fn lookup<L: NodeLoader<Vec<u8>>>(
             &mut self,
             path: &[u8],
             loader: &L,
@@ -891,7 +891,7 @@ mod test_traversal {
 
         /// Test whether a prefix exists in the trie, loading from storage as needed.
         #[allow(clippy::indexing_slicing)] // `rest` is checked non-empty before `rest[0]`; `c <= rest.len()` from common_prefix_len
-        pub(crate) async fn has_prefix<L: NodeLoader>(
+        pub(crate) async fn has_prefix<L: NodeLoader<Vec<u8>>>(
             &mut self,
             path: &[u8],
             loader: &L,
@@ -932,7 +932,7 @@ mod test_traversal {
         /// Each owned frame drains its node's fork map and reattaches saved
         /// children on pop; on failure the detached subtree is dropped and
         /// `self` is left empty.
-        pub(crate) async fn save<L: NodeSaver<R>>(&mut self, saver: &L) -> Result<()> {
+        pub(crate) async fn save<L: NodeSaver<[u8], R>>(&mut self, saver: &L) -> Result<()> {
             if self.reference().is_some() {
                 return Ok(());
             }
@@ -983,7 +983,7 @@ mod test_traversal {
                 finished.node.forks = core::mem::take(&mut finished.done);
                 let data = finished.node.encode()?;
                 let reference = saver
-                    .save(data)
+                    .save(&data)
                     .await
                     .map_err(|e| MantarayError::StorePut {
                         source: alloc::sync::Arc::new(e),
@@ -1013,7 +1013,11 @@ mod test_traversal {
         }
 
         /// Walk all nodes depth-first, calling `f` for each node with its path.
-        pub(crate) async fn walk<L: NodeLoader, F>(&mut self, loader: &L, f: &mut F) -> Result<()>
+        pub(crate) async fn walk<L: NodeLoader<Vec<u8>>, F>(
+            &mut self,
+            loader: &L,
+            f: &mut F,
+        ) -> Result<()>
         where
             F: FnMut(&[u8], &Self) -> Result<()>,
         {
@@ -1022,7 +1026,7 @@ mod test_traversal {
         }
 
         /// Walk the subtree at `root`, calling `f` for each node.
-        pub(crate) async fn walk_from<L: NodeLoader, F>(
+        pub(crate) async fn walk_from<L: NodeLoader<Vec<u8>>, F>(
             &mut self,
             root: &[u8],
             loader: &L,
@@ -1047,7 +1051,7 @@ mod test_traversal {
     /// `FnMut`. Each frame drains its node's fork map and reattaches walked
     /// children on pop, so the trie is intact (and loaded) on return; on
     /// failure the detached subtree is dropped and `node` is left empty.
-    async fn walk_inner<R: Reference, L: NodeLoader, F>(
+    async fn walk_inner<R: Reference, L: NodeLoader<Vec<u8>>, F>(
         path_buf: &mut Vec<u8>,
         node: &mut Node<R>,
         loader: &L,

--- a/crates/mantaray/src/node.rs
+++ b/crates/mantaray/src/node.rs
@@ -9,13 +9,14 @@ use alloc::collections::BTreeMap;
 use core::future::Future;
 use core::pin::Pin;
 
-use crate::error::{DecodeError, DecodeResult, MantarayError, Result};
-use crate::obfuscation::ObfuscationKey;
-use crate::{PATH_SEPARATOR, PREFIX_MAX_LEN};
 use nectar_manifest::NodeLoader;
 use nectar_primitives::chunk::{ChunkRef, Reference};
 use nectar_primitives::store::MaybeSend;
 use nectar_primitives::wire::{Cursor, FromCursor, ToWriter, Writer};
+
+use crate::error::{DecodeError, DecodeResult, MantarayError, Result};
+use crate::obfuscation::ObfuscationKey;
+use crate::{PATH_SEPARATOR, PREFIX_MAX_LEN};
 
 /// Boxed recursion future over what the descent yields: `Send` on
 /// multi-threaded targets, unbounded on wasm32 and under the `unsync` feature,

--- a/crates/mantaray/src/persist.rs
+++ b/crates/mantaray/src/persist.rs
@@ -1,15 +1,14 @@
-//! Node persistence seam: abstract loader and saver over full-width
-//! references.
+//! Node persistence: the trie's instantiation of the seam-owned
+//! [`NodeLoader`] and [`NodeSaver`], at a whole node image.
 //!
 //! The trie never touches chunk stores; the adapter decides the layout.
 //! `NodeLoadSaver` (feature `manifest`) stores through the file pipeline, so a
 //! node over one chunk spans several, matching the reference client.
 
 use alloc::vec::Vec;
-use core::future::Future;
 
-use nectar_primitives::chunk::{ChunkAddress, Reference};
-use nectar_primitives::store::{ChunkStoreError, MaybeSend, MaybeSync, NullLoader};
+use nectar_manifest::{NodeLoader, NodeSaver};
+use nectar_primitives::chunk::ChunkAddress;
 use nectar_primitives::{EncryptedChunkRef, EntryRef};
 
 use crate::format::{FORK_INDEX_SIZE, ForkHeader, NodeHeader};
@@ -31,54 +30,6 @@ const FORK_RECORD_MAX: usize = ForkHeader::PRE_REFERENCE_SIZE
 #[allow(clippy::as_conversions)] // usize -> u64 widening; `u64::try_from` is not const-callable
 pub const MAX_NODE_BYTES: u64 =
     (NodeHeader::SIZE + EncryptedChunkRef::SIZE + FORK_INDEX_SIZE + 256 * FORK_RECORD_MAX) as u64;
-
-/// Read seam: a node's whole image, in memory.
-///
-/// `collect` as in `nectar-file`: materialized, not streamed. The codec reads
-/// the fork index before the records it offsets, so it needs the whole image;
-/// [`MAX_NODE_BYTES`] bounds the cost.
-pub trait NodeLoader: MaybeSend + MaybeSync {
-    /// Loader failure, wrapped by the trie into its store errors.
-    type Error: core::error::Error + MaybeSend + MaybeSync + 'static;
-
-    /// The node image behind `reference`.
-    fn collect(
-        &self,
-        reference: &EntryRef,
-    ) -> impl Future<Output = Result<Vec<u8>, Self::Error>> + MaybeSend;
-
-    /// The image plus the chunk addresses it occupies, root first.
-    ///
-    /// Default: the bytes and the root address, the single-chunk shape.
-    fn collect_with_addresses(
-        &self,
-        reference: &EntryRef,
-    ) -> impl Future<Output = Result<(Vec<u8>, Vec<ChunkAddress>), Self::Error>> + MaybeSend {
-        async move {
-            let bytes = self.collect(reference).await?;
-            Ok((bytes, alloc::vec![*reference.address()]))
-        }
-    }
-}
-
-/// Write seam: persist node bytes under a new reference of width `R`.
-pub trait NodeSaver<R: Reference>: MaybeSend + MaybeSync {
-    /// Saver failure, wrapped by the trie into its store errors.
-    type Error: core::error::Error + MaybeSend + MaybeSync + 'static;
-
-    /// Persist one node image and return its full-width reference.
-    fn save(&self, data: Vec<u8>) -> impl Future<Output = Result<R, Self::Error>> + MaybeSend;
-}
-
-/// Satisfies the seam for purely in-memory tries: every collect is a typed
-/// not-found.
-impl NodeLoader for NullLoader {
-    type Error = ChunkStoreError;
-
-    async fn collect(&self, reference: &EntryRef) -> Result<Vec<u8>, Self::Error> {
-        Err(ChunkStoreError::not_found(reference.address()))
-    }
-}
 
 // Private: it scopes the `std` and `nectar-file` imports the production
 // adapter needs behind one `manifest` gate. Its items surface through the
@@ -168,18 +119,18 @@ mod pipeline {
     #[cfg_attr(docsrs, doc(cfg(feature = "manifest")))]
     pub type NodeCollectError<E> = CollectError<ContentGetError<E>>;
 
-    impl<S, const B: usize> NodeLoader for NodeLoadSaver<S, B>
+    impl<S, const B: usize> NodeLoader<Vec<u8>> for NodeLoadSaver<S, B>
     where
         S: TrustedGet<AnyChunkSet<B>> + Clone + 'static,
     {
         type Error = NodeCollectError<S::Error>;
 
-        async fn collect(&self, reference: &EntryRef) -> Result<Vec<u8>, Self::Error> {
+        async fn load(&self, reference: &EntryRef) -> Result<Vec<u8>, Self::Error> {
             let file = File::<_, B>::new(ContentGet::new(self.store.clone()), Policy::DEFAULT);
             file.collect(reference.clone(), MAX_NODE_BYTES).await
         }
 
-        async fn collect_with_addresses(
+        async fn load_traced(
             &self,
             reference: &EntryRef,
         ) -> Result<(Vec<u8>, Vec<ChunkAddress>), Self::Error> {
@@ -190,18 +141,14 @@ mod pipeline {
         }
     }
 
-    impl<S, const B: usize> NodeSaver<ChunkRef> for NodeLoadSaver<S, B>
+    impl<S, const B: usize> NodeSaver<[u8], ChunkRef> for NodeLoadSaver<S, B>
     where
         S: ChunkPut<AnyChunkSet<B>>,
     {
         type Error = SplitError<S::Error>;
 
-        async fn save(&self, data: Vec<u8>) -> Result<ChunkRef, Self::Error> {
-            let root = self
-                .file()
-                .save(data.as_slice())
-                .await
-                .map_err(unwrap_save)?;
+        async fn save(&self, data: &[u8]) -> Result<ChunkRef, Self::Error> {
+            let root = self.file().save(data).await.map_err(unwrap_save)?;
             Ok(ChunkRef::new(root))
         }
     }
@@ -210,17 +157,14 @@ mod pipeline {
     /// and the returned reference carries the root's decryption key.
     #[cfg(feature = "encryption")]
     #[cfg_attr(docsrs, doc(cfg(all(feature = "manifest", feature = "encryption"))))]
-    impl<S, const B: usize> NodeSaver<EncryptedChunkRef> for NodeLoadSaver<S, B>
+    impl<S, const B: usize> NodeSaver<[u8], EncryptedChunkRef> for NodeLoadSaver<S, B>
     where
         S: ChunkPut<AnyChunkSet<B>>,
     {
         type Error = SplitError<S::Error>;
 
-        async fn save(&self, data: Vec<u8>) -> Result<EncryptedChunkRef, Self::Error> {
-            self.file()
-                .save_encrypted(data.as_slice())
-                .await
-                .map_err(unwrap_save)
+        async fn save(&self, data: &[u8]) -> Result<EncryptedChunkRef, Self::Error> {
+            self.file().save_encrypted(data).await.map_err(unwrap_save)
         }
     }
 
@@ -328,13 +272,13 @@ pub mod single_chunk {
         Chunk(#[from] PrimitivesError),
     }
 
-    impl<S, const BS: usize> NodeLoader for SingleChunkLoadSaver<S, BS>
+    impl<S, const BS: usize> NodeLoader<Vec<u8>> for SingleChunkLoadSaver<S, BS>
     where
         S: TrustedGet<AnyChunkSet<BS>>,
     {
         type Error = SingleChunkError;
 
-        async fn collect(&self, reference: &EntryRef) -> Result<Vec<u8>, Self::Error> {
+        async fn load(&self, reference: &EntryRef) -> Result<Vec<u8>, Self::Error> {
             let chunk = self
                 .0
                 .get(reference.address())
@@ -348,8 +292,8 @@ pub mod single_chunk {
     where
         S: ChunkPut<AnyChunkSet<BS>>,
     {
-        async fn put_node(&self, data: Vec<u8>) -> Result<ChunkAddress, SingleChunkError> {
-            let chunk = ContentChunk::<BS>::new(data)?;
+        async fn put_node(&self, data: &[u8]) -> Result<ChunkAddress, SingleChunkError> {
+            let chunk = ContentChunk::<BS>::new(data.to_vec())?;
             let address = *chunk.address();
             let sealed: Chunk<_, AnyChunkSet<BS>> = Chunk::from_envelope(chunk.into())?;
             self.0
@@ -360,24 +304,24 @@ pub mod single_chunk {
         }
     }
 
-    impl<S, const BS: usize> NodeSaver<ChunkRef> for SingleChunkLoadSaver<S, BS>
+    impl<S, const BS: usize> NodeSaver<[u8], ChunkRef> for SingleChunkLoadSaver<S, BS>
     where
         S: ChunkPut<AnyChunkSet<BS>>,
     {
         type Error = SingleChunkError;
 
-        async fn save(&self, data: Vec<u8>) -> Result<ChunkRef, Self::Error> {
+        async fn save(&self, data: &[u8]) -> Result<ChunkRef, Self::Error> {
             Ok(ChunkRef::new(self.put_node(data).await?))
         }
     }
 
-    impl<S, const BS: usize> NodeSaver<EncryptedChunkRef> for SingleChunkLoadSaver<S, BS>
+    impl<S, const BS: usize> NodeSaver<[u8], EncryptedChunkRef> for SingleChunkLoadSaver<S, BS>
     where
         S: ChunkPut<AnyChunkSet<BS>>,
     {
         type Error = SingleChunkError;
 
-        async fn save(&self, data: Vec<u8>) -> Result<EncryptedChunkRef, Self::Error> {
+        async fn save(&self, data: &[u8]) -> Result<EncryptedChunkRef, Self::Error> {
             Ok(EncryptedChunkRef::new(
                 self.put_node(data).await?,
                 EncryptionKey::from([0u8; EncryptionKey::SIZE]),
@@ -389,34 +333,11 @@ pub mod single_chunk {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nectar_testing::run;
 
     #[test]
     fn max_node_bytes_matches_the_structural_layout() {
         // 64 header + 64 entry + 32 index + 256 * 65633 fork records.
         assert_eq!(MAX_NODE_BYTES, 16_802_208);
-    }
-
-    #[test]
-    fn null_loader_load_is_not_found() {
-        let reference = EntryRef::from(ChunkAddress::from([7u8; 32]));
-        let err = run(NullLoader.collect(&reference)).unwrap_err();
-        assert!(matches!(err, ChunkStoreError::NotFound(a) if a == *reference.address()));
-    }
-
-    #[test]
-    fn default_load_with_addresses_is_bytes_plus_root() {
-        struct Fixed;
-        impl NodeLoader for Fixed {
-            type Error = ChunkStoreError;
-            async fn collect(&self, _: &EntryRef) -> Result<Vec<u8>, Self::Error> {
-                Ok(vec![1, 2, 3])
-            }
-        }
-        let reference = EntryRef::from(ChunkAddress::from([9u8; 32]));
-        let (bytes, addresses) = run(Fixed.collect_with_addresses(&reference)).unwrap();
-        assert_eq!(bytes, vec![1, 2, 3]);
-        assert_eq!(addresses, vec![*reference.address()]);
     }
 }
 
@@ -433,8 +354,8 @@ mod pipeline_tests {
     type Store = MemoryStore<StandardChunkSet>;
     type LoadSaver = NodeLoadSaver<Store>;
 
-    fn save_plain(loadsaver: &LoadSaver, data: Vec<u8>) -> ChunkRef {
-        run(NodeSaver::<ChunkRef>::save(loadsaver, data)).unwrap()
+    fn save_plain(loadsaver: &LoadSaver, data: &[u8]) -> ChunkRef {
+        run(NodeSaver::<[u8], ChunkRef>::save(loadsaver, data)).unwrap()
     }
 
     #[test]
@@ -444,12 +365,12 @@ mod pipeline_tests {
         let want = *ContentChunk::<DEFAULT_BODY_SIZE>::new(Bytes::from(data.clone()))
             .unwrap()
             .address();
-        let root = save_plain(&loadsaver, data.clone());
+        let root = save_plain(&loadsaver, &data);
         assert_eq!(*root.address(), want);
 
         let reference = EntryRef::from(root);
-        assert_eq!(run(loadsaver.collect(&reference)).unwrap(), data);
-        let (bytes, addresses) = run(loadsaver.collect_with_addresses(&reference)).unwrap();
+        assert_eq!(run(loadsaver.load(&reference)).unwrap(), data);
+        let (bytes, addresses) = run(loadsaver.load_traced(&reference)).unwrap();
         assert_eq!(bytes, data);
         assert_eq!(addresses, vec![*reference.address()]);
     }
@@ -458,10 +379,10 @@ mod pipeline_tests {
     fn multi_chunk_save_round_trips_and_reports_every_address() {
         let loadsaver = LoadSaver::new(Store::new());
         let data: Vec<u8> = (0..20_000u32).map(|i| (i % 251) as u8).collect();
-        let root = save_plain(&loadsaver, data.clone());
+        let root = save_plain(&loadsaver, &data);
 
         let reference = EntryRef::from(root);
-        let (bytes, addresses) = run(loadsaver.collect_with_addresses(&reference)).unwrap();
+        let (bytes, addresses) = run(loadsaver.load_traced(&reference)).unwrap();
         assert_eq!(bytes, data);
         // 20000 bytes span five leaves plus the root: six stored chunks.
         let mut stored: Vec<ChunkAddress> = loadsaver
@@ -483,14 +404,13 @@ mod pipeline_tests {
     fn encrypted_save_round_trips() {
         let loadsaver = LoadSaver::new(Store::new());
         let data: Vec<u8> = (0..9_000u32).map(|i| (i % 241) as u8).collect();
-        let root = run(NodeSaver::<EncryptedChunkRef>::save(
-            &loadsaver,
-            data.clone(),
+        let root = run(NodeSaver::<[u8], EncryptedChunkRef>::save(
+            &loadsaver, &data,
         ))
         .unwrap();
         let reference = EntryRef::from(root);
-        assert_eq!(run(loadsaver.collect(&reference)).unwrap(), data);
-        let (bytes, addresses) = run(loadsaver.collect_with_addresses(&reference)).unwrap();
+        assert_eq!(run(loadsaver.load(&reference)).unwrap(), data);
+        let (bytes, addresses) = run(loadsaver.load_traced(&reference)).unwrap();
         assert_eq!(bytes, data);
         assert!(addresses.len() > 1);
     }

--- a/crates/mantaray/src/persist.rs
+++ b/crates/mantaray/src/persist.rs
@@ -1,15 +1,11 @@
-//! Node persistence: the trie's instantiation of the seam-owned
-//! [`NodeLoader`] and [`NodeSaver`], at a whole node image.
+//! Node persistence: the trie's instantiation of the shared node seam, at a
+//! whole node image.
 //!
 //! The trie never touches chunk stores; the adapter decides the layout.
 //! `NodeLoadSaver` (feature `manifest`) stores through the file pipeline, so a
 //! node over one chunk spans several, matching the reference client.
 
-use alloc::vec::Vec;
-
-use nectar_manifest::{NodeLoader, NodeSaver};
-use nectar_primitives::chunk::ChunkAddress;
-use nectar_primitives::{EncryptedChunkRef, EntryRef};
+use nectar_primitives::EncryptedChunkRef;
 
 use crate::format::{FORK_INDEX_SIZE, ForkHeader, NodeHeader};
 
@@ -36,11 +32,14 @@ pub const MAX_NODE_BYTES: u64 =
 // re-export above, so the rendered docs live on the definitions.
 #[cfg(feature = "manifest")]
 mod pipeline {
+    use alloc::vec::Vec;
     use std::collections::BTreeSet;
     use std::sync::{Arc, Mutex, PoisonError};
 
     use nectar_file::{CollectError, File, Policy, PutWindow, SaveError, SplitError};
-    use nectar_primitives::chunk::{ChunkRef, Verified};
+    use nectar_manifest::{NodeLoader, NodeSaver};
+    use nectar_primitives::EntryRef;
+    use nectar_primitives::chunk::{ChunkAddress, ChunkRef, Verified};
     use nectar_primitives::store::{ChunkGet, ChunkPut, ContentGet, ContentGetError, TrustedGet};
     use nectar_primitives::{AnyChunkSet, DEFAULT_BODY_SIZE};
 
@@ -232,8 +231,11 @@ mod pipeline {
 #[doc(hidden)]
 pub mod single_chunk {
     use alloc::sync::Arc;
+    use alloc::vec::Vec;
 
-    use nectar_primitives::chunk::{ChunkOps, ChunkRef, ContentChunk};
+    use nectar_manifest::{NodeLoader, NodeSaver};
+    use nectar_primitives::EntryRef;
+    use nectar_primitives::chunk::{ChunkAddress, ChunkOps, ChunkRef, ContentChunk};
     use nectar_primitives::error::PrimitivesError;
     use nectar_primitives::store::{ChunkPut, SharedError, TrustedGet};
     use nectar_primitives::{AnyChunkSet, Chunk, DEFAULT_BODY_SIZE, EncryptionKey};
@@ -344,7 +346,9 @@ mod tests {
 #[cfg(all(test, feature = "manifest"))]
 mod pipeline_tests {
     use bytes::Bytes;
-    use nectar_primitives::chunk::{ChunkOps, ChunkRef, ContentChunk};
+    use nectar_manifest::{NodeLoader, NodeSaver};
+    use nectar_primitives::EntryRef;
+    use nectar_primitives::chunk::{ChunkAddress, ChunkOps, ChunkRef, ContentChunk};
     use nectar_primitives::store::MemoryStore;
     use nectar_primitives::{DEFAULT_BODY_SIZE, StandardChunkSet};
     use nectar_testing::run;

--- a/crates/mantaray/src/reader.rs
+++ b/crates/mantaray/src/reader.rs
@@ -8,13 +8,13 @@
 
 use alloc::sync::Arc;
 
+use nectar_manifest::NodeLoader;
 use nectar_primitives::EntryRef;
 
 use crate::entry::Entry;
 use crate::error::ReaderError;
 use crate::node::NodeType;
 use crate::view::NodeView;
-use nectar_manifest::NodeLoader;
 
 /// Default per-lookup node-fetch budget.
 ///

--- a/crates/mantaray/src/reader.rs
+++ b/crates/mantaray/src/reader.rs
@@ -13,8 +13,8 @@ use nectar_primitives::EntryRef;
 use crate::entry::Entry;
 use crate::error::ReaderError;
 use crate::node::NodeType;
-use crate::persist::NodeLoader;
 use crate::view::NodeView;
+use nectar_manifest::NodeLoader;
 
 /// Default per-lookup node-fetch budget.
 ///
@@ -64,7 +64,7 @@ impl<L> Reader<L> {
     }
 }
 
-impl<L: NodeLoader> Reader<L> {
+impl<L: NodeLoader<Vec<u8>>> Reader<L> {
     /// The entry at `path` under the trie rooted at `root`, or `None` when
     /// the path is absent or names a bare edge. A metadata-carrying edge
     /// (the root documents node) reads back as an entry with no reference.
@@ -167,7 +167,7 @@ impl<L: NodeLoader> Reader<L> {
         let address = *reference.address();
         let bytes = self
             .store
-            .collect(reference)
+            .load(reference)
             .await
             .map_err(|e| ReaderError::Store {
                 address,
@@ -367,12 +367,12 @@ mod tests {
         }
     }
 
-    impl NodeLoader for CountingStore {
+    impl NodeLoader<Vec<u8>> for CountingStore {
         type Error = SingleChunkError;
 
-        async fn collect(&self, reference: &EntryRef) -> Result<Vec<u8>, Self::Error> {
+        async fn load(&self, reference: &EntryRef) -> Result<Vec<u8>, Self::Error> {
             self.gets.fetch_add(1, Ordering::SeqCst);
-            self.inner.collect(reference).await
+            self.inner.load(reference).await
         }
     }
 


### PR DESCRIPTION
Closes #683

## Summary

Moves the node persistence seam into `nectar-manifest` with the unit of transfer as a trait parameter, and removes ldb's layer-2 verbs from every layer-1 store.

A new ungated `no_std` module `crates/manifest/src/node.rs` declares `NodeLoader<N: MaybeSend>` (`load(&EntryRef) -> N`, defaulted `load_traced` returning the node plus a root-first chunk-address list) and `NodeSaver<N: ?Sized + MaybeSync, R: Reference>` (`save(&N) -> R`). The `impl NodeLoader<N> for NullLoader` moved here, generic over `N`, since it becomes orphan-rule illegal anywhere else once the trait leaves mantaray. Both traits are re-exported from `nectar_manifest`. No new dependency is introduced: `nectar-marker` and `nectar-primitives` were already mandatory.

mantaray instantiates at `N = Vec<u8>`: the two trait declarations and the duplicate `NullLoader` impl are deleted from `crates/mantaray/src/persist.rs`, `collect`/`collect_with_addresses` become `load`/`load_traced`, and the mantaray saver is expressed as `NodeSaver<[u8], R>`. ldb instantiates at `N = Node<F, R>` on `Database`, inside its already-gated `manifest` module (`crates/ldb/src/manifest.rs`), and its hot paths in `store.rs` are rerouted through the free `load_node`/`save_node` functions with matching bounds. ldb's blanket `NodeGet`/`NodePut` extension traits are removed from `crates/ldb/src/store.rs`, along with their call sites across `apply.rs`, `db.rs`, `encryption.rs`, `folder.rs`, `order.rs`, `reader.rs`, `scan.rs`, and `traverse.rs`.

Net diff: 26 files changed, 692 insertions, 389 deletions. New coverage in `crates/manifest/tests/node_seam.rs` (221 lines).

## Testing

All commands ran inside `nix develop --command` on a detached checkout of `refactor/683-node-seam` (3e7f37b5), based on `origin/main`. Working tree clean throughout; no fixes were needed, so no new commit and no push.

Clippy (lint.yml parity, default pass plus every feature pass touching the changed crates), all exit 0 with `-D warnings`:
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo clippy --locked --all-targets -p nectar-ldb --features encryption -- -D warnings`
- `cargo clippy --locked --all-targets -p nectar-manifest --features test-encryption -- -D warnings`
- `cargo clippy --locked --all-targets -p nectar-mantaray --features hazmat,manifest -- -D warnings`
- `cargo clippy --locked --all-targets -p nectar-integration-tests --features rayon,encryption -- -D warnings`

## AI Assistance

Implement: claude-opus-5. Red-team: claude-opus-5. PR: claude-sonnet-5.
