### PR TITLE
refactor(postage)!: converge spec-generic naming on defaulted parameters

### DIFF
--- a/crates/postage-issuer/benches/sign.rs
+++ b/crates/postage-issuer/benches/sign.rs
@@ -47,7 +47,8 @@ fn bench_stamper_mock(c: &mut Criterion) {
 
     group.bench_function("single", |b| {
         b.iter(|| {
-            let issuer = MemoryIssuer::new(BatchId::ZERO, 24, BucketDepth::new(16).unwrap());
+            let issuer: MemoryIssuer =
+                MemoryIssuer::new(BatchId::ZERO, 24, BucketDepth::new(16).unwrap());
             let mut stamper = BatchStamper::new(issuer, MockSigner);
             let address = random_address();
             black_box(stamper.stamp(black_box(&address)))
@@ -59,7 +60,8 @@ fn bench_stamper_mock(c: &mut Criterion) {
 
     group.bench_function("throughput_1000", |b| {
         b.iter(|| {
-            let issuer = MemoryIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
+            let issuer: MemoryIssuer =
+                MemoryIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
             let mut stamper = BatchStamper::new(issuer, MockSigner);
             for addr in &addresses {
                 black_box(stamper.stamp(addr).unwrap());
@@ -80,7 +82,8 @@ fn bench_ecdsa_sign_sequential(c: &mut Criterion) {
 
     group.bench_function("single", |b| {
         b.iter(|| {
-            let issuer = MemoryIssuer::new(BatchId::ZERO, 24, BucketDepth::new(16).unwrap());
+            let issuer: MemoryIssuer =
+                MemoryIssuer::new(BatchId::ZERO, 24, BucketDepth::new(16).unwrap());
             let mut stamper = BatchStamper::new(issuer, &signer);
             let address = random_address();
             black_box(stamper.stamp(black_box(&address)))
@@ -91,7 +94,8 @@ fn bench_ecdsa_sign_sequential(c: &mut Criterion) {
 
     group.bench_function("throughput_100", |b| {
         b.iter(|| {
-            let issuer = MemoryIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
+            let issuer: MemoryIssuer =
+                MemoryIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
             let mut stamper = BatchStamper::new(issuer, &signer);
             for addr in &addresses {
                 black_box(stamper.stamp(addr).unwrap());
@@ -114,7 +118,8 @@ fn bench_ecdsa_sign_parallel(c: &mut Criterion) {
     group.throughput(Throughput::Elements(100));
     group.bench_function("throughput_100", |b| {
         b.iter(|| {
-            let issuer = ShardedIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
+            let issuer: ShardedIssuer =
+                ShardedIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
             let mut handle = &issuer;
             let results: Vec<_> = pipeline
                 .stamp(&mut handle, addresses_100.iter().copied())
@@ -126,7 +131,8 @@ fn bench_ecdsa_sign_parallel(c: &mut Criterion) {
     group.throughput(Throughput::Elements(1000));
     group.bench_function("throughput_1000", |b| {
         b.iter(|| {
-            let issuer = ShardedIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
+            let issuer: ShardedIssuer =
+                ShardedIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
             let mut handle = &issuer;
             let results: Vec<_> = pipeline
                 .stamp(&mut handle, addresses_1000.iter().copied())
@@ -151,7 +157,8 @@ fn bench_sign_comparison(c: &mut Criterion) {
     // Sequential
     group.bench_function("sequential", |b| {
         b.iter(|| {
-            let issuer = MemoryIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
+            let issuer: MemoryIssuer =
+                MemoryIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
             let mut stamper = BatchStamper::new(issuer, &signer);
             for addr in &addresses {
                 black_box(stamper.stamp(addr).unwrap());
@@ -162,7 +169,8 @@ fn bench_sign_comparison(c: &mut Criterion) {
     // Streaming pipeline over the sharded issuer
     group.bench_function("pipeline", |b| {
         b.iter(|| {
-            let issuer = ShardedIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
+            let issuer: ShardedIssuer =
+                ShardedIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
             let mut handle = &issuer;
             let results: Vec<_> = pipeline
                 .stamp(&mut handle, addresses.iter().copied())

--- a/crates/postage-issuer/benches/upload_pipeline.rs
+++ b/crates/postage-issuer/benches/upload_pipeline.rs
@@ -132,7 +132,8 @@ fn bench_pipeline_mock_sequential(c: &mut Criterion) {
                 let (root, chunks) = split_sequential(data);
 
                 // Stamp each chunk
-                let issuer = MemoryIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
+                let issuer: MemoryIssuer =
+                    MemoryIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
                 let mut stamper = BatchStamper::new(issuer, MockSigner);
 
                 let stamps: Vec<_> = chunks
@@ -164,7 +165,8 @@ fn bench_pipeline_mock_parallel_split(c: &mut Criterion) {
                 let (root, chunks) = split_parallel(source);
 
                 // Stamp each chunk (sequential)
-                let issuer = MemoryIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
+                let issuer: MemoryIssuer =
+                    MemoryIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
                 let mut stamper = BatchStamper::new(issuer, MockSigner);
 
                 let stamps: Vec<_> = chunks
@@ -199,7 +201,8 @@ fn bench_pipeline_ecdsa_sequential(c: &mut Criterion) {
                 let (root, chunks) = split_sequential(data);
 
                 // Stamp each chunk with real signatures
-                let issuer = MemoryIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
+                let issuer: MemoryIssuer =
+                    MemoryIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
                 let mut stamper = BatchStamper::new(issuer, &signer);
 
                 let stamps: Vec<_> = chunks
@@ -235,7 +238,8 @@ fn bench_pipeline_fully_parallel(c: &mut Criterion) {
                 let (root, chunks) = split_parallel(source);
 
                 // Stream the addresses through the stamp pipeline
-                let issuer = ShardedIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
+                let issuer: ShardedIssuer =
+                    ShardedIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
                 let mut handle = &issuer;
                 let stamps: Vec<_> = pipeline
                     .stamp(&mut handle, chunks.iter().map(|c| *c.address()))
@@ -268,7 +272,8 @@ fn bench_pipeline_comparison(c: &mut Criterion) {
         b.iter(|| {
             let (root, chunks) = split_sequential(&data);
 
-            let issuer = MemoryIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
+            let issuer: MemoryIssuer =
+                MemoryIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
             let mut stamper = BatchStamper::new(issuer, &signer);
 
             let stamps: Vec<_> = chunks
@@ -285,7 +290,8 @@ fn bench_pipeline_comparison(c: &mut Criterion) {
         b.iter(|| {
             let (root, chunks) = split_parallel(&source);
 
-            let issuer = MemoryIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
+            let issuer: MemoryIssuer =
+                MemoryIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
             let mut stamper = BatchStamper::new(issuer, &signer);
 
             let stamps: Vec<_> = chunks
@@ -302,7 +308,8 @@ fn bench_pipeline_comparison(c: &mut Criterion) {
         b.iter(|| {
             let (root, chunks) = split_parallel(&source);
 
-            let issuer = ShardedIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
+            let issuer: ShardedIssuer =
+                ShardedIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
             let mut handle = &issuer;
             let stamps: Vec<_> = pipeline
                 .stamp(&mut handle, chunks.iter().map(|c| *c.address()))
@@ -348,7 +355,8 @@ fn bench_pipeline_stages(c: &mut Criterion) {
     // Stage 2: Stamp only (sequential)
     group.bench_function("2_stamp_sequential", |b| {
         b.iter(|| {
-            let issuer = MemoryIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
+            let issuer: MemoryIssuer =
+                MemoryIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
             let mut stamper = BatchStamper::new(issuer, &signer);
             let stamps: Vec<_> = addresses
                 .iter()
@@ -363,7 +371,8 @@ fn bench_pipeline_stages(c: &mut Criterion) {
 
     group.bench_function("2_stamp_parallel", |b| {
         b.iter(|| {
-            let issuer = ShardedIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
+            let issuer: ShardedIssuer =
+                ShardedIssuer::new(BatchId::ZERO, 32, BucketDepth::new(16).unwrap());
             let mut handle = &issuer;
             let stamps: Vec<_> = pipeline
                 .stamp(&mut handle, addresses.iter().copied())

--- a/crates/postage-issuer/examples/stamp_pipeline.rs
+++ b/crates/postage-issuer/examples/stamp_pipeline.rs
@@ -12,7 +12,7 @@ use nectar_postage_issuer::{
 use nectar_primitives::ChunkAddress;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut issuer = MemoryIssuer::new(BatchId::ZERO, 24, BucketDepth::new(16)?);
+    let mut issuer: MemoryIssuer = MemoryIssuer::new(BatchId::ZERO, 24, BucketDepth::new(16)?);
     let pipeline = StampPipeline::from_signer(PrivateKeySigner::random())
         .with_window(Window::new(256).ok_or("window must be nonzero")?);
 

--- a/crates/postage-issuer/src/counter.rs
+++ b/crates/postage-issuer/src/counter.rs
@@ -102,11 +102,11 @@ pub enum CounterError {
 /// reserved slot. Fill mode ignores the predicate; nothing protects a fill
 /// watermark because it only ever moves forward.
 ///
-/// The network is a type parameter and reaches the table through its
+/// The network is a type parameter that reaches the table through its
 /// [`BucketDepth`], so the bucket depth a table was built with is one the
-/// network accepts. [`CounterTable`] is the mainnet table.
+/// network accepts. It defaults to [`Mainnet`].
 #[derive(Debug)]
-pub struct CounterTableFor<S: SwarmSpec = Mainnet> {
+pub struct CounterTable<S: SwarmSpec = Mainnet> {
     depth: u8,
     bucket_depth: BucketDepth<S>,
     mode: CounterMode,
@@ -114,14 +114,11 @@ pub struct CounterTableFor<S: SwarmSpec = Mainnet> {
     issued: u64,
 }
 
-/// The [`CounterTableFor`] of the mainnet spec.
-pub type CounterTable = CounterTableFor<Mainnet>;
-
 // The spec is a type-level tag, so the impls below carry no bound on `S` beyond
 // `SwarmSpec`; deriving would demand `S: Clone` and `S: Eq` of a marker type
 // that holds no data.
 
-impl<S: SwarmSpec> Clone for CounterTableFor<S> {
+impl<S: SwarmSpec> Clone for CounterTable<S> {
     fn clone(&self) -> Self {
         Self {
             depth: self.depth,
@@ -133,7 +130,7 @@ impl<S: SwarmSpec> Clone for CounterTableFor<S> {
     }
 }
 
-impl<S: SwarmSpec> PartialEq for CounterTableFor<S> {
+impl<S: SwarmSpec> PartialEq for CounterTable<S> {
     fn eq(&self, other: &Self) -> bool {
         self.depth == other.depth
             && self.bucket_depth == other.bucket_depth
@@ -143,9 +140,9 @@ impl<S: SwarmSpec> PartialEq for CounterTableFor<S> {
     }
 }
 
-impl<S: SwarmSpec> Eq for CounterTableFor<S> {}
+impl<S: SwarmSpec> Eq for CounterTable<S> {}
 
-impl<S: SwarmSpec> CounterTableFor<S> {
+impl<S: SwarmSpec> CounterTable<S> {
     /// Creates an empty table for the given geometry and mode.
     pub fn new(depth: u8, bucket_depth: BucketDepth<S>, mode: CounterMode) -> Self {
         Self {
@@ -418,7 +415,7 @@ mod tests {
     #[test]
     fn fill_is_a_monotone_watermark_that_refuses_a_full_bucket() {
         // depth 17, bucket depth 16 gives 2 slots per bucket.
-        let mut table = CounterTable::new(17, bucket_depth(), CounterMode::Fill);
+        let mut table: CounterTable = CounterTable::new(17, bucket_depth(), CounterMode::Fill);
         assert_eq!(table.record(5, never).unwrap(), 0);
         assert_eq!(table.record(5, never).unwrap(), 1);
         assert_eq!(
@@ -434,7 +431,7 @@ mod tests {
 
     #[test]
     fn ring_wraps_and_keeps_the_cursor_in_range() {
-        let mut table = CounterTable::new(17, bucket_depth(), CounterMode::Ring);
+        let mut table: CounterTable = CounterTable::new(17, bucket_depth(), CounterMode::Ring);
         assert_eq!(table.record(5, never).unwrap(), 0);
         assert_eq!(table.record(5, never).unwrap(), 1);
         // The cursor sits at capacity, the deferred-wrap state.
@@ -447,7 +444,7 @@ mod tests {
     #[test]
     fn ring_skips_protected_slots() {
         // depth 18, bucket depth 16 gives 4 slots per bucket. Protect 1 and 3.
-        let mut table = CounterTable::new(18, bucket_depth(), CounterMode::Ring);
+        let mut table: CounterTable = CounterTable::new(18, bucket_depth(), CounterMode::Ring);
         let protected = |slot: u32| slot == 1 || slot == 3;
         for _ in 0..20 {
             let slot = table.record(0, protected).unwrap();
@@ -457,7 +454,7 @@ mod tests {
 
     #[test]
     fn ring_exhausts_when_every_slot_is_protected() {
-        let mut table = CounterTable::new(17, bucket_depth(), CounterMode::Ring);
+        let mut table: CounterTable = CounterTable::new(17, bucket_depth(), CounterMode::Ring);
         let err = table
             .record(0, |_| true)
             .expect_err("every slot is protected");
@@ -507,7 +504,7 @@ mod tests {
                 excess in 0u8..=6,
                 ops in proptest::collection::vec(0u32..8, 1..200),
             ) {
-                let bucket_depth = BucketDepth::new(bucket_depth).unwrap();
+                let bucket_depth: BucketDepth = BucketDepth::new(bucket_depth).unwrap();
                 let mut table =
                     CounterTable::new(bucket_depth.get() + excess, bucket_depth, CounterMode::Fill);
                 let capacity = table.bucket_capacity();
@@ -545,7 +542,7 @@ mod tests {
                 masks in proptest::array::uniform4(proptest::num::u16::ANY),
                 ops in proptest::collection::vec(0usize..4, 1..200),
             ) {
-                let bucket_depth = BucketDepth::new(bucket_depth).unwrap();
+                let bucket_depth: BucketDepth = BucketDepth::new(bucket_depth).unwrap();
                 let mut table =
                     CounterTable::new(bucket_depth.get() + excess, bucket_depth, CounterMode::Ring);
                 let capacity = table.bucket_capacity();
@@ -588,9 +585,9 @@ mod tests {
                 suffix in proptest::collection::vec(0u32..8, 0..120),
             ) {
                 let mode = if ring { CounterMode::Ring } else { CounterMode::Fill };
-                let bucket_depth = BucketDepth::new(bucket_depth).unwrap();
+                let bucket_depth: BucketDepth = BucketDepth::new(bucket_depth).unwrap();
                 let depth = bucket_depth.get() + excess;
-                let mut live = CounterTable::new(depth, bucket_depth, mode);
+                let mut live: CounterTable = CounterTable::new(depth, bucket_depth, mode);
                 for &bucket in &prefix {
                     let _ = live.record(bucket, never);
                 }

--- a/crates/postage-issuer/src/counter.rs
+++ b/crates/postage-issuer/src/counter.rs
@@ -104,7 +104,7 @@ pub enum CounterError {
 ///
 /// The network is a type parameter that reaches the table through its
 /// [`BucketDepth`], so the bucket depth a table was built with is one the
-/// network accepts. It defaults to [`Mainnet`].
+/// network accepts.
 #[derive(Debug)]
 pub struct CounterTable<S: SwarmSpec = Mainnet> {
     depth: u8,

--- a/crates/postage-issuer/src/dilute_handler.rs
+++ b/crates/postage-issuer/src/dilute_handler.rs
@@ -16,8 +16,8 @@
 use std::collections::HashMap;
 
 use crate::error::IssuerError;
-use crate::issuer::MemoryIssuerFor;
-use crate::sharded::ShardedIssuerFor;
+use crate::issuer::MemoryIssuer;
+use crate::sharded::ShardedIssuer;
 use nectar_postage::{BatchEvent, BatchEventHandler, BatchId};
 use nectar_primitives::SwarmSpec;
 
@@ -25,8 +25,8 @@ use nectar_primitives::SwarmSpec;
 ///
 /// This is the minimal surface the [`IssuerRegistry`] needs to drive a
 /// [`BatchEvent::DepthIncrease`] through to the right issuer. It is implemented
-/// for the fill-only issuers in this crate ([`MemoryIssuerFor`] and
-/// [`ShardedIssuerFor`]); a self-hosting ring issuer dilutes through its snapshot
+/// for the fill-only issuers in this crate ([`MemoryIssuer`] and
+/// [`ShardedIssuer`]); a self-hosting ring issuer dilutes through its snapshot
 /// in `nectar-postage-usage` and is not registered here.
 ///
 /// The trait is spec-agnostic: it only reads scalar geometry, so one registry
@@ -51,7 +51,7 @@ pub trait Dilutable {
     fn dilute(&mut self, new_depth: u8) -> Result<(), IssuerError>;
 }
 
-impl<S: SwarmSpec> Dilutable for MemoryIssuerFor<S> {
+impl<S: SwarmSpec> Dilutable for MemoryIssuer<S> {
     // The geometry accessors come from the StampIssuer trait, so they are named
     // explicitly to avoid resolving back into this Dilutable impl.
     fn batch_id(&self) -> BatchId {
@@ -71,7 +71,7 @@ impl<S: SwarmSpec> Dilutable for MemoryIssuerFor<S> {
     }
 }
 
-impl<S: SwarmSpec> Dilutable for ShardedIssuerFor<S> {
+impl<S: SwarmSpec> Dilutable for ShardedIssuer<S> {
     fn batch_id(&self) -> BatchId {
         Self::batch_id(self)
     }
@@ -176,6 +176,7 @@ mod tests {
     use super::*;
     use crate::{MemoryIssuer, ShardedIssuer};
     use nectar_postage::BucketDepth;
+    use nectar_primitives::Mainnet;
 
     fn batch_id(byte: u8) -> BatchId {
         BatchId::new([byte; 32])
@@ -186,7 +187,7 @@ mod tests {
         // depth=17, bucket_depth=16 gives 2 slots per bucket.
         let tracked = batch_id(0x11);
         let mut registry = IssuerRegistry::new();
-        registry.register(MemoryIssuer::new(
+        registry.register(MemoryIssuer::<Mainnet>::new(
             tracked,
             17,
             BucketDepth::new(16).unwrap(),
@@ -211,7 +212,7 @@ mod tests {
     fn depth_increase_grows_sharded_issuer_capacity() {
         let tracked = batch_id(0x22);
         let mut registry = IssuerRegistry::new();
-        registry.register(ShardedIssuer::new(
+        registry.register(ShardedIssuer::<Mainnet>::new(
             tracked,
             17,
             BucketDepth::new(16).unwrap(),
@@ -236,7 +237,7 @@ mod tests {
         let other = batch_id(0x44);
 
         let mut registry = IssuerRegistry::new();
-        registry.register(MemoryIssuer::new(
+        registry.register(MemoryIssuer::<Mainnet>::new(
             tracked,
             17,
             BucketDepth::new(16).unwrap(),
@@ -264,7 +265,7 @@ mod tests {
     fn non_depth_events_are_ignored() {
         let tracked = batch_id(0x55);
         let mut registry = IssuerRegistry::new();
-        registry.register(MemoryIssuer::new(
+        registry.register(MemoryIssuer::<Mainnet>::new(
             tracked,
             17,
             BucketDepth::new(16).unwrap(),
@@ -292,7 +293,7 @@ mod tests {
         // refuses it and the error propagates.
         let tracked = batch_id(0x66);
         let mut registry = IssuerRegistry::new();
-        registry.register(MemoryIssuer::new(
+        registry.register(MemoryIssuer::<Mainnet>::new(
             tracked,
             18,
             BucketDepth::new(16).unwrap(),

--- a/crates/postage-issuer/src/factory.rs
+++ b/crates/postage-issuer/src/factory.rs
@@ -7,21 +7,18 @@ use nectar_primitives::{Mainnet, SwarmSpec};
 
 /// The result of creating a batch on the network `S`.
 #[derive(Debug)]
-pub struct CreateResultFor<S: SwarmSpec = Mainnet> {
+pub struct CreateResult<S: SwarmSpec = Mainnet> {
     /// The created batch.
     pub batch: Batch<S>,
     /// The transaction hash (if created on-chain).
     pub tx_hash: Option<alloy_primitives::B256>,
 }
 
-/// The [`CreateResultFor`] of the mainnet spec.
-pub type CreateResult = CreateResultFor<Mainnet>;
-
 // The spec is a type-level tag, so the impls below carry no bound on `S` beyond
 // `SwarmSpec`; deriving would demand `S: Clone` and `S: Eq` of a marker type
 // that holds no data.
 
-impl<S: SwarmSpec> Clone for CreateResultFor<S> {
+impl<S: SwarmSpec> Clone for CreateResult<S> {
     fn clone(&self) -> Self {
         Self {
             batch: self.batch.clone(),
@@ -30,13 +27,13 @@ impl<S: SwarmSpec> Clone for CreateResultFor<S> {
     }
 }
 
-impl<S: SwarmSpec> PartialEq for CreateResultFor<S> {
+impl<S: SwarmSpec> PartialEq for CreateResult<S> {
     fn eq(&self, other: &Self) -> bool {
         self.batch == other.batch && self.tx_hash == other.tx_hash
     }
 }
 
-impl<S: SwarmSpec> Eq for CreateResultFor<S> {}
+impl<S: SwarmSpec> Eq for CreateResult<S> {}
 
 /// A trait for creating postage batches.
 ///
@@ -64,7 +61,7 @@ pub trait BatchFactory {
     fn create(
         &self,
         params: BatchParams<Self::Spec>,
-    ) -> impl std::future::Future<Output = Result<CreateResultFor<Self::Spec>, Self::Error>> + Send;
+    ) -> impl std::future::Future<Output = Result<CreateResult<Self::Spec>, Self::Error>> + Send;
 
     /// Tops up a batch with additional funds.
     ///
@@ -103,10 +100,10 @@ pub trait BatchFactory {
 /// This implementation creates batches in memory without any blockchain
 /// interaction. Useful for unit tests and local development.
 ///
-/// The network the batches are minted for is a type parameter;
-/// [`MemoryBatchFactory`] is the mainnet factory.
+/// The network the batches are minted for is a type parameter defaulting to
+/// [`Mainnet`].
 #[derive(Debug)]
-pub struct MemoryBatchFactoryFor<S: SwarmSpec = Mainnet> {
+pub struct MemoryBatchFactory<S: SwarmSpec = Mainnet> {
     /// Counter for generating unique batch IDs.
     next_id: std::sync::atomic::AtomicU64,
     /// The current block number (for start block).
@@ -115,10 +112,7 @@ pub struct MemoryBatchFactoryFor<S: SwarmSpec = Mainnet> {
     spec: PhantomData<fn() -> S>,
 }
 
-/// The [`MemoryBatchFactoryFor`] of the mainnet spec.
-pub type MemoryBatchFactory = MemoryBatchFactoryFor<Mainnet>;
-
-impl<S: SwarmSpec> MemoryBatchFactoryFor<S> {
+impl<S: SwarmSpec> MemoryBatchFactory<S> {
     /// Creates a new memory batch factory.
     pub const fn new(current_block: u64) -> Self {
         Self {
@@ -143,17 +137,17 @@ impl<S: SwarmSpec> MemoryBatchFactoryFor<S> {
     }
 }
 
-impl<S: SwarmSpec> Default for MemoryBatchFactoryFor<S> {
+impl<S: SwarmSpec> Default for MemoryBatchFactory<S> {
     fn default() -> Self {
         Self::new(0)
     }
 }
 
-impl<S: SwarmSpec> BatchFactory for MemoryBatchFactoryFor<S> {
+impl<S: SwarmSpec> BatchFactory for MemoryBatchFactory<S> {
     type Error = std::convert::Infallible;
     type Spec = S;
 
-    async fn create(&self, params: BatchParams<S>) -> Result<CreateResultFor<S>, Self::Error> {
+    async fn create(&self, params: BatchParams<S>) -> Result<CreateResult<S>, Self::Error> {
         let batch_id = self.generate_batch_id();
 
         let batch = Batch::new(
@@ -166,7 +160,7 @@ impl<S: SwarmSpec> BatchFactory for MemoryBatchFactoryFor<S> {
             params.immutable(),
         );
 
-        Ok(CreateResultFor {
+        Ok(CreateResult {
             batch,
             tx_hash: None,
         })
@@ -193,7 +187,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_memory_factory_create() {
-        let factory = MemoryBatchFactory::new(100);
+        let factory: MemoryBatchFactory = MemoryBatchFactory::new(100);
 
         let params = BatchParams::new(Address::ZERO, 20, BucketDepth::new(16).unwrap(), 1000);
         let result = factory.create(params).await.unwrap();
@@ -208,7 +202,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_memory_factory_unique_ids() {
-        let factory = MemoryBatchFactory::new(0);
+        let factory: MemoryBatchFactory = MemoryBatchFactory::new(0);
 
         let params = BatchParams::new(Address::ZERO, 20, BucketDepth::new(16).unwrap(), 1000);
 
@@ -222,7 +216,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_memory_factory_immutable() {
-        let factory = MemoryBatchFactory::new(0);
+        let factory: MemoryBatchFactory = MemoryBatchFactory::new(0);
 
         let params = BatchParams::new(Address::ZERO, 20, BucketDepth::new(16).unwrap(), 1000)
             .with_immutable(true);

--- a/crates/postage-issuer/src/factory.rs
+++ b/crates/postage-issuer/src/factory.rs
@@ -99,9 +99,6 @@ pub trait BatchFactory {
 ///
 /// This implementation creates batches in memory without any blockchain
 /// interaction. Useful for unit tests and local development.
-///
-/// The network the batches are minted for is a type parameter defaulting to
-/// [`Mainnet`].
 #[derive(Debug)]
 pub struct MemoryBatchFactory<S: SwarmSpec = Mainnet> {
     /// Counter for generating unique batch IDs.

--- a/crates/postage-issuer/src/issuer.rs
+++ b/crates/postage-issuer/src/issuer.rs
@@ -1,6 +1,6 @@
 //! Stamp issuer trait for tracking bucket utilization.
 
-use crate::counter::{CounterMode, CounterTableFor};
+use crate::counter::{CounterMode, CounterTable};
 use crate::error::IssuerError;
 use nectar_postage::{
     Batch, BatchId, BucketDepth, StampDigest, StampError, StampIndex, calculate_bucket,
@@ -146,24 +146,21 @@ pub trait StampIssuer {
 /// awareness that lives in `nectar-postage-usage`. See the crate-root
 /// documentation for the steer toward `Snapshot::issuer` / `SnapshotIssuer`.
 ///
-/// The network is a type parameter and reaches the issuer through its
-/// [`BucketDepth`]; [`MemoryIssuer`] is the mainnet issuer.
+/// The network is a type parameter that reaches the issuer through its
+/// [`BucketDepth`] and defaults to [`Mainnet`].
 #[derive(Debug)]
-pub struct MemoryIssuerFor<S: SwarmSpec = Mainnet> {
+pub struct MemoryIssuer<S: SwarmSpec = Mainnet> {
     /// The batch ID.
     batch_id: BatchId,
     /// The shared per-bucket fill watermarks. `counts[b]` is the next unused
     /// slot, monotone and never above the capacity.
-    counters: CounterTableFor<S>,
+    counters: CounterTable<S>,
 }
-
-/// The [`MemoryIssuerFor`] of the mainnet spec.
-pub type MemoryIssuer = MemoryIssuerFor<Mainnet>;
 
 // The spec is a type-level tag, so this carries no bound on `S` beyond
 // `SwarmSpec`; deriving would demand `S: Clone` of a marker type that holds no
 // data.
-impl<S: SwarmSpec> Clone for MemoryIssuerFor<S> {
+impl<S: SwarmSpec> Clone for MemoryIssuer<S> {
     fn clone(&self) -> Self {
         Self {
             batch_id: self.batch_id,
@@ -172,12 +169,12 @@ impl<S: SwarmSpec> Clone for MemoryIssuerFor<S> {
     }
 }
 
-impl<S: SwarmSpec> MemoryIssuerFor<S> {
+impl<S: SwarmSpec> MemoryIssuer<S> {
     /// Creates a new fill-only memory issuer for the given batch geometry.
     pub fn new(batch_id: BatchId, depth: u8, bucket_depth: BucketDepth<S>) -> Self {
         Self {
             batch_id,
-            counters: CounterTableFor::new(depth, bucket_depth, CounterMode::Fill),
+            counters: CounterTable::new(depth, bucket_depth, CounterMode::Fill),
         }
     }
 
@@ -221,7 +218,7 @@ impl<S: SwarmSpec> MemoryIssuerFor<S> {
     }
 }
 
-impl<S: SwarmSpec> StampIssuer for MemoryIssuerFor<S> {
+impl<S: SwarmSpec> StampIssuer for MemoryIssuer<S> {
     fn prepare_stamp(
         &mut self,
         address: &ChunkAddress,
@@ -297,7 +294,7 @@ mod tests {
     #[test]
     fn test_memory_issuer_basic() {
         let batch_id = BatchId::ZERO;
-        let issuer = MemoryIssuer::new(batch_id, 20, BucketDepth::new(16).unwrap());
+        let issuer: MemoryIssuer = MemoryIssuer::new(batch_id, 20, BucketDepth::new(16).unwrap());
 
         assert_eq!(issuer.batch_id(), batch_id);
         assert_eq!(issuer.batch_depth(), 20);
@@ -310,7 +307,8 @@ mod tests {
 
     #[test]
     fn test_memory_issuer_prepare_stamp() {
-        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
+        let mut issuer: MemoryIssuer =
+            MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
 
         let address = test_address(0xCBE5);
         let digest = issuer.prepare_stamp(&address, 12345).unwrap();
@@ -325,7 +323,8 @@ mod tests {
 
     #[test]
     fn test_memory_issuer_increments_index() {
-        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
+        let mut issuer: MemoryIssuer =
+            MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
 
         let address = test_address(0xCBE5);
 
@@ -342,7 +341,8 @@ mod tests {
     #[test]
     fn test_memory_issuer_bucket_full() {
         // depth=17, bucket_depth=16 gives 2 slots per bucket
-        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 17, BucketDepth::new(16).unwrap());
+        let mut issuer: MemoryIssuer =
+            MemoryIssuer::new(BatchId::ZERO, 17, BucketDepth::new(16).unwrap());
 
         let address = test_address(0xABCD);
 
@@ -363,7 +363,8 @@ mod tests {
 
     #[test]
     fn test_memory_issuer_bucket_utilization() {
-        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
+        let mut issuer: MemoryIssuer =
+            MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
 
         let addr1 = test_address(0x1234);
         let addr2 = test_address(0x5678);
@@ -380,7 +381,8 @@ mod tests {
     #[test]
     fn test_memory_issuer_capacity_check() {
         // depth=17, bucket_depth=16 gives 2 slots per bucket
-        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 17, BucketDepth::new(16).unwrap());
+        let mut issuer: MemoryIssuer =
+            MemoryIssuer::new(BatchId::ZERO, 17, BucketDepth::new(16).unwrap());
 
         let address = test_address(0x0001);
 
@@ -396,7 +398,8 @@ mod tests {
     #[test]
     fn test_memory_issuer_near_capacity() {
         // depth=18, bucket_depth=16 gives 4 slots per bucket
-        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 18, BucketDepth::new(16).unwrap());
+        let mut issuer: MemoryIssuer =
+            MemoryIssuer::new(BatchId::ZERO, 18, BucketDepth::new(16).unwrap());
 
         let address = test_address(0x0001);
 
@@ -422,7 +425,7 @@ mod tests {
         // A mutable batch must never yield an issuer: the obvious constructor
         // refuses it instead of handing back a reserved-blind ring that would
         // silently overwrite a self-hosted snapshot's own chunks.
-        let mutable = Batch::new(
+        let mutable: Batch = Batch::new(
             BatchId::ZERO,
             0,
             0,
@@ -445,7 +448,7 @@ mod tests {
         // An immutable batch yields a fill-only issuer byte-for-byte identical
         // to `new` for the same geometry: same indices and the same digest.
         let batch_id = BatchId::new([0x11u8; 32]);
-        let immutable = Batch::new(
+        let immutable: Batch = Batch::new(
             batch_id,
             0,
             0,
@@ -456,7 +459,8 @@ mod tests {
         );
 
         let mut from_batch = MemoryIssuer::from_batch(&immutable).unwrap();
-        let mut from_new = MemoryIssuer::new(batch_id, 17, BucketDepth::new(16).unwrap());
+        let mut from_new: MemoryIssuer =
+            MemoryIssuer::new(batch_id, 17, BucketDepth::new(16).unwrap());
 
         for ts in 0..2u64 {
             for leading in [0xCBE5u16, 0x0001, 0xABCD] {
@@ -479,7 +483,8 @@ mod tests {
     #[test]
     fn test_memory_issuer_dilute_grows_capacity_only() {
         // depth=17, bucket_depth=16 gives 2 slots per bucket.
-        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 17, BucketDepth::new(16).unwrap());
+        let mut issuer: MemoryIssuer =
+            MemoryIssuer::new(BatchId::ZERO, 17, BucketDepth::new(16).unwrap());
         let address = test_address(0xABCD);
 
         // Fill the bucket, then a dilution to depth 18 (4 slots) reopens it
@@ -539,9 +544,9 @@ mod tests {
                 bucket_depth in 16u8..=18,
                 ops in proptest::collection::vec(op_strategy(), 1..120),
             ) {
-                let bucket_depth = BucketDepth::new(bucket_depth).unwrap();
+                let bucket_depth: BucketDepth = BucketDepth::new(bucket_depth).unwrap();
                 let mut depth = bucket_depth.get() + 1;
-                let mut issuer = MemoryIssuer::new(BatchId::ZERO, depth, bucket_depth);
+                let mut issuer: MemoryIssuer = MemoryIssuer::new(BatchId::ZERO, depth, bucket_depth);
                 let mut marks = BTreeMap::<u16, u32>::new();
                 let mut issued = 0u64;
                 let mut ts = 0u64;

--- a/crates/postage-issuer/src/issuer.rs
+++ b/crates/postage-issuer/src/issuer.rs
@@ -147,7 +147,7 @@ pub trait StampIssuer {
 /// documentation for the steer toward `Snapshot::issuer` / `SnapshotIssuer`.
 ///
 /// The network is a type parameter that reaches the issuer through its
-/// [`BucketDepth`] and defaults to [`Mainnet`].
+/// [`BucketDepth`].
 #[derive(Debug)]
 pub struct MemoryIssuer<S: SwarmSpec = Mainnet> {
     /// The batch ID.

--- a/crates/postage-issuer/src/lib.rs
+++ b/crates/postage-issuer/src/lib.rs
@@ -58,7 +58,8 @@
 //! An issuer is parameterized by the [`SwarmSpec`] its batch was built for, and
 //! carries it in the [`BucketDepth`] it is constructed from, so a depth the
 //! network refuses never reaches an issuer. The spec parameter defaults to
-//! [`Mainnet`], so ordinary call sites need no type annotation:
+//! [`Mainnet`] in type position only; a default drives no inference, so a
+//! construction site still names the type it builds:
 //!
 //! ```
 //! use nectar_postage_issuer::{BatchId, BucketDepth, MemoryIssuer, Testnet};

--- a/crates/postage-issuer/src/lib.rs
+++ b/crates/postage-issuer/src/lib.rs
@@ -47,7 +47,7 @@
 //! fn self_hosting_sink(_ring: RingIssuer<Reserved>) {}
 //!
 //! let bucket_depth = BucketDepth::new(16).unwrap();
-//! let batch = Batch::new(BatchId::ZERO, 0, 0, Default::default(), 20, bucket_depth, false);
+//! let batch: Batch = Batch::new(BatchId::ZERO, 0, 0, Default::default(), 20, bucket_depth, false);
 //! let unreserved: RingIssuer<Unreserved> = RingIssuer::external(&batch).unwrap();
 //! // A reserved-blind ring is not a Reserved ring, and there is no conversion.
 //! self_hosting_sink(unreserved);
@@ -57,16 +57,14 @@
 //!
 //! An issuer is parameterized by the [`SwarmSpec`] its batch was built for, and
 //! carries it in the [`BucketDepth`] it is constructed from, so a depth the
-//! network refuses never reaches an issuer. The generic type takes the `...For`
-//! name ([`MemoryIssuerFor`], [`RingIssuerFor`], [`ShardedIssuerFor`],
-//! [`ShardedRingIssuerFor`], [`CounterTableFor`]) and the bare name is the
-//! mainnet alias, so ordinary call sites need no type annotation:
+//! network refuses never reaches an issuer. The spec parameter defaults to
+//! [`Mainnet`], so ordinary call sites need no type annotation:
 //!
 //! ```
-//! use nectar_postage_issuer::{BatchId, BucketDepth, MemoryIssuer, MemoryIssuerFor, Testnet};
+//! use nectar_postage_issuer::{BatchId, BucketDepth, MemoryIssuer, Testnet};
 //!
-//! let mainnet = MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16)?);
-//! let testnet = MemoryIssuerFor::<Testnet>::new(BatchId::ZERO, 20, BucketDepth::new(16)?);
+//! let mainnet: MemoryIssuer = MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16)?);
+//! let testnet = MemoryIssuer::<Testnet>::new(BatchId::ZERO, 20, BucketDepth::new(16)?);
 //! # Ok::<(), nectar_postage_issuer::StampError>(())
 //! ```
 //!
@@ -76,9 +74,9 @@
 //!
 //! # Parallel stamping
 //!
-//! [`ShardedFor`] splits the bucket space across shards, each holding one
+//! [`Sharded`] splits the bucket space across shards, each holding one
 //! sequential issuer behind its own lock. The inner issuer sets the issuance
-//! mode, so [`ShardedIssuerFor`] and [`ShardedRingIssuerFor`] are aliases.
+//! mode, so [`ShardedIssuer`] and [`ShardedRingIssuer`] are aliases.
 //!
 //! # Features
 //!
@@ -99,7 +97,7 @@
 //! use alloy_signer_local::PrivateKeySigner;
 //!
 //! // Create an issuer for a batch
-//! let issuer = MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
+//! let issuer: MemoryIssuer = MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
 //!
 //! // Combine with any SignerSync implementation to create a stamper
 //! let signer = PrivateKeySigner::random();
@@ -159,14 +157,14 @@ pub use nectar_primitives::{Mainnet, NetworkId, SwarmSpec, Testnet};
 pub use error::{IssuerError, RingExhausted, SigningError};
 
 // The shared per-bucket counter table behind every issuer and the snapshot.
-pub use counter::{CounterError, CounterMode, CounterTable, CounterTableFor};
+pub use counter::{CounterError, CounterMode, CounterTable};
 
 // Wiring on-chain depth-increase events through to issuer dilution (std only).
 #[cfg(feature = "std")]
 pub use dilute_handler::{Dilutable, IssuerRegistry};
 
 // Issuing
-pub use issuer::{MemoryIssuer, MemoryIssuerFor, StampIssuer};
+pub use issuer::{MemoryIssuer, StampIssuer};
 pub use stamper::{BatchStamper, Stamper};
 
 // The streaming stamp pipeline; its sign window is the governor window.
@@ -178,16 +176,12 @@ pub use pipeline::{Eip191, SignPrehash, StampPipeline, StampResult, Stamped};
 pub use pipeline::{IssuedBound, StampedPut, StampedPutError};
 
 // Mutable (ring) issuing with a type-state reservation guard
-pub use ring::{Reservation, Reserved, RingIssuer, RingIssuerFor, Unreserved};
+pub use ring::{Reservation, Reserved, RingIssuer, Unreserved};
 
 // Parallel issuance: one sequential issuer per shard of the bucket space.
 #[cfg(feature = "std")]
-pub use sharded::{
-    Sharded, ShardedFor, ShardedIssuer, ShardedIssuerFor, ShardedRingIssuer, ShardedRingIssuerFor,
-};
+pub use sharded::{Sharded, ShardedIssuer, ShardedRingIssuer};
 
 // Factory (std only)
 #[cfg(feature = "std")]
-pub use factory::{
-    BatchFactory, CreateResult, CreateResultFor, MemoryBatchFactory, MemoryBatchFactoryFor,
-};
+pub use factory::{BatchFactory, CreateResult, MemoryBatchFactory};

--- a/crates/postage-issuer/src/pipeline/mod.rs
+++ b/crates/postage-issuer/src/pipeline/mod.rs
@@ -217,7 +217,7 @@ where
     /// use nectar_postage_issuer::{BatchId, BucketDepth, MemoryIssuer, StampPipeline};
     /// use nectar_primitives::ChunkAddress;
     ///
-    /// let mut issuer = MemoryIssuer::new(BatchId::ZERO, 24, BucketDepth::new(16)?);
+    /// let mut issuer: MemoryIssuer = MemoryIssuer::new(BatchId::ZERO, 24, BucketDepth::new(16)?);
     /// let pipeline = StampPipeline::from_signer(PrivateKeySigner::random());
     ///
     /// let addresses = [ChunkAddress::new([0xAB; 32]), ChunkAddress::new([0xCD; 32])];
@@ -751,7 +751,8 @@ mod tests {
     #[test]
     fn duplicates_allocate_independently_mixed_ok_err() {
         // depth=17, bucket_depth=16 gives 2 slots per bucket.
-        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 17, BucketDepth::new(16).unwrap());
+        let mut issuer: MemoryIssuer =
+            MemoryIssuer::new(BatchId::ZERO, 17, BucketDepth::new(16).unwrap());
         let pipeline = StampPipeline::from_signer(FixedSigner);
         let address = ChunkAddress::new([0xAB; 32]);
 
@@ -1034,7 +1035,8 @@ mod tests {
 
     #[test]
     fn sharded_issuer_stamps_by_value() {
-        let mut issuer = ShardedIssuer::new(BatchId::ZERO, 24, BucketDepth::new(16).unwrap());
+        let mut issuer: ShardedIssuer =
+            ShardedIssuer::new(BatchId::ZERO, 24, BucketDepth::new(16).unwrap());
         let pipeline = StampPipeline::from_signer(FixedSigner);
 
         let results: Vec<_> = pipeline.stamp(&mut issuer, addresses(50)).collect();
@@ -1046,7 +1048,8 @@ mod tests {
 
     #[test]
     fn sharded_issuer_admits_concurrently_over_shared_handles() {
-        let issuer = ShardedIssuer::new(BatchId::ZERO, 24, BucketDepth::new(16).unwrap());
+        let issuer: ShardedIssuer =
+            ShardedIssuer::new(BatchId::ZERO, 24, BucketDepth::new(16).unwrap());
         let pipeline = StampPipeline::from_signer(FixedSigner);
 
         std::thread::scope(|scope| {

--- a/crates/postage-issuer/src/pipeline/stamp_sink.rs
+++ b/crates/postage-issuer/src/pipeline/stamp_sink.rs
@@ -524,7 +524,8 @@ mod tests {
     #[test]
     fn duplicates_allocate_independently_mixed_ok_err() {
         // depth=17, bucket_depth=16 gives 2 slots per bucket.
-        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 17, BucketDepth::new(16).unwrap());
+        let mut issuer: MemoryIssuer =
+            MemoryIssuer::new(BatchId::ZERO, 17, BucketDepth::new(16).unwrap());
         let pipeline = StampPipeline::from_signer(FixedSigner).with_window(window(4));
         let address = ChunkAddress::new([0xAB; 32]);
 

--- a/crates/postage-issuer/src/pipeline/stamped_put.rs
+++ b/crates/postage-issuer/src/pipeline/stamped_put.rs
@@ -275,7 +275,7 @@ enum Step {
 /// };
 /// use nectar_primitives::{AnyChunkSet, MemoryStore};
 ///
-/// let issuer = MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16)?);
+/// let issuer: MemoryIssuer = MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16)?);
 /// let sink = StampIndifferent::new(MemoryStore::<AnyChunkSet<4096>>::new());
 /// let store = StampedPut::from_signer(issuer, PrivateKeySigner::random(), sink);
 /// assert_eq!(store.remaining_capacity(), 16);

--- a/crates/postage-issuer/src/prepared.rs
+++ b/crates/postage-issuer/src/prepared.rs
@@ -49,7 +49,8 @@ mod tests {
 
     #[test]
     fn test_prepare_stamps_allocates_in_input_order() {
-        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 24, BucketDepth::new(16).unwrap());
+        let mut issuer: MemoryIssuer =
+            MemoryIssuer::new(BatchId::ZERO, 24, BucketDepth::new(16).unwrap());
         let clock = ManualClock::new(1_234_567_890);
 
         let addresses: Vec<_> = (0..10)
@@ -71,7 +72,8 @@ mod tests {
     #[test]
     fn test_prepare_stamps_bucket_full_passes_through_in_order() {
         // depth=17, bucket_depth=16 gives 2 slots per bucket.
-        let mut issuer = MemoryIssuer::new(BatchId::ZERO, 17, BucketDepth::new(16).unwrap());
+        let mut issuer: MemoryIssuer =
+            MemoryIssuer::new(BatchId::ZERO, 17, BucketDepth::new(16).unwrap());
         let clock = ManualClock::new(0);
 
         let address = ChunkAddress::new([0xAB; 32]);
@@ -91,7 +93,7 @@ mod tests {
     fn test_prepare_stamps_ring_issuer() {
         // The micro-batch is issuer-generic: a mutable batch's ring issuer
         // works too.
-        let mutable = Batch::new(
+        let mutable: Batch = Batch::new(
             BatchId::ZERO,
             0,
             0,

--- a/crates/postage-issuer/src/ring.rs
+++ b/crates/postage-issuer/src/ring.rs
@@ -34,7 +34,7 @@ use nectar_postage::{
 use nectar_primitives::{ChunkAddress, Mainnet, SwarmSpec};
 
 use crate::StampIssuer;
-use crate::counter::{CounterError, CounterMode, CounterTableFor};
+use crate::counter::{CounterError, CounterMode, CounterTable};
 use crate::error::{IssuerError, RingExhausted};
 
 mod sealed {
@@ -133,15 +133,15 @@ impl Reservation for Reserved {
 /// with [`IssuerError::ImmutableNotSupported`]: immutable batches are fill-only
 /// and use [`MemoryIssuer`](crate::MemoryIssuer).
 ///
-/// The network is the leading type parameter and reaches the ring through its
-/// [`BucketDepth`]; [`RingIssuer`] is the mainnet ring.
+/// The network reaches the ring through its [`BucketDepth`] and defaults to
+/// [`Mainnet`].
 #[derive(Debug)]
-pub struct RingIssuerFor<S: SwarmSpec = Mainnet, R = Unreserved> {
+pub struct RingIssuer<R = Unreserved, S: SwarmSpec = Mainnet> {
     /// The batch ID.
     batch_id: BatchId,
     /// The shared per-bucket ring cursors, in the `[0, capacity]` deferred-wrap
     /// representation. `counts[b] == capacity` means "wrap on the next write".
-    counters: CounterTableFor<S>,
+    counters: CounterTable<S>,
     /// Whether each bucket has been written to capacity at least once.
     ///
     /// The wire representation defers each wrap, so once a bucket has wrapped its
@@ -159,13 +159,10 @@ pub struct RingIssuerFor<S: SwarmSpec = Mainnet, R = Unreserved> {
     reservation: R,
 }
 
-/// The [`RingIssuerFor`] of the mainnet spec.
-pub type RingIssuer<R = Unreserved> = RingIssuerFor<Mainnet, R>;
-
 // The spec is a type-level tag, so this carries no bound on `S` beyond
 // `SwarmSpec`; deriving would demand `S: Clone` of a marker type that holds no
 // data.
-impl<S: SwarmSpec, R: Clone> Clone for RingIssuerFor<S, R> {
+impl<R: Clone, S: SwarmSpec> Clone for RingIssuer<R, S> {
     fn clone(&self) -> Self {
         Self {
             batch_id: self.batch_id,
@@ -178,7 +175,7 @@ impl<S: SwarmSpec, R: Clone> Clone for RingIssuerFor<S, R> {
     }
 }
 
-impl<S: SwarmSpec> RingIssuerFor<S, Unreserved> {
+impl<S: SwarmSpec> RingIssuer<Unreserved, S> {
     /// Builds an externally tracked ring for a mutable batch.
     ///
     /// The ring protects nothing: it wraps freely and may re-emit any slot. The
@@ -195,7 +192,7 @@ impl<S: SwarmSpec> RingIssuerFor<S, Unreserved> {
     }
 }
 
-impl<S: SwarmSpec> RingIssuerFor<S, Reserved> {
+impl<S: SwarmSpec> RingIssuer<Reserved, S> {
     /// Builds a self-hosting ring for a mutable batch with a set of protected
     /// slots.
     ///
@@ -216,7 +213,7 @@ impl<S: SwarmSpec> RingIssuerFor<S, Reserved> {
     }
 }
 
-impl<S: SwarmSpec, R: Reservation> RingIssuerFor<S, R> {
+impl<R: Reservation, S: SwarmSpec> RingIssuer<R, S> {
     /// Builds a ring for a mutable batch with the given reservation policy.
     fn for_mutable_batch(batch: &Batch<S>, reservation: R) -> Result<Self, IssuerError> {
         if batch.immutable() {
@@ -240,7 +237,7 @@ impl<S: SwarmSpec, R: Reservation> RingIssuerFor<S, R> {
         let bucket_count = 1usize << bucket_depth.get();
         Self {
             batch_id,
-            counters: CounterTableFor::new(depth, bucket_depth, CounterMode::Ring),
+            counters: CounterTable::new(depth, bucket_depth, CounterMode::Ring),
             saturated: alloc::vec![false; bucket_count],
             max_utilization: 0,
             stamps_issued: 0,
@@ -346,7 +343,7 @@ impl<S: SwarmSpec, R: Reservation> RingIssuerFor<S, R> {
     }
 }
 
-impl<S: SwarmSpec, R: Reservation> StampIssuer for RingIssuerFor<S, R> {
+impl<R: Reservation, S: SwarmSpec> StampIssuer for RingIssuer<R, S> {
     fn prepare_stamp(
         &mut self,
         address: &ChunkAddress,

--- a/crates/postage-issuer/src/ring.rs
+++ b/crates/postage-issuer/src/ring.rs
@@ -133,8 +133,7 @@ impl Reservation for Reserved {
 /// with [`IssuerError::ImmutableNotSupported`]: immutable batches are fill-only
 /// and use [`MemoryIssuer`](crate::MemoryIssuer).
 ///
-/// The network reaches the ring through its [`BucketDepth`] and defaults to
-/// [`Mainnet`].
+/// The network reaches the ring through its [`BucketDepth`].
 #[derive(Debug)]
 pub struct RingIssuer<R = Unreserved, S: SwarmSpec = Mainnet> {
     /// The batch ID.

--- a/crates/postage-issuer/src/sharded.rs
+++ b/crates/postage-issuer/src/sharded.rs
@@ -12,8 +12,8 @@ use nectar_postage::{Batch, BatchId, BucketDepth, StampDigest, StampError, calcu
 use nectar_primitives::{ChunkAddress, Mainnet, SwarmSpec};
 
 use crate::error::IssuerError;
-use crate::issuer::{MemoryIssuerFor, StampIssuer};
-use crate::ring::{Reservation, Reserved, RingIssuerFor, Unreserved};
+use crate::issuer::{MemoryIssuer, StampIssuer};
+use crate::ring::{Reservation, Reserved, RingIssuer, Unreserved};
 
 /// Shards per issuer. A power of two, so a bucket's shard is a shift and a mask.
 const DEFAULT_SHARD_COUNT: usize = 16;
@@ -21,9 +21,9 @@ const DEFAULT_SHARD_COUNT: usize = 16;
 /// A sharded issuer: one sequential issuer per contiguous bucket range.
 ///
 /// Allocation takes `&self`, so several threads may stamp through one issuer.
-/// The inner issuer `I` sets the issuance mode: [`ShardedIssuerFor`] is
-/// fill-only, [`ShardedRingIssuerFor`] is overwrite-aware.
-pub struct ShardedFor<S: SwarmSpec, I> {
+/// The inner issuer `I` sets the issuance mode: [`ShardedIssuer`] is
+/// fill-only, [`ShardedRingIssuer`] is overwrite-aware.
+pub struct Sharded<I, S: SwarmSpec = Mainnet> {
     batch_id: BatchId,
     depth: u8,
     bucket_depth: BucketDepth<S>,
@@ -36,9 +36,9 @@ pub struct ShardedFor<S: SwarmSpec, I> {
 }
 
 // Geometry only: deriving would dump every shard's whole counter table.
-impl<S: SwarmSpec, I> core::fmt::Debug for ShardedFor<S, I> {
+impl<I, S: SwarmSpec> core::fmt::Debug for Sharded<I, S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ShardedFor")
+        f.debug_struct("Sharded")
             .field("batch_id", &self.batch_id)
             .field("depth", &self.depth)
             .field("bucket_depth", &self.bucket_depth.get())
@@ -49,17 +49,11 @@ impl<S: SwarmSpec, I> core::fmt::Debug for ShardedFor<S, I> {
     }
 }
 
-/// The [`ShardedFor`] of the mainnet spec.
-pub type Sharded<I> = ShardedFor<Mainnet, I>;
-
-/// A fill-only sharded issuer: the parallel counterpart of [`MemoryIssuerFor`].
-pub type ShardedIssuerFor<S = Mainnet> = ShardedFor<S, MemoryIssuerFor<S>>;
-
-/// The [`ShardedIssuerFor`] of the mainnet spec.
-pub type ShardedIssuer = ShardedIssuerFor<Mainnet>;
+/// A fill-only sharded issuer: the parallel counterpart of [`MemoryIssuer`].
+pub type ShardedIssuer<S = Mainnet> = Sharded<MemoryIssuer<S>, S>;
 
 /// A sharded mutable (ring) issuer: the parallel counterpart of
-/// [`RingIssuerFor`].
+/// [`RingIssuer`].
 ///
 /// The reservation policy rides on the inner ring, so a sink that demands a
 /// reserved ring cannot be handed a reserved-blind one:
@@ -72,16 +66,13 @@ pub type ShardedIssuer = ShardedIssuerFor<Mainnet>;
 /// fn self_hosting_sink(_ring: ShardedRingIssuer<Reserved>) {}
 ///
 /// let bucket_depth = BucketDepth::new(16).unwrap();
-/// let batch = Batch::new(BatchId::ZERO, 0, 0, Default::default(), 20, bucket_depth, false);
+/// let batch: Batch = Batch::new(BatchId::ZERO, 0, 0, Default::default(), 20, bucket_depth, false);
 /// let unreserved: ShardedRingIssuer<Unreserved> = ShardedRingIssuer::external(&batch).unwrap();
 /// self_hosting_sink(unreserved);
 /// ```
-pub type ShardedRingIssuerFor<S = Mainnet, R = Unreserved> = ShardedFor<S, RingIssuerFor<S, R>>;
+pub type ShardedRingIssuer<R = Unreserved, S = Mainnet> = Sharded<RingIssuer<R, S>, S>;
 
-/// The [`ShardedRingIssuerFor`] of the mainnet spec.
-pub type ShardedRingIssuer<R = Unreserved> = ShardedRingIssuerFor<Mainnet, R>;
-
-impl<S: SwarmSpec, I: StampIssuer> ShardedFor<S, I> {
+impl<I: StampIssuer, S: SwarmSpec> Sharded<I, S> {
     /// Builds `shard_count` shards, each from `make_shard` applied to the
     /// `[base, end)` bucket range it owns.
     // `shard_count` is a nonzero power of two clamped to `2^bucket_depth`, and
@@ -201,7 +192,7 @@ impl<S: SwarmSpec, I: StampIssuer> ShardedFor<S, I> {
     }
 }
 
-impl<S: SwarmSpec> ShardedFor<S, MemoryIssuerFor<S>> {
+impl<S: SwarmSpec> Sharded<MemoryIssuer<S>, S> {
     /// Creates a fill-only sharded issuer with the default shard count.
     pub fn new(batch_id: BatchId, depth: u8, bucket_depth: BucketDepth<S>) -> Self {
         Self::with_shard_count(batch_id, depth, bucket_depth, DEFAULT_SHARD_COUNT)
@@ -223,7 +214,7 @@ impl<S: SwarmSpec> ShardedFor<S, MemoryIssuerFor<S>> {
         shard_count: usize,
     ) -> Self {
         Self::with_shards(batch_id, depth, bucket_depth, shard_count, |_, _| {
-            MemoryIssuerFor::new(batch_id, depth, bucket_depth)
+            MemoryIssuer::new(batch_id, depth, bucket_depth)
         })
     }
 
@@ -268,7 +259,7 @@ impl<S: SwarmSpec> ShardedFor<S, MemoryIssuerFor<S>> {
     }
 }
 
-impl<S: SwarmSpec> ShardedFor<S, RingIssuerFor<S, Unreserved>> {
+impl<S: SwarmSpec> Sharded<RingIssuer<Unreserved, S>, S> {
     /// Builds an externally tracked sharded ring for a mutable batch.
     ///
     /// # Errors
@@ -279,7 +270,7 @@ impl<S: SwarmSpec> ShardedFor<S, RingIssuerFor<S, Unreserved>> {
     }
 }
 
-impl<S: SwarmSpec> ShardedFor<S, RingIssuerFor<S, Reserved>> {
+impl<S: SwarmSpec> Sharded<RingIssuer<Reserved, S>, S> {
     /// Builds a self-hosting sharded ring for a mutable batch, protecting
     /// `slots` from re-issuance.
     ///
@@ -303,7 +294,7 @@ impl<S: SwarmSpec> ShardedFor<S, RingIssuerFor<S, Reserved>> {
     }
 }
 
-impl<S: SwarmSpec, R: Reservation> ShardedFor<S, RingIssuerFor<S, R>> {
+impl<R: Reservation, S: SwarmSpec> Sharded<RingIssuer<R, S>, S> {
     fn for_mutable_batch(
         batch: &Batch<S>,
         make_reservation: impl Fn(u32, u32) -> R,
@@ -317,7 +308,7 @@ impl<S: SwarmSpec, R: Reservation> ShardedFor<S, RingIssuerFor<S, R>> {
             batch.bucket_depth(),
             DEFAULT_SHARD_COUNT,
             |base, end| {
-                RingIssuerFor::with_reservation(
+                RingIssuer::with_reservation(
                     batch.id(),
                     batch.depth(),
                     batch.bucket_depth(),
@@ -328,7 +319,7 @@ impl<S: SwarmSpec, R: Reservation> ShardedFor<S, RingIssuerFor<S, R>> {
     }
 }
 
-impl<S: SwarmSpec, I: StampIssuer> StampIssuer for ShardedFor<S, I> {
+impl<I: StampIssuer, S: SwarmSpec> StampIssuer for Sharded<I, S> {
     fn prepare_stamp(
         &mut self,
         address: &ChunkAddress,
@@ -369,41 +360,41 @@ impl<S: SwarmSpec, I: StampIssuer> StampIssuer for ShardedFor<S, I> {
 }
 
 /// Shared-handle issuance: several pipelines may admit from one issuer.
-impl<S: SwarmSpec, I: StampIssuer> StampIssuer for &ShardedFor<S, I> {
+impl<I: StampIssuer, S: SwarmSpec> StampIssuer for &Sharded<I, S> {
     fn prepare_stamp(
         &mut self,
         address: &ChunkAddress,
         timestamp: u64,
     ) -> Result<StampDigest, StampError> {
-        ShardedFor::prepare_stamp(self, address, timestamp)
+        Sharded::prepare_stamp(self, address, timestamp)
     }
 
     fn batch_id(&self) -> BatchId {
-        ShardedFor::batch_id(self)
+        Sharded::batch_id(self)
     }
 
     fn batch_depth(&self) -> u8 {
-        ShardedFor::batch_depth(self)
+        Sharded::batch_depth(self)
     }
 
     fn bucket_depth(&self) -> u8 {
-        ShardedFor::bucket_depth(self)
+        Sharded::bucket_depth(self)
     }
 
     fn max_bucket_utilization(&self) -> u32 {
-        ShardedFor::max_bucket_utilization(self)
+        Sharded::max_bucket_utilization(self)
     }
 
     fn bucket_utilization(&self, bucket: u32) -> u32 {
-        ShardedFor::bucket_utilization(self, bucket)
+        Sharded::bucket_utilization(self, bucket)
     }
 
     fn bucket_has_capacity(&self, bucket: u32) -> bool {
-        ShardedFor::bucket_has_capacity(self, bucket)
+        Sharded::bucket_has_capacity(self, bucket)
     }
 
     fn stamps_issued(&self) -> Option<u64> {
-        Some(ShardedFor::stamps_issued(self))
+        Some(Sharded::stamps_issued(self))
     }
 }
 
@@ -466,7 +457,8 @@ mod tests {
 
     #[test]
     fn a_sharded_issuer_reports_its_geometry() {
-        let issuer = ShardedIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
+        let issuer: ShardedIssuer =
+            ShardedIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
 
         assert_eq!(issuer.batch_id(), BatchId::ZERO);
         assert_eq!(issuer.batch_depth(), 20);
@@ -477,7 +469,8 @@ mod tests {
 
     #[test]
     fn a_sharded_issuer_stamps_and_counts() {
-        let issuer = ShardedIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
+        let issuer: ShardedIssuer =
+            ShardedIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
         let address = ChunkAddress::from(B256::random());
 
         let digest = issuer.prepare_stamp(&address, 12345).unwrap();
@@ -490,7 +483,7 @@ mod tests {
 
     #[test]
     fn a_smaller_shard_count_still_routes_every_bucket() {
-        let issuer =
+        let issuer: ShardedIssuer =
             ShardedIssuer::with_shard_count(BatchId::ZERO, 20, BucketDepth::new(16).unwrap(), 4);
         assert_eq!(issuer.shard_count(), 4);
         for lead in [0x0000u16, 0x3FFF, 0x4000, 0xBFFF, 0xC000, 0xFFFF] {
@@ -503,7 +496,8 @@ mod tests {
     #[test]
     fn dilution_grows_capacity_only() {
         // depth=17, bucket_depth=16 gives 2 slots per bucket.
-        let mut issuer = ShardedIssuer::new(BatchId::ZERO, 17, BucketDepth::new(16).unwrap());
+        let mut issuer: ShardedIssuer =
+            ShardedIssuer::new(BatchId::ZERO, 17, BucketDepth::new(16).unwrap());
         let address = test_address(0xABCD);
         let bucket = calculate_bucket(&address, bucket_depth());
 
@@ -531,7 +525,8 @@ mod tests {
     #[test]
     fn dilution_reaches_every_shard() {
         // depth=17, bucket_depth=16 gives 2 slots per bucket; one address per shard.
-        let mut issuer = ShardedIssuer::new(BatchId::ZERO, 17, BucketDepth::new(16).unwrap());
+        let mut issuer: ShardedIssuer =
+            ShardedIssuer::new(BatchId::ZERO, 17, BucketDepth::new(16).unwrap());
         let addresses: Vec<_> = (0..DEFAULT_SHARD_COUNT)
             .map(|shard| test_address(u16::try_from(shard).unwrap() << 12))
             .collect();
@@ -553,7 +548,8 @@ mod tests {
     fn stamping_is_concurrent_over_shared_handles() {
         use std::thread;
 
-        let issuer = ShardedIssuer::new(BatchId::ZERO, 24, BucketDepth::new(16).unwrap());
+        let issuer: ShardedIssuer =
+            ShardedIssuer::new(BatchId::ZERO, 24, BucketDepth::new(16).unwrap());
         let threads = 8u64;
         let per_thread = 1000u64;
 
@@ -577,7 +573,8 @@ mod tests {
         use std::thread;
 
         // depth=24, bucket_depth=16 gives 256 slots, which 8 threads fill exactly.
-        let issuer = ShardedIssuer::new(BatchId::ZERO, 24, BucketDepth::new(16).unwrap());
+        let issuer: ShardedIssuer =
+            ShardedIssuer::new(BatchId::ZERO, 24, BucketDepth::new(16).unwrap());
         let address = test_address(0x9BCD);
         let slots = StdMutex::new(Vec::new());
 
@@ -600,7 +597,8 @@ mod tests {
 
     #[test]
     fn a_bucket_outside_the_bucket_space_reads_as_empty() {
-        let issuer = ShardedIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
+        let issuer: ShardedIssuer =
+            ShardedIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
 
         assert_eq!(issuer.bucket_utilization(0x1_0000), 0);
         assert!(!issuer.bucket_has_capacity(0x1_0000));
@@ -609,7 +607,8 @@ mod tests {
     #[test]
     fn every_trait_method_reaches_the_inherent_one() {
         // A body that resolved back into the trait would recurse until the stack died.
-        let mut issuer = ShardedIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
+        let mut issuer: ShardedIssuer =
+            ShardedIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
         let address = test_address(0x1234);
         let bucket = calculate_bucket(&address, bucket_depth());
 
@@ -627,7 +626,8 @@ mod tests {
 
     #[test]
     fn a_shared_handle_implements_stamp_issuer() {
-        let issuer = ShardedIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
+        let issuer: ShardedIssuer =
+            ShardedIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
         let mut handle = &issuer;
 
         let address = ChunkAddress::from(B256::random());
@@ -747,10 +747,10 @@ mod tests {
                 excess in 0u8..=2,
                 leads in leads(),
             ) {
-                let bucket_depth = BucketDepth::new(16).unwrap();
+                let bucket_depth: BucketDepth = BucketDepth::new(16).unwrap();
                 let depth = 16 + excess;
-                let sharded = ShardedIssuer::new(BatchId::ZERO, depth, bucket_depth);
-                let mut sequential = MemoryIssuer::new(BatchId::ZERO, depth, bucket_depth);
+                let sharded: ShardedIssuer = ShardedIssuer::new(BatchId::ZERO, depth, bucket_depth);
+                let mut sequential: MemoryIssuer = MemoryIssuer::new(BatchId::ZERO, depth, bucket_depth);
 
                 let mut ts = 0u64;
                 for &lead in &leads {

--- a/crates/postage-issuer/src/stamper.rs
+++ b/crates/postage-issuer/src/stamper.rs
@@ -280,7 +280,8 @@ mod tests {
 
     #[test]
     fn test_batch_stamper_basic() {
-        let issuer = MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
+        let issuer: MemoryIssuer =
+            MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
         let mut stamper = BatchStamper::new(issuer, MockSigner);
 
         let address = ChunkAddress::new([0xAB; 32]);
@@ -293,7 +294,8 @@ mod tests {
 
     #[test]
     fn test_batch_stamper_increments_index() {
-        let issuer = MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
+        let issuer: MemoryIssuer =
+            MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
         let mut stamper = BatchStamper::new(issuer, MockSigner);
 
         // Use same address to hit same bucket
@@ -316,7 +318,8 @@ mod tests {
     fn test_batch_stamper_injected_clock() {
         use nectar_clock::ManualClock;
 
-        let issuer = MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
+        let issuer: MemoryIssuer =
+            MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
         let clock = ManualClock::new(1_234_567_890);
         let mut stamper = BatchStamper::with_clock(issuer, MockSigner, &clock);
 
@@ -340,7 +343,8 @@ mod tests {
 
         // Create an issuer with very small bucket capacity: depth=17, bucket_depth=16
         // This gives 2^(17-16) = 2 slots per bucket
-        let issuer = MemoryIssuer::new(BatchId::ZERO, 17, BucketDepth::new(16).unwrap());
+        let issuer: MemoryIssuer =
+            MemoryIssuer::new(BatchId::ZERO, 17, BucketDepth::new(16).unwrap());
         let mut stamper = BatchStamper::new(issuer, MockSigner);
 
         let address = ChunkAddress::new([0xAB; 32]);
@@ -359,7 +363,8 @@ mod tests {
 
     #[test]
     fn test_batch_stamper_max_utilization() {
-        let issuer = MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
+        let issuer: MemoryIssuer =
+            MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
         let mut stamper = BatchStamper::new(issuer, MockSigner);
 
         assert_eq!(stamper.max_bucket_utilization(), 0);
@@ -374,7 +379,8 @@ mod tests {
 
     #[test]
     fn test_into_parts_keeps_issuer_state() {
-        let issuer = MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
+        let issuer: MemoryIssuer =
+            MemoryIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
         let mut stamper = BatchStamper::new(issuer, MockSigner);
 
         let address = ChunkAddress::new([0xAB; 32]);

--- a/crates/postage-issuer/tests/non_mainnet.rs
+++ b/crates/postage-issuer/tests/non_mainnet.rs
@@ -9,9 +9,9 @@
 
 use alloy_signer_local::PrivateKeySigner;
 use nectar_postage_issuer::{
-    Batch, BatchId, BatchStamper, BucketDepth, IssuerError, Mainnet, MemoryIssuerFor, Reserved,
-    RingIssuerFor, ShardedIssuerFor, SigningError, StampError, StampIssuer, Stamper,
-    calculate_bucket,
+    Batch, BatchId, BatchStamper, BucketDepth, CounterTable, IssuerError, Mainnet,
+    MemoryBatchFactory, MemoryIssuer, Reserved, RingIssuer, Sharded, ShardedIssuer,
+    ShardedRingIssuer, SigningError, StampError, StampIssuer, Stamper, calculate_bucket,
 };
 use nectar_primitives::ChunkAddress;
 use nectar_testing::HighFloor;
@@ -59,7 +59,7 @@ fn the_floor_is_the_deployments_own() {
 fn a_deep_issuer_stamps_through_a_batch_stamper() {
     // depth 22 over bucket depth 20 gives 4 slots per bucket.
     let batch = deep_batch(22, true);
-    let issuer = MemoryIssuerFor::from_batch(&batch).unwrap();
+    let issuer = MemoryIssuer::from_batch(&batch).unwrap();
     assert_eq!(issuer.bucket_depth(), 20);
     assert_eq!(issuer.bucket_count(), 1 << 20);
     assert_eq!(issuer.bucket_capacity(), 4);
@@ -86,7 +86,7 @@ fn a_deep_issuer_stamps_through_a_batch_stamper() {
 
 #[test]
 fn a_deep_issuer_dilutes_and_a_deep_sharded_issuer_stamps() {
-    let mut issuer = MemoryIssuerFor::<HighFloor>::new(BatchId::ZERO, 21, deep());
+    let mut issuer = MemoryIssuer::<HighFloor>::new(BatchId::ZERO, 21, deep());
     let address = address_in(1);
     assert_eq!(issuer.prepare_stamp(&address, 1).unwrap().index.index(), 0);
     assert_eq!(issuer.prepare_stamp(&address, 2).unwrap().index.index(), 1);
@@ -103,7 +103,7 @@ fn a_deep_issuer_dilutes_and_a_deep_sharded_issuer_stamps() {
         })
     ));
 
-    let sharded = ShardedIssuerFor::from_batch(&deep_batch(22, true)).unwrap();
+    let sharded = ShardedIssuer::from_batch(&deep_batch(22, true)).unwrap();
     assert_eq!(sharded.bucket_depth(), 20);
     let digest = sharded.prepare_stamp(&address, 5).unwrap();
     assert_eq!(digest.index.bucket(), calculate_bucket(&address, deep()));
@@ -116,8 +116,8 @@ fn a_deep_reserved_ring_never_emits_a_reserved_slot() {
     let batch = deep_batch(22, false);
     let address = address_in(0x0FEDC);
     let bucket = calculate_bucket(&address, deep());
-    let mut ring: RingIssuerFor<HighFloor, Reserved> =
-        RingIssuerFor::reserved(&batch, [(bucket, 1), (bucket, 3)]).unwrap();
+    let mut ring: RingIssuer<Reserved, HighFloor> =
+        RingIssuer::reserved(&batch, [(bucket, 1), (bucket, 3)]).unwrap();
 
     // Far past one wrap, so every wrap is exercised.
     for timestamp in 0..40u64 {
@@ -127,3 +127,14 @@ fn a_deep_reserved_ring_never_emits_a_reserved_slot() {
         assert!(slot == 0 || slot == 2, "ring emitted reserved slot {slot}");
     }
 }
+
+// The spec parameter defaults to `Mainnet` and trails any type-state
+// parameter. Each identity fails to compile if a default is dropped, if a bare
+// name stops meaning mainnet, or if the parameters swap back.
+const _: fn(MemoryIssuer) -> MemoryIssuer<Mainnet> = |x| x;
+const _: fn(CounterTable) -> CounterTable<Mainnet> = |x| x;
+const _: fn(RingIssuer<Reserved>) -> RingIssuer<Reserved, Mainnet> = |x| x;
+const _: fn(MemoryBatchFactory) -> MemoryBatchFactory<Mainnet> = |x| x;
+const _: fn(ShardedIssuer<HighFloor>) -> Sharded<MemoryIssuer<HighFloor>, HighFloor> = |x| x;
+type DeepReservedRing = Sharded<RingIssuer<Reserved, HighFloor>, HighFloor>;
+const _: fn(ShardedRingIssuer<Reserved, HighFloor>) -> DeepReservedRing = |x| x;

--- a/crates/postage-issuer/tests/non_mainnet.rs
+++ b/crates/postage-issuer/tests/non_mainnet.rs
@@ -128,9 +128,8 @@ fn a_deep_reserved_ring_never_emits_a_reserved_slot() {
     }
 }
 
-// The spec parameter defaults to `Mainnet` and trails any type-state
-// parameter. Each identity fails to compile if a default is dropped, if a bare
-// name stops meaning mainnet, or if the parameters swap back.
+// Each identity fails to compile if a spec default is dropped, if a bare name
+// stops meaning mainnet, or if the parameters swap order.
 const _: fn(MemoryIssuer) -> MemoryIssuer<Mainnet> = |x| x;
 const _: fn(CounterTable) -> CounterTable<Mainnet> = |x| x;
 const _: fn(RingIssuer<Reserved>) -> RingIssuer<Reserved, Mainnet> = |x| x;

--- a/crates/postage-usage/examples/roam_between_machines.rs
+++ b/crates/postage-usage/examples/roam_between_machines.rs
@@ -85,7 +85,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let signer = PrivateKeySigner::random();
     let owner: Address = signer.address();
     let batch_id = BatchId::new([0x42; 32]);
-    let batch = Batch::new(
+    let batch: Batch = Batch::new(
         batch_id,
         0,
         0,

--- a/crates/postage-usage/examples/roam_between_machines.rs
+++ b/crates/postage-usage/examples/roam_between_machines.rs
@@ -213,7 +213,7 @@ fn stale_persist_is_rejected(
     println!("----------------------------------------------");
 
     // A snapshot sitting at sequence 1 (its next persist would emit 2).
-    let table = UsageTable::new(
+    let table: UsageTable = UsageTable::new(
         batch_id,
         DEPTH,
         BucketDepth::new(BUCKET_DEPTH)?,

--- a/crates/postage-usage/src/client.rs
+++ b/crates/postage-usage/src/client.rs
@@ -51,7 +51,7 @@ use crate::{UsageError, usage_chunk_address};
 /// does not exist. `Err` means the read could not be completed and the caller
 /// must *not* treat the chunk as absent. This distinction is load-bearing:
 /// treating a transport failure as absence would read the published-sequence
-/// floor as [`PublishedSequence::NONE`] and reopen the downgrade that floor
+/// floor as [`PublishedSequence::NONE`] and reopen the downgrade the floor
 /// closes.
 #[auto_impl::auto_impl(&, Arc, Box)]
 pub trait SnapshotSource {

--- a/crates/postage-usage/src/client.rs
+++ b/crates/postage-usage/src/client.rs
@@ -16,10 +16,10 @@
 //!
 //! # Floor safety
 //!
-//! The whole point of the published-sequence floor (nectar issue #70) is that a
-//! persist can never regress the version published at a snapshot's own chunk
-//! addresses. That guarantee survives only if a failed network read is never
-//! mistaken for "the chunk is absent". [`SnapshotSource::fetch`] therefore
+//! The whole point of the published-sequence floor is that a persist can never
+//! regress the version published at a snapshot's own chunk addresses. That
+//! guarantee survives only if a failed network read is never mistaken for
+//! "the chunk is absent". [`SnapshotSource::fetch`] therefore
 //! distinguishes `Ok(None)` (the network definitively agrees the chunk does not
 //! exist) from `Err` (the read could not be completed). [`BatchStamper::open`]
 //! and [`BatchStamper::flush`] both abort on `Err`: a transport failure never
@@ -37,9 +37,9 @@ use nectar_postage::{Batch, BatchId, StampIndex};
 use nectar_primitives::{ChunkAddress, Mainnet, SwarmSpec};
 use thiserror::Error;
 
-use crate::codec::RootInfoFor;
+use crate::codec::RootInfo;
 use crate::seal::{SealError, SealedChunk, seal_plan};
-use crate::snapshot::{PublishedSequence, SnapshotFor};
+use crate::snapshot::{PublishedSequence, Snapshot};
 use crate::{UsageError, usage_chunk_address};
 
 /// Reads a chunk's payload from the network by its single-owner-chunk address.
@@ -51,8 +51,8 @@ use crate::{UsageError, usage_chunk_address};
 /// does not exist. `Err` means the read could not be completed and the caller
 /// must *not* treat the chunk as absent. This distinction is load-bearing:
 /// treating a transport failure as absence would read the published-sequence
-/// floor as [`PublishedSequence::NONE`] and reopen the downgrade that nectar
-/// issue #70 closes.
+/// floor as [`PublishedSequence::NONE`] and reopen the downgrade that floor
+/// closes.
 #[auto_impl::auto_impl(&, Arc, Box)]
 pub trait SnapshotSource {
     /// The error a failed read reports. A value of this type means the read did
@@ -147,13 +147,13 @@ where
 /// system clock; [`open_with_clock`](Self::open_with_clock) injects a
 /// deterministic source.
 #[derive(Debug)]
-pub struct BatchStamperFor<Sg, Src, Snk, S: SwarmSpec = Mainnet, C = SystemClock> {
+pub struct BatchStamper<Sg, Src, Snk, S: SwarmSpec = Mainnet, C = SystemClock> {
     signer: Sg,
     owner: Address,
     batch_id: BatchId,
     source: Src,
     sink: Snk,
-    snapshot: SnapshotFor<S>,
+    snapshot: Snapshot<S>,
     /// The timestamp source for seals.
     clock: C,
     /// Whether a persist has been emitted in this session. A clean snapshot that
@@ -163,10 +163,7 @@ pub struct BatchStamperFor<Sg, Src, Snk, S: SwarmSpec = Mainnet, C = SystemClock
     persisted_this_session: bool,
 }
 
-/// The [`BatchStamperFor`] of the mainnet spec.
-pub type BatchStamper<Sg, Src, Snk, C = SystemClock> = BatchStamperFor<Sg, Src, Snk, Mainnet, C>;
-
-impl<Sg, Src, Snk, S> BatchStamperFor<Sg, Src, Snk, S>
+impl<Sg, Src, Snk, S> BatchStamper<Sg, Src, Snk, S>
 where
     Sg: SignerSync + alloy_signer::Signer,
     Src: SnapshotSource,
@@ -188,7 +185,7 @@ where
     }
 }
 
-impl<Sg, Src, Snk, S, C> BatchStamperFor<Sg, Src, Snk, S, C>
+impl<Sg, Src, Snk, S, C> BatchStamper<Sg, Src, Snk, S, C>
 where
     Sg: SignerSync + alloy_signer::Signer,
     Src: SnapshotSource,
@@ -233,7 +230,7 @@ where
                 // A published root exists: recover its sequence and slots. Every
                 // committed leaf must be present; a missing leaf is corruption,
                 // not a reason to start over.
-                let root = RootInfoFor::<S>::parse(&root_bytes)?;
+                let root = RootInfo::<S>::parse(&root_bytes)?;
                 let mut leaves: Vec<Bytes> = Vec::with_capacity(usize::from(root.leaf_count()));
                 for leaf in 0..root.leaf_count() {
                     // `leaf < leaf_count() <= u16::MAX`, so the increment
@@ -253,7 +250,7 @@ where
                 root.assemble(&leaves)?
             }
             // The network confirms no published root: a genuinely fresh batch.
-            None => SnapshotFor::from_batch(batch)?,
+            None => Snapshot::from_batch(batch)?,
         };
 
         Ok(Self {
@@ -311,7 +308,7 @@ where
             .await
             .map_err(ClientError::Source)?
         {
-            Some(root_bytes) => PublishedSequence::from(&RootInfoFor::<S>::parse(&root_bytes)?),
+            Some(root_bytes) => PublishedSequence::from(&RootInfo::<S>::parse(&root_bytes)?),
             // The network confirms no published root: the floor is NONE.
             None => PublishedSequence::NONE,
         };
@@ -342,7 +339,7 @@ where
     }
 
     /// Returns the wrapped snapshot.
-    pub const fn snapshot(&self) -> &SnapshotFor<S> {
+    pub const fn snapshot(&self) -> &Snapshot<S> {
         &self.snapshot
     }
 

--- a/crates/postage-usage/src/client.rs
+++ b/crates/postage-usage/src/client.rs
@@ -665,7 +665,7 @@ mod tests {
         // A stale machine B sitting at sequence 1: open it, but rewind its
         // snapshot to a sequence-1 state, then issue and flush. The live floor (2)
         // rejects the next sequence (2).
-        let table = UsageTable::new(
+        let table: UsageTable = UsageTable::new(
             batch.id(),
             20,
             BucketDepth::new(16).unwrap(),

--- a/crates/postage-usage/src/codec.rs
+++ b/crates/postage-usage/src/codec.rs
@@ -11,8 +11,8 @@ use nectar_postage::{BatchId, BucketDepth};
 use nectar_primitives::wire::{Cursor, FromCursor, ToWriter, Underrun, Writer};
 use nectar_primitives::{Mainnet, SwarmSpec};
 
-use crate::snapshot::SnapshotFor;
-use crate::table::{Mutability, UsageTableFor, checked_bucket_depth};
+use crate::snapshot::Snapshot;
+use crate::table::{Mutability, UsageTable, checked_bucket_depth};
 use crate::{
     MAGIC, MAX_EXCEPTIONS, MAX_PAYLOAD_SIZE, MAX_WIDTH, ROOT_HEADER_SIZE, Result, UsageError,
 };
@@ -50,9 +50,9 @@ enum LeafSection {
 ///
 /// The network is a type parameter: the geometry on the wire is a bare depth
 /// byte, and parsing it as a snapshot of `S` is what re-establishes the
-/// [`BucketDepth`] proof. [`RootInfo`] is the mainnet root.
+/// [`BucketDepth`] proof. It defaults to [`Mainnet`].
 #[derive(Debug)]
-pub struct RootInfoFor<S: SwarmSpec = Mainnet> {
+pub struct RootInfo<S: SwarmSpec = Mainnet> {
     batch_id: BatchId,
     depth: u8,
     bucket_depth: BucketDepth<S>,
@@ -66,14 +66,11 @@ pub struct RootInfoFor<S: SwarmSpec = Mainnet> {
     leaves: LeafSection,
 }
 
-/// The [`RootInfoFor`] of the mainnet spec.
-pub type RootInfo = RootInfoFor<Mainnet>;
-
 // The spec is a type-level tag, so the impls below carry no bound on `S` beyond
 // `SwarmSpec`; deriving would demand `S: Clone` and `S: Eq` of a marker type
 // that holds no data.
 
-impl<S: SwarmSpec> Clone for RootInfoFor<S> {
+impl<S: SwarmSpec> Clone for RootInfo<S> {
     fn clone(&self) -> Self {
         Self {
             batch_id: self.batch_id,
@@ -91,7 +88,7 @@ impl<S: SwarmSpec> Clone for RootInfoFor<S> {
     }
 }
 
-impl<S: SwarmSpec> PartialEq for RootInfoFor<S> {
+impl<S: SwarmSpec> PartialEq for RootInfo<S> {
     fn eq(&self, other: &Self) -> bool {
         self.batch_id == other.batch_id
             && self.depth == other.depth
@@ -107,7 +104,7 @@ impl<S: SwarmSpec> PartialEq for RootInfoFor<S> {
     }
 }
 
-impl<S: SwarmSpec> Eq for RootInfoFor<S> {}
+impl<S: SwarmSpec> Eq for RootInfo<S> {}
 
 /// The fixed root header, stated once in wire order. Multi-byte fields are
 /// big-endian; `README.md` gives the full layout.
@@ -414,7 +411,7 @@ fn select_width(counts: &[u32], base: u32, buckets: usize, allocated: usize) -> 
 // chunk count), so every saturating operation below is exact.
 #[must_use = "the encoded payloads are the snapshot to publish; dropping them discards the encode"]
 pub(crate) fn encode<S: SwarmSpec>(
-    table: &UsageTableFor<S>,
+    table: &UsageTable<S>,
     sequence: u64,
     slots: &[u32],
 ) -> Result<Encoded> {
@@ -509,7 +506,7 @@ pub(crate) fn encode<S: SwarmSpec>(
     })
 }
 
-impl<S: SwarmSpec> RootInfoFor<S> {
+impl<S: SwarmSpec> RootInfo<S> {
     /// Parses and structurally validates a root payload.
     ///
     /// Untrusted input: every byte access goes through [`Cursor`], and the
@@ -727,7 +724,7 @@ impl<S: SwarmSpec> RootInfoFor<S> {
     // `buckets <= 2^16` and `width <= 32`.
     #[allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)]
     #[must_use = "the reassembled snapshot is the recovered state; dropping it discards the assemble"]
-    pub fn assemble<L: AsRef<[u8]>>(self, leaves: &[L]) -> Result<SnapshotFor<S>> {
+    pub fn assemble<L: AsRef<[u8]>>(self, leaves: &[L]) -> Result<Snapshot<S>> {
         let buckets = 1usize << self.bucket_depth.get();
         let capacity = 1u32 << (self.depth - self.bucket_depth.get());
         let width = self.width;
@@ -850,7 +847,7 @@ impl<S: SwarmSpec> RootInfoFor<S> {
         // their corruption counterparts: reached from the decode path, they mean
         // the fetched bytes are bad, not a caller input that can be adjusted. A
         // direct `Snapshot::from_parts` caller still gets the caller-input variant.
-        let table = UsageTableFor::from_counts(
+        let table = UsageTable::from_counts(
             self.batch_id,
             self.depth,
             self.bucket_depth,
@@ -858,9 +855,9 @@ impl<S: SwarmSpec> RootInfoFor<S> {
             mutability,
         )
         .map_err(UsageError::into_corruption)?;
-        let parts = SnapshotFor::recovered_parts(table, self.sequence, self.slots)
+        let parts = Snapshot::recovered_parts(table, self.sequence, self.slots)
             .map_err(UsageError::into_corruption)?;
-        SnapshotFor::from_parts(parts).map_err(UsageError::into_corruption)
+        Snapshot::from_parts(parts).map_err(UsageError::into_corruption)
     }
 }
 
@@ -950,7 +947,7 @@ mod tests {
         let mut root = encoded.root.to_vec();
         assert_eq!(root[38], 0x01, "mutable flag must be set");
 
-        let info = RootInfo::parse(&root).unwrap();
+        let info: RootInfo = RootInfo::parse(&root).unwrap();
         assert!(info.is_mutable());
 
         // Any reserved flag bit is rejected.
@@ -958,14 +955,14 @@ mod tests {
             let mut bad = root.clone();
             bad[38] = 1 << bit;
             assert_eq!(
-                RootInfo::parse(&bad),
+                RootInfo::<Mainnet>::parse(&bad),
                 Err(UsageError::Malformed("unsupported flags"))
             );
         }
 
         // Clearing bit 0 yields an immutable snapshot.
         root[38] = 0x00;
-        let info = RootInfo::parse(&root).unwrap();
+        let info: RootInfo = RootInfo::parse(&root).unwrap();
         assert!(!info.is_mutable());
     }
 
@@ -978,7 +975,7 @@ mod tests {
         // A single full bucket becomes the lone exception; the rest stay at the
         // base so the encoder packs nothing inline.
         counts[5] = 16;
-        let table = UsageTableFor::from_counts(
+        let table = UsageTable::from_counts(
             BatchId::new([0x42; 32]),
             12,
             low_floor(8),
@@ -1001,7 +998,7 @@ mod tests {
         let mut root = root_with_one_exception();
         // Push the exception bucket index past the 256-bucket range.
         root[ROOT_HEADER_SIZE..ROOT_HEADER_SIZE + 4].copy_from_slice(&300u32.to_be_bytes());
-        let err = RootInfoFor::<LowFloor>::parse(&root).unwrap_err();
+        let err = RootInfo::<LowFloor>::parse(&root).unwrap_err();
         assert_eq!(err, UsageError::CorruptBucket { bucket: 300 });
         assert!(err.is_corruption());
         assert!(!err.is_recoverable());
@@ -1012,7 +1009,7 @@ mod tests {
         let mut root = root_with_one_exception();
         // Push the exception counter past the per-bucket capacity of 16.
         root[ROOT_HEADER_SIZE + 4..ROOT_HEADER_SIZE + 8].copy_from_slice(&17u32.to_be_bytes());
-        let err = RootInfoFor::<LowFloor>::parse(&root).unwrap_err();
+        let err = RootInfo::<LowFloor>::parse(&root).unwrap_err();
         assert_eq!(
             err,
             UsageError::CorruptCounter {
@@ -1032,7 +1029,7 @@ mod tests {
         // bucket-depth byte (here past the supported maximum) is decode
         // corruption, not a caller-input error.
         root[37] = 17;
-        let err = RootInfoFor::<LowFloor>::parse(&root).unwrap_err();
+        let err = RootInfo::<LowFloor>::parse(&root).unwrap_err();
         assert_eq!(
             err,
             UsageError::CorruptGeometry {
@@ -1058,7 +1055,7 @@ mod tests {
         root[60..62].copy_from_slice(&1u16.to_be_bytes()); // allocated = 1
         // exceptions = 0, leaves = 0, base = 0, slot 0 already zeroed.
 
-        let err = RootInfoFor::<LowFloor>::parse(&root).unwrap_err();
+        let err = RootInfo::<LowFloor>::parse(&root).unwrap_err();
         assert_eq!(
             err,
             UsageError::CorruptGeometry {
@@ -1075,7 +1072,7 @@ mod tests {
         let mut root = root_with_one_exception();
         // Push the allocated slot to the capacity bound (valid slots are < 16).
         root[ROOT_HEADER_SIZE + 8..ROOT_HEADER_SIZE + 12].copy_from_slice(&16u32.to_be_bytes());
-        let err = RootInfoFor::<LowFloor>::parse(&root).unwrap_err();
+        let err = RootInfo::<LowFloor>::parse(&root).unwrap_err();
         assert_eq!(
             err,
             UsageError::CorruptSlot {
@@ -1092,7 +1089,7 @@ mod tests {
         // A table whose deltas span 0..16 packs inline at width 5 (no
         // exceptions): every count is within the capacity of 16.
         let counts: Vec<u32> = (0..256u32).map(|b| b % 17).collect();
-        let table = UsageTableFor::from_counts(
+        let table = UsageTable::from_counts(
             BatchId::new([0x42; 32]),
             12,
             low_floor(8),
@@ -1102,9 +1099,7 @@ mod tests {
         .unwrap();
         let mut corrupt = encode(&table, 1, &[4]).unwrap().root.to_vec();
         assert_eq!(
-            RootInfoFor::<LowFloor>::parse(&corrupt)
-                .unwrap()
-                .leaf_count(),
+            RootInfo::<LowFloor>::parse(&corrupt).unwrap().leaf_count(),
             0,
             "this geometry inlines the deltas"
         );
@@ -1115,7 +1110,7 @@ mod tests {
         let packed_start = ROOT_HEADER_SIZE + 4;
         corrupt[packed_start] |= 0b1111_1000;
 
-        let info = RootInfoFor::<LowFloor>::parse(&corrupt).unwrap();
+        let info = RootInfo::<LowFloor>::parse(&corrupt).unwrap();
         let err = info.assemble::<&[u8]>(&[]).unwrap_err();
         assert_eq!(
             err,
@@ -1136,7 +1131,7 @@ mod tests {
         // caller can fix the counts it passed.
         let mut counts = vec![0u32; 256];
         counts[5] = 17; // capacity is 16
-        let err = UsageTableFor::from_counts(
+        let err = UsageTable::from_counts(
             BatchId::new([0x42; 32]),
             12,
             low_floor(8),
@@ -1194,7 +1189,7 @@ mod tests {
             edge_inputs.push(header);
         }
         for data in &edge_inputs {
-            let _ = RootInfo::parse(data);
+            let _ = RootInfo::<Mainnet>::parse(data);
         }
     }
 
@@ -1210,7 +1205,7 @@ mod tests {
         /// ring) is a legitimate skip, bounded by proptest's reject limit.
         #[test]
         fn snapshot_persist_parse_assemble_round_trip(
-            snapshot in arb::<crate::SnapshotFor<LowFloor>>(),
+            snapshot in arb::<crate::Snapshot<LowFloor>>(),
         ) {
             let outcome = crate::oracles::snapshot_persist_round_trip(snapshot);
             prop_assume!(outcome != Ok(false));
@@ -1227,7 +1222,7 @@ mod tests {
     fn seed_replay_usage_snapshot_decode() {
         nectar_testing::SeedReplay::corpus(env!("CARGO_MANIFEST_DIR"), "usage_snapshot_decode")
             .on("valid-", |name, data| {
-                let result = RootInfo::parse(data);
+                let result = RootInfo::<Mainnet>::parse(data);
                 assert!(
                     result.is_ok(),
                     "seed {name} must parse successfully: {result:?}"
@@ -1235,7 +1230,7 @@ mod tests {
             })
             .on("invalid-", |name, data| {
                 assert!(
-                    RootInfo::parse(data).is_err(),
+                    RootInfo::<Mainnet>::parse(data).is_err(),
                     "seed {name} must remain an Err input"
                 );
             })

--- a/crates/postage-usage/src/codec.rs
+++ b/crates/postage-usage/src/codec.rs
@@ -50,7 +50,7 @@ enum LeafSection {
 ///
 /// The network is a type parameter: the geometry on the wire is a bare depth
 /// byte, and parsing it as a snapshot of `S` is what re-establishes the
-/// [`BucketDepth`] proof. It defaults to [`Mainnet`].
+/// [`BucketDepth`] proof.
 #[derive(Debug)]
 pub struct RootInfo<S: SwarmSpec = Mainnet> {
     batch_id: BatchId,

--- a/crates/postage-usage/src/issuer.rs
+++ b/crates/postage-usage/src/issuer.rs
@@ -6,7 +6,7 @@ use nectar_postage::{BatchId, StampDigest, StampError};
 use nectar_postage_issuer::StampIssuer;
 use nectar_primitives::{ChunkAddress, Mainnet, SwarmSpec};
 
-use crate::SnapshotFor;
+use crate::Snapshot;
 use crate::error::UsageError;
 
 /// Maps a usage table error onto a stamp issuer error.
@@ -26,18 +26,15 @@ const fn map_usage_error(err: UsageError) -> StampError {
 /// value to drop into `BatchStamper::new`; recover it with
 /// [`into_snapshot`](Self::into_snapshot).
 #[derive(Debug)]
-pub struct SnapshotIssuerFor<S: SwarmSpec = Mainnet> {
-    snapshot: SnapshotFor<S>,
+pub struct SnapshotIssuer<S: SwarmSpec = Mainnet> {
+    snapshot: Snapshot<S>,
     owner: Address,
 }
-
-/// The [`SnapshotIssuerFor`] of the mainnet spec.
-pub type SnapshotIssuer = SnapshotIssuerFor<Mainnet>;
 
 // The spec is a type-level tag, so this carries no bound on `S` beyond
 // `SwarmSpec`; deriving would demand `S: Clone` of a marker type that holds no
 // data.
-impl<S: SwarmSpec> Clone for SnapshotIssuerFor<S> {
+impl<S: SwarmSpec> Clone for SnapshotIssuer<S> {
     fn clone(&self) -> Self {
         Self {
             snapshot: self.snapshot.clone(),
@@ -46,25 +43,25 @@ impl<S: SwarmSpec> Clone for SnapshotIssuerFor<S> {
     }
 }
 
-impl<S: SwarmSpec> SnapshotIssuerFor<S> {
+impl<S: SwarmSpec> SnapshotIssuer<S> {
     /// Wraps a snapshot and the batch owner address.
-    pub const fn new(snapshot: SnapshotFor<S>, owner: Address) -> Self {
+    pub const fn new(snapshot: Snapshot<S>, owner: Address) -> Self {
         Self { snapshot, owner }
     }
 
     /// Returns a reference to the wrapped snapshot.
-    pub const fn snapshot(&self) -> &SnapshotFor<S> {
+    pub const fn snapshot(&self) -> &Snapshot<S> {
         &self.snapshot
     }
 
     /// Returns a mutable reference to the wrapped snapshot, for example to plan
     /// a persist between batches of content stamping.
-    pub const fn snapshot_mut(&mut self) -> &mut SnapshotFor<S> {
+    pub const fn snapshot_mut(&mut self) -> &mut Snapshot<S> {
         &mut self.snapshot
     }
 
     /// Consumes the adapter and returns the wrapped snapshot.
-    pub fn into_snapshot(self) -> SnapshotFor<S> {
+    pub fn into_snapshot(self) -> Snapshot<S> {
         self.snapshot
     }
 
@@ -74,7 +71,7 @@ impl<S: SwarmSpec> SnapshotIssuerFor<S> {
     }
 }
 
-impl<S: SwarmSpec> StampIssuer for SnapshotIssuerFor<S> {
+impl<S: SwarmSpec> StampIssuer for SnapshotIssuer<S> {
     fn prepare_stamp(
         &mut self,
         address: &ChunkAddress,

--- a/crates/postage-usage/src/lib.rs
+++ b/crates/postage-usage/src/lib.rs
@@ -61,10 +61,11 @@
 //!
 //! A snapshot is parameterized by the [`SwarmSpec`] of the batch it describes,
 //! and carries it in the [`BucketDepth`] its table was built from. The spec
-//! parameter defaults to [`Mainnet`], so ordinary call sites need no type
-//! annotation. The floor is load-bearing on the wire too: [`RootInfo::parse`]
-//! rebuilds the bucket depth for the network asked of it, so a root whose
-//! geometry that network would never issue is refused as corrupt.
+//! parameter defaults to [`Mainnet`] in type position only; a default drives no
+//! inference, so a construction site still names the type it builds. The floor
+//! is load-bearing on the wire too: [`RootInfo::parse`] rebuilds the bucket
+//! depth for the network asked of it, so a root whose geometry that network
+//! would never issue is refused as corrupt.
 //!
 //! The snapshot format supports bucket depths 1 to 16 and mainnet's floor is
 //! 16, so a mainnet snapshot always has exactly 2^16 buckets; the smaller

--- a/crates/postage-usage/src/lib.rs
+++ b/crates/postage-usage/src/lib.rs
@@ -36,7 +36,7 @@
 //!
 //! // Issue a stamp for an uploaded chunk through the snapshot's issuing handle,
 //! // then plan a persist.
-//! let table =
+//! let table: UsageTable =
 //!     UsageTable::new(batch_id, 20, BucketDepth::new(16).unwrap(), Mutability::Immutable).unwrap();
 //! let mut snapshot = Snapshot::new(table);
 //! let address = ChunkAddress::from(B256::repeat_byte(0x99));
@@ -60,13 +60,11 @@
 //! # Networks
 //!
 //! A snapshot is parameterized by the [`SwarmSpec`] of the batch it describes,
-//! and carries it in the [`BucketDepth`] its table was built from. The generic
-//! type takes the `...For` name ([`UsageTableFor`], [`SnapshotFor`],
-//! [`RootInfoFor`] and friends) and the bare name is the mainnet alias, so
-//! ordinary call sites need no type annotation. The floor is load-bearing on
-//! the wire too: [`RootInfo::parse`] rebuilds the bucket depth for the network
-//! asked of it, so a root whose geometry that network would never issue is
-//! refused as corrupt.
+//! and carries it in the [`BucketDepth`] its table was built from. The spec
+//! parameter defaults to [`Mainnet`], so ordinary call sites need no type
+//! annotation. The floor is load-bearing on the wire too: [`RootInfo::parse`]
+//! rebuilds the bucket depth for the network asked of it, so a root whose
+//! geometry that network would never issue is refused as corrupt.
 //!
 //! The snapshot format supports bucket depths 1 to 16 and mainnet's floor is
 //! 16, so a mainnet snapshot always has exactly 2^16 buckets; the smaller
@@ -96,11 +94,11 @@
 //!
 //! Two residual paths to a sequence-0 persist are protocol-level rather than
 //! in-memory representability concerns, so the type guards here do not close
-//! them; the [`PublishedSequence`] floor on [`Snapshot::revalidate`] does
-//! (nectar issue #70). First, the public table constructors ([`UsageTable::new`]
-//! and friends) must keep minting a fresh table for a genuinely new batch, so a
-//! forged fresh table persisted at sequence 0 is caught by the floor, not by the
-//! type system here. Second, the reserve overwrites a snapshot chunk by stamp
+//! them; the [`PublishedSequence`] floor on [`Snapshot::revalidate`] does.
+//! First, the public table constructors ([`UsageTable::new`] and friends) must
+//! keep minting a fresh table for a genuinely new batch, so a forged fresh
+//! table persisted at sequence 0 is caught by the floor, not by the type system
+//! here. Second, the reserve overwrites a snapshot chunk by stamp
 //! timestamp rather than by snapshot sequence, so full cross-version monotonicity
 //! against the *published* sequence needs a compare-and-swap against the live
 //! root chunk. The floor precondition implemented on [`Snapshot::revalidate`]
@@ -144,23 +142,22 @@ mod issuer;
 #[cfg(feature = "seal")]
 mod seal;
 
-pub use codec::{RootInfo, RootInfoFor};
+pub use codec::RootInfo;
 pub use error::UsageError;
 pub use nectar_postage_issuer::RingExhausted;
 pub use snapshot::{
-    Issuer, IssuerFor, PersistPlan, PlannedChunk, PublishedSequence, Snapshot, SnapshotFor,
-    SnapshotParts, SnapshotPartsFor, Validated, ValidatedFor,
+    Issuer, PersistPlan, PlannedChunk, PublishedSequence, Snapshot, SnapshotParts, Validated,
 };
-pub use table::{Mutability, TableView, TableViewFor, UsageTable, UsageTableFor};
+pub use table::{Mutability, TableView, UsageTable};
 
 #[cfg(feature = "issuer")]
-pub use issuer::{SnapshotIssuer, SnapshotIssuerFor};
+pub use issuer::SnapshotIssuer;
 
 #[cfg(feature = "seal")]
 pub use seal::{SealError, SealedChunk, seal_plan};
 
 #[cfg(feature = "client")]
-pub use client::{BatchStamper, BatchStamperFor, ClientError, SnapshotSink, SnapshotSource};
+pub use client::{BatchStamper, ClientError, SnapshotSink, SnapshotSource};
 
 pub use nectar_primitives::{ChunkAddress, Mainnet, NetworkId, SocId, SwarmSpec, Testnet};
 

--- a/crates/postage-usage/src/oracles.rs
+++ b/crates/postage-usage/src/oracles.rs
@@ -10,7 +10,7 @@ use alloy_primitives::Address;
 use nectar_primitives::SwarmSpec;
 use nectar_primitives::oracles::Violation;
 
-use crate::{PublishedSequence, RootInfoFor, SnapshotFor};
+use crate::{PublishedSequence, RootInfo, Snapshot};
 
 /// One full persist round trip: revalidate at the `NONE` floor, plan a
 /// persist for a fixed owner, parse the planned root, assemble the planned
@@ -18,7 +18,7 @@ use crate::{PublishedSequence, RootInfoFor, SnapshotFor};
 /// legitimately refuse a snapshot slot (a full immutable bucket, an
 /// exhausted capacity-1 ring); that skip is `Ok(false)`.
 pub fn snapshot_persist_round_trip<S: SwarmSpec>(
-    mut snapshot: SnapshotFor<S>,
+    mut snapshot: Snapshot<S>,
 ) -> Result<bool, Violation> {
     let owner = Address::repeat_byte(0x11);
 
@@ -33,7 +33,7 @@ pub fn snapshot_persist_round_trip<S: SwarmSpec>(
     let Some((root_chunk, leaf_chunks)) = plan.chunks.split_first() else {
         return Err(Violation::new("a plan carries at least the root chunk"));
     };
-    let Ok(root) = RootInfoFor::<S>::parse(&root_chunk.payload) else {
+    let Ok(root) = RootInfo::<S>::parse(&root_chunk.payload) else {
         return Err(Violation::new("planned root must parse"));
     };
     let leaves: Vec<&[u8]> = leaf_chunks.iter().map(|c| c.payload.as_ref()).collect();

--- a/crates/postage-usage/src/seal.rs
+++ b/crates/postage-usage/src/seal.rs
@@ -7,7 +7,7 @@ use nectar_postage::{Stamp, StampDigest};
 use nectar_primitives::{ChunkOps, SingleOwnerChunk, SwarmSpec};
 use thiserror::Error;
 
-use crate::snapshot::{PersistPlan, SnapshotFor};
+use crate::snapshot::{PersistPlan, Snapshot};
 
 /// Errors produced while sealing a persist plan.
 #[non_exhaustive]
@@ -67,7 +67,7 @@ pub struct SealedChunk {
 /// must have been planned from `snapshot`.
 #[must_use = "the sealed chunks are the snapshot to upload; dropping them discards the seal"]
 pub fn seal_plan<S: SwarmSpec>(
-    snapshot: &mut SnapshotFor<S>,
+    snapshot: &mut Snapshot<S>,
     plan: &PersistPlan,
     timestamp: u64,
     signer: &impl SignerSync,

--- a/crates/postage-usage/src/snapshot.rs
+++ b/crates/postage-usage/src/snapshot.rs
@@ -8,8 +8,8 @@ use bytes::Bytes;
 use nectar_postage::{Batch, BatchId, StampIndex, calculate_bucket};
 use nectar_primitives::{ChunkAddress, Mainnet, SocId, SwarmSpec};
 
-use crate::codec::{self, Encoded, RootInfoFor};
-use crate::table::{TableViewFor, UsageTableFor};
+use crate::codec::{self, Encoded, RootInfo};
+use crate::table::{TableView, UsageTable};
 use crate::{Result, UsageError, usage_chunk_address, usage_chunk_id};
 
 /// The published persist sequence at a snapshot's root chunk address, the floor
@@ -45,8 +45,8 @@ impl PublishedSequence {
     }
 }
 
-impl<S: SwarmSpec> From<&RootInfoFor<S>> for PublishedSequence {
-    fn from(r: &RootInfoFor<S>) -> Self {
+impl<S: SwarmSpec> From<&RootInfo<S>> for PublishedSequence {
+    fn from(r: &RootInfo<S>) -> Self {
         Self(r.sequence())
     }
 }
@@ -55,8 +55,8 @@ impl<S: SwarmSpec> From<&RootInfoFor<S>> for PublishedSequence {
 /// own batch: a monotone sequence number and the within-bucket slots
 /// allocated to the snapshot chunks themselves.
 #[derive(Debug)]
-pub struct SnapshotFor<S: SwarmSpec = Mainnet> {
-    table: UsageTableFor<S>,
+pub struct Snapshot<S: SwarmSpec = Mainnet> {
+    table: UsageTable<S>,
     sequence: u64,
     slots: Vec<u32>,
     /// The counter sum ([`UsageTable::total_issued`]) captured at the last
@@ -69,23 +69,20 @@ pub struct SnapshotFor<S: SwarmSpec = Mainnet> {
     /// the in-process monotonicity floor [`seal_plan`](crate::seal_plan) checks a
     /// new timestamp against. `None` until the first seal, and reset to `None` on
     /// recovery (the published timestamp lives in the reserve, not the snapshot;
-    /// the cross-process floor is [`PublishedSequence`], nectar issue #70). This
-    /// is the single-owner clock-skew guard: it stops a later persist in the same
+    /// the cross-process floor is [`PublishedSequence`]). This is the
+    /// single-owner clock-skew guard: it stops a later persist in the same
     /// process from stamping a non-increasing timestamp, which the reserve would
     /// refuse to overwrite the metadata chunk with.
     #[cfg(feature = "seal")]
     last_seal_timestamp: Option<u64>,
 }
 
-/// The [`SnapshotFor`] of the mainnet spec.
-pub type Snapshot = SnapshotFor<Mainnet>;
-
 // The spec is a type-level tag, so the impls below (here and on
 // [`SnapshotParts`]) carry no bound on `S` beyond `SwarmSpec`; deriving would
 // demand `S: Clone` and `S: Eq` of a marker type that holds no data, and
 // [`Validated::plan_persist`] clones a snapshot generically.
 
-impl<S: SwarmSpec> Clone for SnapshotFor<S> {
+impl<S: SwarmSpec> Clone for Snapshot<S> {
     fn clone(&self) -> Self {
         Self {
             table: self.table.clone(),
@@ -98,7 +95,7 @@ impl<S: SwarmSpec> Clone for SnapshotFor<S> {
     }
 }
 
-impl<S: SwarmSpec> PartialEq for SnapshotFor<S> {
+impl<S: SwarmSpec> PartialEq for Snapshot<S> {
     fn eq(&self, other: &Self) -> bool {
         let equal = self.table == other.table
             && self.sequence == other.sequence
@@ -110,7 +107,7 @@ impl<S: SwarmSpec> PartialEq for SnapshotFor<S> {
     }
 }
 
-impl<S: SwarmSpec> Eq for SnapshotFor<S> {}
+impl<S: SwarmSpec> Eq for Snapshot<S> {}
 
 /// One chunk of a persist plan: the payload to publish and the slot to
 /// stamp it with.
@@ -154,16 +151,13 @@ pub struct PlannedChunk {
 /// [`from_parts`](Snapshot::from_parts).
 #[derive(Debug)]
 #[must_use = "dropping the parts discards the recovered sequence and slots; rebuild with Snapshot::from_parts"]
-pub struct SnapshotPartsFor<S: SwarmSpec = Mainnet> {
-    table: UsageTableFor<S>,
+pub struct SnapshotParts<S: SwarmSpec = Mainnet> {
+    table: UsageTable<S>,
     sequence: u64,
     slots: Vec<u32>,
 }
 
-/// The [`SnapshotPartsFor`] of the mainnet spec.
-pub type SnapshotParts = SnapshotPartsFor<Mainnet>;
-
-impl<S: SwarmSpec> Clone for SnapshotPartsFor<S> {
+impl<S: SwarmSpec> Clone for SnapshotParts<S> {
     fn clone(&self) -> Self {
         Self {
             table: self.table.clone(),
@@ -173,23 +167,23 @@ impl<S: SwarmSpec> Clone for SnapshotPartsFor<S> {
     }
 }
 
-impl<S: SwarmSpec> PartialEq for SnapshotPartsFor<S> {
+impl<S: SwarmSpec> PartialEq for SnapshotParts<S> {
     fn eq(&self, other: &Self) -> bool {
         self.table == other.table && self.sequence == other.sequence && self.slots == other.slots
     }
 }
 
-impl<S: SwarmSpec> Eq for SnapshotPartsFor<S> {}
+impl<S: SwarmSpec> Eq for SnapshotParts<S> {}
 
-impl<S: SwarmSpec> SnapshotPartsFor<S> {
+impl<S: SwarmSpec> SnapshotParts<S> {
     /// Returns a borrowed, read-only [`TableView`] onto the inert usage table.
     ///
     /// There is deliberately no owned-table accessor, and the view is neither
     /// [`Clone`]-to-owned nor a [`Deref`](core::ops::Deref) to the table: an owned
     /// bare table could be passed to [`Snapshot::new`] and reset to sequence 0, so
     /// `parts.table().clone()` must not yield one.
-    pub const fn table(&self) -> TableViewFor<'_, S> {
-        TableViewFor::new(&self.table)
+    pub const fn table(&self) -> TableView<'_, S> {
+        TableView::new(&self.table)
     }
 
     /// Returns the persist sequence carried by these parts.
@@ -225,7 +219,7 @@ pub struct PersistPlan {
     pub previous_timestamp: Option<u64>,
 }
 
-impl<S: SwarmSpec> SnapshotFor<S> {
+impl<S: SwarmSpec> Snapshot<S> {
     /// Wraps a table that has never been persisted, starting a fresh persist
     /// history at sequence 0 with no allocated slots.
     ///
@@ -242,8 +236,8 @@ impl<S: SwarmSpec> SnapshotFor<S> {
     ///
     /// Two residual ways to reach a sequence-0 persist are out of this type's
     /// scope and are enforced by [`Snapshot::revalidate`]'s [`PublishedSequence`]
-    /// floor (nectar issue #70), not here. First, the public constructors
-    /// ([`UsageTable::new`] and friends) legitimately mint a fresh table for a
+    /// floor, not here. First, the public constructors ([`UsageTable::new`]
+    /// and friends) legitimately mint a fresh table for a
     /// genuinely new batch, so a forged fresh table persisted at sequence 0 is a
     /// protocol-level concern, not an in-memory representability bug. Second, the
     /// reserve overwrites a snapshot chunk by stamp timestamp rather than by
@@ -251,7 +245,7 @@ impl<S: SwarmSpec> SnapshotFor<S> {
     /// *published* sequence needs a compare-and-swap against the live root chunk.
     /// Both are enforced by [`Snapshot::revalidate`]'s [`PublishedSequence`]
     /// floor.
-    pub const fn new(table: UsageTableFor<S>) -> Self {
+    pub const fn new(table: UsageTable<S>) -> Self {
         Self {
             table,
             sequence: 0,
@@ -273,13 +267,13 @@ impl<S: SwarmSpec> SnapshotFor<S> {
     /// history at sequence 0 with no allocated slots; recovered or extracted state
     /// round-trips through [`from_parts`](Self::from_parts) instead.
     pub fn from_batch(batch: &Batch<S>) -> Result<Self> {
-        Ok(Self::new(UsageTableFor::from_batch(batch)?))
+        Ok(Self::new(UsageTable::from_batch(batch)?))
     }
 
     /// Validates the slots of a table/sequence/slots triple against the table
     /// geometry, the shared check behind [`from_parts`](Self::from_parts) and
     /// the codec's recovery path.
-    pub(crate) fn validate_parts(table: &UsageTableFor<S>, slots: &[u32]) -> Result<()> {
+    pub(crate) fn validate_parts(table: &UsageTable<S>, slots: &[u32]) -> Result<()> {
         let capacity = table.bucket_capacity();
         if slots.len() > usize::from(u16::MAX) {
             return Err(UsageError::Malformed("too many allocated chunks"));
@@ -295,12 +289,12 @@ impl<S: SwarmSpec> SnapshotFor<S> {
     /// recovery through [`RootInfo::assemble`](crate::RootInfo::assemble), which
     /// flows through here, or through [`into_parts`](Self::into_parts).
     pub(crate) fn recovered_parts(
-        table: UsageTableFor<S>,
+        table: UsageTable<S>,
         sequence: u64,
         slots: Vec<u32>,
-    ) -> Result<SnapshotPartsFor<S>> {
+    ) -> Result<SnapshotParts<S>> {
         Self::validate_parts(&table, &slots)?;
-        Ok(SnapshotPartsFor {
+        Ok(SnapshotParts {
             table,
             sequence,
             slots,
@@ -319,8 +313,8 @@ impl<S: SwarmSpec> SnapshotFor<S> {
     /// automatically the moment you obtain an [`Issuer`] through
     /// [`issuer`](Self::issuer), which is the only way to advance a counter.
     /// Immutable batches issue without reserved state.
-    pub fn from_parts(parts: SnapshotPartsFor<S>) -> Result<Self> {
-        let SnapshotPartsFor {
+    pub fn from_parts(parts: SnapshotParts<S>) -> Result<Self> {
+        let SnapshotParts {
             table,
             sequence,
             slots,
@@ -337,7 +331,7 @@ impl<S: SwarmSpec> SnapshotFor<S> {
             issued_at_persist,
             // Recovery resets the in-process seal clock: the published timestamp
             // lives in the reserve, and the cross-process guard is the
-            // `PublishedSequence` floor (nectar issue #70), not this field.
+            // `PublishedSequence` floor, not this field.
             #[cfg(feature = "seal")]
             last_seal_timestamp: None,
         })
@@ -351,8 +345,8 @@ impl<S: SwarmSpec> SnapshotFor<S> {
     /// another borrowed view, never an owned table that [`new`](Self::new) would
     /// accept at sequence 0. This closes the in-memory clone route that would
     /// otherwise downgrade a recovered snapshot.
-    pub const fn table(&self) -> TableViewFor<'_, S> {
-        TableViewFor::new(&self.table)
+    pub const fn table(&self) -> TableView<'_, S> {
+        TableView::new(&self.table)
     }
 
     /// Returns the inner [`UsageTable`] by reference, for crate-internal callers
@@ -360,7 +354,7 @@ impl<S: SwarmSpec> SnapshotFor<S> {
     /// Never exposed publicly: a public `&UsageTable` would let
     /// `snapshot.table().clone()` reproduce an owned table for
     /// [`new`](Self::new).
-    pub(crate) const fn table_ref(&self) -> &UsageTableFor<S> {
+    pub(crate) const fn table_ref(&self) -> &UsageTable<S> {
         &self.table
     }
 
@@ -377,7 +371,7 @@ impl<S: SwarmSpec> SnapshotFor<S> {
     /// Immutable only: rejects with [`MutableMerge`](UsageError::MutableMerge) if
     /// either table is mutable. The persistence state (sequence and slots) is
     /// untouched; only the counters and depth join.
-    pub fn merge_max(&mut self, other: &UsageTableFor<S>) -> Result<()> {
+    pub fn merge_max(&mut self, other: &UsageTable<S>) -> Result<()> {
         self.table.merge_max(other)
     }
 
@@ -442,8 +436,8 @@ impl<S: SwarmSpec> SnapshotFor<S> {
     /// let reset = Snapshot::new(snapshot.table().clone());
     /// ```
     #[must_use = "the parts carry the recovered sequence and slots; dropping them discards that state"]
-    pub fn into_parts(self) -> SnapshotPartsFor<S> {
-        SnapshotPartsFor {
+    pub fn into_parts(self) -> SnapshotParts<S> {
+        SnapshotParts {
             table: self.table,
             sequence: self.sequence,
             slots: self.slots,
@@ -602,14 +596,14 @@ impl<S: SwarmSpec> SnapshotFor<S> {
     /// which serializes persisting against issuing.
     ///
     /// This single method is the issuance chokepoint. Issuance still flows
-    /// through here, while the network-validation gate (nectar issue #70) guards
-    /// *persistence*: [`revalidate`](Self::revalidate) checks the planned
+    /// through here, while the network-validation gate guards *persistence*:
+    /// [`revalidate`](Self::revalidate) checks the planned
     /// sequence against a [`PublishedSequence`] floor and is the only route to a
     /// [`PersistPlan`], so a snapshot can issue but cannot persist without first
     /// clearing the floor.
-    pub fn issuer(&mut self, owner: Address) -> IssuerFor<'_, S> {
+    pub fn issuer(&mut self, owner: Address) -> Issuer<'_, S> {
         let reserved = self.reserved_slots(&owner);
-        IssuerFor {
+        Issuer {
             snapshot: self,
             owner,
             reserved,
@@ -633,8 +627,8 @@ impl<S: SwarmSpec> SnapshotFor<S> {
     /// bound to `owner`, so content stamping drops into a `BatchStamper` while
     /// persisting through the same table as snapshot allocation.
     #[cfg(feature = "issuer")]
-    pub const fn into_issuer(self, owner: Address) -> crate::SnapshotIssuerFor<S> {
-        crate::SnapshotIssuerFor::new(self, owner)
+    pub const fn into_issuer(self, owner: Address) -> crate::SnapshotIssuer<S> {
+        crate::SnapshotIssuer::new(self, owner)
     }
 
     /// Encodes the snapshot with its current sequence number.
@@ -666,7 +660,7 @@ impl<S: SwarmSpec> SnapshotFor<S> {
     /// mutation. The floor is captured here, so keep the
     /// `revalidate` -> [`plan_persist`](Validated::plan_persist) window tight:
     /// the network floor may advance afterwards.
-    pub fn revalidate(&mut self, floor: PublishedSequence) -> Result<ValidatedFor<'_, S>> {
+    pub fn revalidate(&mut self, floor: PublishedSequence) -> Result<Validated<'_, S>> {
         let next = self
             .sequence
             .checked_add(1)
@@ -677,7 +671,7 @@ impl<S: SwarmSpec> SnapshotFor<S> {
                 floor: floor.get(),
             });
         }
-        Ok(ValidatedFor {
+        Ok(Validated {
             snapshot: self,
             floor: floor.get(),
         })
@@ -693,15 +687,12 @@ impl<S: SwarmSpec> SnapshotFor<S> {
 /// window tight, since the floor is captured at revalidate time and the network
 /// floor may advance afterwards.
 #[derive(Debug)]
-pub struct ValidatedFor<'s, S: SwarmSpec = Mainnet> {
-    snapshot: &'s mut SnapshotFor<S>,
+pub struct Validated<'s, S: SwarmSpec = Mainnet> {
+    snapshot: &'s mut Snapshot<S>,
     floor: u64,
 }
 
-/// The [`ValidatedFor`] of the mainnet spec.
-pub type Validated<'s> = ValidatedFor<'s, Mainnet>;
-
-impl<S: SwarmSpec> ValidatedFor<'_, S> {
+impl<S: SwarmSpec> Validated<'_, S> {
     /// Plans the next persist: bumps the sequence, allocates a slot for any
     /// snapshot chunk that lacks one (folding those stamps into the table), and
     /// encodes.
@@ -797,7 +788,7 @@ impl<S: SwarmSpec> ValidatedFor<'_, S> {
             // carries the new sequence.
             work.sequence = sequence;
 
-            let allocate = |work: &mut SnapshotFor<S>| -> Result<()> {
+            let allocate = |work: &mut Snapshot<S>| -> Result<()> {
                 // The allocation loop stops once the slots outnumber the
                 // leaves (at most the digests that fit a root chunk), far
                 // below u16::MAX.
@@ -891,18 +882,15 @@ impl<S: SwarmSpec> ValidatedFor<'_, S> {
 /// that could wrap a mutable ring onto the snapshot's own chunks. It borrows the
 /// snapshot mutably, so persisting cannot run while issuance is live.
 #[derive(Debug)]
-pub struct IssuerFor<'s, S: SwarmSpec = Mainnet> {
-    snapshot: &'s mut SnapshotFor<S>,
+pub struct Issuer<'s, S: SwarmSpec = Mainnet> {
+    snapshot: &'s mut Snapshot<S>,
     owner: Address,
     /// The `(bucket, index)` slots held by the snapshot's own chunks, installed
     /// at construction from the snapshot's allocated slots.
     reserved: BTreeSet<(u32, u32)>,
 }
 
-/// The [`IssuerFor`] of the mainnet spec.
-pub type Issuer<'s> = IssuerFor<'s, Mainnet>;
-
-impl<S: SwarmSpec> IssuerFor<'_, S> {
+impl<S: SwarmSpec> Issuer<'_, S> {
     /// Assigns the next unused slot for a content chunk address and returns the
     /// resulting stamp index, skipping the snapshot's reserved slots.
     ///
@@ -1024,12 +1012,12 @@ mod arbitrary_impls {
 
     use nectar_primitives::SwarmSpec;
 
-    use super::SnapshotFor;
-    use crate::UsageTableFor;
+    use super::Snapshot;
+    use crate::UsageTable;
 
-    impl<'a, S: SwarmSpec> Arbitrary<'a> for SnapshotFor<S> {
+    impl<'a, S: SwarmSpec> Arbitrary<'a> for Snapshot<S> {
         fn arbitrary(u: &mut Unstructured<'a>) -> ArbitraryResult<Self> {
-            let table = UsageTableFor::<S>::arbitrary(u)?;
+            let table = UsageTable::<S>::arbitrary(u)?;
             // Leave headroom so revalidate/plan_persist can advance the
             // sequence without overflowing.
             let sequence = u.int_in_range(0..=u64::MAX - 1)?;

--- a/crates/postage-usage/src/snapshot.rs
+++ b/crates/postage-usage/src/snapshot.rs
@@ -394,7 +394,7 @@ impl<S: SwarmSpec> Snapshot<S> {
     /// ```compile_fail
     /// use nectar_postage_usage::{BatchId, BucketDepth, Mutability, Snapshot, UsageTable};
     ///
-    /// let table = UsageTable::new(BatchId::new([0x42; 32]), 20, BucketDepth::new(16).unwrap(), Mutability::Immutable).unwrap();
+    /// let table: UsageTable = UsageTable::new(BatchId::new([0x42; 32]), 20, BucketDepth::new(16).unwrap(), Mutability::Immutable).unwrap();
     /// let snapshot = Snapshot::new(table);
     /// // `into_table` no longer exists; only `into_parts` can consume a snapshot.
     /// let table = snapshot.into_table();
@@ -409,7 +409,7 @@ impl<S: SwarmSpec> Snapshot<S> {
     /// use nectar_postage_usage::{BatchId, BucketDepth, Mutability, Snapshot, UsageTable};
     ///
     /// let owner = Address::repeat_byte(0x11);
-    /// let table = UsageTable::new(BatchId::new([0x42; 32]), 20, BucketDepth::new(16).unwrap(), Mutability::Immutable).unwrap();
+    /// let table: UsageTable = UsageTable::new(BatchId::new([0x42; 32]), 20, BucketDepth::new(16).unwrap(), Mutability::Immutable).unwrap();
     /// let snapshot = Snapshot::new(table);
     /// let parts = snapshot.into_parts();
     /// // The move/clone guard is what fails here: `parts.table` is private and
@@ -429,7 +429,7 @@ impl<S: SwarmSpec> Snapshot<S> {
     /// ```compile_fail
     /// use nectar_postage_usage::{BatchId, BucketDepth, Mutability, Snapshot, UsageTable};
     ///
-    /// let table = UsageTable::new(BatchId::new([0x42; 32]), 20, BucketDepth::new(16).unwrap(), Mutability::Immutable).unwrap();
+    /// let table: UsageTable = UsageTable::new(BatchId::new([0x42; 32]), 20, BucketDepth::new(16).unwrap(), Mutability::Immutable).unwrap();
     /// let snapshot = Snapshot::new(table);
     /// // `table()` returns a `TableView`; cloning it yields another view, not a
     /// // `UsageTable`, so this does not type-check.
@@ -718,7 +718,7 @@ impl<S: SwarmSpec> Validated<'_, S> {
     /// use nectar_postage_usage::{BatchId, BucketDepth, Mutability, PublishedSequence, Snapshot, UsageTable};
     ///
     /// let owner = Address::repeat_byte(0x11);
-    /// let table = UsageTable::new(BatchId::new([0x42; 32]), 20, BucketDepth::new(16).unwrap(), Mutability::Immutable).unwrap();
+    /// let table: UsageTable = UsageTable::new(BatchId::new([0x42; 32]), 20, BucketDepth::new(16).unwrap(), Mutability::Immutable).unwrap();
     /// let mut snapshot = Snapshot::new(table);
     /// // Ignoring the plan is a compile error: the persist would be silently lost.
     /// snapshot.revalidate(PublishedSequence::NONE).unwrap().plan_persist(&owner);

--- a/crates/postage-usage/src/table.rs
+++ b/crates/postage-usage/src/table.rs
@@ -3,7 +3,7 @@
 use alloc::vec::Vec;
 
 use nectar_postage::{Batch, BatchId, BucketDepth};
-use nectar_postage_issuer::{CounterError, CounterMode, CounterTableFor};
+use nectar_postage_issuer::{CounterError, CounterMode, CounterTable};
 use nectar_primitives::{Mainnet, SwarmSpec};
 
 use crate::{MAX_BUCKET_DEPTH, MAX_COUNTER_BITS, Result, UsageError};
@@ -163,23 +163,20 @@ impl Mutability {
 /// table.record_address(&ChunkAddress::from(B256::repeat_byte(0x99))).unwrap();
 /// ```
 #[derive(Debug)]
-pub struct UsageTableFor<S: SwarmSpec = Mainnet> {
+pub struct UsageTable<S: SwarmSpec = Mainnet> {
     pub(crate) batch_id: BatchId,
     /// The shared per-bucket counter table. It holds the counters, the issued
     /// sum, the geometry, and the fill-or-ring mode, in the same `[0, capacity]`
     /// representation the wire format serializes. The snapshot wraps this table
     /// rather than carrying its own copy of the counter logic.
-    pub(crate) counters: CounterTableFor<S>,
+    pub(crate) counters: CounterTable<S>,
 }
-
-/// The [`UsageTableFor`] of the mainnet spec.
-pub type UsageTable = UsageTableFor<Mainnet>;
 
 // The spec is a type-level tag, so the impls below carry no bound on `S` beyond
 // `SwarmSpec`; deriving would demand `S: Clone` and `S: Eq` of a marker type
 // that holds no data.
 
-impl<S: SwarmSpec> Clone for UsageTableFor<S> {
+impl<S: SwarmSpec> Clone for UsageTable<S> {
     fn clone(&self) -> Self {
         Self {
             batch_id: self.batch_id,
@@ -188,15 +185,15 @@ impl<S: SwarmSpec> Clone for UsageTableFor<S> {
     }
 }
 
-impl<S: SwarmSpec> PartialEq for UsageTableFor<S> {
+impl<S: SwarmSpec> PartialEq for UsageTable<S> {
     fn eq(&self, other: &Self) -> bool {
         self.batch_id == other.batch_id && self.counters == other.counters
     }
 }
 
-impl<S: SwarmSpec> Eq for UsageTableFor<S> {}
+impl<S: SwarmSpec> Eq for UsageTable<S> {}
 
-impl<S: SwarmSpec> UsageTableFor<S> {
+impl<S: SwarmSpec> UsageTable<S> {
     /// Creates an empty table for a batch with the given geometry and
     /// [`Mutability`].
     ///
@@ -214,7 +211,7 @@ impl<S: SwarmSpec> UsageTableFor<S> {
         validate_geometry(depth, bucket_depth.get())?;
         Ok(Self {
             batch_id,
-            counters: CounterTableFor::new(depth, bucket_depth, mutability.mode()),
+            counters: CounterTable::new(depth, bucket_depth, mutability.mode()),
         })
     }
 
@@ -247,7 +244,7 @@ impl<S: SwarmSpec> UsageTableFor<S> {
         mutability: Mutability,
     ) -> Result<Self> {
         validate_geometry(depth, bucket_depth.get())?;
-        let counters = CounterTableFor::from_counts(depth, bucket_depth, mutability.mode(), counts)
+        let counters = CounterTable::from_counts(depth, bucket_depth, mutability.mode(), counts)
             .map_err(map_counter_error)?;
         Ok(Self { batch_id, counters })
     }
@@ -327,13 +324,13 @@ impl<S: SwarmSpec> UsageTableFor<S> {
 
     /// Returns the shared counter table backing this usage table, for the
     /// snapshot's counter-advance and merge paths.
-    pub(crate) const fn counters(&self) -> &CounterTableFor<S> {
+    pub(crate) const fn counters(&self) -> &CounterTable<S> {
         &self.counters
     }
 
     /// Returns a mutable reference to the shared counter table, the snapshot's
     /// single counter-advance handle.
-    pub(crate) const fn counters_mut(&mut self) -> &mut CounterTableFor<S> {
+    pub(crate) const fn counters_mut(&mut self) -> &mut CounterTable<S> {
         &mut self.counters
     }
 
@@ -397,24 +394,21 @@ impl<S: SwarmSpec> UsageTableFor<S> {
 ///
 /// The view borrows the table, so it cannot outlive the snapshot it came from.
 #[derive(Debug)]
-pub struct TableViewFor<'a, S: SwarmSpec = Mainnet> {
-    table: &'a UsageTableFor<S>,
+pub struct TableView<'a, S: SwarmSpec = Mainnet> {
+    table: &'a UsageTable<S>,
 }
 
-/// The [`TableViewFor`] of the mainnet spec.
-pub type TableView<'a> = TableViewFor<'a, Mainnet>;
-
 // A view is a shared borrow, so it copies whatever the spec marker does.
-impl<S: SwarmSpec> Clone for TableViewFor<'_, S> {
+impl<S: SwarmSpec> Clone for TableView<'_, S> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<S: SwarmSpec> Copy for TableViewFor<'_, S> {}
+impl<S: SwarmSpec> Copy for TableView<'_, S> {}
 
-impl<'a, S: SwarmSpec> TableViewFor<'a, S> {
-    pub(crate) const fn new(table: &'a UsageTableFor<S>) -> Self {
+impl<'a, S: SwarmSpec> TableView<'a, S> {
+    pub(crate) const fn new(table: &'a UsageTable<S>) -> Self {
         Self { table }
     }
 
@@ -498,7 +492,7 @@ mod arbitrary_impls {
     use nectar_postage::{BatchId, BucketDepth};
     use nectar_primitives::SwarmSpec;
 
-    use super::{Mutability, UsageTableFor};
+    use super::{Mutability, UsageTable};
     use crate::{MAX_BUCKET_DEPTH, MAX_COUNTER_BITS};
 
     impl<'a> Arbitrary<'a> for Mutability {
@@ -511,7 +505,7 @@ mod arbitrary_impls {
         }
     }
 
-    impl<'a, S: SwarmSpec> Arbitrary<'a> for UsageTableFor<S> {
+    impl<'a, S: SwarmSpec> Arbitrary<'a> for UsageTable<S> {
         fn arbitrary(u: &mut Unstructured<'a>) -> ArbitraryResult<Self> {
             let batch_id = BatchId::new(u.arbitrary::<[u8; 32]>()?);
             // The window is the format's cap intersected with the network
@@ -598,7 +592,15 @@ mod tests {
         assert!(UsageTable::new(batch_id(), 48, mainnet(), imm).is_err());
         assert!(UsageTable::new(batch_id(), 15, mainnet(), imm).is_err());
         // A bucket depth the network accepts but the format does not.
-        assert!(UsageTable::new(batch_id(), 20, BucketDepth::new(17).unwrap(), imm).is_err());
+        assert!(
+            UsageTable::new(
+                batch_id(),
+                20,
+                BucketDepth::<Mainnet>::new(17).unwrap(),
+                imm
+            )
+            .is_err()
+        );
     }
 
     #[test]

--- a/crates/postage-usage/src/table.rs
+++ b/crates/postage-usage/src/table.rs
@@ -148,7 +148,7 @@ impl Mutability {
 /// use nectar_postage_usage::{BatchId, BucketDepth, Mutability, UsageTable};
 ///
 /// let bucket_depth = BucketDepth::new(16).unwrap();
-/// let mut table = UsageTable::new(BatchId::new([0x42; 32]), 18, bucket_depth, Mutability::Mutable).unwrap();
+/// let mut table: UsageTable = UsageTable::new(BatchId::new([0x42; 32]), 18, bucket_depth, Mutability::Mutable).unwrap();
 /// // `record` no longer exists on the inert table.
 /// table.record(7).unwrap();
 /// ```
@@ -158,7 +158,7 @@ impl Mutability {
 /// use nectar_postage_usage::{BatchId, BucketDepth, ChunkAddress, Mutability, UsageTable};
 ///
 /// let bucket_depth = BucketDepth::new(16).unwrap();
-/// let mut table = UsageTable::new(BatchId::new([0x42; 32]), 18, bucket_depth, Mutability::Mutable).unwrap();
+/// let mut table: UsageTable = UsageTable::new(BatchId::new([0x42; 32]), 18, bucket_depth, Mutability::Mutable).unwrap();
 /// // `record_address` no longer exists on the inert table.
 /// table.record_address(&ChunkAddress::from(B256::repeat_byte(0x99))).unwrap();
 /// ```

--- a/crates/postage-usage/tests/snapshot.rs
+++ b/crates/postage-usage/tests/snapshot.rs
@@ -1142,8 +1142,8 @@ fn published_sequence_reads_from_a_parsed_root() {
     assert_eq!(plan.sequence, 3);
 }
 
-// The spec parameter defaults to `Mainnet`. Each identity fails to compile if
-// a default is dropped or a bare name stops meaning mainnet.
+// Each identity fails to compile if a spec default is dropped or a bare name
+// stops meaning mainnet.
 const _: fn(Snapshot) -> Snapshot<Mainnet> = |x| x;
 const _: fn(SnapshotParts) -> SnapshotParts<Mainnet> = |x| x;
 const _: fn(UsageTable) -> UsageTable<Mainnet> = |x| x;

--- a/crates/postage-usage/tests/snapshot.rs
+++ b/crates/postage-usage/tests/snapshot.rs
@@ -12,8 +12,8 @@
 
 use nectar_postage::calculate_bucket;
 use nectar_postage_usage::{
-    Batch, MAGIC, Mutability, PersistPlan, PublishedSequence, RootInfo, RootInfoFor, Snapshot,
-    SnapshotFor, SwarmSpec, UsageError, UsageTable, UsageTableFor, usage_chunk_address,
+    Batch, MAGIC, Mainnet, Mutability, PersistPlan, PublishedSequence, RootInfo, Snapshot,
+    SnapshotParts, SwarmSpec, TableView, UsageError, UsageTable, usage_chunk_address,
     usage_chunk_id,
 };
 
@@ -38,15 +38,15 @@ fn synthetic_counts(buckets: usize, base: u32, spread: u32) -> Vec<u32> {
 }
 
 fn roundtrip(plan: &PersistPlan) -> Snapshot {
-    let root = RootInfo::parse(&plan.chunks[0].payload).unwrap();
+    let root: RootInfo = RootInfo::parse(&plan.chunks[0].payload).unwrap();
     let leaves: Vec<_> = plan.chunks[1..].iter().map(|c| &c.payload).collect();
     assert_eq!(usize::from(root.leaf_count()), leaves.len());
     root.assemble(&leaves).unwrap()
 }
 
 /// [`roundtrip`] for a snapshot of another network.
-fn roundtrip_for<S: SwarmSpec>(plan: &PersistPlan) -> SnapshotFor<S> {
-    let root = RootInfoFor::<S>::parse(&plan.chunks[0].payload).unwrap();
+fn roundtrip_for<S: SwarmSpec>(plan: &PersistPlan) -> Snapshot<S> {
+    let root = RootInfo::<S>::parse(&plan.chunks[0].payload).unwrap();
     let leaves: Vec<_> = plan.chunks[1..].iter().map(|c| &c.payload).collect();
     assert_eq!(usize::from(root.leaf_count()), leaves.len());
     root.assemble(&leaves).unwrap()
@@ -275,9 +275,9 @@ fn small_bucket_depth_inlines_in_the_root() {
     let counts = synthetic_counts(256, 1000, 4000);
     // Bucket depth 8 is below mainnet's floor, so this runs at `LowFloor`.
     let table =
-        UsageTableFor::from_counts(batch_id(), 21, low_floor(8), counts, Mutability::Immutable)
+        UsageTable::from_counts(batch_id(), 21, low_floor(8), counts, Mutability::Immutable)
             .unwrap();
-    let mut snapshot = SnapshotFor::new(table);
+    let mut snapshot = Snapshot::new(table);
     let plan = snapshot
         .revalidate(PublishedSequence::NONE)
         .unwrap()
@@ -348,19 +348,19 @@ fn corruption_is_rejected() {
     // Bad magic.
     let mut bad = root_payload.clone();
     bad[0] ^= 0xff;
-    assert_eq!(RootInfo::parse(&bad), Err(UsageError::BadMagic));
+    assert_eq!(RootInfo::<Mainnet>::parse(&bad), Err(UsageError::BadMagic));
     assert_eq!(MAGIC, *b"SBU1");
 
     // Truncation.
     assert!(matches!(
-        RootInfo::parse(&root_payload[..root_payload.len() - 1]),
+        RootInfo::<Mainnet>::parse(&root_payload[..root_payload.len() - 1]),
         Err(UsageError::PayloadLength { .. })
     ));
 
     // Tampered issued total (bytes 48..56).
     let mut bad = root_payload.clone();
     bad[55] ^= 0x01;
-    let root = RootInfo::parse(&bad).unwrap();
+    let root: RootInfo = RootInfo::parse(&bad).unwrap();
     assert!(matches!(
         root.assemble(&leaves),
         Err(UsageError::IssuedMismatch { .. })
@@ -369,14 +369,14 @@ fn corruption_is_rejected() {
     // Tampered leaf payload.
     let mut bad_leaves = leaves.clone();
     bad_leaves[0][0] ^= 0xff;
-    let root = RootInfo::parse(&root_payload).unwrap();
+    let root: RootInfo = RootInfo::parse(&root_payload).unwrap();
     assert!(matches!(
         root.assemble(&bad_leaves),
         Err(UsageError::LeafDigestMismatch { index: 0 })
     ));
 
     // Wrong leaf count.
-    let root = RootInfo::parse(&root_payload).unwrap();
+    let root: RootInfo = RootInfo::parse(&root_payload).unwrap();
     assert!(matches!(
         root.assemble(&leaves[1..]),
         Err(UsageError::LeafCount { .. })
@@ -437,7 +437,7 @@ fn mutable_round_trips_and_decodes_as_mutable() {
         .unwrap();
 
     // The flags byte marks the snapshot mutable.
-    let root = RootInfo::parse(&plan.chunks[0].payload).unwrap();
+    let root: RootInfo = RootInfo::parse(&plan.chunks[0].payload).unwrap();
     assert!(root.is_mutable());
 
     let leaves: Vec<_> = plan.chunks[1..].iter().map(|c| &c.payload).collect();
@@ -946,7 +946,7 @@ fn failed_allocation_rolls_back_the_snapshot() {
 fn a_non_mainnet_snapshot_issues_reserves_and_recovers() {
     // Depth 11 over bucket depth 8 gives 8 slots per bucket, on a mutable ring
     // so issuance wraps rather than filling.
-    let table = UsageTableFor::from_counts(
+    let table = UsageTable::from_counts(
         batch_id(),
         11,
         low_floor(8),
@@ -954,7 +954,7 @@ fn a_non_mainnet_snapshot_issues_reserves_and_recovers() {
         Mutability::Mutable,
     )
     .unwrap();
-    let mut snapshot = SnapshotFor::new(table);
+    let mut snapshot = Snapshot::new(table);
 
     // The first persist allocates the snapshot's own chunk, which is reserved
     // from then on.
@@ -985,7 +985,7 @@ fn a_non_mainnet_snapshot_issues_reserves_and_recovers() {
     // The next persist recovers byte-for-byte through the same spec.
     let plan = snapshot
         .revalidate(PublishedSequence::from(
-            &RootInfoFor::<LowFloor>::parse(&first.chunks[0].payload).unwrap(),
+            &RootInfo::<LowFloor>::parse(&first.chunks[0].payload).unwrap(),
         ))
         .unwrap()
         .plan_persist(&owner())
@@ -996,7 +996,7 @@ fn a_non_mainnet_snapshot_issues_reserves_and_recovers() {
 
     // Mainnet refuses the very same payload: its floor is 16.
     assert_eq!(
-        RootInfo::parse(&plan.chunks[0].payload),
+        RootInfo::<Mainnet>::parse(&plan.chunks[0].payload),
         Err(UsageError::CorruptGeometry {
             depth: 11,
             bucket_depth: 8,
@@ -1127,7 +1127,7 @@ fn published_sequence_reads_from_a_parsed_root() {
         .unwrap()
         .plan_persist(&owner())
         .unwrap();
-    let root = RootInfo::parse(&plan.chunks[0].payload).unwrap();
+    let root: RootInfo = RootInfo::parse(&plan.chunks[0].payload).unwrap();
     assert_eq!(root.sequence(), 2);
     let floor = PublishedSequence::from(&root);
     assert_eq!(floor.get(), 2);
@@ -1141,3 +1141,11 @@ fn published_sequence_reads_from_a_parsed_root() {
         .unwrap();
     assert_eq!(plan.sequence, 3);
 }
+
+// The spec parameter defaults to `Mainnet`. Each identity fails to compile if
+// a default is dropped or a bare name stops meaning mainnet.
+const _: fn(Snapshot) -> Snapshot<Mainnet> = |x| x;
+const _: fn(SnapshotParts) -> SnapshotParts<Mainnet> = |x| x;
+const _: fn(UsageTable) -> UsageTable<Mainnet> = |x| x;
+const _: fn(RootInfo) -> RootInfo<Mainnet> = |x| x;
+const _: for<'a> fn(TableView<'a>) -> TableView<'a, Mainnet> = |x| x;

--- a/crates/postage-usage/tests/vector.rs
+++ b/crates/postage-usage/tests/vector.rs
@@ -13,8 +13,8 @@
 use alloy_primitives::hex;
 use nectar_postage::{BucketDepth, calculate_bucket};
 use nectar_postage_usage::{
-    Mutability, PublishedSequence, RootInfo, RootInfoFor, Snapshot, SnapshotFor, UsageTable,
-    UsageTableFor, usage_chunk_address, usage_chunk_id,
+    Mutability, PublishedSequence, RootInfo, Snapshot, UsageTable, usage_chunk_address,
+    usage_chunk_id,
 };
 // The README's small worked example runs at bucket depth 8, which mainnet's
 // floor of 16 forbids, so those vectors are pinned for `LowFloor`.
@@ -39,9 +39,8 @@ fn readme_worked_example_vector() {
     let mut counts: Vec<u32> = (0..256u32).map(|b| 3 + (b & 3)).collect();
     counts[200] = 16;
     let table =
-        UsageTableFor::from_counts(batch_id, 12, low_floor(8), counts, Mutability::Immutable)
-            .unwrap();
-    let mut snapshot = SnapshotFor::new(table);
+        UsageTable::from_counts(batch_id, 12, low_floor(8), counts, Mutability::Immutable).unwrap();
+    let mut snapshot = Snapshot::new(table);
     let plan = snapshot
         .revalidate(PublishedSequence::NONE)
         .unwrap()
@@ -66,7 +65,7 @@ fn readme_worked_example_vector() {
     assert_eq!(hex::encode(&plan.chunks[0].payload), ROOT_PAYLOAD_HEX);
 
     // And the vector decodes back to the same snapshot.
-    let root = RootInfoFor::<LowFloor>::parse(&hex::decode(ROOT_PAYLOAD_HEX).unwrap()).unwrap();
+    let root = RootInfo::<LowFloor>::parse(&hex::decode(ROOT_PAYLOAD_HEX).unwrap()).unwrap();
     let recovered = root.assemble::<&[u8]>(&[]).unwrap();
     assert_eq!(recovered, snapshot);
 }
@@ -86,7 +85,7 @@ fn readme_large_batch_multi_leaf_vector() {
     let mut counts: Vec<u32> = (0..65536u32).map(|b| 100 + (b % 50)).collect();
     counts[0x1234] = 5000;
     counts[0xCBE5] = 8192;
-    let bucket_depth = BucketDepth::new(16).unwrap();
+    let bucket_depth: BucketDepth = BucketDepth::new(16).unwrap();
     let table =
         UsageTable::from_counts(batch_id, 29, bucket_depth, counts, Mutability::Immutable).unwrap();
     let mut snapshot = Snapshot::new(table);
@@ -145,9 +144,9 @@ fn mutable_vector_flags_byte_and_round_trip() {
     let owner = owner();
     let mut counts: Vec<u32> = (0..256u32).map(|b| 3 + (b & 3)).collect();
     counts[200] = 16;
-    let table = UsageTableFor::from_counts(batch_id, 12, low_floor(8), counts, Mutability::Mutable)
-        .unwrap();
-    let mut snapshot = SnapshotFor::new(table);
+    let table =
+        UsageTable::from_counts(batch_id, 12, low_floor(8), counts, Mutability::Mutable).unwrap();
+    let mut snapshot = Snapshot::new(table);
     let plan = snapshot
         .revalidate(PublishedSequence::NONE)
         .unwrap()
@@ -166,7 +165,7 @@ fn mutable_vector_flags_byte_and_round_trip() {
 
     // It decodes back as mutable to the same snapshot.
     let root =
-        RootInfoFor::<LowFloor>::parse(&hex::decode(MUTABLE_ROOT_PAYLOAD_HEX).unwrap()).unwrap();
+        RootInfo::<LowFloor>::parse(&hex::decode(MUTABLE_ROOT_PAYLOAD_HEX).unwrap()).unwrap();
     assert!(root.is_mutable());
     let recovered = root.assemble::<&[u8]>(&[]).unwrap();
     assert!(recovered.table().is_mutable());

--- a/fuzz/fuzz_targets/usage_snapshot_decode.rs
+++ b/fuzz/fuzz_targets/usage_snapshot_decode.rs
@@ -15,8 +15,8 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use nectar_postage_usage::RootInfo;
+use nectar_postage_usage::{Mainnet, RootInfo};
 
 fuzz_target!(|data: &[u8]| {
-    let _ = RootInfo::parse(data);
+    let _ = RootInfo::<Mainnet>::parse(data);
 });

--- a/fuzz/fuzz_targets/usage_snapshot_roundtrip.rs
+++ b/fuzz/fuzz_targets/usage_snapshot_roundtrip.rs
@@ -22,10 +22,10 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use nectar_postage_usage::{SnapshotFor, oracles};
+use nectar_postage_usage::{Snapshot, oracles};
 use nectar_testing::LowFloor;
 
-fuzz_target!(|snapshot: SnapshotFor<LowFloor>| {
+fuzz_target!(|snapshot: Snapshot<LowFloor>| {
     let _ = oracles::snapshot_persist_round_trip(snapshot)
         .expect("persisted snapshots must parse and assemble back");
 });


### PR DESCRIPTION
Closes #762

## What

Converges spec-generic naming in `nectar-postage-issuer` and `nectar-postage-usage` on defaulted parameters, matching `Batch<S = Mainnet>` and `BucketDepth<S = Mainnet>` already established in `nectar-postage`.

Every `FooFor<S>` type becomes `Foo<S = Mainnet>`, and the redundant mainnet type alias is deleted in each case since the bare spelling now means mainnet by default. Renamed: `CounterTableFor`, `MemoryIssuerFor`, `RingIssuerFor`, `ShardedFor`, `ShardedIssuerFor`, `ShardedRingIssuerFor`, `CreateResultFor`, `MemoryBatchFactoryFor`, `UsageTableFor`, `TableViewFor`, `SnapshotFor`, `SnapshotPartsFor`, `ValidatedFor`, `IssuerFor`, `SnapshotIssuerFor`, `RootInfoFor`, `BatchStamperFor`.

Where a defaulted parameter would have preceded an undefaulted one (`Sharded`'s inner issuer, `RingIssuer`, `ShardedRingIssuer`), the spec parameter is reordered; this preserves the old alias meanings.

29 files changed, +438/-430 across `crates/postage-issuer` and `crates/postage-usage` (benches, examples, src, tests, and the fuzz targets).

## Why

Keeps the spec-generic naming convention consistent across the postage crates now that `nectar-postage` itself defaults its spec parameter to `Mainnet`. Removes redundant mainnet-alias types that duplicated the now-defaulted bare names.

## Testing

CI's `cargo clippy (postage-usage surfaces)` step failed on the branch as first received (`a1956eee`) with two `E0283` "type annotations needed" errors: a defaulted type parameter does not drive inference at call sites the default-feature clippy pass never compiles.

- `crates/postage-usage/src/client.rs:668`: `let table = UsageTable::new(...)` in the `client`-gated test module
- `crates/postage-usage/examples/roam_between_machines.rs:215`: same shape in the roaming example

Fixed in `09adcb85` by annotating both bindings as `let table: UsageTable = ...` (the default, i.e. `Mainnet`).

Verified: `cargo nextest list` output is byte-identical between `origin/main` and the branch (173 tests, same names), so no test was dropped. The corpus replay test, the byte-exact README vectors, and the fuzz workspace all still pass.

One correctness fix landed during review: the rename had silently disarmed six `compile_fail` doctests in `nectar-postage-usage` (a defaulted type parameter changes what fails to compile), restored in `a1956eee`.

## AI Assistance

Implementation: claude-opus-5. Red-team review: claude-opus-5. PR: claude-sonnet-5.
