### PR TITLE
refactor(postage)!: put trust and validation state on StampedChunk

### DIFF
--- a/crates/postage-issuer/src/pipeline/stamped_put.rs
+++ b/crates/postage-issuer/src/pipeline/stamped_put.rs
@@ -234,8 +234,8 @@ enum Step {
 /// Stamping decorator over a [`PutStamped`] sink.
 ///
 /// Implements `ChunkPut` facing up and requires `P: PutStamped<Unvalidated>`
-/// facing down: the stamp is minted here rather than checked, so the pair
-/// carries no validation proof. One generic impl over `AnyChunkSet<B>` serves every
+/// facing down: the stamp is minted here, not checked, so the pair carries no
+/// validation proof. One generic impl over `AnyChunkSet<B>` serves every
 /// wrapped call site.
 ///
 /// # Contracts
@@ -256,8 +256,8 @@ enum Step {
 /// - Wrapping a purely local store burns indices for chunks that may never
 ///   reach the network; filter for presence upstream where that matters.
 /// - Put-only sites need `P: PutStamped<Unvalidated>`; commit and apply sites
-///   need `P: PutStamped<Unvalidated> + TrustedGet + ChunkHas`, so a pure network sender
-///   takes a local or teed inner there.
+///   need `P: PutStamped<Unvalidated> + TrustedGet + ChunkHas`, so a pure
+///   network sender takes a local or teed inner there.
 /// - A split's put slots double as sign-plus-put slots: widen the put
 ///   window toward [`StampPipeline`](super::StampPipeline)'s default
 ///   window when wrapping a slow signer, and prefer an owned clone

--- a/crates/postage-issuer/src/pipeline/stamped_put.rs
+++ b/crates/postage-issuer/src/pipeline/stamped_put.rs
@@ -15,7 +15,7 @@ use nectar_clock::Clock;
 #[cfg(feature = "std")]
 use nectar_clock::SystemClock;
 use nectar_marker::{MaybeSend, MaybeSync};
-use nectar_postage::{PutStamped, Stamp, StampDigest, StampError, StampedChunk};
+use nectar_postage::{PutStamped, Stamp, StampDigest, StampError, StampedChunk, Unvalidated};
 use nectar_primitives::{AnyChunkSet, Chunk, ChunkAddress, ChunkGet, ChunkHas, ChunkPut, Verified};
 
 #[cfg(feature = "std")]
@@ -233,9 +233,9 @@ enum Step {
 
 /// Stamping decorator over a [`PutStamped`] sink.
 ///
-/// Implements `ChunkPut` facing up and requires `P: PutStamped` facing
-/// down: every put allocates an index, signs the stamp and forwards the
-/// pair in-band. One generic impl over `AnyChunkSet<B>` serves every
+/// Implements `ChunkPut` facing up and requires `P: PutStamped<Unvalidated>`
+/// facing down: the stamp is minted here rather than checked, so the pair
+/// carries no validation proof. One generic impl over `AnyChunkSet<B>` serves every
 /// wrapped call site.
 ///
 /// # Contracts
@@ -255,8 +255,8 @@ enum Step {
 ///   signed stamp; a re-put through the decorator is idempotent anyway.
 /// - Wrapping a purely local store burns indices for chunks that may never
 ///   reach the network; filter for presence upstream where that matters.
-/// - Put-only sites need `P: PutStamped`; commit and apply sites need
-///   `P: PutStamped + TrustedGet + ChunkHas`, so a pure network sender
+/// - Put-only sites need `P: PutStamped<Unvalidated>`; commit and apply sites
+///   need `P: PutStamped<Unvalidated> + TrustedGet + ChunkHas`, so a pure network sender
 ///   takes a local or teed inner there.
 /// - A split's put slots double as sign-plus-put slots: widen the put
 ///   window toward [`StampPipeline`](super::StampPipeline)'s default
@@ -481,7 +481,7 @@ impl<I, Sg, P, C, const B: usize> ChunkPut<AnyChunkSet<B>> for StampedPut<I, Sg,
 where
     I: StampIssuer + MaybeSend + 'static,
     Sg: SignPrehash + MaybeSend + MaybeSync + 'static,
-    P: PutStamped<B>,
+    P: PutStamped<Unvalidated, B>,
     C: Clock,
 {
     type Error = StampedPutError<P::Error>;
@@ -622,10 +622,13 @@ mod tests {
         seen: Arc<StdMutex<Vec<(ChunkAddress, Stamp)>>>,
     }
 
-    impl PutStamped for CountingSink {
+    impl PutStamped<Unvalidated> for CountingSink {
         type Error = Infallible;
 
-        async fn put_stamped(&self, stamped: StampedChunk) -> Result<(), Self::Error> {
+        async fn put_stamped(
+            &self,
+            stamped: StampedChunk<Verified, Unvalidated>,
+        ) -> Result<(), Self::Error> {
             self.seen
                 .lock()
                 .unwrap()
@@ -645,10 +648,13 @@ mod tests {
         seen: Arc<StdMutex<Vec<Stamp>>>,
     }
 
-    impl PutStamped for FailOnceSink {
+    impl PutStamped<Unvalidated> for FailOnceSink {
         type Error = SinkRefused;
 
-        async fn put_stamped(&self, stamped: StampedChunk) -> Result<(), Self::Error> {
+        async fn put_stamped(
+            &self,
+            stamped: StampedChunk<Verified, Unvalidated>,
+        ) -> Result<(), Self::Error> {
             self.seen.lock().unwrap().push(stamped.stamp().clone());
             if self.failed.swap(true, Ordering::SeqCst) {
                 Ok(())
@@ -664,10 +670,13 @@ mod tests {
         store: Arc<MemoryStore<AnyChunkSet<4096>>>,
     }
 
-    impl PutStamped for StoreSink {
+    impl PutStamped<Unvalidated> for StoreSink {
         type Error = Infallible;
 
-        async fn put_stamped(&self, stamped: StampedChunk) -> Result<(), Self::Error> {
+        async fn put_stamped(
+            &self,
+            stamped: StampedChunk<Verified, Unvalidated>,
+        ) -> Result<(), Self::Error> {
             let (chunk, _stamp) = stamped.into_parts();
             ChunkPut::put(&self.store, chunk).await
         }

--- a/crates/postage/src/generators.rs
+++ b/crates/postage/src/generators.rs
@@ -66,22 +66,28 @@ pub fn signed_stamp(
     Ok(Stamp::with_index(batch.id(), index, timestamp, signature))
 }
 
+/// A batch and a stamp that pays `address` from it, owned by a signer drawn
+/// from `u`.
+pub fn batch_and_stamp(
+    u: &mut Unstructured<'_>,
+    address: &ChunkAddress,
+) -> arbitrary::Result<(Batch, Stamp)> {
+    let signer = nectar_primitives::generators::signer(u)?;
+    let batch = batch(u, signer.address())?;
+    let stamp = signed_stamp(u, &signer, &batch, address)?;
+    Ok((batch, stamp))
+}
+
 /// A fully coherent stamped chunk: a valid chunk paired with a stamp that
 /// verifies against the returned batch's owner.
-///
-/// The signer is drawn from `u` (see `nectar_primitives::generators::signer`);
-/// its address is the batch owner, so
-/// `stamped.stamp().verify(stamped.address(), batch.owner())` passes.
 pub fn signed_stamped_chunk<const BODY_SIZE: usize>(
     u: &mut Unstructured<'_>,
 ) -> arbitrary::Result<(StampedChunk<Verified, Unvalidated, BODY_SIZE>, Batch)> {
-    let signer = nectar_primitives::generators::signer(u)?;
-    let batch = batch(u, signer.address())?;
     let chunk = Chunk::<Verified, AnyChunkSet<BODY_SIZE>>::from_envelope(
         nectar_primitives::generators::any_chunk::<BODY_SIZE>(u)?,
     )
     .map_err(|_| arbitrary::Error::IncorrectFormat)?;
-    let stamp = signed_stamp(u, &signer, &batch, chunk.address())?;
+    let (batch, stamp) = batch_and_stamp(u, chunk.address())?;
     Ok((StampedChunk::new(chunk, stamp), batch))
 }
 

--- a/crates/postage/src/generators.rs
+++ b/crates/postage/src/generators.rs
@@ -16,7 +16,9 @@ use alloy_signer::SignerSync;
 use arbitrary::Unstructured;
 use nectar_primitives::{AnyChunkSet, Chunk, ChunkAddress, Mainnet, SwarmSpec, Verified};
 
-use crate::{Batch, BatchId, BucketDepth, Stamp, StampDigest, StampIndex, StampedChunk};
+use crate::{
+    Batch, BatchId, BucketDepth, Stamp, StampDigest, StampIndex, StampedChunk, Unvalidated,
+};
 
 /// A batch with valid depth invariants and the given owner.
 ///
@@ -72,7 +74,7 @@ pub fn signed_stamp(
 /// `stamped.stamp().verify(stamped.address(), batch.owner())` passes.
 pub fn signed_stamped_chunk<const BODY_SIZE: usize>(
     u: &mut Unstructured<'_>,
-) -> arbitrary::Result<(StampedChunk<BODY_SIZE>, Batch)> {
+) -> arbitrary::Result<(StampedChunk<Verified, Unvalidated, BODY_SIZE>, Batch)> {
     let signer = nectar_primitives::generators::signer(u)?;
     let batch = batch(u, signer.address())?;
     let chunk = Chunk::<Verified, AnyChunkSet<BODY_SIZE>>::from_envelope(
@@ -94,7 +96,7 @@ mod tests {
             seed in proptest::collection::vec(any::<u8>(), 128..2048),
         ) {
             let mut u = Unstructured::new(&seed);
-            let (stamped, batch): (StampedChunk, Batch) =
+            let (stamped, batch): (StampedChunk<Verified, Unvalidated>, Batch) =
                 signed_stamped_chunk(&mut u).unwrap();
 
             let address = *stamped.address();
@@ -110,6 +112,8 @@ mod tests {
             // The stamp round-trips its fixed-size wire encoding.
             let decoded = Stamp::from_bytes(&stamp.to_bytes()).unwrap();
             prop_assert_eq!(stamp, &decoded);
+
+            prop_assert!(stamped.validate(&batch).is_ok());
         }
     }
 }

--- a/crates/postage/src/lib.rs
+++ b/crates/postage/src/lib.rs
@@ -16,6 +16,8 @@
 //! - [`StampDigest`]: The data to be signed when creating a stamp
 //! - [`StampedAddress`]: A stamp bound to an address, and the authority that
 //!   validates the pairing
+//! - [`StampedChunk`]: A chunk and its stamp, carrying the chunk's trust state
+//!   and the stamp's validation state
 //! - [`PostageContext`]: Context for batch expiry calculations
 //! - [`BatchEvent`]: Events emitted by the postage stamp contract (requires `std`)
 //!

--- a/crates/postage/src/sink.rs
+++ b/crates/postage/src/sink.rs
@@ -9,48 +9,52 @@
 use core::future::Future;
 
 use nectar_primitives::marker::{MaybeSend, MaybeSync};
-use nectar_primitives::{AnyChunkSet, ChunkPut, DEFAULT_BODY_SIZE};
+use nectar_primitives::{AnyChunkSet, ChunkPut, DEFAULT_BODY_SIZE, Verified};
 
-use crate::StampedChunk;
+use crate::{StampedChunk, Validated, ValidationState};
 
 /// Async stamped-chunk sink (`&self`).
 ///
 /// The stamp travels in-band with the chunk it pays for. The contract is
 /// delivery only: per-address idempotence belongs to a decorator layered
 /// above the sink, never to this trait. Implementors use interior
-/// mutability, mirroring `ChunkPut`. Ingest ordering: batch existence and
-/// authenticity gates run before chunk certification; the typed decode
-/// takes the stamp structurally before paying the chunk's acceptance rule.
-pub trait PutStamped<const BODY_SIZE: usize = DEFAULT_BODY_SIZE>: MaybeSend + MaybeSync {
+/// mutability, mirroring `ChunkPut`. `V` is the proof the sink demands of
+/// the stamp: a network sink takes [`Validated`], a producer-side sink takes
+/// the pair its own issuer just signed.
+pub trait PutStamped<V: ValidationState = Validated, const BODY_SIZE: usize = DEFAULT_BODY_SIZE>:
+    MaybeSend + MaybeSync
+{
     /// Error type for stamped put operations.
     type Error: core::error::Error + MaybeSend + MaybeSync + 'static;
 
     /// Sink a stamped chunk.
     fn put_stamped(
         &self,
-        stamped: StampedChunk<BODY_SIZE>,
+        stamped: StampedChunk<Verified, V, BODY_SIZE>,
     ) -> impl Future<Output = Result<(), Self::Error>> + MaybeSend;
 }
 
-impl<const BODY_SIZE: usize, T: PutStamped<BODY_SIZE> + ?Sized> PutStamped<BODY_SIZE> for &T {
-    type Error = T::Error;
-
-    fn put_stamped(
-        &self,
-        stamped: StampedChunk<BODY_SIZE>,
-    ) -> impl Future<Output = Result<(), Self::Error>> + MaybeSend {
-        (**self).put_stamped(stamped)
-    }
-}
-
-impl<const BODY_SIZE: usize, T: PutStamped<BODY_SIZE> + ?Sized> PutStamped<BODY_SIZE>
-    for alloc::sync::Arc<T>
+impl<V: ValidationState, const BODY_SIZE: usize, T: PutStamped<V, BODY_SIZE> + ?Sized>
+    PutStamped<V, BODY_SIZE> for &T
 {
     type Error = T::Error;
 
     fn put_stamped(
         &self,
-        stamped: StampedChunk<BODY_SIZE>,
+        stamped: StampedChunk<Verified, V, BODY_SIZE>,
+    ) -> impl Future<Output = Result<(), Self::Error>> + MaybeSend {
+        (**self).put_stamped(stamped)
+    }
+}
+
+impl<V: ValidationState, const BODY_SIZE: usize, T: PutStamped<V, BODY_SIZE> + ?Sized>
+    PutStamped<V, BODY_SIZE> for alloc::sync::Arc<T>
+{
+    type Error = T::Error;
+
+    fn put_stamped(
+        &self,
+        stamped: StampedChunk<Verified, V, BODY_SIZE>,
     ) -> impl Future<Output = Result<(), Self::Error>> + MaybeSend {
         (**self).put_stamped(stamped)
     }
@@ -89,7 +93,8 @@ impl<S> StampIndifferent<S> {
     }
 }
 
-impl<const BODY_SIZE: usize, S> PutStamped<BODY_SIZE> for StampIndifferent<S>
+impl<V: ValidationState, const BODY_SIZE: usize, S> PutStamped<V, BODY_SIZE>
+    for StampIndifferent<S>
 where
     S: ChunkPut<AnyChunkSet<BODY_SIZE>>,
 {
@@ -97,7 +102,7 @@ where
 
     fn put_stamped(
         &self,
-        stamped: StampedChunk<BODY_SIZE>,
+        stamped: StampedChunk<Verified, V, BODY_SIZE>,
     ) -> impl Future<Output = Result<(), Self::Error>> + MaybeSend {
         let (chunk, _stamp) = stamped.into_parts();
         self.inner.put(chunk)
@@ -145,14 +150,17 @@ impl<L, F> Tee<L, F> {
     }
 }
 
-impl<const BODY_SIZE: usize, L, F> PutStamped<BODY_SIZE> for Tee<L, F>
+impl<V: ValidationState, const BODY_SIZE: usize, L, F> PutStamped<V, BODY_SIZE> for Tee<L, F>
 where
-    L: PutStamped<BODY_SIZE>,
-    F: PutStamped<BODY_SIZE>,
+    L: PutStamped<V, BODY_SIZE>,
+    F: PutStamped<V, BODY_SIZE>,
 {
     type Error = TeeError<L::Error, F::Error>;
 
-    async fn put_stamped(&self, stamped: StampedChunk<BODY_SIZE>) -> Result<(), Self::Error> {
+    async fn put_stamped(
+        &self,
+        stamped: StampedChunk<Verified, V, BODY_SIZE>,
+    ) -> Result<(), Self::Error> {
         self.local
             .put_stamped(stamped.clone())
             .await
@@ -182,22 +190,39 @@ mod tests {
     use std::sync::Arc;
     use std::sync::Mutex;
 
-    use alloy_primitives::Signature;
-    use nectar_primitives::{Chunk, ChunkAddress, ChunkHas, ContentChunk, MemoryStore, Verified};
+    use alloy_signer_local::PrivateKeySigner;
+    use arbitrary::Unstructured;
+    use nectar_primitives::{Chunk, ChunkAddress, ChunkHas, ContentChunk, MemoryStore};
     use nectar_testing::run;
 
     use super::*;
-    use crate::{BatchId, Stamp};
+    use crate::{Batch, BatchId, BucketDepth, Unvalidated, generators};
 
     type Store = MemoryStore<AnyChunkSet<DEFAULT_BODY_SIZE>>;
 
-    fn stamped(payload: &'static [u8]) -> StampedChunk<DEFAULT_BODY_SIZE> {
-        let chunk = ContentChunk::new(payload).expect("valid content chunk");
+    fn signed(payload: &'static [u8]) -> (Batch, StampedChunk<Verified, Unvalidated>) {
+        let signer = PrivateKeySigner::from_slice(&[7u8; 32]).expect("valid signer");
+        let batch = Batch::new(
+            BatchId::ZERO,
+            1_000,
+            100,
+            signer.address(),
+            18,
+            BucketDepth::new(16).expect("valid bucket depth"),
+            true,
+        );
         let chunk: Chunk<Verified, AnyChunkSet<DEFAULT_BODY_SIZE>> =
-            Chunk::from_envelope(chunk.into()).expect("locally built chunk certifies");
-        let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
-        let stamp = Stamp::new(BatchId::new([0xaa; 32]), 3, 7, 42, sig);
-        StampedChunk::new(chunk, stamp)
+            Chunk::from_envelope(ContentChunk::new(payload).expect("valid content chunk").into())
+                .expect("locally built chunk certifies");
+        let mut u = Unstructured::new(&[7u8; 32]);
+        let stamp = generators::signed_stamp(&mut u, &signer, &batch, chunk.address())
+            .expect("signed stamp");
+        (batch, StampedChunk::new(chunk, stamp))
+    }
+
+    fn stamped(payload: &'static [u8]) -> StampedChunk {
+        let (batch, pair) = signed(payload);
+        pair.validate(&batch).expect("coherent pairing")
     }
 
     #[derive(Debug, Default)]
@@ -238,6 +263,20 @@ mod tests {
             let store = Store::new();
             let sink = StampIndifferent::new(&store);
             let pair = stamped(b"local persist");
+            let address = *pair.address();
+
+            sink.put_stamped(pair).await.expect("infallible put");
+            assert!(store.has(&address).await);
+        });
+    }
+
+    /// The wrapper drops the stamp, so it demands no proof of it.
+    #[test]
+    fn stamp_indifferent_accepts_an_unvalidated_pair() {
+        run(async {
+            let store = Store::new();
+            let sink = StampIndifferent::new(&store);
+            let (_, pair) = signed(b"unproven stamp");
             let address = *pair.address();
 
             sink.put_stamped(pair).await.expect("infallible put");

--- a/crates/postage/src/sink.rs
+++ b/crates/postage/src/sink.rs
@@ -18,9 +18,9 @@ use crate::{StampedChunk, Validated, ValidationState};
 /// The stamp travels in-band with the chunk it pays for. The contract is
 /// delivery only: per-address idempotence belongs to a decorator layered
 /// above the sink, never to this trait. Implementors use interior
-/// mutability, mirroring `ChunkPut`. `V` is the proof the sink demands of
-/// the stamp: a network sink takes [`Validated`], a producer-side sink takes
-/// the pair its own issuer just signed.
+/// mutability, mirroring `ChunkPut`. `V` is the proof the sink demands of the
+/// stamp: an ingest sink takes [`Validated`], a producer-side sink takes the
+/// [`Unvalidated`](crate::Unvalidated) pair its own issuer just signed.
 pub trait PutStamped<V: ValidationState = Validated, const BODY_SIZE: usize = DEFAULT_BODY_SIZE>:
     MaybeSend + MaybeSync
 {
@@ -190,33 +190,22 @@ mod tests {
     use std::sync::Arc;
     use std::sync::Mutex;
 
-    use alloy_signer_local::PrivateKeySigner;
     use arbitrary::Unstructured;
     use nectar_primitives::{Chunk, ChunkAddress, ChunkHas, ContentChunk, MemoryStore};
     use nectar_testing::run;
 
     use super::*;
-    use crate::{Batch, BatchId, BucketDepth, Unvalidated, generators};
+    use crate::{Batch, Unvalidated, generators};
 
     type Store = MemoryStore<AnyChunkSet<DEFAULT_BODY_SIZE>>;
 
     fn signed(payload: &'static [u8]) -> (Batch, StampedChunk<Verified, Unvalidated>) {
-        let signer = PrivateKeySigner::from_slice(&[7u8; 32]).expect("valid signer");
-        let batch = Batch::new(
-            BatchId::ZERO,
-            1_000,
-            100,
-            signer.address(),
-            18,
-            BucketDepth::new(16).expect("valid bucket depth"),
-            true,
-        );
         let chunk: Chunk<Verified, AnyChunkSet<DEFAULT_BODY_SIZE>> =
             Chunk::from_envelope(ContentChunk::new(payload).expect("valid content chunk").into())
                 .expect("locally built chunk certifies");
-        let mut u = Unstructured::new(&[7u8; 32]);
-        let stamp = generators::signed_stamp(&mut u, &signer, &batch, chunk.address())
-            .expect("signed stamp");
+        let mut u = Unstructured::new(&[7u8; 128]);
+        let (batch, stamp) =
+            generators::batch_and_stamp(&mut u, chunk.address()).expect("coherent stamp");
         (batch, StampedChunk::new(chunk, stamp))
     }
 
@@ -270,7 +259,6 @@ mod tests {
         });
     }
 
-    /// The wrapper drops the stamp, so it demands no proof of it.
     #[test]
     fn stamp_indifferent_accepts_an_unvalidated_pair() {
         run(async {

--- a/crates/postage/src/sink.rs
+++ b/crates/postage/src/sink.rs
@@ -93,8 +93,7 @@ impl<S> StampIndifferent<S> {
     }
 }
 
-impl<V: ValidationState, const BODY_SIZE: usize, S> PutStamped<V, BODY_SIZE>
-    for StampIndifferent<S>
+impl<V: ValidationState, const BODY_SIZE: usize, S> PutStamped<V, BODY_SIZE> for StampIndifferent<S>
 where
     S: ChunkPut<AnyChunkSet<BODY_SIZE>>,
 {
@@ -200,9 +199,12 @@ mod tests {
     type Store = MemoryStore<AnyChunkSet<DEFAULT_BODY_SIZE>>;
 
     fn signed(payload: &'static [u8]) -> (Batch, StampedChunk<Verified, Unvalidated>) {
-        let chunk: Chunk<Verified, AnyChunkSet<DEFAULT_BODY_SIZE>> =
-            Chunk::from_envelope(ContentChunk::new(payload).expect("valid content chunk").into())
-                .expect("locally built chunk certifies");
+        let chunk: Chunk<Verified, AnyChunkSet<DEFAULT_BODY_SIZE>> = Chunk::from_envelope(
+            ContentChunk::new(payload)
+                .expect("valid content chunk")
+                .into(),
+        )
+        .expect("locally built chunk certifies");
         let mut u = Unstructured::new(&[7u8; 128]);
         let (batch, stamp) =
             generators::batch_and_stamp(&mut u, chunk.address()).expect("coherent stamp");

--- a/crates/postage/src/stamped.rs
+++ b/crates/postage/src/stamped.rs
@@ -1,122 +1,129 @@
 //! A chunk paired with the postage stamp that authorizes its storage.
 //!
-//! [`StampedChunk`] is the pairing of a verified [`Chunk`] (a
-//! `nectar-primitives` type) with a [`Stamp`] (a `nectar-postage` type). A
-//! retrieval, a pushsync delivery, and an upload all move a *chunk plus its
-//! proof of payment* as one unit, so this pairing is the cohesive value that
-//! flows across those boundaries instead of two loose fields.
-//!
-//! Both halves are nectar types, so the pairing and its serialization belong
-//! here. The wire codec is pure serialization layered on top of the
-//! registry's type-tagged chunk codec and the fixed-size [`Stamp`] codec.
+//! The two transitions commute and both orders are load-bearing: ingest
+//! validates before it verifies, so an unpaid body never pays for its own
+//! hashing, and the producer path is verified already and only needs
+//! validation.
 
 use alloc::vec::Vec;
+use core::marker::PhantomData;
 
 use nectar_primitives::{
-    AnyChunkSet, Chunk, ChunkAddress, DEFAULT_BODY_SIZE, Unverified, Verified, bytes::Bytes,
-    wire::Cursor,
+    AnyChunkSet, Chunk, ChunkAddress, DEFAULT_BODY_SIZE, SwarmSpec, TrustState, Unverified,
+    Verified, bytes::Bytes, wire::Cursor,
 };
 
-use crate::{BatchId, Stamp, StampError};
+use crate::{
+    Batch, BatchId, Stamp, StampError, StampedAddress, Unvalidated, Validated, ValidationState,
+};
 
-/// A verified chunk together with its postage stamp.
+/// A chunk together with its postage stamp, over trust and validation state.
 ///
-/// The chunk half is `Chunk<Verified>`, so a stamped chunk can only be built
-/// around a certified address: every wire ingress runs parse then verify
-/// before this type exists. [`address`](Self::address) reads the certified
-/// fact; it never recomputes or recovers anything.
+/// [`new`](Self::new) exists only at [`Unvalidated`], so a validated pair
+/// cannot be fabricated:
+///
+/// ```compile_fail
+/// use nectar_postage::{Stamp, StampedChunk, Validated};
+/// use nectar_primitives::{AnyChunkSet, Chunk, DEFAULT_BODY_SIZE, Verified};
+///
+/// fn fabricate(
+///     chunk: Chunk<Verified, AnyChunkSet<DEFAULT_BODY_SIZE>>,
+///     stamp: Stamp,
+/// ) -> StampedChunk<Verified, Validated> {
+///     StampedChunk::new(chunk, stamp)
+/// }
+/// ```
+///
+/// Nor can a fuzzer draw one:
+///
+#[cfg_attr(feature = "arbitrary", doc = "```compile_fail")]
+#[cfg_attr(not(feature = "arbitrary"), doc = "```ignore")]
+/// use nectar_postage::StampedChunk;
+///
+/// fn draw<'a, T: arbitrary::Arbitrary<'a>>() {}
+/// draw::<StampedChunk>();
+/// ```
 ///
 /// # Equality
 ///
 /// Structural: the chunk half compares its address and decoded envelope, the
 /// stamp half all stamp fields.
-#[derive(Debug, Clone)]
-pub struct StampedChunk<const BODY_SIZE: usize = DEFAULT_BODY_SIZE> {
-    chunk: Chunk<Verified, AnyChunkSet<BODY_SIZE>>,
+pub struct StampedChunk<
+    T: TrustState = Verified,
+    V: ValidationState = Validated,
+    const BODY_SIZE: usize = DEFAULT_BODY_SIZE,
+> {
+    chunk: Chunk<T, AnyChunkSet<BODY_SIZE>>,
     stamp: Stamp,
+    _validation: PhantomData<V>,
 }
 
-impl<const BODY_SIZE: usize> StampedChunk<BODY_SIZE> {
-    /// Pair a verified chunk with its stamp.
+impl<T: TrustState, const BODY_SIZE: usize> StampedChunk<T, Unvalidated, BODY_SIZE> {
+    /// Pair a chunk with the stamp that claims to pay for it.
     #[inline]
     #[must_use]
-    pub const fn new(chunk: Chunk<Verified, AnyChunkSet<BODY_SIZE>>, stamp: Stamp) -> Self {
-        Self { chunk, stamp }
+    pub const fn new(chunk: Chunk<T, AnyChunkSet<BODY_SIZE>>, stamp: Stamp) -> Self {
+        Self {
+            chunk,
+            stamp,
+            _validation: PhantomData,
+        }
     }
 
-    /// The verified chunk.
-    #[inline]
-    #[must_use]
-    pub const fn chunk(&self) -> &Chunk<Verified, AnyChunkSet<BODY_SIZE>> {
-        &self.chunk
-    }
-
-    /// The postage stamp.
-    #[inline]
-    #[must_use]
-    pub const fn stamp(&self) -> &Stamp {
-        &self.stamp
-    }
-
-    /// The chunk's certified address: a stored fact, free to read.
-    #[inline]
-    #[must_use]
-    pub const fn address(&self) -> &ChunkAddress {
-        self.chunk.address()
-    }
-
-    /// Split into the verified chunk and its stamp.
-    #[inline]
-    #[must_use]
-    pub fn into_parts(self) -> (Chunk<Verified, AnyChunkSet<BODY_SIZE>>, Stamp) {
-        (self.chunk, self.stamp)
-    }
-
-    /// Encode to a self-describing byte string: the stamp followed by the
-    /// type-tagged chunk.
+    /// Certify the stamp against `batch` and the chunk's own address.
     ///
-    /// The layout is `[stamp: STAMP_SIZE][id: 1][version: 1][chunk wire
-    /// bytes]`, the stamp's fixed-size encoding ([`Stamp::to_bytes`],
-    /// `STAMP_SIZE = 113` bytes) followed by the chunk's registry typed
-    /// encoding. Decode with [`from_typed_bytes`](Self::from_typed_bytes).
-    #[must_use]
-    pub fn to_typed_bytes(&self) -> Vec<u8> {
-        let stamp = self.stamp.to_bytes();
-        let chunk = self.chunk.typed_bytes();
-        let mut out = Vec::with_capacity(stamp.len().saturating_add(chunk.len()));
-        out.extend_from_slice(&stamp);
-        out.extend_from_slice(&chunk);
-        out
+    /// At [`Unverified`] that address is the claim the wire carried, which is
+    /// what the owner signed over, so an unpaid body is refused before it is
+    /// hashed.
+    ///
+    /// # Errors
+    ///
+    /// Whatever [`StampedAddress::validate`] refuses the pairing with.
+    pub fn validate<S: SwarmSpec>(
+        self,
+        batch: &Batch<S>,
+    ) -> Result<StampedChunk<T, Validated, BODY_SIZE>, StampError> {
+        let address = *self.chunk.address_in_state();
+        let (_, stamp) = StampedAddress::new(address, self.stamp)
+            .validate(batch)?
+            .into_parts();
+        Ok(StampedChunk {
+            chunk: self.chunk,
+            stamp,
+            _validation: PhantomData,
+        })
     }
+}
 
-    /// Decode a stamped chunk produced by [`to_typed_bytes`](Self::to_typed_bytes).
+impl<const BODY_SIZE: usize> StampedChunk<Unverified, Unvalidated, BODY_SIZE> {
+    /// Decode a stamped chunk produced by
+    /// [`to_typed_bytes`](Self::to_typed_bytes) without blessing either half.
     ///
     /// The first `STAMP_SIZE` bytes are the stamp ([`Stamp::from_bytes`]); the
-    /// remainder is the type-tagged chunk, parsed under `address` as a claim
-    /// and then verified, so the result holds a certified address.
+    /// remainder is the type-tagged chunk, parsed under `address` as a claim.
     ///
     /// # Errors
     ///
     /// Returns an error (and never panics) when the input is shorter than a
-    /// stamp, the stamp bytes are invalid, the chunk payload cannot be parsed,
-    /// or the chunk fails verification against `address`.
-    pub fn from_typed_bytes(address: &ChunkAddress, bytes: &[u8]) -> Result<Self, StampError> {
+    /// stamp, the stamp bytes are invalid, or the chunk payload cannot be
+    /// parsed.
+    pub fn parse(address: &ChunkAddress, bytes: &[u8]) -> Result<Self, StampError> {
         let mut cur = Cursor::new(bytes);
         let stamp = cur.take::<Stamp>()?;
         let chunk = Chunk::<Unverified, AnyChunkSet<BODY_SIZE>>::parse(*address, cur.finish())
-            .map_err(|_| StampError::Chunk("failed to parse typed chunk"))?
-            .verify()
-            .map_err(|_| StampError::Chunk("chunk does not verify at the claimed address"))?;
+            .map_err(|_| StampError::Chunk("failed to parse typed chunk"))?;
         Ok(Self::new(chunk, stamp))
     }
+}
 
+impl<const BODY_SIZE: usize> StampedChunk<Verified, Unvalidated, BODY_SIZE> {
     /// Rebuild a stamped chunk from the bare chunk wire bytes, its expected
     /// address, and a separately-carried stamp.
     ///
     /// `data` is the bare chunk wire bytes (no type tag), as carried in a
     /// `Delivery { data, stamp }` wire message. Bare wire bytes carry no tag,
     /// so the address routes the decode and certification is inseparable from
-    /// it: the result holds a verified chunk at `expected`.
+    /// it.
     ///
     /// # Errors
     ///
@@ -131,13 +138,65 @@ impl<const BODY_SIZE: usize> StampedChunk<BODY_SIZE> {
             .map_err(|_| StampError::Chunk("chunk bytes do not match expected address"))?;
         Ok(Self::new(chunk, stamp))
     }
+}
+
+impl<V: ValidationState, const BODY_SIZE: usize> StampedChunk<Unverified, V, BODY_SIZE> {
+    /// Certify the claimed address by the chunk member's acceptance rule.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error (and never panics) when the body does not hash to the
+    /// claimed address.
+    pub fn verify(self) -> Result<StampedChunk<Verified, V, BODY_SIZE>, StampError> {
+        let chunk = self
+            .chunk
+            .verify()
+            .map_err(|_| StampError::Chunk("chunk does not verify at the claimed address"))?;
+        Ok(StampedChunk {
+            chunk,
+            stamp: self.stamp,
+            _validation: PhantomData,
+        })
+    }
+}
+
+impl<T: TrustState, V: ValidationState, const BODY_SIZE: usize> StampedChunk<T, V, BODY_SIZE> {
+    /// The chunk.
+    #[inline]
+    #[must_use]
+    pub const fn chunk(&self) -> &Chunk<T, AnyChunkSet<BODY_SIZE>> {
+        &self.chunk
+    }
+
+    /// The postage stamp.
+    #[inline]
+    #[must_use]
+    pub const fn stamp(&self) -> &Stamp {
+        &self.stamp
+    }
+
+    /// The stamp with the address it is bound to, without the body.
+    ///
+    /// `V` transfers because the only route to [`Validated`] is
+    /// [`validate`](StampedChunk::validate), which used this same address.
+    #[inline]
+    #[must_use]
+    pub fn detach(&self) -> StampedAddress<V> {
+        StampedAddress::from_parts(*self.chunk.address_in_state(), self.stamp.clone())
+    }
+
+    /// Split into the chunk and its stamp.
+    #[inline]
+    #[must_use]
+    pub fn into_parts(self) -> (Chunk<T, AnyChunkSet<BODY_SIZE>>, Stamp) {
+        (self.chunk, self.stamp)
+    }
 
     /// Read the batch id from a [`to_typed_bytes`](Self::to_typed_bytes) value
     /// without a full decode.
     ///
     /// The stamp leads the encoding and the batch id is the stamp's first wire
-    /// field, so a cursor over the typed bytes yields it directly. This lets a
-    /// store index a stamped chunk by batch without decoding the chunk.
+    /// field, so a store can index by batch without decoding the chunk.
     ///
     /// # Errors
     ///
@@ -148,21 +207,75 @@ impl<const BODY_SIZE: usize> StampedChunk<BODY_SIZE> {
     }
 }
 
-impl<const BODY_SIZE: usize> PartialEq for StampedChunk<BODY_SIZE> {
+impl<V: ValidationState, const BODY_SIZE: usize> StampedChunk<Verified, V, BODY_SIZE> {
+    /// The chunk's certified address: a stored fact, free to read.
+    #[inline]
+    #[must_use]
+    pub const fn address(&self) -> &ChunkAddress {
+        self.chunk.address()
+    }
+
+    /// Encode to a self-describing byte string: the stamp followed by the
+    /// type-tagged chunk.
+    ///
+    /// The layout is `[stamp: STAMP_SIZE][id: 1][version: 1][chunk wire
+    /// bytes]`. Decode with [`parse`](StampedChunk::parse).
+    #[must_use]
+    pub fn to_typed_bytes(&self) -> Vec<u8> {
+        let stamp = self.stamp.to_bytes();
+        let chunk = self.chunk.typed_bytes();
+        let mut out = Vec::with_capacity(stamp.len().saturating_add(chunk.len()));
+        out.extend_from_slice(&stamp);
+        out.extend_from_slice(&chunk);
+        out
+    }
+}
+
+impl<T: TrustState, V: ValidationState, const BODY_SIZE: usize> Clone
+    for StampedChunk<T, V, BODY_SIZE>
+{
+    fn clone(&self) -> Self {
+        Self {
+            chunk: self.chunk.clone(),
+            stamp: self.stamp.clone(),
+            _validation: PhantomData,
+        }
+    }
+}
+
+impl<T: TrustState, V: ValidationState, const BODY_SIZE: usize> PartialEq
+    for StampedChunk<T, V, BODY_SIZE>
+{
     fn eq(&self, other: &Self) -> bool {
         self.chunk == other.chunk && self.stamp == other.stamp
     }
 }
 
-impl<const BODY_SIZE: usize> Eq for StampedChunk<BODY_SIZE> {}
+impl<T: TrustState, V: ValidationState, const BODY_SIZE: usize> Eq
+    for StampedChunk<T, V, BODY_SIZE>
+{
+}
+
+impl<T: TrustState, V: ValidationState, const BODY_SIZE: usize> core::fmt::Debug
+    for StampedChunk<T, V, BODY_SIZE>
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("StampedChunk")
+            .field("trust", &T::NAME)
+            .field("validation", &V::NAME)
+            .field("chunk", &self.chunk)
+            .field("stamp", &self.stamp)
+            .finish()
+    }
+}
 
 #[cfg(any(test, feature = "arbitrary"))]
-impl<'a, const BODY_SIZE: usize> arbitrary::Arbitrary<'a> for StampedChunk<BODY_SIZE> {
+impl<'a, const BODY_SIZE: usize> arbitrary::Arbitrary<'a>
+    for StampedChunk<Verified, Unvalidated, BODY_SIZE>
+{
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        // The chunk half is valid by construction: the sealed verified type
-        // admits nothing less. The stamp is structurally valid but not signed
-        // over the chunk's address; use `crate::generators::signed_stamped_chunk`
-        // for a pairing whose stamp verifies.
+        // The stamp is structurally valid but signs nothing; use
+        // `crate::generators::signed_stamped_chunk` for one that validates.
         let envelope = nectar_primitives::generators::any_chunk::<BODY_SIZE>(u)?;
         let chunk =
             Chunk::from_envelope(envelope).map_err(|_| arbitrary::Error::IncorrectFormat)?;
@@ -174,14 +287,17 @@ impl<'a, const BODY_SIZE: usize> arbitrary::Arbitrary<'a> for StampedChunk<BODY_
 mod tests {
     use alloy_primitives::{B256, Signature};
     use alloy_signer_local::PrivateKeySigner;
+    use arbitrary::Unstructured;
     use nectar_primitives::{
         AnyChunk, ChunkOps, ContentChunk, SingleOwnerChunk, SocId, bytes::Bytes,
     };
 
     use super::*;
-    use crate::STAMP_SIZE;
+    use crate::{BucketDepth, STAMP_SIZE, generators};
 
-    type DefaultStampedChunk = StampedChunk<DEFAULT_BODY_SIZE>;
+    type Raw = StampedChunk<Unverified, Unvalidated>;
+    type Signed = StampedChunk<Verified, Unvalidated>;
+    type Sealed = StampedChunk<Verified, Validated>;
 
     fn test_stamp() -> Stamp {
         let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
@@ -206,12 +322,31 @@ mod tests {
         Chunk::from_envelope(chunk.into()).expect("locally built chunk certifies")
     }
 
+    /// A pair whose stamp really signs the chunk's address, with its batch.
+    fn signed(chunk: impl Into<AnyChunk<DEFAULT_BODY_SIZE>>) -> (Batch, Signed) {
+        let signer = PrivateKeySigner::from_slice(&[7u8; 32]).expect("valid signer");
+        let batch = Batch::new(
+            BatchId::ZERO,
+            1_000,
+            100,
+            signer.address(),
+            18,
+            BucketDepth::new(16).expect("valid bucket depth"),
+            true,
+        );
+        let chunk = verified(chunk);
+        let mut u = Unstructured::new(&[7u8; 32]);
+        let stamp = generators::signed_stamp(&mut u, &signer, &batch, chunk.address())
+            .expect("signed stamp");
+        (batch, StampedChunk::new(chunk, stamp))
+    }
+
     #[test]
     fn into_parts_round_trips_the_fields() {
         let chunk = verified(content_chunk());
         let address = *chunk.address();
         let stamp = test_stamp();
-        let stamped = DefaultStampedChunk::new(chunk, stamp.clone());
+        let stamped = Signed::new(chunk, stamp.clone());
         assert_eq!(stamped.address(), &address);
         let (got_chunk, got_stamp) = stamped.into_parts();
         assert_eq!(got_chunk.address(), &address);
@@ -223,33 +358,144 @@ mod tests {
         let chunk = content_chunk();
         let address = *chunk.address();
         let stamp = test_stamp();
-        let stamped = DefaultStampedChunk::new(verified(chunk), stamp.clone());
+        let stamped = Signed::new(verified(chunk), stamp.clone());
 
         let bytes = stamped.to_typed_bytes();
-        let decoded = DefaultStampedChunk::from_typed_bytes(&address, &bytes).expect("decode");
+        let decoded = Raw::parse(&address, &bytes).expect("decode");
 
-        assert!(decoded.chunk().envelope().is_content());
-        assert_eq!(*decoded.address(), address);
-        assert_eq!(decoded.stamp().batch(), stamp.batch());
-        assert_eq!(decoded.stamp().timestamp(), stamp.timestamp());
-        assert_eq!(decoded, stamped);
+        let stamp_of = decoded.stamp().clone();
+        assert!(
+            decoded
+                .verify()
+                .expect("verifies")
+                .chunk()
+                .envelope()
+                .is_content()
+        );
+        assert_eq!(stamp_of, stamp);
+    }
+
+    /// The 113-byte stamp leads the encoding and the chunk follows unchanged.
+    #[test]
+    fn typed_encoding_is_the_stamp_then_the_chunk() {
+        let chunk = verified(content_chunk());
+        let typed = chunk.typed_bytes();
+        let stamp = test_stamp();
+        let bytes = Signed::new(chunk, stamp.clone()).to_typed_bytes();
+
+        assert_eq!(bytes.len(), STAMP_SIZE + typed.len());
+        assert_eq!(&bytes[..STAMP_SIZE], stamp.to_bytes().as_slice());
+        assert_eq!(&bytes[STAMP_SIZE..], typed.as_slice());
     }
 
     #[test]
     fn typed_single_owner_round_trip() {
         let chunk = single_owner_chunk();
         let address = *chunk.address();
-        let stamp = test_stamp();
-        let stamped = DefaultStampedChunk::new(verified(chunk), stamp.clone());
+        let stamped = Signed::new(verified(chunk), test_stamp());
 
         let bytes = stamped.to_typed_bytes();
-        let decoded = DefaultStampedChunk::from_typed_bytes(&address, &bytes).expect("decode");
+        let decoded = Raw::parse(&address, &bytes)
+            .expect("decode")
+            .verify()
+            .expect("verifies");
 
         assert!(decoded.chunk().envelope().is_single_owner());
-        assert_eq!(*decoded.address(), address);
-        assert_eq!(decoded.stamp().batch(), stamp.batch());
-        assert_eq!(decoded.stamp().timestamp(), stamp.timestamp());
         assert_eq!(decoded, stamped);
+    }
+
+    /// Both orders reach the same sealed pair, and neither skips a check.
+    #[test]
+    fn the_two_transition_orders_agree() {
+        let (batch, pair) = signed(content_chunk());
+        let address = *pair.address();
+        let bytes = pair.to_typed_bytes();
+
+        let ingest: Sealed = Raw::parse(&address, &bytes)
+            .expect("parse")
+            .validate(&batch)
+            .expect("stamp pays for the claimed address")
+            .verify()
+            .expect("body hashes to the claim");
+        let producer: Sealed = Raw::parse(&address, &bytes)
+            .expect("parse")
+            .verify()
+            .expect("body hashes to the claim")
+            .validate(&batch)
+            .expect("stamp pays for the certified address");
+
+        assert_eq!(ingest, producer);
+        assert_eq!(ingest.to_typed_bytes(), bytes);
+    }
+
+    /// The producer path is verified already and only needs validation.
+    #[test]
+    fn a_verified_pair_validates_without_a_decode() {
+        let (batch, pair) = signed(content_chunk());
+        assert!(pair.validate(&batch).is_ok());
+    }
+
+    /// Parse blesses neither half: a lying claim survives it and dies at
+    /// verify.
+    #[test]
+    fn parse_certifies_nothing() {
+        let stamped = Signed::new(verified(content_chunk()), test_stamp());
+        let bytes = stamped.to_typed_bytes();
+        let wrong: ChunkAddress = [0xFFu8; 32].into();
+
+        let raw = Raw::parse(&wrong, &bytes).expect("parse takes the claim as given");
+        assert_eq!(raw.detach().address(), &wrong);
+        assert!(matches!(raw.verify(), Err(StampError::Chunk(_))));
+    }
+
+    /// The anti-denial-of-service order: an unpaid body is refused before it
+    /// is hashed.
+    #[test]
+    fn validate_refuses_an_unverified_pair_on_a_foreign_batch() {
+        let (batch, pair) = signed(content_chunk());
+        let address = *pair.address();
+        let bytes = pair.to_typed_bytes();
+        let elsewhere: Batch = Batch::new(
+            BatchId::from([1u8; 32]),
+            1_000,
+            100,
+            batch.owner(),
+            18,
+            BucketDepth::new(16).expect("valid bucket depth"),
+            true,
+        );
+
+        let raw = Raw::parse(&address, &bytes).expect("parse");
+        assert!(matches!(
+            raw.validate(&elsewhere),
+            Err(StampError::BatchMismatch { .. })
+        ));
+    }
+
+    /// Validation binds the stamp to the address, not to the body, so a
+    /// re-paired stamp cannot borrow another chunk's proof.
+    #[test]
+    fn validate_refuses_a_re_paired_stamp() {
+        let (batch, pair) = signed(content_chunk());
+        let (_, stamp) = pair.into_parts();
+
+        let elsewhere = Signed::new(verified(single_owner_chunk()), stamp);
+        assert!(elsewhere.validate(&batch).is_err());
+    }
+
+    #[test]
+    fn detach_projects_the_pair_in_either_state() {
+        let (batch, pair) = signed(content_chunk());
+        let address = *pair.address();
+        let stamp = pair.stamp().clone();
+
+        let raw = pair.detach();
+        assert_eq!(raw.address(), &address);
+        assert_eq!(raw.stamp(), &stamp);
+
+        let sealed = pair.validate(&batch).expect("validates").detach();
+        assert_eq!(sealed.address(), &address);
+        assert_eq!(sealed.stamp(), &stamp);
     }
 
     #[test]
@@ -259,8 +505,8 @@ mod tests {
         let data = Bytes::from(chunk);
         let stamp = test_stamp();
 
-        let rebuilt = DefaultStampedChunk::reconstruct(address, data.clone(), stamp.clone())
-            .expect("rebuild");
+        let rebuilt =
+            Signed::reconstruct(address, data.clone(), stamp.clone()).expect("rebuild");
         assert!(rebuilt.chunk().envelope().is_content());
         assert_eq!(*rebuilt.address(), address);
         assert_eq!(rebuilt.stamp(), &stamp);
@@ -274,8 +520,7 @@ mod tests {
         let data = Bytes::from(chunk);
         let stamp = test_stamp();
 
-        let rebuilt =
-            DefaultStampedChunk::reconstruct(address, data, stamp.clone()).expect("rebuild");
+        let rebuilt = Signed::reconstruct(address, data, stamp.clone()).expect("rebuild");
         assert!(rebuilt.chunk().envelope().is_single_owner());
         assert_eq!(*rebuilt.address(), address);
         assert_eq!(rebuilt.stamp(), &stamp);
@@ -284,56 +529,52 @@ mod tests {
     #[test]
     fn equality_compares_address_and_stamp() {
         let stamp = test_stamp();
-        let a = DefaultStampedChunk::new(verified(content_chunk()), stamp.clone());
-        let b = DefaultStampedChunk::new(verified(content_chunk()), stamp.clone());
+        let a = Signed::new(verified(content_chunk()), stamp.clone());
+        let b = Signed::new(verified(content_chunk()), stamp.clone());
         assert_eq!(a, b);
 
         let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
         let other_stamp = Stamp::new(BatchId::new([0xbb; 32]), 3, 7, 42, sig);
-        let c = DefaultStampedChunk::new(verified(content_chunk()), other_stamp);
+        let c = Signed::new(verified(content_chunk()), other_stamp);
         assert_ne!(a, c);
 
-        let d = DefaultStampedChunk::new(verified(single_owner_chunk()), stamp);
+        let d = Signed::new(verified(single_owner_chunk()), stamp);
         assert_ne!(a, d);
     }
 
     #[test]
+    fn debug_names_both_states() {
+        let (batch, pair) = signed(content_chunk());
+        let raw = format!("{pair:?}");
+        assert!(raw.contains("verified") && raw.contains("unvalidated"));
+
+        let sealed = format!("{:?}", pair.validate(&batch).expect("validates"));
+        assert!(sealed.contains("validated"));
+    }
+
+    #[test]
     fn batch_id_matches_stamp_and_leading_bytes() {
-        let chunk = content_chunk();
         let stamp = test_stamp();
-        let stamped = DefaultStampedChunk::new(verified(chunk), stamp.clone());
+        let stamped = Signed::new(verified(content_chunk()), stamp.clone());
         let bytes = stamped.to_typed_bytes();
 
-        let id = DefaultStampedChunk::batch_id(&bytes).expect("batch id");
+        let id = Sealed::batch_id(&bytes).expect("batch id");
         assert_eq!(id, stamp.batch());
         assert_eq!(id.as_slice(), &bytes[0..32]);
     }
 
     #[test]
-    fn from_typed_bytes_empty_errors() {
+    fn parse_empty_errors() {
         let address: ChunkAddress = [0u8; 32].into();
-        assert!(DefaultStampedChunk::from_typed_bytes(&address, &[]).is_err());
+        assert!(Raw::parse(&address, &[]).is_err());
     }
 
     #[test]
-    fn from_typed_bytes_shorter_than_stamp_errors() {
+    fn parse_shorter_than_stamp_errors() {
         let address: ChunkAddress = [0u8; 32].into();
         let short = [0u8; STAMP_SIZE - 1];
-        let err = DefaultStampedChunk::from_typed_bytes(&address, &short)
-            .expect_err("short input must error");
+        let err = Raw::parse(&address, &short).expect_err("short input must error");
         assert!(matches!(err, StampError::Underrun { .. }));
-    }
-
-    #[test]
-    fn from_typed_bytes_address_mismatch_errors() {
-        let chunk = content_chunk();
-        let stamped = DefaultStampedChunk::new(verified(chunk), test_stamp());
-        let bytes = stamped.to_typed_bytes();
-
-        let wrong: ChunkAddress = [0xFFu8; 32].into();
-        let err = DefaultStampedChunk::from_typed_bytes(&wrong, &bytes)
-            .expect_err("address mismatch must error");
-        assert!(matches!(err, StampError::Chunk(_)));
     }
 
     #[test]
@@ -341,14 +582,14 @@ mod tests {
         let chunk = content_chunk();
         let data = Bytes::from(chunk);
         let wrong: ChunkAddress = [0xFFu8; 32].into();
-        let err = DefaultStampedChunk::reconstruct(wrong, data, test_stamp())
-            .expect_err("wrong address must error");
+        let err =
+            Signed::reconstruct(wrong, data, test_stamp()).expect_err("wrong address must error");
         assert!(matches!(err, StampError::Chunk(_)));
     }
 
     #[test]
     fn batch_id_short_errors() {
         let short = [0u8; 31];
-        assert!(DefaultStampedChunk::batch_id(&short).is_err());
+        assert!(Sealed::batch_id(&short).is_err());
     }
 }

--- a/crates/postage/src/stamped.rs
+++ b/crates/postage/src/stamped.rs
@@ -1,9 +1,6 @@
 //! A chunk paired with the postage stamp that authorizes its storage.
 //!
-//! The two transitions commute and both orders are load-bearing: ingest
-//! validates before it verifies, so an unpaid body never pays for its own
-//! hashing, and the producer path is verified already and only needs
-//! validation.
+//! `verify` and `validate` commute, so either order reaches the same pair.
 
 use alloc::vec::Vec;
 use core::marker::PhantomData;
@@ -70,11 +67,8 @@ impl<T: TrustState, const BODY_SIZE: usize> StampedChunk<T, Unvalidated, BODY_SI
         }
     }
 
-    /// Certify the stamp against `batch` and the chunk's own address.
-    ///
-    /// At [`Unverified`] that address is the claim the wire carried, which is
-    /// what the owner signed over, so an unpaid body is refused before it is
-    /// hashed.
+    /// Certify the stamp against `batch` and the chunk's own address, which at
+    /// [`Unverified`] is the claim the wire carried.
     ///
     /// # Errors
     ///
@@ -177,8 +171,8 @@ impl<T: TrustState, V: ValidationState, const BODY_SIZE: usize> StampedChunk<T, 
 
     /// The stamp with the address it is bound to, without the body.
     ///
-    /// `V` transfers because the only route to [`Validated`] is
-    /// [`validate`](StampedChunk::validate), which used this same address.
+    /// `V` transfers: the only route to [`Validated`] is
+    /// [`validate`](StampedChunk::validate), over this same address.
     #[inline]
     #[must_use]
     pub fn detach(&self) -> StampedAddress<V> {
@@ -293,7 +287,7 @@ mod tests {
     };
 
     use super::*;
-    use crate::{BucketDepth, STAMP_SIZE, generators};
+    use crate::{STAMP_SIZE, generators};
 
     type Raw = StampedChunk<Unverified, Unvalidated>;
     type Signed = StampedChunk<Verified, Unvalidated>;
@@ -324,20 +318,10 @@ mod tests {
 
     /// A pair whose stamp really signs the chunk's address, with its batch.
     fn signed(chunk: impl Into<AnyChunk<DEFAULT_BODY_SIZE>>) -> (Batch, Signed) {
-        let signer = PrivateKeySigner::from_slice(&[7u8; 32]).expect("valid signer");
-        let batch = Batch::new(
-            BatchId::ZERO,
-            1_000,
-            100,
-            signer.address(),
-            18,
-            BucketDepth::new(16).expect("valid bucket depth"),
-            true,
-        );
         let chunk = verified(chunk);
-        let mut u = Unstructured::new(&[7u8; 32]);
-        let stamp = generators::signed_stamp(&mut u, &signer, &batch, chunk.address())
-            .expect("signed stamp");
+        let mut u = Unstructured::new(&[7u8; 128]);
+        let (batch, stamp) =
+            generators::batch_and_stamp(&mut u, chunk.address()).expect("coherent stamp");
         (batch, StampedChunk::new(chunk, stamp))
     }
 
@@ -404,7 +388,6 @@ mod tests {
         assert_eq!(decoded, stamped);
     }
 
-    /// Both orders reach the same sealed pair, and neither skips a check.
     #[test]
     fn the_two_transition_orders_agree() {
         let (batch, pair) = signed(content_chunk());
@@ -428,15 +411,13 @@ mod tests {
         assert_eq!(ingest.to_typed_bytes(), bytes);
     }
 
-    /// The producer path is verified already and only needs validation.
     #[test]
     fn a_verified_pair_validates_without_a_decode() {
         let (batch, pair) = signed(content_chunk());
         assert!(pair.validate(&batch).is_ok());
     }
 
-    /// Parse blesses neither half: a lying claim survives it and dies at
-    /// verify.
+    /// A lying claim survives parse and dies at verify.
     #[test]
     fn parse_certifies_nothing() {
         let stamped = Signed::new(verified(content_chunk()), test_stamp());
@@ -448,21 +429,24 @@ mod tests {
         assert!(matches!(raw.verify(), Err(StampError::Chunk(_))));
     }
 
-    /// The anti-denial-of-service order: an unpaid body is refused before it
-    /// is hashed.
+    /// The ingest order refuses an unpaid body before it is hashed.
     #[test]
     fn validate_refuses_an_unverified_pair_on_a_foreign_batch() {
         let (batch, pair) = signed(content_chunk());
         let address = *pair.address();
         let bytes = pair.to_typed_bytes();
+        // Same geometry and owner, so only the id can refuse it.
+        let mut id = [0u8; 32];
+        id.copy_from_slice(batch.id().as_slice());
+        id[0] ^= 0xFF;
         let elsewhere: Batch = Batch::new(
-            BatchId::from([1u8; 32]),
-            1_000,
-            100,
+            BatchId::new(id),
+            batch.value(),
+            batch.start(),
             batch.owner(),
-            18,
-            BucketDepth::new(16).expect("valid bucket depth"),
-            true,
+            batch.depth(),
+            batch.bucket_depth(),
+            batch.immutable(),
         );
 
         let raw = Raw::parse(&address, &bytes).expect("parse");
@@ -472,8 +456,6 @@ mod tests {
         ));
     }
 
-    /// Validation binds the stamp to the address, not to the body, so a
-    /// re-paired stamp cannot borrow another chunk's proof.
     #[test]
     fn validate_refuses_a_re_paired_stamp() {
         let (batch, pair) = signed(content_chunk());
@@ -483,17 +465,18 @@ mod tests {
         assert!(elsewhere.validate(&batch).is_err());
     }
 
+    /// The annotations are the assertion: `detach` carries `V` across.
     #[test]
     fn detach_projects_the_pair_in_either_state() {
         let (batch, pair) = signed(content_chunk());
         let address = *pair.address();
         let stamp = pair.stamp().clone();
 
-        let raw = pair.detach();
+        let raw: StampedAddress<Unvalidated> = pair.detach();
         assert_eq!(raw.address(), &address);
         assert_eq!(raw.stamp(), &stamp);
 
-        let sealed = pair.validate(&batch).expect("validates").detach();
+        let sealed: StampedAddress<Validated> = pair.validate(&batch).expect("validates").detach();
         assert_eq!(sealed.address(), &address);
         assert_eq!(sealed.stamp(), &stamp);
     }

--- a/crates/postage/src/stamped.rs
+++ b/crates/postage/src/stamped.rs
@@ -488,8 +488,7 @@ mod tests {
         let data = Bytes::from(chunk);
         let stamp = test_stamp();
 
-        let rebuilt =
-            Signed::reconstruct(address, data.clone(), stamp.clone()).expect("rebuild");
+        let rebuilt = Signed::reconstruct(address, data.clone(), stamp.clone()).expect("rebuild");
         assert!(rebuilt.chunk().envelope().is_content());
         assert_eq!(*rebuilt.address(), address);
         assert_eq!(rebuilt.stamp(), &stamp);

--- a/crates/postage/src/stamped_address.rs
+++ b/crates/postage/src/stamped_address.rs
@@ -63,19 +63,6 @@ pub struct StampedAddress<V: ValidationState = Validated> {
     _validation: PhantomData<V>,
 }
 
-impl<V: ValidationState> StampedAddress<V> {
-    /// Sound only where a transition over this same address justifies `V`.
-    #[inline]
-    #[must_use]
-    pub(crate) const fn from_parts(address: ChunkAddress, stamp: Stamp) -> Self {
-        Self {
-            address,
-            stamp,
-            _validation: PhantomData,
-        }
-    }
-}
-
 impl StampedAddress<Unvalidated> {
     /// Pair a stamp with the address it claims to pay for.
     #[inline]
@@ -117,6 +104,17 @@ impl StampedAddress<Unvalidated> {
 }
 
 impl<V: ValidationState> StampedAddress<V> {
+    /// Sound only where a transition over this same address justifies `V`.
+    #[inline]
+    #[must_use]
+    pub(crate) const fn from_parts(address: ChunkAddress, stamp: Stamp) -> Self {
+        Self {
+            address,
+            stamp,
+            _validation: PhantomData,
+        }
+    }
+
     /// The address the stamp is bound to.
     #[inline]
     #[must_use]

--- a/crates/postage/src/stamped_address.rs
+++ b/crates/postage/src/stamped_address.rs
@@ -63,16 +63,25 @@ pub struct StampedAddress<V: ValidationState = Validated> {
     _validation: PhantomData<V>,
 }
 
-impl StampedAddress<Unvalidated> {
-    /// Pair a stamp with the address it claims to pay for.
+impl<V: ValidationState> StampedAddress<V> {
+    /// Sound only where a transition over this same address justifies `V`.
     #[inline]
     #[must_use]
-    pub const fn new(address: ChunkAddress, stamp: Stamp) -> Self {
+    pub(crate) const fn from_parts(address: ChunkAddress, stamp: Stamp) -> Self {
         Self {
             address,
             stamp,
             _validation: PhantomData,
         }
+    }
+}
+
+impl StampedAddress<Unvalidated> {
+    /// Pair a stamp with the address it claims to pay for.
+    #[inline]
+    #[must_use]
+    pub const fn new(address: ChunkAddress, stamp: Stamp) -> Self {
+        Self::from_parts(address, stamp)
     }
 
     /// Certify the pairing against `batch`: the stamp names this batch, its
@@ -103,11 +112,7 @@ impl StampedAddress<Unvalidated> {
         batch.validate_bucket(&index, &self.address)?;
         self.stamp.verify(&self.address, batch.owner())?;
 
-        Ok(StampedAddress {
-            address: self.address,
-            stamp: self.stamp,
-            _validation: PhantomData,
-        })
+        Ok(StampedAddress::from_parts(self.address, self.stamp))
     }
 }
 

--- a/crates/primitives-core/src/chunk/trust.rs
+++ b/crates/primitives-core/src/chunk/trust.rs
@@ -121,6 +121,16 @@ where
 
 impl<S: TrustState, R: ChunkRegistry> Eq for Chunk<S, R> where R::Envelope: Eq {}
 
+impl<S: TrustState, R: ChunkRegistry> Chunk<S, R> {
+    /// The address as `S` qualifies it: a fact under [`Verified`], a claim
+    /// under [`Unverified`]. For state-generic carriers only.
+    #[inline]
+    #[must_use]
+    pub const fn address_in_state(&self) -> &ChunkAddress {
+        &self.address
+    }
+}
+
 impl<R: ChunkRegistry> Chunk<Unverified, R> {
     /// Structurally parse the registry's typed (store) encoding under a
     /// claimed address.
@@ -389,6 +399,17 @@ mod tests {
         assert_eq!(verified.address(), &claimed);
         assert_eq!(verified.typed_bytes(), typed);
         assert_eq!(verified.owner(), None, "a content chunk binds no owner");
+    }
+
+    #[test]
+    fn address_in_state_reads_both_states() {
+        let content = DefaultContentChunk::new(&b"either state"[..]).unwrap();
+        let claimed = *content.address();
+        let typed = StandardChunkSet::encode_typed(&content.into());
+
+        let unverified = Chunk::<Unverified>::parse(claimed, &typed).unwrap();
+        assert_eq!(unverified.address_in_state(), &claimed);
+        assert_eq!(unverified.verify().unwrap().address_in_state(), &claimed);
     }
 
     #[test]


### PR DESCRIPTION
Closes #768

## What

Puts trust and validation state on `StampedChunk` as typestate generics, and adds a state-generic address accessor to `Chunk`.

- `crates/primitives-core/src/chunk/trust.rs`: `Chunk<S, R>` gains `address_in_state()`, a state-generic accessor that reads the address regardless of trust state. `claimed_address` and `address` stay pinned to their single states, so nothing existing is loosened.
- `crates/postage/src/stamped.rs`: `StampedChunk` becomes `StampedChunk<T: TrustState = Verified, V: ValidationState = Validated, const BODY_SIZE: usize = DEFAULT_BODY_SIZE>`, holding the chunk, the unchanged `Stamp`, and a `PhantomData<V>`. The parameter order is states first, matching `Chunk<S: TrustState, R>`, with defaults set to the safe states (`Verified`, `Validated`). `new` is only available at `Unvalidated`, so a validated pair cannot be fabricated directly; `validate` is the sole route from `Unvalidated` to `Validated` and certifies the stamp against a `Batch` and the chunk's own address.
- `crates/postage/src/sink.rs`: the sink traits are updated for the new generic shape.
- `crates/postage/src/generators.rs`: adds `batch_and_stamp`, factored out of `signed_stamped_chunk`, and updates the property test to also assert `stamped.validate(&batch).is_ok()`.
- `crates/postage/src/stamped_address.rs`, `crates/postage/src/lib.rs`: supporting type/doc updates for the new state parameters.
- `crates/postage-issuer/src/pipeline/stamped_put.rs`: `PutStamped` is now parametrised by validation state (`PutStamped<Unvalidated>`), since the decorator mints the stamp rather than checking it, so the pair it forwards carries no validation proof. Test sinks updated accordingly.

## Why

A state-generic carrier needs the chunk's address before the trust axis is settled, but `claimed_address`/`address` are each pinned to one state. `address_in_state()` fills that gap without loosening either existing accessor.

Putting trust and validation state directly on `StampedChunk` makes both axes visible in the type, so a validated, verified pair is unrepresentable except through the one function (`validate`) that actually checks it. This closes the previous gap where a `StampedChunk` carried a stamp with no compile-time record of whether it had been validated.

## Testing

- `cargo fmt --all --check`
- Correctness of the typestate was verified by exhausting the routes to `StampedChunk<_, Validated, _>`: `validate` is the only mint and reads the pair's own address; `verify` preserves `V`; `Chunk::verify` never rewrites `address`; `Clone` is state-preserving.
- New unit test `address_in_state_reads_both_states` in `crates/primitives-core/src/chunk/trust.rs`.
- `crates/postage/src/generators.rs` property test extended to assert `stamped.validate(&batch).is_ok()`.

AI Assistance: implement claude-opus-5, red-team claude-opus-5, PR claude-sonnet-5.
