### PR TITLE
refactor(envelope)!: extract the messaging crypto into nectar-envelope

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -86,10 +86,10 @@ jobs:
             # likewise outside the default-features pass.
             - name: cargo clippy (ldb encryption)
               run: cargo clippy --locked --all-targets -p nectar-ldb --features encryption -- -D warnings
-            # The modern envelope sits behind the primitives envelope-unstable
-            # feature, likewise outside the default-features pass.
+            # The envelope sealing lane sits behind the encryption feature,
+            # likewise outside the default-features pass.
             - name: cargo clippy (envelope)
-              run: cargo clippy --locked --all-targets -p nectar-primitives --features envelope-unstable,encryption -- -D warnings
+              run: cargo clippy --locked --all-targets -p nectar-envelope --features encryption -- -D warnings
             # The pipeline's inline engine only compiles with the parallel
             # feature off, so lint the inline shape on its own.
             - name: cargo clippy (postage-issuer inline engine)
@@ -103,7 +103,7 @@ jobs:
             - name: unused lib dependencies
               run: |
                   for crate in nectar-primitives nectar-primitives-core \
-                               nectar-postage \
+                               nectar-envelope nectar-postage \
                                nectar-postage-issuer nectar-postage-usage \
                                nectar-contracts nectar-file \
                                nectar-marker nectar-clock nectar-governor \

--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -93,8 +93,8 @@ jobs:
             - name: Check envelope open builds bare-metal
               if: matrix.target == 'riscv64imac-unknown-none-elf'
               run: |
-                  cargo check --locked -p nectar-primitives \
-                    --no-default-features --features envelope-unstable \
+                  cargo check --locked -p nectar-envelope \
+                    --no-default-features \
                     --target ${{ matrix.target }}
             # The single-thread send escape (the unsync feature) and its
             # !Send-store compile proof, checked for the host inside the

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -119,16 +119,15 @@ jobs:
                   cargo nextest run \
                     -p nectar-mantaray --features manifest,encryption --locked \
                     --no-tests=warn --no-fail-fast
-            # The modern envelope (KAT, differential and forgery batteries)
-            # sits behind the primitives envelope-unstable feature; cover its
-            # tests and the no-downgrade compile-fail doctest here.
+            # The envelope sealing lane sits behind the encryption feature;
+            # cover it and the no-downgrade compile-fail doctest here.
             - name: Run envelope tests
               run: |
                   cargo nextest run \
-                    -p nectar-primitives --features envelope-unstable,encryption --locked \
+                    -p nectar-envelope --features encryption --locked \
                     --no-tests=warn --no-fail-fast
             - name: Run envelope doctests
-              run: cargo test --doc -p nectar-primitives --features envelope-unstable,encryption --locked
+              run: cargo test --doc -p nectar-envelope --features encryption --locked
             # The encrypted allocation probes must see encryption without
             # rayon, matching the encrypted split shape above.
             - name: Run encrypted split integration tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,9 +105,9 @@ The error layer is where duplication now lives, so these six rules are the stand
 Each rule below names a file and line that already conforms, so a reviewer can check the claim rather than take it.
 
 - Rule 1: `crates/feeds/src/error.rs:13`, `#[non_exhaustive]` on `FeedError`.
-- Rule 2: `crates/primitives/src/envelope/mod.rs:580`, a `#[from]` wrapping variant.
+- Rule 2: `crates/envelope/src/lib.rs:598`, a `#[from]` wrapping variant.
 - Rule 3: `crates/feeds/src/error.rs:17`, `AddressMismatch` carrying typed `expected` and `actual` fields rather than a formatted string.
-- Rule 4: `crates/primitives-core/src/error.rs:163`, the `BoxedError` alias.
+- Rule 4: `crates/primitives-core/src/error.rs:142`, the `BoxedError` alias.
 - Rule 5: no conforming example exists yet.
   `RingExhausted` is declared in more than one crate with the same shape and no conversion between them, which is the violation this rule exists to stop; #688 gives it one owner.
 - Rule 6: `crates/postage-usage/src/error.rs:271` and `:330`, `UsageError::is_corruption` and `is_recoverable`, with the exhaustive classification test at `:387` that fails to compile when a variant is added without being classified.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2515,6 +2515,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "nectar-envelope"
