### PR TITLE
feat(postage-issuer): dilute through shared handles behind a confirmation gate

### DIFF
--- a/crates/postage-issuer/src/dilute_handler.rs
+++ b/crates/postage-issuer/src/dilute_handler.rs
@@ -1,17 +1,7 @@
 //! Wiring [`BatchEvent::DepthIncrease`] through to issuer dilution.
 //!
-//! A node that issues stamps holds a live issuer per batch. When the postage
-//! contract emits a depth increase for a batch, the matching issuer must grow
-//! its per-bucket capacity so that previously full buckets can accept more
-//! chunks. This module provides the small adapter that performs that wiring: a
-//! registry of dilutable issuers keyed by [`BatchId`] that implements
-//! [`BatchEventHandler`] and, on a [`BatchEvent::DepthIncrease`], calls
-//! [`Dilutable::dilute`] on the matching issuer.
-//!
-//! The adapter lives in the issuer crate rather than in `nectar-postage`
-//! because dilution is an issuer concern: `nectar-postage` is the lower crate
-//! and knows nothing about issuers, so the dependency points up from the event
-//! trait to the issuer.
+//! The adapter lives here rather than in `nectar-postage`, which is the lower
+//! crate and knows nothing about issuers.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -24,11 +14,8 @@ use nectar_primitives::SwarmSpec;
 
 /// An issuer whose per-bucket capacity can be grown by an on-chain dilution.
 ///
-/// Dilution takes `&self`, so the registry and a signing pipeline hold the
-/// same issuer.
-///
-/// The trait is spec-agnostic: it only reads scalar geometry, so one registry
-/// can hold issuers for different networks behind `dyn Dilutable`.
+/// Spec-agnostic: only scalar geometry is read, so one registry can hold
+/// issuers for different networks behind `dyn Dilutable`.
 pub trait Dilutable: MaybeSend + MaybeSync {
     /// Returns the batch ID this issuer issues stamps for.
     fn batch_id(&self) -> BatchId;
@@ -72,7 +59,6 @@ impl<S: SwarmSpec> Dilutable for MemoryIssuer<S> {
     }
 }
 
