### PR TITLE
refactor(envelope)!: scheme seam holds more than two schemes

### DIFF
--- a/crates/envelope/README.md
+++ b/crates/envelope/README.md
@@ -1,7 +1,9 @@
 # nectar-envelope
 
 Sealed messaging envelopes for Ethereum Swarm.
-Two schemes share one frozen frame inside a chunk payload: the byte-frozen ECIES construction of the reference client, and RFC 9180 HPKE under the domain label `nectar/env/v1`.
+Two schemes share one frozen header inside a chunk payload: the byte-frozen ECIES construction of the reference client, and RFC 9180 HPKE under the domain label `nectar/env/v1`.
+The header carries the hint and the mining nonce, which are the fields the network itself touches.
+Everything after it is scheme-owned opaque bytes, so one anonymity set holds every scheme.
 
 Part of the [nectar](https://github.com/nxm-rs/nectar) workspace, a collection of low-level Ethereum Swarm primitives in Rust.
 See the [workspace README](https://github.com/nxm-rs/nectar) for the full crate list and project context.

--- a/crates/envelope/src/attestation.rs
+++ b/crates/envelope/src/attestation.rs
@@ -27,9 +27,8 @@ pub const ATTESTATION_PREFIX: &[u8] = b"nectar/env/v2 attest";
 /// Byte length of a serialized signature.
 const SIGNATURE_SIZE: usize = 65;
 
-/// A scheme that may be advertised in an attested set.
-///
-/// Compat has no code here by construction, so it cannot be attested.
+/// A scheme an attested set may advertise; compat has no code here by
+/// construction, so it cannot be attested.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum AttestedScheme {
@@ -38,7 +37,7 @@ pub enum AttestedScheme {
 }
 
 impl AttestedScheme {
-    /// Sender preference, strongest first; crate-owned, not caller-supplied.
+    /// Sender preference, strongest first.
     const STRENGTH: &'static [Self] = &[Self::Hpke];
 
     /// Wire code of this scheme.
@@ -59,8 +58,7 @@ impl AttestedScheme {
     }
 }
 
-/// Proof that a [`Recipient`] came from a verified attestation; not
-/// constructible outside this crate.
+/// Proof that a [`Recipient`] came from a verified attestation.
 #[derive(Clone)]
 pub struct Attested {
     scheme: AttestedScheme,
@@ -152,8 +150,8 @@ pub enum AttestationError {
     /// The serialized token is malformed.
     #[error("attestation encoding is malformed")]
     Encoding,
-    /// The entry list is empty or not strictly ascending.
-    #[error("entries are empty or not strictly ascending")]
+    /// The entry list is empty, too long, or not strictly ascending by code.
+    #[error("entry list is empty, too long, or not strictly ascending by code")]
     Order,
     /// A key for a known scheme is not a valid curve point.
     #[error("attested key is not a valid curve point")]
@@ -234,7 +232,7 @@ impl RecipientAttestation {
 
     /// Verify against the pinned identity.
     pub fn verify(&self, identity: Address) -> Result<VerifiedAttestation, AttestationError> {
-        if !strictly_ascending(&self.entries) {
+        if !canonical(&self.entries) {
             return Err(AttestationError::Order);
         }
         let recovered = self
@@ -267,12 +265,12 @@ impl RecipientAttestation {
     }
 }
 
-fn strictly_ascending(entries: &[SchemeEntry]) -> bool {
+/// Codes must be unique and ascending: a repeated code makes selection
+/// ambiguous, and past `u16::MAX` entries the signed count clamps silently.
+fn canonical(entries: &[SchemeEntry]) -> bool {
     !entries.is_empty()
-        && entries.windows(2).all(|pair| match pair {
-            [left, right] => left < right,
-            _ => false,
-        })
+        && entries.len() <= usize::from(u16::MAX)
+        && entries.is_sorted_by(|left, right| left.code < right.code)
 }
 
 impl TryFrom<&[u8]> for RecipientAttestation {
@@ -286,7 +284,9 @@ impl TryFrom<&[u8]> for RecipientAttestation {
             .split_first_chunk::<2>()
             .ok_or(AttestationError::Encoding)?;
         let count = usize::from(u16::from_be_bytes(*count));
-        let mut entries = Vec::with_capacity(count);
+        // An entry is at least four bytes, so cap the claimed count against
+        // the input: a short token must not force a large allocation.
+        let mut entries = Vec::with_capacity(count.min(rest.len() / 4));
         for _ in 0..count {
             let (code, tail) = rest
                 .split_first_chunk::<2>()
@@ -465,14 +465,19 @@ mod tests {
         assert_eq!(recipient.key(), &key);
     }
 
+    /// Two keys under one code would make selection depend on key ordering.
     #[test]
-    fn unsorted_or_duplicate_entries_are_rejected() {
+    fn unsorted_or_repeated_codes_are_rejected() {
         let identity = LocalSigner::random();
         let key = generate_secret().public_key();
         let entry = SchemeEntry::new(AttestedScheme::Hpke, &key);
+        let other = SchemeEntry::new(AttestedScheme::Hpke, &generate_secret().public_key());
+        let mut repeated = alloc::vec![entry.clone(), other];
+        repeated.sort();
         for entries in [
             alloc::vec![unknown(), entry.clone()],
             alloc::vec![entry.clone(), entry],
+            repeated,
             Vec::new(),
         ] {
             let attestation = sign(&identity, 0, entries);
@@ -481,6 +486,17 @@ mod tests {
                 AttestationError::Order
             ));
         }
+    }
+
+    /// A short token must not be able to name a large entry count.
+    #[test]
+    fn an_overstated_entry_count_is_rejected() {
+        let mut bytes = 0u64.to_be_bytes().to_vec();
+        bytes.extend_from_slice(&u16::MAX.to_be_bytes());
+        assert!(matches!(
+            RecipientAttestation::try_from(bytes.as_slice()).unwrap_err(),
+            AttestationError::Encoding
+        ));
     }
 
     #[test]

--- a/crates/envelope/src/attestation.rs
+++ b/crates/envelope/src/attestation.rs
@@ -1,49 +1,161 @@
-//! Recipient-key attestation.
+//! Attested scheme sets.
 //!
-//! A peer pins its HPKE capability by signing its recipient key with its
-//! long-term secp256k1 identity key (EIP-191 personal sign, matching the
-//! handshake). Verification is the only mint of [`Recipient<Hpke>`];
-//! provenance, the pinned-peer registry and fail-closed enforcement live
-//! with the node, which must treat a missing token for a pinned peer as an
-//! attack, never as licence to fall back to compat.
+//! A peer pins the schemes it can receive under by signing the whole set
+//! with its long-term secp256k1 identity key (EIP-191 personal sign,
+//! matching the handshake). Verification is the only mint of a
+//! [`Recipient<Hpke>`]; provenance, the pinned-peer registry and fail-closed
+//! enforcement live with the node, which must treat a missing token for a
+//! pinned peer as an attack, never as licence to fall back to compat.
+//!
+//! Compat is unrepresentable in [`AttestedScheme`], so no verified set can
+//! yield a compat recipient: the reference client publishes no attestations,
+//! and anyone who can verify a set can speak HPKE.
 
 use alloc::vec::Vec;
+use core::fmt;
+
 use alloy_primitives::{Address, Signature};
 use k256::PublicKey;
 use k256::elliptic_curve::sec1::ToEncodedPoint;
 use thiserror::Error;
 
-use nectar_primitives::error::WrongLength;
-
 use super::{Hpke, Recipient};
 
 /// Domain prefix of the attestation sign-data.
-pub const ATTESTATION_PREFIX: &[u8] = b"nectar/env/v1 attest";
+pub const ATTESTATION_PREFIX: &[u8] = b"nectar/env/v2 attest";
 
-/// Byte length of a serialized attestation: compressed key plus signature.
-const SIZE: usize = 33 + 65;
+/// Byte length of a serialized signature.
+const SIGNATURE_SIZE: usize = 65;
 
-/// Build the attestation sign-data: `prefix || compressed SEC1 key`.
+/// A scheme that may be advertised in an attested set.
 ///
-/// Signing is not wrapped: the identity key personal-signs (EIP-191) this
-/// buffer, matching the handshake convention.
-#[must_use]
-pub fn sign_data(key: &PublicKey) -> Vec<u8> {
-    let point = key.to_encoded_point(true);
-    let mut out = Vec::new();
-    out.extend_from_slice(ATTESTATION_PREFIX);
-    out.extend_from_slice(point.as_bytes());
-    out
+/// Compat has no code here by construction, so it cannot be attested.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AttestedScheme {
+    /// RFC 9180 HPKE under the pinned suite.
+    Hpke,
+}
+
+impl AttestedScheme {
+    /// Sender preference, strongest first; crate-owned, not caller-supplied.
+    const STRENGTH: &'static [Self] = &[Self::Hpke];
+
+    /// Wire code of this scheme.
+    #[must_use]
+    pub const fn code(self) -> u16 {
+        match self {
+            Self::Hpke => 0x0001,
+        }
+    }
+
+    /// The scheme a wire code names, if this build knows it.
+    #[must_use]
+    pub const fn from_code(code: u16) -> Option<Self> {
+        match code {
+            0x0001 => Some(Self::Hpke),
+            _ => None,
+        }
+    }
+}
+
+/// Proof that a [`Recipient`] came from a verified attestation; not
+/// constructible outside this crate.
+#[derive(Clone)]
+pub struct Attested {
+    scheme: AttestedScheme,
+    counter: u64,
+}
+
+impl Attested {
+    pub(crate) const fn new(scheme: AttestedScheme, counter: u64) -> Self {
+        Self { scheme, counter }
+    }
+
+    /// The attested scheme.
+    #[must_use]
+    pub const fn scheme(&self) -> AttestedScheme {
+        self.scheme
+    }
+
+    /// The counter of the set this recipient came from.
+    #[must_use]
+    pub const fn counter(&self) -> u64 {
+        self.counter
+    }
+}
+
+impl fmt::Debug for Attested {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Attested")
+            .field("scheme", &self.scheme)
+            .field("counter", &self.counter)
+            .finish()
+    }
+}
+
+/// One advertised scheme and the key it receives under.
+///
+/// An unknown code is carried verbatim so the signed bytes survive a
+/// round-trip through a build that does not know the scheme.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SchemeEntry {
+    code: u16,
+    key: Vec<u8>,
+}
+
+impl SchemeEntry {
+    /// Advertise `key` under `scheme`.
+    #[must_use]
+    pub fn new(scheme: AttestedScheme, key: &PublicKey) -> Self {
+        Self {
+            code: scheme.code(),
+            key: key.to_encoded_point(true).as_bytes().to_vec(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn raw(code: u16, key: Vec<u8>) -> Self {
+        Self { code, key }
+    }
+
+    /// The wire code.
+    #[must_use]
+    pub const fn code(&self) -> u16 {
+        self.code
+    }
+
+    /// The scheme, if this build knows the code.
+    #[must_use]
+    pub const fn scheme(&self) -> Option<AttestedScheme> {
+        AttestedScheme::from_code(self.code)
+    }
+
+    /// The serialized key.
+    #[must_use]
+    pub fn key_bytes(&self) -> &[u8] {
+        &self.key
+    }
+
+    fn encode(&self, out: &mut Vec<u8>) {
+        let len = u16::try_from(self.key.len()).unwrap_or(u16::MAX);
+        out.extend_from_slice(&self.code.to_be_bytes());
+        out.extend_from_slice(&len.to_be_bytes());
+        out.extend_from_slice(&self.key);
+    }
 }
 
 /// Errors from decoding or verifying an attestation.
 #[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum AttestationError {
-    /// The serialized token has the wrong length.
-    #[error(transparent)]
-    Length(#[from] WrongLength),
-    /// The attested key is not a valid curve point.
+    /// The serialized token is malformed.
+    #[error("attestation encoding is malformed")]
+    Encoding,
+    /// The entry list is empty or not strictly ascending.
+    #[error("entries are empty or not strictly ascending")]
+    Order,
+    /// A key for a known scheme is not a valid curve point.
     #[error("attested key is not a valid curve point")]
     Key,
     /// The signature is malformed or unrecoverable.
@@ -59,24 +171,59 @@ pub enum AttestationError {
     },
 }
 
-/// Signed statement that an identity receives under the recipient key.
+/// The signed body: `counter || entry count || entries`.
+fn body(counter: u64, entries: &[SchemeEntry]) -> Vec<u8> {
+    let count = u16::try_from(entries.len()).unwrap_or(u16::MAX);
+    let mut out = Vec::new();
+    out.extend_from_slice(&counter.to_be_bytes());
+    out.extend_from_slice(&count.to_be_bytes());
+    for entry in entries {
+        entry.encode(&mut out);
+    }
+    out
+}
+
+/// Build the attestation sign-data: `prefix || counter || sorted entries`.
+///
+/// Signing is not wrapped: the identity key personal-signs (EIP-191) this
+/// buffer, matching the handshake convention.
+#[must_use]
+pub fn sign_data(counter: u64, entries: &[SchemeEntry]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(ATTESTATION_PREFIX);
+    out.extend_from_slice(&body(counter, entries));
+    out
+}
+
+/// Signed statement of the schemes an identity receives under.
 #[derive(Debug, Clone)]
 pub struct RecipientAttestation {
-    key: PublicKey,
+    counter: u64,
+    entries: Vec<SchemeEntry>,
     signature: Signature,
 }
 
 impl RecipientAttestation {
     /// Assemble a token from its parts; [`Self::verify`] does the checking.
     #[must_use]
-    pub const fn new(key: PublicKey, signature: Signature) -> Self {
-        Self { key, signature }
+    pub const fn new(counter: u64, entries: Vec<SchemeEntry>, signature: Signature) -> Self {
+        Self {
+            counter,
+            entries,
+            signature,
+        }
     }
 
-    /// The attested recipient key.
+    /// The monotonic counter.
     #[must_use]
-    pub const fn key(&self) -> &PublicKey {
-        &self.key
+    pub const fn counter(&self) -> u64 {
+        self.counter
+    }
+
+    /// The advertised entries, as carried.
+    #[must_use]
+    pub fn entries(&self) -> &[SchemeEntry] {
+        &self.entries
     }
 
     /// The identity signature over [`sign_data`].
@@ -85,11 +232,14 @@ impl RecipientAttestation {
         &self.signature
     }
 
-    /// Verify against the pinned identity and mint the sealing handle.
-    pub fn verify(&self, identity: Address) -> Result<Recipient<Hpke>, AttestationError> {
+    /// Verify against the pinned identity.
+    pub fn verify(&self, identity: Address) -> Result<VerifiedAttestation, AttestationError> {
+        if !strictly_ascending(&self.entries) {
+            return Err(AttestationError::Order);
+        }
         let recovered = self
             .signature
-            .recover_address_from_msg(sign_data(&self.key))
+            .recover_address_from_msg(sign_data(self.counter, &self.entries))
             .map_err(|_| AttestationError::Signature)?;
         if recovered != identity {
             return Err(AttestationError::Signer {
@@ -97,36 +247,130 @@ impl RecipientAttestation {
                 recovered,
             });
         }
-        Ok(Recipient::attested(self.key))
+        for entry in &self.entries {
+            if entry.scheme().is_some() && PublicKey::from_sec1_bytes(&entry.key).is_err() {
+                return Err(AttestationError::Key);
+            }
+        }
+        Ok(VerifiedAttestation {
+            counter: self.counter,
+            entries: self.entries.clone(),
+        })
     }
 
-    /// Serialize: `compressed key || 65-byte signature`.
+    /// Serialize: `counter || entry count || entries || 65-byte signature`.
     #[must_use]
     pub fn to_bytes(&self) -> Vec<u8> {
-        let mut out = Vec::new();
-        out.extend_from_slice(self.key.to_encoded_point(true).as_bytes());
+        let mut out = body(self.counter, &self.entries);
         out.extend_from_slice(&self.signature.as_bytes());
         out
     }
+}
+
+fn strictly_ascending(entries: &[SchemeEntry]) -> bool {
+    !entries.is_empty()
+        && entries.windows(2).all(|pair| match pair {
+            [left, right] => left < right,
+            _ => false,
+        })
 }
 
 impl TryFrom<&[u8]> for RecipientAttestation {
     type Error = AttestationError;
 
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
-        let wrong_length = WrongLength {
-            expected: SIZE,
-            got: bytes.len(),
-        };
-        let Some((key_bytes, rest)) = bytes.split_first_chunk::<33>() else {
-            return Err(wrong_length.into());
-        };
-        let signature_bytes: &[u8; 65] = rest.try_into().map_err(|_| wrong_length)?;
-        let key = PublicKey::from_sec1_bytes(key_bytes).map_err(|_| AttestationError::Key)?;
+        let (counter, rest) = bytes
+            .split_first_chunk::<8>()
+            .ok_or(AttestationError::Encoding)?;
+        let (count, mut rest) = rest
+            .split_first_chunk::<2>()
+            .ok_or(AttestationError::Encoding)?;
+        let count = usize::from(u16::from_be_bytes(*count));
+        let mut entries = Vec::with_capacity(count);
+        for _ in 0..count {
+            let (code, tail) = rest
+                .split_first_chunk::<2>()
+                .ok_or(AttestationError::Encoding)?;
+            let (len, tail) = tail
+                .split_first_chunk::<2>()
+                .ok_or(AttestationError::Encoding)?;
+            let (key, tail) = tail
+                .split_at_checked(usize::from(u16::from_be_bytes(*len)))
+                .ok_or(AttestationError::Encoding)?;
+            entries.push(SchemeEntry {
+                code: u16::from_be_bytes(*code),
+                key: key.to_vec(),
+            });
+            rest = tail;
+        }
+        let signature_bytes: &[u8; SIGNATURE_SIZE] =
+            rest.try_into().map_err(|_| AttestationError::Encoding)?;
         let signature =
             Signature::from_raw_array(signature_bytes).map_err(|_| AttestationError::Signature)?;
-        Ok(Self::new(key, signature))
+        Ok(Self::new(u64::from_be_bytes(*counter), entries, signature))
     }
+}
+
+/// A verified set; the only source of attested recipients.
+#[derive(Debug, Clone)]
+pub struct VerifiedAttestation {
+    counter: u64,
+    entries: Vec<SchemeEntry>,
+}
+
+impl VerifiedAttestation {
+    /// The monotonic counter; the node holds the last accepted value, so
+    /// verification alone does not reject a replayed set.
+    #[must_use]
+    pub const fn counter(&self) -> u64 {
+        self.counter
+    }
+
+    /// The verified entries.
+    #[must_use]
+    pub fn entries(&self) -> &[SchemeEntry] {
+        &self.entries
+    }
+
+    /// Mint a recipient for the strongest scheme the set offers.
+    #[must_use]
+    pub fn select(&self) -> Option<AttestedRecipient> {
+        for scheme in AttestedScheme::STRENGTH {
+            let Some(entry) = self.entries.iter().find(|e| e.code == scheme.code()) else {
+                continue;
+            };
+            let key = PublicKey::from_sec1_bytes(&entry.key).ok()?;
+            return Some(match *scheme {
+                AttestedScheme::Hpke => AttestedRecipient::Hpke(Recipient::attested(
+                    key,
+                    Attested::new(AttestedScheme::Hpke, self.counter),
+                )),
+            });
+        }
+        None
+    }
+}
+
+/// A recipient minted from a verified set.
+///
+/// Compat has no variant here, and no conversion exists, so a verified
+/// attestation can never produce a `Recipient<Compat>`:
+///
+/// ```compile_fail
+/// use nectar_envelope::{AttestedRecipient, Compat, Recipient};
+///
+/// fn downgrade(attested: AttestedRecipient) -> Recipient<Compat> {
+///     match attested {
+///         AttestedRecipient::Compat(recipient) => recipient,
+///         _ => unreachable!(),
+///     }
+/// }
+/// ```
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub enum AttestedRecipient {
+    /// An HPKE recipient.
+    Hpke(Recipient<Hpke>),
 }
 
 #[cfg(test)]
@@ -137,26 +381,45 @@ mod tests {
 
     use crate::ecies::generate_secret;
 
-    fn attested() -> (LocalSigner<k256::ecdsa::SigningKey>, RecipientAttestation) {
-        let identity = LocalSigner::random();
-        let recipient_key = generate_secret().public_key();
+    type Signer = LocalSigner<k256::ecdsa::SigningKey>;
+
+    fn sign(identity: &Signer, counter: u64, entries: Vec<SchemeEntry>) -> RecipientAttestation {
         let signature = identity
-            .sign_message_sync(&sign_data(&recipient_key))
+            .sign_message_sync(&sign_data(counter, &entries))
             .unwrap();
-        let attestation = RecipientAttestation::new(recipient_key, signature);
-        (identity, attestation)
+        RecipientAttestation::new(counter, entries, signature)
+    }
+
+    fn attested() -> (Signer, PublicKey, RecipientAttestation) {
+        let identity = LocalSigner::random();
+        let key = generate_secret().public_key();
+        let attestation = sign(
+            &identity,
+            7,
+            alloc::vec![SchemeEntry::new(AttestedScheme::Hpke, &key)],
+        );
+        (identity, key, attestation)
+    }
+
+    /// An entry for a scheme this build does not know, sorting after HPKE.
+    fn unknown() -> SchemeEntry {
+        SchemeEntry::raw(0xffff, alloc::vec![0xab; 33])
     }
 
     #[test]
-    fn verify_mints_the_recipient() {
-        let (identity, attestation) = attested();
-        let recipient = attestation.verify(identity.address()).unwrap();
-        assert_eq!(recipient.key(), attestation.key());
+    fn verify_selects_the_hpke_recipient() {
+        let (identity, key, attestation) = attested();
+        let verified = attestation.verify(identity.address()).unwrap();
+        assert_eq!(verified.counter(), 7);
+        let AttestedRecipient::Hpke(recipient) = verified.select().unwrap();
+        assert_eq!(recipient.key(), &key);
+        assert_eq!(recipient.provenance().counter(), 7);
+        assert_eq!(recipient.provenance().scheme(), AttestedScheme::Hpke);
     }
 
     #[test]
     fn wrong_identity_is_rejected() {
-        let (identity, attestation) = attested();
+        let (identity, _, attestation) = attested();
         let other = LocalSigner::random().address();
         let err = attestation.verify(other).unwrap_err();
         assert!(matches!(
@@ -167,35 +430,107 @@ mod tests {
     }
 
     #[test]
-    fn swapped_key_breaks_the_signature() {
-        let (identity, attestation) = attested();
-        let forged =
-            RecipientAttestation::new(generate_secret().public_key(), *attestation.signature());
-        assert!(forged.verify(identity.address()).is_err());
+    fn dropping_the_strong_scheme_breaks_the_signature() {
+        let identity = LocalSigner::random();
+        let key = generate_secret().public_key();
+        let full = alloc::vec![SchemeEntry::new(AttestedScheme::Hpke, &key), unknown()];
+        let attestation = sign(&identity, 1, full);
+        assert!(attestation.verify(identity.address()).is_ok());
+
+        let stripped =
+            RecipientAttestation::new(1, alloc::vec![unknown()], *attestation.signature());
+        assert!(stripped.verify(identity.address()).is_err());
+    }
+
+    #[test]
+    fn the_counter_is_signed() {
+        let (identity, _, attestation) = attested();
+        let replayed = RecipientAttestation::new(
+            attestation.counter() + 1,
+            attestation.entries().to_vec(),
+            *attestation.signature(),
+        );
+        assert!(replayed.verify(identity.address()).is_err());
+    }
+
+    #[test]
+    fn selection_ignores_unknown_codes() {
+        let identity = LocalSigner::random();
+        let key = generate_secret().public_key();
+        let entries = alloc::vec![SchemeEntry::new(AttestedScheme::Hpke, &key), unknown()];
+        let verified = sign(&identity, 0, entries)
+            .verify(identity.address())
+            .unwrap();
+        let AttestedRecipient::Hpke(recipient) = verified.select().unwrap();
+        assert_eq!(recipient.key(), &key);
+    }
+
+    #[test]
+    fn unsorted_or_duplicate_entries_are_rejected() {
+        let identity = LocalSigner::random();
+        let key = generate_secret().public_key();
+        let entry = SchemeEntry::new(AttestedScheme::Hpke, &key);
+        for entries in [
+            alloc::vec![unknown(), entry.clone()],
+            alloc::vec![entry.clone(), entry],
+            Vec::new(),
+        ] {
+            let attestation = sign(&identity, 0, entries);
+            assert!(matches!(
+                attestation.verify(identity.address()).unwrap_err(),
+                AttestationError::Order
+            ));
+        }
+    }
+
+    #[test]
+    fn a_bad_key_for_a_known_scheme_is_rejected() {
+        let identity = LocalSigner::random();
+        let attestation = sign(
+            &identity,
+            0,
+            alloc::vec![SchemeEntry::raw(
+                AttestedScheme::Hpke.code(),
+                alloc::vec![0u8; 33]
+            )],
+        );
+        assert!(matches!(
+            attestation.verify(identity.address()).unwrap_err(),
+            AttestationError::Key
+        ));
     }
 
     #[test]
     fn bytes_roundtrip() {
-        let (identity, attestation) = attested();
+        let (identity, key, attestation) = attested();
         let bytes = attestation.to_bytes();
-        assert_eq!(bytes.len(), SIZE);
         let decoded = RecipientAttestation::try_from(bytes.as_slice()).unwrap();
-        assert_eq!(decoded.key(), attestation.key());
-        let recipient = decoded.verify(identity.address()).unwrap();
-        assert_eq!(recipient.key(), attestation.key());
+        assert_eq!(decoded.counter(), 7);
+        assert_eq!(decoded.entries(), attestation.entries());
+        let verified = decoded.verify(identity.address()).unwrap();
+        let AttestedRecipient::Hpke(recipient) = verified.select().unwrap();
+        assert_eq!(recipient.key(), &key);
     }
 
     #[test]
-    fn short_token_is_rejected() {
-        let err = RecipientAttestation::try_from([0u8; 10].as_slice()).unwrap_err();
-        assert!(matches!(err, AttestationError::Length(_)));
+    fn truncated_tokens_are_rejected() {
+        let (_, _, attestation) = attested();
+        let bytes = attestation.to_bytes();
+        for len in [0, 9, bytes.len() - 1] {
+            assert!(matches!(
+                RecipientAttestation::try_from(&bytes[..len]).unwrap_err(),
+                AttestationError::Encoding
+            ));
+        }
     }
 
     #[test]
     fn sign_data_layout() {
         let key = generate_secret().public_key();
-        let data = sign_data(&key);
+        let entries = alloc::vec![SchemeEntry::new(AttestedScheme::Hpke, &key)];
+        let data = sign_data(3, &entries);
         assert_eq!(&data[..ATTESTATION_PREFIX.len()], ATTESTATION_PREFIX);
-        assert_eq!(data.len(), ATTESTATION_PREFIX.len() + 33);
+        assert_eq!(&data[ATTESTATION_PREFIX.len()..][..8], &3u64.to_be_bytes());
+        assert_eq!(data.len(), ATTESTATION_PREFIX.len() + 8 + 2 + 4 + 33);
     }
 }

--- a/crates/envelope/src/compat.rs
+++ b/crates/envelope/src/compat.rs
@@ -4,20 +4,40 @@
 //! compat baseline; only the frame around them is shared with HPKE.
 
 use k256::SecretKey;
+use thiserror::Error;
 
-use crate::ecies::{self, Hint, Salt, SharedX};
+use crate::ecdh::ENC_X_SIZE;
+use crate::ecies::{self, EciesError, Hint, Salt, SharedX};
 
 use super::{Compat, Envelope, OpenError, Opened, ecdh, hint_matches};
 #[cfg(any(test, feature = "encryption"))]
 use super::{Recipient, SealedEnvelope};
+
+/// Errors from a compat seal.
+#[non_exhaustive]
+#[derive(Debug, Error)]
+pub enum CompatSealError {
+    /// The tail cannot hold the encapsulation.
+    #[error("tail too small: {tail_len} bytes, minimum {ENC_X_SIZE}")]
+    TailTooSmall {
+        /// Requested tail length.
+        tail_len: usize,
+    },
+    /// The ciphertext region cannot hold the plaintext.
+    #[error(transparent)]
+    Ecies(#[from] EciesError),
+}
 
 #[cfg(any(test, feature = "encryption"))]
 pub(super) fn seal(
     recipient: &Recipient<Compat>,
     salt: Salt<'_>,
     plaintext: &[u8],
-    ct_len: usize,
-) -> Result<SealedEnvelope<Compat>, ecies::EciesError> {
+    tail_len: usize,
+) -> Result<SealedEnvelope<Compat>, CompatSealError> {
+    let ct_len = tail_len
+        .checked_sub(ENC_X_SIZE)
+        .ok_or(CompatSealError::TailTooSmall { tail_len })?;
     let encrypted = ecies::encrypt(recipient.key(), salt, plaintext, Some(ct_len))?;
     let hint = *Hint::derive(&encrypted.key, salt).as_bytes();
     let (tail, nonce_bits) = ecdh::tail(&encrypted.ephemeral, &encrypted.ciphertext);

--- a/crates/envelope/src/compat.rs
+++ b/crates/envelope/src/compat.rs
@@ -5,9 +5,9 @@
 
 use k256::SecretKey;
 
-use crate::ecies::{self, Hint, Salt};
+use crate::ecies::{self, Hint, Salt, SharedX};
 
-use super::{Compat, Envelope, OpenError, Opened, hint_matches};
+use super::{Compat, Envelope, OpenError, Opened, ecdh, hint_matches};
 #[cfg(any(test, feature = "encryption"))]
 use super::{Recipient, SealedEnvelope};
 
@@ -20,31 +20,40 @@ pub(super) fn seal(
 ) -> Result<SealedEnvelope<Compat>, ecies::EciesError> {
     let encrypted = ecies::encrypt(recipient.key(), salt, plaintext, Some(ct_len))?;
     let hint = *Hint::derive(&encrypted.key, salt).as_bytes();
-    let (enc_x, parity) = super::x_and_parity(&encrypted.ephemeral);
+    let (tail, nonce_bits) = ecdh::tail(&encrypted.ephemeral, &encrypted.ciphertext);
     Ok(SealedEnvelope::from_parts(
         hint,
-        parity,
-        enc_x,
-        encrypted.ciphertext,
+        nonce_bits,
+        tail,
         encrypted.key,
     ))
 }
 
-pub(super) fn open(
+/// The ECDH is salt-independent, so one run serves every candidate topic.
+pub(super) fn decap(
     secret: &SecretKey,
+    envelope: &Envelope<'_>,
+) -> Result<Option<SharedX>, OpenError> {
+    // Compat ECDH only uses the shared x, so either parity reconstructs the
+    // same key; use the carried bit for symmetry with HPKE.
+    let Some((ephemeral, _)) = ecdh::split(envelope) else {
+        return Ok(None);
+    };
+    #[cfg(test)]
+    crate::decaps::note(super::SchemeId::Compat);
+    Ok(Some(ecies::shared_x(secret, &ephemeral)))
+}
+
+pub(super) fn probe(
+    shared: &SharedX,
     salt: Salt<'_>,
     envelope: &Envelope<'_>,
 ) -> Result<Option<Opened<Compat>>, OpenError> {
-    // Compat ECDH only uses the shared x, so either parity reconstructs the
-    // same key; use the carried bit for symmetry with HPKE.
-    let Some(ephemeral) = super::reconstruct(envelope.enc_x(), envelope.parity()) else {
-        return Ok(None);
-    };
-    let key = ecies::shared_key(secret, &ephemeral, salt);
+    let key = shared.derive(salt);
     if !hint_matches(Hint::derive(&key, salt).as_bytes(), envelope.hint()) {
         return Ok(None);
     }
-    let plaintext = ecies::decrypt(&key, envelope.ciphertext());
+    let plaintext = ecies::decrypt(&key, ecdh::ciphertext(envelope));
     Ok(Some(Opened {
         plaintext,
         extra: key,

--- a/crates/envelope/src/ecdh.rs
+++ b/crates/envelope/src/ecdh.rs
@@ -11,14 +11,12 @@ use alloc::vec::Vec;
 /// Byte length of the x-only ephemeral slot at the head of the tail.
 pub(crate) const ENC_X_SIZE: usize = 32;
 
-/// Nonce bits these schemes own: the parity bit alone.
 pub(crate) const PARITY: u8 = 0x01;
 
 pub(crate) fn ciphertext<'a>(envelope: &Envelope<'a>) -> &'a [u8] {
     envelope.tail().get(ENC_X_SIZE..).unwrap_or(&[])
 }
 
-/// Reconstruct a public key from an x-only slot and a parity bit.
 pub(crate) fn reconstruct(enc_x: &[u8; ENC_X_SIZE], parity: bool) -> Option<PublicKey> {
     let mut sec1 = [0u8; 33];
     let [tag, x @ ..] = &mut sec1;

--- a/crates/envelope/src/ecdh.rs
+++ b/crates/envelope/src/ecdh.rs
@@ -1,0 +1,50 @@
+//! Tail layout shared by the two secp256k1 ECDH schemes: `enc_x || ct`.
+//!
+//! `enc` travels x-only; the low bit of `nonce[0]` carries its y parity.
+
+use k256::PublicKey;
+
+use super::Envelope;
+#[cfg(any(test, feature = "encryption"))]
+use alloc::vec::Vec;
+
+/// Byte length of the x-only ephemeral slot at the head of the tail.
+pub(crate) const ENC_X_SIZE: usize = 32;
+
+/// Nonce bits these schemes own: the parity bit alone.
+pub(crate) const PARITY: u8 = 0x01;
+
+pub(crate) fn ciphertext<'a>(envelope: &Envelope<'a>) -> &'a [u8] {
+    envelope.tail().get(ENC_X_SIZE..).unwrap_or(&[])
+}
+
+/// Reconstruct a public key from an x-only slot and a parity bit.
+pub(crate) fn reconstruct(enc_x: &[u8; ENC_X_SIZE], parity: bool) -> Option<PublicKey> {
+    let mut sec1 = [0u8; 33];
+    let [tag, x @ ..] = &mut sec1;
+    *tag = if parity { 0x03 } else { 0x02 };
+    *x = *enc_x;
+    PublicKey::from_sec1_bytes(&sec1).ok()
+}
+
+/// Recover the ephemeral key and the ciphertext region; `None` for a short
+/// tail or an off-curve x.
+pub(crate) fn split<'a>(envelope: &Envelope<'a>) -> Option<(PublicKey, &'a [u8])> {
+    let (enc_x, ct) = envelope.tail().split_first_chunk::<ENC_X_SIZE>()?;
+    let [nonce_0, ..] = envelope.nonce();
+    let key = reconstruct(enc_x, *nonce_0 & PARITY == PARITY)?;
+    Some((key, ct))
+}
+
+/// Lay `enc_x || ct` down and report the parity bit for `nonce[0]`.
+#[cfg(any(test, feature = "encryption"))]
+pub(crate) fn tail(ephemeral: &PublicKey, ct: &[u8]) -> (Vec<u8>, u8) {
+    use k256::elliptic_curve::point::AffineCoordinates;
+
+    let affine = ephemeral.as_affine();
+    let x: [u8; ENC_X_SIZE] = affine.x().into();
+    let mut tail = Vec::with_capacity(ENC_X_SIZE.saturating_add(ct.len()));
+    tail.extend_from_slice(&x);
+    tail.extend_from_slice(ct);
+    (tail, u8::from(bool::from(affine.y_is_odd())))
+}

--- a/crates/envelope/src/ecies.rs
+++ b/crates/envelope/src/ecies.rs
@@ -13,6 +13,7 @@ pub use k256::{PublicKey, SecretKey};
 use nectar_primitives::chunk::encryption::{EncryptionKey, transcrypt_in_place};
 use nectar_primitives::error::WrongLength;
 use thiserror::Error;
+use zeroize::Zeroizing;
 
 /// Errors from ECIES operations.
 #[non_exhaustive]
@@ -57,25 +58,52 @@ impl<'a> From<&'a [u8; 32]> for Salt<'a> {
     }
 }
 
+/// The salt-independent product of one ECDH: the shared x coordinate.
+pub struct SharedX {
+    bytes: Zeroizing<[u8; 32]>,
+    start: usize,
+}
+
+impl SharedX {
+    fn as_slice(&self) -> &[u8] {
+        self.bytes.get(self.start..).unwrap_or(&[])
+    }
+
+    /// Derive the cipher key for one salt: `keccak256(x || salt)`.
+    #[must_use]
+    pub fn derive(&self, salt: Salt<'_>) -> EncryptionKey {
+        let mut hasher = Keccak256::new();
+        hasher.update(self.as_slice());
+        hasher.update(salt.as_bytes());
+        EncryptionKey::from(hasher.finalize())
+    }
+}
+
+impl core::fmt::Debug for SharedX {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("SharedX(..)")
+    }
+}
+
+/// Run the ECDH; the salt enters only at [`SharedX::derive`].
+#[must_use]
+pub fn shared_x(secret: &SecretKey, public: &PublicKey) -> SharedX {
+    let shared = k256::ecdh::diffie_hellman(secret.to_nonzero_scalar(), public.as_affine());
+    let mut bytes = Zeroizing::new([0u8; 32]);
+    bytes.copy_from_slice(shared.raw_secret_bytes());
+    // The reference client serialises x as a big integer: leading zero
+    // bytes are dropped before hashing.
+    let start = bytes.iter().position(|byte| *byte != 0).unwrap_or(32);
+    SharedX { bytes, start }
+}
+
 /// Derive the shared cipher key: `keccak256(x || salt)`.
 ///
 /// Symmetric: the encryptor passes `(ephemeral_secret, recipient_public)`,
 /// the decryptor `(recipient_secret, ephemeral_public)`.
 #[must_use]
 pub fn shared_key(secret: &SecretKey, public: &PublicKey, salt: Salt<'_>) -> EncryptionKey {
-    let shared = k256::ecdh::diffie_hellman(secret.to_nonzero_scalar(), public.as_affine());
-
-    // The reference client serialises x as a big integer: leading zero
-    // bytes are dropped before hashing.
-    let mut x: &[u8] = shared.raw_secret_bytes();
-    while let [0, rest @ ..] = x {
-        x = rest;
-    }
-
-    let mut hasher = Keccak256::new();
-    hasher.update(x);
-    hasher.update(salt.as_bytes());
-    EncryptionKey::from(hasher.finalize())
+    shared_x(secret, public).derive(salt)
 }
 
 /// Topic-match hint: `keccak256(key || salt)[..8]`.

--- a/crates/envelope/src/hpke.rs
+++ b/crates/envelope/src/hpke.rs
@@ -34,8 +34,8 @@ const HINT_CONTEXT: &[u8] = b"nectar/env/v1 hint";
 const TAG_SIZE: usize = 16;
 /// Big-endian length prefix inside the sealed plaintext.
 const LEN_PREFIX: usize = 2;
-/// Smallest admissible ciphertext region.
-pub(super) const MIN_CT_LEN: usize = TAG_SIZE + LEN_PREFIX;
+/// Tail bytes that carry no message: encapsulation, tag and length prefix.
+pub(super) const OVERHEAD: usize = ecdh::ENC_X_SIZE + TAG_SIZE + LEN_PREFIX;
 
 /// Key-derivation context: the domain label followed by the topic.
 #[derive(Debug, Clone, Copy)]
@@ -80,11 +80,11 @@ pub enum HpkeSealError {
         /// Region capacity after tag and length prefix.
         max: usize,
     },
-    /// The region cannot hold the tag and length prefix.
-    #[error("ciphertext region too small: {ct_len} bytes, minimum {MIN_CT_LEN}")]
-    RegionTooSmall {
-        /// Requested region length.
-        ct_len: usize,
+    /// The tail cannot hold the encapsulation, tag and length prefix.
+    #[error("tail too small: {tail_len} bytes, minimum {OVERHEAD}")]
+    TailTooSmall {
+        /// Requested tail length.
+        tail_len: usize,
     },
     /// A fixed-size derivation failed; unreachable for the pinned suite.
     #[error("suite derivation invariant violated")]
@@ -316,14 +316,14 @@ pub(super) fn seal(
     recipient: &Recipient<Hpke>,
     ctx: Info<'_>,
     plaintext: &[u8],
-    ct_len: usize,
+    tail_len: usize,
 ) -> Result<SealedEnvelope<Hpke>, HpkeSealError> {
     seal_with_ephemeral(
         &crate::ecies::generate_secret(),
         recipient.key(),
         ctx.topic(),
         plaintext,
-        ct_len,
+        tail_len,
     )
 }
 
@@ -335,11 +335,11 @@ fn seal_with_ephemeral(
     recipient: &PublicKey,
     topic: &Topic,
     plaintext: &[u8],
-    ct_len: usize,
+    tail_len: usize,
 ) -> Result<SealedEnvelope<Hpke>, HpkeSealError> {
-    let capacity = ct_len
-        .checked_sub(MIN_CT_LEN)
-        .ok_or(HpkeSealError::RegionTooSmall { ct_len })?;
+    let capacity = tail_len
+        .checked_sub(OVERHEAD)
+        .ok_or(HpkeSealError::TailTooSmall { tail_len })?;
     let max = capacity.min(usize::from(u16::MAX));
     if plaintext.len() > max {
         return Err(HpkeSealError::MessageTooLong {
@@ -363,10 +363,10 @@ fn seal_with_ephemeral(
     let hint = schedule.hint().map_err(|_| HpkeSealError::Internal)?;
 
     // `len || msg || pad`, sealed to fill the region exactly.
-    let inner_len = ct_len
-        .checked_sub(TAG_SIZE)
+    let inner_len = capacity
+        .checked_add(LEN_PREFIX)
         .ok_or(HpkeSealError::Internal)?;
-    let mut buf = Vec::with_capacity(ct_len);
+    let mut buf = Vec::with_capacity(inner_len.saturating_add(TAG_SIZE));
     buf.extend_from_slice(&length.to_be_bytes());
     buf.extend_from_slice(plaintext);
     buf.resize(inner_len, 0);
@@ -431,7 +431,6 @@ mod tests {
         Envelope::parse(bytes).unwrap()
     }
 
-    /// Route through the trait's provided decap-then-probe.
     fn open(
         secret: &SecretKey,
         ctx: Info<'_>,
@@ -445,7 +444,7 @@ mod tests {
         let (recipient_sk, recipient_pk) = recipient_keys();
         let topic = topic();
         let msg = b"differential message";
-        let sealed = seal_with_ephemeral(&ephemeral_key(), &recipient_pk, &topic, msg, 64).unwrap();
+        let sealed = seal_with_ephemeral(&ephemeral_key(), &recipient_pk, &topic, msg, 96).unwrap();
 
         let enc = ephemeral_key().public_key().to_encoded_point(false);
         let bytes = sealed.to_bytes();
@@ -467,7 +466,7 @@ mod tests {
         let length = usize::from(u16::from_be_bytes(*length));
         assert_eq!(length, msg.len());
         assert_eq!(&rest[..length], msg);
-        assert_eq!(inner.len(), 64 - TAG_SIZE);
+        assert_eq!(inner.len(), 96 - ecdh::ENC_X_SIZE - TAG_SIZE);
     }
 
     #[test]
@@ -510,7 +509,7 @@ mod tests {
         let (recipient_sk, recipient_pk) = recipient_keys();
         let topic = topic();
         let sealed =
-            seal_with_ephemeral(&ephemeral_key(), &recipient_pk, &topic, b"x", 64).unwrap();
+            seal_with_ephemeral(&ephemeral_key(), &recipient_pk, &topic, b"x", 96).unwrap();
         let enc = ephemeral_key().public_key().to_encoded_point(false);
 
         let theirs = reference()
@@ -548,17 +547,17 @@ mod tests {
     }
 
     #[test]
-    fn region_too_small() {
+    fn tail_too_small() {
         let (_, recipient_pk) = recipient_keys();
         let err =
-            seal_with_ephemeral(&ephemeral_key(), &recipient_pk, &topic(), b"", 17).unwrap_err();
-        assert_eq!(err, HpkeSealError::RegionTooSmall { ct_len: 17 });
+            seal_with_ephemeral(&ephemeral_key(), &recipient_pk, &topic(), b"", 49).unwrap_err();
+        assert_eq!(err, HpkeSealError::TailTooSmall { tail_len: 49 });
     }
 
     #[test]
     fn message_too_long() {
         let (_, recipient_pk) = recipient_keys();
-        let err = seal_with_ephemeral(&ephemeral_key(), &recipient_pk, &topic(), &[0u8; 47], 64)
+        let err = seal_with_ephemeral(&ephemeral_key(), &recipient_pk, &topic(), &[0u8; 47], 96)
             .unwrap_err();
         assert_eq!(err, HpkeSealError::MessageTooLong { len: 47, max: 46 });
     }
@@ -567,7 +566,7 @@ mod tests {
     fn off_curve_enc_rejects_cheaply() {
         let (recipient_sk, recipient_pk) = recipient_keys();
         let sealed =
-            seal_with_ephemeral(&ephemeral_key(), &recipient_pk, &topic(), b"msg", 64).unwrap();
+            seal_with_ephemeral(&ephemeral_key(), &recipient_pk, &topic(), b"msg", 96).unwrap();
         let mut bytes = sealed.to_bytes();
         // Find an x that is off-curve for both parities, deterministically.
         let mut x = [0u8; 32];
@@ -588,7 +587,7 @@ mod tests {
     fn exporter_length_bound() {
         let (_, recipient_pk) = recipient_keys();
         let sealed =
-            seal_with_ephemeral(&ephemeral_key(), &recipient_pk, &topic(), b"x", 64).unwrap();
+            seal_with_ephemeral(&ephemeral_key(), &recipient_pk, &topic(), b"x", 96).unwrap();
         let mut too_long = vec![0u8; 32 * 256];
         assert_eq!(
             sealed.extra().export(b"ctx", &mut too_long).unwrap_err(),
@@ -597,7 +596,7 @@ mod tests {
     }
 
     /// Nectar-owned conformance vector in the RFC 9180 appendix shape:
-    /// mode_base, kem 0x0016, kdf 0x0001, aead 0x0003, `ct_len` 64. The
+    /// mode_base, kem 0x0016, kdf 0x0001, aead 0x0003, a 96-byte tail. The
     /// draft KEM has no registry vectors; these pin the whole chain from
     /// scalars to the serialized frame.
     #[test]
@@ -641,7 +640,7 @@ mod tests {
         assert_eq!(schedule.base_nonce, BASE_NONCE);
         assert_eq!(schedule.hint().unwrap(), HINT);
 
-        let sealed = seal_with_ephemeral(&eph, &recipient_pk, &topic, MSG, 64).unwrap();
+        let sealed = seal_with_ephemeral(&eph, &recipient_pk, &topic, MSG, 96).unwrap();
         assert_eq!(sealed.to_bytes(), FRAME);
 
         let envelope = envelope_from(&FRAME);

--- a/crates/envelope/src/hpke.rs
+++ b/crates/envelope/src/hpke.rs
@@ -17,7 +17,7 @@ use subtle::ConstantTimeEq;
 use thiserror::Error;
 use zeroize::Zeroizing;
 
-use super::{Envelope, Hpke, LABEL, OpenError, Opened, Topic, hint_matches};
+use super::{Envelope, Hpke, LABEL, OpenError, Opened, Topic, ecdh, hint_matches};
 #[cfg(any(test, feature = "encryption"))]
 use super::{Recipient, SealedEnvelope};
 
@@ -35,7 +35,7 @@ const TAG_SIZE: usize = 16;
 /// Big-endian length prefix inside the sealed plaintext.
 const LEN_PREFIX: usize = 2;
 /// Smallest admissible ciphertext region.
-const MIN_CT_LEN: usize = TAG_SIZE + LEN_PREFIX;
+pub(super) const MIN_CT_LEN: usize = TAG_SIZE + LEN_PREFIX;
 
 /// Key-derivation context: the domain label followed by the topic.
 #[derive(Debug, Clone, Copy)]
@@ -244,36 +244,50 @@ fn key_schedule(shared: &[u8; 32], topic: &Topic) -> Result<Schedule, ExportErro
     })
 }
 
+/// The KEM shared secret: topic-independent, so one decapsulation serves
+/// every candidate topic.
+pub struct Shared(Zeroizing<[u8; 32]>);
+
+impl core::fmt::Debug for Shared {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("Shared(..)")
+    }
+}
+
 /// Decap once per envelope; `Ok(None)` when `enc_x` is off-curve or the ECDH
 /// output is rejected.
 pub(super) fn decap(
     secret: &SecretKey,
     envelope: &Envelope<'_>,
-) -> Result<Option<Zeroizing<[u8; 32]>>, OpenError> {
-    let Some(enc) = super::reconstruct(envelope.enc_x(), envelope.parity()) else {
+) -> Result<Option<Shared>, OpenError> {
+    let Some((enc, _)) = ecdh::split(envelope) else {
         return Ok(None);
     };
+    #[cfg(test)]
+    crate::decaps::note(super::SchemeId::Hpke);
     let dh = k256::ecdh::diffie_hellman(secret.to_nonzero_scalar(), enc.as_affine());
     let dh_bytes: &[u8] = dh.raw_secret_bytes().as_ref();
     let enc_point = enc.to_encoded_point(false);
     let pkr_point = secret.public_key().to_encoded_point(false);
-    extract_and_expand(dh_bytes, enc_point.as_bytes(), pkr_point.as_bytes())
-        .map_err(|_| OpenError::Internal)
+    let shared = extract_and_expand(dh_bytes, enc_point.as_bytes(), pkr_point.as_bytes())
+        .map_err(|_| OpenError::Internal)?;
+    Ok(shared.map(Shared))
 }
 
 /// Hint probe plus AEAD open for one topic over an established shared
 /// secret; a hint collision fails the tag and falls through as `Ok(None)`.
-pub(super) fn open_with_shared(
-    shared: &Zeroizing<[u8; 32]>,
-    topic: &Topic,
+pub(super) fn probe(
+    shared: &Shared,
+    ctx: Info<'_>,
     envelope: &Envelope<'_>,
 ) -> Result<Option<Opened<Hpke>>, OpenError> {
-    let schedule = key_schedule(shared, topic).map_err(|_| OpenError::Internal)?;
+    let topic = ctx.topic();
+    let schedule = key_schedule(&shared.0, topic).map_err(|_| OpenError::Internal)?;
     let hint = schedule.hint().map_err(|_| OpenError::Internal)?;
     if !hint_matches(&hint, envelope.hint()) {
         return Ok(None);
     }
-    let Some((body, tag)) = envelope.ciphertext().split_last_chunk::<TAG_SIZE>() else {
+    let Some((body, tag)) = ecdh::ciphertext(envelope).split_last_chunk::<TAG_SIZE>() else {
         return Ok(None);
     };
     let cipher = ChaCha20Poly1305::new_from_slice(schedule.key.as_slice())
@@ -295,17 +309,6 @@ pub(super) fn open_with_shared(
         plaintext: message.to_vec(),
         extra: schedule.exporter,
     }))
-}
-
-pub(super) fn open(
-    secret: &SecretKey,
-    ctx: Info<'_>,
-    envelope: &Envelope<'_>,
-) -> Result<Option<Opened<Hpke>>, OpenError> {
-    let Some(shared) = decap(secret, envelope)? else {
-        return Ok(None);
-    };
-    open_with_shared(&shared, ctx.topic(), envelope)
 }
 
 #[cfg(any(test, feature = "encryption"))]
@@ -376,12 +379,11 @@ fn seal_with_ephemeral(
         .map_err(|_| HpkeSealError::Internal)?;
     buf.extend_from_slice(&tag);
 
-    let (enc_x, parity) = super::x_and_parity(&enc);
+    let (tail, nonce_bits) = ecdh::tail(&enc, &buf);
     Ok(SealedEnvelope::from_parts(
         hint,
-        parity,
-        enc_x,
-        buf,
+        nonce_bits,
+        tail,
         schedule.exporter,
     ))
 }
@@ -429,6 +431,15 @@ mod tests {
         Envelope::parse(bytes).unwrap()
     }
 
+    /// Route through the trait's provided decap-then-probe.
+    fn open(
+        secret: &SecretKey,
+        ctx: Info<'_>,
+        envelope: &Envelope<'_>,
+    ) -> Result<Option<Opened<Hpke>>, OpenError> {
+        <Hpke as crate::Scheme>::open(secret, ctx, envelope)
+    }
+
     #[test]
     fn differential_our_seal_reference_open() {
         let (recipient_sk, recipient_pk) = recipient_keys();
@@ -445,7 +456,7 @@ mod tests {
                 &recipient_sk.to_bytes().to_vec().into(),
                 &info_bytes(&topic),
                 b"",
-                envelope.ciphertext(),
+                ecdh::ciphertext(&envelope),
                 None,
                 None,
                 None,
@@ -560,9 +571,7 @@ mod tests {
         let mut bytes = sealed.to_bytes();
         // Find an x that is off-curve for both parities, deterministically.
         let mut x = [0u8; 32];
-        while super::super::reconstruct(&x, false).is_some()
-            || super::super::reconstruct(&x, true).is_some()
-        {
+        while ecdh::reconstruct(&x, false).is_some() || ecdh::reconstruct(&x, true).is_some() {
             x[31] = x[31].wrapping_add(1);
         }
         bytes[40..72].copy_from_slice(&x);

--- a/crates/envelope/src/lib.rs
+++ b/crates/envelope/src/lib.rs
@@ -1,10 +1,13 @@
 //! Sealed envelopes over the frozen ecies compat baseline.
 //!
 //! Two sealed schemes share one frozen frame inside the chunk payload:
-//! `hint[0..8] || nonce[8..40] || enc_x[40..72] || ct[72..]`. Compat is the
-//! byte-frozen [`crate::ecies`] construction; HPKE is RFC 9180 with the
-//! single suite DHKEM(secp256k1, HKDF-SHA256) + HKDF-SHA256 +
-//! ChaCha20-Poly1305 under the domain label `nectar/env/v1`.
+//! `hint[0..8] || nonce[8..40] || tail[40..]`. Only the hint and the nonce
+//! are frozen, because they are the fields the network itself touches: topic
+//! gating and mining. The tail is scheme-owned opaque bytes, and both
+//! shipped schemes lay it out as `enc_x || ct`. Compat is the byte-frozen
+//! [`crate::ecies`] construction; HPKE is RFC 9180 with the single suite
+//! DHKEM(secp256k1, HKDF-SHA256) + HKDF-SHA256 + ChaCha20-Poly1305 under the
+//! domain label `nectar/env/v1`.
 //!
 //! No nectar crate reads or writes this frame yet, so the crate is unstable:
 //! the KEM, the frame and this API may change without a major version until a
@@ -25,12 +28,13 @@
 //! without the hint gate is a partitioning oracle.
 //!
 //! `enc` travels x-only; the low bit of `nonce[0]` carries the ephemeral y
-//! parity in both schemes (miners hold it fixed). HPKE reconstructs
-//! canonical uncompressed SEC1 before `kem_context`; compat ECDH ignores
-//! parity, so a flipped bit is an authenticated decap failure (DoS only)
-//! under HPKE and a no-op for compat. Envelopes of both schemes are
-//! curve-membership-detectable against uniform bytes: the anonymity set is
-//! trojan chunks, at exact parity with the deployed compat path.
+//! parity in both schemes (miners hold it fixed, see [`Scheme::NONCE_KEEP`]).
+//! HPKE reconstructs canonical uncompressed SEC1 before `kem_context`;
+//! compat ECDH ignores parity, so a flipped bit is an authenticated decap
+//! failure (DoS only) under HPKE and a no-op for compat. Envelopes of both
+//! schemes are curve-membership-detectable against uniform bytes: the
+//! anonymity set is trojan chunks, at exact parity with the deployed compat
+//! path.
 //!
 //! The reference client places that bit elsewhere: it mines `nonce[28]` and
 //! reads it back as `chunkData[36]`. Neither side breaks, because compat ECDH
@@ -38,11 +42,11 @@
 //! is a bitwise or, so always true). It matters only to a future scheme that
 //! makes parity load-bearing on the compat frame.
 //!
-//! Trial order: decap once per envelope (after chunk validity and
-//! proof-of-work checks; that per-valid-chunk cost is inherent), one hint
-//! probe per candidate topic, AEAD open only on a hint match. HKDF-SHA256
-//! deliberately adds SHA-256 beside the otherwise keccak-only proving
-//! surface.
+//! Trial order: [`Scheme::decap`] once per envelope per scheme (after chunk
+//! validity and proof-of-work checks; that per-valid-chunk cost is
+//! inherent), one [`Scheme::probe`] per candidate topic, AEAD open only on a
+//! hint match. HKDF-SHA256 deliberately adds SHA-256 beside the otherwise
+//! keccak-only proving surface.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(
@@ -64,9 +68,8 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 use core::fmt;
-use core::marker::PhantomData;
 
-use k256::{PublicKey, SecretKey};
+use k256::SecretKey;
 use nectar_primitives::chunk::encryption::EncryptionKey;
 use subtle::ConstantTimeEq;
 use thiserror::Error;
@@ -75,11 +78,17 @@ use crate::ecies::{EciesError, Salt};
 
 mod attestation;
 mod compat;
+mod ecdh;
 pub mod ecies;
 mod hpke;
 
-pub use attestation::{ATTESTATION_PREFIX, AttestationError, RecipientAttestation, sign_data};
-pub use hpke::{DeriveKeyPairError, ExportError, Exporter, HpkeSealError, Info, derive_key_pair};
+pub use attestation::{
+    ATTESTATION_PREFIX, AttestationError, Attested, AttestedRecipient, AttestedScheme,
+    RecipientAttestation, SchemeEntry, VerifiedAttestation, sign_data,
+};
+pub use hpke::{
+    DeriveKeyPairError, ExportError, Exporter, HpkeSealError, Info, Shared, derive_key_pair,
+};
 
 /// Domain label of the HPKE suite.
 pub const LABEL: &[u8] = b"nectar/env/v1";
@@ -88,17 +97,118 @@ pub const LABEL: &[u8] = b"nectar/env/v1";
 pub const HINT_SIZE: usize = 8;
 /// Byte length of the mining nonce slot.
 pub const NONCE_SIZE: usize = 32;
-/// Byte length of the x-only ephemeral slot.
-pub const ENC_X_SIZE: usize = 32;
-/// Byte length of the frame header preceding the ciphertext region.
-pub const HEADER_SIZE: usize = HINT_SIZE + NONCE_SIZE + ENC_X_SIZE;
+/// Byte length of the frozen header preceding the scheme-owned tail.
+pub const HEADER_SIZE: usize = HINT_SIZE + NONCE_SIZE;
 
 mod sealed {
     pub trait Sealed {}
-    impl Sealed for super::Compat {}
-    impl Sealed for super::Hpke {}
-    impl Sealed for super::HpkeOnly {}
-    impl Sealed for super::HpkeThenCompat {}
+    impl Sealed for super::Refuse {}
+    impl<S: super::Scheme, Rest: super::Policy> Sealed for super::Try<S, Rest> {}
+}
+
+/// Declare the scheme list once; the edge unions follow from it.
+macro_rules! schemes {
+    ($($scheme:ident => $seal_error:ty),+ $(,)?) => {
+        /// Scheme label reported in open results; never a dispatcher.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        pub enum SchemeId {
+            $(
+                #[doc = concat!("[`", stringify!($scheme), "`].")]
+                $scheme,
+            )+
+        }
+
+        $(impl sealed::Sealed for $scheme {})+
+
+        /// Erased inbox delivery; match once at the edge.
+        #[derive(Debug)]
+        pub enum InboxOpened {
+            $(
+                #[doc = concat!("Opened under [`", stringify!($scheme), "`].")]
+                $scheme(Opened<$scheme>),
+            )+
+        }
+
+        impl InboxOpened {
+            /// Which scheme delivered.
+            #[must_use]
+            pub const fn scheme(&self) -> SchemeId {
+                match self {
+                    $(Self::$scheme(_) => SchemeId::$scheme,)+
+                }
+            }
+        }
+
+        /// Edge-only recipient union for heterogeneous collections; matches
+        /// once and calls the monomorphized path, never enters the seam.
+        #[derive(Debug, Clone)]
+        pub enum AnyRecipient {
+            $(
+                #[doc = concat!("A [`", stringify!($scheme), "`] recipient.")]
+                $scheme(Recipient<$scheme>),
+            )+
+        }
+
+        /// Erased sealed envelope from [`AnyRecipient::seal`].
+        #[derive(Debug)]
+        pub enum AnySealed {
+            $(
+                #[doc = concat!("Sealed under [`", stringify!($scheme), "`].")]
+                $scheme(SealedEnvelope<$scheme>),
+            )+
+        }
+
+        impl AnySealed {
+            /// Which scheme sealed.
+            #[must_use]
+            pub const fn scheme(&self) -> SchemeId {
+                match self {
+                    $(Self::$scheme(_) => SchemeId::$scheme,)+
+                }
+            }
+
+            /// Serialize the frozen frame.
+            #[must_use]
+            pub fn to_bytes(&self) -> Vec<u8> {
+                match self {
+                    $(Self::$scheme(envelope) => envelope.to_bytes(),)+
+                }
+            }
+        }
+
+        /// Errors from [`AnyRecipient::seal`].
+        #[non_exhaustive]
+        #[derive(Debug, Error)]
+        pub enum AnySealError {
+            $(
+                #[doc = concat!("The [`", stringify!($scheme), "`] seal failed.")]
+                #[error(transparent)]
+                $scheme(#[from] $seal_error),
+            )+
+        }
+
+        #[cfg(any(test, feature = "encryption"))]
+        impl AnyRecipient {
+            /// Seal toward this recipient, scheme inferred from the handle.
+            pub fn seal(
+                &self,
+                topic: &Topic,
+                plaintext: &[u8],
+                ct_len: usize,
+            ) -> Result<AnySealed, AnySealError> {
+                match self {
+                    $(Self::$scheme(recipient) => Ok(AnySealed::$scheme(
+                        $scheme::seal(recipient, topic.into(), plaintext, ct_len)?,
+                    )),)+
+                }
+            }
+        }
+    };
+}
+
+schemes! {
+    Hpke => HpkeSealError,
+    Compat => EciesError,
 }
 
 /// 32-byte topic an envelope is addressed under.
@@ -131,19 +241,20 @@ impl<'a> From<&'a Topic> for Salt<'a> {
     }
 }
 
-/// Scheme label reported in open results; never a dispatcher.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SchemeId {
-    /// The frozen reference-client construction.
-    Compat,
-    /// RFC 9180 HPKE.
-    Hpke,
-}
-
-/// One of the two sealing schemes; sealed, dispatch rides the type.
+/// One of the sealing schemes; sealed, dispatch rides the type.
+///
+/// Admission rule for a new scheme: its tail must be indistinguishable from
+/// the existing tail distribution to an observer without the recipient key,
+/// and the hint stays 8 bytes, or the anonymity set forks.
 pub trait Scheme: sealed::Sealed + Sized {
+    /// Key an envelope is sealed toward.
+    type PublicKey: Clone + fmt::Debug;
+    /// Key an envelope is opened with.
+    type SecretKey;
     /// Per-scheme key-derivation context built from a topic.
     type Context<'a>: From<&'a Topic>;
+    /// Topic-independent product of one decapsulation.
+    type Decap;
     /// Scheme-specific by-product of a seal or open.
     type Extra: fmt::Debug;
     /// Proof carried by a [`Recipient`] of how it was minted.
@@ -151,13 +262,15 @@ pub trait Scheme: sealed::Sealed + Sized {
     /// Errors from sealing.
     type SealError: core::error::Error;
 
-    /// AEAD tag bytes spent inside the ciphertext region.
-    const TAG: usize;
     /// Report label for open results.
     const ID: SchemeId;
+    /// Tail bytes that carry no payload: encapsulation plus any framing.
+    const OVERHEAD: usize;
+    /// Bits of `nonce[0]` the scheme owns; a miner keeps them fixed.
+    const NONCE_KEEP: u8;
 
-    /// Seal `plaintext` toward `recipient` into a `ct_len`-byte ciphertext
-    /// region.
+    /// Seal `plaintext` toward `recipient`; the tail is the encapsulation
+    /// followed by a `ct_len`-byte ciphertext region.
     #[cfg(any(test, feature = "encryption"))]
     fn seal(
         recipient: &Recipient<Self>,
@@ -166,13 +279,34 @@ pub trait Scheme: sealed::Sealed + Sized {
         ct_len: usize,
     ) -> Result<SealedEnvelope<Self>, Self::SealError>;
 
-    /// Try to open `envelope` under `secret` for one context. `Ok(None)`
-    /// means it is not recognized under this scheme and context.
-    fn open(
-        secret: &SecretKey,
+    /// Decapsulate once per envelope. `Ok(None)` rejects the tail outright.
+    fn decap(
+        secret: &Self::SecretKey,
+        envelope: &Envelope<'_>,
+    ) -> Result<Option<Self::Decap>, OpenError>;
+
+    /// Probe one context against an established decapsulation. `Ok(None)`
+    /// means the envelope is not addressed under this scheme and context.
+    fn probe(
+        decap: &Self::Decap,
         ctx: Self::Context<'_>,
         envelope: &Envelope<'_>,
     ) -> Result<Option<Opened<Self>>, OpenError>;
+
+    /// Inject into the edge union.
+    fn erase(opened: Opened<Self>) -> InboxOpened;
+
+    /// Decap then probe for a single context.
+    fn open(
+        secret: &Self::SecretKey,
+        ctx: Self::Context<'_>,
+        envelope: &Envelope<'_>,
+    ) -> Result<Option<Opened<Self>>, OpenError> {
+        let Some(decap) = Self::decap(secret, envelope)? else {
+            return Ok(None);
+        };
+        Self::probe(&decap, ctx, envelope)
+    }
 }
 
 /// The frozen reference-client construction, adapted over [`crate::ecies`].
@@ -201,17 +335,6 @@ impl InteropReason {
     }
 }
 
-/// Proof that a [`Recipient<Hpke>`] came from a verified
-/// [`RecipientAttestation`]; not constructible outside this crate.
-#[derive(Clone)]
-pub struct Attested(());
-
-impl fmt::Debug for Attested {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("Attested")
-    }
-}
-
 /// Sealing handle for one recipient key under one scheme.
 ///
 /// Upgrade is one-way: no conversion between schemes exists in either
@@ -227,14 +350,14 @@ impl fmt::Debug for Attested {
 /// ```
 #[derive(Clone)]
 pub struct Recipient<S: Scheme> {
-    key: PublicKey,
+    key: S::PublicKey,
     provenance: S::Provenance,
 }
 
 impl<S: Scheme> Recipient<S> {
     /// The recipient public key.
     #[must_use]
-    pub const fn key(&self) -> &PublicKey {
+    pub const fn key(&self) -> &S::PublicKey {
         &self.key
     }
 }
@@ -252,7 +375,7 @@ impl Recipient<Compat> {
     /// The one sanctioned downgrade path: address a reader that only speaks
     /// the reference construction.
     #[must_use]
-    pub const fn assume_reference(key: PublicKey, reason: InteropReason) -> Self {
+    pub const fn assume_reference(key: k256::PublicKey, reason: InteropReason) -> Self {
         Self {
             key,
             provenance: reason,
@@ -268,11 +391,14 @@ impl Recipient<Compat> {
 
 impl Recipient<Hpke> {
     /// Mint from a verified attestation; the only construction path.
-    pub(crate) const fn attested(key: PublicKey) -> Self {
-        Self {
-            key,
-            provenance: Attested(()),
-        }
+    pub(crate) const fn attested(key: k256::PublicKey, provenance: Attested) -> Self {
+        Self { key, provenance }
+    }
+
+    /// How this recipient was attested.
+    #[must_use]
+    pub const fn provenance(&self) -> &Attested {
+        &self.provenance
     }
 }
 
@@ -289,29 +415,20 @@ pub struct EnvelopeTooShort {
 pub struct Envelope<'a> {
     hint: &'a [u8; HINT_SIZE],
     nonce: &'a [u8; NONCE_SIZE],
-    enc_x: &'a [u8; ENC_X_SIZE],
-    ct: &'a [u8],
+    tail: &'a [u8],
 }
 
 impl<'a> Envelope<'a> {
-    /// Split a chunk payload into the frame fields.
+    /// Split a chunk payload into the frozen header and the scheme tail.
     pub const fn parse(payload: &'a [u8]) -> Result<Self, EnvelopeTooShort> {
         let got = payload.len();
         let Some((hint, rest)) = payload.split_first_chunk::<HINT_SIZE>() else {
             return Err(EnvelopeTooShort { got });
         };
-        let Some((nonce, rest)) = rest.split_first_chunk::<NONCE_SIZE>() else {
+        let Some((nonce, tail)) = rest.split_first_chunk::<NONCE_SIZE>() else {
             return Err(EnvelopeTooShort { got });
         };
-        let Some((enc_x, ct)) = rest.split_first_chunk::<ENC_X_SIZE>() else {
-            return Err(EnvelopeTooShort { got });
-        };
-        Ok(Self {
-            hint,
-            nonce,
-            enc_x,
-            ct,
-        })
+        Ok(Self { hint, nonce, tail })
     }
 
     /// The hint slot.
@@ -326,23 +443,10 @@ impl<'a> Envelope<'a> {
         self.nonce
     }
 
-    /// The x-only ephemeral slot.
+    /// The scheme-owned tail.
     #[must_use]
-    pub const fn enc_x(&self) -> &[u8; ENC_X_SIZE] {
-        self.enc_x
-    }
-
-    /// The ciphertext region.
-    #[must_use]
-    pub const fn ciphertext(&self) -> &'a [u8] {
-        self.ct
-    }
-
-    /// Ephemeral y parity carried in the low bit of `nonce[0]`.
-    #[must_use]
-    pub const fn parity(&self) -> bool {
-        let [first, ..] = self.nonce;
-        *first & 1 == 1
+    pub const fn tail(&self) -> &'a [u8] {
+        self.tail
     }
 }
 
@@ -381,49 +485,45 @@ pub enum OpenError {
 pub struct SealedEnvelope<S: Scheme> {
     hint: [u8; HINT_SIZE],
     nonce: [u8; NONCE_SIZE],
-    enc_x: [u8; ENC_X_SIZE],
-    ct: Vec<u8>,
+    tail: Vec<u8>,
     extra: S::Extra,
 }
 
 impl<S: Scheme> SealedEnvelope<S> {
     #[cfg(any(test, feature = "encryption"))]
-    pub(crate) fn from_parts(
+    pub(crate) const fn from_parts(
         hint: [u8; HINT_SIZE],
-        parity: bool,
-        enc_x: [u8; ENC_X_SIZE],
-        ct: Vec<u8>,
+        nonce_bits: u8,
+        tail: Vec<u8>,
         extra: S::Extra,
     ) -> Self {
         let mut nonce = [0u8; NONCE_SIZE];
         let [first, ..] = &mut nonce;
-        *first = u8::from(parity);
+        *first = nonce_bits & S::NONCE_KEEP;
         Self {
             hint,
             nonce,
-            enc_x,
-            ct,
+            tail,
             extra,
         }
     }
 
-    /// Replace the mining nonce; the parity bit is reasserted.
+    /// Replace the mining nonce; the scheme-owned bits are reasserted.
     pub const fn set_nonce(&mut self, mut nonce: [u8; NONCE_SIZE]) {
         let [current, ..] = &self.nonce;
-        let parity = *current & 1;
+        let kept = *current & S::NONCE_KEEP;
         let [first, ..] = &mut nonce;
-        *first = (*first & 0xfe) | parity;
+        *first = (*first & !S::NONCE_KEEP) | kept;
         self.nonce = nonce;
     }
 
     /// Serialize the frozen frame.
     #[must_use]
     pub fn to_bytes(&self) -> Vec<u8> {
-        let mut out = Vec::with_capacity(HEADER_SIZE.saturating_add(self.ct.len()));
+        let mut out = Vec::with_capacity(HEADER_SIZE.saturating_add(self.tail.len()));
         out.extend_from_slice(&self.hint);
         out.extend_from_slice(&self.nonce);
-        out.extend_from_slice(&self.enc_x);
-        out.extend_from_slice(&self.ct);
+        out.extend_from_slice(&self.tail);
         out
     }
 
@@ -444,7 +544,7 @@ impl<S: Scheme> fmt::Debug for SealedEnvelope<S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SealedEnvelope")
             .field("scheme", &S::ID)
-            .field("ct_len", &self.ct.len())
+            .field("tail_len", &self.tail.len())
             .finish_non_exhaustive()
     }
 }
@@ -454,43 +554,109 @@ pub(crate) fn hint_matches(derived: &[u8; HINT_SIZE], carried: &[u8; HINT_SIZE])
     derived.ct_eq(carried).into()
 }
 
-/// Delivery policy of an [`Inbox`]; sealed.
-pub trait Policy: sealed::Sealed {
-    /// Whether compat probes are admitted after the HPKE pass.
-    const COMPAT: bool;
+/// Delivery policy of an [`Inbox`]: a keyed cons list of schemes to try, in
+/// order, each cell owning its own scheme's secret.
+pub trait Policy: sealed::Sealed + fmt::Debug {
+    /// Try each cell in turn; at most one decapsulation per scheme.
+    fn deliver(
+        &self,
+        topics: &[Topic],
+        envelope: &Envelope<'_>,
+    ) -> Result<Option<(Topic, InboxOpened)>, OpenError>;
+}
+
+/// Terminal cell: matches nothing.
+#[derive(Debug, Clone, Copy)]
+pub struct Refuse;
+
+impl Policy for Refuse {
+    fn deliver(
+        &self,
+        _topics: &[Topic],
+        _envelope: &Envelope<'_>,
+    ) -> Result<Option<(Topic, InboxOpened)>, OpenError> {
+        Ok(None)
+    }
+}
+
+/// Cons cell: try `S` under its own secret, then `Rest`.
+pub struct Try<S: Scheme, Rest: Policy = Refuse> {
+    secret: S::SecretKey,
+    rest: Rest,
+}
+
+impl<S: Scheme> Try<S> {
+    /// A single-scheme policy.
+    #[must_use]
+    pub const fn new(secret: S::SecretKey) -> Self {
+        Self {
+            secret,
+            rest: Refuse,
+        }
+    }
+}
+
+impl<S: Scheme, Rest: Policy> Try<S, Rest> {
+    /// Prepend `S` to an existing policy.
+    #[must_use]
+    pub const fn with(secret: S::SecretKey, rest: Rest) -> Self {
+        Self { secret, rest }
+    }
+
+    /// The secret this cell opens with.
+    #[must_use]
+    pub const fn secret(&self) -> &S::SecretKey {
+        &self.secret
+    }
+}
+
+impl Try<Hpke> {
+    /// Append the compat cell; compat opens under its own secret.
+    #[must_use]
+    pub fn then_compat(self, secret: SecretKey) -> HpkeThenCompat {
+        Try::with(self.secret, Try::new(secret))
+    }
+}
+
+impl<S: Scheme, Rest: Policy> fmt::Debug for Try<S, Rest> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Try")
+            .field("scheme", &S::ID)
+            .field("rest", &self.rest)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<S: Scheme, Rest: Policy> Policy for Try<S, Rest> {
+    fn deliver(
+        &self,
+        topics: &[Topic],
+        envelope: &Envelope<'_>,
+    ) -> Result<Option<(Topic, InboxOpened)>, OpenError> {
+        if let Some(decap) = S::decap(&self.secret, envelope)? {
+            for topic in topics {
+                if let Some(opened) = S::probe(&decap, topic.into(), envelope)? {
+                    return Ok(Some((*topic, S::erase(opened))));
+                }
+            }
+        }
+        self.rest.deliver(topics, envelope)
+    }
 }
 
 /// HPKE-only delivery: compat hints are never computed, so compat envelopes
 /// are undeliverable outright.
-#[derive(Debug, Clone, Copy)]
-pub enum HpkeOnly {}
-
-impl Policy for HpkeOnly {
-    const COMPAT: bool = false;
-}
+pub type HpkeOnly = Try<Hpke>;
 
 /// Strictly transitional delivery: HPKE first, compat probes after.
 /// Forbidden for peers pinned HPKE-capable: compat is an unauthenticated
 /// stream cipher. Neither scheme authenticates the sender: HPKE runs base mode.
-#[derive(Debug, Clone, Copy)]
-pub enum HpkeThenCompat {}
+pub type HpkeThenCompat = Try<Hpke, Try<Compat>>;
 
-impl Policy for HpkeThenCompat {
-    const COMPAT: bool = true;
-}
-
-/// Trial-decrypt driver for one recipient secret under a delivery policy.
+/// Trial-decrypt driver for one delivery policy.
+#[derive(Debug)]
 pub struct Inbox<P: Policy> {
-    secret: SecretKey,
-    _policy: PhantomData<P>,
-}
-
-impl<P: Policy> fmt::Debug for Inbox<P> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Inbox")
-            .field("compat", &P::COMPAT)
-            .finish_non_exhaustive()
-    }
+    policy: P,
 }
 
 impl Inbox<HpkeOnly> {
@@ -498,172 +664,77 @@ impl Inbox<HpkeOnly> {
     #[must_use]
     pub const fn new(secret: SecretKey) -> Self {
         Self {
-            secret,
-            _policy: PhantomData,
+            policy: Try::new(secret),
         }
     }
 }
 
 impl Inbox<HpkeThenCompat> {
-    /// Transitional inbox for `secret`; flip to [`HpkeOnly`] the moment
-    /// the peer set is confirmed HPKE-capable.
+    /// Transitional inbox; flip to [`HpkeOnly`] the moment the peer set is
+    /// confirmed HPKE-capable.
     #[must_use]
-    pub const fn transitional(secret: SecretKey) -> Self {
+    pub fn transitional(hpke: SecretKey, compat: SecretKey) -> Self {
         Self {
-            secret,
-            _policy: PhantomData,
+            policy: Try::new(hpke).then_compat(compat),
         }
     }
 }
 
 impl<P: Policy> Inbox<P> {
-    /// Trial-open `envelope` against `topics`: one decap, an HPKE hint
-    /// probe per topic, then compat probes where the policy admits them.
+    /// Drive an arbitrary policy.
+    #[must_use]
+    pub const fn with_policy(policy: P) -> Self {
+        Self { policy }
+    }
+
+    /// Trial-open `envelope` against `topics` under the policy order.
     pub fn open(
         &self,
         topics: &[Topic],
         envelope: &Envelope<'_>,
     ) -> Result<Option<(Topic, InboxOpened)>, OpenError> {
-        if let Some(shared) = hpke::decap(&self.secret, envelope)? {
-            for topic in topics {
-                if let Some(opened) = hpke::open_with_shared(&shared, topic, envelope)? {
-                    return Ok(Some((*topic, InboxOpened::Hpke(opened))));
-                }
-            }
-        }
-        if P::COMPAT {
-            for topic in topics {
-                if let Some(opened) = Compat::open(&self.secret, topic.into(), envelope)? {
-                    return Ok(Some((*topic, InboxOpened::Compat(opened))));
-                }
-            }
-        }
-        Ok(None)
+        self.policy.deliver(topics, envelope)
     }
 }
 
-/// Erased inbox delivery; match once at the edge.
-#[derive(Debug)]
-pub enum InboxOpened {
-    /// Opened under HPKE.
-    Hpke(Opened<Hpke>),
-    /// Opened under compat.
-    Compat(Opened<Compat>),
-}
+/// Decapsulation counter behind the decap-once law.
+#[cfg(test)]
+pub(crate) mod decaps {
+    use super::SchemeId;
+    use core::cell::Cell;
 
-impl InboxOpened {
-    /// Which scheme delivered.
-    #[must_use]
-    pub const fn scheme(&self) -> SchemeId {
-        match self {
-            Self::Hpke(_) => SchemeId::Hpke,
-            Self::Compat(_) => SchemeId::Compat,
-        }
+    std::thread_local! {
+        static COUNT: Cell<(usize, usize)> = const { Cell::new((0, 0)) };
+    }
+
+    pub(crate) fn note(id: SchemeId) {
+        COUNT.with(|count| {
+            let (hpke, compat) = count.get();
+            count.set(match id {
+                SchemeId::Hpke => (hpke + 1, compat),
+                SchemeId::Compat => (hpke, compat + 1),
+            });
+        });
+    }
+
+    /// Counts since the last call, as `(hpke, compat)`.
+    pub(crate) fn take() -> (usize, usize) {
+        COUNT.with(|count| count.replace((0, 0)))
     }
 }
 
-/// Edge-only recipient union for heterogeneous collections; matches once
-/// and calls the monomorphized path, never enters the seam.
-#[derive(Debug, Clone)]
-pub enum AnyRecipient {
-    /// An attested HPKE recipient.
-    Hpke(Recipient<Hpke>),
-    /// A justified compat recipient.
-    Compat(Recipient<Compat>),
-}
-
-/// Erased sealed envelope from [`AnyRecipient::seal`].
-#[derive(Debug)]
-pub enum AnySealed {
-    /// Sealed under HPKE.
-    Hpke(SealedEnvelope<Hpke>),
-    /// Sealed under compat.
-    Compat(SealedEnvelope<Compat>),
-}
-
-impl AnySealed {
-    /// Which scheme sealed.
-    #[must_use]
-    pub const fn scheme(&self) -> SchemeId {
-        match self {
-            Self::Hpke(_) => SchemeId::Hpke,
-            Self::Compat(_) => SchemeId::Compat,
-        }
-    }
-
-    /// Serialize the frozen frame.
-    #[must_use]
-    pub fn to_bytes(&self) -> Vec<u8> {
-        match self {
-            Self::Hpke(envelope) => envelope.to_bytes(),
-            Self::Compat(envelope) => envelope.to_bytes(),
-        }
-    }
-}
-
-/// Errors from [`AnyRecipient::seal`].
-#[derive(Debug, Error)]
-pub enum AnySealError {
-    /// The HPKE seal failed.
-    #[error(transparent)]
-    Hpke(#[from] HpkeSealError),
-    /// The compat seal failed.
-    #[error(transparent)]
-    Compat(#[from] EciesError),
-}
-
-#[cfg(any(test, feature = "encryption"))]
-impl AnyRecipient {
-    /// Seal toward this recipient, scheme inferred from the handle.
-    pub fn seal(
-        &self,
-        topic: &Topic,
-        plaintext: &[u8],
-        ct_len: usize,
-    ) -> Result<AnySealed, AnySealError> {
-        match self {
-            Self::Hpke(recipient) => Ok(AnySealed::Hpke(Hpke::seal(
-                recipient,
-                topic.into(),
-                plaintext,
-                ct_len,
-            )?)),
-            Self::Compat(recipient) => Ok(AnySealed::Compat(Compat::seal(
-                recipient,
-                topic.into(),
-                plaintext,
-                ct_len,
-            )?)),
-        }
-    }
-}
-
-/// Split a public key into its x coordinate and y parity.
-#[cfg(any(test, feature = "encryption"))]
-pub(crate) fn x_and_parity(key: &PublicKey) -> ([u8; 32], bool) {
-    use k256::elliptic_curve::point::AffineCoordinates;
-    let affine = key.as_affine();
-    (affine.x().into(), affine.y_is_odd().into())
-}
-
-/// Reconstruct a public key from an x-only slot and a parity bit.
-pub(crate) fn reconstruct(enc_x: &[u8; ENC_X_SIZE], parity: bool) -> Option<PublicKey> {
-    let mut sec1 = [0u8; 33];
-    let [tag, x @ ..] = &mut sec1;
-    *tag = if parity { 0x03 } else { 0x02 };
-    *x = *enc_x;
-    PublicKey::from_sec1_bytes(&sec1).ok()
-}
-
-// Compat has no extra beyond the derived key; keep the association explicit.
 impl Scheme for Compat {
+    type PublicKey = k256::PublicKey;
+    type SecretKey = SecretKey;
     type Context<'a> = Salt<'a>;
+    type Decap = ecies::SharedX;
     type Extra = EncryptionKey;
     type Provenance = InteropReason;
     type SealError = EciesError;
 
-    const TAG: usize = 0;
     const ID: SchemeId = SchemeId::Compat;
+    const OVERHEAD: usize = ecdh::ENC_X_SIZE;
+    const NONCE_KEEP: u8 = ecdh::PARITY;
 
     #[cfg(any(test, feature = "encryption"))]
     fn seal(
@@ -675,23 +746,38 @@ impl Scheme for Compat {
         compat::seal(recipient, ctx, plaintext, ct_len)
     }
 
-    fn open(
-        secret: &SecretKey,
+    fn decap(
+        secret: &Self::SecretKey,
+        envelope: &Envelope<'_>,
+    ) -> Result<Option<Self::Decap>, OpenError> {
+        compat::decap(secret, envelope)
+    }
+
+    fn probe(
+        decap: &Self::Decap,
         ctx: Self::Context<'_>,
         envelope: &Envelope<'_>,
     ) -> Result<Option<Opened<Self>>, OpenError> {
-        compat::open(secret, ctx, envelope)
+        compat::probe(decap, ctx, envelope)
+    }
+
+    fn erase(opened: Opened<Self>) -> InboxOpened {
+        InboxOpened::Compat(opened)
     }
 }
 
 impl Scheme for Hpke {
+    type PublicKey = k256::PublicKey;
+    type SecretKey = SecretKey;
     type Context<'a> = Info<'a>;
+    type Decap = Shared;
     type Extra = Exporter;
     type Provenance = Attested;
     type SealError = HpkeSealError;
 
-    const TAG: usize = 16;
     const ID: SchemeId = SchemeId::Hpke;
+    const OVERHEAD: usize = ecdh::ENC_X_SIZE + hpke::MIN_CT_LEN;
+    const NONCE_KEEP: u8 = ecdh::PARITY;
 
     #[cfg(any(test, feature = "encryption"))]
     fn seal(
@@ -703,12 +789,23 @@ impl Scheme for Hpke {
         hpke::seal(recipient, ctx, plaintext, ct_len)
     }
 
-    fn open(
-        secret: &SecretKey,
+    fn decap(
+        secret: &Self::SecretKey,
+        envelope: &Envelope<'_>,
+    ) -> Result<Option<Self::Decap>, OpenError> {
+        hpke::decap(secret, envelope)
+    }
+
+    fn probe(
+        decap: &Self::Decap,
         ctx: Self::Context<'_>,
         envelope: &Envelope<'_>,
     ) -> Result<Option<Opened<Self>>, OpenError> {
-        hpke::open(secret, ctx, envelope)
+        hpke::probe(decap, ctx, envelope)
+    }
+
+    fn erase(opened: Opened<Self>) -> InboxOpened {
+        InboxOpened::Hpke(opened)
     }
 }
 
@@ -716,6 +813,7 @@ impl Scheme for Hpke {
 mod tests {
     use super::*;
     use alloy_primitives::keccak256;
+    use k256::PublicKey;
 
     use crate::ecies;
 
@@ -730,11 +828,16 @@ mod tests {
     }
 
     fn hpke_recipient(key: PublicKey) -> Recipient<Hpke> {
-        Recipient::attested(key)
+        Recipient::attested(key, Attested::new(AttestedScheme::Hpke, 0))
     }
 
     fn compat_recipient(key: PublicKey) -> Recipient<Compat> {
         Recipient::assume_reference(key, InteropReason::new("seam test"))
+    }
+
+    /// Total frame length for a scheme tail carrying `ct_len` ciphertext.
+    fn framed(ct_len: usize) -> usize {
+        HEADER_SIZE + ecdh::ENC_X_SIZE + ct_len
     }
 
     #[test]
@@ -744,7 +847,7 @@ mod tests {
         let msg = b"seam roundtrip";
         let sealed = Hpke::seal(&hpke_recipient(public), (&topic).into(), msg, 4024).unwrap();
         let bytes = sealed.to_bytes();
-        assert_eq!(bytes.len(), HEADER_SIZE + 4024);
+        assert_eq!(bytes.len(), framed(4024));
 
         let envelope = Envelope::parse(&bytes).unwrap();
         let opened = Hpke::open(&secret, (&topic).into(), &envelope)
@@ -781,7 +884,7 @@ mod tests {
         let msg = b"compat roundtrip";
         let sealed = Compat::seal(&compat_recipient(public), (&topic).into(), msg, 100).unwrap();
         let bytes = sealed.to_bytes();
-        assert_eq!(bytes.len(), HEADER_SIZE + 100);
+        assert_eq!(bytes.len(), framed(100));
 
         let envelope = Envelope::parse(&bytes).unwrap();
         let opened = Compat::open(&secret, (&topic).into(), &envelope)
@@ -791,17 +894,14 @@ mod tests {
         assert_eq!(opened.plaintext.len(), 100);
 
         // The adapter is byte-for-byte the frozen construction.
-        let ephemeral = reconstruct(envelope.enc_x(), envelope.parity()).unwrap();
+        let (ephemeral, ct) = ecdh::split(&envelope).unwrap();
         let key = ecies::shared_key(&secret, &ephemeral, (&topic).into());
         assert_eq!(key, opened.extra);
         assert_eq!(
             ecies::Hint::derive(&key, (&topic).into()).as_bytes(),
             envelope.hint()
         );
-        assert_eq!(
-            ecies::decrypt(&key, envelope.ciphertext()),
-            opened.plaintext
-        );
+        assert_eq!(ecies::decrypt(&key, ct), opened.plaintext);
     }
 
     #[test]
@@ -840,7 +940,7 @@ mod tests {
         assert!(inbox.open(&[topic], &envelope).unwrap().is_none());
 
         // The transitional inbox still delivers it, reported as compat.
-        let inbox = Inbox::<HpkeThenCompat>::transitional(secret);
+        let inbox = Inbox::<HpkeThenCompat>::transitional(secret.clone(), secret);
         let (delivered_topic, opened) = inbox.open(&[topic], &envelope).unwrap().unwrap();
         assert_eq!(delivered_topic, topic);
         assert_eq!(opened.scheme(), SchemeId::Compat);
@@ -865,6 +965,32 @@ mod tests {
         assert_eq!(opened.plaintext, b"m");
     }
 
+    /// The decap-once law: candidate topics cost probes, never decaps.
+    #[test]
+    fn decap_runs_once_per_scheme_regardless_of_topic_count() {
+        let (secret, public) = keys(b"nectar envelope seam recipient");
+        let topic = topic();
+        let mut topics: Vec<Topic> = (0u8..7).map(|i| Topic::new(keccak256([i]).0)).collect();
+        topics.push(topic);
+
+        let sealed = Compat::seal(&compat_recipient(public), (&topic).into(), b"c", 64).unwrap();
+        let bytes = sealed.to_bytes();
+        let envelope = Envelope::parse(&bytes).unwrap();
+        let inbox = Inbox::<HpkeThenCompat>::transitional(secret.clone(), secret);
+        let _ = decaps::take();
+        let (delivered, opened) = inbox.open(&topics, &envelope).unwrap().unwrap();
+        assert_eq!(delivered, topic);
+        assert_eq!(opened.scheme(), SchemeId::Compat);
+        assert_eq!(decaps::take(), (1, 1));
+
+        let sealed = Hpke::seal(&hpke_recipient(public), (&topic).into(), b"h", 64).unwrap();
+        let bytes = sealed.to_bytes();
+        let envelope = Envelope::parse(&bytes).unwrap();
+        let _ = decaps::take();
+        assert!(inbox.open(&topics, &envelope).unwrap().is_some());
+        assert_eq!(decaps::take(), (1, 0));
+    }
+
     #[test]
     fn remining_the_nonce_keeps_the_envelope_open() {
         let (secret, public) = keys(b"nectar envelope seam recipient");
@@ -877,6 +1003,7 @@ mod tests {
         sealed.set_nonce([0xff; 32]);
         let bytes = sealed.to_bytes();
         assert_eq!(bytes[8] & 1, parity_before);
+        assert_eq!(bytes[8] & 0xfe, 0xfe);
         assert_eq!(&bytes[9..40], &[0xff; 31]);
 
         let envelope = Envelope::parse(&bytes).unwrap();
@@ -923,7 +1050,17 @@ mod tests {
             }
         );
         let envelope = Envelope::parse(&[0u8; HEADER_SIZE]).unwrap();
-        assert!(envelope.ciphertext().is_empty());
+        assert!(envelope.tail().is_empty());
+    }
+
+    /// A tail too short for the ecdh slot is a decap miss, not a parse error.
+    #[test]
+    fn short_tail_is_rejected_by_the_scheme() {
+        let (secret, _) = keys(b"nectar envelope seam recipient");
+        let bytes = [0u8; HEADER_SIZE + ecdh::ENC_X_SIZE - 1];
+        let envelope = Envelope::parse(&bytes).unwrap();
+        assert!(Hpke::decap(&secret, &envelope).unwrap().is_none());
+        assert!(Compat::decap(&secret, &envelope).unwrap().is_none());
     }
 
     #[test]
@@ -967,15 +1104,17 @@ mod tests {
     #[test]
     fn frozen_wire_constants() {
         assert_eq!(LABEL, b"nectar/env/v1");
-        assert_eq!(ATTESTATION_PREFIX, b"nectar/env/v1 attest");
-        assert_eq!((HINT_SIZE, NONCE_SIZE, ENC_X_SIZE), (8, 32, 32));
-        assert_eq!(HEADER_SIZE, 72);
+        assert_eq!(ATTESTATION_PREFIX, b"nectar/env/v2 attest");
+        assert_eq!((HINT_SIZE, NONCE_SIZE), (8, 32));
+        assert_eq!(HEADER_SIZE, 40);
+        assert_eq!(HEADER_SIZE + ecdh::ENC_X_SIZE, 72);
     }
 
     #[test]
     fn scheme_constants() {
-        assert_eq!(Compat::TAG, 0);
-        assert_eq!(Hpke::TAG, 16);
+        assert_eq!(Compat::OVERHEAD, 32);
+        assert_eq!(Hpke::OVERHEAD, 50);
+        assert_eq!((Compat::NONCE_KEEP, Hpke::NONCE_KEEP), (1, 1));
         assert_eq!(Compat::ID, SchemeId::Compat);
         assert_eq!(Hpke::ID, SchemeId::Hpke);
     }

--- a/crates/envelope/src/lib.rs
+++ b/crates/envelope/src/lib.rs
@@ -74,7 +74,7 @@ use nectar_primitives::chunk::encryption::EncryptionKey;
 use subtle::ConstantTimeEq;
 use thiserror::Error;
 
-use crate::ecies::{EciesError, Salt};
+use crate::ecies::Salt;
 
 mod attestation;
 mod compat;
@@ -86,6 +86,7 @@ pub use attestation::{
     ATTESTATION_PREFIX, AttestationError, Attested, AttestedRecipient, AttestedScheme,
     RecipientAttestation, SchemeEntry, VerifiedAttestation, sign_data,
 };
+pub use compat::CompatSealError;
 pub use hpke::{
     DeriveKeyPairError, ExportError, Exporter, HpkeSealError, Info, Shared, derive_key_pair,
 };
@@ -194,11 +195,11 @@ macro_rules! schemes {
                 &self,
                 topic: &Topic,
                 plaintext: &[u8],
-                ct_len: usize,
+                tail_len: usize,
             ) -> Result<AnySealed, AnySealError> {
                 match self {
                     $(Self::$scheme(recipient) => Ok(AnySealed::$scheme(
-                        $scheme::seal(recipient, topic.into(), plaintext, ct_len)?,
+                        $scheme::seal(recipient, topic.into(), plaintext, tail_len)?,
                     )),)+
                 }
             }
@@ -208,7 +209,7 @@ macro_rules! schemes {
 
 schemes! {
     Hpke => HpkeSealError,
-    Compat => EciesError,
+    Compat => CompatSealError,
 }
 
 /// 32-byte topic an envelope is addressed under.
@@ -269,14 +270,14 @@ pub trait Scheme: sealed::Sealed + Sized {
     /// Bits of `nonce[0]` the scheme owns; a miner keeps them fixed.
     const NONCE_KEEP: u8;
 
-    /// Seal `plaintext` toward `recipient`; the tail is the encapsulation
-    /// followed by a `ct_len`-byte ciphertext region.
+    /// Seal `plaintext` into a `tail_len`-byte tail, which carries at most
+    /// `tail_len - OVERHEAD` message bytes.
     #[cfg(any(test, feature = "encryption"))]
     fn seal(
         recipient: &Recipient<Self>,
         ctx: Self::Context<'_>,
         plaintext: &[u8],
-        ct_len: usize,
+        tail_len: usize,
     ) -> Result<SealedEnvelope<Self>, Self::SealError>;
 
     /// Decapsulate once per envelope. `Ok(None)` rejects the tail outright.
@@ -341,11 +342,10 @@ impl InteropReason {
 /// direction.
 ///
 /// ```compile_fail
-/// use nectar_envelope::{Compat, Hpke, Recipient, Scheme, Topic};
+/// use nectar_envelope::{Compat, Hpke, Recipient};
 ///
-/// fn downgrade(recipient: &Recipient<Hpke>, topic: &Topic) {
-///     // compat seal toward an hpke recipient must not typecheck
-///     let _ = Compat::seal(recipient, topic.into(), b"msg", 64);
+/// fn downgrade(recipient: Recipient<Hpke>) -> Recipient<Compat> {
+///     recipient
 /// }
 /// ```
 #[derive(Clone)]
@@ -602,16 +602,10 @@ impl<S: Scheme, Rest: Policy> Try<S, Rest> {
     pub const fn with(secret: S::SecretKey, rest: Rest) -> Self {
         Self { secret, rest }
     }
-
-    /// The secret this cell opens with.
-    #[must_use]
-    pub const fn secret(&self) -> &S::SecretKey {
-        &self.secret
-    }
 }
 
 impl Try<Hpke> {
-    /// Append the compat cell; compat opens under its own secret.
+    /// Append the compat cell.
     #[must_use]
     pub fn then_compat(self, secret: SecretKey) -> HpkeThenCompat {
         Try::with(self.secret, Try::new(secret))
@@ -730,7 +724,7 @@ impl Scheme for Compat {
     type Decap = ecies::SharedX;
     type Extra = EncryptionKey;
     type Provenance = InteropReason;
-    type SealError = EciesError;
+    type SealError = CompatSealError;
 
     const ID: SchemeId = SchemeId::Compat;
     const OVERHEAD: usize = ecdh::ENC_X_SIZE;
@@ -741,9 +735,9 @@ impl Scheme for Compat {
         recipient: &Recipient<Self>,
         ctx: Self::Context<'_>,
         plaintext: &[u8],
-        ct_len: usize,
+        tail_len: usize,
     ) -> Result<SealedEnvelope<Self>, Self::SealError> {
-        compat::seal(recipient, ctx, plaintext, ct_len)
+        compat::seal(recipient, ctx, plaintext, tail_len)
     }
 
     fn decap(
@@ -776,7 +770,7 @@ impl Scheme for Hpke {
     type SealError = HpkeSealError;
 
     const ID: SchemeId = SchemeId::Hpke;
-    const OVERHEAD: usize = ecdh::ENC_X_SIZE + hpke::MIN_CT_LEN;
+    const OVERHEAD: usize = hpke::OVERHEAD;
     const NONCE_KEEP: u8 = ecdh::PARITY;
 
     #[cfg(any(test, feature = "encryption"))]
@@ -784,9 +778,9 @@ impl Scheme for Hpke {
         recipient: &Recipient<Self>,
         ctx: Self::Context<'_>,
         plaintext: &[u8],
-        ct_len: usize,
+        tail_len: usize,
     ) -> Result<SealedEnvelope<Self>, Self::SealError> {
-        hpke::seal(recipient, ctx, plaintext, ct_len)
+        hpke::seal(recipient, ctx, plaintext, tail_len)
     }
 
     fn decap(
@@ -835,19 +829,14 @@ mod tests {
         Recipient::assume_reference(key, InteropReason::new("seam test"))
     }
 
-    /// Total frame length for a scheme tail carrying `ct_len` ciphertext.
-    fn framed(ct_len: usize) -> usize {
-        HEADER_SIZE + ecdh::ENC_X_SIZE + ct_len
-    }
-
     #[test]
     fn hpke_roundtrip_via_seam() {
         let (secret, public) = keys(b"nectar envelope seam recipient");
         let topic = topic();
         let msg = b"seam roundtrip";
-        let sealed = Hpke::seal(&hpke_recipient(public), (&topic).into(), msg, 4024).unwrap();
+        let sealed = Hpke::seal(&hpke_recipient(public), (&topic).into(), msg, 4056).unwrap();
         let bytes = sealed.to_bytes();
-        assert_eq!(bytes.len(), framed(4024));
+        assert_eq!(bytes.len(), HEADER_SIZE + 4056);
 
         let envelope = Envelope::parse(&bytes).unwrap();
         let opened = Hpke::open(&secret, (&topic).into(), &envelope)
@@ -855,7 +844,6 @@ mod tests {
             .unwrap();
         assert_eq!(opened.plaintext, msg);
 
-        // Both sides export identical bytes for the same context.
         let mut sender = [0u8; 16];
         sealed.extra().export(b"reply", &mut sender).unwrap();
         let mut receiver = [0u8; 16];
@@ -863,10 +851,66 @@ mod tests {
         assert_eq!(sender, receiver);
     }
 
+    /// `OVERHEAD` is the whole capacity handle: a tail carries exactly
+    /// `tail_len - OVERHEAD` message bytes, one more is refused.
+    #[test]
+    fn overhead_bounds_the_tail_capacity() {
+        let (_, public) = keys(b"nectar envelope seam recipient");
+        let topic = topic();
+        for tail_len in [96usize, 512, 4056] {
+            let capacity = tail_len - Hpke::OVERHEAD;
+            let sealed = Hpke::seal(
+                &hpke_recipient(public),
+                (&topic).into(),
+                &vec![7u8; capacity],
+                tail_len,
+            )
+            .unwrap();
+            assert_eq!(sealed.to_bytes().len(), HEADER_SIZE + tail_len);
+            assert!(
+                Hpke::seal(
+                    &hpke_recipient(public),
+                    (&topic).into(),
+                    &vec![7u8; capacity + 1],
+                    tail_len
+                )
+                .is_err()
+            );
+
+            let capacity = tail_len - Compat::OVERHEAD;
+            let sealed = Compat::seal(
+                &compat_recipient(public),
+                (&topic).into(),
+                &vec![7u8; capacity],
+                tail_len,
+            )
+            .unwrap();
+            assert_eq!(sealed.to_bytes().len(), HEADER_SIZE + tail_len);
+            assert!(
+                Compat::seal(
+                    &compat_recipient(public),
+                    (&topic).into(),
+                    &vec![7u8; capacity + 1],
+                    tail_len
+                )
+                .is_err()
+            );
+        }
+    }
+
+    /// A tail below the scheme overhead is refused, never truncated.
+    #[test]
+    fn a_tail_below_the_overhead_is_refused() {
+        let (_, public) = keys(b"nectar envelope seam recipient");
+        let topic = topic();
+        assert!(Hpke::seal(&hpke_recipient(public), (&topic).into(), b"", 49).is_err());
+        assert!(Compat::seal(&compat_recipient(public), (&topic).into(), b"", 31).is_err());
+    }
+
     #[test]
     fn hpke_wrong_topic_is_undeliverable() {
         let (secret, public) = keys(b"nectar envelope seam recipient");
-        let sealed = Hpke::seal(&hpke_recipient(public), (&topic()).into(), b"m", 64).unwrap();
+        let sealed = Hpke::seal(&hpke_recipient(public), (&topic()).into(), b"m", 96).unwrap();
         let bytes = sealed.to_bytes();
         let envelope = Envelope::parse(&bytes).unwrap();
         let other = Topic::new(keccak256(b"other topic").0);
@@ -882,16 +926,16 @@ mod tests {
         let (secret, public) = keys(b"nectar envelope seam recipient");
         let topic = topic();
         let msg = b"compat roundtrip";
-        let sealed = Compat::seal(&compat_recipient(public), (&topic).into(), msg, 100).unwrap();
+        let sealed = Compat::seal(&compat_recipient(public), (&topic).into(), msg, 132).unwrap();
         let bytes = sealed.to_bytes();
-        assert_eq!(bytes.len(), framed(100));
+        assert_eq!(bytes.len(), HEADER_SIZE + 132);
 
         let envelope = Envelope::parse(&bytes).unwrap();
         let opened = Compat::open(&secret, (&topic).into(), &envelope)
             .unwrap()
             .unwrap();
         assert_eq!(&opened.plaintext[..msg.len()], msg);
-        assert_eq!(opened.plaintext.len(), 100);
+        assert_eq!(opened.plaintext.len(), 132 - Compat::OVERHEAD);
 
         // The adapter is byte-for-byte the frozen construction.
         let (ephemeral, ct) = ecdh::split(&envelope).unwrap();
@@ -909,7 +953,7 @@ mod tests {
         let (secret, public) = keys(b"nectar envelope seam recipient");
         let topic = topic();
 
-        let sealed = Hpke::seal(&hpke_recipient(public), (&topic).into(), b"e", 64).unwrap();
+        let sealed = Hpke::seal(&hpke_recipient(public), (&topic).into(), b"e", 96).unwrap();
         let bytes = sealed.to_bytes();
         let envelope = Envelope::parse(&bytes).unwrap();
         assert!(
@@ -918,7 +962,7 @@ mod tests {
                 .is_none()
         );
 
-        let sealed = Compat::seal(&compat_recipient(public), (&topic).into(), b"c", 64).unwrap();
+        let sealed = Compat::seal(&compat_recipient(public), (&topic).into(), b"c", 96).unwrap();
         let bytes = sealed.to_bytes();
         let envelope = Envelope::parse(&bytes).unwrap();
         assert!(
@@ -932,14 +976,13 @@ mod tests {
     fn hpke_only_inbox_rejects_compat_forgeries() {
         let (secret, public) = keys(b"nectar envelope seam recipient");
         let topic = topic();
-        let sealed = Compat::seal(&compat_recipient(public), (&topic).into(), b"f", 64).unwrap();
+        let sealed = Compat::seal(&compat_recipient(public), (&topic).into(), b"f", 96).unwrap();
         let bytes = sealed.to_bytes();
         let envelope = Envelope::parse(&bytes).unwrap();
 
         let inbox = Inbox::<HpkeOnly>::new(secret.clone());
         assert!(inbox.open(&[topic], &envelope).unwrap().is_none());
 
-        // The transitional inbox still delivers it, reported as compat.
         let inbox = Inbox::<HpkeThenCompat>::transitional(secret.clone(), secret);
         let (delivered_topic, opened) = inbox.open(&[topic], &envelope).unwrap().unwrap();
         assert_eq!(delivered_topic, topic);
@@ -951,7 +994,7 @@ mod tests {
         let (secret, public) = keys(b"nectar envelope seam recipient");
         let topic = topic();
         let decoy = Topic::new(keccak256(b"decoy topic").0);
-        let sealed = Hpke::seal(&hpke_recipient(public), (&topic).into(), b"m", 64).unwrap();
+        let sealed = Hpke::seal(&hpke_recipient(public), (&topic).into(), b"m", 96).unwrap();
         let bytes = sealed.to_bytes();
         let envelope = Envelope::parse(&bytes).unwrap();
 
@@ -973,7 +1016,7 @@ mod tests {
         let mut topics: Vec<Topic> = (0u8..7).map(|i| Topic::new(keccak256([i]).0)).collect();
         topics.push(topic);
 
-        let sealed = Compat::seal(&compat_recipient(public), (&topic).into(), b"c", 64).unwrap();
+        let sealed = Compat::seal(&compat_recipient(public), (&topic).into(), b"c", 96).unwrap();
         let bytes = sealed.to_bytes();
         let envelope = Envelope::parse(&bytes).unwrap();
         let inbox = Inbox::<HpkeThenCompat>::transitional(secret.clone(), secret);
@@ -983,7 +1026,7 @@ mod tests {
         assert_eq!(opened.scheme(), SchemeId::Compat);
         assert_eq!(decaps::take(), (1, 1));
 
-        let sealed = Hpke::seal(&hpke_recipient(public), (&topic).into(), b"h", 64).unwrap();
+        let sealed = Hpke::seal(&hpke_recipient(public), (&topic).into(), b"h", 96).unwrap();
         let bytes = sealed.to_bytes();
         let envelope = Envelope::parse(&bytes).unwrap();
         let _ = decaps::take();
@@ -995,7 +1038,7 @@ mod tests {
     fn remining_the_nonce_keeps_the_envelope_open() {
         let (secret, public) = keys(b"nectar envelope seam recipient");
         let topic = topic();
-        let mut sealed = Hpke::seal(&hpke_recipient(public), (&topic).into(), b"m", 64).unwrap();
+        let mut sealed = Hpke::seal(&hpke_recipient(public), (&topic).into(), b"m", 96).unwrap();
         let parity_before = {
             let bytes = sealed.to_bytes();
             bytes[8] & 1
@@ -1019,7 +1062,7 @@ mod tests {
         let (secret, public) = keys(b"nectar envelope seam recipient");
         let topic = topic();
 
-        let sealed = Hpke::seal(&hpke_recipient(public), (&topic).into(), b"m", 64).unwrap();
+        let sealed = Hpke::seal(&hpke_recipient(public), (&topic).into(), b"m", 96).unwrap();
         let mut bytes = sealed.to_bytes();
         bytes[8] ^= 1;
         let envelope = Envelope::parse(&bytes).unwrap();
@@ -1030,7 +1073,7 @@ mod tests {
         );
 
         // Compat ECDH ignores parity: the flipped envelope still opens.
-        let sealed = Compat::seal(&compat_recipient(public), (&topic).into(), b"m", 64).unwrap();
+        let sealed = Compat::seal(&compat_recipient(public), (&topic).into(), b"m", 96).unwrap();
         let mut bytes = sealed.to_bytes();
         bytes[8] ^= 1;
         let envelope = Envelope::parse(&bytes).unwrap();
@@ -1069,7 +1112,7 @@ mod tests {
         let topic = topic();
 
         let any = AnyRecipient::Hpke(hpke_recipient(public));
-        let sealed = any.seal(&topic, b"m", 64).unwrap();
+        let sealed = any.seal(&topic, b"m", 96).unwrap();
         assert_eq!(sealed.scheme(), SchemeId::Hpke);
         let bytes = sealed.to_bytes();
         let envelope = Envelope::parse(&bytes).unwrap();
@@ -1080,7 +1123,7 @@ mod tests {
         );
 
         let any = AnyRecipient::Compat(compat_recipient(public));
-        let sealed = any.seal(&topic, b"m", 64).unwrap();
+        let sealed = any.seal(&topic, b"m", 96).unwrap();
         assert_eq!(sealed.scheme(), SchemeId::Compat);
         let bytes = sealed.to_bytes();
         let envelope = Envelope::parse(&bytes).unwrap();


### PR DESCRIPTION
Closes #753

## What

Frame reshuffle in `crates/envelope`, byte-neutral. The frozen header is now `hint[0..8] || nonce[8..40]` (`HEADER_SIZE = 40`, `HINT_SIZE + NONCE_SIZE`) and everything after is a scheme-owned tail. `Envelope` carries `tail()` instead of `enc_x()`/`ciphertext()`/`parity()`. A new crate-private `crates/envelope/src/ecdh.rs` owns the shared secp256k1 tail layout (`ENC_X_SIZE`, `PARITY`, `reconstruct`, `split`, `ciphertext`, `tail`), which both ECDH-based schemes use. `SealedEnvelope::to_bytes` emits `hint || nonce || tail`, identical to the old `hint || nonce || enc_x || ct`.

`Scheme` gained `PublicKey`, `SecretKey`, `Decap`, `OVERHEAD`, `NONCE_KEEP`, and `erase`, and dropped `TAG`. `Scheme::seal` now takes `tail_len` (the full tail budget) instead of `ct_len` (the ciphertext-region budget), so callers can size a seal from `Scheme::OVERHEAD`, a public constant, rather than an internal encapsulation size. `Scheme::open` was replaced by a decapsulate-once path (`Decap`) shared across topics.

## Why

`Scheme::OVERHEAD` is tail-relative, but the previous `seal(..., ct_len)` signature took a ciphertext-region-relative length, and the encapsulation size needed to convert between the two was crate-private. No caller with a chunk-payload budget could compute a valid argument for any scheme. Switching `seal` to `tail_len` closes that gap without changing wire bytes: the pinned HPKE frame vector `hpke::tests::kat_pinned` (136-byte FRAME) is unedited and still passes.

## Commits

- `ccdad93e` refactor(envelope)!: make the scheme seam hold more than two schemes
- `28f63c3a` fix(envelope): size seals by tail length and canonicalize attested sets

The second commit is a red-team fix: it retargets `Scheme::seal` from `ct_len` to `tail_len` and adjusts the `HpkeSealError` variant from `RegionTooSmall { ct_len }` to `TailTooSmall { tail_len }` accordingly.

## Diffstat

```
crates/envelope/README.md          |   4 +-
crates/envelope/src/attestation.rs | 503 +++++++++++++++++++----
crates/envelope/src/compat.rs      |  57 ++-
crates/envelope/src/ecdh.rs        |  48 +++
crates/envelope/src/ecies.rs       |  54 ++-
crates/envelope/src/hpke.rs        | 120 +++---
crates/envelope/src/lib.rs         | 796 +++++++++++++++++++++++--------------
7 files changed, 1115 insertions(+), 467 deletions(-)
```

## Testing

- Byte neutrality: every pinned hex constant in `hpke::tests::kat_pinned`, including `FRAME`, is unchanged from base; only the seal length argument changed (`ct_len` 64 to `tail_len` 96) for the same 136-byte frame.
- `cargo check --locked -p nectar-envelope --no-default-features --target riscv64imac-unknown-none-elf` is green; the diff touches no workflow file, so `nostd.yml` needed zero edits. The `no_std` path stays a compile-time cons list, no allocator, no std.
- Full CI-parity checks for both the implementation and the red-team fix passed on the first run; nothing required a further fix, commit, or push.

## AI Assistance

Implement: claude-opus-5. Red-team: claude-opus-5. PR: claude-sonnet-5.