+version = "0.4.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-signer",
+ "alloy-signer-local",
+ "chacha20poly1305",
+ "hkdf 0.12.4",
+ "hpke-rs",
+ "hpke-rs-crypto",
+ "hpke-rs-rust-crypto",
+ "k256",
+ "nectar-primitives",
+ "rand 0.10.1",
+ "sha2 0.10.9",
+ "subtle",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
 name = "nectar-feeds"
 version = "0.4.0"
 dependencies = [
@@ -2732,7 +2753,6 @@ dependencies = [
  "alloy-signer-local",
  "arbitrary",
  "bytes",
- "chacha20poly1305",
  "criterion",
  "derive_more",
  "digest 0.11.3",
@@ -2741,12 +2761,7 @@ dependencies = [
  "getrandom 0.2.17",
  "getrandom 0.3.4",
  "getrandom 0.4.2",
- "hkdf 0.12.4",
- "hpke-rs",
- "hpke-rs-crypto",
- "hpke-rs-rust-crypto",
  "js-sys",
- "k256",
  "nectar-clock",
  "nectar-marker",
  "nectar-primitives-core",
@@ -2757,7 +2772,6 @@ dependencies = [
  "proptest-arbitrary-interop",
  "rand 0.10.1",
  "serde",
- "sha2 0.10.9",
  "strum 0.28.0",
  "subtle",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ check.all_targets = true
 # nectar crates
 nectar-clock = { version = "0.4.0", path = "crates/clock", default-features = false }
 nectar-contracts = { version = "0.4.0", path = "crates/contracts" }
+nectar-envelope = { version = "0.4.0", path = "crates/envelope", default-features = false }
 nectar-feeds = { version = "0.4.0", path = "crates/feeds" }
 nectar-file = { version = "0.4.0", path = "crates/file", default-features = false }
 nectar-governor = { version = "0.4.0", path = "crates/governor", default-features = false }

--- a/crates/envelope/Cargo.toml
+++ b/crates/envelope/Cargo.toml
@@ -1,0 +1,66 @@
+[package]
+name = "nectar-envelope"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+description = "Sealed messaging envelopes for Ethereum Swarm: RFC 9180 HPKE over the frozen ECIES baseline"
+documentation = "https://docs.rs/nectar-envelope"
+readme = "README.md"
+keywords = ["swarm", "ethereum", "hpke", "ecies", "encryption"]
+categories = ["cryptography"]
+
+[lints]
+workspace = true
+
+[dependencies]
+# nectar
+nectar-primitives.workspace = true
+
+# `k256` for the attestation's EIP-191 address recovery.
+alloy-primitives = { workspace = true, features = ["k256"] }
+k256 = { workspace = true, features = ["ecdh"] }
+
+chacha20poly1305.workspace = true
+hkdf.workspace = true
+sha2.workspace = true
+
+subtle.workspace = true
+thiserror.workspace = true
+zeroize.workspace = true
+
+rand = { workspace = true, optional = true }
+
+[dev-dependencies]
+alloy-signer.workspace = true
+alloy-signer-local.workspace = true
+# The differential oracle for the draft KEM, which publishes no test vectors.
+hpke-rs.workspace = true
+hpke-rs-crypto.workspace = true
+hpke-rs-rust-crypto.workspace = true
+rand.workspace = true
+
+[features]
+default = [ "std" ]
+std = [
+	"alloy-primitives/std",
+	"chacha20poly1305/std",
+	"hkdf/std",
+	"k256/precomputed-tables",
+	"k256/std",
+	"nectar-primitives/std",
+	"sha2/std",
+	"subtle/std",
+	"thiserror/std",
+	"zeroize/std",
+]
+# Sealing only: it needs an RNG. Opening and decap stay bare-metal clean.
+encryption = [ "dep:rand", "nectar-primitives/encryption" ]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/envelope/README.md
+++ b/crates/envelope/README.md
@@ -1,0 +1,26 @@
+# nectar-envelope
+
+Sealed messaging envelopes for Ethereum Swarm.
+Two schemes share one frozen frame inside a chunk payload: the byte-frozen ECIES construction of the reference client, and RFC 9180 HPKE under the domain label `nectar/env/v1`.
+
+Part of the [nectar](https://github.com/nxm-rs/nectar) workspace, a collection of low-level Ethereum Swarm primitives in Rust.
+See the [workspace README](https://github.com/nxm-rs/nectar) for the full crate list and project context.
+
+## Usage
+
+```toml
+[dependencies]
+nectar-envelope = "0.4"
+```
+
+Opening and decap need no random number generator, so they build for `no_std` bare-metal targets.
+Sealing needs one and rides the `encryption` feature.
+
+## Stability
+
+No nectar crate reads or writes this frame yet.
+The key encapsulation mechanism, the frame and this API can change without a major version until a consumer pins them.
+
+## License
+
+AGPL-3.0-or-later. See [LICENSE](https://github.com/nxm-rs/nectar/blob/main/LICENSE).

--- a/crates/envelope/src/attestation.rs
+++ b/crates/envelope/src/attestation.rs
@@ -1,8 +1,8 @@
-//! Envelope-capability attestation.
+//! Recipient-key attestation.
 //!
-//! A peer pins its envelope capability by signing its encryption key with
-//! its long-term secp256k1 identity key (EIP-191 personal sign, matching
-//! the handshake). Verification is the only mint of [`Recipient<Hpke>`];
+//! A peer pins its HPKE capability by signing its recipient key with its
+//! long-term secp256k1 identity key (EIP-191 personal sign, matching the
+//! handshake). Verification is the only mint of [`Recipient<Hpke>`];
 //! provenance, the pinned-peer registry and fail-closed enforcement live
 //! with the node, which must treat a missing token for a pinned peer as an
 //! attack, never as licence to fall back to compat.
@@ -13,7 +13,7 @@ use k256::PublicKey;
 use k256::elliptic_curve::sec1::ToEncodedPoint;
 use thiserror::Error;
 
-use crate::error::WrongLength;
+use nectar_primitives::error::WrongLength;
 
 use super::{Hpke, Recipient};
 
@@ -59,21 +59,21 @@ pub enum AttestationError {
     },
 }
 
-/// Signed statement that an identity receives under the envelope key.
+/// Signed statement that an identity receives under the recipient key.
 #[derive(Debug, Clone)]
-pub struct EnvelopeAttestation {
+pub struct RecipientAttestation {
     key: PublicKey,
     signature: Signature,
 }
 
-impl EnvelopeAttestation {
+impl RecipientAttestation {
     /// Assemble a token from its parts; [`Self::verify`] does the checking.
     #[must_use]
     pub const fn new(key: PublicKey, signature: Signature) -> Self {
         Self { key, signature }
     }
 
-    /// The attested envelope key.
+    /// The attested recipient key.
     #[must_use]
     pub const fn key(&self) -> &PublicKey {
         &self.key
@@ -110,7 +110,7 @@ impl EnvelopeAttestation {
     }
 }
 
-impl TryFrom<&[u8]> for EnvelopeAttestation {
+impl TryFrom<&[u8]> for RecipientAttestation {
     type Error = AttestationError;
 
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
@@ -137,13 +137,13 @@ mod tests {
 
     use crate::ecies::generate_secret;
 
-    fn attested() -> (LocalSigner<k256::ecdsa::SigningKey>, EnvelopeAttestation) {
+    fn attested() -> (LocalSigner<k256::ecdsa::SigningKey>, RecipientAttestation) {
         let identity = LocalSigner::random();
-        let envelope_key = generate_secret().public_key();
+        let recipient_key = generate_secret().public_key();
         let signature = identity
-            .sign_message_sync(&sign_data(&envelope_key))
+            .sign_message_sync(&sign_data(&recipient_key))
             .unwrap();
-        let attestation = EnvelopeAttestation::new(envelope_key, signature);
+        let attestation = RecipientAttestation::new(recipient_key, signature);
         (identity, attestation)
     }
 
@@ -170,7 +170,7 @@ mod tests {
     fn swapped_key_breaks_the_signature() {
         let (identity, attestation) = attested();
         let forged =
-            EnvelopeAttestation::new(generate_secret().public_key(), *attestation.signature());
+            RecipientAttestation::new(generate_secret().public_key(), *attestation.signature());
         assert!(forged.verify(identity.address()).is_err());
     }
 
@@ -179,7 +179,7 @@ mod tests {
         let (identity, attestation) = attested();
         let bytes = attestation.to_bytes();
         assert_eq!(bytes.len(), SIZE);
-        let decoded = EnvelopeAttestation::try_from(bytes.as_slice()).unwrap();
+        let decoded = RecipientAttestation::try_from(bytes.as_slice()).unwrap();
         assert_eq!(decoded.key(), attestation.key());
         let recipient = decoded.verify(identity.address()).unwrap();
         assert_eq!(recipient.key(), attestation.key());
@@ -187,7 +187,7 @@ mod tests {
 
     #[test]
     fn short_token_is_rejected() {
-        let err = EnvelopeAttestation::try_from([0u8; 10].as_slice()).unwrap_err();
+        let err = RecipientAttestation::try_from([0u8; 10].as_slice()).unwrap_err();
         assert!(matches!(err, AttestationError::Length(_)));
     }
 

--- a/crates/envelope/src/compat.rs
+++ b/crates/envelope/src/compat.rs
@@ -1,25 +1,27 @@
 //! Thin adapter over the frozen [`crate::ecies`] construction.
 //!
 //! Wire-frozen: hint, key derivation and ciphertext are byte-for-byte the
-//! compat baseline; only the frame around them is shared with the envelope.
+//! compat baseline; only the frame around them is shared with HPKE.
 
 use k256::SecretKey;
 
 use crate::ecies::{self, Hint, Salt};
 
-use super::{Compat, OpenError, Opened, Recipient, Record, SealedRecord, hint_matches};
+use super::{Compat, Envelope, OpenError, Opened, hint_matches};
+#[cfg(any(test, feature = "encryption"))]
+use super::{Recipient, SealedEnvelope};
 
-#[cfg(feature = "encryption")]
+#[cfg(any(test, feature = "encryption"))]
 pub(super) fn seal(
     recipient: &Recipient<Compat>,
     salt: Salt<'_>,
     plaintext: &[u8],
     ct_len: usize,
-) -> Result<SealedRecord<Compat>, ecies::EciesError> {
+) -> Result<SealedEnvelope<Compat>, ecies::EciesError> {
     let encrypted = ecies::encrypt(recipient.key(), salt, plaintext, Some(ct_len))?;
     let hint = *Hint::derive(&encrypted.key, salt).as_bytes();
     let (enc_x, parity) = super::x_and_parity(&encrypted.ephemeral);
-    Ok(SealedRecord::from_parts(
+    Ok(SealedEnvelope::from_parts(
         hint,
         parity,
         enc_x,
@@ -31,18 +33,18 @@ pub(super) fn seal(
 pub(super) fn open(
     secret: &SecretKey,
     salt: Salt<'_>,
-    record: &Record<'_>,
+    envelope: &Envelope<'_>,
 ) -> Result<Option<Opened<Compat>>, OpenError> {
     // Compat ECDH only uses the shared x, so either parity reconstructs the
-    // same key; use the carried bit for symmetry with the envelope.
-    let Some(ephemeral) = super::reconstruct(record.enc_x(), record.parity()) else {
+    // same key; use the carried bit for symmetry with HPKE.
+    let Some(ephemeral) = super::reconstruct(envelope.enc_x(), envelope.parity()) else {
         return Ok(None);
     };
     let key = ecies::shared_key(secret, &ephemeral, salt);
-    if !hint_matches(Hint::derive(&key, salt).as_bytes(), record.hint()) {
+    if !hint_matches(Hint::derive(&key, salt).as_bytes(), envelope.hint()) {
         return Ok(None);
     }
-    let plaintext = ecies::decrypt(&key, record.ciphertext());
+    let plaintext = ecies::decrypt(&key, envelope.ciphertext());
     Ok(Some(Opened {
         plaintext,
         extra: key,

--- a/crates/envelope/src/ecies.rs
+++ b/crates/envelope/src/ecies.rs
@@ -10,11 +10,23 @@ use alloy_primitives::Keccak256;
 
 pub use k256::{PublicKey, SecretKey};
 
-use crate::chunk::encryption::{EncryptionKey, transcrypt_in_place};
-use crate::error::WrongLength;
+use nectar_primitives::chunk::encryption::{EncryptionKey, transcrypt_in_place};
+use nectar_primitives::error::WrongLength;
+use thiserror::Error;
 
-// Defined in the core crate because `PrimitivesError` wraps it.
-pub use nectar_primitives_core::error::EciesError;
+/// Errors from ECIES operations.
+#[non_exhaustive]
+#[derive(Debug, Error)]
+pub enum EciesError {
+    /// Plaintext exceeds the requested padded length.
+    #[error("plaintext too long: {len} bytes, padded length {padded}")]
+    PlaintextTooLong {
+        /// Plaintext length.
+        len: usize,
+        /// Requested padded length.
+        padded: usize,
+    },
+}
 
 /// KDF salt for the shared-key derivation.
 ///
@@ -187,7 +199,7 @@ pub fn encrypt_with(
 
     if pad_len > 0 {
         use rand::RngExt;
-        let mut padding = vec![0u8; pad_len];
+        let mut padding = alloc::vec![0u8; pad_len];
         rand::rng().fill(padding.as_mut_slice());
         ciphertext.extend_from_slice(&padding);
     }

--- a/crates/envelope/src/hpke.rs
+++ b/crates/envelope/src/hpke.rs
@@ -1,4 +1,4 @@
-//! The envelope suite: RFC 9180 base mode over the draft secp256k1 KEM.
+//! The HPKE suite: RFC 9180 base mode over the draft secp256k1 KEM.
 //!
 //! The KEM is composed directly from k256 and HKDF-SHA256 per
 //! draft-wahby-cfrg-hpke-kem-secp256k1 (codepoint 0x0016): x-only ECDH is
@@ -17,7 +17,9 @@ use subtle::ConstantTimeEq;
 use thiserror::Error;
 use zeroize::Zeroizing;
 
-use super::{Hpke, LABEL, OpenError, Opened, Recipient, Record, SealedRecord, Topic, hint_matches};
+use super::{Envelope, Hpke, LABEL, OpenError, Opened, Topic, hint_matches};
+#[cfg(any(test, feature = "encryption"))]
+use super::{Recipient, SealedEnvelope};
 
 /// `"KEM"` plus the registered codepoint 0x0016.
 const KEM_SUITE_ID: &[u8] = b"KEM\x00\x16";
@@ -25,7 +27,7 @@ const KEM_SUITE_ID: &[u8] = b"KEM\x00\x16";
 const HPKE_SUITE_ID: &[u8] = b"HPKE\x00\x16\x00\x01\x00\x03";
 /// mode_base.
 const MODE_BASE: u8 = 0x00;
-/// Exporter context of the envelope hint.
+/// Exporter context of the HPKE hint.
 const HINT_CONTEXT: &[u8] = b"nectar/env/v1 hint";
 
 /// Poly1305 tag length.
@@ -66,7 +68,7 @@ pub struct ExportError;
 #[error("keypair derivation exhausted its candidate space")]
 pub struct DeriveKeyPairError;
 
-/// Errors from an envelope seal.
+/// Errors from an HPKE seal.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
 pub enum HpkeSealError {
@@ -191,7 +193,7 @@ struct Schedule {
 }
 
 impl Schedule {
-    /// The envelope hint: `export("nectar/env/v1 hint", 8)`.
+    /// The HPKE hint: `export("nectar/env/v1 hint", 8)`.
     fn hint(&self) -> Result<[u8; 8], ExportError> {
         let mut hint = [0u8; 8];
         self.exporter.export(HINT_CONTEXT, &mut hint)?;
@@ -242,13 +244,13 @@ fn key_schedule(shared: &[u8; 32], topic: &Topic) -> Result<Schedule, ExportErro
     })
 }
 
-/// Decap once per record; `Ok(None)` when `enc_x` is off-curve or the ECDH
+/// Decap once per envelope; `Ok(None)` when `enc_x` is off-curve or the ECDH
 /// output is rejected.
 pub(super) fn decap(
     secret: &SecretKey,
-    record: &Record<'_>,
+    envelope: &Envelope<'_>,
 ) -> Result<Option<Zeroizing<[u8; 32]>>, OpenError> {
-    let Some(enc) = super::reconstruct(record.enc_x(), record.parity()) else {
+    let Some(enc) = super::reconstruct(envelope.enc_x(), envelope.parity()) else {
         return Ok(None);
     };
     let dh = k256::ecdh::diffie_hellman(secret.to_nonzero_scalar(), enc.as_affine());
@@ -264,14 +266,14 @@ pub(super) fn decap(
 pub(super) fn open_with_shared(
     shared: &Zeroizing<[u8; 32]>,
     topic: &Topic,
-    record: &Record<'_>,
+    envelope: &Envelope<'_>,
 ) -> Result<Option<Opened<Hpke>>, OpenError> {
     let schedule = key_schedule(shared, topic).map_err(|_| OpenError::Internal)?;
     let hint = schedule.hint().map_err(|_| OpenError::Internal)?;
-    if !hint_matches(&hint, record.hint()) {
+    if !hint_matches(&hint, envelope.hint()) {
         return Ok(None);
     }
-    let Some((body, tag)) = record.ciphertext().split_last_chunk::<TAG_SIZE>() else {
+    let Some((body, tag)) = envelope.ciphertext().split_last_chunk::<TAG_SIZE>() else {
         return Ok(None);
     };
     let cipher = ChaCha20Poly1305::new_from_slice(schedule.key.as_slice())
@@ -298,21 +300,21 @@ pub(super) fn open_with_shared(
 pub(super) fn open(
     secret: &SecretKey,
     ctx: Info<'_>,
-    record: &Record<'_>,
+    envelope: &Envelope<'_>,
 ) -> Result<Option<Opened<Hpke>>, OpenError> {
-    let Some(shared) = decap(secret, record)? else {
+    let Some(shared) = decap(secret, envelope)? else {
         return Ok(None);
     };
-    open_with_shared(&shared, ctx.topic(), record)
+    open_with_shared(&shared, ctx.topic(), envelope)
 }
 
-#[cfg(feature = "encryption")]
+#[cfg(any(test, feature = "encryption"))]
 pub(super) fn seal(
     recipient: &Recipient<Hpke>,
     ctx: Info<'_>,
     plaintext: &[u8],
     ct_len: usize,
-) -> Result<SealedRecord<Hpke>, HpkeSealError> {
+) -> Result<SealedEnvelope<Hpke>, HpkeSealError> {
     seal_with_ephemeral(
         &crate::ecies::generate_secret(),
         recipient.key(),
@@ -324,14 +326,14 @@ pub(super) fn seal(
 
 /// Deterministic apart from the ephemeral; reached from [`seal`] and, for
 /// the pinned vectors, from the KAT tests only.
-#[cfg(feature = "encryption")]
+#[cfg(any(test, feature = "encryption"))]
 fn seal_with_ephemeral(
     ephemeral: &SecretKey,
     recipient: &PublicKey,
     topic: &Topic,
     plaintext: &[u8],
     ct_len: usize,
-) -> Result<SealedRecord<Hpke>, HpkeSealError> {
+) -> Result<SealedEnvelope<Hpke>, HpkeSealError> {
     let capacity = ct_len
         .checked_sub(MIN_CT_LEN)
         .ok_or(HpkeSealError::RegionTooSmall { ct_len })?;
@@ -375,7 +377,7 @@ fn seal_with_ephemeral(
     buf.extend_from_slice(&tag);
 
     let (enc_x, parity) = super::x_and_parity(&enc);
-    Ok(SealedRecord::from_parts(
+    Ok(SealedEnvelope::from_parts(
         hint,
         parity,
         enc_x,
@@ -423,8 +425,8 @@ mod tests {
         SecretKey::from_slice(keccak256(b"nectar envelope kat ephemeral").as_slice()).unwrap()
     }
 
-    fn record_from(bytes: &[u8]) -> Record<'_> {
-        Record::parse(bytes).unwrap()
+    fn envelope_from(bytes: &[u8]) -> Envelope<'_> {
+        Envelope::parse(bytes).unwrap()
     }
 
     #[test]
@@ -436,14 +438,14 @@ mod tests {
 
         let enc = ephemeral_key().public_key().to_encoded_point(false);
         let bytes = sealed.to_bytes();
-        let record = record_from(&bytes);
+        let envelope = envelope_from(&bytes);
         let inner = reference()
             .open(
                 enc.as_bytes(),
                 &recipient_sk.to_bytes().to_vec().into(),
                 &info_bytes(&topic),
                 b"",
-                record.ciphertext(),
+                envelope.ciphertext(),
                 None,
                 None,
                 None,
@@ -513,8 +515,8 @@ mod tests {
             )
             .unwrap();
         let bytes = sealed.to_bytes();
-        let record = record_from(&bytes);
-        assert_eq!(&theirs[..], record.hint());
+        let envelope = envelope_from(&bytes);
+        assert_eq!(&theirs[..], envelope.hint());
 
         let mut ours = [0u8; 8];
         sealed.extra().export(HINT_CONTEXT, &mut ours).unwrap();
@@ -564,10 +566,10 @@ mod tests {
             x[31] = x[31].wrapping_add(1);
         }
         bytes[40..72].copy_from_slice(&x);
-        let record = record_from(&bytes);
-        assert!(decap(&recipient_sk, &record).unwrap().is_none());
+        let envelope = envelope_from(&bytes);
+        assert!(decap(&recipient_sk, &envelope).unwrap().is_none());
         assert!(
-            open(&recipient_sk, Info::from(&topic()), &record)
+            open(&recipient_sk, Info::from(&topic()), &envelope)
                 .unwrap()
                 .is_none()
         );
@@ -633,8 +635,8 @@ mod tests {
         let sealed = seal_with_ephemeral(&eph, &recipient_pk, &topic, MSG, 64).unwrap();
         assert_eq!(sealed.to_bytes(), FRAME);
 
-        let record = record_from(&FRAME);
-        let opened = open(&recipient_sk, Info::from(&topic), &record)
+        let envelope = envelope_from(&FRAME);
+        let opened = open(&recipient_sk, Info::from(&topic), &envelope)
             .unwrap()
             .unwrap();
         assert_eq!(opened.plaintext, MSG);

--- a/crates/envelope/src/lib.rs
+++ b/crates/envelope/src/lib.rs
@@ -1,12 +1,12 @@
-//! Versioned modern envelope over the frozen ecies compat baseline.
+//! Sealed envelopes over the frozen ecies compat baseline.
 //!
 //! Two sealed schemes share one frozen frame inside the chunk payload:
 //! `hint[0..8] || nonce[8..40] || enc_x[40..72] || ct[72..]`. Compat is the
-//! byte-frozen [`crate::ecies`] construction; the envelope is RFC 9180 HPKE
-//! with the single suite DHKEM(secp256k1, HKDF-SHA256) + HKDF-SHA256 +
+//! byte-frozen [`crate::ecies`] construction; HPKE is RFC 9180 with the
+//! single suite DHKEM(secp256k1, HKDF-SHA256) + HKDF-SHA256 +
 //! ChaCha20-Poly1305 under the domain label `nectar/env/v1`.
 //!
-//! No nectar crate reads or writes this frame yet, so the module is unstable:
+//! No nectar crate reads or writes this frame yet, so the crate is unstable:
 //! the KEM, the frame and this API may change without a major version until a
 //! consumer pins them.
 //!
@@ -17,48 +17,65 @@
 //! nectar-owned, and validated differentially against `hpke-rs`.
 //!
 //! The version discriminant is cryptographic, not syntactic: compat keeps
-//! `keccak256(key || salt)[..8]` in the hint slot, the envelope hint is
+//! `keccak256(key || salt)[..8]` in the hint slot, the HPKE hint is
 //! `export("nectar/env/v1 hint", 8)`; the labelled transcripts are
 //! domain-disjoint, so only the recipient can tell the schemes apart. The
-//! hint is mandatory for envelope records: ChaCha20-Poly1305 is not
-//! key-committing, and trial-opening one ciphertext against many per-topic
-//! key schedules without the hint gate is a partitioning oracle.
+//! hint is mandatory under HPKE: ChaCha20-Poly1305 is not key-committing,
+//! and trial-opening one ciphertext against many per-topic key schedules
+//! without the hint gate is a partitioning oracle.
 //!
 //! `enc` travels x-only; the low bit of `nonce[0]` carries the ephemeral y
-//! parity in both schemes (miners hold it fixed). The envelope reconstructs
+//! parity in both schemes (miners hold it fixed). HPKE reconstructs
 //! canonical uncompressed SEC1 before `kem_context`; compat ECDH ignores
-//! parity, so a flipped bit is an authenticated decap failure (DoS only) for
-//! the envelope and a no-op for compat. Records of both schemes are
+//! parity, so a flipped bit is an authenticated decap failure (DoS only)
+//! under HPKE and a no-op for compat. Envelopes of both schemes are
 //! curve-membership-detectable against uniform bytes: the anonymity set is
 //! trojan chunks, at exact parity with the deployed compat path.
 //!
-//! Trial order: decap once per record (after chunk validity and
+//! Trial order: decap once per envelope (after chunk validity and
 //! proof-of-work checks; that per-valid-chunk cost is inherent), one hint
 //! probe per candidate topic, AEAD open only on a hint match. HKDF-SHA256
 //! deliberately adds SHA-256 beside the otherwise keccak-only proving
 //! surface.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::get_unwrap,
+        clippy::indexing_slicing,
+        clippy::string_slice,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::panic_in_result_fn,
+        clippy::as_conversions
+    )
+)]
+extern crate alloc;
 
 use alloc::vec::Vec;
 use core::fmt;
 use core::marker::PhantomData;
 
 use k256::{PublicKey, SecretKey};
+use nectar_primitives::chunk::encryption::EncryptionKey;
 use subtle::ConstantTimeEq;
 use thiserror::Error;
 
-use crate::ecies::Salt;
+use crate::ecies::{EciesError, Salt};
 
 mod attestation;
 mod compat;
+pub mod ecies;
 mod hpke;
 
-pub use attestation::{ATTESTATION_PREFIX, AttestationError, EnvelopeAttestation, sign_data};
+pub use attestation::{ATTESTATION_PREFIX, AttestationError, RecipientAttestation, sign_data};
 pub use hpke::{DeriveKeyPairError, ExportError, Exporter, HpkeSealError, Info, derive_key_pair};
 
-use crate::chunk::encryption::EncryptionKey;
-use crate::ecies::EciesError;
-
-/// Domain label of the envelope suite.
+/// Domain label of the HPKE suite.
 pub const LABEL: &[u8] = b"nectar/env/v1";
 
 /// Byte length of the hint slot.
@@ -74,11 +91,11 @@ mod sealed {
     pub trait Sealed {}
     impl Sealed for super::Compat {}
     impl Sealed for super::Hpke {}
-    impl Sealed for super::EnvelopeOnly {}
-    impl Sealed for super::EnvelopeThenCompat {}
+    impl Sealed for super::HpkeOnly {}
+    impl Sealed for super::HpkeThenCompat {}
 }
 
-/// 32-byte topic a record is addressed under.
+/// 32-byte topic an envelope is addressed under.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Topic([u8; 32]);
 
@@ -113,11 +130,11 @@ impl<'a> From<&'a Topic> for Salt<'a> {
 pub enum SchemeId {
     /// The frozen reference-client construction.
     Compat,
-    /// The HPKE envelope.
-    Envelope,
+    /// RFC 9180 HPKE.
+    Hpke,
 }
 
-/// One of the two envelope schemes; sealed, dispatch rides the type.
+/// One of the two sealing schemes; sealed, dispatch rides the type.
 pub trait Scheme: sealed::Sealed + Sized {
     /// Per-scheme key-derivation context built from a topic.
     type Context<'a>: From<&'a Topic>;
@@ -135,20 +152,20 @@ pub trait Scheme: sealed::Sealed + Sized {
 
     /// Seal `plaintext` toward `recipient` into a `ct_len`-byte ciphertext
     /// region.
-    #[cfg(feature = "encryption")]
+    #[cfg(any(test, feature = "encryption"))]
     fn seal(
         recipient: &Recipient<Self>,
         ctx: Self::Context<'_>,
         plaintext: &[u8],
         ct_len: usize,
-    ) -> Result<SealedRecord<Self>, Self::SealError>;
+    ) -> Result<SealedEnvelope<Self>, Self::SealError>;
 
-    /// Try to open `record` under `secret` for one context. `Ok(None)` means
-    /// the record is not recognized under this scheme and context.
+    /// Try to open `envelope` under `secret` for one context. `Ok(None)`
+    /// means it is not recognized under this scheme and context.
     fn open(
         secret: &SecretKey,
         ctx: Self::Context<'_>,
-        record: &Record<'_>,
+        envelope: &Envelope<'_>,
     ) -> Result<Option<Opened<Self>>, OpenError>;
 }
 
@@ -156,7 +173,7 @@ pub trait Scheme: sealed::Sealed + Sized {
 #[derive(Debug, Clone, Copy)]
 pub enum Compat {}
 
-/// The HPKE envelope suite; one sealed type, no agility.
+/// The HPKE suite; one sealed type, no agility.
 #[derive(Debug, Clone, Copy)]
 pub enum Hpke {}
 
@@ -165,13 +182,13 @@ pub enum Hpke {}
 pub struct InteropReason(&'static str);
 
 impl InteropReason {
-    /// Record why compat interop is unavoidable here.
+    /// State why compat interop is unavoidable here.
     #[must_use]
     pub const fn new(reason: &'static str) -> Self {
         Self(reason)
     }
 
-    /// The recorded justification.
+    /// The stated justification.
     #[must_use]
     pub const fn as_str(&self) -> &'static str {
         self.0
@@ -179,7 +196,7 @@ impl InteropReason {
 }
 
 /// Proof that a [`Recipient<Hpke>`] came from a verified
-/// [`EnvelopeAttestation`]; not constructible outside this crate.
+/// [`RecipientAttestation`]; not constructible outside this crate.
 #[derive(Clone)]
 pub struct Attested(());
 
@@ -195,10 +212,10 @@ impl fmt::Debug for Attested {
 /// direction.
 ///
 /// ```compile_fail
-/// use nectar_primitives::envelope::{Compat, Hpke, Recipient, Scheme, Topic};
+/// use nectar_envelope::{Compat, Hpke, Recipient, Scheme, Topic};
 ///
 /// fn downgrade(recipient: &Recipient<Hpke>, topic: &Topic) {
-///     // compat seal toward an envelope recipient must not typecheck
+///     // compat seal toward an hpke recipient must not typecheck
 ///     let _ = Compat::seal(recipient, topic.into(), b"msg", 64);
 /// }
 /// ```
@@ -253,35 +270,35 @@ impl Recipient<Hpke> {
     }
 }
 
-/// A record payload was shorter than the frame header.
+/// An envelope payload was shorter than the frame header.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
-#[error("record too short: {got} bytes, header is {HEADER_SIZE}")]
-pub struct RecordTooShort {
+#[error("envelope too short: {got} bytes, header is {HEADER_SIZE}")]
+pub struct EnvelopeTooShort {
     /// Observed payload length.
     pub got: usize,
 }
 
 /// Parsed view of the frozen frame.
 #[derive(Debug, Clone, Copy)]
-pub struct Record<'a> {
+pub struct Envelope<'a> {
     hint: &'a [u8; HINT_SIZE],
     nonce: &'a [u8; NONCE_SIZE],
     enc_x: &'a [u8; ENC_X_SIZE],
     ct: &'a [u8],
 }
 
-impl<'a> Record<'a> {
+impl<'a> Envelope<'a> {
     /// Split a chunk payload into the frame fields.
-    pub const fn parse(payload: &'a [u8]) -> Result<Self, RecordTooShort> {
+    pub const fn parse(payload: &'a [u8]) -> Result<Self, EnvelopeTooShort> {
         let got = payload.len();
         let Some((hint, rest)) = payload.split_first_chunk::<HINT_SIZE>() else {
-            return Err(RecordTooShort { got });
+            return Err(EnvelopeTooShort { got });
         };
         let Some((nonce, rest)) = rest.split_first_chunk::<NONCE_SIZE>() else {
-            return Err(RecordTooShort { got });
+            return Err(EnvelopeTooShort { got });
         };
         let Some((enc_x, ct)) = rest.split_first_chunk::<ENC_X_SIZE>() else {
-            return Err(RecordTooShort { got });
+            return Err(EnvelopeTooShort { got });
         };
         Ok(Self {
             hint,
@@ -325,7 +342,7 @@ impl<'a> Record<'a> {
 
 /// Output of a successful open.
 pub struct Opened<S: Scheme> {
-    /// Recovered plaintext. Envelope: the exact message; compat: the whole
+    /// Recovered plaintext. HPKE: the exact message; compat: the whole
     /// decrypted ciphertext region, framing left to the caller.
     pub plaintext: Vec<u8>,
     /// Scheme-specific by-product.
@@ -342,7 +359,7 @@ impl<S: Scheme> fmt::Debug for Opened<S> {
     }
 }
 
-/// Errors from opening a record that was recognized as ours.
+/// Errors from opening an envelope that was recognized as ours.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
 pub enum OpenError {
@@ -354,8 +371,8 @@ pub enum OpenError {
     Internal,
 }
 
-/// A sealed record ready for framing into a chunk payload.
-pub struct SealedRecord<S: Scheme> {
+/// A sealed envelope ready for framing into a chunk payload.
+pub struct SealedEnvelope<S: Scheme> {
     hint: [u8; HINT_SIZE],
     nonce: [u8; NONCE_SIZE],
     enc_x: [u8; ENC_X_SIZE],
@@ -363,7 +380,8 @@ pub struct SealedRecord<S: Scheme> {
     extra: S::Extra,
 }
 
-impl<S: Scheme> SealedRecord<S> {
+impl<S: Scheme> SealedEnvelope<S> {
+    #[cfg(any(test, feature = "encryption"))]
     pub(crate) fn from_parts(
         hint: [u8; HINT_SIZE],
         parity: bool,
@@ -416,9 +434,9 @@ impl<S: Scheme> SealedRecord<S> {
     }
 }
 
-impl<S: Scheme> fmt::Debug for SealedRecord<S> {
+impl<S: Scheme> fmt::Debug for SealedEnvelope<S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SealedRecord")
+        f.debug_struct("SealedEnvelope")
             .field("scheme", &S::ID)
             .field("ct_len", &self.ct.len())
             .finish_non_exhaustive()
@@ -432,26 +450,26 @@ pub(crate) fn hint_matches(derived: &[u8; HINT_SIZE], carried: &[u8; HINT_SIZE])
 
 /// Delivery policy of an [`Inbox`]; sealed.
 pub trait Policy: sealed::Sealed {
-    /// Whether compat probes are admitted after the envelope pass.
+    /// Whether compat probes are admitted after the HPKE pass.
     const COMPAT: bool;
 }
 
-/// Envelope-only delivery: compat hints are never computed, so compat
-/// records are undeliverable outright.
+/// HPKE-only delivery: compat hints are never computed, so compat envelopes
+/// are undeliverable outright.
 #[derive(Debug, Clone, Copy)]
-pub enum EnvelopeOnly {}
+pub enum HpkeOnly {}
 
-impl Policy for EnvelopeOnly {
+impl Policy for HpkeOnly {
     const COMPAT: bool = false;
 }
 
-/// Strictly transitional delivery: envelope first, compat probes after.
-/// Forbidden for peers pinned envelope-capable: compat is an unauthenticated
+/// Strictly transitional delivery: HPKE first, compat probes after.
+/// Forbidden for peers pinned HPKE-capable: compat is an unauthenticated
 /// stream cipher. Neither scheme authenticates the sender: HPKE runs base mode.
 #[derive(Debug, Clone, Copy)]
-pub enum EnvelopeThenCompat {}
+pub enum HpkeThenCompat {}
 
-impl Policy for EnvelopeThenCompat {
+impl Policy for HpkeThenCompat {
     const COMPAT: bool = true;
 }
 
@@ -469,8 +487,8 @@ impl<P: Policy> fmt::Debug for Inbox<P> {
     }
 }
 
-impl Inbox<EnvelopeOnly> {
-    /// Envelope-only inbox for `secret`.
+impl Inbox<HpkeOnly> {
+    /// HPKE-only inbox for `secret`.
     #[must_use]
     pub const fn new(secret: SecretKey) -> Self {
         Self {
@@ -480,9 +498,9 @@ impl Inbox<EnvelopeOnly> {
     }
 }
 
-impl Inbox<EnvelopeThenCompat> {
-    /// Transitional inbox for `secret`; flip to [`EnvelopeOnly`] the moment
-    /// the peer set is confirmed envelope-capable.
+impl Inbox<HpkeThenCompat> {
+    /// Transitional inbox for `secret`; flip to [`HpkeOnly`] the moment
+    /// the peer set is confirmed HPKE-capable.
     #[must_use]
     pub const fn transitional(secret: SecretKey) -> Self {
         Self {
@@ -493,23 +511,23 @@ impl Inbox<EnvelopeThenCompat> {
 }
 
 impl<P: Policy> Inbox<P> {
-    /// Trial-open `record` against `topics`: one decap, an envelope hint
+    /// Trial-open `envelope` against `topics`: one decap, an HPKE hint
     /// probe per topic, then compat probes where the policy admits them.
     pub fn open(
         &self,
         topics: &[Topic],
-        record: &Record<'_>,
+        envelope: &Envelope<'_>,
     ) -> Result<Option<(Topic, InboxOpened)>, OpenError> {
-        if let Some(shared) = hpke::decap(&self.secret, record)? {
+        if let Some(shared) = hpke::decap(&self.secret, envelope)? {
             for topic in topics {
-                if let Some(opened) = hpke::open_with_shared(&shared, topic, record)? {
-                    return Ok(Some((*topic, InboxOpened::Envelope(opened))));
+                if let Some(opened) = hpke::open_with_shared(&shared, topic, envelope)? {
+                    return Ok(Some((*topic, InboxOpened::Hpke(opened))));
                 }
             }
         }
         if P::COMPAT {
             for topic in topics {
-                if let Some(opened) = Compat::open(&self.secret, topic.into(), record)? {
+                if let Some(opened) = Compat::open(&self.secret, topic.into(), envelope)? {
                     return Ok(Some((*topic, InboxOpened::Compat(opened))));
                 }
             }
@@ -521,8 +539,8 @@ impl<P: Policy> Inbox<P> {
 /// Erased inbox delivery; match once at the edge.
 #[derive(Debug)]
 pub enum InboxOpened {
-    /// Opened under the envelope.
-    Envelope(Opened<Hpke>),
+    /// Opened under HPKE.
+    Hpke(Opened<Hpke>),
     /// Opened under compat.
     Compat(Opened<Compat>),
 }
@@ -532,7 +550,7 @@ impl InboxOpened {
     #[must_use]
     pub const fn scheme(&self) -> SchemeId {
         match self {
-            Self::Envelope(_) => SchemeId::Envelope,
+            Self::Hpke(_) => SchemeId::Hpke,
             Self::Compat(_) => SchemeId::Compat,
         }
     }
@@ -542,19 +560,19 @@ impl InboxOpened {
 /// and calls the monomorphized path, never enters the seam.
 #[derive(Debug, Clone)]
 pub enum AnyRecipient {
-    /// An attested envelope recipient.
-    Envelope(Recipient<Hpke>),
+    /// An attested HPKE recipient.
+    Hpke(Recipient<Hpke>),
     /// A justified compat recipient.
     Compat(Recipient<Compat>),
 }
 
-/// Erased sealed record from [`AnyRecipient::seal`].
+/// Erased sealed envelope from [`AnyRecipient::seal`].
 #[derive(Debug)]
 pub enum AnySealed {
-    /// Sealed under the envelope.
-    Envelope(SealedRecord<Hpke>),
+    /// Sealed under HPKE.
+    Hpke(SealedEnvelope<Hpke>),
     /// Sealed under compat.
-    Compat(SealedRecord<Compat>),
+    Compat(SealedEnvelope<Compat>),
 }
 
 impl AnySealed {
@@ -562,7 +580,7 @@ impl AnySealed {
     #[must_use]
     pub const fn scheme(&self) -> SchemeId {
         match self {
-            Self::Envelope(_) => SchemeId::Envelope,
+            Self::Hpke(_) => SchemeId::Hpke,
             Self::Compat(_) => SchemeId::Compat,
         }
     }
@@ -571,8 +589,8 @@ impl AnySealed {
     #[must_use]
     pub fn to_bytes(&self) -> Vec<u8> {
         match self {
-            Self::Envelope(record) => record.to_bytes(),
-            Self::Compat(record) => record.to_bytes(),
+            Self::Hpke(envelope) => envelope.to_bytes(),
+            Self::Compat(envelope) => envelope.to_bytes(),
         }
     }
 }
@@ -580,15 +598,15 @@ impl AnySealed {
 /// Errors from [`AnyRecipient::seal`].
 #[derive(Debug, Error)]
 pub enum AnySealError {
-    /// The envelope seal failed.
+    /// The HPKE seal failed.
     #[error(transparent)]
-    Envelope(#[from] HpkeSealError),
+    Hpke(#[from] HpkeSealError),
     /// The compat seal failed.
     #[error(transparent)]
     Compat(#[from] EciesError),
 }
 
-#[cfg(feature = "encryption")]
+#[cfg(any(test, feature = "encryption"))]
 impl AnyRecipient {
     /// Seal toward this recipient, scheme inferred from the handle.
     pub fn seal(
@@ -598,7 +616,7 @@ impl AnyRecipient {
         ct_len: usize,
     ) -> Result<AnySealed, AnySealError> {
         match self {
-            Self::Envelope(recipient) => Ok(AnySealed::Envelope(Hpke::seal(
+            Self::Hpke(recipient) => Ok(AnySealed::Hpke(Hpke::seal(
                 recipient,
                 topic.into(),
                 plaintext,
@@ -615,6 +633,7 @@ impl AnyRecipient {
 }
 
 /// Split a public key into its x coordinate and y parity.
+#[cfg(any(test, feature = "encryption"))]
 pub(crate) fn x_and_parity(key: &PublicKey) -> ([u8; 32], bool) {
     use k256::elliptic_curve::point::AffineCoordinates;
     let affine = key.as_affine();
@@ -640,22 +659,22 @@ impl Scheme for Compat {
     const TAG: usize = 0;
     const ID: SchemeId = SchemeId::Compat;
 
-    #[cfg(feature = "encryption")]
+    #[cfg(any(test, feature = "encryption"))]
     fn seal(
         recipient: &Recipient<Self>,
         ctx: Self::Context<'_>,
         plaintext: &[u8],
         ct_len: usize,
-    ) -> Result<SealedRecord<Self>, Self::SealError> {
+    ) -> Result<SealedEnvelope<Self>, Self::SealError> {
         compat::seal(recipient, ctx, plaintext, ct_len)
     }
 
     fn open(
         secret: &SecretKey,
         ctx: Self::Context<'_>,
-        record: &Record<'_>,
+        envelope: &Envelope<'_>,
     ) -> Result<Option<Opened<Self>>, OpenError> {
-        compat::open(secret, ctx, record)
+        compat::open(secret, ctx, envelope)
     }
 }
 
@@ -666,24 +685,24 @@ impl Scheme for Hpke {
     type SealError = HpkeSealError;
 
     const TAG: usize = 16;
-    const ID: SchemeId = SchemeId::Envelope;
+    const ID: SchemeId = SchemeId::Hpke;
 
-    #[cfg(feature = "encryption")]
+    #[cfg(any(test, feature = "encryption"))]
     fn seal(
         recipient: &Recipient<Self>,
         ctx: Self::Context<'_>,
         plaintext: &[u8],
         ct_len: usize,
-    ) -> Result<SealedRecord<Self>, Self::SealError> {
+    ) -> Result<SealedEnvelope<Self>, Self::SealError> {
         hpke::seal(recipient, ctx, plaintext, ct_len)
     }
 
     fn open(
         secret: &SecretKey,
         ctx: Self::Context<'_>,
-        record: &Record<'_>,
+        envelope: &Envelope<'_>,
     ) -> Result<Option<Opened<Self>>, OpenError> {
-        hpke::open(secret, ctx, record)
+        hpke::open(secret, ctx, envelope)
     }
 }
 
@@ -704,7 +723,7 @@ mod tests {
         Topic::new(keccak256(b"nectar envelope seam topic").0)
     }
 
-    fn envelope_recipient(key: PublicKey) -> Recipient<Hpke> {
+    fn hpke_recipient(key: PublicKey) -> Recipient<Hpke> {
         Recipient::attested(key)
     }
 
@@ -713,16 +732,16 @@ mod tests {
     }
 
     #[test]
-    fn envelope_roundtrip_via_seam() {
+    fn hpke_roundtrip_via_seam() {
         let (secret, public) = keys(b"nectar envelope seam recipient");
         let topic = topic();
         let msg = b"seam roundtrip";
-        let sealed = Hpke::seal(&envelope_recipient(public), (&topic).into(), msg, 4024).unwrap();
+        let sealed = Hpke::seal(&hpke_recipient(public), (&topic).into(), msg, 4024).unwrap();
         let bytes = sealed.to_bytes();
         assert_eq!(bytes.len(), HEADER_SIZE + 4024);
 
-        let record = Record::parse(&bytes).unwrap();
-        let opened = Hpke::open(&secret, (&topic).into(), &record)
+        let envelope = Envelope::parse(&bytes).unwrap();
+        let opened = Hpke::open(&secret, (&topic).into(), &envelope)
             .unwrap()
             .unwrap();
         assert_eq!(opened.plaintext, msg);
@@ -736,14 +755,14 @@ mod tests {
     }
 
     #[test]
-    fn envelope_wrong_topic_is_undeliverable() {
+    fn hpke_wrong_topic_is_undeliverable() {
         let (secret, public) = keys(b"nectar envelope seam recipient");
-        let sealed = Hpke::seal(&envelope_recipient(public), (&topic()).into(), b"m", 64).unwrap();
+        let sealed = Hpke::seal(&hpke_recipient(public), (&topic()).into(), b"m", 64).unwrap();
         let bytes = sealed.to_bytes();
-        let record = Record::parse(&bytes).unwrap();
+        let envelope = Envelope::parse(&bytes).unwrap();
         let other = Topic::new(keccak256(b"other topic").0);
         assert!(
-            Hpke::open(&secret, (&other).into(), &record)
+            Hpke::open(&secret, (&other).into(), &envelope)
                 .unwrap()
                 .is_none()
         );
@@ -758,22 +777,25 @@ mod tests {
         let bytes = sealed.to_bytes();
         assert_eq!(bytes.len(), HEADER_SIZE + 100);
 
-        let record = Record::parse(&bytes).unwrap();
-        let opened = Compat::open(&secret, (&topic).into(), &record)
+        let envelope = Envelope::parse(&bytes).unwrap();
+        let opened = Compat::open(&secret, (&topic).into(), &envelope)
             .unwrap()
             .unwrap();
         assert_eq!(&opened.plaintext[..msg.len()], msg);
         assert_eq!(opened.plaintext.len(), 100);
 
         // The adapter is byte-for-byte the frozen construction.
-        let ephemeral = reconstruct(record.enc_x(), record.parity()).unwrap();
+        let ephemeral = reconstruct(envelope.enc_x(), envelope.parity()).unwrap();
         let key = ecies::shared_key(&secret, &ephemeral, (&topic).into());
         assert_eq!(key, opened.extra);
         assert_eq!(
             ecies::Hint::derive(&key, (&topic).into()).as_bytes(),
-            record.hint()
+            envelope.hint()
         );
-        assert_eq!(ecies::decrypt(&key, record.ciphertext()), opened.plaintext);
+        assert_eq!(
+            ecies::decrypt(&key, envelope.ciphertext()),
+            opened.plaintext
+        );
     }
 
     #[test]
@@ -781,68 +803,67 @@ mod tests {
         let (secret, public) = keys(b"nectar envelope seam recipient");
         let topic = topic();
 
-        let envelope = Hpke::seal(&envelope_recipient(public), (&topic).into(), b"e", 64).unwrap();
-        let bytes = envelope.to_bytes();
-        let record = Record::parse(&bytes).unwrap();
+        let sealed = Hpke::seal(&hpke_recipient(public), (&topic).into(), b"e", 64).unwrap();
+        let bytes = sealed.to_bytes();
+        let envelope = Envelope::parse(&bytes).unwrap();
         assert!(
-            Compat::open(&secret, (&topic).into(), &record)
+            Compat::open(&secret, (&topic).into(), &envelope)
                 .unwrap()
                 .is_none()
         );
 
-        let compat = Compat::seal(&compat_recipient(public), (&topic).into(), b"c", 64).unwrap();
-        let bytes = compat.to_bytes();
-        let record = Record::parse(&bytes).unwrap();
+        let sealed = Compat::seal(&compat_recipient(public), (&topic).into(), b"c", 64).unwrap();
+        let bytes = sealed.to_bytes();
+        let envelope = Envelope::parse(&bytes).unwrap();
         assert!(
-            Hpke::open(&secret, (&topic).into(), &record)
+            Hpke::open(&secret, (&topic).into(), &envelope)
                 .unwrap()
                 .is_none()
         );
     }
 
     #[test]
-    fn envelope_only_inbox_rejects_compat_forgeries() {
+    fn hpke_only_inbox_rejects_compat_forgeries() {
         let (secret, public) = keys(b"nectar envelope seam recipient");
         let topic = topic();
-        let compat = Compat::seal(&compat_recipient(public), (&topic).into(), b"f", 64).unwrap();
-        let bytes = compat.to_bytes();
-        let record = Record::parse(&bytes).unwrap();
+        let sealed = Compat::seal(&compat_recipient(public), (&topic).into(), b"f", 64).unwrap();
+        let bytes = sealed.to_bytes();
+        let envelope = Envelope::parse(&bytes).unwrap();
 
-        let inbox = Inbox::<EnvelopeOnly>::new(secret.clone());
-        assert!(inbox.open(&[topic], &record).unwrap().is_none());
+        let inbox = Inbox::<HpkeOnly>::new(secret.clone());
+        assert!(inbox.open(&[topic], &envelope).unwrap().is_none());
 
         // The transitional inbox still delivers it, reported as compat.
-        let inbox = Inbox::<EnvelopeThenCompat>::transitional(secret);
-        let (delivered_topic, opened) = inbox.open(&[topic], &record).unwrap().unwrap();
+        let inbox = Inbox::<HpkeThenCompat>::transitional(secret);
+        let (delivered_topic, opened) = inbox.open(&[topic], &envelope).unwrap().unwrap();
         assert_eq!(delivered_topic, topic);
         assert_eq!(opened.scheme(), SchemeId::Compat);
     }
 
     #[test]
-    fn inbox_delivers_envelope_on_the_right_topic() {
+    fn inbox_delivers_hpke_on_the_right_topic() {
         let (secret, public) = keys(b"nectar envelope seam recipient");
         let topic = topic();
         let decoy = Topic::new(keccak256(b"decoy topic").0);
-        let sealed = Hpke::seal(&envelope_recipient(public), (&topic).into(), b"m", 64).unwrap();
+        let sealed = Hpke::seal(&hpke_recipient(public), (&topic).into(), b"m", 64).unwrap();
         let bytes = sealed.to_bytes();
-        let record = Record::parse(&bytes).unwrap();
+        let envelope = Envelope::parse(&bytes).unwrap();
 
-        let inbox = Inbox::<EnvelopeOnly>::new(secret);
-        let (delivered_topic, opened) = inbox.open(&[decoy, topic], &record).unwrap().unwrap();
+        let inbox = Inbox::<HpkeOnly>::new(secret);
+        let (delivered_topic, opened) = inbox.open(&[decoy, topic], &envelope).unwrap().unwrap();
         assert_eq!(delivered_topic, topic);
-        assert_eq!(opened.scheme(), SchemeId::Envelope);
-        let InboxOpened::Envelope(opened) = opened else {
+        assert_eq!(opened.scheme(), SchemeId::Hpke);
+        let InboxOpened::Hpke(opened) = opened else {
             panic!("wrong scheme");
         };
         assert_eq!(opened.plaintext, b"m");
     }
 
     #[test]
-    fn remining_the_nonce_keeps_the_record_open() {
+    fn remining_the_nonce_keeps_the_envelope_open() {
         let (secret, public) = keys(b"nectar envelope seam recipient");
         let topic = topic();
-        let mut sealed =
-            Hpke::seal(&envelope_recipient(public), (&topic).into(), b"m", 64).unwrap();
+        let mut sealed = Hpke::seal(&hpke_recipient(public), (&topic).into(), b"m", 64).unwrap();
         let parity_before = {
             let bytes = sealed.to_bytes();
             bytes[8] & 1
@@ -852,51 +873,51 @@ mod tests {
         assert_eq!(bytes[8] & 1, parity_before);
         assert_eq!(&bytes[9..40], &[0xff; 31]);
 
-        let record = Record::parse(&bytes).unwrap();
+        let envelope = Envelope::parse(&bytes).unwrap();
         assert!(
-            Hpke::open(&secret, (&topic).into(), &record)
+            Hpke::open(&secret, (&topic).into(), &envelope)
                 .unwrap()
                 .is_some()
         );
     }
 
     #[test]
-    fn flipped_parity_is_dos_only_for_the_envelope() {
+    fn flipped_parity_is_dos_only_for_hpke() {
         let (secret, public) = keys(b"nectar envelope seam recipient");
         let topic = topic();
 
-        let sealed = Hpke::seal(&envelope_recipient(public), (&topic).into(), b"m", 64).unwrap();
+        let sealed = Hpke::seal(&hpke_recipient(public), (&topic).into(), b"m", 64).unwrap();
         let mut bytes = sealed.to_bytes();
         bytes[8] ^= 1;
-        let record = Record::parse(&bytes).unwrap();
+        let envelope = Envelope::parse(&bytes).unwrap();
         assert!(
-            Hpke::open(&secret, (&topic).into(), &record)
+            Hpke::open(&secret, (&topic).into(), &envelope)
                 .unwrap()
                 .is_none()
         );
 
-        // Compat ECDH ignores parity: the flipped record still opens.
+        // Compat ECDH ignores parity: the flipped envelope still opens.
         let sealed = Compat::seal(&compat_recipient(public), (&topic).into(), b"m", 64).unwrap();
         let mut bytes = sealed.to_bytes();
         bytes[8] ^= 1;
-        let record = Record::parse(&bytes).unwrap();
+        let envelope = Envelope::parse(&bytes).unwrap();
         assert!(
-            Compat::open(&secret, (&topic).into(), &record)
+            Compat::open(&secret, (&topic).into(), &envelope)
                 .unwrap()
                 .is_some()
         );
     }
 
     #[test]
-    fn record_parse_rejects_short_payloads() {
+    fn envelope_parse_rejects_short_payloads() {
         assert_eq!(
-            Record::parse(&[0u8; HEADER_SIZE - 1]).unwrap_err(),
-            RecordTooShort {
+            Envelope::parse(&[0u8; HEADER_SIZE - 1]).unwrap_err(),
+            EnvelopeTooShort {
                 got: HEADER_SIZE - 1
             }
         );
-        let record = Record::parse(&[0u8; HEADER_SIZE]).unwrap();
-        assert!(record.ciphertext().is_empty());
+        let envelope = Envelope::parse(&[0u8; HEADER_SIZE]).unwrap();
+        assert!(envelope.ciphertext().is_empty());
     }
 
     #[test]
@@ -904,13 +925,13 @@ mod tests {
         let (secret, public) = keys(b"nectar envelope seam recipient");
         let topic = topic();
 
-        let any = AnyRecipient::Envelope(envelope_recipient(public));
+        let any = AnyRecipient::Hpke(hpke_recipient(public));
         let sealed = any.seal(&topic, b"m", 64).unwrap();
-        assert_eq!(sealed.scheme(), SchemeId::Envelope);
+        assert_eq!(sealed.scheme(), SchemeId::Hpke);
         let bytes = sealed.to_bytes();
-        let record = Record::parse(&bytes).unwrap();
+        let envelope = Envelope::parse(&bytes).unwrap();
         assert!(
-            Hpke::open(&secret, (&topic).into(), &record)
+            Hpke::open(&secret, (&topic).into(), &envelope)
                 .unwrap()
                 .is_some()
         );
@@ -919,9 +940,9 @@ mod tests {
         let sealed = any.seal(&topic, b"m", 64).unwrap();
         assert_eq!(sealed.scheme(), SchemeId::Compat);
         let bytes = sealed.to_bytes();
-        let record = Record::parse(&bytes).unwrap();
+        let envelope = Envelope::parse(&bytes).unwrap();
         assert!(
-            Compat::open(&secret, (&topic).into(), &record)
+            Compat::open(&secret, (&topic).into(), &envelope)
                 .unwrap()
                 .is_some()
         );
@@ -936,11 +957,20 @@ mod tests {
         assert_eq!(recipient.key(), &public);
     }
 
+    /// Frozen wire: the crate name must never leak into the format.
+    #[test]
+    fn frozen_wire_constants() {
+        assert_eq!(LABEL, b"nectar/env/v1");
+        assert_eq!(ATTESTATION_PREFIX, b"nectar/env/v1 attest");
+        assert_eq!((HINT_SIZE, NONCE_SIZE, ENC_X_SIZE), (8, 32, 32));
+        assert_eq!(HEADER_SIZE, 72);
+    }
+
     #[test]
     fn scheme_constants() {
         assert_eq!(Compat::TAG, 0);
         assert_eq!(Hpke::TAG, 16);
         assert_eq!(Compat::ID, SchemeId::Compat);
-        assert_eq!(Hpke::ID, SchemeId::Envelope);
+        assert_eq!(Hpke::ID, SchemeId::Hpke);
     }
 }

--- a/crates/envelope/src/lib.rs
+++ b/crates/envelope/src/lib.rs
@@ -32,6 +32,12 @@
 //! curve-membership-detectable against uniform bytes: the anonymity set is
 //! trojan chunks, at exact parity with the deployed compat path.
 //!
+//! The reference client places that bit elsewhere: it mines `nonce[28]` and
+//! reads it back as `chunkData[36]`. Neither side breaks, because compat ECDH
+//! is x-only, and its reader forces odd regardless (`chunkData[36] | 0x1 != 0`
+//! is a bitwise or, so always true). It matters only to a future scheme that
+//! makes parity load-bearing on the compat frame.
+//!
 //! Trial order: decap once per envelope (after chunk validity and
 //! proof-of-work checks; that per-valid-chunk cost is inherent), one hint
 //! probe per candidate topic, AEAD open only on a hint match. HKDF-SHA256

--- a/crates/postage/README.md
+++ b/crates/postage/README.md
@@ -20,7 +20,6 @@ The reference client calls a detached postage stamp an envelope.
 The response carries the issuer address, the packed bucket and index, the timestamp and the signature.
 There is no Go type of that name; it is a route and a response name.
 `Stamp` in this crate is the stamp behind that response, field for field: batch, index, timestamp and signature.
-The `envelope` module in `nectar-primitives` is unrelated: it is the HPKE encryption envelope.
 
 ## License
 

--- a/crates/primitives-core/src/error.rs
+++ b/crates/primitives-core/src/error.rs
@@ -11,7 +11,7 @@
 //! - Component-specific errors: More detailed errors from specific subsystems
 //!   (like `BmtError` and `ChunkError`)
 //!
-//! [`EncryptionError`], [`EciesError`] and [`ChunkStoreError`] name failures of
+//! [`EncryptionError`] and [`ChunkStoreError`] name failures of
 //! `nectar-primitives` subsystems that live outside this crate. They are
 //! defined here because [`PrimitivesError`] wraps them, and are re-exported at
 //! their own module paths there.
@@ -86,10 +86,6 @@ pub enum PrimitivesError {
     #[error(transparent)]
     Encryption(#[from] EncryptionError),
 
-    /// Errors from ECIES operations
-    #[error(transparent)]
-    Ecies(#[from] EciesError),
-
     /// Input/output errors
     #[cfg(feature = "std")]
     #[error("I/O error: {0}")]
@@ -136,23 +132,6 @@ pub enum EncryptionError {
         len: usize,
         /// Required buffer length.
         required: usize,
-    },
-}
-
-/// Errors from ECIES operations.
-///
-/// The scheme itself lives in `nectar_primitives::ecies`; the type is here
-/// because [`PrimitivesError`] wraps it.
-#[non_exhaustive]
-#[derive(Debug, Error)]
-pub enum EciesError {
-    /// Plaintext exceeds the requested padded length.
-    #[error("plaintext too long: {len} bytes, padded length {padded}")]
-    PlaintextTooLong {
-        /// Plaintext length.
-        len: usize,
-        /// Requested padded length.
-        padded: usize,
     },
 }
 

--- a/crates/primitives-core/src/lib.rs
+++ b/crates/primitives-core/src/lib.rs
@@ -5,9 +5,9 @@
 //! and single-owner carriers with their acceptance rules, single-owner owner
 //! recovery, and the address, error and wire types those need.
 //!
-//! Storage, encryption, envelopes, ECIES, the thread-safety markers and the
-//! routing metrics live in `nectar-primitives`, which depends on this crate
-//! and re-exports every item at its original path.
+//! Storage, encryption, the thread-safety markers and the routing metrics
+//! live in `nectar-primitives`, which depends on this crate and re-exports
+//! every item at its original path.
 //!
 //! ## Usage Examples
 //!

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -33,12 +33,6 @@ alloy-chains = { workspace = true }
 # asm-keccak and getrandom extras ride the target tables below.
 alloy-primitives = { workspace = true, features = ["k256"] }
 
-## rust crypto
-chacha20poly1305 = { workspace = true, optional = true }
-hkdf = { workspace = true, optional = true }
-k256 = { workspace = true, features = ["ecdh"] }
-sha2 = { workspace = true, optional = true }
-
 # derive macros
 derive_more.workspace = true
 num_enum.workspace = true
@@ -102,9 +96,6 @@ futures.workspace = true
 # The core's `Arbitrary` impls and generators ride its own feature: this
 # crate's `cfg(test)` does not reach them.
 nectar-primitives-core = { workspace = true, features = ["arbitrary"] }
-hpke-rs.workspace = true
-hpke-rs-crypto.workspace = true
-hpke-rs-rust-crypto.workspace = true
 nectar-testing.workspace = true
 proptest.workspace = true
 proptest-arbitrary-interop.workspace = true
@@ -117,8 +108,6 @@ std = [
 	"dep:parking_lot",
 	"dep:web-time",
 	"futures-core/std",
-	"k256/precomputed-tables",
-	"k256/std",
 	"nectar-clock/std",
 	"nectar-primitives-core/std",
 	"strum/std",
@@ -151,8 +140,6 @@ arbitrary = [
 	"std",
 ]
 encryption = [ "dep:rand" ]
-# Modern envelope: RFC 9180 HPKE over the frozen ecies compat baseline.
-envelope-unstable = [ "dep:chacha20poly1305", "dep:hkdf", "dep:sha2" ]
 # Single-thread send escape for non-wasm targets (e.g. zkVM guests): applies
 # the wasm32 relaxation of MaybeSend/MaybeSync and the boxed error aliases on
 # any target. An explicit feature rather than a target cfg so CI can exercise
@@ -181,5 +168,5 @@ name = "proofs"
 harness = false
 
 [package.metadata.docs.rs]
-features = ["arbitrary", "encryption", "parallel", "serde", "std"]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -168,5 +168,5 @@ name = "proofs"
 harness = false
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["arbitrary", "encryption", "parallel", "serde", "std"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -6,8 +6,7 @@
 //! The chunk-verification subset (the binary merkle tree, the chunk carriers
 //! and their acceptance rules, and the types those need) lives in
 //! [`nectar_primitives_core`] and is re-exported here at its original paths;
-//! storage, encryption, envelopes, ECIES and the routing metrics are this
-//! crate's own.
+//! storage, encryption and the routing metrics are this crate's own.
 //!
 //! ## Key Components
 //!
@@ -69,10 +68,7 @@ pub mod address;
 pub mod bin;
 pub mod bmt;
 pub mod chunk;
-pub mod ecies;
 pub mod entry_ref;
-#[cfg(feature = "envelope-unstable")]
-pub mod envelope;
 pub mod marker;
 pub mod neighborhood_depth;
 pub mod network_id;

--- a/docs/PRODUCTION-PLAN.md
+++ b/docs/PRODUCTION-PLAN.md
@@ -80,10 +80,11 @@ Complete.
 
 #678 alone removed over two thousand lines carrying six `calculate_bucket` call sites, the hand-written `RingExhausted` producer and two shard cursors that three later issues would otherwise have refactored first.
 
-**The workspace is 18 members, down from 23.**
+**The workspace is 19 members.**
+Stage 2 settled at 18, down from 23, and `nectar-envelope` is the only crate added since.
 The count is the number of directories under `crates/` plus one, because `Cargo.toml` declares `members = ["crates/*", "crates/primitives/examples/wasm-demo"]`.
 A directory count alone is off by one, and it produced a wrong figure once during this stage.
-The 17 remaining crates are `clock`, `contracts`, `feeds`, `file`, `governor`, `integration-tests`, `ldb`, `manifest`, `mantaray`, `marker`, `postage`, `postage-issuer`, `postage-usage`, `primitives`, `primitives-core`, `tasks` and `testing`.
+The 18 crates are `clock`, `contracts`, `envelope`, `feeds`, `file`, `governor`, `integration-tests`, `ldb`, `manifest`, `mantaray`, `marker`, `postage`, `postage-issuer`, `postage-usage`, `primitives`, `primitives-core`, `tasks` and `testing`.
 
 What went: `benches` and `examples` (#618); `swarms` (#679, folded into `nectar-primitives`); `feeds-bench` and `ldb-sim` (#680, folded into their host crates as `[[example]]` targets so their drivers stay runnable).
 `nectar-postage-issuer` lost 1131 lines to a generic `Sharded<I>`, and `nectar-governor` is now bounded admission alone, holding only `nectar-marker` and `futures-util`.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1321,7 +1321,6 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "hkdf",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -1610,15 +1609,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830e599c2904b08f0834ee6337d8fe8f0ed4a63b5d9e7a7f49c0ffa06d08d360"
 dependencies = [
  "arrayvec",
-]
-
-[[package]]
-name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac",
 ]
 
 [[package]]
@@ -2049,7 +2039,6 @@ dependencies = [
  "getrandom 0.3.4",
  "getrandom 0.4.3",
  "js-sys",
- "k256",
  "nectar-clock",
  "nectar-marker",
  "nectar-primitives-core",


### PR DESCRIPTION
Closes #747

## Summary

Extracts the messaging crypto out of `nectar-primitives` into a new workspace member, `crates/envelope` (`nectar-envelope`).

Two commits, tip `440ca068` (`origin/main..HEAD`):

- `a8697739` `refactor(envelope)!: extract the messaging crypto into nectar-envelope`: the move itself.
- `440ca068` `build(primitives): keep the docs.rs feature list explicit`: follow-up doc/build tidy-up.

## The move

`crates/primitives/src/envelope/{mod,hpke,compat,attestation}.rs` and `crates/primitives/src/ecies.rs` become the new workspace member `crates/envelope` (`nectar-envelope`), with `envelope/mod.rs` landing as the crate root `src/lib.rs` and `ecies` staying a public module of it.

`EciesError` leaves `crates/primitives-core/src/error.rs` and is now declared in `crates/envelope/src/ecies.rs`; `PrimitivesError` loses its `Ecies` variant.

`chacha20poly1305`, `hkdf`, `sha2`, and the three `hpke-rs*` dev-dependencies move with the code, and the `envelope-unstable` feature disappears with the module rather than being preserved.

The three off-limits crates (`manifest`, `ldb`, `mantaray`) are untouched.

## Renames

`Record` -> `Envelope`, `RecordTooShort` -> `EnvelopeTooShort`, `SealedRecord` -> `SealedEnvelope`.

## Testing

All commands run inside `nix develop --command` at `440ca068` (`origin/main..HEAD` = 2 commits), worktree clean, nothing amended or pushed.

**Clippy (lint.yml parity)**
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: clean
- `cargo clippy --locked --all-targets -p nectar-envelope --features encryption -- -D warnings`: clean (this is the pass `lint.yml` now runs in place of the old `-p nectar-primitives --features envelope-unstable,encryption`)
- `cargo clippy --locked --all-targets -p nectar-envelope -- -D warnings`: clean
- `--all-features` deliberately not run (`compile_error!` guards make it fail by construction on `main` too; CI does not use it)

**Unused dependencies**
- `cargo rustc --locked -p nectar-primitives --lib -- -D unused_crate_dependencies`: clean, confirming `chacha20poly1305`, `hkdf`, `sha2`, and the direct `k256` dep move with the code rather than lingering unused in `nectar-primitives`.

**Red-team verification**
- Re-derived the branch rather than trusting it. The move is faithful: every wire literal and pinned KAT frame is byte-identical to `origin/main`, and a LABEL mutation proves the KAT and the new `frozen_wire_constants` test actually bite.
- 39 tests (38 moved plus 1 new) pass in both the default and the `encryption` configuration; none was deleted or relaxed.
- The `compile_fail` doctest is genuinely non-vacuous under `--features encryption`, proven by inverting the recipient type.
- Gate items check out: 19 workspace members matching the plan's crate list, no `Record` identifier anywhere in the crate, no `Ecies` variant left in `PrimitivesError`.

## AI Assistance

Implementation: claude-opus-5. Red-team review: claude-opus-5. PR: claude-sonnet-5.


## Review follow-ups, added after the first pass

**One word now means two things, deliberately, and the issue's gate wording was wrong.** #747 asked that `rg -n "ecies|envelope"` over `crates/primitives/src` and `crates/primitives-core/src` return nothing. `ecies` does. `envelope` cannot: it is a pre-existing and unrelated word in `primitives-core`, naming the chunk registry's closed member union (`ChunkRegistry::Envelope`, `Chunk::from_envelope`, and about forty doc mentions). Nothing here touches it.

So after this merges the workspace carries `nectar_envelope::Envelope`, a sealed message container, beside `ChunkRegistry::Envelope`, a decoded chunk carrier. That is a genuine live collision rather than the awkward metaphor it was when #745 was filed, which makes #745 (rename the registry's associated type to `Member`) worth more than its original framing suggested.

**A factual correction to the module doc**, carried in the second commit. The doc said the ephemeral y-parity bit rides the low bit of `nonce[0]`, which is true of this crate but reads as a claim about the wire generally. The reference client mines it into `nonce[28]` and reads it back as `chunkData[36]` (`bee/pkg/pss/trojan.go:209-212`, `:259`).

Neither side breaks. Compat ECDH is x-only, so parity never reaches the shared secret, and bee's own reader forces odd regardless: `chunkData[36] | 0x1 != 0` is a bitwise or and is therefore always true. The divergence matters only to a future scheme that makes parity load-bearing on the compat frame, and it is exactly the kind of thing a test against reference-client bytes would pin. No such test exists yet; that gap is now recorded on #752.
