### PR TITLE
refactor: error source chains and single RingExhausted owner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,11 +108,10 @@ Each rule below names a file and line that already conforms, so a reviewer can c
 - Rule 2: `crates/envelope/src/lib.rs:598`, a `#[from]` wrapping variant.
 - Rule 3: `crates/feeds/src/error.rs:17`, `AddressMismatch` carrying typed `expected` and `actual` fields rather than a formatted string.
 - Rule 4: `crates/primitives-core/src/error.rs:142`, the `BoxedError` alias.
-- Rule 5: no conforming example exists yet.
-  `RingExhausted` is declared in more than one crate with the same shape and no conversion between them, which is the violation this rule exists to stop; #688 gives it one owner.
-- Rule 6: `crates/postage-usage/src/error.rs:271` and `:330`, `UsageError::is_corruption` and `is_recoverable`, with the exhaustive classification test at `:387` that fails to compile when a variant is added without being classified.
+- Rule 5: `crates/postage-issuer/src/error.rs:38`, the one `RingExhausted`, which `IssuerError`, `CounterError` and `UsageError` each convert from with `#[from]`.
+- Rule 6: `crates/postage-usage/src/error.rs:268` and `:327`, `UsageError::is_corruption` and `is_recoverable`, with the exhaustive classification test at `:397` that fails to compile when a variant is added without being classified.
 
-Applying rule 3 across the workspace is #319, rule 1 is #690, and rules 2 and 5 for the postage family are #688.
+Applying rule 3 across the workspace is #319, and rule 1 is #690.
 This section is the standard; those issues are the migration.
 
 ## Workflow

--- a/crates/postage-issuer/src/counter.rs
+++ b/crates/postage-issuer/src/counter.rs
@@ -33,6 +33,8 @@ use nectar_postage::BucketDepth;
 use nectar_primitives::{Mainnet, SwarmSpec};
 use thiserror::Error;
 
+use crate::error::RingExhausted;
+
 /// Whether a [`CounterTable`] fills each bucket once or wraps it as a ring.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CounterMode {
@@ -63,14 +65,9 @@ pub enum CounterError {
         capacity: u32,
     },
 
