### PR TITLE
refactor(postage)!: close BatchId/BatchParams public API holes

### DIFF
--- a/crates/postage-issuer/src/factory.rs
+++ b/crates/postage-issuer/src/factory.rs
@@ -163,7 +163,7 @@ impl<S: SwarmSpec> BatchFactory for MemoryBatchFactoryFor<S> {
             params.owner(),
             params.depth(),
             params.bucket_depth(),
-            params.is_immutable(),
+            params.immutable(),
         );
 
         Ok(CreateResultFor {
@@ -225,7 +225,7 @@ mod tests {
         let factory = MemoryBatchFactory::new(0);
 
         let params = BatchParams::new(Address::ZERO, 20, BucketDepth::new(16).unwrap(), 1000)
-            .immutable(true);
+            .with_immutable(true);
         let result = factory.create(params).await.unwrap();
 
         assert!(result.batch.immutable());

--- a/crates/postage-issuer/src/factory.rs
+++ b/crates/postage-issuer/src/factory.rs
@@ -158,12 +158,12 @@ impl<S: SwarmSpec> BatchFactory for MemoryBatchFactoryFor<S> {
 
         let batch = Batch::new(
             batch_id,
-            params.amount,
+            params.amount(),
             self.current_block,
-            params.owner,
-            params.depth,
-            params.bucket_depth,
-            params.immutable,
+            params.owner(),
+            params.depth(),
+            params.bucket_depth(),
+            params.is_immutable(),
         );
 
         Ok(CreateResultFor {

--- a/crates/postage/src/batch.rs
+++ b/crates/postage/src/batch.rs
@@ -5,7 +5,7 @@ use core::{fmt, marker::PhantomData};
 use alloy_primitives::{Address, B256};
 use derive_more::{AsRef, Display, From, Into};
 use nectar_primitives::{
-    ChunkAddress, Mainnet, SwarmSpec,
+    ChunkAddress, Mainnet, SwarmSpec, WrongLength,
     wire::{Cursor, FromCursor, ToWriter, Underrun, Writer},
 };
 
@@ -48,12 +48,25 @@ impl BatchId {
 
     /// Copy an id out of a 32-byte slice.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics when `slice` is not exactly 32 bytes.
+    /// [`WrongLength`] when `slice` is not exactly 32 bytes.
     #[inline]
-    pub fn from_slice(slice: &[u8]) -> Self {
-        Self(B256::from_slice(slice))
+    pub fn from_slice(slice: &[u8]) -> Result<Self, WrongLength> {
+        Self::try_from(slice)
+    }
+}
+
+impl TryFrom<&[u8]> for BatchId {
+    type Error = WrongLength;
+
+    fn try_from(slice: &[u8]) -> Result<Self, WrongLength> {
+        <[u8; Self::SIZE]>::try_from(slice)
+            .map(Self::new)
+            .map_err(|_| WrongLength {
+                expected: Self::SIZE,
+                got: slice.len(),
+            })
     }
 }
 
@@ -269,21 +282,22 @@ impl<'a, S: SwarmSpec> arbitrary::Arbitrary<'a> for BucketDepth<S> {
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(bound(serialize = "", deserialize = "")))]
+#[non_exhaustive]
 pub struct BatchParams<S: SwarmSpec = Mainnet> {
     /// The owner's Ethereum address.
-    pub owner: Address,
+    owner: Address,
     /// The depth of the batch (total capacity = 2^depth chunks).
-    pub depth: u8,
+    depth: u8,
     /// The bucket depth for collision bucket uniformity.
-    pub bucket_depth: BucketDepth<S>,
+    bucket_depth: BucketDepth<S>,
     /// Whether the batch is immutable.
     ///
     /// Immutable batches cannot be diluted (depth increased) and chunks cannot
     /// be overwritten. Mutable batches allow writing new chunks to the same
     /// bucket index with a later timestamp, replacing the previous chunk.
-    pub immutable: bool,
+    immutable: bool,
     /// Initial amount to fund the batch.
-    pub amount: u128,
+    amount: u128,
 }
 
 // As for [`BucketDepth`] above: the spec is a type-level tag, so `Clone` and
@@ -336,6 +350,36 @@ impl<S: SwarmSpec> BatchParams<S> {
     pub const fn immutable(mut self, immutable: bool) -> Self {
         self.immutable = immutable;
         self
+    }
+
+    /// Returns the owner's Ethereum address.
+    #[inline]
+    pub const fn owner(&self) -> Address {
+        self.owner
+    }
+
+    /// Returns the batch depth.
+    #[inline]
+    pub const fn depth(&self) -> u8 {
+        self.depth
+    }
+
+    /// Returns the bucket depth.
+    #[inline]
+    pub const fn bucket_depth(&self) -> BucketDepth<S> {
+        self.bucket_depth
+    }
+
+    /// Returns whether the batch is immutable.
+    #[inline]
+    pub const fn is_immutable(&self) -> bool {
+        self.immutable
+    }
+
+    /// Returns the initial funding amount.
+    #[inline]
+    pub const fn amount(&self) -> u128 {
+        self.amount
     }
 
     /// Validates that the batch depth leaves room above the bucket depth.
@@ -635,13 +679,11 @@ impl<'a, S: SwarmSpec> arbitrary::Arbitrary<'a> for BatchParams<S> {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let (depth, bucket_depth) = arbitrary_geometry::<S>(u)?;
 
-        Ok(Self {
-            owner: Address::arbitrary(u)?,
-            depth,
-            bucket_depth,
-            immutable: u.arbitrary()?,
-            amount: u.arbitrary()?,
-        })
+        let owner = Address::arbitrary(u)?;
+        let immutable = u.arbitrary()?;
+        let amount = u.arbitrary()?;
+
+        Ok(Self::new(owner, depth, bucket_depth, amount).immutable(immutable))
     }
 }
 
@@ -928,10 +970,45 @@ mod tests {
             BatchParams::new(Address::ZERO, 20, BucketDepth::new(16).unwrap(), 1000)
                 .immutable(true);
 
-        assert_eq!(params.owner, Address::ZERO);
-        assert_eq!(params.depth, 20);
-        assert_eq!(params.bucket_depth.get(), 16);
-        assert_eq!(params.amount, 1000);
-        assert!(params.immutable);
+        assert_eq!(params.owner(), Address::ZERO);
+        assert_eq!(params.depth(), 20);
+        assert_eq!(params.bucket_depth().get(), 16);
+        assert_eq!(params.amount(), 1000);
+        assert!(params.is_immutable());
+    }
+
+    #[test]
+    fn test_batch_id_from_slice_length() {
+        let bytes = [7u8; 32];
+        assert_eq!(BatchId::from_slice(&bytes).unwrap(), BatchId::new(bytes));
+
+        assert_eq!(
+            BatchId::from_slice(&bytes[..31]).unwrap_err(),
+            WrongLength {
+                expected: 32,
+                got: 31
+            }
+        );
+        assert_eq!(
+            BatchId::from_slice(&[0u8; 33]).unwrap_err(),
+            WrongLength {
+                expected: 32,
+                got: 33
+            }
+        );
+        assert!(BatchId::from_slice(&[]).is_err());
+    }
+
+    #[test]
+    fn test_batch_params_accessors_round_trip() {
+        let params: BatchParams =
+            BatchParams::new(Address::ZERO, 20, BucketDepth::new(16).unwrap(), 1000)
+                .immutable(true);
+
+        assert_eq!(params.owner(), Address::ZERO);
+        assert_eq!(params.depth(), 20);
+        assert_eq!(params.bucket_depth(), BucketDepth::new(16).unwrap());
+        assert!(params.is_immutable());
+        assert_eq!(params.amount(), 1000);
     }
 }

--- a/crates/postage/src/batch.rs
+++ b/crates/postage/src/batch.rs
@@ -334,7 +334,7 @@ impl<S: SwarmSpec> BatchParams<S> {
 
     /// Sets the immutable flag.
     #[must_use]
-    pub const fn immutable(mut self, immutable: bool) -> Self {
+    pub const fn with_immutable(mut self, immutable: bool) -> Self {
         self.immutable = immutable;
         self
     }
@@ -359,7 +359,7 @@ impl<S: SwarmSpec> BatchParams<S> {
 
     /// Returns whether the batch is immutable: no dilution, no overwrite.
     #[inline]
-    pub const fn is_immutable(&self) -> bool {
+    pub const fn immutable(&self) -> bool {
         self.immutable
     }
 
@@ -670,7 +670,7 @@ impl<'a, S: SwarmSpec> arbitrary::Arbitrary<'a> for BatchParams<S> {
         let immutable = u.arbitrary()?;
         let amount = u.arbitrary()?;
 
-        Ok(Self::new(owner, depth, bucket_depth, amount).immutable(immutable))
+        Ok(Self::new(owner, depth, bucket_depth, amount).with_immutable(immutable))
     }
 }
 
@@ -955,13 +955,13 @@ mod tests {
     fn test_batch_params_builder() {
         let params: BatchParams =
             BatchParams::new(Address::ZERO, 20, BucketDepth::new(16).unwrap(), 1000)
-                .immutable(true);
+                .with_immutable(true);
 
         assert_eq!(params.owner(), Address::ZERO);
         assert_eq!(params.depth(), 20);
         assert_eq!(params.bucket_depth().get(), 16);
         assert_eq!(params.amount(), 1000);
-        assert!(params.is_immutable());
+        assert!(params.immutable());
     }
 
     #[test]
@@ -990,12 +990,12 @@ mod tests {
     fn test_batch_params_accessors_round_trip() {
         let params: BatchParams =
             BatchParams::new(Address::ZERO, 20, BucketDepth::new(16).unwrap(), 1000)
-                .immutable(true);
+                .with_immutable(true);
 
         assert_eq!(params.owner(), Address::ZERO);
         assert_eq!(params.depth(), 20);
         assert_eq!(params.bucket_depth(), BucketDepth::new(16).unwrap());
-        assert!(params.is_immutable());
+        assert!(params.immutable());
         assert_eq!(params.amount(), 1000);
     }
 }

--- a/crates/postage/src/batch.rs
+++ b/crates/postage/src/batch.rs
@@ -47,10 +47,6 @@ impl BatchId {
     }
 
     /// Copy an id out of a 32-byte slice.
-    ///
-    /// # Errors
-    ///
-    /// [`WrongLength`] when `slice` is not exactly 32 bytes.
     #[inline]
     pub fn from_slice(slice: &[u8]) -> Result<Self, WrongLength> {
         Self::try_from(slice)
@@ -284,19 +280,10 @@ impl<'a, S: SwarmSpec> arbitrary::Arbitrary<'a> for BucketDepth<S> {
 #[cfg_attr(feature = "serde", serde(bound(serialize = "", deserialize = "")))]
 #[non_exhaustive]
 pub struct BatchParams<S: SwarmSpec = Mainnet> {
-    /// The owner's Ethereum address.
     owner: Address,
-    /// The depth of the batch (total capacity = 2^depth chunks).
     depth: u8,
-    /// The bucket depth for collision bucket uniformity.
     bucket_depth: BucketDepth<S>,
-    /// Whether the batch is immutable.
-    ///
-    /// Immutable batches cannot be diluted (depth increased) and chunks cannot
-    /// be overwritten. Mutable batches allow writing new chunks to the same
-    /// bucket index with a later timestamp, replacing the previous chunk.
     immutable: bool,
-    /// Initial amount to fund the batch.
     amount: u128,
 }
 
@@ -370,7 +357,7 @@ impl<S: SwarmSpec> BatchParams<S> {
         self.bucket_depth
     }
 
-    /// Returns whether the batch is immutable.
+    /// Returns whether the batch is immutable: no dilution, no overwrite.
     #[inline]
     pub const fn is_immutable(&self) -> bool {
         self.immutable

--- a/crates/postage/src/stamp.rs
+++ b/crates/postage/src/stamp.rs
@@ -628,7 +628,7 @@ mod tests {
         let bytes = hex::decode(TEST_STAMP).unwrap();
         let stamp = Stamp::try_from_slice(&bytes).unwrap();
 
-        let expected_batch = BatchId::from_slice(&hex::decode(TEST_BATCH_ID).unwrap());
+        let expected_batch = BatchId::from_slice(&hex::decode(TEST_BATCH_ID).unwrap()).unwrap();
         assert_eq!(stamp.batch(), expected_batch);
         assert_eq!(stamp.bucket(), 52197); // 0x0000cbe5
         assert_eq!(stamp.index(), 0);


### PR DESCRIPTION
## What

Two holes in the published surface of `crates/postage/src/batch.rs`, closed together because both are breaking and both are small.

`BatchId::from_slice` returns `Result<Self, WrongLength>` instead of panicking on a wrong-length slice, matching its two sibling 32-byte newtypes, `ChunkAddress::from_slice` and `OverlayAddress::from_slice`. A `TryFrom<&[u8]>` impl comes with it.

`BatchParams` loses its five public fields, which become private behind `owner()`, `depth()`, `bucket_depth()`, `immutable()` and `amount()`, and the struct gains `#[non_exhaustive]`. `BatchParams::new` and the builder setter already existed, so no construction logic is added.

The builder setter is renamed from `immutable(bool)` to `with_immutable(bool)`. That is a second breaking rename, made deliberately: the setter previously occupied the name the getter wants, which would have forced the accessor to be `is_immutable()` and diverge from `Batch::immutable()` in the same file. The pair now reads `immutable()` and builds `with_immutable()`, and `with_` matches the builder convention already used in `nectar-manifest`, `nectar-file` and `crates/postage/src/stamp.rs`.

## Why

Closes #685.

`from_slice` was a documented panic on a published API, and its only in-tree caller was a test. `BatchParams` being a plain `pub struct` meant struct-literal construction, so adding a field would break every 0.4.0 user; `#[non_exhaustive]` plus accessors removes that.

Both changes are breaking on `nectar-postage` 0.4.0 and batch into 0.5.0.

## Testing

All commands were run inside `nix develop --command`.

- `cargo clippy --workspace --all-targets --locked -- -D warnings`, clean, plus the `serde` and `parallel` feature passes for `nectar-postage` and the bare and `parallel` passes for `nectar-postage-issuer`.
- `cargo nextest run --locked -p nectar-postage --features serde`, 65 passed, and `-p nectar-postage-issuer`, 111 passed.
- `cargo test --doc --locked -p nectar-postage`, 2 passed.
- `cargo check --locked -p nectar-postage --no-default-features` against `riscv64imac-unknown-none-elf` and `wasm32-unknown-unknown`, both clean.
- `cargo fmt --all --check` and the em dash scan, both clean.

The serde representation is unchanged. Field visibility does not affect what `derive(Serialize)` emits, the field names and their order are untouched, and no rename or skip attributes were added, so the `serde(bound(...))` behaviour carries over as-is. A new test asserts the five accessors round-trip the constructor.

No new dependency is introduced. An earlier revision of this branch added `serde_json` as a dev-dependency to assert the serialized field names; it was removed, and the branch no longer touches `Cargo.lock`.

## AI Assistance

Implement claude-opus-5, red-team claude-opus-5, PR body claude-sonnet-5, corrections claude-opus-5.