-/// A dilution observed on chain and awaiting its confirmations.
 #[derive(Debug, Clone, Copy)]
 struct Pending {
     batch_id: BatchId,
@@ -89,14 +75,11 @@ impl Pending {
 /// A registry of dilutable issuers keyed by [`BatchId`].
 ///
 /// Register a shared issuer with [`register`](Self::register), then feed batch
-/// events through [`BatchEventHandler`]. A [`BatchEvent::DepthIncrease`] for a
-/// registered batch grows that issuer's capacity once the dilution block has
-/// [`confirmations`](Self::confirmations) behind it; an event for an
-/// unregistered batch is a no-op. All other event variants are ignored, since
-/// dilution is the only state this adapter owns.
+/// events through [`BatchEventHandler`].
 ///
-/// Widened capacity is gated because a stamp minted into it is invalid to any
-/// peer that has not yet seen the event.
+/// Widened capacity is withheld until the dilution block has
+/// [`confirmations`](Self::confirmations) behind it: a stamp minted into that
+/// range is invalid to any peer that has not yet seen the event.
 #[derive(Default)]
 pub struct IssuerRegistry {
     issuers: HashMap<BatchId, IssuerHandle>,
@@ -106,8 +89,8 @@ pub struct IssuerRegistry {
 }
 
 impl IssuerRegistry {
-    /// Creates an empty registry that demands `confirmations` blocks behind a
-    /// dilution before it issues into the widened capacity.
+    /// Creates an empty registry. `confirmations` is zero for the ungated
+    /// behaviour.
     pub fn new(confirmations: u64) -> Self {
         Self {
             confirmations,
@@ -120,15 +103,14 @@ impl IssuerRegistry {
         self.confirmations
     }
 
-    /// Returns the highest block the registry has observed.
+    /// Returns the highest block observed, from an event or from
+    /// [`advance_to`](Self::advance_to).
     pub const fn block(&self) -> u64 {
         self.block
     }
 
-    /// Registers a shared issuer under its own batch ID.
-    ///
-    /// A subsequent registration for the same batch ID replaces the previous
-    /// handle and returns it.
+    /// Registers a shared issuer under its own batch ID, returning the handle
+    /// it replaced.
     pub fn register(&mut self, issuer: IssuerHandle) -> Option<IssuerHandle> {
         self.issuers.insert(issuer.batch_id(), issuer)
     }
@@ -155,8 +137,7 @@ impl IssuerRegistry {
         self.issuers.is_empty()
     }
 
-    /// Returns the deepest dilution observed for `batch_id` that is not yet
-    /// confirmed.
+    /// Returns the deepest unconfirmed dilution observed for `batch_id`.
     pub fn pending_depth(&self, batch_id: &BatchId) -> Option<u8> {
         self.pending
             .iter()
@@ -165,19 +146,20 @@ impl IssuerRegistry {
             .max()
     }
 
-    /// Advances the observed chain head, applying every dilution that the head
-    /// now confirms.
+    /// Advances the observed chain head, applying every dilution it confirms.
+    ///
+    /// A gated registry needs this: without head progress the last dilution
+    /// stays parked.
     ///
     /// # Errors
     ///
     /// The first [`Dilutable::dilute`] failure, after every other confirmed
-    /// dilution has been applied.
+    /// dilution has been applied. A failed dilution is dropped, not retried.
     pub fn advance_to(&mut self, block: u64) -> Result<(), IssuerError> {
         self.block = self.block.max(block);
         self.settle()
     }
 
-    /// Applies the confirmed dilutions and keeps the rest.
     fn settle(&mut self) -> Result<(), IssuerError> {
         let (due, held): (Vec<Pending>, Vec<Pending>) = std::mem::take(&mut self.pending)
             .into_iter()
@@ -185,9 +167,8 @@ impl IssuerRegistry {
         self.pending = held;
 
         let mut outcome = Ok(());
+        // Depth is raised by maximum, so this order does not matter.
         for pending in due {
-            // Depth is raised by maximum, so a redelivered or reordered
-            // dilution is a no-op and the order here does not matter.
             if let Some(issuer) = self.issuers.get(&pending.batch_id) {
                 let applied = issuer.dilute(pending.depth);
                 if outcome.is_ok() {
@@ -220,21 +201,18 @@ impl BatchEventHandler for IssuerRegistry {
                 new_depth,
                 block,
             } => {
-                // A depth increase for a batch we do not track is a no-op, not
-                // an error: another handler owns that batch's issuer.
-                if !self.issuers.contains_key(&batch_id) {
-                    return Ok(());
+                // An untracked batch belongs to another handler, but its event
+                // still proves the chain reached this block, so the head moves
+                // either way.
+                if self.issuers.contains_key(&batch_id) {
+                    self.pending.push(Pending {
+                        batch_id,
+                        depth: new_depth,
+                        block,
+                    });
                 }
-                self.pending.push(Pending {
-                    batch_id,
-                    depth: new_depth,
-                    block,
-                });
-                // The event proves the chain reached its own block.
                 self.advance_to(block)
             }
-            // Created, TopUp, and Expired carry no capacity change this adapter
-            // is responsible for.
             BatchEvent::Created { .. } | BatchEvent::TopUp { .. } | BatchEvent::Expired { .. } => {
                 Ok(())
             }
@@ -295,8 +273,6 @@ mod tests {
 
     #[test]
     fn a_registered_handle_stays_usable_for_issuance() {
-        // The registry holds a handle rather than the issuer, so the same
-        // issuer signs while the registry dilutes it.
         let tracked = batch_id(0x22);
         let handle = issuer(tracked);
         let mut registry = IssuerRegistry::new(0);
@@ -326,8 +302,6 @@ mod tests {
 
         registry.handle_event(dilution(tracked, 18)).unwrap();
 
-        // Observed, not yet issuable: the widened range is invalid to any peer
-        // that has not seen the event.
         assert_eq!(registry.pending_depth(&tracked), Some(18));
         assert_eq!(handle.batch_depth(), 17);
         assert!(handle.reserve(&address(), 3).is_err());
@@ -346,8 +320,6 @@ mod tests {
 
     #[test]
     fn a_confirmed_backfill_applies_without_waiting() {
-        // Replayed history is already confirmed, so it must not park the issuer
-        // at the old depth.
         let tracked = batch_id(0x88);
         let handle = issuer(tracked);
         let mut registry = IssuerRegistry::new(CONFIRMATIONS);
@@ -420,18 +392,37 @@ mod tests {
         let mut registry = IssuerRegistry::new(0);
         registry.register(issuer(tracked));
 
-        // An event for a batch we do not track must not error and must leave
-        // the tracked issuer untouched.
         registry.handle_event(dilution(other, 24)).unwrap();
 
         let issuer = registry.get(&tracked).unwrap();
         assert_eq!(issuer.batch_depth(), 17);
         assert_eq!(issuer.bucket_capacity(), 2);
-        // The unrelated batch was never registered, so nothing was created for
-        // it.
         assert!(registry.get(&other).is_none());
         assert_eq!(registry.pending_depth(&other), None);
         assert_eq!(registry.len(), 1);
+    }
+
+    #[test]
+    fn an_untracked_batch_still_advances_the_head() {
+        let tracked = batch_id(0xBB);
+        let other = batch_id(0xCC);
+        let handle = issuer(tracked);
+        let mut registry = IssuerRegistry::new(CONFIRMATIONS);
+        registry.register(handle.clone());
+        registry.handle_event(dilution(tracked, 18)).unwrap();
+        assert_eq!(handle.batch_depth(), 17);
+
+        registry
+            .handle_event(BatchEvent::DepthIncrease {
+                batch_id: other,
+                new_depth: 24,
+                block: DILUTION_BLOCK + CONFIRMATIONS,
+            })
+            .unwrap();
+
+        assert_eq!(registry.block(), DILUTION_BLOCK + CONFIRMATIONS);
+        assert_eq!(registry.pending_depth(&tracked), None);
+        assert_eq!(handle.batch_depth(), 18);
     }
 
     #[test]
@@ -457,9 +448,8 @@ mod tests {
 
     #[test]
     fn depth_decrease_event_surfaces_error_defensively() {
-        // The contract never emits a decrease, but if a malformed event arrives
-        // the adapter must not silently corrupt state: the issuer's own guard
-        // refuses it and the error propagates.
+        // The contract never emits a decrease; a malformed one must surface,
+        // not corrupt the geometry.
         let tracked = batch_id(0x66);
         let handle = Arc::new(MemoryIssuer::<Mainnet>::new(
             tracked,
@@ -479,4 +469,38 @@ mod tests {
         ));
         assert_eq!(registry.pending_depth(&tracked), None);
     }
+
+    #[test]
+    fn a_gated_depth_decrease_surfaces_from_the_confirming_advance() {
+        let tracked = batch_id(0xDD);
+        let handle = Arc::new(MemoryIssuer::<Mainnet>::new(
+            tracked,
+            18,
+            BucketDepth::new(16).unwrap(),
+        ));
+        let mut registry = IssuerRegistry::new(CONFIRMATIONS);
+        registry.register(handle.clone());
+
+        registry.handle_event(dilution(tracked, 17)).unwrap();
+        assert_eq!(registry.pending_depth(&tracked), Some(17));
+
+        let result = registry.advance_to(DILUTION_BLOCK + CONFIRMATIONS);
+        assert!(matches!(
+            result,
+            Err(IssuerError::DepthDecrease {
+                current: 18,
+                requested: 17
+            })
+        ));
+        assert_eq!(handle.batch_depth(), 18);
+        assert_eq!(registry.pending_depth(&tracked), None);
+    }
+
+    // The shared-handle design is void if `MaybeSend`/`MaybeSync` stop reaching
+    // the trait object.
+    const _: fn() = || {
+        fn shareable<T: Send + Sync>() {}
+        shareable::<IssuerRegistry>();
+        shareable::<IssuerHandle>();
+    };
 }

--- a/crates/postage-issuer/src/dilute_handler.rs
+++ b/crates/postage-issuer/src/dilute_handler.rs
@@ -14,22 +14,22 @@
 //! trait to the issuer.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use crate::error::IssuerError;
 use crate::issuer::MemoryIssuer;
+use nectar_marker::{MaybeSend, MaybeSync};
 use nectar_postage::{BatchEvent, BatchEventHandler, BatchId};
 use nectar_primitives::SwarmSpec;
 
 /// An issuer whose per-bucket capacity can be grown by an on-chain dilution.
 ///
-/// This is the minimal surface the [`IssuerRegistry`] needs to drive a
-/// [`BatchEvent::DepthIncrease`] through to the right issuer. It is implemented
-/// for the fill-only [`MemoryIssuer`]; a self-hosting ring issuer dilutes
-/// through its snapshot in `nectar-postage-usage` and is not registered here.
+/// Dilution takes `&self`, so the registry and a signing pipeline hold the
+/// same issuer.
 ///
 /// The trait is spec-agnostic: it only reads scalar geometry, so one registry
 /// can hold issuers for different networks behind `dyn Dilutable`.
-pub trait Dilutable {
+pub trait Dilutable: MaybeSend + MaybeSync {
     /// Returns the batch ID this issuer issues stamps for.
     fn batch_id(&self) -> BatchId;
 
@@ -46,8 +46,11 @@ pub trait Dilutable {
     ///
     /// Returns [`IssuerError::DepthDecrease`] if `new_depth` is below the
     /// current depth.
-    fn dilute(&mut self, new_depth: u8) -> Result<(), IssuerError>;
+    fn dilute(&self, new_depth: u8) -> Result<(), IssuerError>;
 }
+
+/// A registered issuer, shared between the registry and its pipelines.
+pub type IssuerHandle = Arc<dyn Dilutable>;
 
 impl<S: SwarmSpec> Dilutable for MemoryIssuer<S> {
     // The geometry accessors come from the StampIssuer trait, so they are named
@@ -64,48 +67,81 @@ impl<S: SwarmSpec> Dilutable for MemoryIssuer<S> {
         crate::StampIssuer::bucket_capacity(self)
     }
 
-    fn dilute(&mut self, new_depth: u8) -> Result<(), IssuerError> {
+    fn dilute(&self, new_depth: u8) -> Result<(), IssuerError> {
         Self::dilute(self, new_depth)
+    }
+}
+
+/// A dilution observed on chain and awaiting its confirmations.
+#[derive(Debug, Clone, Copy)]
+struct Pending {
+    batch_id: BatchId,
+    depth: u8,
+    block: u64,
+}
+
+impl Pending {
+    const fn is_confirmed(&self, head: u64, confirmations: u64) -> bool {
+        self.block.saturating_add(confirmations) <= head
     }
 }
 
 /// A registry of dilutable issuers keyed by [`BatchId`].
 ///
-/// Register a live issuer with [`register`](Self::register), then feed batch
+/// Register a shared issuer with [`register`](Self::register), then feed batch
 /// events through [`BatchEventHandler`]. A [`BatchEvent::DepthIncrease`] for a
-/// registered batch grows that issuer's capacity; an event for an unregistered
-/// batch is a no-op. All other event variants are ignored, since dilution is
-/// the only state this adapter owns.
+/// registered batch grows that issuer's capacity once the dilution block has
+/// [`confirmations`](Self::confirmations) behind it; an event for an
+/// unregistered batch is a no-op. All other event variants are ignored, since
+/// dilution is the only state this adapter owns.
+///
+/// Widened capacity is gated because a stamp minted into it is invalid to any
+/// peer that has not yet seen the event.
 #[derive(Default)]
 pub struct IssuerRegistry {
-    issuers: HashMap<BatchId, Box<dyn Dilutable + Send>>,
+    issuers: HashMap<BatchId, IssuerHandle>,
+    pending: Vec<Pending>,
+    confirmations: u64,
+    block: u64,
 }
 
 impl IssuerRegistry {
-    /// Creates an empty registry.
-    pub fn new() -> Self {
-        Self::default()
+    /// Creates an empty registry that demands `confirmations` blocks behind a
+    /// dilution before it issues into the widened capacity.
+    pub fn new(confirmations: u64) -> Self {
+        Self {
+            confirmations,
+            ..Self::default()
+        }
     }
 
-    /// Registers an issuer under its own batch ID.
+    /// Returns the confirmations demanded of a dilution before issuance.
+    pub const fn confirmations(&self) -> u64 {
+        self.confirmations
+    }
+
+    /// Returns the highest block the registry has observed.
+    pub const fn block(&self) -> u64 {
+        self.block
+    }
+
+    /// Registers a shared issuer under its own batch ID.
     ///
     /// A subsequent registration for the same batch ID replaces the previous
-    /// issuer and returns it.
-    pub fn register<I>(&mut self, issuer: I) -> Option<Box<dyn Dilutable + Send>>
-    where
-        I: Dilutable + Send + 'static,
-    {
-        self.issuers
-            .insert(Dilutable::batch_id(&issuer), Box::new(issuer))
+    /// handle and returns it.
+    pub fn register(&mut self, issuer: IssuerHandle) -> Option<IssuerHandle> {
+        self.issuers.insert(issuer.batch_id(), issuer)
     }
 
-    /// Returns a shared reference to the issuer registered for `batch_id`.
-    pub fn get(&self, batch_id: &BatchId) -> Option<&(dyn Dilutable + Send)> {
-        self.issuers.get(batch_id).map(|boxed| &**boxed)
+    /// Returns a handle to the issuer registered for `batch_id`.
+    pub fn get(&self, batch_id: &BatchId) -> Option<IssuerHandle> {
+        self.issuers.get(batch_id).map(Arc::clone)
     }
 
-    /// Removes the issuer registered for `batch_id`, if any.
-    pub fn remove(&mut self, batch_id: &BatchId) -> Option<Box<dyn Dilutable + Send>> {
+    /// Removes the issuer registered for `batch_id`, dropping any dilution it
+    /// was still waiting on.
+    pub fn remove(&mut self, batch_id: &BatchId) -> Option<IssuerHandle> {
+        self.pending.retain(|pending| pending.batch_id != *batch_id);
         self.issuers.remove(batch_id)
     }
 
@@ -118,12 +154,58 @@ impl IssuerRegistry {
     pub fn is_empty(&self) -> bool {
         self.issuers.is_empty()
     }
+
+    /// Returns the deepest dilution observed for `batch_id` that is not yet
+    /// confirmed.
+    pub fn pending_depth(&self, batch_id: &BatchId) -> Option<u8> {
+        self.pending
+            .iter()
+            .filter(|pending| pending.batch_id == *batch_id)
+            .map(|pending| pending.depth)
+            .max()
+    }
+
+    /// Advances the observed chain head, applying every dilution that the head
+    /// now confirms.
+    ///
+    /// # Errors
+    ///
+    /// The first [`Dilutable::dilute`] failure, after every other confirmed
+    /// dilution has been applied.
+    pub fn advance_to(&mut self, block: u64) -> Result<(), IssuerError> {
+        self.block = self.block.max(block);
+        self.settle()
+    }
+
+    /// Applies the confirmed dilutions and keeps the rest.
+    fn settle(&mut self) -> Result<(), IssuerError> {
+        let (due, held): (Vec<Pending>, Vec<Pending>) = std::mem::take(&mut self.pending)
+            .into_iter()
+            .partition(|pending| pending.is_confirmed(self.block, self.confirmations));
+        self.pending = held;
+
+        let mut outcome = Ok(());
+        for pending in due {
+            // Depth is raised by maximum, so a redelivered or reordered
+            // dilution is a no-op and the order here does not matter.
+            if let Some(issuer) = self.issuers.get(&pending.batch_id) {
+                let applied = issuer.dilute(pending.depth);
+                if outcome.is_ok() {
+                    outcome = applied;
+                }
+            }
+        }
+        outcome
+    }
 }
 
 impl std::fmt::Debug for IssuerRegistry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("IssuerRegistry")
             .field("issuers", &self.issuers.keys().collect::<Vec<_>>())
+            .field("pending", &self.pending)
+            .field("confirmations", &self.confirmations)
+            .field("block", &self.block)
             .finish()
     }
 }
@@ -136,12 +218,21 @@ impl BatchEventHandler for IssuerRegistry {
             BatchEvent::DepthIncrease {
                 batch_id,
                 new_depth,
-            } => self
-                .issuers
-                .get_mut(&batch_id)
+                block,
+            } => {
                 // A depth increase for a batch we do not track is a no-op, not
                 // an error: another handler owns that batch's issuer.
-                .map_or(Ok(()), |issuer| issuer.dilute(new_depth)),
+                if !self.issuers.contains_key(&batch_id) {
+                    return Ok(());
+                }
+                self.pending.push(Pending {
+                    batch_id,
+                    depth: new_depth,
+                    block,
+                });
+                // The event proves the chain reached its own block.
+                self.advance_to(block)
+            }
             // Created, TopUp, and Expired carry no capacity change this adapter
             // is responsible for.
             BatchEvent::Created { .. } | BatchEvent::TopUp { .. } | BatchEvent::Expired { .. } => {
@@ -155,31 +246,45 @@ impl BatchEventHandler for IssuerRegistry {
 mod tests {
     use super::*;
     use crate::MemoryIssuer;
-    use nectar_postage::BucketDepth;
-    use nectar_primitives::Mainnet;
+    use nectar_postage::{BucketDepth, StampError};
+    use nectar_primitives::{ChunkAddress, Mainnet};
+
+    const DILUTION_BLOCK: u64 = 1_000;
+    const CONFIRMATIONS: u64 = 8;
 
     fn batch_id(byte: u8) -> BatchId {
         BatchId::new([byte; 32])
     }
 
-    #[test]
-    fn depth_increase_grows_registered_issuer_capacity() {
-        // depth=17, bucket_depth=16 gives 2 slots per bucket.
-        let tracked = batch_id(0x11);
-        let mut registry = IssuerRegistry::new();
-        registry.register(MemoryIssuer::<Mainnet>::new(
-            tracked,
+    /// A two-slot issuer: depth 17 over bucket depth 16.
+    fn issuer(id: BatchId) -> Arc<MemoryIssuer> {
+        Arc::new(MemoryIssuer::<Mainnet>::new(
+            id,
             17,
             BucketDepth::new(16).unwrap(),
-        ));
+        ))
+    }
+
+    fn address() -> ChunkAddress {
+        ChunkAddress::new([0xAB; 32])
+    }
+
+    fn dilution(batch_id: BatchId, new_depth: u8) -> BatchEvent {
+        BatchEvent::DepthIncrease {
+            batch_id,
+            new_depth,
+            block: DILUTION_BLOCK,
+        }
+    }
+
+    #[test]
+    fn depth_increase_grows_registered_issuer_capacity() {
+        let tracked = batch_id(0x11);
+        let mut registry = IssuerRegistry::new(0);
+        registry.register(issuer(tracked));
         assert_eq!(registry.get(&tracked).unwrap().bucket_capacity(), 2);
 
-        registry
-            .handle_event(BatchEvent::DepthIncrease {
-                batch_id: tracked,
-                new_depth: 18,
-            })
-            .unwrap();
+        registry.handle_event(dilution(tracked, 18)).unwrap();
 
         // The diluted issuer reflects the new depth: depth 18 over bucket_depth
         // 16 is 4 slots per bucket.
@@ -189,25 +294,135 @@ mod tests {
     }
 
     #[test]
+    fn a_registered_handle_stays_usable_for_issuance() {
+        // The registry holds a handle rather than the issuer, so the same
+        // issuer signs while the registry dilutes it.
+        let tracked = batch_id(0x22);
+        let handle = issuer(tracked);
+        let mut registry = IssuerRegistry::new(0);
+        registry.register(handle.clone());
+
+        handle.reserve(&address(), 1).unwrap();
+        handle.reserve(&address(), 2).unwrap();
+        assert!(matches!(
+            handle.reserve(&address(), 3),
+            Err(StampError::BucketFull { capacity: 2, .. })
+        ));
+
+        registry.handle_event(dilution(tracked, 18)).unwrap();
+
+        // The watermark does not move, so the reopened bucket continues at 2.
+        assert_eq!(handle.reserve(&address(), 4).unwrap().index().index(), 2);
+    }
+
+    #[test]
+    fn issuance_waits_for_the_dilution_to_confirm() {
+        let tracked = batch_id(0x77);
+        let handle = issuer(tracked);
+        let mut registry = IssuerRegistry::new(CONFIRMATIONS);
+        registry.register(handle.clone());
+        handle.reserve(&address(), 1).unwrap();
+        handle.reserve(&address(), 2).unwrap();
+
+        registry.handle_event(dilution(tracked, 18)).unwrap();
+
+        // Observed, not yet issuable: the widened range is invalid to any peer
+        // that has not seen the event.
+        assert_eq!(registry.pending_depth(&tracked), Some(18));
+        assert_eq!(handle.batch_depth(), 17);
+        assert!(handle.reserve(&address(), 3).is_err());
+
+        registry
+            .advance_to(DILUTION_BLOCK + CONFIRMATIONS - 1)
+            .unwrap();
+        assert_eq!(handle.batch_depth(), 17);
+        assert!(handle.reserve(&address(), 4).is_err());
+
+        registry.advance_to(DILUTION_BLOCK + CONFIRMATIONS).unwrap();
+        assert_eq!(registry.pending_depth(&tracked), None);
+        assert_eq!(handle.batch_depth(), 18);
+        assert_eq!(handle.reserve(&address(), 5).unwrap().index().index(), 2);
+    }
+
+    #[test]
+    fn a_confirmed_backfill_applies_without_waiting() {
+        // Replayed history is already confirmed, so it must not park the issuer
+        // at the old depth.
+        let tracked = batch_id(0x88);
+        let handle = issuer(tracked);
+        let mut registry = IssuerRegistry::new(CONFIRMATIONS);
+        registry.register(handle.clone());
+
+        registry.handle_event(dilution(tracked, 18)).unwrap();
+        registry
+            .advance_to(DILUTION_BLOCK + CONFIRMATIONS * 4)
+            .unwrap();
+        registry
+            .handle_event(BatchEvent::DepthIncrease {
+                batch_id: tracked,
+                new_depth: 19,
+                block: DILUTION_BLOCK + 1,
+            })
+            .unwrap();
+
+        assert_eq!(handle.batch_depth(), 19);
+        assert_eq!(registry.pending_depth(&tracked), None);
+    }
+
+    #[test]
+    fn each_pending_dilution_confirms_on_its_own_block() {
+        let tracked = batch_id(0x99);
+        let handle = issuer(tracked);
+        let mut registry = IssuerRegistry::new(CONFIRMATIONS);
+        registry.register(handle.clone());
+
+        registry.handle_event(dilution(tracked, 18)).unwrap();
+        registry
+            .handle_event(BatchEvent::DepthIncrease {
+                batch_id: tracked,
+                new_depth: 20,
+                block: DILUTION_BLOCK + 10,
+            })
+            .unwrap();
+        assert_eq!(registry.pending_depth(&tracked), Some(20));
+
+        registry.advance_to(DILUTION_BLOCK + CONFIRMATIONS).unwrap();
+        assert_eq!(handle.batch_depth(), 18);
+        assert_eq!(registry.pending_depth(&tracked), Some(20));
+
+        registry
+            .advance_to(DILUTION_BLOCK + 10 + CONFIRMATIONS)
+            .unwrap();
+        assert_eq!(handle.batch_depth(), 20);
+    }
+
+    #[test]
+    fn a_removed_issuer_leaves_no_dilution_behind() {
+        let tracked = batch_id(0xAA);
+        let handle = issuer(tracked);
+        let mut registry = IssuerRegistry::new(CONFIRMATIONS);
+        registry.register(handle.clone());
+        registry.handle_event(dilution(tracked, 18)).unwrap();
+
+        assert!(registry.remove(&tracked).is_some());
+        registry.advance_to(DILUTION_BLOCK + CONFIRMATIONS).unwrap();
+
+        assert_eq!(registry.pending_depth(&tracked), None);
+        assert_eq!(handle.batch_depth(), 17);
+        assert!(registry.is_empty());
+    }
+
+    #[test]
     fn depth_increase_for_unknown_batch_leaves_tracked_issuer_untouched() {
         let tracked = batch_id(0x33);
         let other = batch_id(0x44);
 
-        let mut registry = IssuerRegistry::new();
-        registry.register(MemoryIssuer::<Mainnet>::new(
-            tracked,
-            17,
-            BucketDepth::new(16).unwrap(),
-        ));
+        let mut registry = IssuerRegistry::new(0);
+        registry.register(issuer(tracked));
 
         // An event for a batch we do not track must not error and must leave
         // the tracked issuer untouched.
-        registry
-            .handle_event(BatchEvent::DepthIncrease {
-                batch_id: other,
-                new_depth: 24,
-            })
-            .unwrap();
+        registry.handle_event(dilution(other, 24)).unwrap();
 
         let issuer = registry.get(&tracked).unwrap();
         assert_eq!(issuer.batch_depth(), 17);
@@ -215,18 +430,15 @@ mod tests {
         // The unrelated batch was never registered, so nothing was created for
         // it.
         assert!(registry.get(&other).is_none());
+        assert_eq!(registry.pending_depth(&other), None);
         assert_eq!(registry.len(), 1);
     }
 
     #[test]
     fn non_depth_events_are_ignored() {
         let tracked = batch_id(0x55);
-        let mut registry = IssuerRegistry::new();
-        registry.register(MemoryIssuer::<Mainnet>::new(
-            tracked,
-            17,
-            BucketDepth::new(16).unwrap(),
-        ));
+        let mut registry = IssuerRegistry::new(0);
+        registry.register(issuer(tracked));
 
         registry
             .handle_event(BatchEvent::TopUp {
@@ -249,17 +461,15 @@ mod tests {
         // the adapter must not silently corrupt state: the issuer's own guard
         // refuses it and the error propagates.
         let tracked = batch_id(0x66);
-        let mut registry = IssuerRegistry::new();
-        registry.register(MemoryIssuer::<Mainnet>::new(
+        let handle = Arc::new(MemoryIssuer::<Mainnet>::new(
             tracked,
             18,
             BucketDepth::new(16).unwrap(),
         ));
+        let mut registry = IssuerRegistry::new(0);
+        registry.register(handle);
 
-        let result = registry.handle_event(BatchEvent::DepthIncrease {
-            batch_id: tracked,
-            new_depth: 17,
-        });
+        let result = registry.handle_event(dilution(tracked, 17));
         assert!(matches!(
             result,
             Err(IssuerError::DepthDecrease {
@@ -267,5 +477,6 @@ mod tests {
                 requested: 17
             })
         ));
+        assert_eq!(registry.pending_depth(&tracked), None);
     }
 }

--- a/crates/postage-issuer/src/lib.rs
+++ b/crates/postage-issuer/src/lib.rs
@@ -80,6 +80,14 @@
 //! permit returns its [`WindowToken`] to the [`AdmissionWindow`] and burns the
 //! slot, so a cancelled future recovers backpressure but never capacity.
 //!
+//! # Online dilution
+//!
+//! [`Dilutable::dilute`] takes `&self` and [`IssuerRegistry`] holds
+//! [`IssuerHandle`]s, so a chain event dilutes the very issuer a pipeline is
+//! signing through. The registry withholds the widened capacity until the
+//! dilution block carries its confirmations: a peer that has not ingested the
+//! event rejects a stamp minted into that range.
+//!
 //! # Parallel stamping
 //!
 //! [`MemoryIssuer`] allocates without a lock, so any number of threads may
@@ -172,7 +180,7 @@ pub use counter::{CounterError, CounterMode, CounterTable};
 
 // Wiring on-chain depth-increase events through to issuer dilution (std only).
 #[cfg(feature = "std")]
-pub use dilute_handler::{Dilutable, IssuerRegistry};
+pub use dilute_handler::{Dilutable, IssuerHandle, IssuerRegistry};
 
 // Issuing
 pub use issuer::{MemoryIssuer, StampIssuer};

--- a/crates/postage-issuer/src/lib.rs
+++ b/crates/postage-issuer/src/lib.rs
@@ -83,10 +83,12 @@
 //! # Online dilution
 //!
 //! [`Dilutable::dilute`] takes `&self` and [`IssuerRegistry`] holds
-//! [`IssuerHandle`]s, so a chain event dilutes the very issuer a pipeline is
-//! signing through. The registry withholds the widened capacity until the
-//! dilution block carries its confirmations: a peer that has not ingested the
-//! event rejects a stamp minted into that range.
+//! [`IssuerHandle`]s, so a chain event dilutes an issuer a pipeline is signing
+//! through. The registry withholds the widened capacity until the dilution
+//! block carries its confirmations, because a peer that has not ingested the
+//! event rejects a stamp minted into that range. A gated registry therefore
+//! needs [`IssuerRegistry::advance_to`]: without head progress the last
+//! dilution never applies.
 //!
 //! # Parallel stamping
 //!

--- a/crates/postage-issuer/src/watermarks.rs
+++ b/crates/postage-issuer/src/watermarks.rs
@@ -53,7 +53,7 @@ mod word {
             self.0.load(ORDER)
         }
 
-        /// The depth every completed dilution has published.
+        /// Acquire, so this is a second load and not the first one folded.
         pub(super) fn reload(&self) -> u8 {
             self.0.load(Ordering::Acquire)
         }
@@ -119,7 +119,6 @@ mod word {
             self.0.get()
         }
 
-        /// The depth every completed dilution has published.
         pub(super) fn reload(&self) -> u8 {
             self.0.get()
         }
@@ -209,8 +208,7 @@ impl<S: SwarmSpec> Watermarks<S> {
         self.capacity_at(self.depth.get())
     }
 
-    /// The capacity of every dilution that has already returned.
-    fn confirmed_capacity(&self) -> u32 {
+    fn reloaded_capacity(&self) -> u32 {
         self.capacity_at(self.depth.reload())
     }
 
@@ -253,17 +251,16 @@ impl<S: SwarmSpec> Watermarks<S> {
         let mut count = counter.get();
         let mut reloaded = false;
         loop {
-            // Re-read the capacity every attempt: a dilution landing mid-loop
-            // reopens the bucket, and a stale read only refuses early.
+            // A dilution landing mid-loop reopens the bucket, so a full bucket
+            // is confirmed by one fresh load before it is refused. Once per
+            // call: the retry is a courtesy on a path that was going to fail.
             let mut capacity = self.bucket_capacity();
             if count >= capacity {
                 if reloaded {
                     return Err(CounterError::BucketFull { bucket, capacity });
                 }
-                // One confirmed re-read turns a dilution window's stale
-                // refusal into a claim.
                 reloaded = true;
-                capacity = self.confirmed_capacity();
+                capacity = self.reloaded_capacity();
                 if count >= capacity {
                     return Err(CounterError::BucketFull { bucket, capacity });
                 }

--- a/crates/postage-issuer/src/watermarks.rs
+++ b/crates/postage-issuer/src/watermarks.rs
@@ -53,9 +53,14 @@ mod word {
             self.0.load(ORDER)
         }
 
+        /// The depth every completed dilution has published.
+        pub(super) fn reload(&self) -> u8 {
+            self.0.load(Ordering::Acquire)
+        }
+
         /// Raises the depth, returning the depth before the call.
         pub(super) fn raise(&self, value: u8) -> u8 {
-            self.0.fetch_max(value, ORDER)
+            self.0.fetch_max(value, Ordering::AcqRel)
         }
     }
 
@@ -111,6 +116,11 @@ mod word {
         }
 
         pub(super) fn get(&self) -> u8 {
+            self.0.get()
+        }
+
+        /// The depth every completed dilution has published.
+        pub(super) fn reload(&self) -> u8 {
             self.0.get()
         }
 
@@ -195,10 +205,19 @@ impl<S: SwarmSpec> Watermarks<S> {
     }
 
     /// Slots per bucket, `2^(depth - bucket_depth)`.
+    pub(crate) fn bucket_capacity(&self) -> u32 {
+        self.capacity_at(self.depth.get())
+    }
+
+    /// The capacity of every dilution that has already returned.
+    fn confirmed_capacity(&self) -> u32 {
+        self.capacity_at(self.depth.reload())
+    }
+
     // An unvalidated geometry saturates rather than panicking; the `Batch`
     // constructors keep the shift in range.
-    pub(crate) fn bucket_capacity(&self) -> u32 {
-        let slot_bits = self.depth.get().saturating_sub(self.bucket_depth.get());
+    fn capacity_at(&self, depth: u8) -> u32 {
+        let slot_bits = depth.saturating_sub(self.bucket_depth.get());
         1u32.checked_shl(u32::from(slot_bits)).unwrap_or(u32::MAX)
     }
 
@@ -232,12 +251,22 @@ impl<S: SwarmSpec> Watermarks<S> {
         let bucket = bucket.value();
         let counter = self.counter(bucket)?;
         let mut count = counter.get();
+        let mut reloaded = false;
         loop {
             // Re-read the capacity every attempt: a dilution landing mid-loop
             // reopens the bucket, and a stale read only refuses early.
-            let capacity = self.bucket_capacity();
+            let mut capacity = self.bucket_capacity();
             if count >= capacity {
-                return Err(CounterError::BucketFull { bucket, capacity });
+                if reloaded {
+                    return Err(CounterError::BucketFull { bucket, capacity });
+                }
+                // One confirmed re-read turns a dilution window's stale
+                // refusal into a claim.
+                reloaded = true;
+                capacity = self.confirmed_capacity();
+                if count >= capacity {
+                    return Err(CounterError::BucketFull { bucket, capacity });
+                }
             }
             match counter.claim(count, count.saturating_add(1)) {
                 Ok(()) => {

--- a/crates/postage-issuer/tests/online_dilution.rs
+++ b/crates/postage-issuer/tests/online_dilution.rs
@@ -1,8 +1,7 @@
 //! Dilution observed while a signing stream is in flight.
 //!
-//! The registry and the pipeline hold the same issuer, so the chain event lands
-//! mid-stream. A barrier pins the interleaving: exactly `HALF` addresses are
-//! admitted at the narrow depth, the rest at the wide one.
+//! A barrier pins the interleaving: exactly `HALF` addresses are admitted at
+//! the narrow depth, the rest at the wide one.
 
 #![allow(clippy::arithmetic_side_effects, clippy::panic, clippy::unwrap_used)]
 
@@ -25,6 +24,15 @@ const TOTAL: u32 = 256;
 const HALF: u32 = TOTAL / 2;
 const DILUTION_BLOCK: u64 = 4_200;
 const CONFIRMATIONS: u64 = 12;
+const NARROW_CAPACITY: u32 = 1 << (NARROW_DEPTH - BUCKET_DEPTH);
+const NARROW_SLOTS: u32 = BUCKETS * NARROW_CAPACITY;
+
+/// A window of exactly the narrow slot total. The first refill takes all of
+/// them, so every later micro-batch is one address and none can straddle the
+/// barrier and reserve a pre-barrier address at the wide depth.
+fn window() -> Window {
+    Window::new(u16::try_from(NARROW_SLOTS).unwrap()).unwrap()
+}
 
 /// An address whose leading bytes place it in bucket `i % BUCKETS`.
 fn address_for(i: u32) -> ChunkAddress {
@@ -63,12 +71,9 @@ fn a_dilution_mid_stream_widens_the_batch_without_minting_an_invalid_stamp() {
 
     // Observations are asserted after the join: a panic between the barriers
     // would strand the stamping thread.
-    let (results, unconfirmed, confirmed) = thread::scope(|scope| {
+    let (results, unconfirmed, confirmed, gated) = thread::scope(|scope| {
         let stamping = scope.spawn(|| {
-            // A window under HALF keeps admission lazy, so the barrier lands
-            // mid-stream rather than after the whole input is pulled.
-            let pipeline =
-                StampPipeline::from_signer(signer.clone()).with_window(Window::new(16).unwrap());
+            let pipeline = StampPipeline::from_signer(signer.clone()).with_window(window());
             let addresses = (0..TOTAL).map(|i| {
                 if i == HALF {
                     at_half.wait();
@@ -93,28 +98,35 @@ fn a_dilution_mid_stream_widens_the_batch_without_minting_an_invalid_stamp() {
                 .unwrap();
             unconfirmed.push(StampIssuer::batch_depth(&*issuer));
         }
+        let gated = (
+            StampIssuer::max_bucket_utilization(&*issuer),
+            StampIssuer::stamps_issued(&*issuer),
+        );
         registry.advance_to(DILUTION_BLOCK + CONFIRMATIONS).unwrap();
         let confirmed = StampIssuer::batch_depth(&*issuer);
         resumed.wait();
 
-        (stamping.join().unwrap(), unconfirmed, confirmed)
+        (stamping.join().unwrap(), unconfirmed, confirmed, gated)
     });
 
     // Nothing is issuable into the widened range until the event confirms.
     assert!(unconfirmed.iter().all(|depth| *depth == NARROW_DEPTH));
     assert_eq!(confirmed, WIDE_DEPTH);
+    assert_eq!(gated, (NARROW_CAPACITY, Some(u64::from(NARROW_SLOTS))));
 
     let batch = batch_at(owner, WIDE_DEPTH);
-    let narrow_capacity = 1u32 << (NARROW_DEPTH - BUCKET_DEPTH);
+    let narrow = batch_at(owner, NARROW_DEPTH);
     let mut slots = HashSet::new();
     let mut issued = 0u32;
     let mut refused = 0u32;
+    let mut narrow_valid = 0u32;
 
     assert_eq!(u32::try_from(results.len()).unwrap(), TOTAL);
     for outcome in results {
         match outcome.result {
             Ok(stamp) => {
                 issued += 1;
+                narrow_valid += u32::from(narrow.validate_index(&stamp.stamp_index()).is_ok());
                 stamp.verify(&outcome.address, owner).unwrap();
                 batch.validate_index(&stamp.stamp_index()).unwrap();
                 batch
@@ -129,9 +141,12 @@ fn a_dilution_mid_stream_widens_the_batch_without_minting_an_invalid_stamp() {
 
     // The first half sees the narrow geometry, so each bucket fills at its old
     // capacity; the second half sees the wide one and every address lands.
-    assert_eq!(issued, BUCKETS * narrow_capacity + HALF);
+    assert_eq!(issued, NARROW_SLOTS + HALF);
     assert_eq!(refused, TOTAL - issued);
     assert_eq!(u32::try_from(slots.len()).unwrap(), issued);
+    // A peer still on the narrow geometry accepts exactly the pre-dilution
+    // slots and no more.
+    assert_eq!(narrow_valid, NARROW_SLOTS);
     assert_eq!(
         StampIssuer::stamps_issued(&*issuer),
         Some(u64::from(issued))
@@ -152,8 +167,7 @@ fn an_unsynchronized_dilution_never_reissues_a_slot() {
 
     let results = thread::scope(|scope| {
         let stamping = scope.spawn(|| {
-            let pipeline =
-                StampPipeline::from_signer(signer.clone()).with_window(Window::new(16).unwrap());
+            let pipeline = StampPipeline::from_signer(signer.clone()).with_window(window());
             pipeline
                 .stamp(&*issuer, (0..TOTAL).map(address_for))
                 .collect::<Vec<_>>()

--- a/crates/postage-issuer/tests/online_dilution.rs
+++ b/crates/postage-issuer/tests/online_dilution.rs
@@ -1,0 +1,191 @@
+//! Dilution observed while a signing stream is in flight.
+//!
+//! The registry and the pipeline hold the same issuer, so the chain event lands
+//! mid-stream. A barrier pins the interleaving: exactly `HALF` addresses are
+//! admitted at the narrow depth, the rest at the wide one.
+
+#![allow(clippy::arithmetic_side_effects, clippy::panic, clippy::unwrap_used)]
+
+use std::collections::HashSet;
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+use alloy_signer_local::PrivateKeySigner;
+use nectar_postage_issuer::{
+    Batch, BatchEvent, BatchEventHandler, BatchId, BucketDepth, IssuerRegistry, MemoryIssuer,
+    SigningError, StampError, StampIssuer, StampPipeline, Window,
+};
+use nectar_primitives::ChunkAddress;
+
+const BUCKETS: u32 = 8;
+const NARROW_DEPTH: u8 = 17;
+const WIDE_DEPTH: u8 = 21;
+const BUCKET_DEPTH: u8 = 16;
+const TOTAL: u32 = 256;
+const HALF: u32 = TOTAL / 2;
+const DILUTION_BLOCK: u64 = 4_200;
+const CONFIRMATIONS: u64 = 12;
+
+/// An address whose leading bytes place it in bucket `i % BUCKETS`.
+fn address_for(i: u32) -> ChunkAddress {
+    let mut bytes = [0u8; 32];
+    let bucket = u16::try_from(i % BUCKETS).unwrap();
+    bytes[..2].copy_from_slice(&bucket.to_be_bytes());
+    bytes[2..6].copy_from_slice(&i.to_be_bytes());
+    ChunkAddress::new(bytes)
+}
+
+fn batch_at(owner: alloy_primitives::Address, depth: u8) -> Batch {
+    Batch::new(
+        BatchId::ZERO,
+        1_000,
+        0,
+        owner,
+        depth,
+        BucketDepth::new(BUCKET_DEPTH).unwrap(),
+        true,
+    )
+}
+
+#[test]
+fn a_dilution_mid_stream_widens_the_batch_without_minting_an_invalid_stamp() {
+    let signer = PrivateKeySigner::from_slice(&[9u8; 32]).unwrap();
+    let owner = signer.address();
+    let issuer: Arc<MemoryIssuer> = Arc::new(MemoryIssuer::new(
+        BatchId::ZERO,
+        NARROW_DEPTH,
+        BucketDepth::new(BUCKET_DEPTH).unwrap(),
+    ));
+    let mut registry = IssuerRegistry::new(CONFIRMATIONS);
+    registry.register(issuer.clone());
+    let at_half = Barrier::new(2);
+    let resumed = Barrier::new(2);
+
+    // Observations are asserted after the join: a panic between the barriers
+    // would strand the stamping thread.
+    let (results, unconfirmed, confirmed) = thread::scope(|scope| {
+        let stamping = scope.spawn(|| {
+            // A window under HALF keeps admission lazy, so the barrier lands
+            // mid-stream rather than after the whole input is pulled.
+            let pipeline =
+                StampPipeline::from_signer(signer.clone()).with_window(Window::new(16).unwrap());
+            let addresses = (0..TOTAL).map(|i| {
+                if i == HALF {
+                    at_half.wait();
+                    resumed.wait();
+                }
+                address_for(i)
+            });
+            pipeline.stamp(&*issuer, addresses).collect::<Vec<_>>()
+        });
+
+        // Half the stream is admitted, and its signatures are outstanding,
+        // before the chain event lands.
+        at_half.wait();
+        let mut unconfirmed = Vec::new();
+        for depth in NARROW_DEPTH + 1..=WIDE_DEPTH {
+            registry
+                .handle_event(BatchEvent::DepthIncrease {
+                    batch_id: BatchId::ZERO,
+                    new_depth: depth,
+                    block: DILUTION_BLOCK,
+                })
+                .unwrap();
+            unconfirmed.push(StampIssuer::batch_depth(&*issuer));
+        }
+        registry.advance_to(DILUTION_BLOCK + CONFIRMATIONS).unwrap();
+        let confirmed = StampIssuer::batch_depth(&*issuer);
+        resumed.wait();
+
+        (stamping.join().unwrap(), unconfirmed, confirmed)
+    });
+
+    // Nothing is issuable into the widened range until the event confirms.
+    assert!(unconfirmed.iter().all(|depth| *depth == NARROW_DEPTH));
+    assert_eq!(confirmed, WIDE_DEPTH);
+
+    let batch = batch_at(owner, WIDE_DEPTH);
+    let narrow_capacity = 1u32 << (NARROW_DEPTH - BUCKET_DEPTH);
+    let mut slots = HashSet::new();
+    let mut issued = 0u32;
+    let mut refused = 0u32;
+
+    assert_eq!(u32::try_from(results.len()).unwrap(), TOTAL);
+    for outcome in results {
+        match outcome.result {
+            Ok(stamp) => {
+                issued += 1;
+                stamp.verify(&outcome.address, owner).unwrap();
+                batch.validate_index(&stamp.stamp_index()).unwrap();
+                batch
+                    .validate_bucket(&stamp.stamp_index(), &outcome.address)
+                    .unwrap();
+                assert!(slots.insert(stamp.stamp_index().encode()), "slot reissued");
+            }
+            Err(SigningError::Stamp(StampError::BucketFull { .. })) => refused += 1,
+            Err(other) => panic!("unexpected stamping error: {other}"),
+        }
+    }
+
+    // The first half sees the narrow geometry, so each bucket fills at its old
+    // capacity; the second half sees the wide one and every address lands.
+    assert_eq!(issued, BUCKETS * narrow_capacity + HALF);
+    assert_eq!(refused, TOTAL - issued);
+    assert_eq!(u32::try_from(slots.len()).unwrap(), issued);
+    assert_eq!(
+        StampIssuer::stamps_issued(&*issuer),
+        Some(u64::from(issued))
+    );
+}
+
+#[test]
+fn an_unsynchronized_dilution_never_reissues_a_slot() {
+    let signer = PrivateKeySigner::from_slice(&[11u8; 32]).unwrap();
+    let owner = signer.address();
+    let issuer: Arc<MemoryIssuer> = Arc::new(MemoryIssuer::new(
+        BatchId::ZERO,
+        NARROW_DEPTH,
+        BucketDepth::new(BUCKET_DEPTH).unwrap(),
+    ));
+    let mut registry = IssuerRegistry::new(0);
+    registry.register(issuer.clone());
+
+    let results = thread::scope(|scope| {
+        let stamping = scope.spawn(|| {
+            let pipeline =
+                StampPipeline::from_signer(signer.clone()).with_window(Window::new(16).unwrap());
+            pipeline
+                .stamp(&*issuer, (0..TOTAL).map(address_for))
+                .collect::<Vec<_>>()
+        });
+
+        for depth in NARROW_DEPTH + 1..=WIDE_DEPTH {
+            registry
+                .handle_event(BatchEvent::DepthIncrease {
+                    batch_id: BatchId::ZERO,
+                    new_depth: depth,
+                    block: DILUTION_BLOCK,
+                })
+                .unwrap();
+            thread::yield_now();
+        }
+
+        stamping.join().unwrap()
+    });
+
+    let batch = batch_at(owner, WIDE_DEPTH);
+    let mut slots = HashSet::new();
+    for outcome in results {
+        if let Ok(stamp) = outcome.result {
+            stamp.verify(&outcome.address, owner).unwrap();
+            batch.validate_index(&stamp.stamp_index()).unwrap();
+            assert!(slots.insert(stamp.stamp_index().encode()), "slot reissued");
+        }
+    }
+
+    assert_eq!(
+        StampIssuer::stamps_issued(&*issuer),
+        Some(u64::try_from(slots.len()).unwrap())
+    );
+    assert_eq!(StampIssuer::batch_depth(&*issuer), WIDE_DEPTH);
+}

--- a/crates/postage/src/events.rs
+++ b/crates/postage/src/events.rs
@@ -31,8 +31,8 @@ pub enum BatchEvent {
         batch_id: BatchId,
         /// The new depth.
         new_depth: u8,
-        /// The block the dilution was mined in; the issuance gate counts
-        /// confirmations from it.
+        /// The block it was mined in, which the issuance gate counts
+        /// confirmations from.
         block: u64,
     },
 

--- a/crates/postage/src/events.rs
+++ b/crates/postage/src/events.rs
@@ -31,6 +31,9 @@ pub enum BatchEvent {
         batch_id: BatchId,
         /// The new depth.
         new_depth: u8,
+        /// The block the dilution was mined in; the issuance gate counts
+        /// confirmations from it.
+        block: u64,
     },
 
     /// A batch expired.
@@ -110,6 +113,7 @@ mod tests {
         let depth = BatchEvent::DepthIncrease {
             batch_id,
             new_depth: 21,
+            block: 120,
         };
         assert_eq!(depth.batch_id(), batch_id);
 


### PR DESCRIPTION
## What

Wires on-chain dilution (`BatchEvent::DepthIncrease`) through to live issuers behind a confirmation gate, and fixes a one-load-per-`allocate` capacity refresh so a dilution landing mid-loop reopens a full bucket without paying a reload on every retry.

- `Watermarks::bucket_capacity` splits into `capacity_at(depth)` plus a `reloaded_capacity` that takes an `Acquire` load; `allocate` now reloads the depth once, with `Ordering::Acquire`, before it surfaces `CounterError::BucketFull`. `Depth::raise` pairs with it as `AcqRel`.
- `Dilutable::dilute` takes `&self` and gains `MaybeSend + MaybeSync` supertraits, so `dyn Dilutable` is `Send + Sync` where threads exist and unbounded under unsync/wasm/bare metal.
- `IssuerRegistry` now keys `IssuerHandle = Arc<dyn Dilutable>` instead of owning `Box<dyn Dilutable + Send>`, so a registered issuer stays usable for issuance through pipelines holding the same handle.
- `IssuerRegistry::new` takes a `confirmations: u64`; a `DepthIncrease` for a tracked batch is queued as `Pending { batch_id, depth, block }` rather than applied immediately, and only settles once `advance_to` (or a later event) moves the observed head past `block + confirmations`. Widened capacity is withheld until then, because a peer that has not ingested the event rejects a stamp minted into that range.
- `BatchEvent::DepthIncrease` gains a `block: u64` field carrying the block the depth increase was mined in.
- Fixed in a follow-up commit: `handle_event` was returning early for a `DepthIncrease` on an untracked batch before advancing the chain head, so a confirmed dilution for a batch the registry *does* track stayed parked at the narrow depth. The head advance now runs ahead of the registration check, with a regression test that fails on the pre-fix code.
- `crates/postage-issuer/tests/online_dilution.rs` adds an integration test exercising dilution against a live signing stream.

## Why

Depth increases confirmed on-chain must reach the issuer that mints stamps for that batch, but applying the new depth before the block has enough confirmations would let a node mint stamps a peer running slightly behind chain head would reject. Sharing issuer handles via `Arc` rather than exclusive ownership lets a pipeline keep signing through the same issuer the registry dilutes.

## Testing

All commands run at branch tip `9f01765` inside `nix develop --command`.

Clippy, mirroring `lint.yml` (never `--all-features`):
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: clean.
- `cargo clippy --locked --all-targets -p nectar-postage-issuer --features parallel -- -D warnings`: clean.
- `cargo clippy --locked --all-targets -p nectar-postage-issuer -- -D warnings` (inline engine): clean.
- `cargo clippy --locked --all-targets -p nectar-postage --features serde -- -D warnings`: clean.
- `cargo clippy --locked --all-targets -p nectar-postage --features parallel -- -D warnings`: clean.
- `cargo clippy --workspace --all-targets --locked --features nectar-postage-usage/client,nectar-postage-usage/issuer -- -D warnings`: clean.

Doctests: `cargo test --doc -p nectar-postage-issuer`: 3 passed, 3 ignored.

## AI Assistance

Implementation: claude-opus-5. Red-team: claude-opus-5. PR: claude-sonnet-5.

Closes #766
</content>
