### PR TITLE
refactor(primitives,postage)!: make ChunkPut generic over its put unit

### DIFF
--- a/crates/feeds/src/publisher.rs
+++ b/crates/feeds/src/publisher.rs
@@ -62,7 +62,7 @@ impl<S, Sig, const BODY_SIZE: usize> Publisher<S, Sig, BODY_SIZE> {
 
 impl<S, Sig, const BODY_SIZE: usize> Publisher<S, Sig, BODY_SIZE>
 where
-    S: ChunkPut<SingleOwnerOnlyChunkSet<BODY_SIZE>>,
+    S: ChunkPut<Chunk<Verified, SingleOwnerOnlyChunkSet<BODY_SIZE>>>,
     Sig: SignerSync,
 {
     /// Sign and publish `payload` at the next sequence position, advancing

--- a/crates/file/benches/latency_bench.rs
+++ b/crates/file/benches/latency_bench.rs
@@ -90,7 +90,7 @@ impl<const B: usize> ChunkGet<AnyChunkSet<B>> for LatencyStore<B> {
     }
 }
 
-impl<const B: usize> ChunkPut<AnyChunkSet<B>> for LatencyStore<B> {
+impl<const B: usize> ChunkPut<Chunk<Verified, AnyChunkSet<B>>> for LatencyStore<B> {
     type Error = ChunkStoreError;
 
     async fn put(&self, chunk: Chunk<Verified, AnyChunkSet<B>>) -> Result<(), ChunkStoreError> {

--- a/crates/file/src/handle.rs
+++ b/crates/file/src/handle.rs
@@ -39,7 +39,7 @@ use core::time::Duration;
 
 use bytes::Bytes;
 use futures_util::stream::Stream;
-use nectar_primitives::chunk::{AnyChunkSet, ChunkAddress, ContentOnlyChunkSet};
+use nectar_primitives::chunk::{AnyChunkSet, Chunk, ChunkAddress, ContentOnlyChunkSet, Verified};
 use nectar_primitives::store::{ChunkPut, TrustedGet};
 use nectar_primitives::{DEFAULT_BODY_SIZE, EntryRef};
 
@@ -387,7 +387,7 @@ where
 
 impl<S, const B: usize> File<S, B>
 where
-    S: ChunkPut<AnyChunkSet<B>>,
+    S: ChunkPut<Chunk<Verified, AnyChunkSet<B>>>,
 {
     /// Split `src` into a plain chunk tree, returning its root address.
     ///

--- a/crates/file/src/handle/tests.rs
+++ b/crates/file/src/handle/tests.rs
@@ -26,7 +26,7 @@ async fn split_read_at<R, S, M, const B: usize>(
 ) -> Result<M::Root, SaveError<S::Error, ReadAtError>>
 where
     R: ReadAt,
-    S: ChunkPut<AnyChunkSet<B>>,
+    S: ChunkPut<Chunk<Verified, AnyChunkSet<B>>>,
     M: SplitMode + Default,
 {
     File::<S, B>::new(store, Policy::DEFAULT.with_put_window(window))
@@ -42,7 +42,7 @@ async fn split_slice<S, M, const B: usize>(
     window: PutWindow,
 ) -> Result<M::Root, SaveError<S::Error, core::convert::Infallible>>
 where
-    S: ChunkPut<AnyChunkSet<B>>,
+    S: ChunkPut<Chunk<Verified, AnyChunkSet<B>>>,
     M: SplitMode + Default,
 {
     File::<S, B>::new(store, Policy::DEFAULT.with_put_window(window))
@@ -105,7 +105,7 @@ impl<const B: usize> TestStore<B> {
     }
 }
 
-impl<const B: usize> ChunkPut<AnyChunkSet<B>> for TestStore<B> {
+impl<const B: usize> ChunkPut<Chunk<Verified, AnyChunkSet<B>>> for TestStore<B> {
     type Error = ChunkStoreError;
 
     async fn put(&self, chunk: Chunk<Verified, AnyChunkSet<B>>) -> Result<(), ChunkStoreError> {

--- a/crates/file/src/split/engine.rs
+++ b/crates/file/src/split/engine.rs
@@ -108,7 +108,7 @@ enum Phase {
 /// admission invariants.
 pub struct Split<'a, S, M, const B: usize = DEFAULT_BODY_SIZE>
 where
-    S: ChunkPut<AnyChunkSet<B>>,
+    S: ChunkPut<Chunk<Verified, AnyChunkSet<B>>>,
     M: SplitMode,
 {
     store: S,
@@ -134,7 +134,7 @@ where
 
 impl<'a, S, M, const B: usize> Split<'a, S, M, B>
 where
-    S: ChunkPut<AnyChunkSet<B>> + Clone + 'a,
+    S: ChunkPut<Chunk<Verified, AnyChunkSet<B>>> + Clone + 'a,
     M: SplitMode,
 {
     /// Compile-time profile guard for the split's span arithmetic.
@@ -660,7 +660,7 @@ where
 
 impl<S, M, const B: usize> fmt::Debug for Split<'_, S, M, B>
 where
-    S: ChunkPut<AnyChunkSet<B>>,
+    S: ChunkPut<Chunk<Verified, AnyChunkSet<B>>>,
     M: SplitMode,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/file/src/split/save.rs
+++ b/crates/file/src/split/save.rs
@@ -9,7 +9,7 @@ use core::future::poll_fn;
 
 use alloc::vec;
 
-use nectar_primitives::chunk::AnyChunkSet;
+use nectar_primitives::chunk::{AnyChunkSet, Chunk, Verified};
 use nectar_primitives::store::ChunkPut;
 
 use super::SplitStats;
@@ -39,7 +39,7 @@ pub(crate) async fn save_source<'a, T, M, Src, const B: usize>(
     mut src: Src,
 ) -> Result<(M::Root, SplitStats), SaveError<T::Error, Src::Error>>
 where
-    T: ChunkPut<AnyChunkSet<B>>,
+    T: ChunkPut<Chunk<Verified, AnyChunkSet<B>>>,
     M: SplitMode,
     Src: Source,
 {
@@ -75,7 +75,7 @@ pub(crate) async fn collect_into<T, M, const B: usize>(
     data: &[u8],
 ) -> Result<M::Root, SplitError<T::Error>>
 where
-    T: ChunkPut<AnyChunkSet<B>>,
+    T: ChunkPut<Chunk<Verified, AnyChunkSet<B>>>,
     M: SplitMode + Default,
 {
     let policy = Policy::DEFAULT.with_put_window(window);

--- a/crates/file/src/split/tests.rs
+++ b/crates/file/src/split/tests.rs
@@ -79,7 +79,7 @@ impl<const B: usize> TestStore<B> {
     }
 }
 
-impl<const B: usize> ChunkPut<AnyChunkSet<B>> for TestStore<B> {
+impl<const B: usize> ChunkPut<Chunk<Verified, AnyChunkSet<B>>> for TestStore<B> {
     type Error = ChunkStoreError;
 
     async fn put(&self, chunk: Chunk<Verified, AnyChunkSet<B>>) -> Result<(), ChunkStoreError> {
@@ -1202,7 +1202,7 @@ fn huge_stream_root_matches_the_batch_ingest() {
     #[derive(Clone)]
     struct Discard;
 
-    impl ChunkPut<AnyChunkSet<B>> for Discard {
+    impl ChunkPut<Chunk<Verified, AnyChunkSet<B>>> for Discard {
         type Error = std::convert::Infallible;
 
         async fn put(&self, _chunk: Chunk<Verified, AnyChunkSet<B>>) -> Result<(), Self::Error> {
@@ -1275,7 +1275,7 @@ mod borrowed {
         }
     }
 
-    impl<const B: usize> ChunkPut<AnyChunkSet<B>> for OverlapStore<B> {
+    impl<const B: usize> ChunkPut<Chunk<Verified, AnyChunkSet<B>>> for OverlapStore<B> {
         type Error = ChunkStoreError;
 
         async fn put(&self, _chunk: Chunk<Verified, AnyChunkSet<B>>) -> Result<(), Self::Error> {

--- a/crates/file/src/testutil.rs
+++ b/crates/file/src/testutil.rs
@@ -36,7 +36,7 @@ impl<S: Clone, P: Clone, const B: usize> Clone for FaultStore<S, P, B> {
 
 impl<S, P, const B: usize> FaultStore<S, P, B>
 where
-    S: ChunkPut<AnyChunkSet<B>>,
+    S: ChunkPut<Chunk<Verified, AnyChunkSet<B>>>,
     P: Fn(usize) -> Result<(), ChunkStoreError>,
 {
     /// Wrap `inner`, consulting `policy` against the running put index.
@@ -49,9 +49,9 @@ where
     }
 }
 
-impl<S, P, const B: usize> ChunkPut<AnyChunkSet<B>> for FaultStore<S, P, B>
+impl<S, P, const B: usize> ChunkPut<Chunk<Verified, AnyChunkSet<B>>> for FaultStore<S, P, B>
 where
-    S: ChunkPut<AnyChunkSet<B>>,
+    S: ChunkPut<Chunk<Verified, AnyChunkSet<B>>>,
     P: Fn(usize) -> Result<(), ChunkStoreError> + MaybeSend + MaybeSync,
 {
     type Error = ChunkStoreError;
@@ -73,7 +73,7 @@ pub(crate) fn failing_at<S, const B: usize>(
     n: usize,
 ) -> FaultStore<S, impl Fn(usize) -> Result<(), ChunkStoreError> + Clone, B>
 where
-    S: ChunkPut<AnyChunkSet<B>>,
+    S: ChunkPut<Chunk<Verified, AnyChunkSet<B>>>,
 {
     FaultStore::new(inner, move |index| {
         if index >= n {
@@ -89,7 +89,7 @@ pub(crate) fn reject_all<S, const B: usize>(
     inner: S,
 ) -> FaultStore<S, impl Fn(usize) -> Result<(), ChunkStoreError> + Clone, B>
 where
-    S: ChunkPut<AnyChunkSet<B>>,
+    S: ChunkPut<Chunk<Verified, AnyChunkSet<B>>>,
 {
     failing_at(inner, 0)
 }

--- a/crates/file/src/tokio/tests.rs
+++ b/crates/file/src/tokio/tests.rs
@@ -177,7 +177,7 @@ async fn walk_failures_surface_as_io_errors() {
 #[derive(Clone, Default)]
 struct SharedStore(Arc<MemoryStore<AnyChunkSet<TINY>>>);
 
-impl ChunkPut<AnyChunkSet<TINY>> for SharedStore {
+impl ChunkPut<Chunk<Verified, AnyChunkSet<TINY>>> for SharedStore {
     type Error = std::convert::Infallible;
 
     async fn put(

--- a/crates/integration-tests/tests/file/membound.rs
+++ b/crates/integration-tests/tests/file/membound.rs
@@ -191,7 +191,7 @@ impl<const B: usize> ChunkGet<AnyChunkSet<B>> for GaugeStore<B> {
     }
 }
 
-impl<const B: usize> ChunkPut<AnyChunkSet<B>> for GaugeStore<B> {
+impl<const B: usize> ChunkPut<Chunk<Verified, AnyChunkSet<B>>> for GaugeStore<B> {
     type Error = ChunkStoreError;
 
     async fn put(&self, chunk: Chunk<Verified, AnyChunkSet<B>>) -> Result<(), ChunkStoreError> {

--- a/crates/integration-tests/tests/file/split_membound.rs
+++ b/crates/integration-tests/tests/file/split_membound.rs
@@ -64,7 +64,7 @@ impl DropStore {
     }
 }
 
-impl ChunkPut<AnyChunkSet<B>> for DropStore {
+impl ChunkPut<Chunk<Verified, AnyChunkSet<B>>> for DropStore {
     type Error = ChunkStoreError;
 
     async fn put(&self, chunk: Chunk<Verified, AnyChunkSet<B>>) -> Result<(), ChunkStoreError> {

--- a/crates/mantaray/src/persist.rs
+++ b/crates/mantaray/src/persist.rs
@@ -41,7 +41,7 @@ mod pipeline {
     use nectar_primitives::EntryRef;
     use nectar_primitives::chunk::{ChunkAddress, ChunkRef, Verified};
     use nectar_primitives::store::{ChunkGet, ChunkPut, ContentGet, ContentGetError, TrustedGet};
-    use nectar_primitives::{AnyChunkSet, DEFAULT_BODY_SIZE};
+    use nectar_primitives::{AnyChunkSet, Chunk, DEFAULT_BODY_SIZE};
 
     use super::*;
 
@@ -142,7 +142,7 @@ mod pipeline {
 
     impl<S, const B: usize> NodeSaver<[u8], ChunkRef> for NodeLoadSaver<S, B>
     where
-        S: ChunkPut<AnyChunkSet<B>>,
+        S: ChunkPut<Chunk<Verified, AnyChunkSet<B>>>,
     {
         type Error = SplitError<S::Error>;
 
@@ -158,7 +158,7 @@ mod pipeline {
     #[cfg_attr(docsrs, doc(cfg(all(feature = "manifest", feature = "encryption"))))]
     impl<S, const B: usize> NodeSaver<[u8], EncryptedChunkRef> for NodeLoadSaver<S, B>
     where
-        S: ChunkPut<AnyChunkSet<B>>,
+        S: ChunkPut<Chunk<Verified, AnyChunkSet<B>>>,
     {
         type Error = SplitError<S::Error>;
 
@@ -238,7 +238,7 @@ pub mod single_chunk {
     use nectar_primitives::chunk::{ChunkAddress, ChunkOps, ChunkRef, ContentChunk};
     use nectar_primitives::error::PrimitivesError;
     use nectar_primitives::store::{ChunkPut, SharedError, TrustedGet};
-    use nectar_primitives::{AnyChunkSet, Chunk, DEFAULT_BODY_SIZE, EncryptionKey};
+    use nectar_primitives::{AnyChunkSet, Chunk, DEFAULT_BODY_SIZE, EncryptionKey, Verified};
 
     use super::*;
 
@@ -292,7 +292,7 @@ pub mod single_chunk {
 
     impl<S, const BS: usize> SingleChunkLoadSaver<S, BS>
     where
-        S: ChunkPut<AnyChunkSet<BS>>,
+        S: ChunkPut<Chunk<Verified, AnyChunkSet<BS>>>,
     {
         async fn put_node(&self, data: &[u8]) -> Result<ChunkAddress, SingleChunkError> {
             let chunk = ContentChunk::<BS>::new(data.to_vec())?;
@@ -308,7 +308,7 @@ pub mod single_chunk {
 
     impl<S, const BS: usize> NodeSaver<[u8], ChunkRef> for SingleChunkLoadSaver<S, BS>
     where
-        S: ChunkPut<AnyChunkSet<BS>>,
+        S: ChunkPut<Chunk<Verified, AnyChunkSet<BS>>>,
     {
         type Error = SingleChunkError;
 
@@ -319,7 +319,7 @@ pub mod single_chunk {
 
     impl<S, const BS: usize> NodeSaver<[u8], EncryptedChunkRef> for SingleChunkLoadSaver<S, BS>
     where
-        S: ChunkPut<AnyChunkSet<BS>>,
+        S: ChunkPut<Chunk<Verified, AnyChunkSet<BS>>>,
     {
         type Error = SingleChunkError;
 

--- a/crates/postage-issuer/benches/upload_pipeline.rs
+++ b/crates/postage-issuer/benches/upload_pipeline.rs
@@ -38,7 +38,7 @@ type SealedChunk = Chunk<Verified, AnyChunkSet<DEFAULT_BODY_SIZE>>;
 #[derive(Clone, Default)]
 struct Collect(Arc<Mutex<Vec<SealedChunk>>>);
 
-impl ChunkPut<AnyChunkSet<DEFAULT_BODY_SIZE>> for Collect {
+impl ChunkPut<Chunk<Verified, AnyChunkSet<DEFAULT_BODY_SIZE>>> for Collect {
     type Error = std::convert::Infallible;
 
     async fn put(&self, chunk: SealedChunk) -> Result<(), Self::Error> {

--- a/crates/postage-issuer/src/pipeline/stamped_put.rs
+++ b/crates/postage-issuer/src/pipeline/stamped_put.rs
@@ -235,8 +235,7 @@ enum Step {
 /// Stamping decorator over a stamped-pair sink.
 ///
 /// Takes bare chunks and puts pairs: the stamp is minted here, not checked,
-/// so the pair carries no validation proof. One generic impl over
-/// `AnyChunkSet<B>` serves every wrapped call site.
+/// so the pair carries no validation proof.
 ///
 /// # Contracts
 ///

--- a/crates/postage-issuer/src/pipeline/stamped_put.rs
+++ b/crates/postage-issuer/src/pipeline/stamped_put.rs
@@ -1,5 +1,6 @@
-//! Stamping store decorator: `ChunkPut` facing up, [`PutStamped`] facing
-//! down, so existing persistence call sites stamp at put with no changes.
+//! Stamping store decorator: a bare-chunk sink facing up, a stamped-pair
+//! sink facing down, so existing persistence call sites stamp at put with no
+//! changes.
 
 use alloc::collections::BTreeMap;
 use alloc::sync::Arc;
@@ -15,7 +16,7 @@ use nectar_clock::Clock;
 #[cfg(feature = "std")]
 use nectar_clock::SystemClock;
 use nectar_marker::{MaybeSend, MaybeSync};
-use nectar_postage::{PutStamped, Stamp, StampDigest, StampError, StampedChunk, Unvalidated};
+use nectar_postage::{Stamp, StampDigest, StampError, StampedChunk, Unvalidated};
 use nectar_primitives::{AnyChunkSet, Chunk, ChunkAddress, ChunkGet, ChunkHas, ChunkPut, Verified};
 
 #[cfg(feature = "std")]
@@ -231,12 +232,11 @@ enum Step {
     Refused(StampError),
 }
 
-/// Stamping decorator over a [`PutStamped`] sink.
+/// Stamping decorator over a stamped-pair sink.
 ///
-/// Implements `ChunkPut` facing up and requires `P: PutStamped<Unvalidated>`
-/// facing down: the stamp is minted here, not checked, so the pair carries no
-/// validation proof. One generic impl over `AnyChunkSet<B>` serves every
-/// wrapped call site.
+/// Takes bare chunks and puts pairs: the stamp is minted here, not checked,
+/// so the pair carries no validation proof. One generic impl over
+/// `AnyChunkSet<B>` serves every wrapped call site.
 ///
 /// # Contracts
 ///
@@ -251,12 +251,12 @@ enum Step {
 ///   switches.
 /// - The decorator stamps per put, not per reachable chunk: a wrapped
 ///   re-commit stamps only newly-put chunks.
-/// - Transport retries compose below [`PutStamped`], reusing the already
+/// - Transport retries compose below the pair sink, reusing the already
 ///   signed stamp; a re-put through the decorator is idempotent anyway.
 /// - Wrapping a purely local store burns indices for chunks that may never
 ///   reach the network; filter for presence upstream where that matters.
-/// - Put-only sites need `P: PutStamped<Unvalidated>`; commit and apply sites
-///   need `P: PutStamped<Unvalidated> + TrustedGet + ChunkHas`, so a pure
+/// - Put-only sites need `P: ChunkPut<StampedChunk<Verified, Unvalidated, B>>`;
+///   commit and apply sites need `TrustedGet + ChunkHas` as well, so a pure
 ///   network sender takes a local or teed inner there.
 /// - A split's put slots double as sign-plus-put slots: widen the put
 ///   window toward [`StampPipeline`](super::StampPipeline)'s default
@@ -477,11 +477,12 @@ where
     }
 }
 
-impl<I, Sg, P, C, const B: usize> ChunkPut<AnyChunkSet<B>> for StampedPut<I, Sg, P, C>
+impl<I, Sg, P, C, const B: usize> ChunkPut<Chunk<Verified, AnyChunkSet<B>>>
+    for StampedPut<I, Sg, P, C>
 where
     I: StampIssuer + MaybeSend + 'static,
     Sg: SignPrehash + MaybeSend + MaybeSync + 'static,
-    P: PutStamped<Unvalidated, B>,
+    P: ChunkPut<StampedChunk<Verified, Unvalidated, B>>,
     C: Clock,
 {
     type Error = StampedPutError<P::Error>;
@@ -521,7 +522,7 @@ where
             armed: true,
         });
         self.inner
-            .put_stamped(StampedChunk::new(chunk, stamp))
+            .put(StampedChunk::new(chunk, stamp))
             .await
             .map_err(StampedPutError::Put)?;
         if let Some(guard) = guard {
@@ -622,10 +623,10 @@ mod tests {
         seen: Arc<StdMutex<Vec<(ChunkAddress, Stamp)>>>,
     }
 
-    impl PutStamped<Unvalidated> for CountingSink {
+    impl ChunkPut<StampedChunk<Verified, Unvalidated>> for CountingSink {
         type Error = Infallible;
 
-        async fn put_stamped(
+        async fn put(
             &self,
             stamped: StampedChunk<Verified, Unvalidated>,
         ) -> Result<(), Self::Error> {
@@ -648,10 +649,10 @@ mod tests {
         seen: Arc<StdMutex<Vec<Stamp>>>,
     }
 
-    impl PutStamped<Unvalidated> for FailOnceSink {
+    impl ChunkPut<StampedChunk<Verified, Unvalidated>> for FailOnceSink {
         type Error = SinkRefused;
 
-        async fn put_stamped(
+        async fn put(
             &self,
             stamped: StampedChunk<Verified, Unvalidated>,
         ) -> Result<(), Self::Error> {
@@ -670,10 +671,10 @@ mod tests {
         store: Arc<MemoryStore<AnyChunkSet<4096>>>,
     }
 
-    impl PutStamped<Unvalidated> for StoreSink {
+    impl ChunkPut<StampedChunk<Verified, Unvalidated>> for StoreSink {
         type Error = Infallible;
 
-        async fn put_stamped(
+        async fn put(
             &self,
             stamped: StampedChunk<Verified, Unvalidated>,
         ) -> Result<(), Self::Error> {

--- a/crates/postage/src/lib.rs
+++ b/crates/postage/src/lib.rs
@@ -24,8 +24,9 @@
 //! # Traits
 //!
 //! - [`StampValidator`]: Validate stamps against batches
-//! - [`PutStamped`]: Downward-facing sink for a [`StampedChunk`], with
-//!   [`StampIndifferent`] and [`Tee`] bridging plain chunk stores into it
+//! - [`ChunkPut`](nectar_primitives::ChunkPut) over a [`StampedChunk`]: the
+//!   sink for a paid chunk, with [`StampIndifferent`] bridging a plain chunk
+//!   store into it
 //! - [`BatchStore`]: Persist and retrieve batches (requires `std`). The trait is
 //!   synchronous and, having an associated `Error` and no generic methods, is
 //!   naturally object-safe; drive it from an async edge (a gRPC service, an FFI
@@ -93,7 +94,7 @@ pub mod parallel;
 // Core types
 pub use batch::{Batch, BatchId, BatchParams, BucketDepth};
 pub use error::StampError;
-pub use sink::{PutStamped, StampIndifferent, Tee, TeeError};
+pub use sink::StampIndifferent;
 pub use stamp::{STAMP_SIZE, Stamp, StampBytes, StampDigest, StampIndex};
 pub use stamped::StampedChunk;
 pub use stamped_address::{StampedAddress, Unvalidated, Validated, ValidationState};

--- a/crates/postage/src/sink.rs
+++ b/crates/postage/src/sink.rs
@@ -1,10 +1,7 @@
 //! The stamped chunk as a unit of transfer, and the bridge beneath it.
 //!
-//! One seam carries both directions: a network sink is a
-//! `ChunkPut<StampedChunk<Verified, V, BODY_SIZE>>`, and
-//! [`StampIndifferent`] puts a plain chunk store beneath one. A consumer that
-//! needs payment proof names [`Validated`], and an unproven pair is then a
-//! type error at the call:
+//! A sink that demands payment proof names [`Validated`]; handing it an
+//! unproven pair is then a type error:
 //!
 //! ```compile_fail
 //! use nectar_postage::{StampedChunk, Unvalidated, Validated};
@@ -84,14 +81,11 @@ where
 #[cfg(test)]
 mod tests {
     use std::convert::Infallible;
-    use std::error::Error as _;
     use std::sync::Arc;
     use std::sync::Mutex;
 
     use arbitrary::Unstructured;
-    use nectar_primitives::{
-        Chunk, ChunkHas, ContentChunk, DEFAULT_BODY_SIZE, MemoryStore, Tee, TeeError,
-    };
+    use nectar_primitives::{Chunk, ChunkHas, ContentChunk, DEFAULT_BODY_SIZE, MemoryStore, Tee};
     use nectar_testing::run;
 
     use super::*;
@@ -134,23 +128,6 @@ mod tests {
         }
     }
 
-    #[derive(Debug, thiserror::Error)]
-    #[error("leg refused")]
-    struct LegRefused;
-
-    #[derive(Debug, Default)]
-    struct FailSink;
-
-    impl ChunkPut<StampedChunk> for FailSink {
-        type Error = LegRefused;
-
-        async fn put(&self, _stamped: StampedChunk) -> Result<(), Self::Error> {
-            Err(LegRefused)
-        }
-    }
-
-    // A sink that speaks both units at once: the collapse gives it two
-    // instantiations of one verb rather than two verbs.
     #[derive(Debug, Default)]
     struct DualSink {
         bare: Mutex<Vec<ChunkAddress>>,
@@ -223,36 +200,9 @@ mod tests {
     }
 
     #[test]
-    fn tee_local_failure_short_circuits() {
-        run(async {
-            let recorder = RecordingSink::default();
-            let tee = Tee::new(FailSink, &recorder);
-            let pair = stamped(b"local refusal");
-
-            let err = tee.put(pair).await.expect_err("local leg fails");
-            assert!(matches!(err, TeeError::Local(LegRefused)));
-            assert!(recorder.seen.lock().expect("recording lock").is_empty());
-            assert!(
-                err.source()
-                    .expect("the leg error is the source")
-                    .downcast_ref::<LegRefused>()
-                    .is_some()
-            );
-        });
-    }
-
-    #[test]
-    fn tee_forward_failure_keeps_local_write() {
-        run(async {
-            let store = Store::new();
-            let tee = Tee::new(StampIndifferent::new(&store), FailSink);
-            let pair = stamped(b"forward refusal");
-            let address = *pair.address();
-
-            let err = tee.put(pair).await.expect_err("forward leg fails");
-            assert!(matches!(err, TeeError::Forward(LegRefused)));
-            assert!(store.has(&address).await);
-        });
+    fn put_unit_address_is_the_chunk_address() {
+        let pair = stamped(b"unit address");
+        assert_eq!(PutUnit::address(&pair), pair.address());
     }
 
     async fn demand_paid<S: ChunkPut<StampedChunk<Verified, Validated>>>(

--- a/crates/postage/src/sink.rs
+++ b/crates/postage/src/sink.rs
@@ -1,70 +1,42 @@
-//! Downward-facing stamped sink and the bridges into it.
+//! The stamped chunk as a unit of transfer, and the bridge beneath it.
 //!
-//! The seam: `ChunkPut` faces up (persistence callers put sealed chunks),
-//! [`PutStamped`] faces down (the sink receives the `(chunk, stamp)` pair
-//! in-band). A network sink implements [`PutStamped`] directly;
-//! [`StampIndifferent`] admits a plain chunk store; [`Tee`] fans one put out
-//! to a local leg and a forward leg.
+//! One seam carries both directions: a network sink is a
+//! `ChunkPut<StampedChunk<Verified, V, BODY_SIZE>>`, and
+//! [`StampIndifferent`] puts a plain chunk store beneath one. A consumer that
+//! needs payment proof names [`Validated`], and an unproven pair is then a
+//! type error at the call:
+//!
+//! ```compile_fail
+//! use nectar_postage::{StampedChunk, Unvalidated, Validated};
+//! use nectar_primitives::{ChunkPut, Verified};
+//!
+//! async fn pushsync<S: ChunkPut<StampedChunk<Verified, Validated>>>(
+//!     sink: S,
+//!     pair: StampedChunk<Verified, Unvalidated>,
+//! ) -> Result<(), S::Error> {
+//!     sink.put(pair).await
+//! }
+//! ```
 
 use core::future::Future;
 
-use nectar_primitives::marker::{MaybeSend, MaybeSync};
-use nectar_primitives::{AnyChunkSet, ChunkPut, DEFAULT_BODY_SIZE, Verified};
+use nectar_primitives::marker::MaybeSend;
+use nectar_primitives::{AnyChunkSet, Chunk, ChunkAddress, ChunkPut, PutUnit, Verified};
 
-use crate::{StampedChunk, Validated, ValidationState};
+use crate::{StampedChunk, ValidationState};
 
-/// Async stamped-chunk sink (`&self`).
-///
-/// The stamp travels in-band with the chunk it pays for. The contract is
-/// delivery only: per-address idempotence belongs to a decorator layered
-/// above the sink, never to this trait. Implementors use interior
-/// mutability, mirroring `ChunkPut`. `V` is the proof the sink demands of the
-/// stamp: an ingest sink takes [`Validated`], a producer-side sink takes the
-/// [`Unvalidated`](crate::Unvalidated) pair its own issuer just signed.
-pub trait PutStamped<V: ValidationState = Validated, const BODY_SIZE: usize = DEFAULT_BODY_SIZE>:
-    MaybeSend + MaybeSync
-{
-    /// Error type for stamped put operations.
-    type Error: core::error::Error + MaybeSend + MaybeSync + 'static;
-
-    /// Sink a stamped chunk.
-    fn put_stamped(
-        &self,
-        stamped: StampedChunk<Verified, V, BODY_SIZE>,
-    ) -> impl Future<Output = Result<(), Self::Error>> + MaybeSend;
-}
-
-impl<V: ValidationState, const BODY_SIZE: usize, T: PutStamped<V, BODY_SIZE> + ?Sized>
-    PutStamped<V, BODY_SIZE> for &T
-{
-    type Error = T::Error;
-
-    fn put_stamped(
-        &self,
-        stamped: StampedChunk<Verified, V, BODY_SIZE>,
-    ) -> impl Future<Output = Result<(), Self::Error>> + MaybeSend {
-        (**self).put_stamped(stamped)
-    }
-}
-
-impl<V: ValidationState, const BODY_SIZE: usize, T: PutStamped<V, BODY_SIZE> + ?Sized>
-    PutStamped<V, BODY_SIZE> for alloc::sync::Arc<T>
-{
-    type Error = T::Error;
-
-    fn put_stamped(
-        &self,
-        stamped: StampedChunk<Verified, V, BODY_SIZE>,
-    ) -> impl Future<Output = Result<(), Self::Error>> + MaybeSend {
-        (**self).put_stamped(stamped)
+impl<V: ValidationState, const BODY_SIZE: usize> PutUnit for StampedChunk<Verified, V, BODY_SIZE> {
+    #[inline]
+    fn address(&self) -> &ChunkAddress {
+        Self::address(self)
     }
 }
 
 /// Admits a stamp-indifferent store as a stamped sink.
 ///
-/// `put_stamped` splits the pair and persists the chunk; the stamp is
-/// dropped. Correct only for local-persist targets whose storage does not
-/// account for payment.
+/// The put splits the pair and persists the chunk; the stamp is dropped.
+/// Correct only for local-persist targets whose storage does not account for
+/// payment.
 #[derive(Debug, Clone, Default)]
 pub struct StampIndifferent<S> {
     inner: S,
@@ -93,93 +65,20 @@ impl<S> StampIndifferent<S> {
     }
 }
 
-impl<V: ValidationState, const BODY_SIZE: usize, S> PutStamped<V, BODY_SIZE> for StampIndifferent<S>
+impl<V: ValidationState, const BODY_SIZE: usize, S> ChunkPut<StampedChunk<Verified, V, BODY_SIZE>>
+    for StampIndifferent<S>
 where
-    S: ChunkPut<AnyChunkSet<BODY_SIZE>>,
+    S: ChunkPut<Chunk<Verified, AnyChunkSet<BODY_SIZE>>>,
 {
     type Error = S::Error;
 
-    fn put_stamped(
+    fn put(
         &self,
         stamped: StampedChunk<Verified, V, BODY_SIZE>,
     ) -> impl Future<Output = Result<(), Self::Error>> + MaybeSend {
         let (chunk, _stamp) = stamped.into_parts();
         self.inner.put(chunk)
     }
-}
-
-/// Fans one stamped put out to two sinks: a local leg, then a forward leg.
-///
-/// Legs run sequentially and fail fast: a local failure means the pair never
-/// reached the forward leg; a forward failure leaves the local write in
-/// place. Either failure fails the put.
-#[derive(Debug, Clone, Default)]
-pub struct Tee<L, F> {
-    local: L,
-    forward: F,
-}
-
-impl<L, F> Tee<L, F> {
-    /// Pair a local leg with a forward leg.
-    #[inline]
-    #[must_use]
-    pub const fn new(local: L, forward: F) -> Self {
-        Self { local, forward }
-    }
-
-    /// The local leg.
-    #[inline]
-    #[must_use]
-    pub const fn local(&self) -> &L {
-        &self.local
-    }
-
-    /// The forward leg.
-    #[inline]
-    #[must_use]
-    pub const fn forward(&self) -> &F {
-        &self.forward
-    }
-
-    /// Unwrap into the legs.
-    #[inline]
-    #[must_use]
-    pub fn into_parts(self) -> (L, F) {
-        (self.local, self.forward)
-    }
-}
-
-impl<V: ValidationState, const BODY_SIZE: usize, L, F> PutStamped<V, BODY_SIZE> for Tee<L, F>
-where
-    L: PutStamped<V, BODY_SIZE>,
-    F: PutStamped<V, BODY_SIZE>,
-{
-    type Error = TeeError<L::Error, F::Error>;
-
-    async fn put_stamped(
-        &self,
-        stamped: StampedChunk<Verified, V, BODY_SIZE>,
-    ) -> Result<(), Self::Error> {
-        self.local
-            .put_stamped(stamped.clone())
-            .await
-            .map_err(TeeError::Local)?;
-        self.forward
-            .put_stamped(stamped)
-            .await
-            .map_err(TeeError::Forward)
-    }
-}
-
-/// A [`Tee`] put failure, tagged with the leg that refused it.
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-pub enum TeeError<L, F> {
-    /// The local leg failed; the pair never reached the forward leg.
-    #[error("local leg refused the put")]
-    Local(#[source] L),
-    /// The forward leg failed; the local write stands.
-    #[error("forward leg refused the put")]
-    Forward(#[source] F),
 }
 
 #[cfg(test)]
@@ -190,11 +89,13 @@ mod tests {
     use std::sync::Mutex;
 
     use arbitrary::Unstructured;
-    use nectar_primitives::{Chunk, ChunkAddress, ChunkHas, ContentChunk, MemoryStore};
+    use nectar_primitives::{
+        Chunk, ChunkHas, ContentChunk, DEFAULT_BODY_SIZE, MemoryStore, Tee, TeeError,
+    };
     use nectar_testing::run;
 
     use super::*;
-    use crate::{Batch, Unvalidated, generators};
+    use crate::{Batch, Unvalidated, Validated, generators};
 
     type Store = MemoryStore<AnyChunkSet<DEFAULT_BODY_SIZE>>;
 
@@ -221,10 +122,10 @@ mod tests {
         seen: Mutex<Vec<ChunkAddress>>,
     }
 
-    impl PutStamped for RecordingSink {
+    impl ChunkPut<StampedChunk> for RecordingSink {
         type Error = Infallible;
 
-        async fn put_stamped(&self, stamped: StampedChunk) -> Result<(), Self::Error> {
+        async fn put(&self, stamped: StampedChunk) -> Result<(), Self::Error> {
             self.seen
                 .lock()
                 .expect("recording lock")
@@ -240,11 +141,43 @@ mod tests {
     #[derive(Debug, Default)]
     struct FailSink;
 
-    impl PutStamped for FailSink {
+    impl ChunkPut<StampedChunk> for FailSink {
         type Error = LegRefused;
 
-        async fn put_stamped(&self, _stamped: StampedChunk) -> Result<(), Self::Error> {
+        async fn put(&self, _stamped: StampedChunk) -> Result<(), Self::Error> {
             Err(LegRefused)
+        }
+    }
+
+    // A sink that speaks both units at once: the collapse gives it two
+    // instantiations of one verb rather than two verbs.
+    #[derive(Debug, Default)]
+    struct DualSink {
+        bare: Mutex<Vec<ChunkAddress>>,
+        paid: Mutex<Vec<ChunkAddress>>,
+    }
+
+    impl ChunkPut<Chunk<Verified, AnyChunkSet<DEFAULT_BODY_SIZE>>> for DualSink {
+        type Error = Infallible;
+
+        async fn put(
+            &self,
+            chunk: Chunk<Verified, AnyChunkSet<DEFAULT_BODY_SIZE>>,
+        ) -> Result<(), Self::Error> {
+            self.bare.lock().expect("bare lock").push(*chunk.address());
+            Ok(())
+        }
+    }
+
+    impl ChunkPut<StampedChunk> for DualSink {
+        type Error = Infallible;
+
+        async fn put(&self, stamped: StampedChunk) -> Result<(), Self::Error> {
+            self.paid
+                .lock()
+                .expect("paid lock")
+                .push(*stamped.address());
+            Ok(())
         }
     }
 
@@ -256,7 +189,7 @@ mod tests {
             let pair = stamped(b"local persist");
             let address = *pair.address();
 
-            sink.put_stamped(pair).await.expect("infallible put");
+            sink.put(pair).await.expect("infallible put");
             assert!(store.has(&address).await);
         });
     }
@@ -269,13 +202,13 @@ mod tests {
             let (_, pair) = signed(b"unproven stamp");
             let address = *pair.address();
 
-            sink.put_stamped(pair).await.expect("infallible put");
+            sink.put(pair).await.expect("infallible put");
             assert!(store.has(&address).await);
         });
     }
 
     #[test]
-    fn tee_delivers_to_both_legs() {
+    fn tee_carries_the_stamped_unit() {
         run(async {
             let store = Store::new();
             let recorder = RecordingSink::default();
@@ -283,7 +216,7 @@ mod tests {
             let pair = stamped(b"both legs");
             let address = *pair.address();
 
-            tee.put_stamped(pair).await.expect("both legs accept");
+            tee.put(pair).await.expect("both legs accept");
             assert!(store.has(&address).await);
             assert_eq!(*recorder.seen.lock().expect("recording lock"), [address]);
         });
@@ -296,7 +229,7 @@ mod tests {
             let tee = Tee::new(FailSink, &recorder);
             let pair = stamped(b"local refusal");
 
-            let err = tee.put_stamped(pair).await.expect_err("local leg fails");
+            let err = tee.put(pair).await.expect_err("local leg fails");
             assert!(matches!(err, TeeError::Local(LegRefused)));
             assert!(recorder.seen.lock().expect("recording lock").is_empty());
             assert!(
@@ -316,20 +249,17 @@ mod tests {
             let pair = stamped(b"forward refusal");
             let address = *pair.address();
 
-            let err = tee.put_stamped(pair).await.expect_err("forward leg fails");
+            let err = tee.put(pair).await.expect_err("forward leg fails");
             assert!(matches!(err, TeeError::Forward(LegRefused)));
             assert!(store.has(&address).await);
-            assert!(
-                err.source()
-                    .expect("the leg error is the source")
-                    .downcast_ref::<LegRefused>()
-                    .is_some()
-            );
         });
     }
 
-    async fn sink_via<S: PutStamped>(sink: S, pair: StampedChunk) -> Result<(), S::Error> {
-        sink.put_stamped(pair).await
+    async fn demand_paid<S: ChunkPut<StampedChunk<Verified, Validated>>>(
+        sink: S,
+        pair: StampedChunk,
+    ) -> Result<(), S::Error> {
+        sink.put(pair).await
     }
 
     #[test]
@@ -339,14 +269,29 @@ mod tests {
             let pair = stamped(b"delegation");
             let address = *pair.address();
 
-            sink_via(Arc::clone(&recorder), pair.clone())
+            demand_paid(Arc::clone(&recorder), pair.clone())
                 .await
                 .expect("arc delegates");
-            sink_via(&*recorder, pair).await.expect("ref delegates");
+            demand_paid(&*recorder, pair).await.expect("ref delegates");
             assert_eq!(
                 *recorder.seen.lock().expect("recording lock"),
                 [address, address]
             );
+        });
+    }
+
+    #[test]
+    fn one_sink_serves_both_units() {
+        run(async {
+            let sink = DualSink::default();
+            let pair = stamped(b"two units");
+            let address = *pair.address();
+            let (chunk, _) = pair.clone().into_parts();
+
+            sink.put(chunk).await.expect("bare unit accepted");
+            demand_paid(&sink, pair).await.expect("paid unit accepted");
+            assert_eq!(*sink.bare.lock().expect("bare lock"), [address]);
+            assert_eq!(*sink.paid.lock().expect("paid lock"), [address]);
         });
     }
 }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -163,7 +163,8 @@ pub type DefaultMemoryStore = MemoryStore<StandardChunkSet>;
 // Chunk storage traits
 pub use store::{
     ChunkGet, ChunkHas, ChunkPut, ChunkStoreError, ContentGet, ContentGetError, MemoryStore,
-    SingleOwnerGet, SingleOwnerGetError, TrustedGet, VerifyError, VerifyingStore,
+    PutUnit, SingleOwnerGet, SingleOwnerGetError, Tee, TeeError, TrustedGet, VerifyError,
+    VerifyingStore,
 };
 #[cfg(feature = "std")]
 pub use store::{RetryConfig, RetryingChunkGet, Sleeper};

--- a/crates/primitives/src/store/content.rs
+++ b/crates/primitives/src/store/content.rs
@@ -1,10 +1,8 @@
 //! Content-only narrowing store adapter.
 
-use crate::chunk::{
-    AnyChunkSet, Chunk, ChunkAddress, ChunkRegistry, ContentOnlyChunkSet, Verified,
-};
+use crate::chunk::{AnyChunkSet, Chunk, ChunkAddress, ContentOnlyChunkSet, Verified};
 
-use super::typed::{ChunkGet, ChunkHas, ChunkPut};
+use super::typed::{ChunkGet, ChunkHas, ChunkPut, PutUnit};
 
 /// Content-only view over a store typed at [`AnyChunkSet`].
 ///
@@ -61,11 +59,11 @@ where
 
 // Writes pass through untouched: only the read face narrows, so one wrapped
 // store serves a read-narrowed, write-wide surface.
-impl<R: ChunkRegistry, T: ChunkPut<R>> ChunkPut<R> for ContentGet<T> {
+impl<U: PutUnit, T: ChunkPut<U>> ChunkPut<U> for ContentGet<T> {
     type Error = T::Error;
 
-    async fn put(&self, chunk: Chunk<Verified, R>) -> Result<(), Self::Error> {
-        self.0.put(chunk).await
+    async fn put(&self, unit: U) -> Result<(), Self::Error> {
+        self.0.put(unit).await
     }
 }
 

--- a/crates/primitives/src/store/memory.rs
+++ b/crates/primitives/src/store/memory.rs
@@ -98,7 +98,7 @@ impl<R: ChunkRegistry> MemoryStore<R> {
     }
 }
 
-impl<R: ChunkRegistry> ChunkPut<R> for MemoryStore<R> {
+impl<R: ChunkRegistry> ChunkPut<Chunk<Verified, R>> for MemoryStore<R> {
     type Error = core::convert::Infallible;
 
     async fn put(&self, chunk: Chunk<Verified, R>) -> Result<(), Self::Error> {

--- a/crates/primitives/src/store/mod.rs
+++ b/crates/primitives/src/store/mod.rs
@@ -9,6 +9,7 @@ mod memory;
 #[cfg(feature = "std")]
 mod retry;
 mod single_owner;
+mod tee;
 mod typed;
 mod verify;
 
@@ -18,7 +19,8 @@ pub use memory::MemoryStore;
 #[cfg(feature = "std")]
 pub use retry::{RetryConfig, RetryingChunkGet, Sleeper};
 pub use single_owner::{SingleOwnerGet, SingleOwnerGetError};
-pub use typed::{ChunkGet, ChunkHas, ChunkPut, TrustedGet};
+pub use tee::{Tee, TeeError};
+pub use typed::{ChunkGet, ChunkHas, ChunkPut, PutUnit, TrustedGet};
 pub use verify::{VerifyError, VerifyingStore};
 
 use crate::chunk::{Chunk, ChunkAddress, ChunkRegistry, Verified};

--- a/crates/primitives/src/store/retry.rs
+++ b/crates/primitives/src/store/retry.rs
@@ -15,8 +15,8 @@ use std::fmt;
 use std::future::Future;
 use std::time::Duration;
 
-use super::typed::{ChunkGet, ChunkHas, ChunkPut};
-use crate::chunk::{Chunk, ChunkAddress, ChunkRegistry, Verified};
+use super::typed::{ChunkGet, ChunkHas, ChunkPut, PutUnit};
+use crate::chunk::{Chunk, ChunkAddress, ChunkRegistry};
 use crate::marker::{MaybeSend, MaybeSync};
 
 /// Injected async delay so the decorator owns its timer: nectar takes no new
@@ -146,13 +146,11 @@ impl<R: ChunkRegistry, G: ChunkGet<R>, S: Sleeper> ChunkGet<R> for RetryingChunk
     }
 }
 
-impl<R: ChunkRegistry, G: ChunkPut<R>, S: MaybeSend + MaybeSync> ChunkPut<R>
-    for RetryingChunkGet<G, S>
-{
+impl<U: PutUnit, G: ChunkPut<U>, S: MaybeSend + MaybeSync> ChunkPut<U> for RetryingChunkGet<G, S> {
     type Error = G::Error;
 
-    async fn put(&self, chunk: Chunk<Verified, R>) -> Result<(), Self::Error> {
-        self.inner.put(chunk).await
+    async fn put(&self, unit: U) -> Result<(), Self::Error> {
+        self.inner.put(unit).await
     }
 }
 
@@ -172,7 +170,7 @@ mod tests {
     use nectar_testing::run;
 
     use crate::DefaultContentChunk;
-    use crate::chunk::StandardChunkSet;
+    use crate::chunk::{StandardChunkSet, Verified};
 
     /// A [`Sleeper`] that returns immediately, so tests never wait real time.
     struct NoSleep;
@@ -224,7 +222,7 @@ mod tests {
         }
     }
 
-    impl ChunkPut<StandardChunkSet> for FlakyStore {
+    impl ChunkPut<Chunk> for FlakyStore {
         type Error = Transient;
 
         async fn put(&self, _chunk: Chunk) -> Result<(), Self::Error> {

--- a/crates/primitives/src/store/tee.rs
+++ b/crates/primitives/src/store/tee.rs
@@ -76,6 +76,7 @@ mod tests {
     use alloc::sync::Arc;
     use alloc::vec::Vec;
     use core::convert::Infallible;
+    use core::error::Error as _;
 
     use nectar_testing::run;
 
@@ -150,6 +151,12 @@ mod tests {
                 .expect_err("local leg fails");
             assert!(matches!(err, TeeError::Local(LegRefused)));
             assert!(recorder.seen.lock().is_empty());
+            assert!(
+                err.source()
+                    .expect("the leg error is the source")
+                    .downcast_ref::<LegRefused>()
+                    .is_some()
+            );
         });
     }
 

--- a/crates/primitives/src/store/tee.rs
+++ b/crates/primitives/src/store/tee.rs
@@ -1,0 +1,182 @@
+//! Fan-out over the put seam.
+
+use super::typed::{ChunkPut, PutUnit};
+
+/// Fans one put out to two sinks: a local leg, then a forward leg.
+///
+/// Legs run sequentially and fail fast: a local failure means the unit never
+/// reached the forward leg; a forward failure leaves the local write in
+/// place. Either failure fails the put.
+#[derive(Debug, Clone, Default)]
+pub struct Tee<L, F> {
+    local: L,
+    forward: F,
+}
+
+impl<L, F> Tee<L, F> {
+    /// Pair a local leg with a forward leg.
+    #[inline]
+    #[must_use]
+    pub const fn new(local: L, forward: F) -> Self {
+        Self { local, forward }
+    }
+
+    /// The local leg.
+    #[inline]
+    #[must_use]
+    pub const fn local(&self) -> &L {
+        &self.local
+    }
+
+    /// The forward leg.
+    #[inline]
+    #[must_use]
+    pub const fn forward(&self) -> &F {
+        &self.forward
+    }
+
+    /// Unwrap into the legs.
+    #[inline]
+    #[must_use]
+    pub fn into_parts(self) -> (L, F) {
+        (self.local, self.forward)
+    }
+}
+
+impl<U, L, F> ChunkPut<U> for Tee<L, F>
+where
+    U: PutUnit + Clone,
+    L: ChunkPut<U>,
+    F: ChunkPut<U>,
+{
+    type Error = TeeError<L::Error, F::Error>;
+
+    async fn put(&self, unit: U) -> Result<(), Self::Error> {
+        self.local
+            .put(unit.clone())
+            .await
+            .map_err(TeeError::Local)?;
+        self.forward.put(unit).await.map_err(TeeError::Forward)
+    }
+}
+
+/// A [`Tee`] put failure, tagged with the leg that refused it.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum TeeError<L, F> {
+    /// The local leg failed; the unit never reached the forward leg.
+    #[error("local leg refused the put")]
+    Local(#[source] L),
+    /// The forward leg failed; the local write stands.
+    #[error("forward leg refused the put")]
+    Forward(#[source] F),
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::sync::Arc;
+    use alloc::vec::Vec;
+    use core::convert::Infallible;
+
+    use nectar_testing::run;
+
+    use super::super::{ChunkHas, MemoryStore};
+    use super::*;
+    use crate::chunk::{Chunk, ChunkAddress, ContentChunk, StandardChunkSet, Verified};
+
+    type Sealed = Chunk<Verified, StandardChunkSet>;
+
+    fn sealed(payload: &'static [u8]) -> Sealed {
+        Chunk::from_envelope(
+            ContentChunk::new(payload)
+                .expect("valid content chunk")
+                .into(),
+        )
+        .expect("locally built chunk certifies")
+    }
+
+    #[derive(Debug, Default)]
+    struct RecordingSink {
+        seen: parking_lot::Mutex<Vec<ChunkAddress>>,
+    }
+
+    impl ChunkPut for RecordingSink {
+        type Error = Infallible;
+
+        async fn put(&self, unit: Sealed) -> Result<(), Self::Error> {
+            self.seen.lock().push(*PutUnit::address(&unit));
+            Ok(())
+        }
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("leg refused")]
+    struct LegRefused;
+
+    #[derive(Debug, Default)]
+    struct FailSink;
+
+    impl ChunkPut for FailSink {
+        type Error = LegRefused;
+
+        async fn put(&self, _unit: Sealed) -> Result<(), Self::Error> {
+            Err(LegRefused)
+        }
+    }
+
+    #[test]
+    fn delivers_to_both_legs() {
+        run(async {
+            let store = MemoryStore::<StandardChunkSet>::new();
+            let recorder = RecordingSink::default();
+            let tee = Tee::new(&store, &recorder);
+            let chunk = sealed(b"both legs");
+            let address = *chunk.address();
+
+            tee.put(chunk).await.expect("both legs accept");
+            assert!(store.has(&address).await);
+            assert_eq!(*recorder.seen.lock(), [address]);
+        });
+    }
+
+    #[test]
+    fn local_failure_short_circuits() {
+        run(async {
+            let recorder = RecordingSink::default();
+            let tee = Tee::new(FailSink, &recorder);
+
+            let err = tee
+                .put(sealed(b"local refusal"))
+                .await
+                .expect_err("local leg fails");
+            assert!(matches!(err, TeeError::Local(LegRefused)));
+            assert!(recorder.seen.lock().is_empty());
+        });
+    }
+
+    #[test]
+    fn forward_failure_keeps_local_write() {
+        run(async {
+            let store = MemoryStore::<StandardChunkSet>::new();
+            let tee = Tee::new(&store, FailSink);
+            let chunk = sealed(b"forward refusal");
+            let address = *chunk.address();
+
+            let err = tee.put(chunk).await.expect_err("forward leg fails");
+            assert!(matches!(err, TeeError::Forward(LegRefused)));
+            assert!(store.has(&address).await);
+        });
+    }
+
+    #[test]
+    fn blanket_impls_delegate() {
+        run(async {
+            let recorder = Arc::new(RecordingSink::default());
+            let chunk = sealed(b"delegation");
+            let address = *chunk.address();
+
+            let tee = Tee::new(Arc::clone(&recorder), &*recorder);
+            tee.put(chunk).await.expect("both legs accept");
+            assert_eq!(*recorder.seen.lock(), [address, address]);
+        });
+    }
+}

--- a/crates/primitives/src/store/typed.rs
+++ b/crates/primitives/src/store/typed.rs
@@ -2,9 +2,8 @@
 //!
 //! `ChunkGet`, `ChunkPut`, and `ChunkHas` are async and carry `MaybeSend`/
 //! `MaybeSync` bounds (on the traits and their error types) so a store may be
-//! `!Send` on single-threaded targets. Writes are uniformly sealed (a
-//! [`PutUnit`] carries a certified address); trust is a property of the read
-//! medium, declared once per backend through [`ChunkGet::Trust`].
+//! `!Send` on single-threaded targets. Trust is a property of the read medium,
+//! declared once per backend through [`ChunkGet::Trust`].
 
 use core::future::Future;
 
@@ -72,10 +71,10 @@ impl<T: ChunkHas + ?Sized> ChunkHas for alloc::sync::Arc<T> {
     }
 }
 
-/// What a [`ChunkPut`] moves: a sealed chunk, or a richer unit some other
-/// crate defines over one.
+/// What a [`ChunkPut`] moves. Not sealed, so whether a unit wraps a verified
+/// chunk is a property of the chosen `U`, not of the trait.
 pub trait PutUnit: MaybeSend + 'static {
-    /// The certified address the unit is stored under.
+    /// The address the unit is stored under.
     fn address(&self) -> &ChunkAddress;
 }
 
@@ -88,11 +87,7 @@ impl<R: ChunkRegistry> PutUnit for Chunk<Verified, R> {
 
 /// Async chunk storage (primary API, `&self`).
 ///
-/// Only accepts proof: there is no trust parameter to widen, so an
-/// uncertified chunk cannot enter any store. `U` is the unit the sink
-/// demands, so a sink wanting more than a sealed chunk names a richer unit
-/// instead of gaining a second verb. Implementors should use interior
-/// mutability (e.g. `Mutex`, `RwLock`).
+/// Implementors should use interior mutability (e.g. `Mutex`, `RwLock`).
 pub trait ChunkPut<U: PutUnit = Chunk<Verified>>: MaybeSend + MaybeSync {
     /// Error type for put operations.
     type Error: core::error::Error + MaybeSend + MaybeSync + 'static;

--- a/crates/primitives/src/store/typed.rs
+++ b/crates/primitives/src/store/typed.rs
@@ -2,9 +2,9 @@
 //!
 //! `ChunkGet`, `ChunkPut`, and `ChunkHas` are async and carry `MaybeSend`/
 //! `MaybeSync` bounds (on the traits and their error types) so a store may be
-//! `!Send` on single-threaded targets. Writes are uniformly sealed ([`ChunkPut`] only accepts
-//! `Chunk<Verified, R>`); trust is a property of the read medium, declared
-//! once per backend through [`ChunkGet::Trust`].
+//! `!Send` on single-threaded targets. Writes are uniformly sealed (a
+//! [`PutUnit`] carries a certified address); trust is a property of the read
+//! medium, declared once per backend through [`ChunkGet::Trust`].
 
 use core::future::Future;
 
@@ -72,41 +72,48 @@ impl<T: ChunkHas + ?Sized> ChunkHas for alloc::sync::Arc<T> {
     }
 }
 
-/// Async chunk storage (primary API, `&self`).
-///
-/// Only accepts proof: there is no trust parameter to widen, so an
-/// uncertified chunk cannot enter any store. Implementors should use interior
-/// mutability (e.g. `Mutex`, `RwLock`).
-pub trait ChunkPut<R: ChunkRegistry = StandardChunkSet>: MaybeSend + MaybeSync {
-    /// Error type for put operations.
-    type Error: core::error::Error + MaybeSend + MaybeSync + 'static;
-
-    /// Store a sealed chunk.
-    fn put(
-        &self,
-        chunk: Chunk<Verified, R>,
-    ) -> impl Future<Output = Result<(), Self::Error>> + MaybeSend;
+/// What a [`ChunkPut`] moves: a sealed chunk, or a richer unit some other
+/// crate defines over one.
+pub trait PutUnit: MaybeSend + 'static {
+    /// The certified address the unit is stored under.
+    fn address(&self) -> &ChunkAddress;
 }
 
-impl<R: ChunkRegistry, T: ChunkPut<R> + ?Sized> ChunkPut<R> for &T {
-    type Error = T::Error;
-
-    fn put(
-        &self,
-        chunk: Chunk<Verified, R>,
-    ) -> impl Future<Output = Result<(), Self::Error>> + MaybeSend {
-        (**self).put(chunk)
+impl<R: ChunkRegistry> PutUnit for Chunk<Verified, R> {
+    #[inline]
+    fn address(&self) -> &ChunkAddress {
+        Self::address(self)
     }
 }
 
-impl<R: ChunkRegistry, T: ChunkPut<R> + ?Sized> ChunkPut<R> for alloc::sync::Arc<T> {
+/// Async chunk storage (primary API, `&self`).
+///
+/// Only accepts proof: there is no trust parameter to widen, so an
+/// uncertified chunk cannot enter any store. `U` is the unit the sink
+/// demands, so a sink wanting more than a sealed chunk names a richer unit
+/// instead of gaining a second verb. Implementors should use interior
+/// mutability (e.g. `Mutex`, `RwLock`).
+pub trait ChunkPut<U: PutUnit = Chunk<Verified>>: MaybeSend + MaybeSync {
+    /// Error type for put operations.
+    type Error: core::error::Error + MaybeSend + MaybeSync + 'static;
+
+    /// Store one unit.
+    fn put(&self, unit: U) -> impl Future<Output = Result<(), Self::Error>> + MaybeSend;
+}
+
+impl<U: PutUnit, T: ChunkPut<U> + ?Sized> ChunkPut<U> for &T {
     type Error = T::Error;
 
-    fn put(
-        &self,
-        chunk: Chunk<Verified, R>,
-    ) -> impl Future<Output = Result<(), Self::Error>> + MaybeSend {
-        (**self).put(chunk)
+    fn put(&self, unit: U) -> impl Future<Output = Result<(), Self::Error>> + MaybeSend {
+        (**self).put(unit)
+    }
+}
+
+impl<U: PutUnit, T: ChunkPut<U> + ?Sized> ChunkPut<U> for alloc::sync::Arc<T> {
+    type Error = T::Error;
+
+    fn put(&self, unit: U) -> impl Future<Output = Result<(), Self::Error>> + MaybeSend {
+        (**self).put(unit)
     }
 }
 

--- a/crates/primitives/src/store/verify.rs
+++ b/crates/primitives/src/store/verify.rs
@@ -3,7 +3,7 @@
 use crate::chunk::{Chunk, ChunkAddress, ChunkRegistry, Unverified, Verified};
 use crate::error::PrimitivesError;
 
-use super::typed::{ChunkGet, ChunkHas, ChunkPut};
+use super::typed::{ChunkGet, ChunkHas, ChunkPut, PutUnit};
 
 /// Lifts an untrusted medium to `Trust = Verified`: every get runs the
 /// member's full acceptance rule against the requested address, so a
@@ -68,11 +68,11 @@ impl<R: ChunkRegistry, S: ChunkGet<R, Trust = Unverified>> ChunkGet<R> for Verif
 }
 
 // Writes carry sealed chunks already, so they pass through untouched.
-impl<R: ChunkRegistry, S: ChunkPut<R>> ChunkPut<R> for VerifyingStore<S> {
+impl<U: PutUnit, S: ChunkPut<U>> ChunkPut<U> for VerifyingStore<S> {
     type Error = S::Error;
 
-    async fn put(&self, chunk: Chunk<Verified, R>) -> Result<(), Self::Error> {
-        self.0.put(chunk).await
+    async fn put(&self, unit: U) -> Result<(), Self::Error> {
+        self.0.put(unit).await
     }
 }
 

--- a/crates/testing/src/bench.rs
+++ b/crates/testing/src/bench.rs
@@ -142,7 +142,7 @@ impl<R: ChunkRegistry> CountingStore<R> {
     }
 }
 
-impl<R: ChunkRegistry> ChunkPut<R> for CountingStore<R> {
+impl<R: ChunkRegistry> ChunkPut<Chunk<Verified, R>> for CountingStore<R> {
     type Error = std::convert::Infallible;
 
     async fn put(&self, chunk: Chunk<Verified, R>) -> Result<(), Self::Error> {

--- a/crates/testing/tests/wasm_smoke.rs
+++ b/crates/testing/tests/wasm_smoke.rs
@@ -26,7 +26,7 @@ struct RcStore {
     peak: Rc<Cell<usize>>,
 }
 
-impl ChunkPut<AnyChunkSet<DEFAULT_BODY_SIZE>> for RcStore {
+impl ChunkPut<Chunk<Verified, AnyChunkSet<DEFAULT_BODY_SIZE>>> for RcStore {
     type Error = std::convert::Infallible;
 
     async fn put(&self, chunk: SealedChunk) -> Result<(), Self::Error> {

--- a/fuzz/fuzz_targets/file_split_root.rs
+++ b/fuzz/fuzz_targets/file_split_root.rs
@@ -36,7 +36,7 @@ impl Clone for SharedStore {
     }
 }
 
-impl ChunkPut<AnyChunkSet<BODY>> for SharedStore {
+impl ChunkPut<Chunk<Verified, AnyChunkSet<BODY>>> for SharedStore {
     type Error = ChunkStoreError;
 
     async fn put(&self, chunk: Chunk<Verified, AnyChunkSet<BODY>>) -> Result<(), Self::Error> {


### PR DESCRIPTION
Closes #769

## Summary

The chunk sink is now generic over its unit of transfer, following the reth `Table` idiom: `ChunkPut<U: PutUnit = Chunk<Verified>>` in `crates/primitives/src/store/typed.rs`.
The trait parameter changed meaning from a registry (`R: ChunkRegistry`) to a unit type, so every bound spelled `ChunkPut<AnyChunkSet<B>>` is now `ChunkPut<Chunk<Verified, AnyChunkSet<B>>>`; that rewrite is the bulk of the file count and is purely mechanical.
The new seam trait is minimal: `pub trait PutUnit: MaybeSend + 'static { fn address(&self) -> &ChunkAddress; }`, implemented in primitives only for `Chunk<Verified, R>`.

`PutStamped` is deleted. `nectar-postage` implements `PutUnit` for `StampedChunk<Verified, V, BODY_SIZE>` in `crates/postage/src/sink.rs`, so the pair reaches the seam as a type argument the postage crate supplies. `StampIndifferent` now implements `ChunkPut<StampedChunk<Verified, V, B>>` directly instead of going through the old `PutStamped` indirection.

## Changes

- `crates/primitives/src/store/typed.rs`: `ChunkPut<U: PutUnit>`, new `PutUnit` trait
- `crates/primitives/src/store/tee.rs`: new file (189 lines) adding a tee-store implementation over the generic seam
- `crates/primitives/src/store/content.rs`, `memory.rs`, `mod.rs`, `retry.rs`, `verify.rs`: bounds widened from `ChunkPut<AnyChunkSet<B>>` to `ChunkPut<Chunk<Verified, AnyChunkSet<B>>>`
- `crates/primitives/src/lib.rs`: export changes for the new seam
- `crates/postage/src/sink.rs`: `PutStamped` removed; `PutUnit` implemented for `StampedChunk<Verified, V, BODY_SIZE>`; `StampIndifferent` implements `ChunkPut<StampedChunk<...>>` directly
- `crates/postage/src/lib.rs`: export adjustments to match
- `crates/postage-issuer/src/pipeline/stamped_put.rs`: call-site updates for the new bound shape
- `crates/mantaray/src/persist.rs`, `crates/feeds/src/publisher.rs`, `crates/file/**`, `crates/testing/**`, `crates/integration-tests/**`, `fuzz/fuzz_targets/file_split_root.rs`: mechanical call-site/bound updates to the new `ChunkPut<Chunk<Verified, ...>>` spelling

27 files changed, 382 insertions(+), 296 deletions(-). No `Cargo.toml`/`Cargo.lock` changes.

## Red-team

No blocker or major defect found. The collapse is behaviour-preserving: the `ChunkPut`/`PutUnit` widening at `ContentGet`, `VerifyingStore`, and `RetryingChunkGet` is a strict superset of the old `ChunkRegistry`-keyed impls, and no correctness, race, panic, or cfg-arm regression surfaced.

## Testing

All commands run inside `nix develop --command` on branch tip `4a37987a` (rustc 1.94.0, which is also the declared MSRV), detached from `origin/refactor/769-payload-generic-chunkput`, base `origin/refactor/768-stampedchunk-typestate`. No `Cargo.toml`/`Cargo.lock` changed on this branch, so no zepter feature-format work applied; every cargo invocation used `--locked` and the tree stayed clean throughout (nothing to fix, commit, or push).

### Clippy (lint.yml parity: default pass plus every feature pass touching a changed crate)

- `cargo clippy --workspace --all-targets --locked -- -D warnings`: clean
- `cargo clippy --locked --all-targets -p nectar-file --features tokio -- -D warnings`: clean
- `cargo clippy --locked --all-targets -p nectar-file --features rayon -- -D warnings`: clean

## AI Assistance

Implement: claude-opus-5. Red-team: claude-opus-5. PR: claude-sonnet-5.
