### PR TITLE
postage: add sealed ValidationState and StampedAddress

### DIFF
--- a/crates/postage/src/error.rs
+++ b/crates/postage/src/error.rs
@@ -51,6 +51,19 @@ pub enum StampError {
         bucket_depth: u8,
     },
 
+    /// The stamp names a different batch from the one it was checked against.
+    ///
+    /// The digest binds the stamp's own batch id, so spending one batch's
+    /// stamp against another's geometry would otherwise pass whenever the two
+    /// share an owner.
+    #[error("batch mismatch: expected {expected}, got {actual}")]
+    BatchMismatch {
+        /// The batch the stamp was checked against.
+        expected: BatchId,
+        /// The batch the stamp names.
+        actual: BatchId,
+    },
+
     /// The batch was not found.
     #[error("batch not found: {0}")]
     BatchNotFound(BatchId),

--- a/crates/postage/src/error.rs
+++ b/crates/postage/src/error.rs
@@ -52,10 +52,6 @@ pub enum StampError {
     },
 
     /// The stamp names a different batch from the one it was checked against.
-    ///
-    /// The digest binds the stamp's own batch id, so spending one batch's
-    /// stamp against another's geometry would otherwise pass whenever the two
-    /// share an owner.
     #[error("batch mismatch: expected {expected}, got {actual}")]
     BatchMismatch {
         /// The batch the stamp was checked against.

--- a/crates/postage/src/lib.rs
+++ b/crates/postage/src/lib.rs
@@ -14,6 +14,8 @@
 //! - [`Stamp`]: A postage stamp proving payment for chunk storage
 //! - [`StampIndex`]: The bucket and position index within a stamp
 //! - [`StampDigest`]: The data to be signed when creating a stamp
+//! - [`StampedAddress`]: A stamp bound to the address it was validated
+//!   against, and the single validation authority
 //! - [`PostageContext`]: Context for batch expiry calculations
 //! - [`BatchEvent`]: Events emitted by the postage stamp contract (requires `std`)
 //!
@@ -70,6 +72,7 @@ pub mod oracles;
 mod sink;
 mod stamp;
 mod stamped;
+mod stamped_address;
 mod util;
 mod validation;
 
@@ -91,6 +94,7 @@ pub use error::StampError;
 pub use sink::{PutStamped, StampIndifferent, Tee, TeeError};
 pub use stamp::{STAMP_SIZE, Stamp, StampBytes, StampDigest, StampIndex};
 pub use stamped::StampedChunk;
+pub use stamped_address::{StampedAddress, Unvalidated, Validated, ValidationState};
 pub use util::{PostageContext, calculate_bucket};
 pub use validation::StampValidator;
 #[cfg(feature = "std")]

--- a/crates/postage/src/lib.rs
+++ b/crates/postage/src/lib.rs
@@ -14,8 +14,8 @@
 //! - [`Stamp`]: A postage stamp proving payment for chunk storage
 //! - [`StampIndex`]: The bucket and position index within a stamp
 //! - [`StampDigest`]: The data to be signed when creating a stamp
-//! - [`StampedAddress`]: A stamp bound to the address it was validated
-//!   against, and the single validation authority
+//! - [`StampedAddress`]: A stamp bound to an address, and the authority that
+//!   validates the pairing
 //! - [`PostageContext`]: Context for batch expiry calculations
 //! - [`BatchEvent`]: Events emitted by the postage stamp contract (requires `std`)
 //!

--- a/crates/postage/src/stamped_address.rs
+++ b/crates/postage/src/stamped_address.rs
@@ -46,6 +46,17 @@ impl ValidationState for Unvalidated {
 ///
 /// Pairing exists only at [`Unvalidated`], so [`validate`](Self::validate) is
 /// the only route to [`Validated`].
+///
+/// The type carries no serde impls in any state, so no wire format can hand
+/// back a [`Validated`] value:
+///
+#[cfg_attr(feature = "serde", doc = "```compile_fail")]
+#[cfg_attr(not(feature = "serde"), doc = "```ignore")]
+/// use nectar_postage::{StampedAddress, Validated};
+///
+/// fn de<T: serde::de::DeserializeOwned>() {}
+/// de::<StampedAddress<Validated>>();
+/// ```
 pub struct StampedAddress<V: ValidationState = Validated> {
     address: ChunkAddress,
     stamp: Stamp,

--- a/crates/postage/src/stamped_address.rs
+++ b/crates/postage/src/stamped_address.rs
@@ -1,0 +1,386 @@
+//! Typestate validation carrier for a stamp bound to an address.
+//!
+//! The signature covers `address | batchID | index | timestamp`, so validity
+//! is a fact about a stamp and an address, never about a chunk body. A marker
+//! on a bare [`Stamp`] would be unsound, because the address is not on the
+//! wire: the value would assert a fact about a subject it does not hold, and
+//! could be re-paired with another address while still reading as validated.
+
+use core::marker::PhantomData;
+
+use nectar_primitives::{ChunkAddress, SwarmSpec};
+
+use crate::{Batch, BatchId, Stamp, StampError, StampIndex};
+
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for super::Validated {}
+    impl Sealed for super::Unvalidated {}
+}
+
+/// Sealed validation state of a stamp against an address: [`Validated`] or
+/// [`Unvalidated`].
+pub trait ValidationState: sealed::Sealed + Send + Sync + 'static {
+    /// State name for diagnostics.
+    const NAME: &'static str;
+}
+
+/// The stamp's geometry and the owner's signature over this address are facts.
+///
+/// Timeless facts only. Batch usability and expiry decay, so every consumer
+/// still gates on them at the moment of use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Validated;
+
+impl ValidationState for Validated {
+    const NAME: &'static str = "validated";
+}
+
+/// The pairing is a claim: nothing has checked the stamp against the address.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Unvalidated;
+
+impl ValidationState for Unvalidated {
+    const NAME: &'static str = "unvalidated";
+}
+
+/// A stamp together with the address it is bound to, carrying its validation
+/// state in the type.
+///
+/// [`validate`](Self::validate) is the single validation authority: pure,
+/// synchronous, store-free and `no_std`, so aggregating validity over a set of
+/// addresses needs no chunk bodies. Pairing exists only at [`Unvalidated`], so
+/// a validated value cannot be fabricated.
+pub struct StampedAddress<V: ValidationState = Validated> {
+    address: ChunkAddress,
+    stamp: Stamp,
+    _validation: PhantomData<V>,
+}
+
+impl StampedAddress<Unvalidated> {
+    /// Pair a stamp with the address it claims to pay for.
+    #[inline]
+    #[must_use]
+    pub const fn new(address: ChunkAddress, stamp: Stamp) -> Self {
+        Self {
+            address,
+            stamp,
+            _validation: PhantomData,
+        }
+    }
+
+    /// Certify the pairing against `batch`: the stamp names this batch, its
+    /// index and bucket fit the batch geometry, and the owner signed this
+    /// address.
+    ///
+    /// Deliberately silent on expiry and confirmations: those decay, so they
+    /// stay runtime gates at each consumer. Dilution only raises `depth`, so a
+    /// pairing that passes here passes at every later depth.
+    ///
+    /// # Errors
+    ///
+    /// [`StampError::BatchMismatch`], [`StampError::InvalidIndex`],
+    /// [`StampError::BucketMismatch`], [`StampError::OwnerMismatch`] or
+    /// [`StampError::InvalidSignature`].
+    pub fn validate<S: SwarmSpec>(
+        self,
+        batch: &Batch<S>,
+    ) -> Result<StampedAddress<Validated>, StampError> {
+        if self.stamp.batch() != batch.id() {
+            return Err(StampError::BatchMismatch {
+                expected: batch.id(),
+                actual: self.stamp.batch(),
+            });
+        }
+
+        let index = self.stamp.stamp_index();
+        batch.validate_index(&index)?;
+        batch.validate_bucket(&index, &self.address)?;
+        self.stamp.verify(&self.address, batch.owner())?;
+
+        Ok(StampedAddress {
+            address: self.address,
+            stamp: self.stamp,
+            _validation: PhantomData,
+        })
+    }
+}
+
+impl<V: ValidationState> StampedAddress<V> {
+    /// The address the stamp is bound to.
+    #[inline]
+    #[must_use]
+    pub const fn address(&self) -> &ChunkAddress {
+        &self.address
+    }
+
+    /// The stamp.
+    #[inline]
+    #[must_use]
+    pub const fn stamp(&self) -> &Stamp {
+        &self.stamp
+    }
+
+    /// The batch the stamp draws on.
+    #[inline]
+    #[must_use]
+    pub const fn batch(&self) -> BatchId {
+        self.stamp.batch()
+    }
+
+    /// The stamp's bucket and position.
+    #[inline]
+    #[must_use]
+    pub const fn stamp_index(&self) -> StampIndex {
+        self.stamp.stamp_index()
+    }
+
+    /// Split into the address and the stamp.
+    #[inline]
+    #[must_use]
+    pub const fn into_parts(self) -> (ChunkAddress, Stamp) {
+        (self.address, self.stamp)
+    }
+}
+
+impl<V: ValidationState> Clone for StampedAddress<V> {
+    fn clone(&self) -> Self {
+        Self {
+            address: self.address,
+            stamp: self.stamp.clone(),
+            _validation: PhantomData,
+        }
+    }
+}
+
+impl<V: ValidationState> PartialEq for StampedAddress<V> {
+    fn eq(&self, other: &Self) -> bool {
+        self.address == other.address && self.stamp == other.stamp
+    }
+}
+
+impl<V: ValidationState> Eq for StampedAddress<V> {}
+
+impl<V: ValidationState> core::fmt::Debug for StampedAddress<V> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("StampedAddress")
+            .field("state", &V::NAME)
+            .field("address", &self.address)
+            .field("stamp", &self.stamp)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::Address;
+    use alloy_signer_local::PrivateKeySigner;
+    use arbitrary::Unstructured;
+    use proptest::prelude::*;
+
+    use super::*;
+    use crate::{BucketDepth, generators};
+
+    const DEPTH: u8 = 18;
+    const BUCKET_DEPTH: u8 = 16;
+
+    fn signer() -> PrivateKeySigner {
+        PrivateKeySigner::from_slice(&[7u8; 32]).unwrap()
+    }
+
+    fn other_signer() -> PrivateKeySigner {
+        PrivateKeySigner::from_slice(&[9u8; 32]).unwrap()
+    }
+
+    fn batch_owned_by(owner: Address, id: BatchId) -> Batch {
+        Batch::new(
+            id,
+            1_000,
+            100,
+            owner,
+            DEPTH,
+            BucketDepth::new(BUCKET_DEPTH).unwrap(),
+            true,
+        )
+    }
+
+    /// Bucket 0xCBE5 at bucket depth 16.
+    fn address_with(tail: u8) -> ChunkAddress {
+        let mut bytes = [0u8; 32];
+        bytes[0] = 0xCB;
+        bytes[1] = 0xE5;
+        bytes[31] = tail;
+        ChunkAddress::new(bytes)
+    }
+
+    fn stamp_for(signer: &PrivateKeySigner, batch: &Batch, address: &ChunkAddress) -> Stamp {
+        let mut u = Unstructured::new(&[7u8; 32]);
+        generators::signed_stamp(&mut u, signer, batch, address).unwrap()
+    }
+
+    fn coherent() -> (Batch, StampedAddress<Unvalidated>) {
+        let signer = signer();
+        let batch = batch_owned_by(signer.address(), BatchId::ZERO);
+        let address = address_with(0);
+        let stamp = stamp_for(&signer, &batch, &address);
+        (batch, StampedAddress::new(address, stamp))
+    }
+
+    #[test]
+    fn validate_certifies_a_coherent_pairing() {
+        let (batch, pairing) = coherent();
+        let address = *pairing.address();
+        let stamp = pairing.stamp().clone();
+
+        let validated = pairing.validate(&batch).unwrap();
+        assert_eq!(validated.address(), &address);
+        assert_eq!(validated.stamp(), &stamp);
+        assert_eq!(validated.batch(), batch.id());
+    }
+
+    /// The digest binds the stamp's own batch id, so a stamp bought from one
+    /// batch must not spend another batch's geometry, even when the two share
+    /// an owner and a shape.
+    #[test]
+    fn validate_refuses_a_foreign_batch() {
+        let signer = signer();
+        let bought = batch_owned_by(signer.address(), BatchId::ZERO);
+        let spent = batch_owned_by(signer.address(), BatchId::from([1u8; 32]));
+        let address = address_with(0);
+        let stamp = stamp_for(&signer, &bought, &address);
+
+        assert!(matches!(
+            StampedAddress::new(address, stamp).validate(&spent),
+            Err(StampError::BatchMismatch { .. })
+        ));
+    }
+
+    /// Same bucket, so geometry passes and the signature is what refuses it.
+    #[test]
+    fn validate_refuses_a_re_paired_address() {
+        let (batch, pairing) = coherent();
+        let (_, stamp) = pairing.into_parts();
+        let elsewhere = address_with(0xFF);
+
+        assert!(matches!(
+            StampedAddress::new(elsewhere, stamp).validate(&batch),
+            Err(StampError::OwnerMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn validate_refuses_a_bucket_mismatch() {
+        let (batch, pairing) = coherent();
+        let (_, stamp) = pairing.into_parts();
+        let other_bucket = ChunkAddress::new([0x12u8; 32]);
+
+        assert!(matches!(
+            StampedAddress::new(other_bucket, stamp).validate(&batch),
+            Err(StampError::BucketMismatch)
+        ));
+    }
+
+    #[test]
+    fn validate_refuses_a_position_past_capacity() {
+        let (batch, pairing) = coherent();
+        let (address, stamp) = pairing.into_parts();
+        let past_end = StampIndex::new(stamp.bucket(), batch.bucket_upper_bound());
+        let stamp = Stamp::with_index(
+            stamp.batch(),
+            past_end,
+            stamp.timestamp(),
+            *stamp.signature(),
+        );
+
+        assert!(matches!(
+            StampedAddress::new(address, stamp).validate(&batch),
+            Err(StampError::InvalidIndex)
+        ));
+    }
+
+    #[test]
+    fn validate_refuses_a_foreign_signer() {
+        let signer = other_signer();
+        let batch = batch_owned_by(signer.address(), BatchId::ZERO);
+        let address = address_with(0);
+        let stamp = stamp_for(&signer, &batch, &address);
+        let owned_elsewhere = batch_owned_by(self::signer().address(), BatchId::ZERO);
+
+        assert!(matches!(
+            StampedAddress::new(address, stamp).validate(&owned_elsewhere),
+            Err(StampError::OwnerMismatch { .. })
+        ));
+    }
+
+    /// Dilution raises depth only, so it can never invalidate an allocated
+    /// index. This is the theorem the concurrency design rests on.
+    #[test]
+    fn validation_survives_dilution() {
+        let (mut batch, pairing) = coherent();
+        batch.set_depth(DEPTH + 4);
+
+        assert!(pairing.validate(&batch).is_ok());
+    }
+
+    /// Expiry and confirmations decay, so the marker must not certify them.
+    #[test]
+    fn validation_ignores_expiry_and_confirmations() {
+        let signer = signer();
+        let mut batch = batch_owned_by(signer.address(), BatchId::ZERO);
+        let address = address_with(0);
+        let stamp = stamp_for(&signer, &batch, &address);
+        batch.set_value(0);
+
+        assert!(batch.is_expired(1));
+        assert!(!batch.is_usable(batch.start(), 50));
+        assert!(StampedAddress::new(address, stamp).validate(&batch).is_ok());
+    }
+
+    #[test]
+    fn debug_names_the_validation_state() {
+        let (batch, pairing) = coherent();
+        assert!(format!("{pairing:?}").contains("unvalidated"));
+        assert!(format!("{:?}", pairing.validate(&batch).unwrap()).contains("validated"));
+    }
+
+    #[test]
+    fn state_names_are_distinct() {
+        assert_eq!(Validated::NAME, "validated");
+        assert_eq!(Unvalidated::NAME, "unvalidated");
+    }
+
+    proptest! {
+        #[test]
+        fn a_signed_pairing_validates_against_its_batch(
+            seed in proptest::collection::vec(any::<u8>(), 128..2048),
+        ) {
+            let mut u = Unstructured::new(&seed);
+            let signer = nectar_primitives::generators::signer(&mut u).unwrap();
+            let batch = generators::batch(&mut u, signer.address()).unwrap();
+            let address = ChunkAddress::new(u.arbitrary::<[u8; 32]>().unwrap());
+            let stamp = generators::signed_stamp(&mut u, &signer, &batch, &address).unwrap();
+
+            let validated = StampedAddress::new(address, stamp).validate(&batch);
+            prop_assert!(validated.is_ok());
+        }
+
+        /// A stamp is bound to one address: re-pairing it with any other one
+        /// is refused, whatever the refusal.
+        #[test]
+        fn a_re_paired_stamp_never_validates(
+            seed in proptest::collection::vec(any::<u8>(), 128..2048),
+            other in any::<[u8; 32]>(),
+        ) {
+            let mut u = Unstructured::new(&seed);
+            let signer = nectar_primitives::generators::signer(&mut u).unwrap();
+            let batch = generators::batch(&mut u, signer.address()).unwrap();
+            let address = ChunkAddress::new(u.arbitrary::<[u8; 32]>().unwrap());
+            let stamp = generators::signed_stamp(&mut u, &signer, &batch, &address).unwrap();
+
+            let other = ChunkAddress::new(other);
+            prop_assume!(other != address);
+
+            prop_assert!(StampedAddress::new(other, stamp).validate(&batch).is_err());
+        }
+    }
+}

--- a/crates/postage/src/stamped_address.rs
+++ b/crates/postage/src/stamped_address.rs
@@ -1,10 +1,7 @@
 //! Typestate validation carrier for a stamp bound to an address.
 //!
-//! The signature covers `address | batchID | index | timestamp`, so validity
-//! is a fact about a stamp and an address, never about a chunk body. A marker
-//! on a bare [`Stamp`] would be unsound, because the address is not on the
-//! wire: the value would assert a fact about a subject it does not hold, and
-//! could be re-paired with another address while still reading as validated.
+//! The signature covers `address | batchID | index | timestamp`, and the
+//! address is not on the wire, so the address has to travel inside the value.
 
 use core::marker::PhantomData;
 
@@ -27,8 +24,8 @@ pub trait ValidationState: sealed::Sealed + Send + Sync + 'static {
 
 /// The stamp's geometry and the owner's signature over this address are facts.
 ///
-/// Timeless facts only. Batch usability and expiry decay, so every consumer
-/// still gates on them at the moment of use.
+/// Expiry and batch usability are not: they decay, so consumers still gate on
+/// them at the moment of use.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Validated;
 
@@ -47,10 +44,8 @@ impl ValidationState for Unvalidated {
 /// A stamp together with the address it is bound to, carrying its validation
 /// state in the type.
 ///
-/// [`validate`](Self::validate) is the single validation authority: pure,
-/// synchronous, store-free and `no_std`, so aggregating validity over a set of
-/// addresses needs no chunk bodies. Pairing exists only at [`Unvalidated`], so
-/// a validated value cannot be fabricated.
+/// Pairing exists only at [`Unvalidated`], so [`validate`](Self::validate) is
+/// the only route to [`Validated`].
 pub struct StampedAddress<V: ValidationState = Validated> {
     address: ChunkAddress,
     stamp: Stamp,
@@ -73,9 +68,8 @@ impl StampedAddress<Unvalidated> {
     /// index and bucket fit the batch geometry, and the owner signed this
     /// address.
     ///
-    /// Deliberately silent on expiry and confirmations: those decay, so they
-    /// stay runtime gates at each consumer. Dilution only raises `depth`, so a
-    /// pairing that passes here passes at every later depth.
+    /// Silent on expiry and confirmations, which decay. Dilution only raises
+    /// `depth`, so a pass here holds at every later depth.
     ///
     /// # Errors
     ///
@@ -238,9 +232,7 @@ mod tests {
         assert_eq!(validated.batch(), batch.id());
     }
 
-    /// The digest binds the stamp's own batch id, so a stamp bought from one
-    /// batch must not spend another batch's geometry, even when the two share
-    /// an owner and a shape.
+    /// Same owner and same shape, so only the batch id can refuse it.
     #[test]
     fn validate_refuses_a_foreign_batch() {
         let signer = signer();
@@ -313,7 +305,7 @@ mod tests {
     }
 
     /// Dilution raises depth only, so it can never invalidate an allocated
-    /// index. This is the theorem the concurrency design rests on.
+    /// index.
     #[test]
     fn validation_survives_dilution() {
         let (mut batch, pairing) = coherent();
@@ -364,12 +356,12 @@ mod tests {
             prop_assert!(validated.is_ok());
         }
 
-        /// A stamp is bound to one address: re-pairing it with any other one
-        /// is refused, whatever the refusal.
+        /// The re-paired address keeps the leading 4 bytes, so it shares the
+        /// bucket at every bucket depth and only the signature can refuse it.
         #[test]
         fn a_re_paired_stamp_never_validates(
             seed in proptest::collection::vec(any::<u8>(), 128..2048),
-            other in any::<[u8; 32]>(),
+            tail in any::<[u8; 28]>(),
         ) {
             let mut u = Unstructured::new(&seed);
             let signer = nectar_primitives::generators::signer(&mut u).unwrap();
@@ -377,10 +369,18 @@ mod tests {
             let address = ChunkAddress::new(u.arbitrary::<[u8; 32]>().unwrap());
             let stamp = generators::signed_stamp(&mut u, &signer, &batch, &address).unwrap();
 
-            let other = ChunkAddress::new(other);
-            prop_assume!(other != address);
+            let mut bytes = *address.as_array();
+            prop_assume!(bytes[4..] != tail[..]);
+            bytes[4..].copy_from_slice(&tail);
 
-            prop_assert!(StampedAddress::new(other, stamp).validate(&batch).is_err());
+            let refused = StampedAddress::new(ChunkAddress::new(bytes), stamp).validate(&batch);
+            prop_assert!(
+                matches!(
+                    refused,
+                    Err(StampError::OwnerMismatch { .. } | StampError::InvalidSignature)
+                ),
+                "the signature must refuse a re-paired address"
+            );
         }
     }
 }

--- a/crates/postage/src/validation.rs
+++ b/crates/postage/src/validation.rs
@@ -10,7 +10,7 @@ use crate::{Batch, BatchId};
 use crate::StampIndex;
 
 #[cfg(feature = "std")]
-use crate::{BatchStore, BatchStoreExt};
+use crate::{BatchStore, BatchStoreExt, StampedAddress};
 
 /// A trait for validating postage stamps.
 ///
@@ -162,8 +162,7 @@ impl<S: BatchStore> StoreValidator<S> {
     /// `Ok(())` if the stamp is valid, or a [`StampError`] describing the failure.
     pub fn validate(&self, stamp: &Stamp, address: &ChunkAddress) -> Result<(), StampError> {
         let batch = self.get_batch_for_stamp(stamp)?;
-        self.validate_structure_with_batch(stamp, address, &batch)?;
-        stamp.verify(address, batch.owner())?;
+        StampedAddress::new(*address, stamp.clone()).validate(&batch)?;
 
         Ok(())
     }

--- a/crates/postage/src/validation.rs
+++ b/crates/postage/src/validation.rs
@@ -386,6 +386,24 @@ mod tests {
         ));
     }
 
+    /// The structural checks all pass, so only the signature can refuse it.
+    #[test]
+    fn acceptance_refuses_a_foreign_signature() {
+        let (validator, _, address, _) = unconfirmed();
+        let other = PrivateKeySigner::from_slice(&[9u8; 32]).unwrap();
+        let stamp = stamp_for(
+            &other,
+            &batch_started_at(other.address(), START_BLOCK),
+            &address,
+        );
+
+        assert!(validator.validate_structure(&stamp, &address).is_ok());
+        assert!(matches!(
+            validator.validate(&stamp, &address),
+            Err(StampError::OwnerMismatch { .. })
+        ));
+    }
+
     #[test]
     fn acceptance_refuses_an_unknown_batch() {
         let (validator, _, address, _) = unconfirmed();


### PR DESCRIPTION
Closes #767

## Summary

Adds a sealed `ValidationState` marker (`Validated`, `Unvalidated`) and `StampedAddress<V = Validated>` to `nectar-postage`, in a new module `crates/postage/src/stamped_address.rs`. `StampedAddress` pairs a `ChunkAddress` with a `Stamp` and carries whether that pairing has been checked in its type: `new` exists only on `StampedAddress<Unvalidated>`, and the only route to `Validated` is the consuming `validate<S: SwarmSpec>(self, &Batch<S>) -> Result<StampedAddress<Validated>, StampError>`, so a `Validated` value cannot be fabricated by construction, and the type carries no serde impl in any state so it cannot be handed back from the wire either. `Stamp` itself is untouched by this change.

`validate` checks, in order: the stamp names the batch it is checked against (new `StampError::BatchMismatch`), the stamp's index and bucket fit the batch geometry, and the owner's signature covers the address. It is deliberately silent on expiry and batch usability, which decay over time and so remain the caller's responsibility at the point of use.

`StoreValidator::validate` in `crates/postage/src/validation.rs` is rewired to go through `StampedAddress::new(...).validate(&batch)` instead of calling `validate_structure_with_batch` and `stamp.verify` directly, making `StampedAddress` the single validation authority for the address/stamp pairing. A new test, `acceptance_refuses_a_foreign_signature`, confirms that a stamp which passes structural checks is still refused when the signature belongs to a different owner.

`crates/postage/src/lib.rs` re-exports `StampedAddress`, `Unvalidated`, `Validated` and `ValidationState`, and documents `StampedAddress` alongside the crate's other core types.

## Changes

- `crates/postage/src/stamped_address.rs` (new, 397 lines): `ValidationState` sealed trait, `Validated`/`Unvalidated` marker types, `StampedAddress<V>` with `new`, `validate`, accessors (`address`, `stamp`, `batch`, `stamp_index`, `into_parts`) and a manual `Clone` impl.
- `crates/postage/src/error.rs`: new `StampError::BatchMismatch { expected, actual }` variant.
- `crates/postage/src/validation.rs`: `StoreValidator::validate` now delegates to `StampedAddress::validate`; adds `acceptance_refuses_a_foreign_signature` test.
- `crates/postage/src/lib.rs`: exports the new module's public items and documents `StampedAddress` in the crate-level docs.

## Testing

All commands ran inside `nix develop --command`, once, on the pushed head (884e94c6).

Clippy, mirroring lint.yml (never `--all-features`):
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean.
- `cargo clippy --locked --all-targets -p nectar-postage --features serde -- -D warnings` — clean.
- `cargo clippy --locked --all-targets -p nectar-postage --features parallel -- -D warnings` — clean.
- `cargo clippy --workspace --all-targets --locked --features nectar-postage-usage/client,nectar-postage-usage/issuer -- -D warnings` — clean.
- `cargo clippy --locked --all-targets -p nectar-postage-issuer --features parallel -- -D warnings` — clean.
- `cargo clippy --locked --all-targets -p nectar-postage-issuer -- -D warnings` — clean.

Doctests:
- `cargo test --doc -p nectar-postage --locked` — 2 passed, 0 failed.

## Red-team

Red-teamed by re-deriving correctness from the code and running mutation tests against the suite rather than trusting the implementation report alone. The design is sound: the new `StampError::BatchMismatch` check is genuinely load-bearing rather than defensive padding, because `Stamp::recover_signer` builds its digest from the stamp's own batch id, so a stamp bought against one batch and checked against a different batch with the same owner would otherwise pass signature verification.

## AI Assistance

Implementation: claude-opus-5. Red-team: claude-opus-5. PR: claude-sonnet-5.