-    /// Every slot in a ring bucket is protected, so the ring cannot advance
-    /// without re-emitting a protected slot. The batch geometry forbids this at
-    /// real depths, so it signals a malformed reservation.
-    #[error("ring bucket {bucket} has no unprotected slot to issue")]
-    RingExhausted {
-        /// The exhausted bucket.
-        bucket: u32,
-    },
+    /// A ring bucket had no unprotected slot to issue.
+    #[error("counter advance failed")]
+    RingExhausted(#[from] RingExhausted),
 
     /// A counter vector does not match the bucket count.
     #[error("expected {expected} counters, got {got}")]
@@ -347,7 +344,7 @@ impl<S: SwarmSpec> CounterTableFor<S> {
             candidate = (candidate + 1) % capacity;
             steps += 1;
             if steps >= capacity {
-                return Err(CounterError::RingExhausted { bucket });
+                return Err(CounterError::RingExhausted(RingExhausted::new(bucket)));
             }
         }
         let index = candidate;
@@ -461,9 +458,14 @@ mod tests {
     #[test]
     fn ring_exhausts_when_every_slot_is_protected() {
         let mut table = CounterTable::new(17, bucket_depth(), CounterMode::Ring);
-        assert_eq!(
-            table.record(0, |_| true),
-            Err(CounterError::RingExhausted { bucket: 0 })
+        let err = table
+            .record(0, |_| true)
+            .expect_err("every slot is protected");
+        assert_eq!(err, CounterError::RingExhausted(RingExhausted::new(0)));
+        assert!(
+            core::error::Error::source(&err)
+                .expect("the shared condition is the source")
+                .is::<RingExhausted>()
         );
     }
 
@@ -564,7 +566,7 @@ mod tests {
                         None => {
                             prop_assert_eq!(
                                 table.record(bucket, protected),
-                                Err(CounterError::RingExhausted { bucket })
+                                Err(CounterError::RingExhausted(RingExhausted::new(bucket)))
                             );
                         }
                     }

--- a/crates/postage-issuer/src/error.rs
+++ b/crates/postage-issuer/src/error.rs
@@ -31,15 +31,27 @@ pub enum IssuerError {
     },
 
     /// A ring bucket had no unprotected slot to issue.
-    ///
-    /// Every slot in the bucket is reserved, so the ring cannot advance without
-    /// re-emitting a protected slot. This is geometrically impossible at real
-    /// batch depths and signals a malformed reservation.
-    #[error("ring bucket {bucket} has no unprotected slot to issue")]
-    RingExhausted {
-        /// The bucket that had no unprotected slot.
-        bucket: u32,
-    },
+    #[error("ring issuance failed")]
+    RingExhausted(#[from] RingExhausted),
+}
+
+/// Every slot in a ring bucket is reserved, so the ring cannot advance without
+/// re-emitting a protected slot. Real batch depths make this geometrically
+/// impossible, so it signals a malformed reservation.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+#[error("ring bucket {bucket} has no unprotected slot to issue")]
+pub struct RingExhausted {
+    /// The exhausted bucket.
+    pub bucket: u32,
+}
+
+impl RingExhausted {
+    /// The condition for `bucket`.
+    #[must_use]
+    pub const fn new(bucket: u32) -> Self {
+        Self { bucket }
+    }
 }
 
 /// Errors that can occur when signing stamps.

--- a/crates/postage-issuer/src/lib.rs
+++ b/crates/postage-issuer/src/lib.rs
@@ -156,7 +156,7 @@ pub use nectar_postage::*;
 pub use nectar_primitives::{Mainnet, NetworkId, SwarmSpec, Testnet};
 
 // Errors (override nectar_postage::StampError with our own that includes signing)
-pub use error::{IssuerError, SigningError};
+pub use error::{IssuerError, RingExhausted, SigningError};
 
 // The shared per-bucket counter table behind every issuer and the snapshot.
 pub use counter::{CounterError, CounterMode, CounterTable, CounterTableFor};

--- a/crates/postage-issuer/src/pipeline/stamped_put.rs
+++ b/crates/postage-issuer/src/pipeline/stamped_put.rs
@@ -53,11 +53,11 @@ pub enum StampedPutError<E> {
     #[error(transparent)]
     Stamp(#[from] StampError),
     /// Signing failed; the allocated index is burnt.
-    #[error(transparent)]
-    Sign(SigningError),
+    #[error("stamp signing failed")]
+    Sign(#[source] SigningError),
     /// The sink refused the pair; the signed stamp is retained for reuse.
-    #[error("stamped sink: {0}")]
-    Put(E),
+    #[error("stamped sink refused the pair")]
+    Put(#[source] E),
 }
 
 /// One address's stamping progress, shared across clones.
@@ -782,6 +782,11 @@ mod tests {
 
             let error = store.put(chunk.clone()).await.unwrap_err();
             assert!(matches!(error, StampedPutError::Put(SinkRefused)));
+            assert!(
+                core::error::Error::source(&error)
+                    .expect("the sink error is the source")
+                    .is::<SinkRefused>()
+            );
             store.put(chunk).await.unwrap();
 
             // Both attempts carried the same stamp: one allocation total.
@@ -803,6 +808,11 @@ mod tests {
             for _ in 0..2 {
                 let error = store.put(chunk.clone()).await.unwrap_err();
                 assert!(matches!(error, StampedPutError::Sign(_)));
+                let signing = core::error::Error::source(&error)
+                    .expect("the signing error is the source")
+                    .downcast_ref::<SigningError>()
+                    .expect("the source is the signing error");
+                assert!(signing.is_systemic());
             }
             // Each failure burnt an index rather than wedging on a dead
             // entry; the bucket is now full.

--- a/crates/postage-issuer/src/ring.rs
+++ b/crates/postage-issuer/src/ring.rs
@@ -280,8 +280,9 @@ impl<S: SwarmSpec, R: Reservation> RingIssuerFor<S, R> {
             .record(bucket, |slot| reservation.is_protected(bucket, slot))
             .map_err(|err| match err {
                 CounterError::RingExhausted(exhausted) => IssuerError::RingExhausted(exhausted),
-                // Ring mode never reports BucketFull, and construction errors
-                // cannot arise from `record`.
+                // `record` reports nothing else here: ring mode never fills, the
+                // bucket comes from the address so it is in range, and
+                // construction errors cannot arise from an advance.
                 _ => IssuerError::RingExhausted(RingExhausted::new(bucket)),
             })?;
         // A cursor sitting at the capacity has just filled the bucket's last

--- a/crates/postage-issuer/src/ring.rs
+++ b/crates/postage-issuer/src/ring.rs
@@ -35,7 +35,7 @@ use nectar_primitives::{ChunkAddress, Mainnet, SwarmSpec};
 
 use crate::StampIssuer;
 use crate::counter::{CounterError, CounterMode, CounterTableFor};
-use crate::error::IssuerError;
+use crate::error::{IssuerError, RingExhausted};
 
 mod sealed {
     /// Seals [`Reservation`](super::Reservation) so external crates cannot add
@@ -279,11 +279,10 @@ impl<S: SwarmSpec, R: Reservation> RingIssuerFor<S, R> {
             .counters
             .record(bucket, |slot| reservation.is_protected(bucket, slot))
             .map_err(|err| match err {
-                CounterError::RingExhausted { bucket } => IssuerError::RingExhausted { bucket },
-                CounterError::InvalidBucket { bucket } => IssuerError::RingExhausted { bucket },
+                CounterError::RingExhausted(exhausted) => IssuerError::RingExhausted(exhausted),
                 // Ring mode never reports BucketFull, and construction errors
                 // cannot arise from `record`.
-                _ => IssuerError::RingExhausted { bucket },
+                _ => IssuerError::RingExhausted(RingExhausted::new(bucket)),
             })?;
         // A cursor sitting at the capacity has just filled the bucket's last
         // fresh slot, so the bucket is saturated from here on.
@@ -358,8 +357,8 @@ impl<S: SwarmSpec, R: Reservation> StampIssuer for RingIssuerFor<S, R> {
         // Stamper contract without a new wire error.
         self.prepare_ring_stamp(address, timestamp)
             .map_err(|err| match err {
-                IssuerError::RingExhausted { bucket } => StampError::BucketFull {
-                    bucket,
+                IssuerError::RingExhausted(exhausted) => StampError::BucketFull {
+                    bucket: exhausted.bucket,
                     capacity: self.counters.bucket_capacity(),
                 },
                 // Invariant: `prepare_ring_stamp` only ever yields RingExhausted
@@ -525,10 +524,18 @@ mod tests {
         let mut issuer = RingIssuer::reserved(&batch, [(bucket, 0), (bucket, 1)]).unwrap();
 
         let address = test_address(0x0001);
+        let err = issuer
+            .prepare_ring_stamp(&address, 1)
+            .expect_err("every slot is protected");
         assert!(matches!(
-            issuer.prepare_ring_stamp(&address, 1),
-            Err(IssuerError::RingExhausted { bucket: b }) if b == bucket
+            err,
+            IssuerError::RingExhausted(RingExhausted { bucket: b }) if b == bucket
         ));
+        let cause = core::error::Error::source(&err)
+            .expect("the shared condition is the source")
+            .downcast_ref::<RingExhausted>()
+            .expect("the source is the shared condition");
+        assert_eq!(cause.bucket, bucket);
     }
 
     #[test]

--- a/crates/postage-usage/src/error.rs
+++ b/crates/postage-usage/src/error.rs
@@ -1,5 +1,6 @@
 //! Error types for usage table operations and the snapshot codec.
 
+use nectar_postage_issuer::RingExhausted;
 use nectar_primitives::wire::Underrun;
 use thiserror::Error;
 
@@ -72,13 +73,9 @@ pub enum UsageError {
     MutableMerge,
 
     /// A mutable bucket has no free ring slot because every slot is reserved
-    /// by the snapshot's own chunks. The batch geometry forbids this, so it
-    /// signals an internal inconsistency rather than an expected condition.
-    #[error("mutable bucket {bucket} has no free ring slot")]
-    RingExhausted {
-        /// The exhausted bucket.
-        bucket: u32,
-    },
+    /// by the snapshot's own chunks.
+    #[error("mutable bucket record failed")]
+    RingExhausted(#[from] RingExhausted),
 
     /// A within-bucket slot index is outside the bucket capacity.
     #[error("slot {slot} exceeds bucket capacity {capacity}")]
@@ -295,7 +292,7 @@ impl UsageError {
             | Self::InvalidBucket { .. }
             | Self::InvalidSlot { .. }
             | Self::CounterOverflow { .. }
-            | Self::RingExhausted { .. } => false,
+            | Self::RingExhausted(_) => false,
         }
     }
 
@@ -357,14 +354,27 @@ impl UsageError {
             | Self::CorruptGeometry { .. } => false,
 
             // Internal invariant: a bug to report, not a recoverable condition.
-            Self::RingExhausted { .. } => false,
+            Self::RingExhausted(_) => false,
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::UsageError;
+    use core::error::Error as _;
+
+    use super::{RingExhausted, UsageError};
+
+    #[test]
+    fn ring_exhaustion_reaches_the_top_of_the_chain() {
+        let err = UsageError::from(RingExhausted::new(7));
+        let cause = err
+            .source()
+            .expect("the shared condition is the source")
+            .downcast_ref::<RingExhausted>()
+            .expect("the source is the shared condition");
+        assert_eq!(cause.bucket, 7);
+    }
 
     #[test]
     fn classification_of_a_representative_from_each_group() {
@@ -379,7 +389,7 @@ mod tests {
         assert!(recoverable.is_recoverable());
 
         // Internal invariant: neither corruption nor recoverable.
-        let internal = UsageError::RingExhausted { bucket: 0 };
+        let internal = UsageError::RingExhausted(RingExhausted::new(0));
         assert!(!internal.is_corruption());
         assert!(!internal.is_recoverable());
     }
@@ -405,7 +415,7 @@ mod tests {
             // future unclassified variant cannot hide here silently.
             if !corruption && !recoverable {
                 assert!(
-                    matches!(err, UsageError::RingExhausted { .. }),
+                    matches!(err, UsageError::RingExhausted(_)),
                     "{err:?} is unclassified: neither corruption, recoverable, nor the known internal invariant"
                 );
             }
@@ -439,7 +449,7 @@ mod tests {
             },
             UsageError::BatchMismatch,
             UsageError::MutableMerge,
-            UsageError::RingExhausted { bucket: 0 },
+            UsageError::RingExhausted(RingExhausted::new(0)),
             UsageError::InvalidSlot {
                 slot: 0,
                 capacity: 0,
@@ -508,7 +518,7 @@ mod tests {
                 | UsageError::CounterOverflow { .. } => {
                     assert!(!err.is_corruption() && err.is_recoverable());
                 }
-                UsageError::RingExhausted { .. } => {
+                UsageError::RingExhausted(_) => {
                     assert!(!err.is_corruption() && !err.is_recoverable());
                 }
             }

--- a/crates/postage-usage/src/lib.rs
+++ b/crates/postage-usage/src/lib.rs
@@ -146,6 +146,7 @@ mod seal;
 
 pub use codec::{RootInfo, RootInfoFor};
 pub use error::UsageError;
+pub use nectar_postage_issuer::RingExhausted;
 pub use snapshot::{
     Issuer, IssuerFor, PersistPlan, PlannedChunk, PublishedSequence, Snapshot, SnapshotFor,
     SnapshotParts, SnapshotPartsFor, Validated, ValidatedFor,

--- a/crates/postage-usage/src/table.rs
+++ b/crates/postage-usage/src/table.rs
@@ -18,7 +18,7 @@ pub(crate) const fn map_counter_error(err: CounterError) -> UsageError {
         CounterError::BucketFull { bucket, capacity } => {
             UsageError::BucketFull { bucket, capacity }
         }
-        CounterError::RingExhausted { bucket } => UsageError::RingExhausted { bucket },
+        CounterError::RingExhausted(exhausted) => UsageError::RingExhausted(exhausted),
         CounterError::CounterLength { expected, got } => {
             UsageError::CounterLength { expected, got }
         }

--- a/crates/postage/src/sink.rs
+++ b/crates/postage/src/sink.rs
@@ -168,16 +168,17 @@ where
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum TeeError<L, F> {
     /// The local leg failed; the pair never reached the forward leg.
-    #[error("local leg: {0}")]
-    Local(L),
+    #[error("local leg refused the put")]
+    Local(#[source] L),
     /// The forward leg failed; the local write stands.
-    #[error("forward leg: {0}")]
-    Forward(F),
+    #[error("forward leg refused the put")]
+    Forward(#[source] F),
 }
 
 #[cfg(test)]
 mod tests {
     use std::convert::Infallible;
+    use std::error::Error as _;
     use std::sync::Arc;
     use std::sync::Mutex;
 
@@ -269,7 +270,12 @@ mod tests {
             let err = tee.put_stamped(pair).await.expect_err("local leg fails");
             assert!(matches!(err, TeeError::Local(LegRefused)));
             assert!(recorder.seen.lock().expect("recording lock").is_empty());
-            assert_eq!(err.to_string(), "local leg: leg refused");
+            assert!(
+                err.source()
+                    .expect("the leg error is the source")
+                    .downcast_ref::<LegRefused>()
+                    .is_some()
+            );
         });
     }
 
@@ -284,7 +290,12 @@ mod tests {
             let err = tee.put_stamped(pair).await.expect_err("forward leg fails");
             assert!(matches!(err, TeeError::Forward(LegRefused)));
             assert!(store.has(&address).await);
-            assert_eq!(err.to_string(), "forward leg: leg refused");
+            assert!(
+                err.source()
+                    .expect("the leg error is the source")
+                    .downcast_ref::<LegRefused>()
+                    .is_some()
+            );
         });
     }
 


### PR DESCRIPTION
## What

Two applications of the AGENTS.md error section to the published postage family, batched because they break the same three crates.

**1. Source chains.** `TeeError::Local` and `TeeError::Forward` (`crates/postage/src/sink.rs`) and `StampedPutError::Put` (`crates/postage-issuer/src/pipeline/stamped_put.rs`) now carry `#[source]` on the wrapped field and their own message ("local leg refused the put", "forward leg refused the put", "stamped sink refused the pair") instead of interpolating `{0}`. `StampedPutError::Sign` drops `#[error(transparent)]` for `#[error("stamp signing failed")]` plus `#[source] SigningError`, so the `SigningError` layer stays visible and downcastable instead of being delegated past.

**2. One home for ring exhaustion.** New owner `nectar_postage_issuer::RingExhausted` (`crates/postage-issuer/src/error.rs`): `#[non_exhaustive]`, `Debug + Clone + Copy + PartialEq + Eq + Error`, a public `bucket` field, and a `const fn new`. `CounterError::RingExhausted` and `IssuerError::RingExhausted` both wrap it via `#[from]` instead of duplicating the bucket-carrying variant, so both error enums source down to the same type.

## Why

Closes #688.

A caller could not walk to a leg's own error or downcast it, because the wrapped errors were interpolated into the message and registered no source, and `Sign` delegated `source()` past itself so the `SigningError` layer was invisible. Ring exhaustion existed as three identical variants in three crates with no conversion between them, so the origin was lost by the time it reached the top of a chain.

Adding `#[source]` to a generic field makes thiserror add `E: core::error::Error + 'static` to the generated impl, which is the breaking part; the generic parameters themselves stay unbounded. This batches into 0.5.0.

The wider stringly-variant sweep stays on #319.

## Testing

All commands run inside `nix develop --command`, on the pinned toolchain `rustc 1.94.0` (matches the declared MSRV in `rust-toolchain.toml`).

Clippy (lint.yml parity, no `--all-features`):
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: clean
- `cargo clippy --workspace --all-targets --locked --features nectar-postage-usage/client,nectar-postage-usage/issuer -- -D warnings`: clean
- `cargo clippy --locked --all-targets -p nectar-postage --features serde -- -D warnings`: clean
- `cargo clippy --locked --all-targets -p nectar-postage --features parallel -- -D warnings`: clean

## AI Assistance

Implementation: claude-opus-5. Red-team: claude-opus-5. PR: claude-sonnet-5.

