### PR TITLE
refactor(postage): add Bucket<S> and BatchDepth<S> in new geometry module

### DIFF
--- a/crates/postage-issuer/src/counter.rs
+++ b/crates/postage-issuer/src/counter.rs
@@ -29,7 +29,7 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
-use nectar_postage::BucketDepth;
+use nectar_postage::{Bucket, BucketDepth};
 use nectar_primitives::{Mainnet, SwarmSpec};
 use thiserror::Error;
 
@@ -54,6 +54,15 @@ pub enum CounterError {
     InvalidBucket {
         /// The offending bucket index.
         bucket: u32,
+    },
+
+    /// A bucket was cut at a depth other than the table's.
+    #[error("bucket cut at depth {got}, table is at depth {expected}")]
+    BucketDepthMismatch {
+        /// The table's bucket depth.
+        expected: u8,
+        /// The depth the bucket was cut at.
+        got: u8,
     },
 
     /// A fill bucket has no remaining slot. Never produced in ring mode.
@@ -282,6 +291,10 @@ impl<S: SwarmSpec> CounterTable<S> {
     /// Advances the counter of `bucket`, skipping any slot for which
     /// `is_protected` returns `true`, and returns the assigned slot.
     ///
+    /// The bucket carries the depth it was cut at, so a bucket cut at a shallower
+    /// depth is refused rather than landing in the wrong counter: it is inside
+    /// this table's bucket range, so a range check alone would not catch it.
+    ///
     /// Fill mode returns the watermark and bumps it, failing with
     /// [`CounterError::BucketFull`] at capacity; the predicate is unused because a
     /// monotone watermark never lands on a reserved slot. Ring mode starts at the
@@ -291,9 +304,16 @@ impl<S: SwarmSpec> CounterTable<S> {
     /// [`CounterError::RingExhausted`]; the geometry forbids this at real depths.
     pub fn record(
         &mut self,
-        bucket: u32,
+        bucket: Bucket<S>,
         is_protected: impl Fn(u32) -> bool,
     ) -> Result<u32, CounterError> {
+        if bucket.depth() != self.bucket_depth {
+            return Err(CounterError::BucketDepthMismatch {
+                expected: self.bucket_depth.get(),
+                got: bucket.depth().get(),
+            });
+        }
+        let bucket = bucket.value();
         // `u32` always fits `usize` on the >=32-bit targets this crate supports.
         #[allow(clippy::as_conversions)]
         let bucket_idx = bucket as usize;
@@ -412,14 +432,19 @@ mod tests {
         BucketDepth::new(16).unwrap()
     }
 
+    /// A bucket cut at the fixture depth.
+    fn at(bucket: u32) -> Bucket {
+        Bucket::checked(bucket, bucket_depth()).unwrap()
+    }
+
     #[test]
     fn fill_is_a_monotone_watermark_that_refuses_a_full_bucket() {
         // depth 17, bucket depth 16 gives 2 slots per bucket.
         let mut table: CounterTable = CounterTable::new(17, bucket_depth(), CounterMode::Fill);
-        assert_eq!(table.record(5, never).unwrap(), 0);
-        assert_eq!(table.record(5, never).unwrap(), 1);
+        assert_eq!(table.record(at(5), never).unwrap(), 0);
+        assert_eq!(table.record(at(5), never).unwrap(), 1);
         assert_eq!(
-            table.record(5, never),
+            table.record(at(5), never),
             Err(CounterError::BucketFull {
                 bucket: 5,
                 capacity: 2
@@ -432,12 +457,12 @@ mod tests {
     #[test]
     fn ring_wraps_and_keeps_the_cursor_in_range() {
         let mut table: CounterTable = CounterTable::new(17, bucket_depth(), CounterMode::Ring);
-        assert_eq!(table.record(5, never).unwrap(), 0);
-        assert_eq!(table.record(5, never).unwrap(), 1);
+        assert_eq!(table.record(at(5), never).unwrap(), 0);
+        assert_eq!(table.record(at(5), never).unwrap(), 1);
         // The cursor sits at capacity, the deferred-wrap state.
         assert_eq!(table.count(5).unwrap(), 2);
         // The next write wraps back to slot 0.
-        assert_eq!(table.record(5, never).unwrap(), 0);
+        assert_eq!(table.record(at(5), never).unwrap(), 0);
         assert_eq!(table.count(5).unwrap(), 1);
     }
 
@@ -447,7 +472,7 @@ mod tests {
         let mut table: CounterTable = CounterTable::new(18, bucket_depth(), CounterMode::Ring);
         let protected = |slot: u32| slot == 1 || slot == 3;
         for _ in 0..20 {
-            let slot = table.record(0, protected).unwrap();
+            let slot = table.record(at(0), protected).unwrap();
             assert!(slot == 0 || slot == 2, "ring emitted protected slot {slot}");
         }
     }
@@ -456,7 +481,7 @@ mod tests {
     fn ring_exhausts_when_every_slot_is_protected() {
         let mut table: CounterTable = CounterTable::new(17, bucket_depth(), CounterMode::Ring);
         let err = table
-            .record(0, |_| true)
+            .record(at(0), |_| true)
             .expect_err("every slot is protected");
         assert_eq!(err, CounterError::RingExhausted(RingExhausted::new(0)));
         assert!(
@@ -464,6 +489,24 @@ mod tests {
                 .expect("the shared condition is the source")
                 .is::<RingExhausted>()
         );
+    }
+
+    #[test]
+    fn a_bucket_cut_at_another_depth_never_lands_in_a_counter() {
+        // Bucket 5 is in range for a depth-20 table, so only the depth it was
+        // cut at distinguishes it from the depth-20 bucket 5.
+        let mut table: CounterTable =
+            CounterTable::new(24, BucketDepth::new(20).unwrap(), CounterMode::Fill);
+        let shallow = Bucket::checked(5, bucket_depth()).unwrap();
+        assert_eq!(
+            table.record(shallow, never),
+            Err(CounterError::BucketDepthMismatch {
+                expected: 20,
+                got: 16
+            })
+        );
+        assert_eq!(table.count(5), Ok(0));
+        assert_eq!(table.total_issued(), 0);
     }
 
     #[test]
@@ -512,7 +555,7 @@ mod tests {
                 let mut successes = 0u64;
                 for &bucket in &ops {
                     let mark = marks.entry(bucket).or_insert(0);
-                    match table.record(bucket, never) {
+                    match table.record(Bucket::checked(bucket, bucket_depth).unwrap(), never) {
                         Ok(slot) => {
                             prop_assert!(*mark < capacity);
                             prop_assert_eq!(slot, *mark);
@@ -557,12 +600,15 @@ mod tests {
                         .find(|&slot| !protected(slot));
                     match expected {
                         Some(want) => {
-                            prop_assert_eq!(table.record(bucket, protected), Ok(want));
+                            prop_assert_eq!(
+                                table.record(Bucket::checked(bucket, bucket_depth).unwrap(), protected),
+                                Ok(want)
+                            );
                             cursors[idx] = want + 1;
                         }
                         None => {
                             prop_assert_eq!(
-                                table.record(bucket, protected),
+                                table.record(Bucket::checked(bucket, bucket_depth).unwrap(), protected),
                                 Err(CounterError::RingExhausted(RingExhausted::new(bucket)))
                             );
                         }
@@ -589,13 +635,14 @@ mod tests {
                 let depth = bucket_depth.get() + excess;
                 let mut live: CounterTable = CounterTable::new(depth, bucket_depth, mode);
                 for &bucket in &prefix {
-                    let _ = live.record(bucket, never);
+                    let _ = live.record(Bucket::checked(bucket, bucket_depth).unwrap(), never);
                 }
                 let mut restored =
                     CounterTable::from_counts(depth, bucket_depth, mode, live.counts().to_vec())
                         .unwrap();
                 prop_assert_eq!(&restored, &live);
                 for &bucket in &suffix {
+                    let bucket = Bucket::checked(bucket, bucket_depth).unwrap();
                     prop_assert_eq!(restored.record(bucket, never), live.record(bucket, never));
                 }
                 prop_assert_eq!(&restored, &live);
@@ -625,13 +672,13 @@ mod tests {
                     fill.total_issued(),
                     u64::from(capacity - 1) + u64::from(capacity)
                 );
-                prop_assert_eq!(fill.record(0, never), Ok(capacity - 1));
+                prop_assert_eq!(fill.record(at(0), never), Ok(capacity - 1));
                 prop_assert_eq!(
-                    fill.record(0, never),
+                    fill.record(at(0), never),
                     Err(CounterError::BucketFull { bucket: 0, capacity })
                 );
                 prop_assert_eq!(
-                    fill.record(1, never),
+                    fill.record(at(1), never),
                     Err(CounterError::BucketFull { bucket: 1, capacity })
                 );
 
@@ -650,11 +697,11 @@ mod tests {
                     CounterTable::from_counts(depth, bucket_depth(), CounterMode::Ring, counts)
                         .unwrap();
                 prop_assert_eq!(ring.has_capacity(1), Ok(false));
-                prop_assert_eq!(ring.record(1, never), Ok(0));
+                prop_assert_eq!(ring.record(at(1), never), Ok(0));
                 prop_assert_eq!(ring.count(1), Ok(1));
-                prop_assert_eq!(ring.record(0, never), Ok(capacity - 1));
+                prop_assert_eq!(ring.record(at(0), never), Ok(capacity - 1));
                 prop_assert_eq!(ring.count(0), Ok(capacity));
-                prop_assert_eq!(ring.record(0, never), Ok(0));
+                prop_assert_eq!(ring.record(at(0), never), Ok(0));
                 prop_assert_eq!(ring.count(0), Ok(1));
                 prop_assert_eq!(ring.total_issued(), 2);
             }

--- a/crates/postage-issuer/src/counter.rs
+++ b/crates/postage-issuer/src/counter.rs
@@ -291,9 +291,8 @@ impl<S: SwarmSpec> CounterTable<S> {
     /// Advances the counter of `bucket`, skipping any slot for which
     /// `is_protected` returns `true`, and returns the assigned slot.
     ///
-    /// The bucket carries the depth it was cut at, so a bucket cut at a shallower
-    /// depth is refused rather than landing in the wrong counter: it is inside
-    /// this table's bucket range, so a range check alone would not catch it.
+    /// A bucket cut at another depth is refused: it is inside this table's
+    /// bucket range, so a range check alone would not catch it.
     ///
     /// Fill mode returns the watermark and bumps it, failing with
     /// [`CounterError::BucketFull`] at capacity; the predicate is unused because a
@@ -432,7 +431,6 @@ mod tests {
         BucketDepth::new(16).unwrap()
     }
 
-    /// A bucket cut at the fixture depth.
     fn at(bucket: u32) -> Bucket {
         Bucket::checked(bucket, bucket_depth()).unwrap()
     }
@@ -493,8 +491,8 @@ mod tests {
 
     #[test]
     fn a_bucket_cut_at_another_depth_never_lands_in_a_counter() {
-        // Bucket 5 is in range for a depth-20 table, so only the depth it was
-        // cut at distinguishes it from the depth-20 bucket 5.
+        // Bucket 5 is in range for a depth-20 table, so only the cut depth
+        // tells it apart from the depth-20 bucket 5.
         let mut table: CounterTable =
             CounterTable::new(24, BucketDepth::new(20).unwrap(), CounterMode::Fill);
         let shallow = Bucket::checked(5, bucket_depth()).unwrap();

--- a/crates/postage-issuer/src/error.rs
+++ b/crates/postage-issuer/src/error.rs
@@ -33,6 +33,10 @@ pub enum IssuerError {
     /// A ring bucket had no unprotected slot to issue.
     #[error("ring issuance failed")]
     RingExhausted(#[from] RingExhausted),
+
+    /// The batch depth decoded from chain is not one a counter table can hold.
+    #[error("invalid batch geometry")]
+    Geometry(#[from] nectar_postage::StampError),
 }
 
 /// Every slot in a ring bucket is reserved, so the ring cannot advance without

--- a/crates/postage-issuer/src/issuer.rs
+++ b/crates/postage-issuer/src/issuer.rs
@@ -231,14 +231,14 @@ impl<S: SwarmSpec> StampIssuer for MemoryIssuer<S> {
             self.counters
                 .record(bucket, |_| false)
                 .map_err(|err| StampError::BucketFull {
-                    bucket,
+                    bucket: bucket.value(),
                     capacity: match err {
                         crate::counter::CounterError::BucketFull { capacity, .. } => capacity,
                         _ => self.counters.bucket_capacity(),
                     },
                 })?;
 
-        let index = StampIndex::new(bucket, position);
+        let index = StampIndex::new(bucket.value(), position);
 
         Ok(StampDigest::new(*address, self.batch_id, index, timestamp))
     }

--- a/crates/postage-issuer/src/issuer.rs
+++ b/crates/postage-issuer/src/issuer.rs
@@ -211,6 +211,9 @@ impl<S: SwarmSpec> MemoryIssuer<S> {
     /// self-hosting, where the protected slots come from `nectar-postage-usage`.
     pub fn from_batch(batch: &Batch<S>) -> Result<Self, IssuerError> {
         if batch.immutable() {
+            // Chain decode leaves the depth a raw byte; an unheld geometry would
+            // otherwise overflow the counter table's capacity shift.
+            batch.geometry()?;
             Ok(Self::new(batch.id(), batch.depth(), batch.bucket_depth()))
         } else {
             Err(IssuerError::MutableNotSupported)
@@ -439,6 +442,29 @@ mod tests {
             MemoryIssuer::from_batch(&mutable),
             Err(IssuerError::MutableNotSupported)
         ));
+    }
+
+    #[test]
+    fn from_batch_refuses_a_depth_no_counter_table_can_hold() {
+        use nectar_postage::Batch;
+
+        // Chain decode is total, so a depth this far above the bucket depth
+        // reaches here; building the table would overflow its capacity shift.
+        for depth in [8u8, 48, u8::MAX] {
+            let batch: Batch = Batch::new(
+                BatchId::ZERO,
+                0,
+                0,
+                Default::default(),
+                depth,
+                BucketDepth::new(16).unwrap(),
+                true,
+            );
+            assert!(matches!(
+                MemoryIssuer::from_batch(&batch),
+                Err(IssuerError::Geometry(_))
+            ));
+        }
     }
 
     #[test]

--- a/crates/postage-issuer/src/pipeline/stamped_put.rs
+++ b/crates/postage-issuer/src/pipeline/stamped_put.rs
@@ -718,7 +718,7 @@ mod tests {
             let mut buckets: BTreeMap<u32, u32> = BTreeMap::new();
             for address in per_address.keys() {
                 *buckets
-                    .entry(calculate_bucket(address, bucket_depth()))
+                    .entry(calculate_bucket(address, bucket_depth()).value())
                     .or_insert(0) += 1;
             }
             let fullest = buckets.values().copied().max().unwrap();

--- a/crates/postage-issuer/src/ring.rs
+++ b/crates/postage-issuer/src/ring.rs
@@ -185,7 +185,9 @@ impl<S: SwarmSpec> RingIssuer<Unreserved, S> {
     ///
     /// Returns [`IssuerError::ImmutableNotSupported`] if the batch is immutable;
     /// immutable batches are fill-only and use
-    /// [`MemoryIssuer`](crate::MemoryIssuer).
+    /// [`MemoryIssuer`](crate::MemoryIssuer). Returns
+    /// [`IssuerError::Geometry`] if the chain-decoded depth is one no counter
+    /// table can hold.
     pub fn external(batch: &Batch<S>) -> Result<Self, IssuerError> {
         Self::for_mutable_batch(batch, Unreserved)
     }
@@ -203,7 +205,9 @@ impl<S: SwarmSpec> RingIssuer<Reserved, S> {
     ///
     /// Returns [`IssuerError::ImmutableNotSupported`] if the batch is immutable;
     /// immutable batches are fill-only and use
-    /// [`MemoryIssuer`](crate::MemoryIssuer).
+    /// [`MemoryIssuer`](crate::MemoryIssuer). Returns
+    /// [`IssuerError::Geometry`] if the chain-decoded depth is one no counter
+    /// table can hold.
     pub fn reserved(
         batch: &Batch<S>,
         slots: impl IntoIterator<Item = (u32, u32)>,
@@ -218,6 +222,7 @@ impl<R: Reservation, S: SwarmSpec> RingIssuer<R, S> {
         if batch.immutable() {
             return Err(IssuerError::ImmutableNotSupported);
         }
+        batch.geometry()?;
         Ok(Self::with_reservation(
             batch.id(),
             batch.depth(),
@@ -478,6 +483,21 @@ mod tests {
         assert_eq!(d3.index.index(), 1);
 
         assert_eq!(issuer.stamps_issued(), Some(4));
+    }
+
+    #[test]
+    fn a_ring_refuses_a_depth_no_counter_table_can_hold() {
+        for depth in [8u8, 48, u8::MAX] {
+            let batch = mutable_batch(depth, 16);
+            assert!(matches!(
+                RingIssuer::external(&batch),
+                Err(IssuerError::Geometry(_))
+            ));
+            assert!(matches!(
+                RingIssuer::reserved(&batch, []),
+                Err(IssuerError::Geometry(_))
+            ));
+        }
     }
 
     #[test]

--- a/crates/postage-issuer/src/ring.rs
+++ b/crates/postage-issuer/src/ring.rs
@@ -29,7 +29,7 @@ use alloc::collections::BTreeSet;
 use alloc::vec::Vec;
 
 use nectar_postage::{
-    Batch, BatchId, BucketDepth, StampDigest, StampError, StampIndex, calculate_bucket,
+    Batch, BatchId, Bucket, BucketDepth, StampDigest, StampError, StampIndex, calculate_bucket,
 };
 use nectar_primitives::{ChunkAddress, Mainnet, SwarmSpec};
 
@@ -269,27 +269,28 @@ impl<R: Reservation, S: SwarmSpec> RingIssuer<R, S> {
     /// written the bucket's last fresh slot. If every slot is protected the table
     /// returns [`CounterError::RingExhausted`], mapped to
     /// [`IssuerError::RingExhausted`].
-    fn next_slot(&mut self, bucket: u32) -> Result<u32, IssuerError> {
+    fn next_slot(&mut self, bucket: Bucket<S>) -> Result<u32, IssuerError> {
         let reservation = &self.reservation;
+        let value = bucket.value();
         let position = self
             .counters
-            .record(bucket, |slot| reservation.is_protected(bucket, slot))
+            .record(bucket, |slot| reservation.is_protected(value, slot))
             .map_err(|err| match err {
                 CounterError::RingExhausted(exhausted) => IssuerError::RingExhausted(exhausted),
                 // `record` reports nothing else here: ring mode never fills, the
-                // bucket comes from the address so it is in range, and
-                // construction errors cannot arise from an advance.
-                _ => IssuerError::RingExhausted(RingExhausted::new(bucket)),
+                // bucket comes from the address at the table's own depth so it is
+                // in range, and construction errors cannot arise from an advance.
+                _ => IssuerError::RingExhausted(RingExhausted::new(value)),
             })?;
         // A cursor sitting at the capacity has just filled the bucket's last
         // fresh slot, so the bucket is saturated from here on.
-        if self.counters.count(bucket).unwrap_or(0) == self.counters.bucket_capacity() {
+        if self.counters.count(value).unwrap_or(0) == self.counters.bucket_capacity() {
             // `record` above succeeded, so `bucket` is within the bucket count and
             // `saturated` has that same length by construction; `u32` always fits
             // `usize` on the >=32-bit targets this crate supports.
             #[allow(clippy::indexing_slicing, clippy::as_conversions)]
             {
-                self.saturated[bucket as usize] = true;
+                self.saturated[value as usize] = true;
             }
         }
         Ok(position)
@@ -322,12 +323,12 @@ impl<R: Reservation, S: SwarmSpec> RingIssuer<R, S> {
 
         // `u32` always fits `usize` on the >=32-bit targets this crate supports.
         #[allow(clippy::as_conversions)]
-        let fill = self.bucket_fill(bucket as usize);
+        let fill = self.bucket_fill(bucket.value() as usize);
         if fill > self.max_utilization {
             self.max_utilization = fill;
         }
 
-        let index = StampIndex::new(bucket, position);
+        let index = StampIndex::new(bucket.value(), position);
         Ok(StampDigest::new(*address, self.batch_id, index, timestamp))
     }
 
@@ -499,7 +500,7 @@ mod tests {
         // depth=18, bucket_depth=16 gives 4 slots per bucket. Protect slots 1
         // and 3 in the target bucket; the ring may only ever emit 0 and 2.
         let batch = mutable_batch(18, 16);
-        let bucket = calculate_bucket(&test_address(0x00AA), bucket_depth());
+        let bucket = calculate_bucket(&test_address(0x00AA), bucket_depth()).value();
         let mut issuer = RingIssuer::reserved(&batch, [(bucket, 1), (bucket, 3)]).unwrap();
 
         let address = test_address(0x00AA);
@@ -521,7 +522,7 @@ mod tests {
         // depth=17, bucket_depth=16 gives 2 slots per bucket. Protect both, so
         // the bucket has no issuable slot.
         let batch = mutable_batch(17, 16);
-        let bucket = calculate_bucket(&test_address(0x0001), bucket_depth());
+        let bucket = calculate_bucket(&test_address(0x0001), bucket_depth()).value();
         let mut issuer = RingIssuer::reserved(&batch, [(bucket, 0), (bucket, 1)]).unwrap();
 
         let address = test_address(0x0001);
@@ -564,7 +565,7 @@ mod tests {
         let mut issuer = RingIssuer::external(&batch).unwrap();
 
         let address = test_address(0x0001);
-        let bucket = calculate_bucket(&address, bucket_depth());
+        let bucket = calculate_bucket(&address, bucket_depth()).value();
 
         assert!(issuer.bucket_has_capacity(bucket));
         issuer.prepare_ring_stamp(&address, 1).unwrap();
@@ -612,7 +613,7 @@ mod tests {
     #[test]
     fn ring_stamp_issuer_surfaces_exhaustion_as_bucket_full() {
         let batch = mutable_batch(17, 16);
-        let bucket = calculate_bucket(&test_address(0x0001), bucket_depth());
+        let bucket = calculate_bucket(&test_address(0x0001), bucket_depth()).value();
         let mut issuer = RingIssuer::reserved(&batch, [(bucket, 0), (bucket, 1)]).unwrap();
 
         let address = test_address(0x0001);

--- a/crates/postage-issuer/src/sharded.rs
+++ b/crates/postage-issuer/src/sharded.rs
@@ -135,7 +135,7 @@ impl<I: StampIssuer, S: SwarmSpec> Sharded<I, S> {
         address: &ChunkAddress,
         timestamp: u64,
     ) -> Result<StampDigest, StampError> {
-        let bucket = calculate_bucket(address, self.bucket_depth);
+        let bucket = calculate_bucket(address, self.bucket_depth).value();
         let (digest, fill) = {
             let mut issuer = self.shard(bucket).lock();
             let digest = issuer.prepare_stamp(address, timestamp)?;
@@ -499,7 +499,7 @@ mod tests {
         let mut issuer: ShardedIssuer =
             ShardedIssuer::new(BatchId::ZERO, 17, BucketDepth::new(16).unwrap());
         let address = test_address(0xABCD);
-        let bucket = calculate_bucket(&address, bucket_depth());
+        let bucket = calculate_bucket(&address, bucket_depth()).value();
 
         issuer.prepare_stamp(&address, 1).unwrap();
         issuer.prepare_stamp(&address, 2).unwrap();
@@ -610,7 +610,7 @@ mod tests {
         let mut issuer: ShardedIssuer =
             ShardedIssuer::new(BatchId::ZERO, 20, BucketDepth::new(16).unwrap());
         let address = test_address(0x1234);
-        let bucket = calculate_bucket(&address, bucket_depth());
+        let bucket = calculate_bucket(&address, bucket_depth()).value();
 
         let digest = StampIssuer::prepare_stamp(&mut issuer, &address, 7).unwrap();
 
@@ -639,7 +639,7 @@ mod tests {
         assert_eq!(StampIssuer::stamps_issued(&handle), Some(1));
         assert!(StampIssuer::bucket_has_capacity(
             &handle,
-            calculate_bucket(&address, bucket_depth())
+            calculate_bucket(&address, bucket_depth()).value()
         ));
     }
 
@@ -669,7 +669,7 @@ mod tests {
         // leaves only 0 and 2.
         let mutable = batch(18, false);
         let address = test_address(0x00AA);
-        let bucket = calculate_bucket(&address, bucket_depth());
+        let bucket = calculate_bucket(&address, bucket_depth()).value();
         let issuer = ShardedRingIssuer::reserved(&mutable, [(bucket, 1), (bucket, 3)]).unwrap();
 
         for ts in 0..50u64 {
@@ -714,7 +714,7 @@ mod tests {
     fn a_fully_protected_bucket_surfaces_as_bucket_full() {
         let mutable = batch(17, false);
         let address = test_address(0x0001);
-        let bucket = calculate_bucket(&address, bucket_depth());
+        let bucket = calculate_bucket(&address, bucket_depth()).value();
         let issuer = ShardedRingIssuer::reserved(&mutable, [(bucket, 0), (bucket, 1)]).unwrap();
 
         assert!(matches!(
@@ -756,7 +756,7 @@ mod tests {
                 for &lead in &leads {
                     ts += 1;
                     let address = test_address(lead);
-                    let bucket = calculate_bucket(&address, bucket_depth);
+                    let bucket = calculate_bucket(&address, bucket_depth).value();
                     let mine = sharded.prepare_stamp(&address, ts);
                     let theirs = StampIssuer::prepare_stamp(&mut sequential, &address, ts);
                     prop_assert_eq!(mine, theirs);
@@ -802,7 +802,7 @@ mod tests {
                 for &lead in &leads {
                     ts += 1;
                     let address = test_address(lead);
-                    let bucket = calculate_bucket(&address, mutable.bucket_depth());
+                    let bucket = calculate_bucket(&address, mutable.bucket_depth()).value();
                     let mine = sharded.prepare_stamp(&address, ts);
                     let theirs = StampIssuer::prepare_stamp(&mut sequential, &address, ts);
                     prop_assert_eq!(mine, theirs);

--- a/crates/postage-issuer/src/sharded.rs
+++ b/crates/postage-issuer/src/sharded.rs
@@ -224,9 +224,11 @@ impl<S: SwarmSpec> Sharded<MemoryIssuer<S>, S> {
     ///
     /// [`IssuerError::MutableNotSupported`] for a mutable batch: overwrite-aware
     /// issuance is requested by name through [`ShardedRingIssuer::external`] or
-    /// [`ShardedRingIssuer::reserved`].
+    /// [`ShardedRingIssuer::reserved`]. [`IssuerError::Geometry`] if the
+    /// chain-decoded depth is one no counter table can hold.
     pub fn from_batch(batch: &Batch<S>) -> Result<Self, IssuerError> {
         if batch.immutable() {
+            batch.geometry()?;
             Ok(Self::new(batch.id(), batch.depth(), batch.bucket_depth()))
         } else {
             Err(IssuerError::MutableNotSupported)
@@ -264,7 +266,9 @@ impl<S: SwarmSpec> Sharded<RingIssuer<Unreserved, S>, S> {
     ///
     /// # Errors
     ///
-    /// [`IssuerError::ImmutableNotSupported`] if the batch is immutable.
+    /// [`IssuerError::ImmutableNotSupported`] if the batch is immutable, or
+    /// [`IssuerError::Geometry`] if the chain-decoded depth is one no counter
+    /// table can hold.
     pub fn external(batch: &Batch<S>) -> Result<Self, IssuerError> {
         Self::for_mutable_batch(batch, |_, _| Unreserved)
     }
@@ -276,7 +280,9 @@ impl<S: SwarmSpec> Sharded<RingIssuer<Reserved, S>, S> {
     ///
     /// # Errors
     ///
-    /// [`IssuerError::ImmutableNotSupported`] if the batch is immutable.
+    /// [`IssuerError::ImmutableNotSupported`] if the batch is immutable, or
+    /// [`IssuerError::Geometry`] if the chain-decoded depth is one no counter
+    /// table can hold.
     pub fn reserved(
         batch: &Batch<S>,
         slots: impl IntoIterator<Item = (u32, u32)>,
@@ -302,6 +308,7 @@ impl<R: Reservation, S: SwarmSpec> Sharded<RingIssuer<R, S>, S> {
         if batch.immutable() {
             return Err(IssuerError::ImmutableNotSupported);
         }
+        batch.geometry()?;
         Ok(Self::with_shards(
             batch.id(),
             batch.depth(),

--- a/crates/postage-issuer/tests/non_mainnet.rs
+++ b/crates/postage-issuer/tests/non_mainnet.rs
@@ -106,7 +106,10 @@ fn a_deep_issuer_dilutes_and_a_deep_sharded_issuer_stamps() {
     let sharded = ShardedIssuer::from_batch(&deep_batch(22, true)).unwrap();
     assert_eq!(sharded.bucket_depth(), 20);
     let digest = sharded.prepare_stamp(&address, 5).unwrap();
-    assert_eq!(digest.index.bucket(), calculate_bucket(&address, deep()));
+    assert_eq!(
+        digest.index.bucket(),
+        calculate_bucket(&address, deep()).value()
+    );
     assert_eq!(sharded.stamps_issued(), 1);
 }
 
@@ -115,7 +118,7 @@ fn a_deep_reserved_ring_never_emits_a_reserved_slot() {
     // depth 22 over bucket depth 20 gives 4 slots per bucket; reserve two.
     let batch = deep_batch(22, false);
     let address = address_in(0x0FEDC);
-    let bucket = calculate_bucket(&address, deep());
+    let bucket = calculate_bucket(&address, deep()).value();
     let mut ring: RingIssuer<Reserved, HighFloor> =
         RingIssuer::reserved(&batch, [(bucket, 1), (bucket, 3)]).unwrap();
 

--- a/crates/postage-usage/src/snapshot.rs
+++ b/crates/postage-usage/src/snapshot.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 
 use alloy_primitives::Address;
 use bytes::Bytes;
-use nectar_postage::{Batch, BatchId, StampIndex, calculate_bucket};
+use nectar_postage::{Batch, BatchId, Bucket, StampIndex, calculate_bucket};
 use nectar_primitives::{ChunkAddress, Mainnet, SocId, SwarmSpec};
 
 use crate::codec::{self, Encoded, RootInfo};
@@ -533,7 +533,7 @@ impl<S: SwarmSpec> Snapshot<S> {
                 #[allow(clippy::as_conversions)]
                 let index = index as u16;
                 let address = usage_chunk_address(&batch_id, owner, index);
-                StampIndex::new(calculate_bucket(&address, bucket_depth), slot)
+                StampIndex::new(calculate_bucket(&address, bucket_depth).value(), slot)
             })
             .collect()
     }
@@ -571,16 +571,17 @@ impl<S: SwarmSpec> Snapshot<S> {
     /// if every slot is reserved, which the geometry forbids).
     pub(crate) fn record_bucket(
         &mut self,
-        bucket: u32,
+        bucket: Bucket<S>,
         reserved: &BTreeSet<(u32, u32)>,
     ) -> Result<u32> {
         // Both branches (fill watermark and reserved-aware ring) live in the
         // shared counter table now. The reserved set is mapped into the table's
         // per-slot protection predicate so a ring never re-emits a slot held by
         // the snapshot's own chunks.
+        let value = bucket.value();
         self.table
             .counters_mut()
-            .record(bucket, |slot| reserved.contains(&(bucket, slot)))
+            .record(bucket, |slot| reserved.contains(&(value, slot)))
             .map_err(crate::table::map_counter_error)
     }
 
@@ -851,7 +852,7 @@ impl<S: SwarmSpec> Validated<'_, S> {
                 index,
                 id,
                 address,
-                stamp_index: StampIndex::new(bucket, slots[usize::from(index)]),
+                stamp_index: StampIndex::new(bucket.value(), slots[usize::from(index)]),
                 payload: payload.clone(),
                 newly_allocated: usize::from(index) >= previously_allocated,
             });
@@ -921,9 +922,9 @@ impl<S: SwarmSpec> Issuer<'_, S> {
     ) -> Result<(StampIndex, bool)> {
         let bucket = calculate_bucket(address, self.snapshot.table.bucket_depth());
         // Decide before the write: afterwards the cursor has already advanced.
-        let wrapped = self.will_wrap(bucket)?;
+        let wrapped = self.will_wrap(bucket.value())?;
         let index = self.snapshot.record_bucket(bucket, &self.reserved)?;
-        Ok((StampIndex::new(bucket, index), wrapped))
+        Ok((StampIndex::new(bucket.value(), index), wrapped))
     }
 
     /// Returns whether the next content write into `bucket` would wrap a mutable

--- a/crates/postage-usage/src/table.rs
+++ b/crates/postage-usage/src/table.rs
@@ -35,8 +35,8 @@ pub(crate) const fn map_counter_error(err: CounterError) -> UsageError {
     }
 }
 
-// The format's counter width and the width a `u32` slot count holds are the
-// same bound; `checked_geometry` delegates that half of the check.
+// The format's counter width and the width a `u32` slot count holds are one
+// bound, so `checked_geometry` delegates that half of the check.
 const _: () = assert!(MAX_COUNTER_BITS == BatchDepth::<Mainnet>::MAX_SLOT_BITS);
 
 /// Validates a batch geometry against the snapshot format's extra ceiling on

--- a/crates/postage-usage/src/table.rs
+++ b/crates/postage-usage/src/table.rs
@@ -2,7 +2,7 @@
 
 use alloc::vec::Vec;
 
-use nectar_postage::{Batch, BatchId, BucketDepth};
+use nectar_postage::{Batch, BatchDepth, BatchId, BucketDepth};
 use nectar_postage_issuer::{CounterError, CounterMode, CounterTable};
 use nectar_primitives::{Mainnet, SwarmSpec};
 
@@ -35,26 +35,24 @@ pub(crate) const fn map_counter_error(err: CounterError) -> UsageError {
     }
 }
 
-/// Validates that a batch geometry is within the range supported by the
-/// snapshot format: `1 <= bucket_depth <= 16` and `depth - bucket_depth <= 31`.
-///
-/// A zero bucket depth is rejected: a batch with no collision buckets is
-/// meaningless.
-// `depth - bucket_depth` is short-circuit guarded by the preceding
-// `depth < bucket_depth` disjunct, so it cannot underflow.
-#[allow(clippy::arithmetic_side_effects)]
-pub(crate) const fn validate_geometry(depth: u8, bucket_depth: u8) -> Result<()> {
-    if bucket_depth == 0
-        || bucket_depth > MAX_BUCKET_DEPTH
-        || depth < bucket_depth
-        || depth - bucket_depth > MAX_COUNTER_BITS
-    {
-        return Err(UsageError::InvalidGeometry {
-            depth,
-            bucket_depth,
-        });
+// The format's counter width and the width a `u32` slot count holds are the
+// same bound; `checked_geometry` delegates that half of the check.
+const _: () = assert!(MAX_COUNTER_BITS == BatchDepth::<Mainnet>::MAX_SLOT_BITS);
+
+/// Validates a batch geometry against the snapshot format's extra ceiling on
+/// the bucket depth, and against the two bounds [`BatchDepth`] settles.
+pub(crate) fn checked_geometry<S: SwarmSpec>(
+    depth: u8,
+    bucket_depth: BucketDepth<S>,
+) -> Result<BatchDepth<S>> {
+    let invalid = || UsageError::InvalidGeometry {
+        depth,
+        bucket_depth: bucket_depth.get(),
+    };
+    if bucket_depth.get() > MAX_BUCKET_DEPTH {
+        return Err(invalid());
     }
-    Ok(())
+    BatchDepth::new(depth, bucket_depth).map_err(|_| invalid())
 }
 
 /// Validates a raw geometry against both the snapshot format and the network
@@ -67,11 +65,12 @@ pub(crate) fn checked_bucket_depth<S: SwarmSpec>(
     depth: u8,
     bucket_depth: u8,
 ) -> Result<BucketDepth<S>> {
-    validate_geometry(depth, bucket_depth)?;
-    BucketDepth::new(bucket_depth).map_err(|_| UsageError::InvalidGeometry {
+    let bucket_depth = BucketDepth::new(bucket_depth).map_err(|_| UsageError::InvalidGeometry {
         depth,
         bucket_depth,
-    })
+    })?;
+    checked_geometry(depth, bucket_depth)?;
+    Ok(bucket_depth)
 }
 
 /// Whether a usage table is an immutable fill watermark or a mutable ring.
@@ -208,7 +207,7 @@ impl<S: SwarmSpec> UsageTable<S> {
         bucket_depth: BucketDepth<S>,
         mutability: Mutability,
     ) -> Result<Self> {
-        validate_geometry(depth, bucket_depth.get())?;
+        checked_geometry(depth, bucket_depth)?;
         Ok(Self {
             batch_id,
             counters: CounterTable::new(depth, bucket_depth, mutability.mode()),
@@ -243,7 +242,7 @@ impl<S: SwarmSpec> UsageTable<S> {
         counts: Vec<u32>,
         mutability: Mutability,
     ) -> Result<Self> {
-        validate_geometry(depth, bucket_depth.get())?;
+        checked_geometry(depth, bucket_depth)?;
         let counters = CounterTable::from_counts(depth, bucket_depth, mutability.mode(), counts)
             .map_err(map_counter_error)?;
         Ok(Self { batch_id, counters })
@@ -347,7 +346,7 @@ impl<S: SwarmSpec> UsageTable<S> {
                 requested: new_depth,
             });
         }
-        validate_geometry(new_depth, self.counters.bucket_depth().get())?;
+        checked_geometry(new_depth, self.counters.bucket_depth())?;
         // The geometry is validated against the snapshot format above, so the
         // shared table only needs to adopt the new depth.
         self.counters.set_depth(new_depth);
@@ -373,7 +372,7 @@ impl<S: SwarmSpec> UsageTable<S> {
             return Err(UsageError::BatchMismatch);
         }
         let depth = self.depth().max(other.depth());
-        validate_geometry(depth, self.bucket_depth().get())?;
+        checked_geometry(depth, self.bucket_depth())?;
         self.counters.merge_counts_max(other.counters(), depth);
         Ok(())
     }
@@ -480,7 +479,7 @@ impl<'a, S: SwarmSpec> TableView<'a, S> {
 }
 
 /// `Arbitrary` implementations that generate *valid* tables: the geometry is
-/// within the format bounds ([`validate_geometry`]) and every counter is
+/// within the format bounds ([`checked_geometry`]) and every counter is
 /// within `[0, capacity]`, so a generated table always encodes, and a
 /// structured fuzz target can assert a full round trip instead of merely "no
 /// panic". Counters cluster around a base with a few outliers, matching the
@@ -605,17 +604,8 @@ mod tests {
 
     #[test]
     fn geometry_rejects_zero_bucket_depth() {
-        for depth in [0u8, 1, 20, 31] {
-            assert_eq!(
-                validate_geometry(depth, 0),
-                Err(UsageError::InvalidGeometry {
-                    depth,
-                    bucket_depth: 0,
-                })
-            );
-        }
-        // The constructors cannot even be reached with one: no network can
-        // declare a floor of zero, so the shallowest depth is 1.
+        // No network can declare a floor of zero, so the shallowest depth is 1
+        // and `checked_geometry` cannot be reached with a zero.
         assert!(BucketDepth::<LowFloor>::new(0).is_err());
         // The wire path rejoins the type here, so a decoded zero is refused.
         assert_eq!(
@@ -625,6 +615,22 @@ mod tests {
                 bucket_depth: 0,
             })
         );
+    }
+
+    #[test]
+    fn geometry_rejects_a_depth_the_counters_cannot_hold() {
+        let bucket_depth = BucketDepth::<LowFloor>::new(8).unwrap();
+        assert_eq!(checked_geometry(39, bucket_depth).unwrap().slot_bits(), 31);
+        // Below the bucket depth, and past the counter width.
+        for depth in [7u8, 40] {
+            assert_eq!(
+                checked_geometry(depth, bucket_depth),
+                Err(UsageError::InvalidGeometry {
+                    depth,
+                    bucket_depth: 8,
+                })
+            );
+        }
     }
 
     #[test]

--- a/crates/postage-usage/tests/issuer.rs
+++ b/crates/postage-usage/tests/issuer.rs
@@ -119,7 +119,7 @@ fn shared_table_mutable_skips_reserved_across_wraps() {
             .collect();
         for salt in 0..200u8 {
             let addr = content_address(bucket, salt);
-            assert_eq!(calculate_bucket(&addr, bucket_depth()), bucket);
+            assert_eq!(calculate_bucket(&addr, bucket_depth()).value(), bucket);
             let index = snapshot.issuer(owner()).record_address(&addr).unwrap();
             assert!(
                 !reserved_here.contains(&index),

--- a/crates/postage-usage/tests/snapshot.rs
+++ b/crates/postage-usage/tests/snapshot.rs
@@ -226,7 +226,7 @@ fn snapshot_accounts_for_its_own_chunks() {
     let allocated = plan.chunks.len() as u64;
     assert_eq!(snapshot.table().total_issued(), issued_before + allocated);
     for chunk in &plan.chunks {
-        let bucket = calculate_bucket(&chunk.address, bucket_depth());
+        let bucket = calculate_bucket(&chunk.address, bucket_depth()).value();
         assert_eq!(chunk.stamp_index.bucket(), bucket);
         // The recorded counter covers the assigned slot.
         assert!(snapshot.table().count(bucket).unwrap() > chunk.stamp_index.index());
@@ -542,7 +542,7 @@ fn recovered_mutable_issues_reserved_aware_through_the_handle() {
     // Find a content address that maps to the root's reserved bucket.
     let bucket = root_index.bucket();
     let content = address_in_bucket(bucket);
-    assert_eq!(calculate_bucket(&content, bucket_depth()), bucket);
+    assert_eq!(calculate_bucket(&content, bucket_depth()).value(), bucket);
     for _ in 0..32 {
         let index = issuing.issuer(owner()).record_address(&content).unwrap();
         assert_ne!(
@@ -805,7 +805,7 @@ fn mutable_ring_wrap_is_signalled() {
 
     // Pick a content bucket clear of the snapshot's reserved slots.
     let content = address_in_bucket(0x1234);
-    let bucket = calculate_bucket(&content, bucket_depth());
+    let bucket = calculate_bucket(&content, bucket_depth()).value();
 
     let mut issuer = snapshot.issuer(owner());
 
@@ -847,7 +847,7 @@ fn immutable_never_wraps() {
     let table = UsageTable::new(batch_id(), 17, bucket_depth(), Mutability::Immutable).unwrap();
     let mut snapshot = Snapshot::new(table);
     let content = address_in_bucket(0x1234);
-    let bucket = calculate_bucket(&content, bucket_depth());
+    let bucket = calculate_bucket(&content, bucket_depth()).value();
 
     let mut issuer = snapshot.issuer(owner());
     assert!(!issuer.will_wrap(bucket).unwrap());

--- a/crates/postage-usage/tests/vector.rs
+++ b/crates/postage-usage/tests/vector.rs
@@ -56,7 +56,10 @@ fn readme_worked_example_vector() {
 
     // The root chunk's own stamp lands in bucket 41 at index 4, as
     // narrated in the README.
-    assert_eq!(calculate_bucket(&plan.chunks[0].address, low_floor(8)), 41);
+    assert_eq!(
+        calculate_bucket(&plan.chunks[0].address, low_floor(8)).value(),
+        41
+    );
     assert_eq!(snapshot.allocated_slots(), &[4]);
     assert_eq!(snapshot.table().total_issued(), 1166);
 
@@ -103,7 +106,7 @@ fn readme_large_batch_multi_leaf_vector() {
     // The root's own slot is the watermark of its bucket at allocation
     // time: bucket 0x296d held 100 + (0x296d mod 50) = 105 stamps.
     assert_eq!(
-        calculate_bucket(&plan.chunks[0].address, bucket_depth),
+        calculate_bucket(&plan.chunks[0].address, bucket_depth).value(),
         0x296d
     );
     assert_eq!(snapshot.allocated_slots()[0], 105);
@@ -154,7 +157,10 @@ fn mutable_vector_flags_byte_and_round_trip() {
         .unwrap();
 
     // Same self-allocation as the immutable vector: bucket 41, slot 4.
-    assert_eq!(calculate_bucket(&plan.chunks[0].address, low_floor(8)), 41);
+    assert_eq!(
+        calculate_bucket(&plan.chunks[0].address, low_floor(8)).value(),
+        41
+    );
     assert_eq!(snapshot.allocated_slots(), &[4]);
 
     // Exactly one byte differs from the immutable vector: the flags byte.

--- a/crates/postage/src/batch.rs
+++ b/crates/postage/src/batch.rs
@@ -370,13 +370,10 @@ impl<S: SwarmSpec> Batch<S> {
     // Validation methods
     // =========================================================================
 
-    /// Validates the depth decoded from chain against the bucket depth, and
-    /// yields the geometry every allocation path is cut against.
+    /// Validates the chain-decoded depth against the bucket depth.
     ///
-    /// Chain decode keeps [`depth`](Self::depth) a raw byte, so this is the one
-    /// place the validated geometry is born. [`set_depth`](Self::set_depth)
-    /// takes a bare depth for a dilution, so a diluted batch has to be asked
-    /// again.
+    /// [`set_depth`](Self::set_depth) takes a bare depth, so a diluted batch
+    /// has to be asked again.
     ///
     /// # Errors
     ///

--- a/crates/postage/src/batch.rs
+++ b/crates/postage/src/batch.rs
@@ -1,7 +1,5 @@
 //! Postage batch types.
 
-use core::{fmt, marker::PhantomData};
-
 use alloy_primitives::{Address, B256};
 use derive_more::{AsRef, Display, From, Into};
 use nectar_primitives::{
@@ -9,7 +7,7 @@ use nectar_primitives::{
     wire::{Cursor, FromCursor, ToWriter, Underrun, Writer},
 };
 
-use crate::{StampError, StampIndex, calculate_bucket};
+use crate::{BatchDepth, Bucket, BucketDepth, StampError, StampIndex, calculate_bucket};
 
 /// A 32-byte batch identifier.
 ///
@@ -89,191 +87,6 @@ impl<'a> arbitrary::Arbitrary<'a> for BatchId {
     }
 }
 
-/// The number of leading chunk-address bits that select a collision bucket, as
-/// the network `S` accepts it.
-///
-/// Two bounds hold at construction: [`SwarmSpec::MIN_BUCKET_DEPTH`], the floor
-/// the PostageStamp contract publishes as `minimumBucketDepth()`, and
-/// [`MAX`](Self::MAX), the width of the bucket key. Bucket selection shifts a
-/// `u32` right by `32 - depth`; holding both bounds in the type keeps that
-/// shift total wherever a depth reaches it.
-///
-/// The floor is a compile-time property: a `BucketDepth<Mainnet>` below 16 does
-/// not exist, and one network's depth does not type-check where another's is
-/// wanted. Every constructor funnels through [`new`](Self::new), including the
-/// serde and `Arbitrary` paths.
-///
-/// A depth carries its network, so this does not compile:
-///
-/// ```compile_fail
-/// use nectar_postage::{Batch, BatchId, BucketDepth};
-/// use nectar_primitives::Testnet;
-///
-/// let bucket_depth = BucketDepth::<Testnet>::new(16).unwrap();
-/// // `Batch` without a spec argument is a mainnet batch.
-/// let batch: Batch = Batch::new(
-///     BatchId::ZERO, 0, 0, Default::default(), 20, bucket_depth, false,
-/// );
-/// ```
-#[repr(transparent)]
-pub struct BucketDepth<S: SwarmSpec = Mainnet> {
-    depth: u8,
-    // `fn() -> S` rather than `S`: the tag carries no data, so the depth (and
-    // everything holding one) is `Send`/`Sync` whatever the spec marker is.
-    spec: PhantomData<fn() -> S>,
-}
-
-impl<S: SwarmSpec> BucketDepth<S> {
-    /// Largest representable depth, the bit width of the bucket key.
-    pub const MAX: u8 = 32;
-
-    /// Validates a raw depth against the spec floor and [`MAX`](Self::MAX).
-    ///
-    /// # Errors
-    ///
-    /// [`StampError::BucketDepthBelowMinimum`] when `depth` is under
-    /// [`SwarmSpec::MIN_BUCKET_DEPTH`], [`StampError::InvalidBucketDepth`] when
-    /// it is above [`MAX`](Self::MAX).
-    #[inline]
-    pub const fn new(depth: u8) -> Result<Self, StampError> {
-        if depth < S::MIN_BUCKET_DEPTH.get() {
-            return Err(StampError::BucketDepthBelowMinimum {
-                bucket_depth: depth,
-                minimum: S::MIN_BUCKET_DEPTH.get(),
-            });
-        }
-        if depth > Self::MAX {
-            return Err(StampError::InvalidBucketDepth {
-                bucket_depth: depth,
-            });
-        }
-        Ok(Self {
-            depth,
-            spec: PhantomData,
-        })
-    }
-
-    /// Returns the depth as a bit count.
-    #[inline]
-    pub const fn get(self) -> u8 {
-        self.depth
-    }
-
-    /// Returns the number of collision buckets, `2^depth`.
-    ///
-    /// Widened to `u64` because depth 32 overflows a `u32` count by one.
-    #[inline]
-    pub const fn bucket_count(self) -> u64 {
-        1u64 << self.depth
-    }
-
-    /// Returns whether a bucket index is one this depth addresses.
-    #[inline]
-    pub const fn contains_bucket(self, bucket: u32) -> bool {
-        // At the maximum depth every `u32` is a bucket, and the count no longer
-        // fits the `u32` shift used below.
-        self.depth == Self::MAX || bucket < (1u32 << self.depth)
-    }
-}
-
-// The spec is a type-level tag, so the manual impls below carry no bound on
-// `S` beyond `SwarmSpec`; deriving would demand `S: Clone`, `S: Eq` and the
-// rest of a marker type that holds no data.
-
-impl<S: SwarmSpec> Clone for BucketDepth<S> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<S: SwarmSpec> Copy for BucketDepth<S> {}
-
-impl<S: SwarmSpec> fmt::Debug for BucketDepth<S> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("BucketDepth").field(&self.depth).finish()
-    }
-}
-
-impl<S: SwarmSpec> fmt::Display for BucketDepth<S> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.depth, f)
-    }
-}
-
-impl<S: SwarmSpec> PartialEq for BucketDepth<S> {
-    fn eq(&self, other: &Self) -> bool {
-        self.depth == other.depth
-    }
-}
-
-impl<S: SwarmSpec> Eq for BucketDepth<S> {}
-
-impl<S: SwarmSpec> PartialOrd for BucketDepth<S> {
-    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<S: SwarmSpec> Ord for BucketDepth<S> {
-    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        self.depth.cmp(&other.depth)
-    }
-}
-
-impl<S: SwarmSpec> core::hash::Hash for BucketDepth<S> {
-    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
-        self.depth.hash(state);
-    }
-}
-
-impl<S: SwarmSpec> From<BucketDepth<S>> for u8 {
-    #[inline]
-    fn from(depth: BucketDepth<S>) -> Self {
-        depth.depth
-    }
-}
-
-impl<S: SwarmSpec> TryFrom<u8> for BucketDepth<S> {
-    type Error = StampError;
-
-    #[inline]
-    fn try_from(depth: u8) -> Result<Self, StampError> {
-        Self::new(depth)
-    }
-}
-
-/// Serializes as the bare depth byte.
-#[cfg(feature = "serde")]
-impl<S: SwarmSpec> serde::Serialize for BucketDepth<S> {
-    fn serialize<Z: serde::Serializer>(&self, serializer: Z) -> Result<Z::Ok, Z::Error> {
-        serializer.serialize_u8(self.depth)
-    }
-}
-
-/// Deserializes through [`BucketDepth::new`], so a stored depth below the spec
-/// floor is refused rather than reconstructed.
-#[cfg(feature = "serde")]
-impl<'de, S: SwarmSpec> serde::Deserialize<'de> for BucketDepth<S> {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let depth = u8::deserialize(deserializer)?;
-        Self::new(depth).map_err(serde::de::Error::custom)
-    }
-}
-
-/// Draws from the spec's accepted window, so every generated depth is one the
-/// network accepts.
-#[cfg(any(test, feature = "arbitrary"))]
-impl<'a, S: SwarmSpec> arbitrary::Arbitrary<'a> for BucketDepth<S> {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let low = S::MIN_BUCKET_DEPTH.get();
-        if low > Self::MAX {
-            // A spec whose floor is past the bucket-key width admits no depth.
-            return Err(arbitrary::Error::IncorrectFormat);
-        }
-        Self::new(u.int_in_range(low..=Self::MAX)?).map_err(|_| arbitrary::Error::IncorrectFormat)
-    }
-}
-
 /// Parameters for creating a new batch on the network `S`.
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -287,7 +100,7 @@ pub struct BatchParams<S: SwarmSpec = Mainnet> {
     amount: u128,
 }
 
-// As for [`BucketDepth`] above: the spec is a type-level tag, so `Clone` and
+// As for [`BucketDepth`]: the spec is a type-level tag, so `Clone` and
 // equality carry no bound on `S` beyond `SwarmSpec`. Only `Debug` is derived,
 // following the marker's own.
 
@@ -370,34 +183,15 @@ impl<S: SwarmSpec> BatchParams<S> {
         self.amount
     }
 
-    /// Validates that the batch depth leaves room above the bucket depth.
-    ///
-    /// The bucket depth clears the network floor by construction; this is the
-    /// one geometry bound left to check, because `depth` is a plain `u8` the
-    /// type system cannot relate to it.
+    /// Validates the raw depth against the bucket depth.
     ///
     /// # Errors
     ///
-    /// [`StampError::DepthBelowBucketDepth`] when `depth` is under the bucket
-    /// depth.
+    /// See [`BatchDepth::new`].
     #[inline]
-    pub const fn validate_depth(&self) -> Result<(), StampError> {
-        validate_depth(self.depth, self.bucket_depth)
+    pub const fn geometry(&self) -> Result<BatchDepth<S>, StampError> {
+        BatchDepth::new(self.depth, self.bucket_depth)
     }
-}
-
-/// Validates that a batch depth leaves room above its bucket depth.
-const fn validate_depth<S: SwarmSpec>(
-    depth: u8,
-    bucket_depth: BucketDepth<S>,
-) -> Result<(), StampError> {
-    if depth < bucket_depth.get() {
-        return Err(StampError::DepthBelowBucketDepth {
-            depth,
-            bucket_depth: bucket_depth.get(),
-        });
-    }
-    Ok(())
 }
 
 /// A postage batch represents a prepaid storage allocation in the Swarm network.
@@ -576,21 +370,20 @@ impl<S: SwarmSpec> Batch<S> {
     // Validation methods
     // =========================================================================
 
-    /// Validates that the batch depth leaves room above the bucket depth.
+    /// Validates the depth decoded from chain against the bucket depth, and
+    /// yields the geometry every allocation path is cut against.
     ///
-    /// The bucket depth clears the network floor by construction; this is the
-    /// one geometry bound left to check, because `depth` is a plain `u8` the
-    /// type system cannot relate to it. [`set_depth`](Self::set_depth) takes a
-    /// bare depth for a dilution, so a batch stays well-formed across one only
-    /// while the new depth clears the bucket depth.
+    /// Chain decode keeps [`depth`](Self::depth) a raw byte, so this is the one
+    /// place the validated geometry is born. [`set_depth`](Self::set_depth)
+    /// takes a bare depth for a dilution, so a diluted batch has to be asked
+    /// again.
     ///
     /// # Errors
     ///
-    /// [`StampError::DepthBelowBucketDepth`] when `depth` is under the bucket
-    /// depth.
+    /// See [`BatchDepth::new`].
     #[inline]
-    pub const fn validate_depth(&self) -> Result<(), StampError> {
-        validate_depth(self.depth, self.bucket_depth)
+    pub const fn geometry(&self) -> Result<BatchDepth<S>, StampError> {
+        BatchDepth::new(self.depth, self.bucket_depth)
     }
 
     /// Validates that an index is within the valid range for this batch.
@@ -616,12 +409,10 @@ impl<S: SwarmSpec> Batch<S> {
         Ok(())
     }
 
-    /// Calculates which bucket a chunk address belongs to.
-    ///
-    /// The bucket is determined by taking the first `bucket_depth` bits of the
-    /// chunk address, interpreted as a big-endian unsigned integer.
+    /// Cuts the collision bucket of a chunk address at this batch's bucket
+    /// depth.
     #[inline]
-    pub fn bucket_for_address(&self, address: &ChunkAddress) -> u32 {
+    pub fn bucket_for_address(&self, address: &ChunkAddress) -> Bucket<S> {
         calculate_bucket(address, self.bucket_depth)
     }
 
@@ -635,8 +426,7 @@ impl<S: SwarmSpec> Batch<S> {
         index: &StampIndex,
         address: &ChunkAddress,
     ) -> Result<(), StampError> {
-        let expected_bucket = self.bucket_for_address(address);
-        if index.bucket() != expected_bucket {
+        if index.bucket() != self.bucket_for_address(address).value() {
             return Err(StampError::BucketMismatch);
         }
         Ok(())
@@ -688,8 +478,6 @@ impl<'a, S: SwarmSpec> arbitrary::Arbitrary<'a> for Batch<S> {
 
 #[cfg(test)]
 mod tests {
-    use nectar_testing::{HighFloor, LowFloor};
-
     use super::*;
 
     #[test]
@@ -703,88 +491,29 @@ mod tests {
     }
 
     #[test]
-    fn bucket_depth_takes_its_floor_from_the_spec() {
-        // Below the mainnet floor, at it, and deeper than it.
-        assert!(matches!(
-            BucketDepth::<Mainnet>::new(15),
-            Err(StampError::BucketDepthBelowMinimum {
-                bucket_depth: 15,
-                minimum: 16
-            })
-        ));
-        assert_eq!(BucketDepth::<Mainnet>::new(16).unwrap().get(), 16);
-        assert_eq!(BucketDepth::<Mainnet>::new(20).unwrap().get(), 20);
-        assert_eq!(
-            BucketDepth::<Mainnet>::new(BucketDepth::<Mainnet>::MAX)
-                .unwrap()
-                .get(),
-            32
-        );
-    }
-
-    #[test]
-    fn bucket_depth_rejects_an_unrepresentable_depth() {
-        assert!(matches!(
-            BucketDepth::<Mainnet>::new(33),
-            Err(StampError::InvalidBucketDepth { bucket_depth: 33 })
-        ));
-        assert!(matches!(
-            BucketDepth::<Mainnet>::try_from(u8::MAX),
-            Err(StampError::InvalidBucketDepth {
-                bucket_depth: u8::MAX
-            })
-        ));
-    }
-
-    #[test]
-    fn the_lowest_floor_admits_a_one_bit_bucket() {
-        assert_eq!(BucketDepth::<LowFloor>::new(1).unwrap().get(), 1);
-        assert!(matches!(
-            BucketDepth::<LowFloor>::new(0),
-            Err(StampError::BucketDepthBelowMinimum {
-                bucket_depth: 0,
-                minimum: 1
-            })
-        ));
-    }
-
-    #[test]
-    fn a_raised_floor_refuses_a_depth_mainnet_accepts() {
-        assert!(BucketDepth::<Mainnet>::new(16).is_ok());
-        assert!(matches!(
-            BucketDepth::<HighFloor>::new(16),
-            Err(StampError::BucketDepthBelowMinimum {
-                bucket_depth: 16,
-                minimum: 20
-            })
-        ));
-        assert!(BucketDepth::<HighFloor>::new(20).is_ok());
-    }
-
-    #[test]
     fn depth_below_bucket_depth_is_rejected_through_batch_and_params() {
         let bucket_depth = BucketDepth::<Mainnet>::new(16).unwrap();
 
         let params = BatchParams::new(Address::ZERO, 20, bucket_depth, 1000);
-        assert!(params.validate_depth().is_ok());
+        assert_eq!(params.geometry().unwrap().slots_per_bucket(), 16);
 
         let batch = Batch::new(BatchId::ZERO, 0, 0, Address::ZERO, 20, bucket_depth, false);
-        assert!(batch.validate_depth().is_ok());
+        assert_eq!(batch.geometry().unwrap().get(), 20);
 
         // A batch exactly as deep as its buckets holds one slot each.
         let flat = Batch::new(BatchId::ZERO, 0, 0, Address::ZERO, 16, bucket_depth, false);
-        assert!(flat.validate_depth().is_ok());
+        assert_eq!(flat.geometry().unwrap().slots_per_bucket(), 1);
 
         let shallow = Batch::new(BatchId::ZERO, 0, 0, Address::ZERO, 8, bucket_depth, false);
         assert!(matches!(
-            shallow.validate_depth(),
+            shallow.geometry(),
             Err(StampError::DepthBelowBucketDepth {
                 depth: 8,
                 bucket_depth: 16
             })
         ));
         assert!(matches!(
-            BatchParams::new(Address::ZERO, 8, bucket_depth, 1000).validate_depth(),
+            BatchParams::new(Address::ZERO, 8, bucket_depth, 1000).geometry(),
             Err(StampError::DepthBelowBucketDepth {
                 depth: 8,
                 bucket_depth: 16
@@ -794,7 +523,32 @@ mod tests {
         // Dilution moves the depth, so the check survives a `set_depth`.
         let mut diluted = batch;
         diluted.set_depth(15);
-        assert!(diluted.validate_depth().is_err());
+        assert!(diluted.geometry().is_err());
+    }
+
+    #[test]
+    fn chain_decode_stays_total_where_the_geometry_is_unrepresentable() {
+        // A depth this far above the bucket depth has no `u32` slot count, yet
+        // decoding it must not fail: only `geometry` refuses it.
+        let batch: Batch = Batch::new(
+            BatchId::ZERO,
+            0,
+            0,
+            Address::ZERO,
+            u8::MAX,
+            BucketDepth::new(16).unwrap(),
+            false,
+        );
+        assert_eq!(batch.depth(), u8::MAX);
+        assert!(batch.validate_index(&StampIndex::new(0, 0)).is_ok());
+        assert!(matches!(
+            batch.geometry(),
+            Err(StampError::SlotsTooWide {
+                depth: 255,
+                bucket_depth: 16,
+                max: 31
+            })
+        ));
     }
 
     #[test]
@@ -810,7 +564,8 @@ mod tests {
         );
         assert_eq!(min.bucket_count(), 65536);
         assert_eq!(
-            min.bucket_for_address(&ChunkAddress::new([0xFF; 32])),
+            min.bucket_for_address(&ChunkAddress::new([0xFF; 32]))
+                .value(),
             65535
         );
 
@@ -825,7 +580,8 @@ mod tests {
         );
         assert_eq!(max.bucket_count(), 1 << 32);
         assert_eq!(
-            max.bucket_for_address(&ChunkAddress::new([0xFF; 32])),
+            max.bucket_for_address(&ChunkAddress::new([0xFF; 32]))
+                .value(),
             u32::MAX
         );
         // Every `u32` is a bucket at the maximum depth, and the per-bucket slot
@@ -846,29 +602,6 @@ mod tests {
             false,
         );
         assert_eq!(batch.bucket_upper_bound(), 1);
-    }
-
-    #[cfg(feature = "serde")]
-    #[test]
-    fn serde_decodes_a_depth_and_enforces_the_floor() {
-        use serde::{Deserialize, de::IntoDeserializer, de::value::Error};
-
-        fn decode<S: SwarmSpec>(raw: u8) -> Result<BucketDepth<S>, Error> {
-            BucketDepth::deserialize(IntoDeserializer::<Error>::into_deserializer(raw))
-        }
-
-        assert_eq!(
-            decode::<Mainnet>(16).unwrap(),
-            BucketDepth::<Mainnet>::new(16).unwrap()
-        );
-
-        // The floor and the representable bound both survive the wire.
-        assert!(decode::<Mainnet>(15).is_err());
-        assert!(decode::<Mainnet>(33).is_err());
-        // And the floor is the spec's, not a constant: 16 decodes on mainnet
-        // and is refused on a deployment that asks for 20.
-        assert!(decode::<HighFloor>(16).is_err());
-        assert!(decode::<HighFloor>(20).is_ok());
     }
 
     #[test]

--- a/crates/postage/src/error.rs
+++ b/crates/postage/src/error.rs
@@ -51,6 +51,18 @@ pub enum StampError {
         bucket_depth: u8,
     },
 
+    /// The batch depth exceeds the bucket depth by more bits than a `u32` slot
+    /// count holds.
+    #[error("batch depth {depth} exceeds bucket depth {bucket_depth} by more than {max} bits")]
+    SlotsTooWide {
+        /// The rejected batch depth.
+        depth: u8,
+        /// The bucket depth beneath it.
+        bucket_depth: u8,
+        /// The widest difference a slot count holds.
+        max: u8,
+    },
+
     /// The batch was not found.
     #[error("batch not found: {0}")]
     BatchNotFound(BatchId),

--- a/crates/postage/src/generators.rs
+++ b/crates/postage/src/generators.rs
@@ -53,7 +53,7 @@ pub fn signed_stamp(
 ) -> arbitrary::Result<Stamp> {
     let bucket = batch.bucket_for_address(address);
     let position = u.int_in_range(0..=batch.bucket_upper_bound().saturating_sub(1))?;
-    let index = StampIndex::new(bucket, position);
+    let index = StampIndex::new(bucket.value(), position);
     let timestamp = u.arbitrary()?;
 
     let digest = StampDigest::new(*address, batch.id(), index, timestamp);

--- a/crates/postage/src/geometry.rs
+++ b/crates/postage/src/geometry.rs
@@ -1,0 +1,682 @@
+//! Batch geometry: the bucket depth, a bucket derived at one, and the batch
+//! depth above one.
+
+use core::{fmt, marker::PhantomData};
+
+use nectar_primitives::{ChunkAddress, Mainnet, SwarmSpec};
+
+use crate::{StampError, StampIndex};
+
+/// The number of leading chunk-address bits that select a collision bucket, as
+/// the network `S` accepts it.
+///
+/// Two bounds hold at construction: [`SwarmSpec::MIN_BUCKET_DEPTH`], the floor
+/// the PostageStamp contract publishes as `minimumBucketDepth()`, and
+/// [`MAX`](Self::MAX), the width of the bucket key. Bucket selection shifts a
+/// `u32` right by `32 - depth`; holding both bounds in the type keeps that
+/// shift total wherever a depth reaches it.
+///
+/// The floor is a compile-time property: a `BucketDepth<Mainnet>` below 16 does
+/// not exist, and one network's depth does not type-check where another's is
+/// wanted. Every constructor funnels through [`new`](Self::new), including the
+/// serde and `Arbitrary` paths.
+///
+/// A depth carries its network, so this does not compile:
+///
+/// ```compile_fail
+/// use nectar_postage::{Batch, BatchId, BucketDepth};
+/// use nectar_primitives::Testnet;
+///
+/// let bucket_depth = BucketDepth::<Testnet>::new(16).unwrap();
+/// // `Batch` without a spec argument is a mainnet batch.
+/// let batch: Batch = Batch::new(
+///     BatchId::ZERO, 0, 0, Default::default(), 20, bucket_depth, false,
+/// );
+/// ```
+#[repr(transparent)]
+pub struct BucketDepth<S: SwarmSpec = Mainnet> {
+    depth: u8,
+    // `fn() -> S` rather than `S`: the tag carries no data, so the depth (and
+    // everything holding one) is `Send`/`Sync` whatever the spec marker is.
+    spec: PhantomData<fn() -> S>,
+}
+
+impl<S: SwarmSpec> BucketDepth<S> {
+    /// Largest representable depth, the bit width of the bucket key.
+    pub const MAX: u8 = 32;
+
+    /// Validates a raw depth against the spec floor and [`MAX`](Self::MAX).
+    ///
+    /// # Errors
+    ///
+    /// [`StampError::BucketDepthBelowMinimum`] when `depth` is under
+    /// [`SwarmSpec::MIN_BUCKET_DEPTH`], [`StampError::InvalidBucketDepth`] when
+    /// it is above [`MAX`](Self::MAX).
+    #[inline]
+    pub const fn new(depth: u8) -> Result<Self, StampError> {
+        if depth < S::MIN_BUCKET_DEPTH.get() {
+            return Err(StampError::BucketDepthBelowMinimum {
+                bucket_depth: depth,
+                minimum: S::MIN_BUCKET_DEPTH.get(),
+            });
+        }
+        if depth > Self::MAX {
+            return Err(StampError::InvalidBucketDepth {
+                bucket_depth: depth,
+            });
+        }
+        Ok(Self {
+            depth,
+            spec: PhantomData,
+        })
+    }
+
+    /// Returns the depth as a bit count.
+    #[inline]
+    pub const fn get(self) -> u8 {
+        self.depth
+    }
+
+    /// Returns the number of collision buckets, `2^depth`.
+    ///
+    /// Widened to `u64` because depth 32 overflows a `u32` count by one.
+    #[inline]
+    pub const fn bucket_count(self) -> u64 {
+        1u64 << self.depth
+    }
+
+    /// Returns whether a bucket index is one this depth addresses.
+    #[inline]
+    pub const fn contains_bucket(self, bucket: u32) -> bool {
+        // At the maximum depth every `u32` is a bucket, and the count no longer
+        // fits the `u32` shift used below.
+        self.depth == Self::MAX || bucket < (1u32 << self.depth)
+    }
+}
+
+// The spec is a type-level tag, so the manual impls below carry no bound on
+// `S` beyond `SwarmSpec`; deriving would demand `S: Clone`, `S: Eq` and the
+// rest of a marker type that holds no data.
+
+impl<S: SwarmSpec> Clone for BucketDepth<S> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<S: SwarmSpec> Copy for BucketDepth<S> {}
+
+impl<S: SwarmSpec> fmt::Debug for BucketDepth<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("BucketDepth").field(&self.depth).finish()
+    }
+}
+
+impl<S: SwarmSpec> fmt::Display for BucketDepth<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.depth, f)
+    }
+}
+
+impl<S: SwarmSpec> PartialEq for BucketDepth<S> {
+    fn eq(&self, other: &Self) -> bool {
+        self.depth == other.depth
+    }
+}
+
+impl<S: SwarmSpec> Eq for BucketDepth<S> {}
+
+impl<S: SwarmSpec> PartialOrd for BucketDepth<S> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<S: SwarmSpec> Ord for BucketDepth<S> {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.depth.cmp(&other.depth)
+    }
+}
+
+impl<S: SwarmSpec> core::hash::Hash for BucketDepth<S> {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.depth.hash(state);
+    }
+}
+
+impl<S: SwarmSpec> From<BucketDepth<S>> for u8 {
+    #[inline]
+    fn from(depth: BucketDepth<S>) -> Self {
+        depth.depth
+    }
+}
+
+impl<S: SwarmSpec> TryFrom<u8> for BucketDepth<S> {
+    type Error = StampError;
+
+    #[inline]
+    fn try_from(depth: u8) -> Result<Self, StampError> {
+        Self::new(depth)
+    }
+}
+
+/// Serializes as the bare depth byte.
+#[cfg(feature = "serde")]
+impl<S: SwarmSpec> serde::Serialize for BucketDepth<S> {
+    fn serialize<Z: serde::Serializer>(&self, serializer: Z) -> Result<Z::Ok, Z::Error> {
+        serializer.serialize_u8(self.depth)
+    }
+}
+
+/// Deserializes through [`BucketDepth::new`], so a stored depth below the spec
+/// floor is refused rather than reconstructed.
+#[cfg(feature = "serde")]
+impl<'de, S: SwarmSpec> serde::Deserialize<'de> for BucketDepth<S> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let depth = u8::deserialize(deserializer)?;
+        Self::new(depth).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Draws from the spec's accepted window, so every generated depth is one the
+/// network accepts.
+#[cfg(any(test, feature = "arbitrary"))]
+impl<'a, S: SwarmSpec> arbitrary::Arbitrary<'a> for BucketDepth<S> {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let low = S::MIN_BUCKET_DEPTH.get();
+        if low > Self::MAX {
+            // A spec whose floor is past the bucket-key width admits no depth.
+            return Err(arbitrary::Error::IncorrectFormat);
+        }
+        Self::new(u.int_in_range(low..=Self::MAX)?).map_err(|_| arbitrary::Error::IncorrectFormat)
+    }
+}
+
+/// A collision bucket together with the [`BucketDepth`] that derived it.
+///
+/// The depth travels with the value because a bucket is only meaningful under
+/// the depth it was cut at: a bucket cut at depth 16 is inside the bucket range
+/// of a depth-20 table, so a bare `u32` lands in the wrong bucket undetected.
+pub struct Bucket<S: SwarmSpec = Mainnet> {
+    value: u32,
+    depth: BucketDepth<S>,
+}
+
+impl<S: SwarmSpec> Bucket<S> {
+    /// Cuts the bucket of `address`: its leading `depth` bits, read big-endian.
+    ///
+    /// Infallible: the depth is the input, so the result is in range by
+    /// construction.
+    #[inline]
+    pub fn of(address: &ChunkAddress, depth: BucketDepth<S>) -> Self {
+        let &[a, b, c, d, ..] = address.as_array();
+        // Depth is 1..=32, so the shift is 0..=31 and never wraps.
+        let value = u32::from_be_bytes([a, b, c, d])
+            .wrapping_shr(u32::from(BucketDepth::<S>::MAX.saturating_sub(depth.get())));
+        Self { value, depth }
+    }
+
+    /// Rejoins a bucket read from a stamp or a snapshot with the depth it must
+    /// belong to.
+    ///
+    /// # Errors
+    ///
+    /// [`StampError::InvalidIndex`] when `value` is outside the range `depth`
+    /// addresses.
+    #[inline]
+    pub const fn checked(value: u32, depth: BucketDepth<S>) -> Result<Self, StampError> {
+        if !depth.contains_bucket(value) {
+            return Err(StampError::InvalidIndex);
+        }
+        Ok(Self { value, depth })
+    }
+
+    /// Returns the bucket index.
+    #[inline]
+    pub const fn value(self) -> u32 {
+        self.value
+    }
+
+    /// Returns the depth the bucket was cut at.
+    #[inline]
+    pub const fn depth(self) -> BucketDepth<S> {
+        self.depth
+    }
+}
+
+impl<S: SwarmSpec> Clone for Bucket<S> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<S: SwarmSpec> Copy for Bucket<S> {}
+
+impl<S: SwarmSpec> fmt::Debug for Bucket<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Bucket")
+            .field("value", &self.value)
+            .field("depth", &self.depth.get())
+            .finish()
+    }
+}
+
+impl<S: SwarmSpec> fmt::Display for Bucket<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.value, f)
+    }
+}
+
+impl<S: SwarmSpec> PartialEq for Bucket<S> {
+    fn eq(&self, other: &Self) -> bool {
+        self.value == other.value && self.depth == other.depth
+    }
+}
+
+impl<S: SwarmSpec> Eq for Bucket<S> {}
+
+impl<S: SwarmSpec> core::hash::Hash for Bucket<S> {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.value.hash(state);
+        self.depth.hash(state);
+    }
+}
+
+impl<S: SwarmSpec> From<Bucket<S>> for u32 {
+    #[inline]
+    fn from(bucket: Bucket<S>) -> Self {
+        bucket.value
+    }
+}
+
+/// A validated batch depth together with the [`BucketDepth`] beneath it.
+///
+/// Construction settles both geometry bounds, so `depth - bucket_depth` is a
+/// subtraction that cannot underflow and `2^(depth - bucket_depth)` is a slot
+/// count that fits a `u32`.
+pub struct BatchDepth<S: SwarmSpec = Mainnet> {
+    depth: u8,
+    bucket_depth: BucketDepth<S>,
+}
+
+impl<S: SwarmSpec> BatchDepth<S> {
+    /// Widest `depth - bucket_depth` whose slot count fits a `u32`.
+    pub const MAX_SLOT_BITS: u8 = 31;
+
+    /// Validates a raw batch depth against `bucket_depth`.
+    ///
+    /// # Errors
+    ///
+    /// [`StampError::DepthBelowBucketDepth`] when `depth` is under the bucket
+    /// depth, [`StampError::SlotsTooWide`] when it exceeds the bucket depth by
+    /// more than [`MAX_SLOT_BITS`](Self::MAX_SLOT_BITS) bits.
+    #[inline]
+    pub const fn new(depth: u8, bucket_depth: BucketDepth<S>) -> Result<Self, StampError> {
+        if depth < bucket_depth.get() {
+            return Err(StampError::DepthBelowBucketDepth {
+                depth,
+                bucket_depth: bucket_depth.get(),
+            });
+        }
+        // Guarded by the disjunct above.
+        #[allow(clippy::arithmetic_side_effects)]
+        let slot_bits = depth - bucket_depth.get();
+        if slot_bits > Self::MAX_SLOT_BITS {
+            return Err(StampError::SlotsTooWide {
+                depth,
+                bucket_depth: bucket_depth.get(),
+                max: Self::MAX_SLOT_BITS,
+            });
+        }
+        Ok(Self {
+            depth,
+            bucket_depth,
+        })
+    }
+
+    /// Returns the batch depth as a bit count.
+    #[inline]
+    pub const fn get(self) -> u8 {
+        self.depth
+    }
+
+    /// Returns the bucket depth beneath it.
+    #[inline]
+    pub const fn bucket_depth(self) -> BucketDepth<S> {
+        self.bucket_depth
+    }
+
+    /// Returns `depth - bucket_depth`, the bit width of a slot position.
+    #[inline]
+    // Settled by `new`.
+    #[allow(clippy::arithmetic_side_effects)]
+    pub const fn slot_bits(self) -> u8 {
+        self.depth - self.bucket_depth.get()
+    }
+
+    /// Returns the number of slots in each bucket, `2^(depth - bucket_depth)`.
+    #[inline]
+    pub const fn slots_per_bucket(self) -> u32 {
+        1u32 << self.slot_bits()
+    }
+
+    /// Returns the number of collision buckets, `2^bucket_depth`.
+    #[inline]
+    pub const fn bucket_count(self) -> u64 {
+        self.bucket_depth.bucket_count()
+    }
+
+    /// Returns the total number of slots, `2^depth`.
+    #[inline]
+    pub const fn total_slots(self) -> u64 {
+        1u64 << self.depth
+    }
+
+    /// Returns whether both coordinates of `index` are inside this geometry.
+    #[inline]
+    pub const fn contains(self, index: &StampIndex) -> bool {
+        self.bucket_depth.contains_bucket(index.bucket()) && index.index() < self.slots_per_bucket()
+    }
+
+    /// Adopts an on-chain dilution.
+    ///
+    /// A depth at or below the current one yields the geometry unchanged, so a
+    /// redelivered or reordered dilution event is a no-op rather than a shrink.
+    ///
+    /// # Errors
+    ///
+    /// [`StampError::SlotsTooWide`] when the new depth leaves more slots per
+    /// bucket than a `u32` count holds.
+    #[inline]
+    pub const fn diluted(self, new_depth: u8) -> Result<Self, StampError> {
+        if new_depth <= self.depth {
+            return Ok(self);
+        }
+        Self::new(new_depth, self.bucket_depth)
+    }
+}
+
+impl<S: SwarmSpec> Clone for BatchDepth<S> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<S: SwarmSpec> Copy for BatchDepth<S> {}
+
+impl<S: SwarmSpec> fmt::Debug for BatchDepth<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BatchDepth")
+            .field("depth", &self.depth)
+            .field("bucket_depth", &self.bucket_depth.get())
+            .finish()
+    }
+}
+
+impl<S: SwarmSpec> fmt::Display for BatchDepth<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.depth, f)
+    }
+}
+
+impl<S: SwarmSpec> PartialEq for BatchDepth<S> {
+    fn eq(&self, other: &Self) -> bool {
+        self.depth == other.depth && self.bucket_depth == other.bucket_depth
+    }
+}
+
+impl<S: SwarmSpec> Eq for BatchDepth<S> {}
+
+impl<S: SwarmSpec> core::hash::Hash for BatchDepth<S> {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.depth.hash(state);
+        self.bucket_depth.hash(state);
+    }
+}
+
+/// Returns the collision bucket of `address` at `bucket_depth`.
+///
+/// # Example
+///
+/// ```
+/// use nectar_postage::{BucketDepth, calculate_bucket};
+/// use nectar_primitives::{ChunkAddress, Mainnet};
+///
+/// let address = ChunkAddress::new([0xCB, 0xE5, 0x00, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+/// let bucket_depth = BucketDepth::<Mainnet>::new(16).unwrap();
+/// assert_eq!(calculate_bucket(&address, bucket_depth).value(), 0xCBE5);
+/// ```
+#[inline]
+pub fn calculate_bucket<S: SwarmSpec>(
+    address: &ChunkAddress,
+    bucket_depth: BucketDepth<S>,
+) -> Bucket<S> {
+    Bucket::of(address, bucket_depth)
+}
+
+#[cfg(test)]
+mod tests {
+    use nectar_primitives::Mainnet;
+    use nectar_testing::{HighFloor, LowFloor};
+
+    use super::*;
+
+    // `nectar_testing::low_floor` returns the `BucketDepth` of the
+    // `nectar-postage` instance it links, which is not this one.
+    fn low_floor(depth: u8) -> BucketDepth<LowFloor> {
+        BucketDepth::new(depth).unwrap()
+    }
+
+    fn address_cbe5() -> ChunkAddress {
+        ChunkAddress::new([
+            0xCB, 0xE5, 0x00, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0,
+        ])
+    }
+
+    #[test]
+    fn bucket_depth_takes_its_floor_from_the_spec() {
+        // Below the mainnet floor, at it, and deeper than it.
+        assert!(matches!(
+            BucketDepth::<Mainnet>::new(15),
+            Err(StampError::BucketDepthBelowMinimum {
+                bucket_depth: 15,
+                minimum: 16
+            })
+        ));
+        assert_eq!(BucketDepth::<Mainnet>::new(16).unwrap().get(), 16);
+        assert_eq!(BucketDepth::<Mainnet>::new(20).unwrap().get(), 20);
+        assert_eq!(
+            BucketDepth::<Mainnet>::new(BucketDepth::<Mainnet>::MAX)
+                .unwrap()
+                .get(),
+            32
+        );
+    }
+
+    #[test]
+    fn bucket_depth_rejects_an_unrepresentable_depth() {
+        assert!(matches!(
+            BucketDepth::<Mainnet>::new(33),
+            Err(StampError::InvalidBucketDepth { bucket_depth: 33 })
+        ));
+        assert!(matches!(
+            BucketDepth::<Mainnet>::try_from(u8::MAX),
+            Err(StampError::InvalidBucketDepth {
+                bucket_depth: u8::MAX
+            })
+        ));
+    }
+
+    #[test]
+    fn the_lowest_floor_admits_a_one_bit_bucket() {
+        assert_eq!(BucketDepth::<LowFloor>::new(1).unwrap().get(), 1);
+        assert!(matches!(
+            BucketDepth::<LowFloor>::new(0),
+            Err(StampError::BucketDepthBelowMinimum {
+                bucket_depth: 0,
+                minimum: 1
+            })
+        ));
+    }
+
+    #[test]
+    fn a_raised_floor_refuses_a_depth_mainnet_accepts() {
+        assert!(BucketDepth::<Mainnet>::new(16).is_ok());
+        assert!(matches!(
+            BucketDepth::<HighFloor>::new(16),
+            Err(StampError::BucketDepthBelowMinimum {
+                bucket_depth: 16,
+                minimum: 20
+            })
+        ));
+        assert!(BucketDepth::<HighFloor>::new(20).is_ok());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_decodes_a_depth_and_enforces_the_floor() {
+        use serde::{Deserialize, de::IntoDeserializer, de::value::Error};
+
+        fn decode<S: SwarmSpec>(raw: u8) -> Result<BucketDepth<S>, Error> {
+            BucketDepth::deserialize(IntoDeserializer::<Error>::into_deserializer(raw))
+        }
+
+        assert_eq!(
+            decode::<Mainnet>(16).unwrap(),
+            BucketDepth::<Mainnet>::new(16).unwrap()
+        );
+
+        // The floor and the representable bound both survive the wire.
+        assert!(decode::<Mainnet>(15).is_err());
+        assert!(decode::<Mainnet>(33).is_err());
+        // And the floor is the spec's, not a constant: 16 decodes on mainnet
+        // and is refused on a deployment that asks for 20.
+        assert!(decode::<HighFloor>(16).is_err());
+        assert!(decode::<HighFloor>(20).is_ok());
+    }
+
+    #[test]
+    fn test_calculate_bucket() {
+        let address = address_cbe5();
+
+        assert_eq!(
+            calculate_bucket(&address, BucketDepth::<Mainnet>::new(16).unwrap()).value(),
+            0xCBE5
+        );
+        assert_eq!(calculate_bucket(&address, low_floor(8)).value(), 0xCB);
+        assert_eq!(calculate_bucket(&address, low_floor(4)).value(), 0xC);
+    }
+
+    #[test]
+    fn calculate_bucket_spans_the_whole_depth_range() {
+        let address = address_cbe5();
+
+        assert_eq!(calculate_bucket(&address, low_floor(1)).value(), 1);
+        assert_eq!(
+            calculate_bucket(&address, low_floor(32)).value(),
+            0xCBE5_0000
+        );
+    }
+
+    #[test]
+    fn a_bucket_carries_the_depth_that_cut_it() {
+        let address = address_cbe5();
+        let shallow = Bucket::of(&address, low_floor(8));
+        let deep = Bucket::of(&address, low_floor(16));
+
+        assert_eq!(shallow.depth(), low_floor(8));
+        assert_eq!(deep.depth(), low_floor(16));
+        // Same address, same numeric range, different geometry: the depth is
+        // what tells the two apart.
+        assert_eq!(Bucket::of(&address, low_floor(16)), deep);
+        assert_ne!(shallow, Bucket::checked(0xCB, low_floor(16)).unwrap());
+    }
+
+    #[test]
+    fn checked_refuses_a_bucket_outside_the_depth() {
+        assert_eq!(Bucket::checked(0xFF, low_floor(8)).unwrap().value(), 0xFF);
+        assert!(matches!(
+            Bucket::checked(0x100, low_floor(8)),
+            Err(StampError::InvalidIndex)
+        ));
+        // Every `u32` is a bucket at the widest depth.
+        assert!(Bucket::checked(u32::MAX, low_floor(32)).is_ok());
+    }
+
+    #[test]
+    fn batch_depth_folds_both_geometry_bounds() {
+        let bucket_depth = BucketDepth::<Mainnet>::new(16).unwrap();
+
+        let geometry = BatchDepth::new(20, bucket_depth).unwrap();
+        assert_eq!(geometry.get(), 20);
+        assert_eq!(geometry.bucket_depth(), bucket_depth);
+        assert_eq!(geometry.slot_bits(), 4);
+        assert_eq!(geometry.slots_per_bucket(), 16);
+        assert_eq!(geometry.bucket_count(), 1 << 16);
+        assert_eq!(geometry.total_slots(), 1 << 20);
+
+        // A batch as deep as its buckets holds one slot each.
+        assert_eq!(
+            BatchDepth::new(16, bucket_depth)
+                .unwrap()
+                .slots_per_bucket(),
+            1
+        );
+
+        assert!(matches!(
+            BatchDepth::new(15, bucket_depth),
+            Err(StampError::DepthBelowBucketDepth {
+                depth: 15,
+                bucket_depth: 16
+            })
+        ));
+    }
+
+    #[test]
+    fn batch_depth_refuses_a_slot_count_wider_than_a_u32() {
+        let bucket_depth = BucketDepth::<Mainnet>::new(16).unwrap();
+
+        assert_eq!(
+            BatchDepth::new(47, bucket_depth)
+                .unwrap()
+                .slots_per_bucket(),
+            1 << 31
+        );
+        assert!(matches!(
+            BatchDepth::new(48, bucket_depth),
+            Err(StampError::SlotsTooWide {
+                depth: 48,
+                bucket_depth: 16,
+                max: 31
+            })
+        ));
+    }
+
+    #[test]
+    fn contains_bounds_both_coordinates() {
+        let geometry = BatchDepth::new(18, BucketDepth::<Mainnet>::new(16).unwrap()).unwrap();
+
+        assert!(geometry.contains(&StampIndex::new(0xFFFF, 3)));
+        // One past the bucket range, and one past the slot range.
+        assert!(!geometry.contains(&StampIndex::new(0x1_0000, 0)));
+        assert!(!geometry.contains(&StampIndex::new(0, 4)));
+    }
+
+    #[test]
+    fn dilution_is_monotone_and_stays_representable() {
+        let bucket_depth = BucketDepth::<Mainnet>::new(16).unwrap();
+        let geometry = BatchDepth::new(18, bucket_depth).unwrap();
+
+        assert_eq!(geometry.diluted(20).unwrap().get(), 20);
+        // A replayed or reordered event cannot shrink the batch.
+        assert_eq!(geometry.diluted(17).unwrap(), geometry);
+        assert_eq!(geometry.diluted(18).unwrap(), geometry);
+        assert_eq!(geometry.diluted(0).unwrap(), geometry);
+
+        assert!(matches!(
+            geometry.diluted(48),
+            Err(StampError::SlotsTooWide { .. })
+        ));
+    }
+}

--- a/crates/postage/src/geometry.rs
+++ b/crates/postage/src/geometry.rs
@@ -10,16 +10,10 @@ use crate::{StampError, StampIndex};
 /// The number of leading chunk-address bits that select a collision bucket, as
 /// the network `S` accepts it.
 ///
-/// Two bounds hold at construction: [`SwarmSpec::MIN_BUCKET_DEPTH`], the floor
-/// the PostageStamp contract publishes as `minimumBucketDepth()`, and
-/// [`MAX`](Self::MAX), the width of the bucket key. Bucket selection shifts a
-/// `u32` right by `32 - depth`; holding both bounds in the type keeps that
-/// shift total wherever a depth reaches it.
-///
-/// The floor is a compile-time property: a `BucketDepth<Mainnet>` below 16 does
-/// not exist, and one network's depth does not type-check where another's is
-/// wanted. Every constructor funnels through [`new`](Self::new), including the
-/// serde and `Arbitrary` paths.
+/// Construction holds it between [`SwarmSpec::MIN_BUCKET_DEPTH`], the floor the
+/// PostageStamp contract publishes as `minimumBucketDepth()`, and
+/// [`MAX`](Self::MAX), the bucket-key width, so the `32 - depth` selection shift
+/// is total wherever a depth reaches it.
 ///
 /// A depth carries its network, so this does not compile:
 ///
@@ -192,11 +186,10 @@ impl<'a, S: SwarmSpec> arbitrary::Arbitrary<'a> for BucketDepth<S> {
     }
 }
 
-/// A collision bucket together with the [`BucketDepth`] that derived it.
+/// A collision bucket together with the [`BucketDepth`] that cut it.
 ///
-/// The depth travels with the value because a bucket is only meaningful under
-/// the depth it was cut at: a bucket cut at depth 16 is inside the bucket range
-/// of a depth-20 table, so a bare `u32` lands in the wrong bucket undetected.
+/// A bucket cut at depth 16 is in range for a depth-20 table, so a bare `u32`
+/// lands in the wrong bucket undetected.
 pub struct Bucket<S: SwarmSpec = Mainnet> {
     value: u32,
     depth: BucketDepth<S>,
@@ -204,9 +197,6 @@ pub struct Bucket<S: SwarmSpec = Mainnet> {
 
 impl<S: SwarmSpec> Bucket<S> {
     /// Cuts the bucket of `address`: its leading `depth` bits, read big-endian.
-    ///
-    /// Infallible: the depth is the input, so the result is in range by
-    /// construction.
     #[inline]
     pub fn of(address: &ChunkAddress, depth: BucketDepth<S>) -> Self {
         let &[a, b, c, d, ..] = address.as_array();
@@ -291,9 +281,8 @@ impl<S: SwarmSpec> From<Bucket<S>> for u32 {
 
 /// A validated batch depth together with the [`BucketDepth`] beneath it.
 ///
-/// Construction settles both geometry bounds, so `depth - bucket_depth` is a
-/// subtraction that cannot underflow and `2^(depth - bucket_depth)` is a slot
-/// count that fits a `u32`.
+/// Construction settles both bounds, so `depth - bucket_depth` cannot underflow
+/// and `2^(depth - bucket_depth)` fits a `u32`.
 pub struct BatchDepth<S: SwarmSpec = Mainnet> {
     depth: u8,
     bucket_depth: BucketDepth<S>,
@@ -378,10 +367,8 @@ impl<S: SwarmSpec> BatchDepth<S> {
         self.bucket_depth.contains_bucket(index.bucket()) && index.index() < self.slots_per_bucket()
     }
 
-    /// Adopts an on-chain dilution.
-    ///
-    /// A depth at or below the current one yields the geometry unchanged, so a
-    /// redelivered or reordered dilution event is a no-op rather than a shrink.
+    /// Adopts an on-chain dilution; a depth at or below the current one is a
+    /// no-op, so a redelivered or reordered event cannot shrink the batch.
     ///
     /// # Errors
     ///
@@ -587,8 +574,6 @@ mod tests {
 
         assert_eq!(shallow.depth(), low_floor(8));
         assert_eq!(deep.depth(), low_floor(16));
-        // Same address, same numeric range, different geometry: the depth is
-        // what tells the two apart.
         assert_eq!(Bucket::of(&address, low_floor(16)), deep);
         assert_ne!(shallow, Bucket::checked(0xCB, low_floor(16)).unwrap());
     }
@@ -616,7 +601,6 @@ mod tests {
         assert_eq!(geometry.bucket_count(), 1 << 16);
         assert_eq!(geometry.total_slots(), 1 << 20);
 
-        // A batch as deep as its buckets holds one slot each.
         assert_eq!(
             BatchDepth::new(16, bucket_depth)
                 .unwrap()
@@ -658,7 +642,6 @@ mod tests {
         let geometry = BatchDepth::new(18, BucketDepth::<Mainnet>::new(16).unwrap()).unwrap();
 
         assert!(geometry.contains(&StampIndex::new(0xFFFF, 3)));
-        // One past the bucket range, and one past the slot range.
         assert!(!geometry.contains(&StampIndex::new(0x1_0000, 0)));
         assert!(!geometry.contains(&StampIndex::new(0, 4)));
     }
@@ -669,7 +652,6 @@ mod tests {
         let geometry = BatchDepth::new(18, bucket_depth).unwrap();
 
         assert_eq!(geometry.diluted(20).unwrap().get(), 20);
-        // A replayed or reordered event cannot shrink the batch.
         assert_eq!(geometry.diluted(17).unwrap(), geometry);
         assert_eq!(geometry.diluted(18).unwrap(), geometry);
         assert_eq!(geometry.diluted(0).unwrap(), geometry);

--- a/crates/postage/src/lib.rs
+++ b/crates/postage/src/lib.rs
@@ -11,6 +11,8 @@
 //! - [`Batch`]: A postage batch representing prepaid storage
 //! - [`BucketDepth`]: A collision-bucket depth a network accepts, checked
 //!   against the [`SwarmSpec`](nectar_primitives::SwarmSpec) it is built for
+//! - [`Bucket`]: A collision bucket carrying the depth that cut it
+//! - [`BatchDepth`]: A batch depth carrying the bucket depth beneath it
 //! - [`Stamp`]: A postage stamp proving payment for chunk storage
 //! - [`StampIndex`]: The bucket and position index within a stamp
 //! - [`StampDigest`]: The data to be signed when creating a stamp
@@ -65,6 +67,7 @@ mod batch;
 mod error;
 #[cfg(any(test, feature = "arbitrary"))]
 pub mod generators;
+mod geometry;
 #[cfg(any(test, feature = "arbitrary"))]
 pub mod oracles;
 mod sink;
@@ -86,12 +89,13 @@ mod store;
 pub mod parallel;
 
 // Core types
-pub use batch::{Batch, BatchId, BatchParams, BucketDepth};
+pub use batch::{Batch, BatchId, BatchParams};
 pub use error::StampError;
+pub use geometry::{BatchDepth, Bucket, BucketDepth, calculate_bucket};
 pub use sink::{PutStamped, StampIndifferent, Tee, TeeError};
 pub use stamp::{STAMP_SIZE, Stamp, StampBytes, StampDigest, StampIndex};
 pub use stamped::StampedChunk;
-pub use util::{PostageContext, calculate_bucket};
+pub use util::PostageContext;
 pub use validation::StampValidator;
 #[cfg(feature = "std")]
 pub use validation::StoreValidator;

--- a/crates/postage/src/util.rs
+++ b/crates/postage/src/util.rs
@@ -1,30 +1,4 @@
-//! Utility functions for postage operations.
-
-use nectar_primitives::{ChunkAddress, SwarmSpec};
-
-use crate::BucketDepth;
-
-/// Returns the collision bucket of `address`: its leading `bucket_depth` bits
-/// read big-endian.
-///
-/// # Example
-///
-/// ```
-/// use nectar_postage::{BucketDepth, calculate_bucket};
-/// use nectar_primitives::{ChunkAddress, Mainnet};
-///
-/// let address = ChunkAddress::new([0xCB, 0xE5, 0x00, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
-/// let bucket_depth = BucketDepth::<Mainnet>::new(16).unwrap();
-/// assert_eq!(calculate_bucket(&address, bucket_depth), 0xCBE5);
-/// ```
-#[inline]
-pub fn calculate_bucket<S: SwarmSpec>(address: &ChunkAddress, bucket_depth: BucketDepth<S>) -> u32 {
-    let &[a, b, c, d, ..] = address.as_array();
-    // Depth is 1..=32, so the shift is 0..=31 and never wraps.
-    u32::from_be_bytes([a, b, c, d]).wrapping_shr(u32::from(
-        BucketDepth::<S>::MAX.saturating_sub(bucket_depth.get()),
-    ))
-}
+//! Chain state shared by the postage validation paths.
 
 /// Context for postage validation.
 ///
@@ -80,43 +54,7 @@ impl PostageContext {
 
 #[cfg(test)]
 mod tests {
-    use nectar_primitives::Mainnet;
-    use nectar_testing::LowFloor;
-
     use super::*;
-
-    // `nectar_testing::low_floor` returns the `BucketDepth` of the
-    // `nectar-postage` instance it links, which is not this one.
-    fn low_floor(depth: u8) -> BucketDepth<LowFloor> {
-        BucketDepth::new(depth).unwrap()
-    }
-
-    fn address_cbe5() -> ChunkAddress {
-        ChunkAddress::new([
-            0xCB, 0xE5, 0x00, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0,
-        ])
-    }
-
-    #[test]
-    fn test_calculate_bucket() {
-        let address = address_cbe5();
-
-        assert_eq!(
-            calculate_bucket(&address, BucketDepth::<Mainnet>::new(16).unwrap()),
-            0xCBE5
-        );
-        assert_eq!(calculate_bucket(&address, low_floor(8)), 0xCB);
-        assert_eq!(calculate_bucket(&address, low_floor(4)), 0xC);
-    }
-
-    #[test]
-    fn calculate_bucket_spans_the_whole_depth_range() {
-        let address = address_cbe5();
-
-        assert_eq!(calculate_bucket(&address, low_floor(1)), 1);
-        assert_eq!(calculate_bucket(&address, low_floor(32)), 0xCBE5_0000);
-    }
 
     #[test]
     fn test_chain_state() {

--- a/crates/postage/src/validation.rs
+++ b/crates/postage/src/validation.rs
@@ -493,7 +493,7 @@ mod tests {
             0, 0, 0, 0, 0, 0, 0,
         ]);
 
-        assert_eq!(batch.bucket_for_address(&address), 0xCBE5);
+        assert_eq!(batch.bucket_for_address(&address).value(), 0xCBE5);
     }
 
     #[test]


### PR DESCRIPTION
Closes #763

## Summary

Implements #763 on top of `integration/wave1` (which already carries #761 and #762): moves `BucketDepth<S>` and `calculate_bucket` into a new `crates/postage/src/geometry.rs`, and adds two new types alongside them, `Bucket<S>` and `BatchDepth<S>`, that carry the depth a bucket or a batch was cut at instead of trusting a bare integer.

## What changed

- New module `crates/postage/src/geometry.rs` (664 lines). `BucketDepth<S>` moves here verbatim from `batch.rs`; `calculate_bucket` moves here from `util.rs`, which now holds only `PostageContext`. Public paths are unchanged: `nectar_postage::{BucketDepth, calculate_bucket}` still resolve, and `Bucket`/`BatchDepth` join them.
- `Bucket<S = Mainnet> { value: u32, depth: BucketDepth<S> }`: `Bucket::of(address, depth)` derives a bucket from a chunk address (infallible); `Bucket::checked(value, depth)` reconstructs one from a stored value and fails with `StampError::InvalidIndex` if the value is out of range for the depth. `calculate_bucket` is now a thin alias returning `Bucket<S>` via `Bucket::of`.
- `BatchDepth<S = Mainnet> { depth: u8, bucket_depth: BucketDepth<S> }`: `BatchDepth::new(depth, bucket_depth)` validates `depth >= bucket_depth` (`StampError::DepthBelowBucketDepth`) and that the slot-count width `depth - bucket_depth` fits a `u32` shift, capped at `MAX_SLOT_BITS = 31` (new `StampError::SlotsTooWide`).
- `crates/postage/src/batch.rs` shrinks by 372 lines as the moved types and their validation logic are cut over to `geometry.rs`.
- `crates/postage/src/error.rs` gains `StampError::SlotsTooWide { depth, bucket_depth, max }`.
- `crates/postage-issuer/src/counter.rs`: `CounterTable::record` now takes `Bucket<S>` instead of a raw `u32` bucket, and rejects a bucket cut at a depth other than the table's own with a new `CounterError::BucketDepthMismatch { expected, got }`: a bucket cut at a shallower depth can still be numerically in-range for a deeper table, so a plain bounds check would not have caught it.
- `crates/postage-issuer/src/ring.rs`, `sharded.rs`, `issuer.rs`, `error.rs`, `pipeline/stamped_put.rs`, and `crates/postage-usage/src/snapshot.rs`, `table.rs` are updated to construct and thread `Bucket<S>` through instead of raw `u32` buckets.

## Notes from the implementation and red-team passes

- No reimplementation duplication: `Bucket<S>` and `BatchDepth<S>` are genuinely new types; `BucketDepth<S>` is a verbatim move. `postage-usage`'s prior `validate_geometry` logic was folded into `BatchDepth::new` rather than reimplemented alongside it, and `const _: () = assert!(MAX_COUNTER_BITS == BatchDepth::<Mainnet>::MAX_SLOT_BITS)` pins the two bounds together so they cannot drift apart silently.
- Red-team pass found and fixed one genuine build break: `crates/postage-usage/tests/issuer.rs:122` still compared `calculate_bucket(...)` (now returning `Bucket<S>`) against a raw `u32`, failing with E0308. This test is behind the `issuer` feature, so it was not caught by the default-feature nextest run. Fixed by appending `.value()` (commit `28455e26`).
- Two follow-up commits were pushed after the initial implementation: `b1669b7d` (fix: reject a batch geometry no counter table can hold) and `45dd868a` (docs: cut the geometry rustdoc to the invariants), plus the `28455e26` test fix above.

## Testing

All commands run inside `nix develop --command` on the dev-shell toolchain (rustc 1.94.0, matching the declared MSRV).

- `cargo clippy --workspace --all-targets --locked`: clean (exit 0)
- Clippy run with the `issuer` feature enabled: clean after the `28455e26` fix
- `cargo nextest run` default-feature pass: green

AI Assistance: implement claude-opus-5, red-team claude-opus-5, PR claude-sonnet-5.
