### PR TITLE
refactor(postage): calculate_bucket takes BucketDepth<S> not raw u8

### DIFF
--- a/crates/postage-issuer/src/issuer.rs
+++ b/crates/postage-issuer/src/issuer.rs
@@ -227,7 +227,7 @@ impl<S: SwarmSpec> StampIssuer for MemoryIssuerFor<S> {
         address: &ChunkAddress,
         timestamp: u64,
     ) -> Result<StampDigest, StampError> {
-        let bucket = calculate_bucket(address, self.counters.bucket_depth().get());
+        let bucket = calculate_bucket(address, self.counters.bucket_depth());
         // Fill mode ignores the predicate; a monotone watermark never lands on a
         // reserved slot.
         let position =

--- a/crates/postage-issuer/src/pipeline/stamped_put.rs
+++ b/crates/postage-issuer/src/pipeline/stamped_put.rs
@@ -585,6 +585,10 @@ mod tests {
         MemoryIssuer::new(BatchId::ZERO, depth, BucketDepth::new(16).unwrap())
     }
 
+    fn bucket_depth() -> BucketDepth {
+        BucketDepth::new(16).unwrap()
+    }
+
     fn sealed(payload: &'static [u8]) -> TestChunk {
         let content = ContentChunk::new(payload).unwrap();
         Chunk::from_envelope(content.into()).unwrap()
@@ -713,7 +717,9 @@ mod tests {
             // Exactly one allocation per touched bucket.
             let mut buckets: BTreeMap<u32, u32> = BTreeMap::new();
             for address in per_address.keys() {
-                *buckets.entry(calculate_bucket(address, 16)).or_insert(0) += 1;
+                *buckets
+                    .entry(calculate_bucket(address, bucket_depth()))
+                    .or_insert(0) += 1;
             }
             let fullest = buckets.values().copied().max().unwrap();
             assert_eq!(store.remaining_capacity(), 16 - fullest);

--- a/crates/postage-issuer/src/ring.rs
+++ b/crates/postage-issuer/src/ring.rs
@@ -314,7 +314,7 @@ impl<S: SwarmSpec, R: Reservation> RingIssuerFor<S, R> {
         address: &ChunkAddress,
         timestamp: u64,
     ) -> Result<StampDigest, IssuerError> {
-        let bucket = calculate_bucket(address, self.counters.bucket_depth().get());
+        let bucket = calculate_bucket(address, self.counters.bucket_depth());
         let position = self.next_slot(bucket)?;
 
         // Monotone u64 issuance counter; one increment per stamp cannot
@@ -456,6 +456,10 @@ mod tests {
         )
     }
 
+    fn bucket_depth() -> BucketDepth {
+        BucketDepth::new(16).unwrap()
+    }
+
     #[test]
     fn external_ring_wraps_and_reuses_slots() {
         // depth=17, bucket_depth=16 gives 2 slots per bucket.
@@ -499,7 +503,7 @@ mod tests {
         // depth=18, bucket_depth=16 gives 4 slots per bucket. Protect slots 1
         // and 3 in the target bucket; the ring may only ever emit 0 and 2.
         let batch = mutable_batch(18, 16);
-        let bucket = calculate_bucket(&test_address(0x00AA), 16);
+        let bucket = calculate_bucket(&test_address(0x00AA), bucket_depth());
         let mut issuer = RingIssuer::reserved(&batch, [(bucket, 1), (bucket, 3)]).unwrap();
 
         let address = test_address(0x00AA);
@@ -521,7 +525,7 @@ mod tests {
         // depth=17, bucket_depth=16 gives 2 slots per bucket. Protect both, so
         // the bucket has no issuable slot.
         let batch = mutable_batch(17, 16);
-        let bucket = calculate_bucket(&test_address(0x0001), 16);
+        let bucket = calculate_bucket(&test_address(0x0001), bucket_depth());
         let mut issuer = RingIssuer::reserved(&batch, [(bucket, 0), (bucket, 1)]).unwrap();
 
         let address = test_address(0x0001);
@@ -556,7 +560,7 @@ mod tests {
         let mut issuer = RingIssuer::external(&batch).unwrap();
 
         let address = test_address(0x0001);
-        let bucket = calculate_bucket(&address, 16);
+        let bucket = calculate_bucket(&address, bucket_depth());
 
         assert!(issuer.bucket_has_capacity(bucket));
         issuer.prepare_ring_stamp(&address, 1).unwrap();
@@ -604,7 +608,7 @@ mod tests {
     #[test]
     fn ring_stamp_issuer_surfaces_exhaustion_as_bucket_full() {
         let batch = mutable_batch(17, 16);
-        let bucket = calculate_bucket(&test_address(0x0001), 16);
+        let bucket = calculate_bucket(&test_address(0x0001), bucket_depth());
         let mut issuer = RingIssuer::reserved(&batch, [(bucket, 0), (bucket, 1)]).unwrap();
 
         let address = test_address(0x0001);

--- a/crates/postage-issuer/src/sharded.rs
+++ b/crates/postage-issuer/src/sharded.rs
@@ -144,7 +144,7 @@ impl<S: SwarmSpec, I: StampIssuer> ShardedFor<S, I> {
         address: &ChunkAddress,
         timestamp: u64,
     ) -> Result<StampDigest, StampError> {
-        let bucket = calculate_bucket(address, self.bucket_depth.get());
+        let bucket = calculate_bucket(address, self.bucket_depth);
         let (digest, fill) = {
             let mut issuer = self.shard(bucket).lock();
             let digest = issuer.prepare_stamp(address, timestamp)?;
@@ -431,6 +431,10 @@ mod tests {
         )
     }
 
+    fn bucket_depth() -> BucketDepth {
+        BucketDepth::new(16).unwrap()
+    }
+
     #[test]
     fn the_aliases_name_the_generic() {
         fn self_hosting_sink(ring: ShardedRingIssuer<Reserved>) -> u64 {
@@ -501,7 +505,7 @@ mod tests {
         // depth=17, bucket_depth=16 gives 2 slots per bucket.
         let mut issuer = ShardedIssuer::new(BatchId::ZERO, 17, BucketDepth::new(16).unwrap());
         let address = test_address(0xABCD);
-        let bucket = calculate_bucket(&address, 16);
+        let bucket = calculate_bucket(&address, bucket_depth());
 
         issuer.prepare_stamp(&address, 1).unwrap();
         issuer.prepare_stamp(&address, 2).unwrap();
@@ -607,7 +611,7 @@ mod tests {
         // A body that resolved back into the trait would recurse until the stack died.
         let mut issuer = ShardedIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
         let address = test_address(0x1234);
-        let bucket = calculate_bucket(&address, 16);
+        let bucket = calculate_bucket(&address, bucket_depth());
 
         let digest = StampIssuer::prepare_stamp(&mut issuer, &address, 7).unwrap();
 
@@ -635,7 +639,7 @@ mod tests {
         assert_eq!(StampIssuer::stamps_issued(&handle), Some(1));
         assert!(StampIssuer::bucket_has_capacity(
             &handle,
-            calculate_bucket(&address, 16)
+            calculate_bucket(&address, bucket_depth())
         ));
     }
 
@@ -665,7 +669,7 @@ mod tests {
         // leaves only 0 and 2.
         let mutable = batch(18, false);
         let address = test_address(0x00AA);
-        let bucket = calculate_bucket(&address, 16);
+        let bucket = calculate_bucket(&address, bucket_depth());
         let issuer = ShardedRingIssuer::reserved(&mutable, [(bucket, 1), (bucket, 3)]).unwrap();
 
         for ts in 0..50u64 {
@@ -710,7 +714,7 @@ mod tests {
     fn a_fully_protected_bucket_surfaces_as_bucket_full() {
         let mutable = batch(17, false);
         let address = test_address(0x0001);
-        let bucket = calculate_bucket(&address, 16);
+        let bucket = calculate_bucket(&address, bucket_depth());
         let issuer = ShardedRingIssuer::reserved(&mutable, [(bucket, 0), (bucket, 1)]).unwrap();
 
         assert!(matches!(
@@ -752,7 +756,7 @@ mod tests {
                 for &lead in &leads {
                     ts += 1;
                     let address = test_address(lead);
-                    let bucket = calculate_bucket(&address, 16);
+                    let bucket = calculate_bucket(&address, bucket_depth);
                     let mine = sharded.prepare_stamp(&address, ts);
                     let theirs = StampIssuer::prepare_stamp(&mut sequential, &address, ts);
                     prop_assert_eq!(mine, theirs);
@@ -798,7 +802,7 @@ mod tests {
                 for &lead in &leads {
                     ts += 1;
                     let address = test_address(lead);
-                    let bucket = calculate_bucket(&address, 16);
+                    let bucket = calculate_bucket(&address, mutable.bucket_depth());
                     let mine = sharded.prepare_stamp(&address, ts);
                     let theirs = StampIssuer::prepare_stamp(&mut sequential, &address, ts);
                     prop_assert_eq!(mine, theirs);

--- a/crates/postage-issuer/tests/non_mainnet.rs
+++ b/crates/postage-issuer/tests/non_mainnet.rs
@@ -106,7 +106,7 @@ fn a_deep_issuer_dilutes_and_a_deep_sharded_issuer_stamps() {
     let sharded = ShardedIssuerFor::from_batch(&deep_batch(22, true)).unwrap();
     assert_eq!(sharded.bucket_depth(), 20);
     let digest = sharded.prepare_stamp(&address, 5).unwrap();
-    assert_eq!(digest.index.bucket(), calculate_bucket(&address, 20));
+    assert_eq!(digest.index.bucket(), calculate_bucket(&address, deep()));
     assert_eq!(sharded.stamps_issued(), 1);
 }
 
@@ -115,7 +115,7 @@ fn a_deep_reserved_ring_never_emits_a_reserved_slot() {
     // depth 22 over bucket depth 20 gives 4 slots per bucket; reserve two.
     let batch = deep_batch(22, false);
     let address = address_in(0x0FEDC);
-    let bucket = calculate_bucket(&address, 20);
+    let bucket = calculate_bucket(&address, deep());
     let mut ring: RingIssuerFor<HighFloor, Reserved> =
         RingIssuerFor::reserved(&batch, [(bucket, 1), (bucket, 3)]).unwrap();
 

--- a/crates/postage-usage/src/codec.rs
+++ b/crates/postage-usage/src/codec.rs
@@ -1048,11 +1048,7 @@ mod tests {
     fn parse_rejects_zero_bucket_depth_as_corruption() {
         // A handcrafted root that is valid in every other respect: depth 5,
         // bucket depth 0 (one zero-width bucket), width 0, sequence 1, one
-        // allocated slot, no exceptions, no leaves. Before bucket depth 0 was
-        // rejected by `validate_geometry`, this payload parsed `Ok` and the
-        // recovered snapshot panicked downstream in `calculate_bucket`
-        // (`leading >> (32 - 0)` is a shift overflow) on the persist and
-        // issue paths.
+        // allocated slot, no exceptions, no leaves.
         let mut root = vec![0u8; ROOT_HEADER_SIZE + 4];
         root[..4].copy_from_slice(&MAGIC);
         root[4..36].copy_from_slice(B256::repeat_byte(0x42).as_slice());

--- a/crates/postage-usage/src/snapshot.rs
+++ b/crates/postage-usage/src/snapshot.rs
@@ -529,7 +529,7 @@ impl<S: SwarmSpec> SnapshotFor<S> {
     /// any write.
     pub fn reserved_stamp_indices(&self, owner: &Address) -> Vec<StampIndex> {
         let batch_id = self.table.batch_id();
-        let bucket_depth = self.table.bucket_depth().get();
+        let bucket_depth = self.table.bucket_depth();
         self.slots
             .iter()
             .enumerate()
@@ -755,7 +755,7 @@ impl<S: SwarmSpec> ValidatedFor<'_, S> {
         }
 
         let batch_id = self.snapshot.table.batch_id();
-        let bucket_depth = self.snapshot.table.bucket_depth().get();
+        let bucket_depth = self.snapshot.table.bucket_depth();
         let previously_allocated = self.snapshot.slots.len();
         let previous_sequence = self.snapshot.sequence;
 
@@ -931,7 +931,7 @@ impl<S: SwarmSpec> IssuerFor<'_, S> {
         &mut self,
         address: &ChunkAddress,
     ) -> Result<(StampIndex, bool)> {
-        let bucket = calculate_bucket(address, self.snapshot.table.bucket_depth().get());
+        let bucket = calculate_bucket(address, self.snapshot.table.bucket_depth());
         // Decide before the write: afterwards the cursor has already advanced.
         let wrapped = self.will_wrap(bucket)?;
         let index = self.snapshot.record_bucket(bucket, &self.reserved)?;

--- a/crates/postage-usage/src/table.rs
+++ b/crates/postage-usage/src/table.rs
@@ -39,9 +39,7 @@ pub(crate) const fn map_counter_error(err: CounterError) -> UsageError {
 /// snapshot format: `1 <= bucket_depth <= 16` and `depth - bucket_depth <= 31`.
 ///
 /// A zero bucket depth is rejected: a batch with no collision buckets is
-/// meaningless, and `nectar_postage::calculate_bucket` shifts a `u32` right by
-/// `32 - bucket_depth`, so `bucket_depth == 0` would overflow the shift on the
-/// persist and issue paths.
+/// meaningless.
 // `depth - bucket_depth` is short-circuit guarded by the preceding
 // `depth < bucket_depth` disjunct, so it cannot underflow.
 #[allow(clippy::arithmetic_side_effects)]
@@ -605,9 +603,6 @@ mod tests {
 
     #[test]
     fn geometry_rejects_zero_bucket_depth() {
-        // A zero bucket depth would overflow `calculate_bucket`'s
-        // `32 - bucket_depth` shift on the persist and issue paths, so the
-        // geometry validator rejects it outright.
         for depth in [0u8, 1, 20, 31] {
             assert_eq!(
                 validate_geometry(depth, 0),

--- a/crates/postage-usage/tests/issuer.rs
+++ b/crates/postage-usage/tests/issuer.rs
@@ -119,7 +119,7 @@ fn shared_table_mutable_skips_reserved_across_wraps() {
             .collect();
         for salt in 0..200u8 {
             let addr = content_address(bucket, salt);
-            assert_eq!(calculate_bucket(&addr, BUCKET_DEPTH), bucket);
+            assert_eq!(calculate_bucket(&addr, bucket_depth()), bucket);
             let index = snapshot.issuer(owner()).record_address(&addr).unwrap();
             assert!(
                 !reserved_here.contains(&index),

--- a/crates/postage-usage/tests/snapshot.rs
+++ b/crates/postage-usage/tests/snapshot.rs
@@ -226,7 +226,7 @@ fn snapshot_accounts_for_its_own_chunks() {
     let allocated = plan.chunks.len() as u64;
     assert_eq!(snapshot.table().total_issued(), issued_before + allocated);
     for chunk in &plan.chunks {
-        let bucket = calculate_bucket(&chunk.address, BUCKET_DEPTH);
+        let bucket = calculate_bucket(&chunk.address, bucket_depth());
         assert_eq!(chunk.stamp_index.bucket(), bucket);
         // The recorded counter covers the assigned slot.
         assert!(snapshot.table().count(bucket).unwrap() > chunk.stamp_index.index());
@@ -542,7 +542,7 @@ fn recovered_mutable_issues_reserved_aware_through_the_handle() {
     // Find a content address that maps to the root's reserved bucket.
     let bucket = root_index.bucket();
     let content = address_in_bucket(bucket);
-    assert_eq!(calculate_bucket(&content, BUCKET_DEPTH), bucket);
+    assert_eq!(calculate_bucket(&content, bucket_depth()), bucket);
     for _ in 0..32 {
         let index = issuing.issuer(owner()).record_address(&content).unwrap();
         assert_ne!(
@@ -805,7 +805,7 @@ fn mutable_ring_wrap_is_signalled() {
 
     // Pick a content bucket clear of the snapshot's reserved slots.
     let content = address_in_bucket(0x1234);
-    let bucket = calculate_bucket(&content, BUCKET_DEPTH);
+    let bucket = calculate_bucket(&content, bucket_depth());
 
     let mut issuer = snapshot.issuer(owner());
 
@@ -847,7 +847,7 @@ fn immutable_never_wraps() {
     let table = UsageTable::new(batch_id(), 17, bucket_depth(), Mutability::Immutable).unwrap();
     let mut snapshot = Snapshot::new(table);
     let content = address_in_bucket(0x1234);
-    let bucket = calculate_bucket(&content, BUCKET_DEPTH);
+    let bucket = calculate_bucket(&content, bucket_depth());
 
     let mut issuer = snapshot.issuer(owner());
     assert!(!issuer.will_wrap(bucket).unwrap());

--- a/crates/postage-usage/tests/vector.rs
+++ b/crates/postage-usage/tests/vector.rs
@@ -57,7 +57,7 @@ fn readme_worked_example_vector() {
 
     // The root chunk's own stamp lands in bucket 41 at index 4, as
     // narrated in the README.
-    assert_eq!(calculate_bucket(&plan.chunks[0].address, 8), 41);
+    assert_eq!(calculate_bucket(&plan.chunks[0].address, low_floor(8)), 41);
     assert_eq!(snapshot.allocated_slots(), &[4]);
     assert_eq!(snapshot.table().total_issued(), 1166);
 
@@ -86,14 +86,9 @@ fn readme_large_batch_multi_leaf_vector() {
     let mut counts: Vec<u32> = (0..65536u32).map(|b| 100 + (b % 50)).collect();
     counts[0x1234] = 5000;
     counts[0xCBE5] = 8192;
-    let table = UsageTable::from_counts(
-        batch_id,
-        29,
-        BucketDepth::new(16).unwrap(),
-        counts,
-        Mutability::Immutable,
-    )
-    .unwrap();
+    let bucket_depth = BucketDepth::new(16).unwrap();
+    let table =
+        UsageTable::from_counts(batch_id, 29, bucket_depth, counts, Mutability::Immutable).unwrap();
     let mut snapshot = Snapshot::new(table);
     let plan = snapshot
         .revalidate(PublishedSequence::NONE)
@@ -108,7 +103,10 @@ fn readme_large_batch_multi_leaf_vector() {
 
     // The root's own slot is the watermark of its bucket at allocation
     // time: bucket 0x296d held 100 + (0x296d mod 50) = 105 stamps.
-    assert_eq!(calculate_bucket(&plan.chunks[0].address, 16), 0x296d);
+    assert_eq!(
+        calculate_bucket(&plan.chunks[0].address, bucket_depth),
+        0x296d
+    );
     assert_eq!(snapshot.allocated_slots()[0], 105);
 
     // Width 6 packs floor(32768 / 6) = 5461 buckets per leaf: twelve full
@@ -157,7 +155,7 @@ fn mutable_vector_flags_byte_and_round_trip() {
         .unwrap();
 
     // Same self-allocation as the immutable vector: bucket 41, slot 4.
-    assert_eq!(calculate_bucket(&plan.chunks[0].address, 8), 41);
+    assert_eq!(calculate_bucket(&plan.chunks[0].address, low_floor(8)), 41);
     assert_eq!(snapshot.allocated_slots(), &[4]);
 
     // Exactly one byte differs from the immutable vector: the flags byte.

--- a/crates/postage/src/batch.rs
+++ b/crates/postage/src/batch.rs
@@ -627,7 +627,7 @@ impl<S: SwarmSpec> Batch<S> {
     /// chunk address, interpreted as a big-endian unsigned integer.
     #[inline]
     pub fn bucket_for_address(&self, address: &ChunkAddress) -> u32 {
-        calculate_bucket(address, self.bucket_depth.get())
+        calculate_bucket(address, self.bucket_depth)
     }
 
     /// Checks if a chunk address matches the expected bucket for a stamp index.

--- a/crates/postage/src/util.rs
+++ b/crates/postage/src/util.rs
@@ -17,24 +17,11 @@ use crate::BucketDepth;
 /// let bucket_depth = BucketDepth::<Mainnet>::new(16).unwrap();
 /// assert_eq!(calculate_bucket(&address, bucket_depth), 0xCBE5);
 /// ```
-///
-/// An unvalidated depth does not compile:
-///
-/// ```compile_fail
-/// use nectar_postage::calculate_bucket;
-/// use nectar_primitives::ChunkAddress;
-///
-/// calculate_bucket(&ChunkAddress::ZERO, 0u8);
-/// ```
 #[inline]
 pub fn calculate_bucket<S: SwarmSpec>(address: &ChunkAddress, bucket_depth: BucketDepth<S>) -> u32 {
-    // A `ChunkAddress` is 32 bytes, so the split always yields a head.
-    let leading = address
-        .as_bytes()
-        .split_first_chunk::<4>()
-        .map_or(0, |(head, _)| u32::from_be_bytes(*head));
-    // A `BucketDepth` is 1..=32, so the shift is at most 31 and never wraps.
-    leading.wrapping_shr(u32::from(
+    let &[a, b, c, d, ..] = address.as_array();
+    // Depth is 1..=32, so the shift is 0..=31 and never wraps.
+    u32::from_be_bytes([a, b, c, d]).wrapping_shr(u32::from(
         BucketDepth::<S>::MAX.saturating_sub(bucket_depth.get()),
     ))
 }
@@ -98,6 +85,12 @@ mod tests {
 
     use super::*;
 
+    // `nectar_testing::low_floor` returns the `BucketDepth` of the
+    // `nectar-postage` instance it links, which is not this one.
+    fn low_floor(depth: u8) -> BucketDepth<LowFloor> {
+        BucketDepth::new(depth).unwrap()
+    }
+
     fn address_cbe5() -> ChunkAddress {
         ChunkAddress::new([
             0xCB, 0xE5, 0x00, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -113,30 +106,16 @@ mod tests {
             calculate_bucket(&address, BucketDepth::<Mainnet>::new(16).unwrap()),
             0xCBE5
         );
-        assert_eq!(
-            calculate_bucket(&address, BucketDepth::<LowFloor>::new(8).unwrap()),
-            0xCB
-        );
-        assert_eq!(
-            calculate_bucket(&address, BucketDepth::<LowFloor>::new(4).unwrap()),
-            0xC
-        );
+        assert_eq!(calculate_bucket(&address, low_floor(8)), 0xCB);
+        assert_eq!(calculate_bucket(&address, low_floor(4)), 0xC);
     }
 
     #[test]
     fn calculate_bucket_spans_the_whole_depth_range() {
         let address = address_cbe5();
 
-        // Depth 1 is the shallowest a `BucketDepth` can hold and shifts by 31;
-        // depth 32 shifts by 0 and keeps the whole leading word.
-        assert_eq!(
-            calculate_bucket(&address, BucketDepth::<LowFloor>::new(1).unwrap()),
-            1
-        );
-        assert_eq!(
-            calculate_bucket(&address, BucketDepth::<LowFloor>::new(32).unwrap()),
-            0xCBE5_0000
-        );
+        assert_eq!(calculate_bucket(&address, low_floor(1)), 1);
+        assert_eq!(calculate_bucket(&address, low_floor(32)), 0xCBE5_0000);
     }
 
     #[test]

--- a/crates/postage/src/util.rs
+++ b/crates/postage/src/util.rs
@@ -1,48 +1,42 @@
 //! Utility functions for postage operations.
 
-use nectar_primitives::ChunkAddress;
+use nectar_primitives::{ChunkAddress, SwarmSpec};
 
-/// Calculates which collision bucket a chunk belongs to based on its address.
-///
-/// The bucket is determined by taking the first `bucket_depth` bits of the
-/// chunk address, interpreted as a big-endian unsigned integer.
-///
-/// # Arguments
-///
-/// * `address` - The chunk's Swarm address
-/// * `bucket_depth` - The number of leading bits to use (from the batch configuration)
-///
-/// # Returns
-///
-/// The bucket number (0 to 2^bucket_depth - 1)
-///
-/// # Panics
-///
-/// `bucket_depth` must be in `1..=32`: the implementation shifts a `u32`
-/// right by `32 - bucket_depth`, so `bucket_depth == 0` overflows the shift
-/// (and values above 32 overflow the subtraction), which panics with
-/// overflow checks enabled and yields an unspecified value without them.
-/// Callers validate the batch geometry (e.g. `nectar-postage-usage` rejects
-/// `bucket_depth == 0` at decode) before reaching this function.
+use crate::BucketDepth;
+
+/// Returns the collision bucket of `address`: its leading `bucket_depth` bits
+/// read big-endian.
 ///
 /// # Example
 ///
 /// ```
+/// use nectar_postage::{BucketDepth, calculate_bucket};
+/// use nectar_primitives::{ChunkAddress, Mainnet};
+///
+/// let address = ChunkAddress::new([0xCB, 0xE5, 0x00, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+/// let bucket_depth = BucketDepth::<Mainnet>::new(16).unwrap();
+/// assert_eq!(calculate_bucket(&address, bucket_depth), 0xCBE5);
+/// ```
+///
+/// An unvalidated depth does not compile:
+///
+/// ```compile_fail
 /// use nectar_postage::calculate_bucket;
 /// use nectar_primitives::ChunkAddress;
 ///
-/// let address = ChunkAddress::new([0xCB, 0xE5, 0x00, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
-/// let bucket = calculate_bucket(&address, 16);
-/// assert_eq!(bucket, 0xCBE5);
+/// calculate_bucket(&ChunkAddress::ZERO, 0u8);
 /// ```
 #[inline]
-#[allow(clippy::indexing_slicing, clippy::unwrap_used)] // ChunkAddress is a fixed 32-byte array: `[0..4]` and the 4-byte `try_into` are infallible
-#[allow(clippy::arithmetic_side_effects)] // `32 - bucket_depth` underflow is the documented `# Panics` contract (`bucket_depth` in 1..=32)
-pub fn calculate_bucket(address: &ChunkAddress, bucket_depth: u8) -> u32 {
-    // Take the first 4 bytes as a big-endian u32
-    let leading = u32::from_be_bytes(address.as_bytes()[0..4].try_into().unwrap());
-    // Shift right to get only the top `bucket_depth` bits
-    leading >> (32 - bucket_depth)
+pub fn calculate_bucket<S: SwarmSpec>(address: &ChunkAddress, bucket_depth: BucketDepth<S>) -> u32 {
+    // A `ChunkAddress` is 32 bytes, so the split always yields a head.
+    let leading = address
+        .as_bytes()
+        .split_first_chunk::<4>()
+        .map_or(0, |(head, _)| u32::from_be_bytes(*head));
+    // A `BucketDepth` is 1..=32, so the shift is at most 31 and never wraps.
+    leading.wrapping_shr(u32::from(
+        BucketDepth::<S>::MAX.saturating_sub(bucket_depth.get()),
+    ))
 }
 
 /// Context for postage validation.
@@ -99,24 +93,50 @@ impl PostageContext {
 
 #[cfg(test)]
 mod tests {
+    use nectar_primitives::Mainnet;
+    use nectar_testing::LowFloor;
+
     use super::*;
+
+    fn address_cbe5() -> ChunkAddress {
+        ChunkAddress::new([
+            0xCB, 0xE5, 0x00, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0,
+        ])
+    }
 
     #[test]
     fn test_calculate_bucket() {
-        // Address starting with 0xCBE5...
-        let address = ChunkAddress::new([
-            0xCB, 0xE5, 0x00, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0,
-        ]);
+        let address = address_cbe5();
 
-        // With bucket_depth=16, we should get 0xCBE5
-        assert_eq!(calculate_bucket(&address, 16), 0xCBE5);
+        assert_eq!(
+            calculate_bucket(&address, BucketDepth::<Mainnet>::new(16).unwrap()),
+            0xCBE5
+        );
+        assert_eq!(
+            calculate_bucket(&address, BucketDepth::<LowFloor>::new(8).unwrap()),
+            0xCB
+        );
+        assert_eq!(
+            calculate_bucket(&address, BucketDepth::<LowFloor>::new(4).unwrap()),
+            0xC
+        );
+    }
 
-        // With bucket_depth=8, we should get 0xCB
-        assert_eq!(calculate_bucket(&address, 8), 0xCB);
+    #[test]
+    fn calculate_bucket_spans_the_whole_depth_range() {
+        let address = address_cbe5();
 
-        // With bucket_depth=4, we should get 0xC
-        assert_eq!(calculate_bucket(&address, 4), 0xC);
+        // Depth 1 is the shallowest a `BucketDepth` can hold and shifts by 31;
+        // depth 32 shifts by 0 and keeps the whole leading word.
+        assert_eq!(
+            calculate_bucket(&address, BucketDepth::<LowFloor>::new(1).unwrap()),
+            1
+        );
+        assert_eq!(
+            calculate_bucket(&address, BucketDepth::<LowFloor>::new(32).unwrap()),
+            0xCBE5_0000
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

`calculate_bucket` now takes `BucketDepth<S>` rather than a raw `u8`, so the shift overflow at `bucket_depth == 0` is unrepresentable rather than guarded at a distance.

The signature in `crates/postage/src/util.rs` becomes `pub fn calculate_bucket<S: SwarmSpec>(address: &ChunkAddress, bucket_depth: BucketDepth<S>) -> u32`. The body is now total: the leading word comes from destructuring `address.as_array()` instead of `[0..4].try_into().unwrap()`, and the shift is `wrapping_shr(BucketDepth::<S>::MAX.saturating_sub(bucket_depth.get()))`. That lets the function drop all three suppressions it carried, namely `clippy::arithmetic_side_effects`, `clippy::indexing_slicing` and `clippy::unwrap_used`. The `# Panics` section and the `# Arguments` and `# Returns` boilerplate are gone, leaving two lines plus the example.

Production callers now pass the newtype directly instead of discarding it with `.get()`:

- `crates/postage/src/batch.rs`
- `crates/postage-issuer/src/issuer.rs`
- `crates/postage-issuer/src/ring.rs`
- `crates/postage-issuer/src/sharded.rs`
- `crates/postage-usage/src/snapshot.rs`, two call sites

Test call sites in `crates/postage-issuer/src/pipeline/stamped_put.rs`, `ring.rs` and `sharded.rs` build a typed `BucketDepth` through a local `bucket_depth()` helper in place of the bare `16` literal. The tests in `crates/postage/src/util.rs` use a `low_floor` helper that wraps `BucketDepth<LowFloor>`, because the depths below the mainnet floor of 16 cannot be constructed on `Mainnet`, and a new `calculate_bucket_spans_the_whole_depth_range` test exercises depth 1 and depth 32.

Doc comments in `crates/postage-usage/src/codec.rs` and `crates/postage-usage/src/table.rs` that explained the old shift-overflow hazard are trimmed, since the type now makes that state unconstructible. The runtime check in `table.rs` stays, because the snapshot format independently caps at `MAX_BUCKET_DEPTH` of 16.

## Why

Closes #687.

A fuzzer reached the shift through decoded snapshot bytes and the recovered snapshot panicked downstream. The fix that shipped at the time was a runtime guard in another crate, which left the hazard live in the signature and merely unreachable along one path. Taking the validated newtype moves the guarantee to the type system, where `BucketDepth::<S>::new` already rejects anything below `S::MIN_BUCKET_DEPTH`, a `NonZeroU8`.

This is breaking on `nectar-postage` 0.4.0 and batches into 0.5.0.

## Testing

All commands were run inside `nix develop --command`.

- `cargo clippy --workspace --all-targets --locked -- -D warnings`, clean with the three suppressions deleted.
- `cargo clippy --locked --all-targets -p nectar-postage-issuer --features parallel -- -D warnings`, clean.
- `cargo nextest run --locked -p nectar-postage -p nectar-postage-issuer -p nectar-postage-usage`, 235 passed.
- `cargo test --doc --locked -p nectar-postage`, 2 passed, the doctest having changed shape.
- `cargo check --locked -p nectar-postage --no-default-features` against `riscv64imac-unknown-none-elf` and `wasm32-unknown-unknown`, both clean.
- `cargo fmt --all --check` and the em dash scan, both clean.

The wire is untouched, and the committed `usage_snapshot_decode` corpus replays unchanged.

## AI Assistance

Implement claude-opus-5, red-team claude-opus-5, PR body claude-sonnet-5, corrections claude-opus-5.
