### PR TITLE
fix(ldb): state the MaybeSend bound on load_node

### DIFF
--- a/crates/ldb/src/store.rs
+++ b/crates/ldb/src/store.rs
@@ -170,14 +170,21 @@ const MAX_DIR_DEPTH: usize = 2;
 
 /// Load the node `reference` reaches, reassembling a spilled node's forks
 /// from its segments under a bounded fetch window.
-pub async fn load_node<S, F, R>(store: &S, reference: &R) -> Result<Node<F, R>, StoreError>
+// `async fn` cannot state the `MaybeSend` bound, and the callers box this future.
+#[allow(clippy::manual_async_fn)]
+pub fn load_node<'a, S, F, R>(
+    store: &'a S,
+    reference: &'a R,
+) -> impl Future<Output = Result<Node<F, R>, StoreError>> + MaybeSend + 'a
 where
     S: TrustedGet<ContentOnlyChunkSet> + MaybeSync,
-    F: Format,
-    R: NodeRef,
+    F: Format + 'a,
+    R: NodeRef + 'a,
 {
-    let (node, _) = materialize_traced::<S, F, R>(store, reference).await?;
-    Ok(node)
+    async move {
+        let (node, _) = materialize_traced::<S, F, R>(store, reference).await?;
+        Ok(node)
+    }
 }
 
 /// Load the node `reference` reaches, decrypting with the key it carries, and


### PR DESCRIPTION
## What

States the `MaybeSend` bound on `load_node`'s returned future, instead of leaving it to be inferred.

`load_node` replaced `NodeGet::get_node` in #748. The trait method declared `-> impl Future<Output = ...> + MaybeSend`; the free function that replaced it is a plain `pub async fn`, so nothing asserts the bound at the definition any more. It is checked only where a caller boxes the future, in `scan.rs`, `traverse.rs` and `apply.rs::prefetch_children`.

`save_node` two hundred lines below already declares `+ MaybeSend + 'a`, so the two halves of the same seam disagreed.

## Why

Nothing is broken today. This is about where a future mistake surfaces: a `!Send` value captured inside `load_node` currently produces errors at three distant call sites rather than at the function that caused it. The bound moves that check back to the definition.

Closes #750

## The cost, stated plainly

This adds one lint suppression, and that is a real cost against #230.

Clippy's `manual_async_fn` fires on a function whose entire body is one `async move` block, and `async fn` cannot express the `MaybeSend` bound, so both cannot be satisfied at once. `save_node` escapes the lint only incidentally, because it does work before its async block.

The suppression is the mechanism the workspace documents for exactly this: `Cargo.toml:29-32` records that provably-safe internal sites carry a justified `#[allow(...)]`. It is one attribute with a one-line reason.

## Testing

`cargo clippy --workspace --all-targets --locked -- -D warnings` clean, and the same for `-p nectar-ldb` bare and with `--features encryption`.

`cargo check --locked -p nectar-ldb --features unsync` clean. This is the case that matters most: `unsync` relaxes `MaybeSend` to no bound at all, so the change must not have introduced a hard `Send` requirement. It has not.

`cargo check --locked -p nectar-ldb --no-default-features` green on both `riscv64imac-unknown-none-elf` and `wasm32-unknown-unknown`.

`cargo nextest run --locked -p nectar-ldb --features encryption`: 264 tests run, 264 passed.

`cargo fmt --all --check` clean.

## AI Assistance

Implementation and verification: claude-opus-5.
